### PR TITLE
Fix empty first-chat character setup copy

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -192,7 +192,6 @@ function characterMatchesSearch(
 function characterPickerEmptyText({
   hasError,
   isPending,
-  hasSearch,
   hasCharacters,
   hasUnselectedCharacters,
   noCharactersText,
@@ -200,7 +199,6 @@ function characterPickerEmptyText({
 }: {
   hasError: boolean;
   isPending: boolean;
-  hasSearch: boolean;
   hasCharacters: boolean;
   hasUnselectedCharacters: boolean;
   noCharactersText: string;
@@ -210,7 +208,6 @@ function characterPickerEmptyText({
   if (isPending) return "Loading characters...";
   if (!hasCharacters) return noCharactersText;
   if (!hasUnselectedCharacters) return allAddedText;
-  if (hasSearch) return "No matches.";
   return "No matches.";
 }
 
@@ -813,7 +810,6 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
                       {characterPickerEmptyText({
                         hasError: emptyStateCharacterError,
                         isPending: emptyStateCharacterPending,
-                        hasSearch: hasCharacterSearch,
                         hasCharacters: emptyStateCharacters.length > 0,
                         hasUnselectedCharacters,
                         noCharactersText: "No characters yet. Create or import one before starting a conversation.",
@@ -1437,7 +1433,6 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                 {characterPickerEmptyText({
                   hasError: emptyStateCharacterError,
                   isPending: emptyStateCharacterPending,
-                  hasSearch: hasCharacterSearch,
                   hasCharacters: emptyStateCharacters.length > 0,
                   hasUnselectedCharacters,
                   noCharactersText: "No characters yet. Create or import one before adding them to this roleplay.",
@@ -1725,7 +1720,6 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                           {characterPickerEmptyText({
                             hasError: emptyStateCharacterError,
                             isPending: emptyStateCharacterPending,
-                            hasSearch: hasCharacterSearch,
                             hasCharacters: emptyStateCharacters.length > 0,
                             hasUnselectedCharacters,
                             noCharactersText: "No characters yet. Create or import one before applying setup.",

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -447,7 +447,7 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     data: unfilteredCharactersForEmptyState,
     isFetching: unfilteredCharactersForEmptyStateFetching,
     isError: unfilteredCharactersForEmptyStateError,
-  } = useCharacterSummaries(hasCharacterSearch);
+  } = useCharacterSummaries(hasCharacterSearch, "");
   const { data: selectedCharacters } = useCharacterSummariesByIds(chatCharIds, chatCharIds.length > 0);
   const { data: allPersonas } = usePersonaSummaries();
   const updateChat = useUpdateChat();
@@ -1029,7 +1029,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     data: unfilteredCharactersForEmptyState,
     isFetching: unfilteredCharactersForEmptyStateFetching,
     isError: unfilteredCharactersForEmptyStateError,
-  } = useCharacterSummaries(shouldLoadCharacters && hasCharacterSearch);
+  } = useCharacterSummaries(shouldLoadCharacters && hasCharacterSearch, "");
   const { data: lorebooks } = useLorebooks();
 
   // Chat-settings presets for the shortcut view

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -211,6 +211,39 @@ function characterPickerEmptyText({
   return "No matches.";
 }
 
+function deriveCharacterPickerEmptyState({
+  hasSearch,
+  characters,
+  unfilteredCharacters,
+  searchPending,
+  baseError,
+  unfilteredFetching,
+  unfilteredError,
+  selectedCharacterIds,
+}: {
+  hasSearch: boolean;
+  characters: CharacterSetupOption[];
+  unfilteredCharacters: CharacterSetupOption[] | undefined;
+  searchPending: boolean;
+  baseError: boolean;
+  unfilteredFetching: boolean;
+  unfilteredError: boolean;
+  selectedCharacterIds: string[];
+}): {
+  characters: CharacterSetupOption[];
+  isPending: boolean;
+  hasError: boolean;
+  hasUnselectedCharacters: boolean;
+} {
+  const charactersForEmptyState = hasSearch ? (unfilteredCharacters ?? []) : characters;
+  return {
+    characters: charactersForEmptyState,
+    isPending: searchPending || (hasSearch && unfilteredFetching),
+    hasError: baseError || (hasSearch && unfilteredError),
+    hasUnselectedCharacters: charactersForEmptyState.some((character) => !selectedCharacterIds.includes(character.id)),
+  };
+}
+
 function getPersonaTitle(persona: PersonaDisplayInfo): string | null {
   const title = persona.comment?.trim();
   return title ? title : null;
@@ -409,6 +442,7 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     isError: allCharactersError,
   } = useCharacterSummaries(true, debouncedSearch);
   const hasCharacterSearch = search.trim().length > 0;
+  // Keep this query unfiltered so search misses can distinguish "No matches" from an empty library.
   const {
     data: unfilteredCharactersForEmptyState,
     isFetching: unfilteredCharactersForEmptyStateFetching,
@@ -558,13 +592,16 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     if (chatCharIds.includes(c.id)) return false;
     return characterMatchesSearch(c, search);
   });
-  const emptyStateCharacters = hasCharacterSearch
-    ? ((unfilteredCharactersForEmptyState as CharacterSetupOption[] | undefined) ?? [])
-    : characters;
-  const emptyStateCharacterPending =
-    characterSearchPending || (hasCharacterSearch && unfilteredCharactersForEmptyStateFetching);
-  const emptyStateCharacterError = allCharactersError || (hasCharacterSearch && unfilteredCharactersForEmptyStateError);
-  const hasUnselectedCharacters = emptyStateCharacters.some((c) => !chatCharIds.includes(c.id));
+  const characterEmptyState = deriveCharacterPickerEmptyState({
+    hasSearch: hasCharacterSearch,
+    characters,
+    unfilteredCharacters: unfilteredCharactersForEmptyState as CharacterSetupOption[] | undefined,
+    searchPending: characterSearchPending,
+    baseError: allCharactersError,
+    unfilteredFetching: unfilteredCharactersForEmptyStateFetching,
+    unfilteredError: unfilteredCharactersForEmptyStateError,
+    selectedCharacterIds: chatCharIds,
+  });
 
   const hasConnection = !!chat.connectionId;
   const hasCharacters = chatCharIds.length > 0;
@@ -808,10 +845,10 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
                   {available.length === 0 && (
                     <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
                       {characterPickerEmptyText({
-                        hasError: emptyStateCharacterError,
-                        isPending: emptyStateCharacterPending,
-                        hasCharacters: emptyStateCharacters.length > 0,
-                        hasUnselectedCharacters,
+                        hasError: characterEmptyState.hasError,
+                        isPending: characterEmptyState.isPending,
+                        hasCharacters: characterEmptyState.characters.length > 0,
+                        hasUnselectedCharacters: characterEmptyState.hasUnselectedCharacters,
                         noCharactersText: "No characters yet. Create or import one before starting a conversation.",
                         allAddedText: "All characters added.",
                       })}
@@ -987,6 +1024,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   } = useCharacterSummaries(currentStep.key === "characters" || shortcutMode, debouncedCharSearch);
   const hasCharacterSearch = charSearch.trim().length > 0;
   const shouldLoadCharacters = currentStep.key === "characters" || shortcutMode;
+  // Keep this query unfiltered so search misses can distinguish "No matches" from an empty library.
   const {
     data: unfilteredCharactersForEmptyState,
     isFetching: unfilteredCharactersForEmptyStateFetching,
@@ -1051,14 +1089,16 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     [searchedCharacters, selectedCharacters],
   );
   const characterSearchPending = searchedCharactersFetching || charSearch.trim() !== debouncedCharSearch.trim();
-  const emptyStateCharacters = hasCharacterSearch
-    ? ((unfilteredCharactersForEmptyState as CharacterSetupOption[] | undefined) ?? [])
-    : characters;
-  const emptyStateCharacterPending =
-    characterSearchPending || (hasCharacterSearch && unfilteredCharactersForEmptyStateFetching);
-  const emptyStateCharacterError =
-    searchedCharactersError || (hasCharacterSearch && unfilteredCharactersForEmptyStateError);
-  const hasUnselectedCharacters = emptyStateCharacters.some((c) => !chatCharIds.includes(c.id));
+  const characterEmptyState = deriveCharacterPickerEmptyState({
+    hasSearch: hasCharacterSearch,
+    characters,
+    unfilteredCharacters: unfilteredCharactersForEmptyState as CharacterSetupOption[] | undefined,
+    searchPending: characterSearchPending,
+    baseError: searchedCharactersError,
+    unfilteredFetching: unfilteredCharactersForEmptyStateFetching,
+    unfilteredError: unfilteredCharactersForEmptyStateError,
+    selectedCharacterIds: chatCharIds,
+  });
 
   const activeLorebookIds: string[] = useMemo(() => metadata.activeLorebookIds ?? [], [metadata.activeLorebookIds]);
 
@@ -1431,10 +1471,10 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
             {available.length === 0 && (
               <p className="px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)]">
                 {characterPickerEmptyText({
-                  hasError: emptyStateCharacterError,
-                  isPending: emptyStateCharacterPending,
-                  hasCharacters: emptyStateCharacters.length > 0,
-                  hasUnselectedCharacters,
+                  hasError: characterEmptyState.hasError,
+                  isPending: characterEmptyState.isPending,
+                  hasCharacters: characterEmptyState.characters.length > 0,
+                  hasUnselectedCharacters: characterEmptyState.hasUnselectedCharacters,
                   noCharactersText: "No characters yet. Create or import one before adding them to this roleplay.",
                   allAddedText: "All characters already added.",
                 })}
@@ -1718,10 +1758,10 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                       }).length === 0 && (
                         <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
                           {characterPickerEmptyText({
-                            hasError: emptyStateCharacterError,
-                            isPending: emptyStateCharacterPending,
-                            hasCharacters: emptyStateCharacters.length > 0,
-                            hasUnselectedCharacters,
+                            hasError: characterEmptyState.hasError,
+                            isPending: characterEmptyState.isPending,
+                            hasCharacters: characterEmptyState.characters.length > 0,
+                            hasUnselectedCharacters: characterEmptyState.hasUnselectedCharacters,
                             noCharactersText: "No characters yet. Create or import one before applying setup.",
                             allAddedText: "All characters added.",
                           })}

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -208,9 +208,10 @@ function characterPickerEmptyText({
 }): string {
   if (hasError) return "Characters could not be loaded.";
   if (isPending) return "Loading characters...";
-  if (hasSearch) return "No matches.";
   if (!hasCharacters) return noCharactersText;
-  return hasUnselectedCharacters ? "No matches." : allAddedText;
+  if (!hasUnselectedCharacters) return allAddedText;
+  if (hasSearch) return "No matches.";
+  return "No matches.";
 }
 
 function getPersonaTitle(persona: PersonaDisplayInfo): string | null {
@@ -410,6 +411,12 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     isFetching: allCharactersFetching,
     isError: allCharactersError,
   } = useCharacterSummaries(true, debouncedSearch);
+  const hasCharacterSearch = search.trim().length > 0;
+  const {
+    data: unfilteredCharactersForEmptyState,
+    isFetching: unfilteredCharactersForEmptyStateFetching,
+    isError: unfilteredCharactersForEmptyStateError,
+  } = useCharacterSummaries(hasCharacterSearch);
   const { data: selectedCharacters } = useCharacterSummariesByIds(chatCharIds, chatCharIds.length > 0);
   const { data: allPersonas } = usePersonaSummaries();
   const updateChat = useUpdateChat();
@@ -554,8 +561,13 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     if (chatCharIds.includes(c.id)) return false;
     return characterMatchesSearch(c, search);
   });
-  const hasCharacterSearch = search.trim().length > 0;
-  const hasUnselectedCharacters = characters.some((c) => !chatCharIds.includes(c.id));
+  const emptyStateCharacters = hasCharacterSearch
+    ? ((unfilteredCharactersForEmptyState as CharacterSetupOption[] | undefined) ?? [])
+    : characters;
+  const emptyStateCharacterPending =
+    characterSearchPending || (hasCharacterSearch && unfilteredCharactersForEmptyStateFetching);
+  const emptyStateCharacterError = allCharactersError || (hasCharacterSearch && unfilteredCharactersForEmptyStateError);
+  const hasUnselectedCharacters = emptyStateCharacters.some((c) => !chatCharIds.includes(c.id));
 
   const hasConnection = !!chat.connectionId;
   const hasCharacters = chatCharIds.length > 0;
@@ -799,10 +811,10 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
                   {available.length === 0 && (
                     <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
                       {characterPickerEmptyText({
-                        hasError: allCharactersError,
-                        isPending: characterSearchPending,
+                        hasError: emptyStateCharacterError,
+                        isPending: emptyStateCharacterPending,
                         hasSearch: hasCharacterSearch,
-                        hasCharacters: characters.length > 0,
+                        hasCharacters: emptyStateCharacters.length > 0,
                         hasUnselectedCharacters,
                         noCharactersText: "No characters yet. Create or import one before starting a conversation.",
                         allAddedText: "All characters added.",
@@ -977,6 +989,13 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     isFetching: searchedCharactersFetching,
     isError: searchedCharactersError,
   } = useCharacterSummaries(currentStep.key === "characters" || shortcutMode, debouncedCharSearch);
+  const hasCharacterSearch = charSearch.trim().length > 0;
+  const shouldLoadCharacters = currentStep.key === "characters" || shortcutMode;
+  const {
+    data: unfilteredCharactersForEmptyState,
+    isFetching: unfilteredCharactersForEmptyStateFetching,
+    isError: unfilteredCharactersForEmptyStateError,
+  } = useCharacterSummaries(shouldLoadCharacters && hasCharacterSearch);
   const { data: lorebooks } = useLorebooks();
 
   // Chat-settings presets for the shortcut view
@@ -1036,6 +1055,14 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     [searchedCharacters, selectedCharacters],
   );
   const characterSearchPending = searchedCharactersFetching || charSearch.trim() !== debouncedCharSearch.trim();
+  const emptyStateCharacters = hasCharacterSearch
+    ? ((unfilteredCharactersForEmptyState as CharacterSetupOption[] | undefined) ?? [])
+    : characters;
+  const emptyStateCharacterPending =
+    characterSearchPending || (hasCharacterSearch && unfilteredCharactersForEmptyStateFetching);
+  const emptyStateCharacterError =
+    searchedCharactersError || (hasCharacterSearch && unfilteredCharactersForEmptyStateError);
+  const hasUnselectedCharacters = emptyStateCharacters.some((c) => !chatCharIds.includes(c.id));
 
   const activeLorebookIds: string[] = useMemo(() => metadata.activeLorebookIds ?? [], [metadata.activeLorebookIds]);
 
@@ -1311,8 +1338,6 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
       if (chatCharIds.includes(c.id)) return false;
       return characterMatchesSearch(c, charSearch);
     });
-    const hasCharacterSearch = charSearch.trim().length > 0;
-    const hasUnselectedCharacters = characters.some((c) => !chatCharIds.includes(c.id));
 
     return (
       <div className="space-y-2">
@@ -1410,10 +1435,10 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
             {available.length === 0 && (
               <p className="px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)]">
                 {characterPickerEmptyText({
-                  hasError: searchedCharactersError,
-                  isPending: characterSearchPending,
+                  hasError: emptyStateCharacterError,
+                  isPending: emptyStateCharacterPending,
                   hasSearch: hasCharacterSearch,
-                  hasCharacters: characters.length > 0,
+                  hasCharacters: emptyStateCharacters.length > 0,
                   hasUnselectedCharacters,
                   noCharactersText: "No characters yet. Create or import one before adding them to this roleplay.",
                   allAddedText: "All characters already added.",
@@ -1698,11 +1723,11 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                       }).length === 0 && (
                         <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
                           {characterPickerEmptyText({
-                            hasError: searchedCharactersError,
-                            isPending: characterSearchPending,
-                            hasSearch: charSearch.trim().length > 0,
-                            hasCharacters: characters.length > 0,
-                            hasUnselectedCharacters: characters.some((c) => !chatCharIds.includes(c.id)),
+                            hasError: emptyStateCharacterError,
+                            isPending: emptyStateCharacterPending,
+                            hasSearch: hasCharacterSearch,
+                            hasCharacters: emptyStateCharacters.length > 0,
+                            hasUnselectedCharacters,
                             noCharactersText: "No characters yet. Create or import one before applying setup.",
                             allAddedText: "All characters added.",
                           })}

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -189,6 +189,30 @@ function characterMatchesSearch(
   return terms.every((term) => values.some((value) => value.includes(term)));
 }
 
+function characterPickerEmptyText({
+  hasError,
+  isPending,
+  hasSearch,
+  hasCharacters,
+  hasUnselectedCharacters,
+  noCharactersText,
+  allAddedText,
+}: {
+  hasError: boolean;
+  isPending: boolean;
+  hasSearch: boolean;
+  hasCharacters: boolean;
+  hasUnselectedCharacters: boolean;
+  noCharactersText: string;
+  allAddedText: string;
+}): string {
+  if (hasError) return "Characters could not be loaded.";
+  if (isPending) return "Loading characters...";
+  if (hasSearch) return "No matches.";
+  if (!hasCharacters) return noCharactersText;
+  return hasUnselectedCharacters ? "No matches." : allAddedText;
+}
+
 function getPersonaTitle(persona: PersonaDisplayInfo): string | null {
   const title = persona.comment?.trim();
   return title ? title : null;
@@ -530,6 +554,8 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     if (chatCharIds.includes(c.id)) return false;
     return characterMatchesSearch(c, search);
   });
+  const hasCharacterSearch = search.trim().length > 0;
+  const hasUnselectedCharacters = characters.some((c) => !chatCharIds.includes(c.id));
 
   const hasConnection = !!chat.connectionId;
   const hasCharacters = chatCharIds.length > 0;
@@ -772,13 +798,15 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
                   })}
                   {available.length === 0 && (
                     <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
-                      {allCharactersError
-                        ? "Characters could not be loaded."
-                        : characterSearchPending
-                          ? "Loading characters..."
-                          : characters.filter((c) => !chatCharIds.includes(c.id)).length === 0
-                            ? "All characters added."
-                            : "No matches."}
+                      {characterPickerEmptyText({
+                        hasError: allCharactersError,
+                        isPending: characterSearchPending,
+                        hasSearch: hasCharacterSearch,
+                        hasCharacters: characters.length > 0,
+                        hasUnselectedCharacters,
+                        noCharactersText: "No characters yet. Create or import one before starting a conversation.",
+                        allAddedText: "All characters added.",
+                      })}
                     </p>
                   )}
                 </div>
@@ -1283,6 +1311,8 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
       if (chatCharIds.includes(c.id)) return false;
       return characterMatchesSearch(c, charSearch);
     });
+    const hasCharacterSearch = charSearch.trim().length > 0;
+    const hasUnselectedCharacters = characters.some((c) => !chatCharIds.includes(c.id));
 
     return (
       <div className="space-y-2">
@@ -1379,13 +1409,15 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
             })}
             {available.length === 0 && (
               <p className="px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                {searchedCharactersError
-                  ? "Characters could not be loaded."
-                  : characterSearchPending
-                    ? "Loading characters..."
-                    : characters.filter((c) => !chatCharIds.includes(c.id)).length === 0
-                      ? "All characters already added."
-                      : "No matches."}
+                {characterPickerEmptyText({
+                  hasError: searchedCharactersError,
+                  isPending: characterSearchPending,
+                  hasSearch: hasCharacterSearch,
+                  hasCharacters: characters.length > 0,
+                  hasUnselectedCharacters,
+                  noCharactersText: "No characters yet. Create or import one before adding them to this roleplay.",
+                  allAddedText: "All characters already added.",
+                })}
               </p>
             )}
           </div>
@@ -1665,13 +1697,15 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                         return characterMatchesSearch(c, charSearch);
                       }).length === 0 && (
                         <p className="px-3 py-3 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
-                          {searchedCharactersError
-                            ? "Characters could not be loaded."
-                            : characterSearchPending
-                              ? "Loading characters..."
-                              : characters.filter((c) => !chatCharIds.includes(c.id)).length === 0
-                                ? "All characters added."
-                                : "No matches."}
+                          {characterPickerEmptyText({
+                            hasError: searchedCharactersError,
+                            isPending: characterSearchPending,
+                            hasSearch: charSearch.trim().length > 0,
+                            hasCharacters: characters.length > 0,
+                            hasUnselectedCharacters: characters.some((c) => !chatCharIds.includes(c.id)),
+                            noCharactersText: "No characters yet. Create or import one before applying setup.",
+                            allAddedText: "All characters added.",
+                          })}
                         </p>
                       )}
                     </div>


### PR DESCRIPTION
## Linked issue

Closes #1700

## Why this change

- Empty New Conversation setup showed "All characters added." when there were zero characters, leaving Start Chatting disabled with no clear next step.

## What changed

- Split character picker empty states into loading, load failure, no characters, search miss, and all-selected states.
- Added unfiltered character presence checks so typing into an empty library still shows the create/import blocker.
- Applied the same empty-library distinction to roleplay setup and quick setup character pickers.

## Refactor impact

Primary owner:

- Shared mode UI

Impact areas reviewed:

- Conversation setup wizard
- Roleplay setup wizard
- Roleplay quick setup character picker

Boundary notes:

- Feature UI-only change.
- No engine, shared API, Rust, storage, or remote-runtime boundary changes.

Pressure points touched:

- Shared mode UI: `ChatSetupWizard.tsx`

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Reproduced before fix in a 390x844 browser viewport with one language connection, zero chats, and zero characters: New Conversation showed "All characters added." while Start Chatting was disabled.
- Verified after fix in the same flow: New Conversation showed "No characters yet. Create or import one before starting a conversation." and Start Chatting remained disabled.
- Edge checked zero characters plus typed search: no-characters blocker remained visible instead of "No matches."
- Edge checked one existing character plus no-match search: picker showed "No matches."
- Edge checked one selected character: picker showed "All characters added." and Start Chatting became enabled.
- Tauri QA through the QA app window/WebView2 CDP: `nativeIpc=true`; empty initial, empty with search, existing character no-match search, and all-selected rows passed with no console errors.
- Ran `pnpm typecheck`.
- Ran `pnpm exec prettier --check src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx`.
- Ran `git diff --check`.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: no docs changes needed; behavior is localized setup-wizard copy/state.

## UI evidence

Local QA screenshots were captured under `scratch/` during verification:

- `scratch/issue-1700-tauriqa-empty.png`
- `scratch/issue-1700-tauriqa-all-selected.png`

They are local proof artifacts, not reviewer-visible attachments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized character selection messaging and display across all chat setup wizards to provide a more consistent user experience.
  * Enhanced character search functionality with improved result retrieval and better handling of loading states and empty result scenarios.
  * Improved interface consistency for character picker interactions across different wizard flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->