### PR TITLE
Fix persona import cache refresh

### DIFF
--- a/src/features/catalog/personas/components/ImportPersonaModal.tsx
+++ b/src/features/catalog/personas/components/ImportPersonaModal.tsx
@@ -5,7 +5,7 @@ import { useState, useRef } from "react";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import { Download, FileJson, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { personaKeys } from "../query-keys";
+import { invalidatePersonaCollectionQueries } from "../hooks/use-personas";
 import { importApi } from "../../../../shared/api/import-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 
@@ -126,7 +126,7 @@ export function ImportPersonaModal({ open, onClose }: Props) {
     setResults(nextResults);
     setStatus("done");
     if (nextResults.some((result) => result.success)) {
-      qc.invalidateQueries({ queryKey: personaKeys.list });
+      invalidatePersonaCollectionQueries(qc);
     }
   };
 

--- a/src/features/catalog/personas/hooks/use-personas.test.tsx
+++ b/src/features/catalog/personas/hooks/use-personas.test.tsx
@@ -11,6 +11,7 @@ import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import { personaKeys } from "../query-keys";
 import {
+  invalidatePersonaCollectionQueries,
   useDeletePersona,
   usePersona,
   usePersonaSummaries,
@@ -151,6 +152,20 @@ describe("persona hooks", () => {
   function expectActivePersonaInvalidated() {
     expect(queryClient.getQueryState(personaKeys.active)?.isInvalidated).toBe(true);
   }
+
+  it("invalidates persona list and summary caches together", () => {
+    queryClient.setQueryData(personaKeys.list, [{ id: "persona-1", name: "Full Persona" }]);
+    queryClient.setQueryData(personaKeys.summaries, [{ id: "persona-1", name: "Summary Persona" }]);
+    queryClient.setQueryData(personaKeys.detail("persona-1"), { id: "persona-1", name: "Detail Persona" });
+    queryClient.setQueryData(personaKeys.active, { id: "persona-1", name: "Active Persona" });
+
+    invalidatePersonaCollectionQueries(queryClient);
+
+    expect(queryClient.getQueryState(personaKeys.list)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(personaKeys.summaries)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(personaKeys.detail("persona-1"))?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(personaKeys.active)?.isInvalidated).toBe(false);
+  });
 
   it("projects persona summaries with file-backed avatar fields", async () => {
     storageListMock.mockResolvedValue([

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { personaKeys } from "../query-keys";
 import { personaApi } from "../../../../shared/api/persona-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -118,6 +118,11 @@ export function useActivePersona(enabled = true) {
   });
 }
 
+export function invalidatePersonaCollectionQueries(queryClient: Pick<QueryClient, "invalidateQueries">): void {
+  queryClient.invalidateQueries({ queryKey: personaKeys.list, exact: true });
+  queryClient.invalidateQueries({ queryKey: personaKeys.summaries, exact: true });
+}
+
 export function useCreatePersona() {
   const qc = useQueryClient();
   return useMutation({
@@ -140,8 +145,7 @@ export function useCreatePersona() {
       avatarCrop?: unknown;
     }) => storageApi.create("personas", data),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: personaKeys.list });
-      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      invalidatePersonaCollectionQueries(qc);
     },
   });
 }
@@ -187,8 +191,7 @@ export function useUpdatePersona() {
         });
       });
 
-      qc.invalidateQueries({ queryKey: personaKeys.list });
-      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      invalidatePersonaCollectionQueries(qc);
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.active });
@@ -203,8 +206,7 @@ export function useDeletePersona() {
     onSuccess: (_data, id) => {
       qc.removeQueries({ queryKey: personaKeys.detail(id) });
       qc.removeQueries({ queryKey: personaKeys.summaryDetail(id) });
-      qc.invalidateQueries({ queryKey: personaKeys.list });
-      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      invalidatePersonaCollectionQueries(qc);
       qc.invalidateQueries({ queryKey: personaKeys.active });
     },
   });
@@ -215,8 +217,7 @@ export function useDuplicatePersona() {
   return useMutation({
     mutationFn: (id: string) => storageCommandsApi.duplicate("personas", id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: personaKeys.list });
-      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      invalidatePersonaCollectionQueries(qc);
     },
   });
 }
@@ -226,8 +227,7 @@ export function useActivatePersona() {
   return useMutation({
     mutationFn: (id: string) => personaApi.activate(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: personaKeys.list });
-      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      invalidatePersonaCollectionQueries(qc);
       qc.invalidateQueries({ queryKey: personaKeys.active });
     },
   });
@@ -239,8 +239,7 @@ export function useUploadPersonaAvatar() {
     mutationFn: ({ id, avatar, filename }: { id: string; avatar: string; filename?: string }) =>
       personaApi.uploadAvatar(id, avatar, filename),
     onSuccess: (_data, variables) => {
-      qc.invalidateQueries({ queryKey: personaKeys.list });
-      qc.invalidateQueries({ queryKey: personaKeys.summaries });
+      invalidatePersonaCollectionQueries(qc);
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.active });

--- a/src/features/shell/imports/components/STBulkImportModal.tsx
+++ b/src/features/shell/imports/components/STBulkImportModal.tsx
@@ -29,7 +29,7 @@ import { ApiError } from "../../../../shared/api/api-errors";
 import { importApi } from "../../../../shared/api/import-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
 import { invalidateCharacterCollectionQueries } from "../../../catalog/characters/index";
-import { personaKeys } from "../../../catalog/personas/index";
+import { invalidatePersonaCollectionQueries } from "../../../catalog/personas/index";
 import { chatKeys } from "../../../catalog/chats/index";
 import { lorebookKeys } from "../../../catalog/lorebooks/index";
 import { presetKeys } from "../../../catalog/presets/index";
@@ -371,7 +371,7 @@ export function STBulkImportModal({ open, onClose }: Props) {
           qc.invalidateQueries({ queryKey: presetKeys.all });
         }
         if (hasImported(data.imported, "personas")) {
-          qc.invalidateQueries({ queryKey: personaKeys.list });
+          invalidatePersonaCollectionQueries(qc);
         }
         if (hasImported(data.imported, "backgrounds")) {
           qc.invalidateQueries({ queryKey: ["backgrounds"] });


### PR DESCRIPTION
## Linked issue

None.

## Why this change

Persona import refresh relied on `personaKeys.list` also matching summary queries by prefix. That worked with current React Query matching, but it made import refresh behavior easy to regress or misread after the refactor split full persona reads from summary reads.

## What changed

- Added `invalidatePersonaCollectionQueries()` to invalidate full persona lists and persona summaries explicitly.
- Switched direct persona import and SillyTavern bulk persona import to use the shared invalidation helper.
- Added a focused regression test proving the helper invalidates list and summary caches without broad invalidation of detail or active-persona caches.

## Refactor impact

Primary owner:

Catalog personas.

Impact areas reviewed:

- Direct persona import modal.
- SillyTavern bulk import modal.
- Persona panel summary query cache.
- Existing persona create/update/delete/duplicate/activate/avatar mutation cache refresh.

Boundary notes:

No engine, shared API, Rust, or remote-runtime contract changes. Change stays in React feature/cache ownership.

Pressure points touched:

Import modal surfaces only; no broad mode surfaces or Tauri command registration touched.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated validation run by Codex:

- `pnpm vitest run src/features/catalog/personas/hooks/use-personas.test.tsx`
- `pnpm typecheck`
- `pnpm check:architecture`
- `git diff --check origin/refactor...HEAD`
- Local React Query refetch probe confirmed list and summaries each refetch once after exact invalidation.

No native Tauri manual QA was run; this is a React Query cache-refresh-only change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note updates made; behavior change is internal cache refresh.

## UI evidence

Not applicable; no visible layout change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal cache management for persona imports and bulk import operations to improve code maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->