### PR TITLE
Restore generation contract parity

### DIFF
--- a/src/engine/contracts/schemas/chat.schema.test.ts
+++ b/src/engine/contracts/schemas/chat.schema.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { chatModeSchema, createChatSchema, generateRequestSchema } from "./chat.schema";
+
+describe("chat schemas", () => {
+  it("migrates legacy visual_novel chat modes to roleplay", () => {
+    expect(chatModeSchema.parse("visual_novel")).toBe("roleplay");
+    expect(createChatSchema.parse({ name: "Legacy VN", mode: "visual_novel" }).mode).toBe("roleplay");
+  });
+
+  it("preserves userTimeZone on generation requests", () => {
+    const parsed = generateRequestSchema.parse({
+      chatId: "chat-1",
+      userTimeZone: "America/New_York",
+    });
+
+    expect(parsed.userTimeZone).toBe("America/New_York");
+  });
+});

--- a/src/engine/contracts/schemas/chat.schema.ts
+++ b/src/engine/contracts/schemas/chat.schema.ts
@@ -3,7 +3,12 @@
 // ──────────────────────────────────────────────
 import { z } from "zod";
 
-export const chatModeSchema = z.enum(["conversation", "roleplay", "game"]);
+const canonicalChatModeSchema = z.enum(["conversation", "roleplay", "game"]);
+
+export const chatModeSchema = z.preprocess(
+  (value) => (value === "visual_novel" ? "roleplay" : value),
+  canonicalChatModeSchema,
+);
 
 const messageRoleSchema = z.enum(["user", "assistant", "system", "narrator"]);
 
@@ -34,6 +39,7 @@ export const generateRequestSchema = z.object({
   streaming: z.boolean().optional().default(true),
   userStatus: z.enum(["active", "idle", "dnd"]).optional().default("active"),
   userActivity: z.string().max(120).optional().default(""),
+  userTimeZone: z.string().max(128).optional(),
   mentionedCharacterNames: z.array(z.string()).optional().default([]),
   forCharacterId: z.string().nullable().optional().default(null),
   generationGuide: z.string().nullable().optional().default(null),

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -6,6 +6,8 @@ import type { GenerationGuideSource } from "../../shared/text/generation-guide.j
 
 /** The primary chat modes the engine supports. */
 export type ChatMode = "conversation" | "roleplay" | "game";
+/** Legacy persisted/imported mode name. New inputs should migrate this to "roleplay". */
+export type LegacyChatMode = "visual_novel";
 export type SpotifySourceType = "liked" | "playlist" | "artist" | "any";
 
 /** How a multi-character (group) chat is handled. */

--- a/src/engine/generation/main-tool-loop.test.ts
+++ b/src/engine/generation/main-tool-loop.test.ts
@@ -6,6 +6,7 @@ import { startGeneration, type GenerationEngineDeps } from "./start-generation";
 import {
   buildMainToolDefinitions,
   executeBuiltInTool,
+  customToolExecutor,
   executeMainToolCall,
   searchLorebookTool,
   normalizeToolCall,
@@ -992,6 +993,28 @@ describe("row 10 — custom-tool name collision with built-in: built-in wins, no
     expect(built).not.toBeNull();
     const names = built!.toolDefs.map((tool) => tool.name);
     expect(names).toContain("legacy_calc");
+  });
+
+  it("executes script custom tools locally without requiring the custom-tools integration capability", async () => {
+    const execute = vi.fn();
+    const result = await customToolExecutor(
+      { customTools: { execute } } as Partial<IntegrationGateway> as IntegrationGateway,
+      toolCallChunk("legacy_calc", { a: 2, b: 3 }).data as Parameters<typeof customToolExecutor>[1],
+      {
+        id: "ct-legacy",
+        name: "legacy_calc",
+        description: "old script tool",
+        parametersSchema: { type: "object", properties: {} },
+        executionType: "script",
+        webhookUrl: null,
+        staticResult: null,
+        scriptBody: "return arguments.a + arguments.b;",
+        enabled: true,
+      },
+    );
+
+    expect(result).toBe("5");
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("usage is aggregated across multi-turn tool-call loops, not overwritten by the last turn", async () => {

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -2301,6 +2301,31 @@ describe("startGeneration Discord mirror", () => {
 });
 
 describe("startGeneration group turn prompt toggle", () => {
+  it("auto-targets the next active character for sequential individual roleplay groups", async () => {
+    const { deps, createChatMessage, streamedRequests } = generationDepsForChat({
+      chatPatch: { mode: "roleplay", characterIds: ["char-1", "char-2"] },
+      chatMetadata: { groupChatMode: "individual", groupResponseOrder: "sequential" },
+      characters: [
+        { id: "char-1", data: { name: "Marina" } },
+        { id: "char-2", data: { name: "Celia" } },
+      ],
+      initialMessages: [
+        { id: "user-1", chatId: "chat-1", role: "user", content: "hello" },
+        { id: "assistant-1", chatId: "chat-1", role: "assistant", characterId: "char-1", content: "Hi." },
+      ],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, { chatId: "chat-1", userMessage: "your turn", impersonateBlockAgents: true }),
+    );
+
+    const assistantSave = createChatMessage.mock.calls.find(([, value]) => value.role === "assistant");
+    expect(assistantSave?.[1]).toMatchObject({ characterId: "char-2" });
+    expect((streamedRequests[0] as { messages: Array<{ content: string }> }).messages).toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: expect.stringContaining("Respond only as Celia") })]),
+    );
+  });
+
   it("keeps target character instructions enabled by default for individual roleplay groups", async () => {
     const { deps, streamedRequests } = generationDepsForChat({
       chatPatch: { mode: "roleplay", characterIds: ["char-1", "char-2"] },

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1184,6 +1184,26 @@ async function resolveGroupTargetForGeneration(args: {
   return sequentialGroupTarget(args.storedMessages, activeIds);
 }
 
+function sequentialGroupTargetCharacterId(
+  chat: JsonRecord,
+  input: StartGenerationInput,
+  messages: JsonRecord[],
+): string | null {
+  if (input.impersonate === true) return null;
+  if (readString(input.forCharacterId).trim()) return null;
+  const metadata = parseRecord(chat.metadata);
+  if (readString(chat.mode || chat.chatMode).trim() !== "roleplay") return null;
+  if (readString(metadata.groupChatMode, "merged") !== "individual") return null;
+  if (readString(metadata.groupResponseOrder, "smart") !== "sequential") return null;
+  const activeIds = activeCharacterIds(chat);
+  if (activeIds.length <= 1) return null;
+
+  const regenerateMessageId = readString(input.regenerateMessageId).trim();
+  if (regenerateMessageId) return explicitGroupTarget(input, messages, activeIds);
+
+  return sequentialGroupTarget(messages, activeIds);
+}
+
 function isPassiveGenerationRequest(input: StartGenerationInput, prepared: PreparedUserInput): boolean {
   return (
     input.impersonate !== true &&
@@ -2157,6 +2177,10 @@ export async function* startGeneration(
     storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
   }
   const generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
+  const sequentialGroupTargetId = sequentialGroupTargetCharacterId(chat, input, storedMessages);
+  if (sequentialGroupTargetId) {
+    input = { ...input, forCharacterId: sequentialGroupTargetId };
+  }
   const generationTrackerBaseline = await selectGenerationTrackerBaseline(
     deps.storage,
     chatId,

--- a/src/features/runtime/generation/hooks/use-generate.test.ts
+++ b/src/features/runtime/generation/hooks/use-generate.test.ts
@@ -362,4 +362,23 @@ describe("runGenerationWithUi", () => {
     });
     expect(message?.extra).not.toHaveProperty("generationPromptSnapshotsBySwipe");
   });
+
+  it("updates generation phase for tool call and tool result stream events without appending them as text", async () => {
+    const queryClient = queryClientWithChat();
+    const observedPhases: Array<string | null> = [];
+
+    const streamFactory = vi.fn<TestStreamFactory>(async function* () {
+      yield { type: "tool_call", data: { id: "call-1", name: "roll_dice", arguments: "{}" } };
+      observedPhases.push(useChatStore.getState().generationPhase);
+      yield { type: "tool_result", data: { toolCallId: "call-1", name: "roll_dice", result: "4", success: true } };
+      observedPhases.push(useChatStore.getState().generationPhase);
+      yield { type: "token", data: "Rolled a 4." };
+      yield { type: "done" };
+    });
+
+    await expect(runGenerationWithUi(queryClient, { chatId: "chat-1" }, streamFactory)).resolves.toBe(true);
+
+    expect(observedPhases).toEqual(["Running tool: roll_dice...", "Tool finished: roll_dice."]);
+    expect(useChatStore.getState().streamBuffer).toBe("Rolled a 4.");
+  });
 });

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -106,6 +106,10 @@ function readPositiveNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+function toolEventName(data: unknown): string {
+  return readString(parseMaybeRecord(data).name).trim();
+}
+
 function resolveUserTimeZone(): string {
   // Engine has its own live-host fallback in resolvePromptTimeZone, so this is
   // explicit-intent plumbing rather than a load-bearing source of truth.
@@ -1217,6 +1221,22 @@ export async function runGenerationWithUi(
         case "agent_result":
           queueAgentResultEffect(event.data);
           break;
+        case "tool_call": {
+          const name = toolEventName(event.data);
+          useChatStore.getState().setGenerationPhase(name ? `Running tool: ${name}...` : "Running tool...");
+          break;
+        }
+        case "tool_result": {
+          const data = parseMaybeRecord(event.data);
+          const name = toolEventName(data);
+          const success = data.success !== false;
+          useChatStore
+            .getState()
+            .setGenerationPhase(
+              name ? `Tool ${success ? "finished" : "failed"}: ${name}.` : `Tool ${success ? "finished" : "failed"}.`,
+            );
+          break;
+        }
         case "agent_injection_review": {
           const data = parseMaybeRecord(event.data);
           const reviewChatId = readString(data.chatId).trim();


### PR DESCRIPTION
﻿<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - refactor readiness blocker found during contract/generation parity review.

## Why this change

The refactor branch needs to preserve legacy generation contracts where parity is claimed. The review found contract drift around legacy `visual_novel` chat mode ingress, missing `userTimeZone`, sequential group generation targeting, and stream tool event handling.

## What changed

- Migrate legacy `visual_novel` chat mode values to `roleplay` at schema ingress.
- Preserve `userTimeZone` in chat schema/type contracts.
- Restore sequential individual roleplay group targeting for the next active character while preserving upstream group targeting behavior.
- Treat stream `tool_call` and `tool_result` events as phase/status updates without appending visible chat text.
- Add focused contract/generation/runtime tests for these parity claims.

## Refactor impact

Primary owner:

Engine generation and runtime generation wrapper.

Impact areas reviewed:

- Chat schema ingress and TypeScript contract.
- Generation start payload construction.
- Runtime stream event handling in the shared generation hook.
- Custom tool/script event test coverage.

Boundary notes:

- Product behavior remains in `src/engine`.
- React hook change is limited to consuming stream event phases and does not own prompt or generation policy.
- No raw Tauri/HTTP boundary change is included in this lane.

Pressure points touched:

- `src/engine/contracts/schemas/chat.schema.ts`
- `src/engine/generation/start-generation.ts`
- `src/features/runtime/generation/hooks/use-generate.ts`

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Codex-run proof:

- `pnpm check` passed in `scratch/refactor-lane-worktrees/generation`.
- `pnpm exec vitest run src/engine/contracts/schemas/chat.schema.test.ts src/engine/generation/start-generation.test.ts src/features/runtime/generation/hooks/use-generate.test.ts src/engine/generation/main-tool-loop.test.ts` passed: 96 tests.
- `pnpm typecheck` passed.
- `git diff --check upstream/refactor...HEAD` passed.
- Bunny pre-PR review pass: no blocking findings; remaining risk is manual end-to-end generation parity for smart/manual group orchestration beyond the sequential individual path.

### Manual verification notes

- No live model/provider generation run was performed.
- Smart/manual group orchestration parity remains outside this focused lane.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes included.

## UI evidence

N/A - generation contract/runtime behavior only; no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-character selection for sequential roleplay group conversations
  * Tool execution feedback during message generation
  * Optional timezone field for API requests

* **Improvements**
  * Legacy chat mode values now properly migrate to roleplay mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->