### PR TITLE
Fix authenticated game asset playback

### DIFF
--- a/src/features/modes/game/lib/game-audio.test.ts
+++ b/src/features/modes/game/lib/game-audio.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const localFileApiMock = {
+  resolveGameAssetFileUrl: vi.fn<(path: string) => Promise<string>>(),
+};
+
+class FakeAudio {
+  static instances: FakeAudio[] = [];
+
+  src = "";
+  loop = false;
+  preload = "";
+  muted = false;
+  volume = 1;
+  currentTime = 0;
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(src?: string) {
+    if (src) this.src = src;
+    FakeAudio.instances.push(this);
+  }
+
+  play = vi.fn(() => Promise.resolve());
+  pause = vi.fn();
+  load = vi.fn();
+  removeAttribute = vi.fn((name: string) => {
+    if (name === "src") this.src = "";
+  });
+}
+
+async function createGameAudioManager() {
+  vi.resetModules();
+  vi.doMock("../../../../shared/api/local-file-api", () => localFileApiMock);
+  const module = await import("./game-audio");
+  return new module.GameAudioManager();
+}
+
+describe("GameAudioManager remote asset resolution", () => {
+  beforeEach(() => {
+    FakeAudio.instances = [];
+    localFileApiMock.resolveGameAssetFileUrl.mockImplementation(async (path) => `blob:${path}`);
+    vi.stubGlobal("Audio", FakeAudio);
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../../../shared/api/local-file-api");
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves music through the async game asset resolver before playback", async () => {
+    const manager = await createGameAudioManager();
+    manager.unlock();
+
+    manager.playMusic("music:boss", { "music:boss": { path: "music/boss.mp3" } });
+
+    await vi.waitFor(() => {
+      expect(localFileApiMock.resolveGameAssetFileUrl).toHaveBeenCalledWith("music/boss.mp3");
+      expect(FakeAudio.instances.some((audio) => audio.src === "blob:music/boss.mp3" && audio.loop)).toBe(true);
+    });
+  });
+
+  it("resolves ambient audio through the async game asset resolver before playback", async () => {
+    const manager = await createGameAudioManager();
+    manager.unlock();
+
+    manager.playAmbient("ambient:rain", { "ambient:rain": { path: "ambient/rain.mp3" } });
+
+    await vi.waitFor(() => {
+      expect(localFileApiMock.resolveGameAssetFileUrl).toHaveBeenCalledWith("ambient/rain.mp3");
+      expect(FakeAudio.instances.some((audio) => audio.src === "blob:ambient/rain.mp3" && audio.loop)).toBe(true);
+    });
+  });
+
+  it("resolves SFX through the async game asset resolver before playback", async () => {
+    const manager = await createGameAudioManager();
+    manager.unlock();
+
+    manager.playSfx("sfx:hit", { "sfx:hit": { path: "sfx/hit.wav" } });
+
+    await vi.waitFor(() => {
+      expect(localFileApiMock.resolveGameAssetFileUrl).toHaveBeenCalledWith("sfx/hit.wav");
+      expect(FakeAudio.instances.some((audio) => audio.src === "blob:sfx/hit.wav")).toBe(true);
+    });
+  });
+});

--- a/src/features/modes/game/lib/game-audio.test.ts
+++ b/src/features/modes/game/lib/game-audio.test.ts
@@ -84,4 +84,25 @@ describe("GameAudioManager remote asset resolution", () => {
       expect(FakeAudio.instances.some((audio) => audio.src === "blob:sfx/hit.wav")).toBe(true);
     });
   });
+
+  it("does not play SFX if mute is enabled while async asset resolution is pending", async () => {
+    let resolveAsset!: (url: string) => void;
+    localFileApiMock.resolveGameAssetFileUrl.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveAsset = resolve;
+        }),
+    );
+    const manager = await createGameAudioManager();
+    manager.unlock();
+
+    manager.playSfx("sfx:hit", { "sfx:hit": { path: "sfx/hit.wav" } });
+    manager.setMuted(true);
+    resolveAsset("blob:sfx/hit.wav");
+
+    await vi.waitFor(() => {
+      expect(localFileApiMock.resolveGameAssetFileUrl).toHaveBeenCalledWith("sfx/hit.wav");
+    });
+    expect(FakeAudio.instances.some((audio) => audio.src === "blob:sfx/hit.wav")).toBe(false);
+  });
 });

--- a/src/features/modes/game/lib/game-audio.ts
+++ b/src/features/modes/game/lib/game-audio.ts
@@ -6,7 +6,7 @@
 // for smooth transitions.
 // ──────────────────────────────────────────────
 
-import { gameAssetFileUrlFromPath } from "../../../../shared/api/local-file-api";
+import { resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
 import { loadUrlArrayBuffer } from "../../../../shared/lib/url-blob";
 
 const CROSSFADE_MS = 2000;
@@ -80,7 +80,7 @@ function setAmbientAudioSession(): void {
 }
 
 /** Singleton audio manager for game mode. */
-class GameAudioManager {
+export class GameAudioManager {
   private musicElement: LoopingAudioLayer | null = null;
   private nextMusicElement: LoopingAudioLayer | null = null;
   private ambientElement: LoopingAudioLayer | null = null;
@@ -171,19 +171,19 @@ class GameAudioManager {
   }
 
   /** Resolve an asset tag to a URL. */
-  private resolveUrl(tag: string): string {
+  private resolveUrl(tag: string): Promise<string> {
     // Tag format: "category:subcategory:name" → path: "category/subcategory/name.*"
     // The manifest stores the full relative path with extension
     const path = assetTagToPath(tag);
-    return gameAssetFileUrlFromPath(path);
+    return resolveGameAssetFileUrl(path);
   }
 
   /** Try to find the full path from manifest, falling back to tag-based URL. */
-  resolveAssetUrl(tag: string, manifest?: AssetMap | null): string {
+  resolveAssetUrl(tag: string, manifest?: AssetMap | null): Promise<string> {
     const normalizedTag = normalizeAssetTag(tag);
     const manifestEntry = manifest?.[tag] ?? manifest?.[normalizedTag];
     if (manifestEntry) {
-      return gameAssetFileUrlFromPath(manifestEntry.path, manifestEntry.absolutePath);
+      return resolveGameAssetFileUrl(manifestEntry.path);
     }
     return this.resolveUrl(tag);
   }
@@ -653,83 +653,96 @@ class GameAudioManager {
       return;
     }
 
-    const url = this.resolveAssetUrl(tag, manifest);
-    const newAudio = this.createLoopingAudioLayer(url, 0, this.isMuted);
+    void this.resolveAssetUrl(tag, manifest)
+      .then((url) => {
+        if (this.currentMusicTag !== tag) return;
+        const newAudio = this.createLoopingAudioLayer(url, 0, this.isMuted);
 
-    if (this.fadeInterval) {
-      clearInterval(this.fadeInterval);
-      this.fadeInterval = null;
-    }
-
-    const oldAudio = this.musicElement;
-    if (this.nextMusicElement && this.nextMusicElement !== oldAudio) {
-      this.nextMusicElement.stop();
-      this.nextMusicElement = null;
-    }
-    if (oldAudio) {
-      oldAudio.setMuted(this.isMuted);
-      oldAudio.setVolume(this.musicVolume);
-    }
-    this.nextMusicElement = newAudio;
-
-    newAudio.ready
-      .then(() => {
-        if (this.nextMusicElement !== newAudio) {
-          newAudio.stop();
-          return;
-        }
-        // Playback started — clear any pending retry
-        this.pendingMusic = null;
-        const steps = CROSSFADE_MS / 50;
-        const fadeStep = this.musicVolume / steps;
-        let step = 0;
-
-        const interval = setInterval(() => {
-          if (this.nextMusicElement !== newAudio) {
-            clearInterval(interval);
-            if (this.fadeInterval === interval) this.fadeInterval = null;
-            newAudio.stop();
-            return;
-          }
-
-          step++;
-          // Fade in new
-          newAudio.setMuted(this.isMuted);
-          newAudio.setVolume(Math.min(this.musicVolume, fadeStep * step));
-          // Fade out old
-          if (oldAudio) {
-            oldAudio.setMuted(this.isMuted);
-            oldAudio.setVolume(Math.max(0, this.musicVolume - fadeStep * step));
-          }
-
-          if (step >= steps) {
-            clearInterval(interval);
-            if (this.fadeInterval === interval) this.fadeInterval = null;
-            if (oldAudio) {
-              oldAudio.stop();
-            }
-            this.musicElement = newAudio;
-            this.nextMusicElement = null;
-          }
-        }, 50);
-
-        this.fadeInterval = interval;
-      })
-      .catch(() => {
-        if (this.nextMusicElement !== newAudio) {
-          newAudio.stop();
-          return;
+        if (this.fadeInterval) {
+          clearInterval(this.fadeInterval);
+          this.fadeInterval = null;
         }
 
-        this.nextMusicElement = null;
-        newAudio.stop();
-
-        // Autoplay blocked — queue for retry on user gesture
-        this.pendingMusic = { tag, manifest };
-        this.currentMusicTag = previousMusicTag;
+        const oldAudio = this.musicElement;
+        if (this.nextMusicElement && this.nextMusicElement !== oldAudio) {
+          this.nextMusicElement.stop();
+          this.nextMusicElement = null;
+        }
         if (oldAudio) {
           oldAudio.setMuted(this.isMuted);
           oldAudio.setVolume(this.musicVolume);
+        }
+        this.nextMusicElement = newAudio;
+
+        newAudio.ready
+          .then(() => {
+            if (this.nextMusicElement !== newAudio) {
+              newAudio.stop();
+              return;
+            }
+            // Playback started — clear any pending retry
+            this.pendingMusic = null;
+            const steps = CROSSFADE_MS / 50;
+            const fadeStep = this.musicVolume / steps;
+            let step = 0;
+
+            const interval = setInterval(() => {
+              if (this.nextMusicElement !== newAudio) {
+                clearInterval(interval);
+                if (this.fadeInterval === interval) this.fadeInterval = null;
+                newAudio.stop();
+                return;
+              }
+
+              step++;
+              // Fade in new
+              newAudio.setMuted(this.isMuted);
+              newAudio.setVolume(Math.min(this.musicVolume, fadeStep * step));
+              // Fade out old
+              if (oldAudio) {
+                oldAudio.setMuted(this.isMuted);
+                oldAudio.setVolume(Math.max(0, this.musicVolume - fadeStep * step));
+              }
+
+              if (step >= steps) {
+                clearInterval(interval);
+                if (this.fadeInterval === interval) this.fadeInterval = null;
+                if (oldAudio) {
+                  oldAudio.stop();
+                }
+                this.musicElement = newAudio;
+                this.nextMusicElement = null;
+              }
+            }, 50);
+
+            this.fadeInterval = interval;
+          })
+          .catch(() => {
+            if (this.nextMusicElement !== newAudio) {
+              newAudio.stop();
+              return;
+            }
+
+            this.nextMusicElement = null;
+            newAudio.stop();
+
+            // Autoplay blocked — queue for retry on user gesture
+            this.pendingMusic = { tag, manifest };
+            this.currentMusicTag = previousMusicTag;
+            if (oldAudio) {
+              oldAudio.setMuted(this.isMuted);
+              oldAudio.setVolume(this.musicVolume);
+            }
+            this.ensureGestureListener();
+          });
+      })
+      .catch(() => {
+        if (this.currentMusicTag !== tag) return;
+        this.pendingMusic = { tag, manifest };
+        this.currentMusicTag = previousMusicTag;
+        if (this.musicElement) {
+          this.musicElement.setMuted(this.isMuted);
+          this.musicElement.setVolume(this.musicVolume);
         }
         this.ensureGestureListener();
       });
@@ -771,20 +784,25 @@ class GameAudioManager {
   /** Play a one-shot sound effect. */
   playSfx(tag: string, manifest?: AssetMap | null): void {
     if (this.isMuted || this.sfxVolume <= 0 || !this.userHasInteracted) return;
-    const url = this.resolveAssetUrl(tag, manifest);
-    const audio = this.sfxPool[this.sfxIndex % SFX_POOL_SIZE]!;
-    this.sfxIndex++;
-    audio.onerror = () => {
-      audio.onerror = null;
-      this.playProceduralSfx(tag);
-    };
-    audio.src = url;
-    this.setElementLayerVolume(audio, this.sfxVolume);
-    audio.muted = false;
-    audio.currentTime = 0;
-    audio.play().catch(() => {
-      this.playProceduralSfx(tag);
-    });
+    void this.resolveAssetUrl(tag, manifest)
+      .then((url) => {
+        const audio = this.sfxPool[this.sfxIndex % SFX_POOL_SIZE]!;
+        this.sfxIndex++;
+        audio.onerror = () => {
+          audio.onerror = null;
+          this.playProceduralSfx(tag);
+        };
+        audio.src = url;
+        this.setElementLayerVolume(audio, this.sfxVolume);
+        audio.muted = false;
+        audio.currentTime = 0;
+        audio.play().catch(() => {
+          this.playProceduralSfx(tag);
+        });
+      })
+      .catch(() => {
+        this.playProceduralSfx(tag);
+      });
   }
 
   /** Set looping ambient sound. */
@@ -800,27 +818,33 @@ class GameAudioManager {
       return;
     }
 
-    const url = this.resolveAssetUrl(tag, manifest);
-    const nextAmbient = this.createLoopingAudioLayer(url, this.ambientVolume, this.isMuted);
-    nextAmbient.ready
-      .then(() => {
+    void this.resolveAssetUrl(tag, manifest)
+      .then((url) => {
         if (this.currentAmbientTag !== tag) {
-          nextAmbient.stop();
           return;
         }
+        const nextAmbient = this.createLoopingAudioLayer(url, this.ambientVolume, this.isMuted);
 
-        if (previousAmbient && previousAmbient !== nextAmbient) {
-          previousAmbient.stop();
-        }
-        this.ambientElement = nextAmbient;
-        this.pendingAmbient = null;
+        return nextAmbient.ready
+          .then(() => {
+            if (this.currentAmbientTag !== tag) {
+              nextAmbient.stop();
+              return;
+            }
+
+            if (previousAmbient && previousAmbient !== nextAmbient) {
+              previousAmbient.stop();
+            }
+            this.ambientElement = nextAmbient;
+            this.pendingAmbient = null;
+          })
+          .catch((err) => {
+            nextAmbient.stop();
+            throw err;
+          });
       })
       .catch((err) => {
-        nextAmbient.stop();
-        if (this.currentAmbientTag !== tag) {
-          return;
-        }
-
+        if (this.currentAmbientTag !== tag) return;
         console.warn("[audio] Ambient playback failed:", tag, err);
         this.pendingAmbient = { tag, manifest };
         this.currentAmbientTag = previousAmbientTag;

--- a/src/features/modes/game/lib/game-audio.ts
+++ b/src/features/modes/game/lib/game-audio.ts
@@ -786,6 +786,7 @@ export class GameAudioManager {
     if (this.isMuted || this.sfxVolume <= 0 || !this.userHasInteracted) return;
     void this.resolveAssetUrl(tag, manifest)
       .then((url) => {
+        if (this.isMuted || this.sfxVolume <= 0) return;
         const audio = this.sfxPool[this.sfxIndex % SFX_POOL_SIZE]!;
         this.sfxIndex++;
         audio.onerror = () => {
@@ -794,7 +795,7 @@ export class GameAudioManager {
         };
         audio.src = url;
         this.setElementLayerVolume(audio, this.sfxVolume);
-        audio.muted = false;
+        audio.muted = this.isMuted;
         audio.currentTime = 0;
         audio.play().catch(() => {
           this.playProceduralSfx(tag);

--- a/src/shared/api/assets-api.test.ts
+++ b/src/shared/api/assets-api.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { gameAssetsApi } from "./assets-api";
+import { invalidateRemoteManagedAssetObjectUrls } from "./local-file-api";
+import { invokeTauri } from "./tauri-client";
+
+vi.mock("./tauri-client", () => ({
+  invokeTauri: vi.fn(),
+}));
+
+vi.mock("./local-file-api", () => ({
+  invalidateRemoteManagedAssetObjectUrls: vi.fn(),
+}));
+
+const invokeTauriMock = vi.mocked(invokeTauri);
+const invalidateRemoteManagedAssetObjectUrlsMock = vi.mocked(invalidateRemoteManagedAssetObjectUrls);
+
+describe("gameAssetsApi remote asset cache invalidation", () => {
+  beforeEach(() => {
+    invokeTauriMock.mockReset();
+    invalidateRemoteManagedAssetObjectUrlsMock.mockReset();
+    invokeTauriMock.mockResolvedValue(undefined);
+  });
+
+  it("invalidates cached remote game asset blobs after mutating asset commands", async () => {
+    await gameAssetsApi.deleteFile("music/theme.mp3");
+    await gameAssetsApi.rescan();
+
+    expect(invalidateRemoteManagedAssetObjectUrlsMock).toHaveBeenCalledTimes(2);
+    expect(invalidateRemoteManagedAssetObjectUrlsMock).toHaveBeenNthCalledWith(1, "game");
+    expect(invalidateRemoteManagedAssetObjectUrlsMock).toHaveBeenNthCalledWith(2, "game");
+  });
+
+  it("does not invalidate cached remote game asset blobs when a mutating command fails", async () => {
+    invokeTauriMock.mockRejectedValueOnce(new Error("delete failed"));
+
+    await expect(gameAssetsApi.deleteFile("music/theme.mp3")).rejects.toThrow("delete failed");
+    expect(invalidateRemoteManagedAssetObjectUrlsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/api/assets-api.ts
+++ b/src/shared/api/assets-api.ts
@@ -1,6 +1,7 @@
 import { fileToUploadPayload, GAME_ASSET_SIZE_ERROR } from "./file-payload";
 import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
 import { invokeTauri } from "./tauri-client";
+import { invalidateRemoteManagedAssetObjectUrls } from "./local-file-api";
 
 interface GameAssetFileInfo {
   name: string;
@@ -26,16 +27,24 @@ async function uploadGameAsset({
   category: string;
   subcategory?: string;
 }) {
-  return invokeTauri("game_assets_upload", {
-    body: {
-      category,
-      subcategory: subcategory ?? "",
-      file: await fileToUploadPayload(file, {
-        maxBytes: MAX_FILE_SIZES.GAME_ASSET,
-        tooLargeMessage: GAME_ASSET_SIZE_ERROR,
-      }),
-    },
-  });
+  return invalidateGameAssetObjectUrlsAfter(
+    invokeTauri("game_assets_upload", {
+      body: {
+        category,
+        subcategory: subcategory ?? "",
+        file: await fileToUploadPayload(file, {
+          maxBytes: MAX_FILE_SIZES.GAME_ASSET,
+          tooLargeMessage: GAME_ASSET_SIZE_ERROR,
+        }),
+      },
+    }),
+  );
+}
+
+async function invalidateGameAssetObjectUrlsAfter<T>(operation: Promise<T>): Promise<T> {
+  const result = await operation;
+  invalidateRemoteManagedAssetObjectUrls("game");
+  return result;
 }
 
 const gameAssetCommands = {
@@ -44,24 +53,33 @@ const gameAssetCommands = {
   list: (path?: string) => invokeTauri<unknown[]>("game_assets_list", { path: path ?? null }),
   createFolder: (path: string) => invokeTauri("game_assets_create_folder", { path }),
   deleteFolder: (path: string, recursive?: boolean) =>
-    invokeTauri("game_assets_delete_folder", { path, recursive: recursive ?? false }),
-  rename: (path: string, newName: string) => invokeTauri("game_assets_rename", { path, newName }),
-  move: (path: string, targetFolder: string) => invokeTauri("game_assets_move", { path, targetFolder }),
+    invalidateGameAssetObjectUrlsAfter(
+      invokeTauri("game_assets_delete_folder", { path, recursive: recursive ?? false }),
+    ),
+  rename: (path: string, newName: string) =>
+    invalidateGameAssetObjectUrlsAfter(invokeTauri("game_assets_rename", { path, newName })),
+  move: (path: string, targetFolder: string) =>
+    invalidateGameAssetObjectUrlsAfter(invokeTauri("game_assets_move", { path, targetFolder })),
   copy: (path: string, targetFolder: string) => invokeTauri("game_assets_copy", { path, targetFolder }),
-  deleteFile: (path: string) => invokeTauri<void>("game_assets_delete_file", { path }),
+  deleteFile: (path: string) =>
+    invalidateGameAssetObjectUrlsAfter(invokeTauri<void>("game_assets_delete_file", { path })),
   openFolder: (subfolder?: string) => invokeTauri<void>("game_assets_open_folder", { subfolder: subfolder ?? null }),
-  rescan: () => invokeTauri("game_assets_rescan"),
+  rescan: () => invalidateGameAssetObjectUrlsAfter(invokeTauri("game_assets_rescan")),
   upload: uploadGameAsset,
   updateFolderDescription: (path: string, description: string) =>
     invokeTauri("game_assets_folder_description", { path, description }),
   readText: <T = { content: string }>(path: string) => invokeTauri<T>("game_assets_read_text", { path }),
-  writeText: (path: string, content: string) => invokeTauri<void>("game_assets_write_text", { path, content }),
+  writeText: (path: string, content: string) =>
+    invalidateGameAssetObjectUrlsAfter(invokeTauri<void>("game_assets_write_text", { path, content })),
   fileInfo: (path: string) => invokeTauri<GameAssetFileInfo>("game_assets_file_info", { path }),
   moveBulk: (paths: string[], targetFolder: string) =>
-    invokeTauri<BulkOperationResult & { targetFolder: string }>("game_assets_move_bulk", { paths, targetFolder }),
+    invalidateGameAssetObjectUrlsAfter(
+      invokeTauri<BulkOperationResult & { targetFolder: string }>("game_assets_move_bulk", { paths, targetFolder }),
+    ),
   copyBulk: (paths: string[], targetFolder: string) =>
     invokeTauri<BulkOperationResult & { targetFolder: string }>("game_assets_copy_bulk", { paths, targetFolder }),
-  deleteBulk: (paths: string[]) => invokeTauri<BulkOperationResult>("game_assets_delete_bulk", { paths }),
+  deleteBulk: (paths: string[]) =>
+    invalidateGameAssetObjectUrlsAfter(invokeTauri<BulkOperationResult>("game_assets_delete_bulk", { paths })),
 };
 
 export const gameAssetsApi = {

--- a/src/shared/api/local-file-api.test.ts
+++ b/src/shared/api/local-file-api.test.ts
@@ -4,9 +4,12 @@ import { useUIStore } from "../stores/ui.store";
 import {
   avatarFileUrlFromPath,
   backgroundFileUrlFromPath,
+  gameAssetFileUrlFromPath,
+  invalidateRemoteManagedAssetObjectUrls,
   resolveAvatarFileUrl,
   resolveBackgroundFileUrl,
   resolveGameAssetFileUrl,
+  resolveManagedLocalAssetUrl,
 } from "./local-file-api";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -17,6 +20,7 @@ const convertFileSrcMock = vi.mocked(convertFileSrc);
 
 describe("managed remote asset URLs", () => {
   beforeEach(() => {
+    invalidateRemoteManagedAssetObjectUrls();
     useUIStore.setState({ remoteRuntimeUrl: "" });
     convertFileSrcMock.mockReset();
     convertFileSrcMock.mockImplementation((path) => `asset://localhost/${encodeURIComponent(path)}`);
@@ -26,6 +30,7 @@ describe("managed remote asset URLs", () => {
   });
 
   afterEach(() => {
+    invalidateRemoteManagedAssetObjectUrls();
     useUIStore.setState({ remoteRuntimeUrl: "" });
     vi.unstubAllGlobals();
   });
@@ -42,6 +47,7 @@ describe("managed remote asset URLs", () => {
     useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
 
     expect(backgroundFileUrlFromPath("scene one.png")).toBe("marinara-background:scene%20one.png");
+    expect(gameAssetFileUrlFromPath("backgrounds/forest.png")).toBe("marinara-game-asset:backgrounds%2Fforest.png");
   });
 
   it("fetches authenticated remote assets into blob URLs", async () => {
@@ -65,6 +71,72 @@ describe("managed remote asset URLs", () => {
     expect(createObjectURL).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves authenticated game asset protocol URLs through the async managed bridge", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+    const createObjectURL = vi.fn(() => "blob:game-background");
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response("asset bytes")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const syncUrl = gameAssetFileUrlFromPath("backgrounds/forest.png");
+
+    await expect(resolveManagedLocalAssetUrl(syncUrl)).resolves.toBe("blob:game-background");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.local:8787/api/assets/game/backgrounds/forest.png",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Basic dXNlcjpwYXNz" }),
+      }),
+    );
+  });
+
+  it("deduplicates concurrent authenticated remote asset fetches", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+    const createObjectURL = vi.fn(() => "blob:deduped-asset");
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(new Response("asset bytes")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = resolveGameAssetFileUrl("music/theme.mp3");
+    const second = resolveGameAssetFileUrl("music/theme.mp3");
+
+    await expect(first).resolves.toBe("blob:deduped-asset");
+    await expect(second).resolves.toBe("blob:deduped-asset");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears failed authenticated remote asset fetches so later calls can retry", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+    const createObjectURL = vi.fn(() => "blob:retry-asset");
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve(new Response("", { status: 500 })))
+      .mockImplementationOnce(() => Promise.resolve(new Response("asset bytes")));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveGameAssetFileUrl("sfx/hit.wav")).rejects.toThrow("Remote managed asset returned 500");
+    await expect(resolveGameAssetFileUrl("sfx/hit.wav")).resolves.toBe("blob:retry-asset");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("revokes invalidated authenticated remote asset object URLs", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
+    const createObjectURL = vi.fn(() => "blob:stale-asset");
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: revokeObjectURL });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => Promise.resolve(new Response("asset bytes"))),
+    );
+
+    await expect(resolveGameAssetFileUrl("music/theme.mp3")).resolves.toBe("blob:stale-asset");
+    invalidateRemoteManagedAssetObjectUrls("game", "music/theme.mp3");
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:stale-asset");
+  });
+
   it("fetches authenticated background and avatar assets through async resolvers", async () => {
     useUIStore.setState({ remoteRuntimeUrl: "http://user:pass@runtime.local:8787/" });
     const createObjectURL = vi.fn().mockReturnValueOnce("blob:background").mockReturnValueOnce("blob:avatar");
@@ -73,9 +145,9 @@ describe("managed remote asset URLs", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(resolveBackgroundFileUrl("scene one.png")).resolves.toBe("blob:background");
-    await expect(resolveAvatarFileUrl("Avatar One.png", "C:\\Marinara\\avatars\\characters\\Avatar One.png")).resolves.toBe(
-      "blob:avatar",
-    );
+    await expect(
+      resolveAvatarFileUrl("Avatar One.png", "C:\\Marinara\\avatars\\characters\\Avatar One.png"),
+    ).resolves.toBe("blob:avatar");
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       "http://runtime.local:8787/api/assets/background/scene%20one.png",

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -12,7 +12,12 @@ type RemoteManagedAsset = {
   target: RuntimeTarget;
 };
 
-const remoteAssetObjectUrls = new Map<string, string>();
+type RemoteAssetObjectUrlEntry = {
+  promise: Promise<string>;
+  objectUrl?: string;
+};
+
+const remoteAssetObjectUrls = new Map<string, RemoteAssetObjectUrlEntry>();
 
 function hasScheme(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(value);
@@ -63,10 +68,7 @@ function filePathToAssetUrl(path: string | null | undefined): string {
 
 type RemoteManagedAssetKind = "avatar" | "background" | "font" | "game" | "lorebook";
 
-function remoteManagedAsset(
-  kind: RemoteManagedAssetKind,
-  path: string | null | undefined,
-): RemoteManagedAsset | null {
+function remoteManagedAsset(kind: RemoteManagedAssetKind, path: string | null | undefined): RemoteManagedAsset | null {
   const target = remoteRuntimeTarget();
   if (!target || !path?.trim()) return null;
   const encodedPath = path
@@ -79,10 +81,7 @@ function remoteManagedAsset(
   return encodedPath ? { url: `${target.baseUrl}/api/assets/${kind}/${encodedPath}`, target } : null;
 }
 
-function remoteManagedAssetUrl(
-  kind: RemoteManagedAssetKind,
-  path: string | null | undefined,
-): string | null {
+function remoteManagedAssetUrl(kind: RemoteManagedAssetKind, path: string | null | undefined): string | null {
   const asset = remoteManagedAsset(kind, path);
   if (!asset || asset.target.authorization) return null;
   return asset.url;
@@ -99,20 +98,79 @@ async function remoteManagedAssetResolvableUrl(
 }
 
 async function fetchRemoteManagedAssetBlobUrl(asset: RemoteManagedAsset): Promise<string> {
-  const cacheKey = `${asset.target.baseUrl}\0${asset.target.authorization ?? ""}\0${asset.url}`;
+  const cacheKey = remoteManagedAssetCacheKey(asset);
   const cached = remoteAssetObjectUrls.get(cacheKey);
-  if (cached) return cached;
+  if (cached) return cached.promise;
 
-  const response = await fetch(asset.url, {
-    method: "GET",
-    headers: remoteHeaders(asset.target),
+  const entry: RemoteAssetObjectUrlEntry = { promise: Promise.resolve("") };
+  entry.promise = (async () => {
+    const response = await fetch(asset.url, {
+      method: "GET",
+      headers: remoteHeaders(asset.target),
+    });
+    if (!response.ok) {
+      throw new Error(`Remote managed asset returned ${response.status}`);
+    }
+    const objectUrl = URL.createObjectURL(await response.blob());
+    entry.objectUrl = objectUrl;
+    return objectUrl;
+  })();
+
+  remoteAssetObjectUrls.set(cacheKey, entry);
+  entry.promise.catch(() => {
+    if (remoteAssetObjectUrls.get(cacheKey) === entry) {
+      remoteAssetObjectUrls.delete(cacheKey);
+    }
   });
-  if (!response.ok) {
-    throw new Error(`Remote managed asset returned ${response.status}`);
+  return entry.promise;
+}
+
+function remoteManagedAssetCacheKey(asset: RemoteManagedAsset): string {
+  return `${asset.target.baseUrl}\0${asset.target.authorization ?? ""}\0${asset.url}`;
+}
+
+function revokeRemoteAssetObjectUrl(entry: RemoteAssetObjectUrlEntry): void {
+  if (entry.objectUrl && typeof URL.revokeObjectURL === "function") {
+    URL.revokeObjectURL(entry.objectUrl);
   }
-  const objectUrl = URL.createObjectURL(await response.blob());
-  remoteAssetObjectUrls.set(cacheKey, objectUrl);
-  return objectUrl;
+}
+
+function deleteRemoteAssetObjectUrl(cacheKey: string): void {
+  const entry = remoteAssetObjectUrls.get(cacheKey);
+  if (!entry) return;
+  remoteAssetObjectUrls.delete(cacheKey);
+  if (entry.objectUrl) {
+    revokeRemoteAssetObjectUrl(entry);
+    return;
+  }
+  entry.promise
+    .then((objectUrl) => {
+      if (typeof URL.revokeObjectURL === "function") {
+        URL.revokeObjectURL(objectUrl);
+      }
+    })
+    .catch(() => {});
+}
+
+export function invalidateRemoteManagedAssetObjectUrls(kind?: RemoteManagedAssetKind, path?: string | null): void {
+  if (kind && path) {
+    const asset = remoteManagedAsset(kind, path);
+    if (asset) deleteRemoteAssetObjectUrl(remoteManagedAssetCacheKey(asset));
+    return;
+  }
+  if (kind) {
+    const routeMarker = `/api/assets/${kind}/`;
+    for (const cacheKey of [...remoteAssetObjectUrls.keys()]) {
+      if (cacheKey.includes(routeMarker)) {
+        deleteRemoteAssetObjectUrl(cacheKey);
+      }
+    }
+    return;
+  }
+
+  for (const cacheKey of [...remoteAssetObjectUrls.keys()]) {
+    deleteRemoteAssetObjectUrl(cacheKey);
+  }
 }
 
 function filenameFromPath(path: string | null | undefined): string | null {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

No linked issue. This addresses the post-merge refactor validation blocker for authenticated hostable game asset parity.

## Why this change

- Authenticated hostable runtimes could still break game-mode backgrounds/audio because some runtime paths used synchronous game asset URLs that cannot carry Basic Auth headers.
- The remote managed asset blob cache also needed proof against duplicate fetches, failed fetch poisoning, and stale object URLs after asset mutation.

## What changed

- Route game music, ambient audio, and SFX playback through `resolveGameAssetFileUrl` before creating/playing audio elements.
- Prove authenticated `marinara-game-asset:` background URLs resolve through the async managed asset bridge.
- Cache authenticated remote asset blob URL promises, clear failed fetches, and expose invalidation/revocation.
- Invalidate remote game asset blob URLs after game asset upload/delete/move/rename/rescan/write mutations.
- Add focused tests for authenticated game asset background/audio resolution and cache invalidation behavior.

## Refactor impact

Primary owner:

shared API / game mode

Impact areas reviewed:

- Authenticated hostable remote asset resolution
- Game-mode background rendering via managed local asset bridge
- Game-mode music, ambient, and SFX playback
- Game asset mutation wrappers

Boundary notes:

- Feature game audio still calls a shared API wrapper; it does not reach into raw remote runtime or Tauri command plumbing.
- The authenticated fetch remains owned by `src/shared/api/local-file-api.ts`.
- Game asset mutation invalidation is centralized in `src/shared/api/assets-api.ts`.

Pressure points touched:

- Game audio runtime
- Managed asset wrappers
- Remote authenticated asset cache

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm test src/shared/api/local-file-api.test.ts src/shared/api/assets-api.test.ts src/features/modes/game/lib/game-audio.test.ts`; 3 files / 18 tests passed.
- Codex ran `pnpm check`; line endings, architecture, TypeScript, Rust cargo check, and docs checks passed.
- Codex ran `git diff --check`; no whitespace errors.
- Bunny pre-PR review pass: pass on the current diff.
- True manual follow-up still recommended: secured remote runtime with real game background/music/SFX assets.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed; this is a focused runtime contract fix.

## UI evidence

N/A. This is a runtime asset contract fix covered by focused unit tests and repo checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Game audio playback refactored to use asynchronous asset URL resolution.
  * Asset management operations now invalidate remote asset caches after mutations (delete, move, rescan, upload, and bulk operations).
  * Improved concurrent request handling and cache invalidation for remote assets.

* **Tests**
  * Added test coverage for audio playback, asset cache invalidation, and managed asset URL resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/1682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->