### PR TITLE
[codex] Lazy-load startup shell paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,11 +90,13 @@
   "size-limit": [
     {
       "path": "dist/assets/*.js",
-      "limit": "1.7 MB"
+      "limit": "1.7 MB",
+      "running": false
     },
     {
       "path": "dist/assets/*.css",
-      "limit": "250 KB"
+      "limit": "250 KB",
+      "running": false
     }
   ]
 }

--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -5,10 +5,6 @@ import { ChatSidebar, type ChatSidebarTab } from "./ChatSidebar";
 import { AppFindOverlay } from "./AppFindOverlay";
 import { TopBar } from "./TopBar";
 import { WindowTitleBar } from "./WindowTitleBar";
-import { SpotifyMobileWidget } from "../../features/shell/spotify/shell";
-import { ChatNotificationBubbles } from "../../features/shell/notifications/shell";
-import { AgentDebugPanel } from "../../features/catalog/agents/shell";
-import { ProfessorMariSurface } from "../../features/shell/mari/shell";
 import {
   getTrackerPanelWidthForProfile,
   RIGHT_PANEL_WIDTH_MAX,
@@ -19,8 +15,9 @@ import {
 } from "../../shared/stores/ui.store";
 import type { TrackerPanelSizeProfile } from "../../shared/stores/ui.store";
 import { useChatStore } from "../../shared/stores/chat.store";
-import { useBackgroundAutonomousPolling } from "../../features/modes/conversation/index";
-import { useClearAutonomousUnread } from "../../features/catalog/chats/index";
+import { useAgentStore } from "../../shared/stores/agent.store";
+import { useBackgroundAutonomousPolling } from "../../features/modes/conversation/background-autonomous";
+import { useClearAutonomousUnread } from "../../features/catalog/chats/autonomous-unread";
 import { useIdleDetection } from "../../shared/hooks/use-idle-detection";
 import { ImagePromptReviewHost } from "../../shared/components/ui/ImagePromptReviewHost";
 import { cn } from "../../shared/lib/utils";
@@ -57,6 +54,22 @@ const TrackerDataSidebar = lazy(() =>
 const OnboardingTutorial = lazy(() =>
   import("../../features/shell/onboarding/shell").then((module) => ({ default: module.OnboardingTutorial })),
 );
+const ProfessorMariSurface = lazy(() =>
+  import("../../features/shell/mari/shell").then((module) => ({ default: module.ProfessorMariSurface })),
+);
+const ChatNotificationBubbles = lazy(() =>
+  import("../../features/shell/notifications/shell").then((module) => ({
+    default: module.ChatNotificationBubbles,
+  })),
+);
+const AgentDebugPanel = lazy(() =>
+  import("../../features/catalog/agents/debug-shell").then((module) => ({
+    default: module.AgentDebugPanel,
+  })),
+);
+const SpotifyMobileWidget = lazy(() =>
+  import("../../features/shell/spotify/shell").then((module) => ({ default: module.SpotifyMobileWidget })),
+);
 
 function clampWidth(width: number, min: number, max: number) {
   return Math.max(min, Math.min(max, width));
@@ -75,6 +88,7 @@ function getMobileTrackerPanelWidthForProfile(profile: TrackerPanelSizeProfile) 
 }
 
 const PANEL_RESIZE_STEP = 16;
+const NOTIFICATION_BUBBLES_EXIT_MS = 500;
 const PANEL_RESIZE_LARGE_STEP = 48;
 const RESIZER_HITBOX = 10;
 const TRACKER_PANEL_EDGE_OFFSET = 8;
@@ -209,6 +223,11 @@ export function AppShell() {
   const [rightPanelDragWidth, setRightPanelDragWidth] = useState<number | null>(null);
   const [activeChatSidebarTab, setActiveChatSidebarTab] = useState<ChatSidebarTab>("conversation");
   const [professorMariOpen, setProfessorMariOpen] = useState(false);
+  const chatNotificationCount = useChatStore((s) => s.chatNotifications.size);
+  const [notificationBubblesMounted, setNotificationBubblesMounted] = useState(false);
+  const debugMode = useUIStore((s) => s.debugMode);
+  const hasAgentDebugActivity = useAgentStore((s) => debugMode && (s.debugLog.length > 0 || s.lastResults.size > 0));
+  const spotifyPlayerEnabled = useUIStore((s) => s.spotifyPlayerEnabled);
   const sidebarDragWidthRef = useRef<number | null>(null);
   const rightPanelDragWidthRef = useRef<number | null>(null);
   const headerRef = useRef<HTMLElement>(null);
@@ -216,6 +235,16 @@ export function AppShell() {
   const liveRightPanelWidth = rightPanelDragWidth ?? rightPanelWidth;
   const trackerPanelWidth = getTrackerPanelWidthForProfile(trackerPanelSizeProfile);
   const mobileTrackerPanelWidth = getMobileTrackerPanelWidthForProfile(trackerPanelSizeProfile);
+
+  useEffect(() => {
+    if (chatNotificationCount > 0) {
+      setNotificationBubblesMounted(true);
+      return;
+    }
+    if (!notificationBubblesMounted) return;
+    const timeoutId = window.setTimeout(() => setNotificationBubblesMounted(false), NOTIFICATION_BUBBLES_EXIT_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [chatNotificationCount, notificationBubblesMounted]);
 
   // Track mobile breakpoint for right-panel animation strategy
   const [isMobile, setIsMobile] = useState(() => typeof window !== "undefined" && window.innerWidth < 768);
@@ -1038,7 +1067,11 @@ export function AppShell() {
             </div>
           </div>
           {/* Floating avatar notification bubbles (right edge) */}
-          <ChatNotificationBubbles />
+          {notificationBubblesMounted && (
+            <Suspense fallback={null}>
+              <ChatNotificationBubbles />
+            </Suspense>
+          )}
         </main>
 
         <AnimatePresence initial={false}>
@@ -1153,8 +1186,16 @@ export function AppShell() {
             <OnboardingTutorial onShellInertResync={syncMobilePanelInert} />
           </Suspense>
         )}
-        <AgentDebugPanel />
-        <SpotifyMobileWidget />
+        {debugMode && hasAgentDebugActivity && (
+          <Suspense fallback={null}>
+            <AgentDebugPanel />
+          </Suspense>
+        )}
+        {spotifyPlayerEnabled && (
+          <Suspense fallback={null}>
+            <SpotifyMobileWidget />
+          </Suspense>
+        )}
       </div>
     </div>
   );

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -35,7 +35,7 @@ import {
   useDeleteChatGroup,
   useUpdateChatMetadata,
   type BulkChatExportFormat,
-} from "../../features/catalog/chats/index";
+} from "../../features/catalog/chats/sidebar";
 import {
   useChatFolders,
   useCreateFolder,
@@ -43,7 +43,7 @@ import {
   useDeleteFolder,
   useReorderFolders,
   useMoveChat,
-} from "../../features/catalog/chats/index";
+} from "../../features/catalog/chats/sidebar";
 import { useCharacterSummariesByIds } from "../../features/catalog/characters/index";
 import { useChatStore } from "../../shared/stores/chat.store";
 import { showConfirmDialog } from "../../shared/lib/app-dialogs";

--- a/src/app/shell/WindowTitleBar.tsx
+++ b/src/app/shell/WindowTitleBar.tsx
@@ -1,5 +1,5 @@
 import { Maximize2, Minus, Square, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type MouseEvent as ReactMouseEvent } from "react";
 import {
   closeDesktopWindow,
   getDesktopWindowVisualState,
@@ -14,9 +14,12 @@ import {
 import { cn } from "../../shared/lib/utils";
 import { useChatStore } from "../../shared/stores/chat.store";
 import { useUIStore } from "../../shared/stores/ui.store";
-import { SpotifyMiniPlayer } from "../../features/shell/spotify/shell";
 import { ChatTitleControls } from "./ChatTitleControls";
 import { PanelNavButtons } from "./PanelNavButtons";
+
+const SpotifyMiniPlayer = lazy(() =>
+  import("../../features/shell/spotify/shell").then((module) => ({ default: module.SpotifyMiniPlayer })),
+);
 
 type DesktopPlatform = "darwin" | "windows" | "linux";
 type WindowControlAction = "close" | "minimize" | "maximize" | "fullscreen";
@@ -236,7 +239,9 @@ export function WindowTitleBar({
             onMouseDown={(event) => event.stopPropagation()}
             onDoubleClick={(event) => event.stopPropagation()}
           >
-            <SpotifyMiniPlayer />
+            <Suspense fallback={null}>
+              <SpotifyMiniPlayer />
+            </Suspense>
           </div>
         )}
         <div

--- a/src/app/shell/useStartNewChat.ts
+++ b/src/app/shell/useStartNewChat.ts
@@ -8,7 +8,7 @@ import {
   listChatPresets,
   useApplyChatPreset,
 } from "../../features/catalog/chat-presets/index";
-import { useCreateChat } from "../../features/catalog/chats/index";
+import { useCreateChat } from "../../features/catalog/chats/sidebar";
 import { connectionKeys } from "../../features/catalog/connections/index";
 import { storageApi } from "../../shared/api/storage-api";
 import { filterLanguageGenerationConnections } from "../../shared/lib/connection-filters";

--- a/src/features/catalog/agents/debug-shell.ts
+++ b/src/features/catalog/agents/debug-shell.ts
@@ -1,0 +1,1 @@
+export { AgentDebugPanel } from "./components/AgentDebugPanel";

--- a/src/features/catalog/chats/autonomous-unread.ts
+++ b/src/features/catalog/chats/autonomous-unread.ts
@@ -1,0 +1,1 @@
+export { useClearAutonomousUnread } from "./hooks/use-clear-autonomous-unread";

--- a/src/features/catalog/chats/hooks/chat-cache.ts
+++ b/src/features/catalog/chats/hooks/chat-cache.ts
@@ -1,0 +1,77 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { useChatStore } from "../../../../shared/stores/chat.store";
+import { chatKeys } from "../query-keys";
+
+export type ChatCacheRecord = Record<string, unknown> & { id?: string; metadata?: unknown };
+
+function parseCacheRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function updateCachedChatRows<T extends ChatCacheRecord>(
+  rows: T[] | undefined,
+  id: string,
+  updater: (row: T) => T,
+): T[] | undefined {
+  if (!Array.isArray(rows)) return rows;
+  let changed = false;
+  const next = rows.map((row) => {
+    if (!row || row.id !== id) return row;
+    changed = true;
+    return updater(row);
+  });
+  return changed ? next : rows;
+}
+
+export function applyChatFieldPatch<T extends ChatCacheRecord>(chat: T, patch: Record<string, unknown>): T {
+  return { ...chat, ...patch };
+}
+
+export function applyChatMetadataPatch<T extends ChatCacheRecord>(chat: T, patch: Record<string, unknown>): T {
+  return {
+    ...chat,
+    metadata: {
+      ...parseCacheRecord(chat.metadata),
+      ...patch,
+    },
+  };
+}
+
+export function setChatCacheRecord(
+  qc: Pick<QueryClient, "setQueryData" | "setQueriesData">,
+  id: string,
+  updater: (chat: ChatCacheRecord) => ChatCacheRecord,
+) {
+  qc.setQueryData<ChatCacheRecord | undefined>(chatKeys.detail(id), (current) =>
+    current ? updater(current) : current,
+  );
+  qc.setQueriesData<ChatCacheRecord[]>({ queryKey: chatKeys.list() }, (rows) =>
+    updateCachedChatRows(rows, id, updater),
+  );
+  qc.setQueriesData<ChatCacheRecord[]>({ queryKey: [...chatKeys.all, "group"] }, (rows) =>
+    updateCachedChatRows(rows, id, updater),
+  );
+
+  const activeChat = useChatStore.getState().activeChat as ChatCacheRecord | null;
+  if (activeChat?.id === id) {
+    useChatStore.getState().setActiveChat(updater(activeChat) as unknown as Chat);
+  }
+}
+
+export function cancelChatCacheQueries(qc: QueryClient, id: string) {
+  // Tauri-backed reads are not abortable, so awaiting broad cache cancellation
+  // can make optimistic chat-setting toggles wait behind large startup loads.
+  void qc.cancelQueries({ queryKey: chatKeys.detail(id) }).catch(() => undefined);
+  void qc.cancelQueries({ queryKey: chatKeys.list() }).catch(() => undefined);
+  void qc.cancelQueries({ queryKey: [...chatKeys.all, "group"] }).catch(() => undefined);
+}

--- a/src/features/catalog/chats/hooks/use-bulk-export-chats.ts
+++ b/src/features/catalog/chats/hooks/use-bulk-export-chats.ts
@@ -1,0 +1,68 @@
+import { useMutation } from "@tanstack/react-query";
+
+import type { Chat, Message } from "../../../../engine/contracts/types/chat";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { downloadBlobFile, downloadTextFile } from "../lib/download";
+import type { BulkChatExportFormat } from "../lib/chat-transcript-export";
+
+async function loadChatsForExport(chatIds: string[]) {
+  const ids = Array.from(new Set(chatIds.map((id) => id.trim()).filter(Boolean)));
+  if (ids.length === 0) throw new Error("Choose at least one chat to export.");
+  return Promise.all(
+    ids.map(async (chatId) => {
+      const [chat, messages] = await Promise.all([
+        storageApi.get<Chat>("chats", chatId).then((chat) => {
+          if (!chat) throw new Error("Chat was not found.");
+          return chat;
+        }),
+        storageApi.listChatMessages<Message>(chatId),
+      ]);
+      return { chat, messages };
+    }),
+  );
+}
+
+/** Export selected chats as native JSON or a ZIP of JSONL/text transcripts. */
+export function useBulkExportChats() {
+  return useMutation({
+    mutationFn: async ({
+      chatIds,
+      format = "native",
+      scope = "selected",
+    }: {
+      chatIds?: string[];
+      format?: BulkChatExportFormat;
+      scope?: "selected" | "all";
+    }) => {
+      const exportIds =
+        scope === "all" ? (await storageApi.list<Chat>("chats")).map((chat) => chat.id) : (chatIds ?? []);
+      const chats = await loadChatsForExport(exportIds);
+      const exportedAt = new Date().toISOString();
+      if (format === "jsonl" || format === "text") {
+        const [{ buildChatTranscriptZipFiles }, { createStoredZip }] = await Promise.all([
+          import("../lib/chat-transcript-export"),
+          import("../../../../shared/lib/zip"),
+        ]);
+        const files = buildChatTranscriptZipFiles(chats, format);
+        downloadBlobFile(createStoredZip(files), `chat-transcripts-${format}-${exportedAt.slice(0, 10)}.zip`);
+        return;
+      }
+
+      downloadTextFile(
+        JSON.stringify(
+          {
+            format: "marinara-chat-bulk",
+            version: 1,
+            exportedAt,
+            count: chats.length,
+            chats,
+          },
+          null,
+          2,
+        ),
+        `marinara-chats-${exportedAt.slice(0, 10)}.json`,
+        "application/json;charset=utf-8",
+      );
+    },
+  });
+}

--- a/src/features/catalog/chats/hooks/use-chat-folders.ts
+++ b/src/features/catalog/chats/hooks/use-chat-folders.ts
@@ -4,7 +4,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { storageApi } from "../../../../shared/api/storage-api";
 import type { ChatFolder } from "../../../../engine/contracts/types/chat";
-import { chatKeys } from "./use-chats";
+import { chatKeys } from "../query-keys";
 
 const folderKeys = {
   all: ["chat-folders"] as const,

--- a/src/features/catalog/chats/hooks/use-chat-lifecycle.ts
+++ b/src/features/catalog/chats/hooks/use-chat-lifecycle.ts
@@ -1,0 +1,210 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createChatSchema } from "../../../../engine/contracts/schemas/chat.schema";
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { clearChatActivity } from "../../../../engine/modes/chat/autonomous/autonomous.service";
+import { chatCommandApi } from "../../../../shared/api/chat-command-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { useChatStore } from "../../../../shared/stores/chat.store";
+import { lorebookKeys } from "../../lorebooks/query-keys";
+import { chatKeys } from "../query-keys";
+import {
+  applyChatMetadataPatch,
+  cancelChatCacheQueries,
+  setChatCacheRecord,
+  type ChatCacheRecord,
+} from "./chat-cache";
+import type { ChatListItem } from "./use-chat-summaries";
+
+type DeleteChatInput = string | { id: string; groupId?: string | null };
+
+interface DeleteChatResult {
+  deleted: boolean;
+  deletedChatIds?: string[];
+}
+
+function getDeleteChatId(input: DeleteChatInput) {
+  return typeof input === "string" ? input : input.id;
+}
+
+function getDeleteChatGroupId(input: DeleteChatInput) {
+  return typeof input === "string" ? null : (input.groupId ?? null);
+}
+
+function uniqueIds(ids: Array<string | null | undefined>) {
+  return Array.from(new Set(ids.filter((id): id is string => typeof id === "string" && id.length > 0)));
+}
+
+function patchAffectsActiveLorebooks(patch: Record<string, unknown>): boolean {
+  return [
+    "activeLorebookIds",
+    "lorebookTokenBudget",
+    "lorebookKeeperTargetLorebookId",
+    "gameLorebookKeeperEnabled",
+    "gameLorebookKeeperLorebookId",
+  ].some((key) => Object.prototype.hasOwnProperty.call(patch, key));
+}
+
+export function useCreateChat() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: {
+      name: string;
+      mode: string;
+      characterIds?: string[];
+      groupId?: string | null;
+      connectionId?: string | null;
+      personaId?: string | null;
+      promptPresetId?: string | null;
+    }) => storageApi.create<Chat>("chats", createChatSchema.parse(data)),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      qc.invalidateQueries({ queryKey: chatKeys.summaries() });
+      if (variables.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(variables.groupId) });
+      }
+    },
+  });
+}
+
+export function useDeleteChat() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: DeleteChatInput): Promise<DeleteChatResult> =>
+      (await storageApi.delete("chats", getDeleteChatId(input))) as DeleteChatResult,
+    onMutate: async (input) => {
+      const id = getDeleteChatId(input);
+      const providedGroupId = getDeleteChatGroupId(input);
+      await qc.cancelQueries({ queryKey: chatKeys.list() });
+      if (providedGroupId) {
+        await qc.cancelQueries({ queryKey: chatKeys.group(providedGroupId) });
+      }
+      await qc.cancelQueries({ queryKey: chatKeys.summaries() });
+      const previous = qc.getQueryData<Chat[]>(chatKeys.list());
+      const previousSummaries = qc.getQueriesData<ChatListItem[]>({ queryKey: chatKeys.summaries() });
+      const previousGroup = providedGroupId ? qc.getQueryData<Chat[]>(chatKeys.group(providedGroupId)) : undefined;
+      const deletedChat =
+        previous?.find((c) => c.id === id) ??
+        previousGroup?.find((c) => c.id === id) ??
+        previousSummaries.flatMap(([, rows]) => rows ?? []).find((c) => c.id === id) ??
+        null;
+      const groupId = deletedChat?.groupId ?? providedGroupId;
+
+      qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.id !== id));
+      qc.setQueriesData<ChatListItem[]>({ queryKey: chatKeys.summaries() }, (old) => old?.filter((c) => c.id !== id));
+
+      if (groupId) {
+        qc.setQueryData<Chat[]>(chatKeys.group(groupId), (old) => old?.filter((c) => c.id !== id));
+      }
+
+      return { previous, previousSummaries, previousGroup, groupId };
+    },
+    onSuccess: (data, input) => {
+      for (const chatId of uniqueIds([getDeleteChatId(input), ...(data.deletedChatIds ?? [])])) {
+        clearChatActivity(chatId);
+      }
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previous) {
+        qc.setQueryData(chatKeys.list(), context.previous);
+      } else {
+        qc.invalidateQueries({ queryKey: chatKeys.list() });
+      }
+      for (const [queryKey, data] of context?.previousSummaries ?? []) {
+        qc.setQueryData(queryKey, data);
+      }
+      if (context?.groupId) {
+        if (context.previousGroup) {
+          qc.setQueryData(chatKeys.group(context.groupId), context.previousGroup);
+        } else {
+          qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
+        }
+      }
+    },
+    onSettled: (_data, _err, input, context) => {
+      const groupId = context?.groupId ?? getDeleteChatGroupId(input);
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      qc.invalidateQueries({ queryKey: chatKeys.summaries() });
+      if (groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(groupId) });
+      }
+    },
+  });
+}
+
+export function useDeleteChatGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (groupId: string) => chatCommandApi.groupDelete(groupId),
+    onMutate: async (groupId) => {
+      await qc.cancelQueries({ queryKey: chatKeys.list() });
+      await qc.cancelQueries({ queryKey: chatKeys.summaries() });
+      const previous = qc.getQueryData<Chat[]>(chatKeys.list());
+      const previousSummaries = qc.getQueriesData<ChatListItem[]>({ queryKey: chatKeys.summaries() });
+
+      qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.groupId !== groupId));
+      qc.setQueriesData<ChatListItem[]>({ queryKey: chatKeys.summaries() }, (old) =>
+        old?.filter((c) => c.groupId !== groupId),
+      );
+      qc.setQueryData<Chat[]>(chatKeys.group(groupId), []);
+
+      return { previous, previousSummaries, groupId };
+    },
+    onSuccess: (data) => {
+      for (const chatId of uniqueIds(data.deletedChatIds ?? [])) {
+        clearChatActivity(chatId);
+      }
+    },
+    onError: (_err, _groupId, context) => {
+      if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
+      for (const [queryKey, data] of context?.previousSummaries ?? []) {
+        qc.setQueryData(queryKey, data);
+      }
+      if (context?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
+      }
+    },
+    onSettled: (_data, _err, _groupId, context) => {
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      qc.invalidateQueries({ queryKey: chatKeys.summaries() });
+      if (context?.groupId) {
+        qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
+      }
+    },
+  });
+}
+
+export function useUpdateChatMetadata() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
+      storageApi.patchChatMetadata<Chat>(id, metadata),
+    onMutate: ({ id, ...metadata }) => {
+      cancelChatCacheQueries(qc, id);
+      const previousDetail = qc.getQueryData<ChatCacheRecord>(chatKeys.detail(id));
+      const previousListQueries = qc.getQueriesData<ChatCacheRecord[]>({ queryKey: chatKeys.list() });
+      const previousGroupQueries = qc.getQueriesData<ChatCacheRecord[]>({ queryKey: [...chatKeys.all, "group"] });
+      const previousActiveChat = useChatStore.getState().activeChat;
+
+      setChatCacheRecord(qc, id, (chat) => applyChatMetadataPatch(chat, metadata));
+
+      return { previousDetail, previousListQueries, previousGroupQueries, previousActiveChat };
+    },
+    onError: (_error, vars, context) => {
+      if (context?.previousDetail) qc.setQueryData(chatKeys.detail(vars.id), context.previousDetail);
+      for (const [queryKey, data] of context?.previousListQueries ?? []) qc.setQueryData(queryKey, data);
+      for (const [queryKey, data] of context?.previousGroupQueries ?? []) qc.setQueryData(queryKey, data);
+      if (context?.previousActiveChat) useChatStore.getState().setActiveChat(context.previousActiveChat);
+    },
+    onSuccess: (data, vars) => {
+      const { id, ...metadata } = vars;
+      if (data) {
+        qc.setQueryData(chatKeys.detail(id), data);
+      } else {
+        qc.invalidateQueries({ queryKey: chatKeys.detail(id) });
+      }
+      setChatCacheRecord(qc, id, (chat) => applyChatMetadataPatch(chat, metadata));
+      if (patchAffectsActiveLorebooks(metadata)) qc.invalidateQueries({ queryKey: lorebookKeys.active(id) });
+    },
+  });
+}

--- a/src/features/catalog/chats/hooks/use-chat-summaries.ts
+++ b/src/features/catalog/chats/hooks/use-chat-summaries.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { apiQueryRetryDelay, shouldRetryApiQuery } from "../../../../shared/api/query-retry";
+import { chatKeys } from "../query-keys";
+
+export const CHAT_SUMMARY_FIELDS = [
+  "id",
+  "name",
+  "mode",
+  "characterIds",
+  "groupId",
+  "personaId",
+  "promptPresetId",
+  "connectionId",
+  "folderId",
+  "sortOrder",
+  "connectedChatId",
+  "createdAt",
+  "updatedAt",
+  "metadata",
+] as const;
+
+const CHAT_SUMMARY_METADATA_FIELDS = [
+  "autonomousUnreadAt",
+  "autonomousUnreadCharacterIds",
+  "autonomousUnreadCount",
+  "branchName",
+  "gameId",
+  "pinned",
+  "tags",
+] as const;
+
+type ChatSummaryField = Exclude<(typeof CHAT_SUMMARY_FIELDS)[number], "metadata">;
+type ChatSummaryMetadataField = (typeof CHAT_SUMMARY_METADATA_FIELDS)[number];
+
+export type ChatListItem = Pick<Chat, ChatSummaryField> & {
+  metadata: Partial<Pick<Chat["metadata"], ChatSummaryMetadataField>>;
+};
+
+export function useChatSummaries() {
+  return useQuery({
+    queryKey: chatKeys.summaries(),
+    queryFn: () =>
+      storageApi.list<ChatListItem>("chats", {
+        fields: [...CHAT_SUMMARY_FIELDS],
+        fieldSelections: { metadata: [...CHAT_SUMMARY_METADATA_FIELDS] },
+      }),
+    staleTime: 10_000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: true,
+    retry: (failureCount, error) => shouldRetryApiQuery(failureCount, error, { maxRetries: 10 }),
+    retryDelay: (attempt, error) => apiQueryRetryDelay(attempt, error, { baseDelayMs: 750, maxDelayMs: 5_000 }),
+  });
+}
+
+export function useRecentChatSummaries(limit = 3) {
+  return useQuery({
+    queryKey: chatKeys.recentSummaries(limit),
+    queryFn: () =>
+      storageApi.list<ChatListItem>("chats", {
+        fields: [...CHAT_SUMMARY_FIELDS],
+        fieldSelections: { metadata: [...CHAT_SUMMARY_METADATA_FIELDS] },
+        orderBy: "updatedAt",
+        descending: true,
+        limit,
+      }),
+    staleTime: 10_000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: true,
+    retry: (failureCount, error) => shouldRetryApiQuery(failureCount, error, { maxRetries: 10 }),
+    retryDelay: (attempt, error) => apiQueryRetryDelay(attempt, error, { baseDelayMs: 750, maxDelayMs: 5_000 }),
+  });
+}

--- a/src/features/catalog/chats/hooks/use-chats.test.tsx
+++ b/src/features/catalog/chats/hooks/use-chats.test.tsx
@@ -7,12 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearChatActivity } from "../../../../engine/modes/chat/autonomous/autonomous.service";
 import { chatCommandApi } from "../../../../shared/api/chat-command-api";
 import { storageApi } from "../../../../shared/api/storage-api";
-import { chatKeys, useDeleteChat, useDeleteChatGroup, useSetActiveSwipe } from "./use-chats";
+import { chatKeys, useCreateChat, useDeleteChat, useDeleteChatGroup, useSetActiveSwipe } from "./use-chats";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock("../../../../shared/api/storage-api", () => ({
   storageApi: {
+    create: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -29,6 +30,7 @@ vi.mock("../../../../engine/modes/chat/autonomous/autonomous.service", () => ({
 }));
 
 const storageDeleteMock = vi.mocked(storageApi.delete);
+const storageCreateMock = vi.mocked(storageApi.create);
 const groupDeleteMock = vi.mocked(chatCommandApi.groupDelete);
 const setActiveSwipeMock = vi.mocked(chatCommandApi.setActiveSwipe);
 const clearChatActivityMock = vi.mocked(clearChatActivity);
@@ -68,6 +70,7 @@ describe("chat deletion mutations", () => {
     container.remove();
     queryClient.clear();
     storageDeleteMock.mockReset();
+    storageCreateMock.mockReset();
     groupDeleteMock.mockReset();
     setActiveSwipeMock.mockReset();
     clearChatActivityMock.mockReset();
@@ -113,6 +116,23 @@ describe("chat deletion mutations", () => {
     expect(clearChatActivityMock).toHaveBeenCalledWith("scene-chat");
   });
 
+  it("invalidates the group cache after creating a grouped chat", async () => {
+    const createChat = await renderMutation(useCreateChat);
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+    storageCreateMock.mockResolvedValue({
+      id: "chat-1",
+      name: "Grouped chat",
+      mode: "conversation",
+      groupId: "group-1",
+    });
+
+    await act(async () => {
+      await createChat.mutateAsync({ name: "Grouped chat", mode: "conversation", groupId: "group-1" });
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: chatKeys.group("group-1") });
+  });
+
   it("keeps autonomous activity when chat deletion fails", async () => {
     const deleteChat = await renderMutation(useDeleteChat);
     storageDeleteMock.mockRejectedValue(new Error("delete failed"));
@@ -145,6 +165,23 @@ describe("chat deletion mutations", () => {
     expect(clearChatActivityMock).toHaveBeenCalledWith("chat-2");
     expect(clearChatActivityMock).toHaveBeenCalledWith("scene-chat");
     expect(clearChatActivityMock).not.toHaveBeenCalledWith("chat-other");
+  });
+
+  it("removes deleted group chats from cached summaries", async () => {
+    const deleteChatGroup = await renderMutation(useDeleteChatGroup);
+    groupDeleteMock.mockResolvedValue({ deleted: 1, deletedChatIds: ["chat-1"] });
+    queryClient.setQueryData(chatKeys.summaries(), [
+      { id: "chat-1", name: "Grouped chat", mode: "conversation", groupId: "group-1" },
+      { id: "chat-other", name: "Other chat", mode: "conversation", groupId: "group-other" },
+    ]);
+
+    await act(async () => {
+      await deleteChatGroup.mutateAsync("group-1");
+    });
+
+    expect(queryClient.getQueryData(chatKeys.summaries())).toEqual([
+      { id: "chat-other", name: "Other chat", mode: "conversation", groupId: "group-other" },
+    ]);
   });
 
   it("does not crash when a chat group delete response omits deleted chat ids", async () => {

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -15,13 +15,8 @@ import {
   type PromptPreviewInput,
   type PromptPreviewResult,
 } from "../../../../engine/generation/prompt-preview";
-import {
-  createChatSchema,
-  createMessageSchema,
-  summariesPatchSchema,
-} from "../../../../engine/contracts/schemas/chat.schema";
+import { createMessageSchema, summariesPatchSchema } from "../../../../engine/contracts/schemas/chat.schema";
 import { boolish } from "../../../../engine/generation/runtime-records";
-import { clearChatActivity } from "../../../../engine/modes/chat/autonomous/autonomous.service";
 import { backfillConversationSummaries } from "../../../../engine/modes/chat/core/summaries/auto-summary.service";
 import { appendChatSummaryEntryToMetadata } from "../../../../engine/shared/text/chat-summary-entries";
 import { chatCommandApi } from "../../../../shared/api/chat-command-api";
@@ -29,18 +24,22 @@ import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { ApiError } from "../../../../shared/api/api-errors";
-import { apiQueryRetryDelay, shouldRetryApiQuery } from "../../../../shared/api/query-retry";
-import { createStoredZip } from "../../../../shared/lib/zip";
 import {
-  buildChatTranscriptZipFiles,
   chatExportFilename,
   formatChatJsonl,
   formatChatText,
-  type BulkChatExportFormat,
   type ChatTranscriptExportFormat,
 } from "../lib/chat-transcript-export";
+import { downloadTextFile } from "../lib/download";
 import { sanitizeTimelineMessage, timelineMessageProjection } from "../lib/timeline-message";
 import { lorebookKeys } from "../../lorebooks/query-keys";
+import { CHAT_SUMMARY_FIELDS } from "./use-chat-summaries";
+import {
+  applyChatFieldPatch,
+  cancelChatCacheQueries,
+  setChatCacheRecord,
+  type ChatCacheRecord,
+} from "./chat-cache";
 import type {
   Chat,
   ChatMemoryChunk,
@@ -52,7 +51,10 @@ import type {
 import type { ChatMemoryRecallImportResult } from "../../../../engine/contracts/types/export";
 
 export { chatKeys } from "../query-keys";
-export type { BulkChatExportFormat, ChatTranscriptExportFormat } from "../lib/chat-transcript-export";
+export { useCreateChat, useDeleteChat, useDeleteChatGroup, useUpdateChatMetadata } from "./use-chat-lifecycle";
+export { useChatSummaries, useRecentChatSummaries } from "./use-chat-summaries";
+export type { ChatListItem } from "./use-chat-summaries";
+export type { ChatTranscriptExportFormat } from "../lib/chat-transcript-export";
 
 const RECENT_MESSAGE_CONTENT_EDIT_TTL_MS = 5 * 60 * 1000;
 const DEFAULT_CHAT_MESSAGE_PAGE_SIZE = 20;
@@ -152,173 +154,11 @@ export function preserveRecentMessageContentEdit(chatId: string, message: Messag
   return { ...message, content: edit.content };
 }
 
-const CHAT_SUMMARY_FIELDS = [
-  "id",
-  "name",
-  "mode",
-  "characterIds",
-  "groupId",
-  "personaId",
-  "promptPresetId",
-  "connectionId",
-  "folderId",
-  "sortOrder",
-  "connectedChatId",
-  "createdAt",
-  "updatedAt",
-  "metadata",
-];
-
-const CHAT_SUMMARY_METADATA_FIELDS = [
-  "autonomousUnreadAt",
-  "autonomousUnreadCharacterIds",
-  "autonomousUnreadCount",
-  "branchName",
-  "gameId",
-  "pinned",
-  "tags",
-];
-
-export type ChatListItem = Pick<
-  Chat,
-  | "id"
-  | "name"
-  | "mode"
-  | "characterIds"
-  | "groupId"
-  | "personaId"
-  | "promptPresetId"
-  | "connectionId"
-  | "folderId"
-  | "sortOrder"
-  | "connectedChatId"
-  | "createdAt"
-  | "updatedAt"
-> & {
-  metadata: Partial<
-    Pick<
-      Chat["metadata"],
-      | "autonomousUnreadAt"
-      | "autonomousUnreadCharacterIds"
-      | "autonomousUnreadCount"
-      | "branchName"
-      | "gameId"
-      | "pinned"
-      | "tags"
-    >
-  >;
-};
-
-type ChatCacheRecord = Record<string, unknown> & { id?: string; metadata?: unknown };
-
-function updateCachedChatRows<T extends ChatCacheRecord>(
-  rows: T[] | undefined,
-  id: string,
-  updater: (row: T) => T,
-): T[] | undefined {
-  if (!Array.isArray(rows)) return rows;
-  let changed = false;
-  const next = rows.map((row) => {
-    if (!row || row.id !== id) return row;
-    changed = true;
-    return updater(row);
-  });
-  return changed ? next : rows;
-}
-
-function applyChatFieldPatch<T extends ChatCacheRecord>(chat: T, patch: Record<string, unknown>): T {
-  return { ...chat, ...patch };
-}
-
-function applyChatMetadataPatch<T extends ChatCacheRecord>(chat: T, patch: Record<string, unknown>): T {
-  return {
-    ...chat,
-    metadata: {
-      ...parseRecord(chat.metadata),
-      ...patch,
-    },
-  };
-}
-
-function setChatCacheRecord(
-  qc: Pick<QueryClient, "setQueryData" | "setQueriesData">,
-  id: string,
-  updater: (chat: ChatCacheRecord) => ChatCacheRecord,
-) {
-  qc.setQueryData<ChatCacheRecord | undefined>(chatKeys.detail(id), (current) =>
-    current ? updater(current) : current,
-  );
-  qc.setQueriesData<ChatCacheRecord[]>({ queryKey: chatKeys.list() }, (rows) =>
-    updateCachedChatRows(rows, id, updater),
-  );
-  qc.setQueriesData<ChatCacheRecord[]>({ queryKey: [...chatKeys.all, "group"] }, (rows) =>
-    updateCachedChatRows(rows, id, updater),
-  );
-
-  const activeChat = useChatStore.getState().activeChat as ChatCacheRecord | null;
-  if (activeChat?.id === id) {
-    useChatStore.getState().setActiveChat(updater(activeChat) as unknown as Chat);
-  }
-}
-
-function cancelChatCacheQueries(qc: QueryClient, id: string) {
-  // Tauri-backed reads are not abortable, so awaiting broad cache cancellation
-  // can make optimistic chat-setting toggles wait behind large startup loads.
-  void qc.cancelQueries({ queryKey: chatKeys.detail(id) }).catch(() => undefined);
-  void qc.cancelQueries({ queryKey: chatKeys.list() }).catch(() => undefined);
-  void qc.cancelQueries({ queryKey: [...chatKeys.all, "group"] }).catch(() => undefined);
-}
-
-function patchAffectsActiveLorebooks(patch: Record<string, unknown>): boolean {
-  return [
-    "activeLorebookIds",
-    "lorebookTokenBudget",
-    "lorebookKeeperTargetLorebookId",
-    "gameLorebookKeeperEnabled",
-    "gameLorebookKeeperLorebookId",
-  ].some((key) => Object.prototype.hasOwnProperty.call(patch, key));
-}
-
-export function useChatSummaries() {
-  return useQuery({
-    queryKey: chatKeys.summaries(),
-    queryFn: () =>
-      storageApi.list<ChatListItem>("chats", {
-        fields: CHAT_SUMMARY_FIELDS,
-        fieldSelections: { metadata: CHAT_SUMMARY_METADATA_FIELDS },
-      }),
-    staleTime: 10_000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
-    retry: (failureCount, error) => shouldRetryApiQuery(failureCount, error, { maxRetries: 10 }),
-    retryDelay: (attempt, error) => apiQueryRetryDelay(attempt, error, { baseDelayMs: 750, maxDelayMs: 5_000 }),
-  });
-}
-
-export function useRecentChatSummaries(limit = 3) {
-  return useQuery({
-    queryKey: chatKeys.recentSummaries(limit),
-    queryFn: () =>
-      storageApi.list<ChatListItem>("chats", {
-        fields: CHAT_SUMMARY_FIELDS,
-        fieldSelections: { metadata: CHAT_SUMMARY_METADATA_FIELDS },
-        orderBy: "updatedAt",
-        descending: true,
-        limit,
-      }),
-    staleTime: 10_000,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: true,
-  });
-}
-
 export function useChat(id: string | null) {
   return useQuery({
     queryKey: chatKeys.detail(id ?? ""),
     queryFn: () =>
-      storageApi.get<Chat>("chats", id!, { fields: CHAT_SUMMARY_FIELDS }).then((chat) => {
+      storageApi.get<Chat>("chats", id!, { fields: [...CHAT_SUMMARY_FIELDS] }).then((chat) => {
         if (!chat) throw new ApiError("Chat not found", 404);
         return chat;
       }),
@@ -480,142 +320,6 @@ export function useChatGroup(groupId: string | null) {
   });
 }
 
-type DeleteChatInput = string | { id: string; groupId?: string | null };
-
-interface DeleteChatResult {
-  deleted: boolean;
-  deletedChatIds?: string[];
-}
-
-function getDeleteChatId(input: DeleteChatInput) {
-  return typeof input === "string" ? input : input.id;
-}
-
-function getDeleteChatGroupId(input: DeleteChatInput) {
-  return typeof input === "string" ? null : (input.groupId ?? null);
-}
-
-function uniqueIds(ids: Array<string | null | undefined>) {
-  return Array.from(new Set(ids.filter((id): id is string => typeof id === "string" && id.length > 0)));
-}
-
-export function useCreateChat() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (data: {
-      name: string;
-      mode: string;
-      characterIds?: string[];
-      groupId?: string | null;
-      connectionId?: string | null;
-      personaId?: string | null;
-      promptPresetId?: string | null;
-    }) => storageApi.create<Chat>("chats", createChatSchema.parse(data)),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: chatKeys.list() });
-      qc.invalidateQueries({ queryKey: chatKeys.summaries() });
-    },
-  });
-}
-
-export function useDeleteChat() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: async (input: DeleteChatInput): Promise<DeleteChatResult> =>
-      (await storageApi.delete("chats", getDeleteChatId(input))) as DeleteChatResult,
-    onMutate: async (input) => {
-      const id = getDeleteChatId(input);
-      const providedGroupId = getDeleteChatGroupId(input);
-      await qc.cancelQueries({ queryKey: chatKeys.list() });
-      if (providedGroupId) {
-        await qc.cancelQueries({ queryKey: chatKeys.group(providedGroupId) });
-      }
-      await qc.cancelQueries({ queryKey: chatKeys.summaries() });
-      const previous = qc.getQueryData<Chat[]>(chatKeys.list());
-      const previousSummaries = qc.getQueriesData<ChatListItem[]>({ queryKey: chatKeys.summaries() });
-      const previousGroup = providedGroupId ? qc.getQueryData<Chat[]>(chatKeys.group(providedGroupId)) : undefined;
-      const deletedChat =
-        previous?.find((c) => c.id === id) ??
-        previousGroup?.find((c) => c.id === id) ??
-        previousSummaries.flatMap(([, rows]) => rows ?? []).find((c) => c.id === id) ??
-        null;
-      const groupId = deletedChat?.groupId ?? providedGroupId;
-
-      qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.id !== id));
-      qc.setQueriesData<ChatListItem[]>({ queryKey: chatKeys.summaries() }, (old) => old?.filter((c) => c.id !== id));
-
-      if (groupId) {
-        qc.setQueryData<Chat[]>(chatKeys.group(groupId), (old) => old?.filter((c) => c.id !== id));
-      }
-
-      return { previous, previousSummaries, previousGroup, groupId };
-    },
-    onSuccess: (data, input) => {
-      for (const chatId of uniqueIds([getDeleteChatId(input), ...(data.deletedChatIds ?? [])])) {
-        clearChatActivity(chatId);
-      }
-    },
-    onError: (_err, _id, context) => {
-      if (context?.previous) {
-        qc.setQueryData(chatKeys.list(), context.previous);
-      } else {
-        qc.invalidateQueries({ queryKey: chatKeys.list() });
-      }
-      for (const [queryKey, data] of context?.previousSummaries ?? []) {
-        qc.setQueryData(queryKey, data);
-      }
-      if (context?.groupId) {
-        if (context.previousGroup) {
-          qc.setQueryData(chatKeys.group(context.groupId), context.previousGroup);
-        } else {
-          qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
-        }
-      }
-    },
-    onSettled: (_data, _err, input, context) => {
-      const groupId = context?.groupId ?? getDeleteChatGroupId(input);
-      qc.invalidateQueries({ queryKey: chatKeys.list() });
-      qc.invalidateQueries({ queryKey: chatKeys.summaries() });
-      if (groupId) {
-        qc.invalidateQueries({ queryKey: chatKeys.group(groupId) });
-      }
-    },
-  });
-}
-
-export function useDeleteChatGroup() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (groupId: string) => chatCommandApi.groupDelete(groupId),
-    onMutate: async (groupId) => {
-      await qc.cancelQueries({ queryKey: chatKeys.list() });
-      const previous = qc.getQueryData<Chat[]>(chatKeys.list());
-
-      qc.setQueryData<Chat[]>(chatKeys.list(), (old) => old?.filter((c) => c.groupId !== groupId));
-      qc.setQueryData<Chat[]>(chatKeys.group(groupId), []);
-
-      return { previous, groupId };
-    },
-    onSuccess: (data) => {
-      for (const chatId of uniqueIds(data.deletedChatIds ?? [])) {
-        clearChatActivity(chatId);
-      }
-    },
-    onError: (_err, _groupId, context) => {
-      if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
-      if (context?.groupId) {
-        qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
-      }
-    },
-    onSettled: (_data, _err, _groupId, context) => {
-      qc.invalidateQueries({ queryKey: chatKeys.list() });
-      if (context?.groupId) {
-        qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
-      }
-    },
-  });
-}
-
 export function useUpdateChat() {
   const qc = useQueryClient();
   return useMutation({
@@ -666,60 +370,6 @@ export function useUpdateChat() {
       if ("characterIds" in vars || "personaId" in vars || "promptPresetId" in vars || "connectionId" in vars) {
         qc.invalidateQueries({ queryKey: lorebookKeys.active(vars.id) });
       }
-    },
-  });
-}
-
-export function useUpdateChatMetadata() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
-      storageApi.patchChatMetadata<Chat>(id, metadata),
-    onMutate: ({ id, ...metadata }) => {
-      cancelChatCacheQueries(qc, id);
-      const previousDetail = qc.getQueryData<ChatCacheRecord>(chatKeys.detail(id));
-      const previousListQueries = qc.getQueriesData<ChatCacheRecord[]>({ queryKey: chatKeys.list() });
-      const previousGroupQueries = qc.getQueriesData<ChatCacheRecord[]>({ queryKey: [...chatKeys.all, "group"] });
-      const previousActiveChat = useChatStore.getState().activeChat;
-
-      setChatCacheRecord(qc, id, (chat) => applyChatMetadataPatch(chat, metadata));
-
-      return { previousDetail, previousListQueries, previousGroupQueries, previousActiveChat };
-    },
-    onError: (_error, vars, context) => {
-      if (context?.previousDetail) qc.setQueryData(chatKeys.detail(vars.id), context.previousDetail);
-      for (const [queryKey, data] of context?.previousListQueries ?? []) qc.setQueryData(queryKey, data);
-      for (const [queryKey, data] of context?.previousGroupQueries ?? []) qc.setQueryData(queryKey, data);
-      if (context?.previousActiveChat) useChatStore.getState().setActiveChat(context.previousActiveChat);
-    },
-    onSuccess: (data, vars) => {
-      const { id, ...metadata } = vars;
-      // Write the saved response straight into the detail cache. Plain
-      // invalidation alone leaves stale data in place when no observer is
-      // mounted to trigger a refetch (e.g. user navigated away after firing
-      // the mutation), causing later renders to re-read the pre-mutation
-      // value — which is what made cleared chat backgrounds reappear after
-      // a chat switch round-trip.
-      if (data) {
-        qc.setQueryData(chatKeys.detail(id), data);
-      } else {
-        qc.invalidateQueries({ queryKey: chatKeys.detail(id) });
-      }
-      setChatCacheRecord(qc, id, (chat) => applyChatMetadataPatch(chat, metadata));
-      if (patchAffectsActiveLorebooks(metadata)) qc.invalidateQueries({ queryKey: lorebookKeys.active(id) });
-    },
-  });
-}
-
-export function useClearAutonomousUnread() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: (chatId: string) => chatCommandApi.clearAutonomousUnread<Chat>(chatId),
-    onSuccess: (data, chatId) => {
-      if (data) {
-        qc.setQueryData(chatKeys.detail(chatId), data);
-      }
-      qc.invalidateQueries({ queryKey: chatKeys.list() });
     },
   });
 }
@@ -1088,20 +738,6 @@ function extraForActiveSwipe(baseExtra: unknown, swipeExtra: Record<string, unkn
   return next;
 }
 
-function downloadTextFile(contents: string, filename: string, type: string) {
-  const blob = new Blob([contents], { type });
-  downloadBlobFile(blob, filename);
-}
-
-function downloadBlobFile(blob: Blob, filename: string) {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}
-
 function parseRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
     try {
@@ -1256,64 +892,6 @@ export function useExportChat() {
       } else {
         downloadTextFile(formatChatJsonl(messages), filename, "application/x-ndjson;charset=utf-8");
       }
-    },
-  });
-}
-
-async function loadChatsForExport(chatIds: string[]) {
-  const ids = Array.from(new Set(chatIds.map((id) => id.trim()).filter(Boolean)));
-  if (ids.length === 0) throw new Error("Choose at least one chat to export.");
-  return Promise.all(
-    ids.map(async (chatId) => {
-      const [chat, messages] = await Promise.all([
-        storageApi.get<Chat>("chats", chatId).then((chat) => {
-          if (!chat) throw new Error("Chat was not found.");
-          return chat;
-        }),
-        storageApi.listChatMessages<Message>(chatId),
-      ]);
-      return { chat, messages };
-    }),
-  );
-}
-
-/** Export selected chats as native JSON or a ZIP of JSONL/text transcripts. */
-export function useBulkExportChats() {
-  return useMutation({
-    mutationFn: async ({
-      chatIds,
-      format = "native",
-      scope = "selected",
-    }: {
-      chatIds?: string[];
-      format?: BulkChatExportFormat;
-      scope?: "selected" | "all";
-    }) => {
-      const exportIds =
-        scope === "all" ? (await storageApi.list<Chat>("chats")).map((chat) => chat.id) : (chatIds ?? []);
-      const chats = await loadChatsForExport(exportIds);
-      const exportedAt = new Date().toISOString();
-      if (format === "jsonl" || format === "text") {
-        const files = buildChatTranscriptZipFiles(chats, format);
-        downloadBlobFile(createStoredZip(files), `chat-transcripts-${format}-${exportedAt.slice(0, 10)}.zip`);
-        return;
-      }
-
-      downloadTextFile(
-        JSON.stringify(
-          {
-            format: "marinara-chat-bulk",
-            version: 1,
-            exportedAt,
-            count: chats.length,
-            chats,
-          },
-          null,
-          2,
-        ),
-        `marinara-chats-${exportedAt.slice(0, 10)}.json`,
-        "application/json;charset=utf-8",
-      );
     },
   });
 }

--- a/src/features/catalog/chats/hooks/use-clear-autonomous-unread.ts
+++ b/src/features/catalog/chats/hooks/use-clear-autonomous-unread.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { chatCommandApi } from "../../../../shared/api/chat-command-api";
+import { chatKeys } from "../query-keys";
+
+export function useClearAutonomousUnread() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (chatId: string) => chatCommandApi.clearAutonomousUnread<Chat>(chatId),
+    onSuccess: (data, chatId) => {
+      if (data) {
+        qc.setQueryData(chatKeys.detail(chatId), data);
+      }
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+    },
+  });
+}

--- a/src/features/catalog/chats/lib/download.ts
+++ b/src/features/catalog/chats/lib/download.ts
@@ -1,0 +1,13 @@
+export function downloadTextFile(contents: string, filename: string, type: string) {
+  const blob = new Blob([contents], { type });
+  downloadBlobFile(blob, filename);
+}
+
+export function downloadBlobFile(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/features/catalog/chats/sidebar.ts
+++ b/src/features/catalog/chats/sidebar.ts
@@ -1,0 +1,12 @@
+export { useBulkExportChats } from "./hooks/use-bulk-export-chats";
+export { useChatSummaries } from "./hooks/use-chat-summaries";
+export { useCreateChat, useDeleteChat, useDeleteChatGroup, useUpdateChatMetadata } from "./hooks/use-chat-lifecycle";
+export {
+  useChatFolders,
+  useCreateFolder,
+  useDeleteFolder,
+  useMoveChat,
+  useReorderFolders,
+  useUpdateFolder,
+} from "./hooks/use-chat-folders";
+export type { BulkChatExportFormat } from "./lib/chat-transcript-export";

--- a/src/features/modes/conversation/background-autonomous.ts
+++ b/src/features/modes/conversation/background-autonomous.ts
@@ -1,0 +1,1 @@
+export { useBackgroundAutonomousPolling } from "./hooks/autonomous/use-background-autonomous";

--- a/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
@@ -10,7 +10,6 @@ import type { Chat } from "../../../../../engine/contracts/types/chat";
 import type { AvatarCropValue } from "../../../../../shared/lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { startGeneration } from "../../../../../engine/generation/start-generation";
 import {
   checkConversationAutonomous,
   getConversationBusyDelay,
@@ -132,6 +131,7 @@ export function useBackgroundAutonomousPolling() {
                 }
 
                 // Drain the TS generation engine; tokens aren't displayed for background chats.
+                const { startGeneration } = await import("../../../../../engine/generation/start-generation");
                 for await (const _event of startGeneration(
                   { storage: storageApi, llm: llmApi, integrations: integrationGateway },
                   {

--- a/src/features/shell/notifications/components/ChatNotificationBubbles.tsx
+++ b/src/features/shell/notifications/components/ChatNotificationBubbles.tsx
@@ -38,9 +38,6 @@ export function ChatNotificationBubbles() {
   };
 
   const notifications = Array.from(chatNotifications.values());
-
-  if (notifications.length === 0) return null;
-
   const totalCount = notifications.reduce((sum, n) => sum + n.count, 0);
 
   return (
@@ -62,7 +59,7 @@ export function ChatNotificationBubbles() {
       {/* ── Mobile: collapsed or expanded ── */}
       <div className="flex flex-col items-end gap-2 md:hidden">
         <AnimatePresence mode="popLayout">
-          {notifications.length === 1 || mobileExpanded ? (
+          {notifications.length === 0 ? null : notifications.length === 1 || mobileExpanded ? (
             /* Show all individual bubbles */
             notifications.map((notif) => (
               <NotificationBubble

--- a/src/shared/components/ui/ImagePromptReviewHost.tsx
+++ b/src/shared/components/ui/ImagePromptReviewHost.tsx
@@ -1,5 +1,10 @@
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { create } from "zustand";
-import { ImagePromptReviewModal, type ImagePromptOverride, type ImagePromptReviewItem } from "./ImagePromptReviewModal";
+import type { ImagePromptOverride, ImagePromptReviewItem } from "./ImagePromptReviewModal";
+
+const ImagePromptReviewModal = lazy(() =>
+  import("./ImagePromptReviewModal").then((module) => ({ default: module.ImagePromptReviewModal })),
+);
 
 type PromptReviewRequest = {
   id: string;
@@ -32,20 +37,55 @@ export function requestImagePromptReview(items: ImagePromptReviewItem[]): Promis
 export function ImagePromptReviewHost() {
   const request = useImagePromptReviewStore((state) => state.request);
   const setRequest = useImagePromptReviewStore((state) => state.setRequest);
+  const [displayRequest, setDisplayRequest] = useState<PromptReviewRequest | null>(null);
+  const [open, setOpen] = useState(false);
+  const pendingCloseRef = useRef<{
+    request: PromptReviewRequest;
+    overrides: ImagePromptOverride[] | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!request) return;
+    pendingCloseRef.current = null;
+    setDisplayRequest(request);
+    setOpen(true);
+  }, [request]);
 
   const close = (overrides: ImagePromptOverride[] | null) => {
     const current = useImagePromptReviewStore.getState().request;
     if (!current) return;
-    setRequest(null);
-    current.resolve(overrides);
+    pendingCloseRef.current = { request: current, overrides };
+    setOpen(false);
   };
 
+  const handleExited = () => {
+    const pendingClose = pendingCloseRef.current;
+    if (pendingClose) {
+      pendingCloseRef.current = null;
+      if (useImagePromptReviewStore.getState().request?.id === pendingClose.request.id) {
+        setRequest(null);
+        setDisplayRequest(null);
+        pendingClose.request.resolve(pendingClose.overrides);
+        return;
+      }
+    }
+
+    if (!useImagePromptReviewStore.getState().request) {
+      setDisplayRequest(null);
+    }
+  };
+
+  if (!displayRequest) return null;
+
   return (
-    <ImagePromptReviewModal
-      open={request !== null}
-      items={request?.items ?? []}
-      onCancel={() => close(null)}
-      onConfirm={(overrides) => close(overrides)}
-    />
+    <Suspense fallback={null}>
+      <ImagePromptReviewModal
+        open={open}
+        items={displayRequest.items}
+        onCancel={() => close(null)}
+        onConfirm={(overrides) => close(overrides)}
+        onExited={handleExited}
+      />
+    </Suspense>
   );
 }

--- a/src/shared/components/ui/ImagePromptReviewModal.tsx
+++ b/src/shared/components/ui/ImagePromptReviewModal.tsx
@@ -27,6 +27,7 @@ type ImagePromptReviewModalProps = {
   isSubmitting?: boolean;
   onCancel: () => void;
   onConfirm: (overrides: ImagePromptOverride[]) => void;
+  onExited?: () => void;
 };
 
 export function ImagePromptReviewModal({
@@ -35,6 +36,7 @@ export function ImagePromptReviewModal({
   isSubmitting = false,
   onCancel,
   onConfirm,
+  onExited,
 }: ImagePromptReviewModalProps) {
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [negativeDrafts, setNegativeDrafts] = useState<Record<string, string>>({});
@@ -63,6 +65,7 @@ export function ImagePromptReviewModal({
       onClose={isSubmitting ? () => {} : onCancel}
       title={items.length === 1 ? "Review Image Prompt" : "Review Image Prompts"}
       width="max-w-4xl"
+      onExited={onExited}
     >
       <div className="flex max-h-[72vh] flex-col gap-4">
         <div className="text-xs leading-relaxed text-[var(--muted-foreground)]">

--- a/src/shared/components/ui/Modal.tsx
+++ b/src/shared/components/ui/Modal.tsx
@@ -13,15 +13,17 @@ interface ModalProps {
   children: ReactNode;
   /** Width class, e.g. "max-w-md", "max-w-lg" */
   width?: string;
+  onExited?: () => void;
 }
 
-export function Modal({ open, onClose, title, children, width = "max-w-md" }: ModalProps) {
+export function Modal({ open, onClose, title, children, width = "max-w-md", onExited }: ModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   // Track mounted state separately so we can play the exit animation
   // before actually removing the DOM nodes.
   const [mounted, setMounted] = useState(false);
   const [animating, setAnimating] = useState<"enter" | "exit" | null>(null);
   const enterRafRef = useRef<number | null>(null);
+  const exitHandledRef = useRef(false);
 
   useEffect(() => {
     if (enterRafRef.current !== null) {
@@ -31,11 +33,13 @@ export function Modal({ open, onClose, title, children, width = "max-w-md" }: Mo
 
     if (open) {
       setMounted(true);
+      exitHandledRef.current = false;
       // Start enter animation on next frame so the DOM is present
       enterRafRef.current = requestAnimationFrame(() => {
         setAnimating("enter");
       });
     } else if (mounted) {
+      exitHandledRef.current = false;
       setAnimating("exit");
     }
 
@@ -59,9 +63,11 @@ export function Modal({ open, onClose, title, children, width = "max-w-md" }: Mo
 
   // Remove from DOM after exit animation completes
   const handleAnimationEnd = () => {
-    if (animating === "exit") {
+    if (animating === "exit" && !exitHandledRef.current) {
+      exitHandledRef.current = true;
       setMounted(false);
       setAnimating(null);
+      onExited?.();
     }
   };
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

#1712 

## Why this change

- Reduce startup bundle work by deferring optional shell surfaces and heavyweight chat-sidebar-only hooks until they are actually needed.

## What changed

- Lazy-load optional AppShell surfaces: Professor Mari, chat notification bubbles, agent debug, Spotify widgets, and image prompt review modal.
- Move chat sidebar hooks into smaller public entrypoints so AppShell/ChatSidebar do not pull all chat runtime hooks into startup.
- Dynamically import background autonomous generation only when an inactive autonomous chat actually triggers.
- Keep agent debug activity from re-rendering AppShell while debug mode is disabled.

## Refactor impact

Primary owner:

App shell and catalog chat hooks.

Impact areas reviewed:

- AppShell startup imports and optional surface gates.
- Chat sidebar hook entrypoints and compatibility exports from `features/catalog/chats`.
- Conversation background autonomous import timing.
- Image prompt review modal lifecycle.

Boundary notes:

- UI changes stay in `src/app` and `src/features`.
- No engine, shared API, Rust command, or remote runtime behavior changes.
- New feature entrypoints expose existing hooks without adding raw Tauri or HTTP calls.

Pressure points touched:

- AppShell startup composition.
- Broad `use-chats` hook file was split into focused chat hook modules.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Ran:

- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm build`
- `pnpm test src/features/catalog/chats/hooks/use-chats.test.tsx`
- `pnpm test:ui:run`
- `git diff --check`

Browser smoke passed through Playwright. Native Tauri manual QA was not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes included; this is internal startup-loading structure.

## UI evidence

No screenshot or recording added; this changes loading boundaries, not intended visuals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk export functionality for chats in multiple formats.

* **Performance**
  * Improved performance through lazy-loading of non-essential UI components, including chat notifications, debug panel, and media player widgets.
  * UI elements now render conditionally only when needed, reducing initial load time.

* **Refactor**
  * Reorganized internal chat management modules for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->