### PR TITLE
Fix conversation summaries getting deleted in refactor

### DIFF
--- a/src/shared/api/storage-api.test.ts
+++ b/src/shared/api/storage-api.test.ts
@@ -65,6 +65,45 @@ describe("storageApi typed JSON read normalization", () => {
     });
   });
 
+  it("merges day/week summary deltas into existing entries instead of replacing them", async () => {
+    invokeMock.mockResolvedValueOnce({
+      id: "chat-1",
+      metadata: {
+        daySummaries: {
+          "28.03.2026": { summary: "old day", keyDetails: [] },
+          "29.03.2026": { summary: "another old day", keyDetails: [] },
+        },
+        weekSummaries: {
+          "23.03.2026": { summary: "old week", keyDetails: [] },
+        },
+        dayRolloverHour: 4,
+      },
+    });
+    invokeMock.mockResolvedValueOnce({ id: "chat-1" });
+
+    await storageApi.patchChatSummaries("chat-1", {
+      daySummaries: { "30.03.2026": { summary: "new day", keyDetails: ["remember this"] } },
+    });
+
+    expect(invokeMock).toHaveBeenLastCalledWith("storage_update", {
+      entity: "chats",
+      id: "chat-1",
+      patch: {
+        metadata: {
+          daySummaries: {
+            "28.03.2026": { summary: "old day", keyDetails: [] },
+            "29.03.2026": { summary: "another old day", keyDetails: [] },
+            "30.03.2026": { summary: "new day", keyDetails: ["remember this"] },
+          },
+          weekSummaries: {
+            "23.03.2026": { summary: "old week", keyDetails: [] },
+          },
+          dayRolloverHour: 4,
+        },
+      },
+    });
+  });
+
   it("routes conditional message-content updates through the storage command", async () => {
     invokeMock.mockResolvedValueOnce({
       updated: true,

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -138,6 +138,24 @@ async function patchChatObjectField<T>(chatId: string, field: string, patch: Rec
   return storageApi.update<T>("chats", chatId, { [field]: { ...current, ...patch } });
 }
 
+// Day/week summary maps live inside chat metadata, but callers send only the
+// entries they changed (a delta), not the whole map. A plain metadata patch
+// would replace `metadata.daySummaries` with just the delta and drop every
+// other summary, so merge each map at the entry level instead.
+const SUMMARY_MAP_FIELDS = ["daySummaries", "weekSummaries"] as const;
+
+async function patchChatSummariesField<T>(chatId: string, patch: Record<string, unknown>): Promise<T> {
+  const chat = await storageApi.get<Record<string, unknown>>("chats", chatId, { fields: ["metadata"] });
+  if (!chat) throw new ApiError(`Chat ${chatId} was not found`, 404);
+  const current = asRecord(chat.metadata);
+  const metadata: Record<string, unknown> = { ...current };
+  for (const field of SUMMARY_MAP_FIELDS) {
+    if (patch[field] === undefined) continue;
+    metadata[field] = { ...asRecord(current[field]), ...asRecord(patch[field]) };
+  }
+  return storageApi.update<T>("chats", chatId, { metadata });
+}
+
 export const storageApi: StorageGateway = {
   list: async (entity: string, options?: StorageListOptions) =>
     normalizeStorageReadResult(
@@ -213,7 +231,7 @@ export const storageApi: StorageGateway = {
       body: chatMessageSwipeBody(content, options),
     }),
   patchChatMetadata: (chatId, patch) => patchChatObjectField(chatId, "metadata", patch),
-  patchChatSummaries: (chatId, patch) => patchChatObjectField(chatId, "metadata", patch),
+  patchChatSummaries: (chatId, patch) => patchChatSummariesField(chatId, patch),
   listChatMemories: async (chatId) => {
     const chat = await storageApi.get<Record<string, unknown>>("chats", chatId);
     return asArray(chat?.memories);


### PR DESCRIPTION
Fixes summaries getting overwritten in the refactor

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #1684 

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- Summarization was broken. This fixes it.

## What changed

<!-- List the key changes in this PR -->

- Brings the behavior closer to what 1.6.1 does.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Open the refactor. 
- Import an old conversation with summaries
- Trigger a new summary with a message. 
- Verify that the summary didn't override all the previous summaries. 
- Verify that manually editing the summaries doesn't result in everything being overridden 

## Docs and release impact

- [x] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->
