### PR TITLE
Fix game setup gate dialog semantics

### DIFF
--- a/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
+++ b/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { BookOpen, Loader2, MessageCircle, Plug, Settings, X } from "lucide-react";
 import { useCreateChat } from "../../../../catalog/chats/index";
 import { findUserStarredChatPreset, useApplyChatPreset, useChatPresets } from "../../../../catalog/chat-presets/index";
@@ -29,6 +29,8 @@ interface NewChatConnectionGateProps {
 }
 
 export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGateProps) {
+  const dialogTitleId = useId();
+  const dialogDescriptionId = useId();
   const { data: connections, isLoading } = useConnections();
   const createChat = useCreateChat();
   const { data: chatPresetsData } = useChatPresets();
@@ -102,15 +104,23 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
 
   return (
     <>
-      <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[3px]" onClick={onClose} />
+      <div aria-hidden="true" className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[3px]" onClick={onClose} />
       <div className="fixed inset-0 z-50 flex items-center justify-center p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4">
-        <div className="flex max-h-[calc(100dvh-1.5rem)] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl sm:max-h-[min(90dvh,38rem)]">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={dialogTitleId}
+          aria-describedby={dialogDescriptionId}
+          className="flex max-h-[calc(100dvh-1.5rem)] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl sm:max-h-[min(90dvh,38rem)]"
+        >
           <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <div className="flex items-center gap-2">
               <span className="text-[var(--primary)]">{MODE_META[mode].icon}</span>
               <div>
-                <h3 className="text-sm font-semibold">Set Up {MODE_META[mode].label}</h3>
-                <p className="text-[0.6875rem] text-[var(--muted-foreground)]">
+                <h3 id={dialogTitleId} className="text-sm font-semibold">
+                  Set Up {MODE_META[mode].label}
+                </h3>
+                <p id={dialogDescriptionId} className="text-[0.6875rem] text-[var(--muted-foreground)]">
                   Choose a connection before we create the chat.
                 </p>
               </div>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - refactor multi-agent bug-hunt lane 4.

## Why this change

- Game quick-start with no configured remote runtime opens a visual setup gate, but the gate was not exposed as a `dialog` to role-based browser automation or assistive technology.
- This made the no-provider setup/error state harder to identify and verify even though it visually behaved like a modal.

## What changed

- Added `role="dialog"`, `aria-modal`, and title/description wiring to the shared new-chat connection gate used by Game setup.
- Marked the backdrop as `aria-hidden` so the semantic dialog is the accessible modal surface.

## Refactor impact

Primary owner:

shared mode UI

Impact areas reviewed:

- Game quick-start no-provider gate
- Shared new-chat connection gate behavior for disabled Create Chat, Cancel, and Open Advanced Settings

Boundary notes:

- UI-only change in `src/features`.
- No engine, shared API, Rust, storage, provider, schema, dependency, auth, prompt-pipeline, or HUD-widget changes.

Pressure points touched:

- `NewChatConnectionGate` in shared mode UI, reached from Game quick-start setup before gameplay.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex reproduced before fix with `node scratch\lane4-no-provider-dialog-a11y-repro.mjs`: Game quick-start no-provider gate showed Remote Runtime required and disabled Create Chat, but `hasDialogRole=false`.
- Codex verified after fix with `node scratch\lane4-no-provider-dialog-a11y-repro.mjs --expect-fixed`: `hasDialogRole=true`, Remote Runtime required remains visible, and Create Chat remains disabled.
- Codex checked adjacent no-provider controls with `node scratch\lane4-no-provider-gate-hunt.mjs`: Cancel closes the gate; Open Advanced Settings closes the gate and opens Settings > Advanced.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Codex ran `pnpm check`: passed after fast-forwarding to current `upstream/refactor`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI layout change. Local Playwright evidence was captured under:

- `scratch/lane4-no-provider-dialog-before.png`
- `scratch/lane4-no-provider-dialog-after.png`
- `scratch/lane4-no-provider-gate-before.png`
- `scratch/lane4-no-provider-after-cancel.png`
- `scratch/lane4-no-provider-advanced-settings.png`
