### PR TITLE
Reject non-image ST background imports

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -66,6 +66,8 @@ fn empty_import_counts() -> Value {
     })
 }
 
+const ST_BACKGROUND_EXTENSIONS: &[&str] = &[".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"];
+
 fn imported_count(imported: &Value, key: &str) -> i64 {
     imported.get(key).and_then(Value::as_i64).unwrap_or(0)
 }
@@ -444,7 +446,7 @@ pub(super) fn scan_st_folder(body: Value) -> AppResult<Value> {
         .collect();
     let backgrounds: Vec<Value> = list_files(
         &data_dir.join("backgrounds"),
-        &[".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"],
+        ST_BACKGROUND_EXTENSIONS,
         true,
     )
     .into_iter()
@@ -812,6 +814,11 @@ fn restore_record(
 }
 
 fn copy_background_file(state: &AppState, path: &Path) -> AppResult<Value> {
+    if !has_allowed_extension(path, ST_BACKGROUND_EXTENSIONS) {
+        return Err(AppError::invalid_input(
+            "Background import only supports image files",
+        ));
+    }
     let name = path
         .file_name()
         .map(|name| name.to_string_lossy().to_string())
@@ -840,6 +847,15 @@ fn copy_background_file(state: &AppState, path: &Path) -> AppResult<Value> {
     }
     fs::copy(path, &final_target)?;
     Ok(json!({ "success": true, "path": final_target.to_string_lossy() }))
+}
+
+fn has_allowed_extension(path: &Path, extensions: &[&str]) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| format!(".{}", ext.to_ascii_lowercase()))
+        .unwrap_or_default();
+    extensions.iter().any(|allowed| *allowed == ext)
 }
 
 fn run_st_bulk_import_inner(
@@ -1587,6 +1603,64 @@ mod tests {
         assert!(
             persona.get("avatar").and_then(Value::as_str).is_none(),
             "persona imports should not duplicate avatar bytes into the avatar field"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+        let _ = fs::remove_dir_all(st_root);
+    }
+
+    #[test]
+    fn run_st_bulk_import_rejects_unscanned_non_image_background_selection() {
+        let app_root = temp_path("app");
+        let st_root = temp_path("source");
+        let data_dir = st_root.join("data").join("default-user");
+        fs::create_dir_all(data_dir.join("characters")).expect("characters dir should be created");
+        write_bytes(
+            &data_dir.join("backgrounds").join("valid.png"),
+            b"valid-background",
+        );
+        write_bytes(
+            &data_dir.join("backgrounds").join("not-image.txt"),
+            b"do not import me",
+        );
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        let (folder_path, folder_token) = folder_access(&st_root);
+        let scan = scan_st_folder(json!({
+            "folderPath": folder_path,
+            "folderToken": folder_token,
+        }))
+        .expect("fixture scan should succeed");
+
+        assert_eq!(
+            scan_ids(&scan, "backgrounds"),
+            vec!["backgrounds:backgrounds/valid.png".to_string()],
+            "scan must not advertise non-image background files"
+        );
+
+        let result = run_st_bulk_import_inner(
+            &state,
+            json!({
+                "folderPath": folder_path,
+                "folderToken": folder_token,
+                "options": {
+                    "backgrounds": [
+                        "backgrounds:backgrounds/valid.png",
+                        "backgrounds:backgrounds/not-image.txt"
+                    ],
+                }
+            }),
+            None,
+        )
+        .expect("unsupported stale background selection should be reported, not abort the import");
+
+        assert_eq!(result["success"], Value::Bool(true));
+        assert_eq!(result["imported"]["backgrounds"], json!(1));
+        assert_eq!(result["errors"].as_array().map(Vec::len), Some(1));
+        assert!(state.backgrounds.root().join("valid.png").is_file());
+        assert!(
+            !state.backgrounds.root().join("not-image.txt").exists(),
+            "non-image background selections must not be copied into managed backgrounds"
         );
 
         let _ = fs::remove_dir_all(app_root);


### PR DESCRIPTION
## Linked issue

N/A - multi-agent refactor bug-hunt lane 6.

## Why this change

- SillyTavern bulk background scan only advertises image files, but `import_st_bulk_run` could still accept a crafted or stale selected background ID for a non-image file and copy it into managed background storage.

## What changed

- Reused one allowed background extension list for scan and import-run behavior.
- Added an import-run guard so background copying rejects non-image file extensions before writing managed storage.
- Added a regression test covering a valid `.png` positive row and a `.txt` should-not-match negative control.

## Refactor impact

Primary owner:

Rust storage/imports.

Impact areas reviewed:

- SillyTavern bulk scan/run background import path
- Managed background storage copy path
- Path resolution for selected import IDs
- Hostable import dispatch via the scratch repro harness

Boundary notes:

- Fix stays in `src-tauri` storage/import code.
- No client, shared API, engine, schema, dependency, version, auth, or prompt-pipeline changes.

Pressure points touched:

- Import modules: `src-tauri/src/commands/storage/imports/bulk_imports.rs`
- No command registration, UI, or remote-runtime wrapper changes.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Reproduced before fix with disposable copied data: `node scratch\lane6-storage-bulk-background-repro.mjs`
  - Evidence: `scratch/lane6-storage-bulk-background/before-proof.json`
  - Observed valid `.png` imported and crafted/stale `.txt` selected ID also copied into managed backgrounds.
- Verified after fix: `node scratch\lane6-storage-bulk-background-repro.mjs --after`
  - Evidence: `scratch/lane6-storage-bulk-background/after-proof.json`
  - Observed valid `.png` imported, `.txt` returned `Background import only supports image files`, and no managed `.txt` file was created.
- Targeted Rust test passed: `cargo test --manifest-path src-tauri/Cargo.toml run_st_bulk_import_rejects_unscanned_non_image_background_selection --workspace`
- Rust storage check passed: `cargo check --manifest-path src-tauri/Cargo.toml --workspace`
- Baseline passed: `pnpm check`
- Proof gate passed: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`
- Bunny/proof review passed on the final diff: narrow PR boundary, no unrelated files, positive image row and realistic should-not-match non-image row covered, no manual blockers.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release files changed.

## UI evidence

N/A - non-UI storage/import bug. Raw hostable-runtime proof output is saved under `scratch/lane6-storage-bulk-background/before-proof.json` and `scratch/lane6-storage-bulk-background/after-proof.json`.
