### PR TITLE
[codex] Fix persona ungrouped group parity

### DIFF
--- a/src/features/catalog/personas/components/PersonaGroupsSection.tsx
+++ b/src/features/catalog/personas/components/PersonaGroupsSection.tsx
@@ -127,6 +127,7 @@ export function PersonaGroupsSection({
 
             {groups.map((group) => {
               const isExpanded = expandedGroupId === group.id;
+              const isSynthetic = group.isSynthetic === true;
               return (
                 <div key={group.id} className="rounded-xl bg-[var(--secondary)]/60 ring-1 ring-[var(--border)]/50">
                   <div className="flex items-center gap-1.5 px-2.5 py-2">
@@ -165,54 +166,56 @@ export function PersonaGroupsSection({
                       </span>
                     )}
 
-                    <div className="flex items-center gap-0.5">
-                      <button
-                        onClick={() => {
-                          if (assigningToGroup !== group.id) onExitSelectionMode();
-                          onAssigningToGroupChange(assigningToGroup === group.id ? null : group.id);
-                        }}
-                        className={cn(
-                          "rounded-lg p-1 transition-colors",
-                          assigningToGroup === group.id
-                            ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-                            : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                        )}
-                        title="Assign personas"
-                      >
-                        <UserPlus size="0.75rem" />
-                      </button>
-                      <button
-                        onClick={() => {
-                          onEditingGroupIdChange(group.id);
-                          onEditGroupNameChange(group.name);
-                        }}
-                        className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                        title="Rename"
-                      >
-                        <Pencil size="0.75rem" />
-                      </button>
-                      <button
-                        onClick={async () => {
-                          if (
-                            !(await showConfirmDialog({
-                              title: "Delete Group",
-                              message: `Delete group "${group.name}"?`,
-                              confirmLabel: "Delete",
-                              tone: "destructive",
-                            }))
-                          ) {
-                            return;
-                          }
-                          onDeleteGroup(group.id);
-                          if (expandedGroupId === group.id) onExpandedGroupIdChange(null);
-                          if (assigningToGroup === group.id) onAssigningToGroupChange(null);
-                        }}
-                        className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
-                        title="Delete group"
-                      >
-                        <Trash2 size="0.75rem" />
-                      </button>
-                    </div>
+                    {!isSynthetic && (
+                      <div className="flex items-center gap-0.5">
+                        <button
+                          onClick={() => {
+                            if (assigningToGroup !== group.id) onExitSelectionMode();
+                            onAssigningToGroupChange(assigningToGroup === group.id ? null : group.id);
+                          }}
+                          className={cn(
+                            "rounded-lg p-1 transition-colors",
+                            assigningToGroup === group.id
+                              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
+                              : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                          )}
+                          title="Assign personas"
+                        >
+                          <UserPlus size="0.75rem" />
+                        </button>
+                        <button
+                          onClick={() => {
+                            onEditingGroupIdChange(group.id);
+                            onEditGroupNameChange(group.name);
+                          }}
+                          className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                          title="Rename"
+                        >
+                          <Pencil size="0.75rem" />
+                        </button>
+                        <button
+                          onClick={async () => {
+                            if (
+                              !(await showConfirmDialog({
+                                title: "Delete Group",
+                                message: `Delete group "${group.name}"?`,
+                                confirmLabel: "Delete",
+                                tone: "destructive",
+                              }))
+                            ) {
+                              return;
+                            }
+                            onDeleteGroup(group.id);
+                            if (expandedGroupId === group.id) onExpandedGroupIdChange(null);
+                            if (assigningToGroup === group.id) onAssigningToGroupChange(null);
+                          }}
+                          className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
+                          title="Delete group"
+                        >
+                          <Trash2 size="0.75rem" />
+                        </button>
+                      </div>
+                    )}
                   </div>
 
                   {isExpanded && (
@@ -240,13 +243,15 @@ export function PersonaGroupsSection({
                                   )}
                                 </div>
                                 <span className="min-w-0 flex-1 truncate">{persona.name}</span>
-                                <button
-                                  onClick={() => onToggleGroupMember(group.id, personaId, group.memberIds)}
-                                  className="rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
-                                  title="Remove from group"
-                                >
-                                  <UserMinus size="0.625rem" />
-                                </button>
+                                {!isSynthetic && (
+                                  <button
+                                    onClick={() => onToggleGroupMember(group.id, personaId, group.memberIds)}
+                                    className="rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
+                                    title="Remove from group"
+                                  >
+                                    <UserMinus size="0.625rem" />
+                                  </button>
+                                )}
                               </div>
                             );
                           })}

--- a/src/features/catalog/personas/components/PersonasPanel.tsx
+++ b/src/features/catalog/personas/components/PersonasPanel.tsx
@@ -136,8 +136,8 @@ export function PersonasPanel() {
   const personaMap = useMemo(() => buildPersonaMap(rawList), [rawList]);
 
   const parsedGroups = useMemo(
-    () => parsePersonaGroups(personaGroupsRaw as PersonaGroupRow[] | undefined),
-    [personaGroupsRaw],
+    () => parsePersonaGroups(personaGroupsRaw as PersonaGroupRow[] | undefined, rawList),
+    [personaGroupsRaw, rawList],
   );
 
   const handleCreateGroup = useCallback(() => {

--- a/src/features/catalog/personas/lib/personas-panel-model.test.ts
+++ b/src/features/catalog/personas/lib/personas-panel-model.test.ts
@@ -4,6 +4,7 @@ import {
   filterPersonas,
   parsePersonaGroups,
   sortPersonas,
+  UNGROUPED_PERSONA_GROUP_ID,
   type PersonaGroupRow,
   type PersonaPanelRow,
 } from "./personas-panel-model";
@@ -103,27 +104,35 @@ describe("personas panel model", () => {
     expect(parsed[0]?.memberIds).not.toBe(groups[0]?.personaIds);
   });
 
+  it("appends a synthetic ungrouped bucket for personas outside real groups", () => {
+    const groups: PersonaGroupRow[] = [{ id: "group-2", name: "Archive", description: "", personaIds: ["persona-3"] }];
+
+    const parsed = parsePersonaGroups(groups, personas);
+
+    expect(parsed.at(-1)).toEqual({
+      id: UNGROUPED_PERSONA_GROUP_ID,
+      name: "Ungrouped",
+      description: "Personas not assigned to any group",
+      personaIds: ["persona-1", "persona-2"],
+      memberIds: ["persona-1", "persona-2"],
+      isSynthetic: true,
+    });
+    expect(groups).toEqual([{ id: "group-2", name: "Archive", description: "", personaIds: ["persona-3"] }]);
+  });
+
+  it("omits the synthetic ungrouped bucket when every persona belongs to a group", () => {
+    const groups: PersonaGroupRow[] = [
+      { id: "group-1", name: "All", description: "", personaIds: ["persona-1", "persona-2", "persona-3"] },
+    ];
+
+    expect(parsePersonaGroups(groups, personas).some((group) => group.isSynthetic)).toBe(false);
+  });
+
   it("sorts personas by name, creation date, and estimated token size", () => {
-    expect(sortPersonas(personas, "name-asc").map((row) => row.id)).toEqual([
-      "persona-1",
-      "persona-2",
-      "persona-3",
-    ]);
-    expect(sortPersonas(personas, "name-desc").map((row) => row.id)).toEqual([
-      "persona-3",
-      "persona-2",
-      "persona-1",
-    ]);
-    expect(sortPersonas(personas, "newest").map((row) => row.id)).toEqual([
-      "persona-1",
-      "persona-3",
-      "persona-2",
-    ]);
-    expect(sortPersonas(personas, "oldest").map((row) => row.id)).toEqual([
-      "persona-2",
-      "persona-3",
-      "persona-1",
-    ]);
+    expect(sortPersonas(personas, "name-asc").map((row) => row.id)).toEqual(["persona-1", "persona-2", "persona-3"]);
+    expect(sortPersonas(personas, "name-desc").map((row) => row.id)).toEqual(["persona-3", "persona-2", "persona-1"]);
+    expect(sortPersonas(personas, "newest").map((row) => row.id)).toEqual(["persona-1", "persona-3", "persona-2"]);
+    expect(sortPersonas(personas, "oldest").map((row) => row.id)).toEqual(["persona-2", "persona-3", "persona-1"]);
     expect(sortPersonas(personas, "tokens").map((row) => row.id)[0]).toBe("persona-2");
   });
 });

--- a/src/features/catalog/personas/lib/personas-panel-model.test.ts
+++ b/src/features/catalog/personas/lib/personas-panel-model.test.ts
@@ -128,6 +128,21 @@ describe("personas panel model", () => {
     expect(parsePersonaGroups(groups, personas).some((group) => group.isSynthetic)).toBe(false);
   });
 
+  it("buckets every persona as ungrouped when no real groups exist", () => {
+    const parsed = parsePersonaGroups([], personas);
+
+    expect(parsed).toEqual([
+      {
+        id: UNGROUPED_PERSONA_GROUP_ID,
+        name: "Ungrouped",
+        description: "Personas not assigned to any group",
+        personaIds: ["persona-1", "persona-2", "persona-3"],
+        memberIds: ["persona-1", "persona-2", "persona-3"],
+        isSynthetic: true,
+      },
+    ]);
+  });
+
   it("sorts personas by name, creation date, and estimated token size", () => {
     expect(sortPersonas(personas, "name-asc").map((row) => row.id)).toEqual(["persona-1", "persona-2", "persona-3"]);
     expect(sortPersonas(personas, "name-desc").map((row) => row.id)).toEqual(["persona-3", "persona-2", "persona-1"]);

--- a/src/features/catalog/personas/lib/personas-panel-model.ts
+++ b/src/features/catalog/personas/lib/personas-panel-model.ts
@@ -15,7 +15,9 @@ export type PersonaPanelRow = {
 
 export type PersonaGroupRow = { id: string; name: string; description: string; personaIds: string[] };
 
-export type PersonaPanelGroup = PersonaGroupRow & { memberIds: string[] };
+export type PersonaPanelGroup = PersonaGroupRow & { memberIds: string[]; isSynthetic?: boolean };
+
+export const UNGROUPED_PERSONA_GROUP_ID = "__ungrouped-personas__";
 
 export type SortOption = "name-asc" | "name-desc" | "newest" | "oldest" | "tokens";
 
@@ -50,12 +52,41 @@ export function buildPersonaMap(personas: PersonaPanelRow[]): Map<string, Person
   return map;
 }
 
-export function parsePersonaGroups(personaGroupsRaw: PersonaGroupRow[] | undefined): PersonaPanelGroup[] {
+export function parsePersonaGroups(
+  personaGroupsRaw: PersonaGroupRow[] | undefined,
+  personas?: PersonaPanelRow[],
+): PersonaPanelGroup[] {
   if (!personaGroupsRaw) return [];
-  return personaGroupsRaw.map((group) => ({
-    ...group,
-    memberIds: Array.isArray(group.personaIds) ? [...group.personaIds] : [],
-  }));
+  const assignedIds = new Set<string>();
+  const groups = personaGroupsRaw.map((group) => {
+    const memberIds = Array.isArray(group.personaIds) ? [...group.personaIds] : [];
+    for (const id of memberIds) assignedIds.add(id);
+    return {
+      ...group,
+      memberIds,
+    };
+  });
+
+  if (!personas) return groups;
+
+  const ungroupedMemberIds = personas
+    .filter((persona) => !assignedIds.has(persona.id))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((persona) => persona.id);
+
+  if (ungroupedMemberIds.length === 0) return groups;
+
+  return [
+    ...groups,
+    {
+      id: UNGROUPED_PERSONA_GROUP_ID,
+      name: "Ungrouped",
+      description: "Personas not assigned to any group",
+      personaIds: [...ungroupedMemberIds],
+      memberIds: ungroupedMemberIds,
+      isSynthetic: true,
+    },
+  ];
 }
 
 export function filterPersonas({


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

No linked issue.

## Why this change

- Restores legacy persona panel parity for personas that are not assigned to any persona group.
- Root cause: the refactor group model only mapped persisted groups and did not derive the legacy UI-only `Ungrouped` bucket from the persona list.

## What changed

- Derive a synthetic `Ungrouped` persona group when one or more personas are outside every real group.
- Pass persona summaries into the group model so unassigned personas can be detected.
- Mark the synthetic group as UI-only and hide assign, rename, delete, and remove-member actions for it.
- Add focused model coverage for creating and omitting the synthetic group.

## Refactor impact

Primary owner:

- Catalog personas UI.

Impact areas reviewed:

- Persona panel model.
- Persona panel group wiring.
- Persona group UI mutation controls.
- Persona group storage hook contract.

Boundary notes:

- Feature-layer UI/model change only.
- No engine, shared API, Rust, storage schema, Tauri command, or remote runtime boundary changes.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm exec vitest run src/features/catalog/personas/lib/personas-panel-model.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm exec prettier --check src/features/catalog/personas/lib/personas-panel-model.ts src/features/catalog/personas/lib/personas-panel-model.test.ts src/features/catalog/personas/components/PersonasPanel.tsx src/features/catalog/personas/components/PersonaGroupsSection.tsx` passed.
- `git diff --check` passed.
- `pnpm check` passed.
- Native Tauri QA passed with `pnpm tauri dev --no-watch --config scratch\tauri-qa.config.json`: seeded temporary personas/groups through embedded Tauri storage, opened Personas, verified `GROUPS (2)`, `QA Real Group (1)`, expanded `Ungrouped (2)`, saw both ungrouped members, confirmed only the real group exposed assign/rename/delete actions, and cleaned up temp records.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed; this is a narrow UI parity bugfix.

## UI evidence

Native Tauri QA was completed locally for the persona grouping path. No screenshot is attached to this PR body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personas without assigned groups are now automatically organized into a system-managed "Ungrouped" group.

* **Improvements**
  * Synthetic groups are now read-only; management actions (rename, delete, assign) are hidden and persona removal is restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->