### PR TITLE
[codex] Extract active lorebook scanner

### DIFF
--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -1,0 +1,634 @@
+import type { StorageGateway } from "../capabilities/storage";
+import type { LorebookEntry, LorebookEntryTimingState, LorebookMatchingSource } from "../contracts/types/lorebook";
+import { LIMITS } from "../contracts/constants/defaults";
+import {
+  applyTokenBudgetWithSkipped,
+  processActivatedEntries,
+  type BudgetSkippedActivatedEntry,
+} from "../generation-core/lorebooks/prompt-injector";
+import {
+  resolveGameLorebookScopeExclusions,
+  type LorebookScopeExclusions,
+} from "../generation-core/lorebooks/game-lorebook-scope";
+import {
+  recursiveScan,
+  scanForActivatedEntries,
+  updateTimingStatesForScan,
+  type ActivatedEntry,
+  type EntryTimingState,
+  type ScanMessage,
+  type ScanOptions,
+} from "../generation-core/lorebooks/keyword-scanner";
+import {
+  boolish,
+  hiddenFromAi,
+  isRecord,
+  parseRecord,
+  readNumber,
+  readString,
+  stringArray,
+  type JsonRecord,
+} from "./runtime-records";
+
+export interface LorebookActivationCharacterContext {
+  id: string;
+  name: string;
+  description: string;
+  personality?: string;
+  scenario?: string;
+  tags: string[];
+}
+
+export interface LorebookActivationPersonaContext {
+  name: string;
+  description: string;
+  personality?: string;
+  backstory?: string;
+  appearance?: string;
+  scenario?: string;
+  tags: string[];
+}
+
+export interface BudgetSkippedLorebookEntry {
+  id: string;
+  name: string;
+  lorebookId: string;
+  lorebookName: string;
+  matchedKeys: string[];
+  estimatedTokens: number;
+  lorebookBudget: number;
+  lorebookUsedTokens: number;
+  chatBudget: number;
+  chatUsedTokens: number;
+  blockedBy: "lorebook" | "chat" | "both";
+}
+
+type ActiveLorebookScopeReasonType = "global" | "character" | "persona" | "chat" | "selected";
+
+interface ActiveLorebookScopeReason {
+  lorebookId: string;
+  lorebookName: string;
+  reason: ActiveLorebookScopeReasonType;
+  matchedIds: string[];
+}
+
+export interface LorebookSemanticScanStatus {
+  state: "not_applicable" | "missing_embedding_source" | "empty_query" | "ready" | "unavailable" | "failed";
+  vectorizedEntryCount: number;
+}
+
+interface LorebookEmbeddingSource {
+  embed(texts: string[]): Promise<number[][] | null>;
+}
+
+interface LoadedLorebookBudgetSkippedEntry {
+  activatedEntry: ActivatedEntry;
+  lorebookName: string;
+  lorebookBudget: number;
+  lorebookUsedTokens: number;
+  estimatedTokens: number;
+}
+
+interface ScannedLorebookEntries {
+  activatedEntries: ActivatedEntry[];
+  budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
+  entriesForTiming: LorebookEntry[];
+}
+
+interface LoadedActivatedLore {
+  activatedEntries: ActivatedEntry[];
+  budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
+  entriesForTiming: LorebookEntry[];
+  previousTimingStates: Map<string, EntryTimingState>;
+  lorebookNamesById: Map<string, string>;
+  currentMessageIndex: number;
+  activeLorebookReasons: ActiveLorebookScopeReason[];
+  scopeExclusions: LorebookScopeExclusions;
+  semanticStatus: LorebookSemanticScanStatus;
+}
+
+export interface ActiveLorebookScannerInput {
+  storage: StorageGateway;
+  chat: JsonRecord;
+  characters: LorebookActivationCharacterContext[];
+  persona: LorebookActivationPersonaContext | null;
+  storedMessages: JsonRecord[];
+  request?: JsonRecord;
+  latestUserInput?: string;
+  embeddingSource?: LorebookEmbeddingSource | null;
+  ignoreTiming?: boolean;
+}
+
+export interface ActiveLorebookScannerResult {
+  activatedEntries: ActivatedEntry[];
+  processedLore: ReturnType<typeof processActivatedEntries>;
+  entriesForTiming: LorebookEntry[];
+  previousTimingStates: Map<string, EntryTimingState>;
+  nextTimingStates: Map<string, EntryTimingState>;
+  lorebookTimingStates: Record<string, LorebookEntryTimingState> | null;
+  budgetSkippedLorebookEntries: BudgetSkippedLorebookEntry[];
+  lorebookNamesById: Map<string, string>;
+  currentMessageIndex: number;
+  activeLorebookReasons: ActiveLorebookScopeReason[];
+  scopeExclusions: LorebookScopeExclusions;
+  semanticStatus: LorebookSemanticScanStatus;
+}
+
+const MAX_LOREBOOK_RECURSION_DEPTH = 10;
+
+function nonNegativeInteger(value: unknown, fallback = 0): number {
+  return Math.max(0, Math.floor(readNumber(value, fallback)));
+}
+
+function stringRecord(value: unknown): Record<string, string> {
+  const record = parseRecord(value);
+  return Object.fromEntries(
+    Object.entries(record)
+      .filter((entry): entry is [string, string | number | boolean] =>
+        ["string", "number", "boolean"].includes(typeof entry[1]),
+      )
+      .map(([key, entry]) => [key, String(entry)]),
+  );
+}
+
+function normalizeRole(value: unknown): "system" | "user" | "assistant" {
+  const role = readString(value, "system").toLowerCase();
+  return role === "user" || role === "assistant" ? role : "system";
+}
+
+function normalizeLorebookEntry(entry: JsonRecord): LorebookEntry {
+  return {
+    id: readString(entry.id),
+    lorebookId: readString(entry.lorebookId),
+    name: readString(entry.name) || "Entry",
+    content: readString(entry.content),
+    description: readString(entry.description),
+    keys: stringArray(entry.keys),
+    secondaryKeys: stringArray(entry.secondaryKeys),
+    selective: boolish(entry.selective, false),
+    selectiveLogic: readString(entry.selectiveLogic, "and") as LorebookEntry["selectiveLogic"],
+    constant: boolish(entry.constant, false),
+    enabled: boolish(entry.enabled, true),
+    position: readNumber(entry.position, 0),
+    role: normalizeRole(entry.role) as LorebookEntry["role"],
+    depth: readNumber(entry.depth, 0),
+    order: readNumber(entry.order ?? entry.sortOrder, 0),
+    probability: entry.probability == null ? null : readNumber(entry.probability, 100),
+    useRegex: boolish(entry.useRegex, false),
+    matchWholeWords: boolish(entry.matchWholeWords, false),
+    caseSensitive: boolish(entry.caseSensitive, false),
+    ephemeral: entry.ephemeral == null ? null : readNumber(entry.ephemeral, 0),
+    group: readString(entry.group),
+    groupWeight: entry.groupWeight == null ? null : readNumber(entry.groupWeight, 100),
+    folderId: readString(entry.folderId) || null,
+    locked: boolish(entry.locked, false),
+    preventRecursion: boolish(entry.preventRecursion, false),
+    tag: readString(entry.tag),
+    relationships: stringRecord(entry.relationships),
+    dynamicState: parseRecord(entry.dynamicState),
+    scanDepth: entry.scanDepth == null ? null : readNumber(entry.scanDepth, 0),
+    sticky: entry.sticky == null ? null : readNumber(entry.sticky, 0),
+    cooldown: entry.cooldown == null ? null : readNumber(entry.cooldown, 0),
+    delay: entry.delay == null ? null : readNumber(entry.delay, 0),
+    activationConditions: Array.isArray(entry.activationConditions) ? entry.activationConditions : [],
+    schedule: isRecord(entry.schedule) ? (entry.schedule as unknown as LorebookEntry["schedule"]) : null,
+    excludeFromVectorization: boolish(entry.excludeFromVectorization, false),
+    embedding: Array.isArray(entry.embedding)
+      ? entry.embedding.filter((item): item is number => typeof item === "number")
+      : null,
+    additionalMatchingSources: stringArray(
+      entry.additionalMatchingSources,
+    ) as LorebookEntry["additionalMatchingSources"],
+    characterFilterMode: readString(entry.characterFilterMode, "any") as LorebookEntry["characterFilterMode"],
+    characterFilterIds: stringArray(entry.characterFilterIds),
+    characterTagFilterMode: readString(entry.characterTagFilterMode, "any") as LorebookEntry["characterTagFilterMode"],
+    characterTagFilters: stringArray(entry.characterTagFilters),
+    generationTriggerFilterMode: readString(
+      entry.generationTriggerFilterMode,
+      "any",
+    ) as LorebookEntry["generationTriggerFilterMode"],
+    generationTriggerFilters: stringArray(entry.generationTriggerFilters),
+    createdAt: readString(entry.createdAt),
+    updatedAt: readString(entry.updatedAt),
+  };
+}
+
+function resolveActiveLorebookScopeReason(
+  lorebook: JsonRecord,
+  chat: JsonRecord,
+  characters: LorebookActivationCharacterContext[],
+  persona: LorebookActivationPersonaContext | null,
+  scopeExclusions: LorebookScopeExclusions = resolveGameLorebookScopeExclusions(
+    readString(chat.mode || chat.chatMode),
+    parseRecord(chat.metadata),
+  ),
+): ActiveLorebookScopeReason | null {
+  if (!boolish(lorebook.enabled, true)) return null;
+  const lorebookId = readString(lorebook.id);
+  const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
+  if (scopeExclusions.excludedLorebookIds.includes(lorebookId)) return null;
+  if (scopeExclusions.excludedSourceAgentIds.includes(readString(lorebook.sourceAgentId))) return null;
+  if (boolish(lorebook.isGlobal ?? lorebook.global, false)) {
+    return { lorebookId, lorebookName, reason: "global", matchedIds: [] };
+  }
+
+  const activeIds = new Set(characters.map((character) => character.id));
+  const lorebookCharacterIds = stringArray(lorebook.characterIds);
+  const matchedCharacterIds = [
+    ...lorebookCharacterIds.filter((id) => activeIds.has(id)),
+    readString(lorebook.characterId),
+  ].filter((id, index, ids) => id && activeIds.has(id) && ids.indexOf(id) === index);
+  if (matchedCharacterIds.length > 0) {
+    return { lorebookId, lorebookName, reason: "character", matchedIds: matchedCharacterIds };
+  }
+
+  const personaId = readString(chat.personaId);
+  if (persona && personaId) {
+    const personaIds = stringArray(lorebook.personaIds);
+    if (personaIds.includes(personaId) || readString(lorebook.personaId) === personaId) {
+      return { lorebookId, lorebookName, reason: "persona", matchedIds: [personaId] };
+    }
+  }
+
+  const chatId = readString(chat.id).trim();
+  const chatScopedId = readString(lorebook.chatId).trim();
+  if (chatScopedId && chatScopedId === chatId) {
+    return { lorebookId, lorebookName, reason: "chat", matchedIds: [chatId] };
+  }
+
+  const meta = parseRecord(chat.metadata);
+  if (stringArray(meta.activeLorebookIds ?? chat.activeLorebookIds).includes(lorebookId)) {
+    return { lorebookId, lorebookName, reason: "selected", matchedIds: [lorebookId] };
+  }
+
+  return null;
+}
+
+export function lorebookAppliesToContext(
+  lorebook: JsonRecord,
+  chat: JsonRecord,
+  characters: LorebookActivationCharacterContext[],
+  persona: LorebookActivationPersonaContext | null,
+): boolean {
+  return !!resolveActiveLorebookScopeReason(lorebook, chat, characters, persona);
+}
+
+function joinMatchingSourceParts(parts: Array<string | undefined>): string {
+  return parts
+    .map((part) => part?.trim() ?? "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildAdditionalMatchingSourceText(
+  characters: LorebookActivationCharacterContext[],
+  persona: LorebookActivationPersonaContext | null,
+): Partial<Record<LorebookMatchingSource, string>> {
+  return {
+    character_name: joinMatchingSourceParts(characters.map((character) => character.name)),
+    character_description: joinMatchingSourceParts(characters.map((character) => character.description)),
+    character_personality: joinMatchingSourceParts(characters.map((character) => character.personality)),
+    character_scenario: joinMatchingSourceParts(characters.map((character) => character.scenario)),
+    character_tags: joinMatchingSourceParts(characters.flatMap((character) => character.tags)),
+    persona_description: persona?.description ?? "",
+    persona_tags: joinMatchingSourceParts(persona?.tags ?? []),
+  };
+}
+
+function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): number {
+  const meta = parseRecord(chat.metadata);
+  return nonNegativeInteger(
+    request.lorebookTokenBudget,
+    readNumber(meta.lorebookTokenBudget, LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET),
+  );
+}
+
+function resolveLorebookRecursionDepth(lorebook: JsonRecord): number {
+  return Math.min(MAX_LOREBOOK_RECURSION_DEPTH, Math.max(1, nonNegativeInteger(lorebook.maxRecursionDepth, 3)));
+}
+
+function normalizeLorebookTimingState(value: unknown): EntryTimingState | null {
+  if (!isRecord(value)) return null;
+  const stickyCount = readNumber(value.stickyCount, Number.NaN);
+  const cooldownRemaining = readNumber(value.cooldownRemaining, Number.NaN);
+  const delayRemaining = readNumber(value.delayRemaining, Number.NaN);
+  if (![stickyCount, cooldownRemaining, delayRemaining].every(Number.isFinite)) return null;
+  const lastActivatedAt =
+    value.lastActivatedAt === null || value.lastActivatedAt === undefined
+      ? null
+      : readNumber(value.lastActivatedAt, Number.NaN);
+  if (lastActivatedAt !== null && !Number.isFinite(lastActivatedAt)) return null;
+  return {
+    lastActivatedAt: lastActivatedAt === null ? null : Math.max(0, Math.trunc(lastActivatedAt)),
+    stickyCount: Math.max(0, Math.trunc(stickyCount)),
+    cooldownRemaining: Math.max(0, Math.trunc(cooldownRemaining)),
+    delayRemaining: Math.max(0, Math.trunc(delayRemaining)),
+  };
+}
+
+function lorebookTimingStateMap(value: unknown): Map<string, EntryTimingState> {
+  const states = new Map<string, EntryTimingState>();
+  for (const [entryId, state] of Object.entries(parseRecord(value))) {
+    const normalizedId = entryId.trim();
+    const normalizedState = normalizeLorebookTimingState(state);
+    if (normalizedId && normalizedState) states.set(normalizedId, normalizedState);
+  }
+  return states;
+}
+
+function serializeLorebookTimingStates(
+  states: Map<string, EntryTimingState>,
+): Record<string, LorebookEntryTimingState> {
+  return Object.fromEntries(
+    [...states.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([entryId, state]) => [
+        entryId,
+        {
+          lastActivatedAt: state.lastActivatedAt,
+          stickyCount: state.stickyCount,
+          cooldownRemaining: state.cooldownRemaining,
+          delayRemaining: state.delayRemaining,
+        },
+      ]),
+  );
+}
+
+function lorebookTimingStatesChanged(
+  previous: Map<string, EntryTimingState>,
+  next: Map<string, EntryTimingState>,
+): boolean {
+  if (previous.size !== next.size) return true;
+  for (const [entryId, previousState] of previous) {
+    const nextState = next.get(entryId);
+    if (!nextState) return true;
+    if (
+      previousState.lastActivatedAt !== nextState.lastActivatedAt ||
+      previousState.stickyCount !== nextState.stickyCount ||
+      previousState.cooldownRemaining !== nextState.cooldownRemaining ||
+      previousState.delayRemaining !== nextState.delayRemaining
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function loadLorebookEntriesForActivation(
+  storage: StorageGateway,
+  lorebook: JsonRecord,
+): Promise<LorebookEntry[]> {
+  const id = readString(lorebook.id);
+  if (!id) return [];
+  const [rows, folders] = await Promise.all([
+    storage.listLorebookEntries<JsonRecord>(id),
+    storage.list<JsonRecord>("lorebook-folders", { filters: { lorebookId: id } }),
+  ]);
+  const disabledFolderIds = new Set(
+    folders
+      .filter((folder) => !boolish(folder.enabled, true))
+      .map((folder) => readString(folder.id))
+      .filter(Boolean),
+  );
+  const defaultScanDepth = nonNegativeInteger(lorebook.scanDepth, 0);
+  const excludeFromVectorization = boolish(lorebook.excludeFromVectorization, false);
+  return rows
+    .map((row) => normalizeLorebookEntry(excludeFromVectorization ? { ...row, excludeFromVectorization: true } : row))
+    .map((entry) => ({
+      ...entry,
+      scanDepth: entry.scanDepth == null ? defaultScanDepth : entry.scanDepth,
+    }))
+    .filter((entry) => entry.enabled && entry.content.trim())
+    .filter((entry) => !entry.folderId || !disabledFolderIds.has(entry.folderId));
+}
+
+function scanLorebookEntries(
+  messages: ScanMessage[],
+  entries: LorebookEntry[],
+  lorebook: JsonRecord,
+  options: ScanOptions,
+): ScannedLorebookEntries {
+  const activated = boolish(lorebook.recursiveScanning, false)
+    ? recursiveScan(messages, entries, options, resolveLorebookRecursionDepth(lorebook))
+    : scanForActivatedEntries(messages, entries, options);
+  const lorebookId = readString(lorebook.id);
+  const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
+  const lorebookBudget = nonNegativeInteger(lorebook.tokenBudget, 0);
+  const budgeted = applyTokenBudgetWithSkipped(activated, lorebookBudget);
+  return {
+    activatedEntries: budgeted.includedEntries,
+    budgetSkippedEntries: budgeted.skippedEntries.map((skipped) => ({
+      activatedEntry: skipped.activatedEntry,
+      lorebookName,
+      lorebookBudget,
+      lorebookUsedTokens: skipped.usedTokensBefore,
+      estimatedTokens: skipped.estimatedTokens,
+    })),
+    entriesForTiming: entries,
+  };
+}
+
+function semanticQueryText(messages: ScanMessage[], latestUserInput: string | undefined): string {
+  const latest = latestUserInput?.trim();
+  if (latest) return latest;
+  return messages
+    .slice(-10)
+    .map((message) => message.content.trim())
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function countSemanticCandidateEntries(entries: LorebookEntry[]): number {
+  return entries.filter(
+    (entry) =>
+      !entry.constant &&
+      !entry.excludeFromVectorization &&
+      Array.isArray(entry.embedding) &&
+      entry.embedding.some((value) => Number.isFinite(value)),
+  ).length;
+}
+
+async function resolveSemanticChatEmbedding(
+  messages: ScanMessage[],
+  latestUserInput: string | undefined,
+  embeddingSource: LorebookEmbeddingSource | null | undefined,
+  vectorizedEntryCount: number,
+): Promise<{ chatEmbedding: number[] | null; status: LorebookSemanticScanStatus }> {
+  if (vectorizedEntryCount === 0) {
+    return { chatEmbedding: null, status: { state: "not_applicable", vectorizedEntryCount } };
+  }
+  if (!embeddingSource) {
+    return { chatEmbedding: null, status: { state: "missing_embedding_source", vectorizedEntryCount } };
+  }
+  const query = semanticQueryText(messages, latestUserInput);
+  if (!query) {
+    return { chatEmbedding: null, status: { state: "empty_query", vectorizedEntryCount } };
+  }
+  try {
+    const sourceEmbedding = await embeddingSource.embed([query]);
+    const vector = sourceEmbedding?.[0]?.filter((value): value is number => Number.isFinite(value));
+    if (!vector?.length) {
+      return { chatEmbedding: null, status: { state: "unavailable", vectorizedEntryCount } };
+    }
+    return { chatEmbedding: vector, status: { state: "ready", vectorizedEntryCount } };
+  } catch {
+    return { chatEmbedding: null, status: { state: "failed", vectorizedEntryCount } };
+  }
+}
+
+async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<LoadedActivatedLore> {
+  const meta = parseRecord(input.chat.metadata);
+  const scopeExclusions = resolveGameLorebookScopeExclusions(readString(input.chat.mode || input.chat.chatMode), meta);
+  const scopedLorebooks = (await input.storage.list<JsonRecord>("lorebooks"))
+    .map((book) => ({
+      book,
+      reason: resolveActiveLorebookScopeReason(book, input.chat, input.characters, input.persona, scopeExclusions),
+    }))
+    .filter((entry): entry is { book: JsonRecord; reason: ActiveLorebookScopeReason } => !!entry.reason);
+  const lorebooks = scopedLorebooks.map((entry) => entry.book);
+  const activeLorebookReasons = scopedLorebooks.map((entry) => entry.reason);
+  const activeCharacterIds = input.characters.map((character) => character.id);
+  const activeCharacterTags = input.characters.flatMap((character) => character.tags);
+  const gameState = parseRecord(input.chat.gameState ?? meta.gameState);
+  const previousTimingStates = lorebookTimingStateMap(meta.entryTimingStates);
+  const messages = input.storedMessages
+    .filter((message) => !hiddenFromAi(message))
+    .map((message) => ({
+      role: readString(message.role, "user"),
+      content: readString(message.content),
+    }));
+  const generationTriggers = ["chat", readString(input.chat.mode || input.chat.chatMode)].filter(Boolean);
+  const lorebookNamesById = new Map(
+    lorebooks.map((book) => {
+      const id = readString(book.id);
+      return [id, readString(book.name, id || "Lorebook")] as const;
+    }),
+  );
+  const entriesByBook = await Promise.all(
+    lorebooks.map(async (book) => ({ book, entries: await loadLorebookEntriesForActivation(input.storage, book) })),
+  );
+  const vectorizedEntryCount = entriesByBook.reduce(
+    (sum, item) => sum + countSemanticCandidateEntries(item.entries),
+    0,
+  );
+  const semantic = await resolveSemanticChatEmbedding(
+    messages,
+    input.latestUserInput,
+    input.embeddingSource,
+    vectorizedEntryCount,
+  );
+  const options: ScanOptions = {
+    activeCharacterIds,
+    activeCharacterTags,
+    generationTriggers,
+    gameState,
+    timingStates: previousTimingStates,
+    currentMessageIndex: messages.length,
+    additionalMatchingSourceText: buildAdditionalMatchingSourceText(input.characters, input.persona),
+    chatEmbedding: semantic.chatEmbedding,
+    ignoreTiming: input.ignoreTiming,
+  };
+  const scanned = entriesByBook.map(({ book, entries }) => scanLorebookEntries(messages, entries, book, options));
+  return {
+    activatedEntries: scanned
+      .flatMap((result) => result.activatedEntries)
+      .sort((a, b) => a.injectionOrder - b.injectionOrder),
+    budgetSkippedEntries: scanned.flatMap((result) => result.budgetSkippedEntries),
+    entriesForTiming: scanned.flatMap((result) => result.entriesForTiming),
+    previousTimingStates,
+    lorebookNamesById,
+    currentMessageIndex: messages.length,
+    activeLorebookReasons,
+    scopeExclusions,
+    semanticStatus: semantic.status,
+  };
+}
+
+function lorebookBudgetSkippedLoreForEvent(
+  skipped: LoadedLorebookBudgetSkippedEntry,
+  chatBudget: number,
+): BudgetSkippedLorebookEntry {
+  const entry = skipped.activatedEntry.entry;
+  return {
+    id: entry.id,
+    name: entry.name,
+    lorebookId: entry.lorebookId,
+    lorebookName: skipped.lorebookName,
+    matchedKeys: skipped.activatedEntry.matchedKeys,
+    estimatedTokens: skipped.estimatedTokens,
+    lorebookBudget: skipped.lorebookBudget,
+    lorebookUsedTokens: skipped.lorebookUsedTokens,
+    chatBudget,
+    chatUsedTokens: 0,
+    blockedBy: "lorebook",
+  };
+}
+
+function budgetSkippedLoreForEvent(
+  skipped: BudgetSkippedActivatedEntry,
+  lorebookNamesById: Map<string, string>,
+  chatBudget: number,
+): BudgetSkippedLorebookEntry {
+  const entry = skipped.activatedEntry.entry;
+  return {
+    id: entry.id,
+    name: entry.name,
+    lorebookId: entry.lorebookId,
+    lorebookName: lorebookNamesById.get(entry.lorebookId) ?? entry.lorebookId,
+    matchedKeys: skipped.activatedEntry.matchedKeys,
+    estimatedTokens: skipped.estimatedTokens,
+    lorebookBudget: 0,
+    lorebookUsedTokens: 0,
+    chatBudget,
+    chatUsedTokens: skipped.usedTokensBefore,
+    blockedBy: "chat",
+  };
+}
+
+export function lorebookActivatedEntryForEvent(entry: ActivatedEntry) {
+  return {
+    id: entry.entry.id,
+    lorebookId: entry.entry.lorebookId,
+    name: entry.entry.name,
+    content: entry.entry.content,
+    tag: entry.matchedKeys.join(", "),
+    matchedKeys: entry.matchedKeys,
+    order: entry.entry.order,
+    constant: entry.entry.constant,
+  };
+}
+
+export async function scanActiveLorebooks(input: ActiveLorebookScannerInput): Promise<ActiveLorebookScannerResult> {
+  const loadedLore = await loadActivatedLore(input);
+  const lorebookTokenBudget = resolveLorebookTokenBudget(input.chat, input.request ?? {});
+  const processedLore = processActivatedEntries(loadedLore.activatedEntries, lorebookTokenBudget);
+  const nextTimingStates = updateTimingStatesForScan(
+    loadedLore.entriesForTiming,
+    processedLore.includedEntries,
+    loadedLore.previousTimingStates,
+    loadedLore.currentMessageIndex,
+  );
+  const lorebookTimingStates = lorebookTimingStatesChanged(loadedLore.previousTimingStates, nextTimingStates)
+    ? serializeLorebookTimingStates(nextTimingStates)
+    : null;
+  const budgetSkippedLorebookEntries = [
+    ...loadedLore.budgetSkippedEntries.map((entry) => lorebookBudgetSkippedLoreForEvent(entry, lorebookTokenBudget)),
+    ...processedLore.skippedEntries.map((entry) =>
+      budgetSkippedLoreForEvent(entry, loadedLore.lorebookNamesById, lorebookTokenBudget),
+    ),
+  ];
+  return {
+    activatedEntries: loadedLore.activatedEntries,
+    processedLore,
+    entriesForTiming: loadedLore.entriesForTiming,
+    previousTimingStates: loadedLore.previousTimingStates,
+    nextTimingStates,
+    lorebookTimingStates,
+    budgetSkippedLorebookEntries,
+    lorebookNamesById: loadedLore.lorebookNamesById,
+    currentMessageIndex: loadedLore.currentMessageIndex,
+    activeLorebookReasons: loadedLore.activeLorebookReasons,
+    scopeExclusions: loadedLore.scopeExclusions,
+    semanticStatus: loadedLore.semanticStatus,
+  };
+}

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -1,6 +1,12 @@
 import type { StorageGateway } from "../capabilities/storage";
-import { loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
-import { assembleGenerationPrompt, type BudgetSkippedLorebookEntry } from "./prompt-assembly";
+import {
+  lorebookActivatedEntryForEvent,
+  scanActiveLorebooks,
+  type BudgetSkippedLorebookEntry,
+  type LorebookSemanticScanStatus,
+} from "./active-lorebook-scanner";
+import { loadChatMessages, requireRecord } from "./context";
+import { loadCharacters, loadPersona } from "./prompt-assembly";
 
 export interface ActiveLorebookScanResult {
   entries: Array<{
@@ -15,6 +21,7 @@ export interface ActiveLorebookScanResult {
   budgetSkippedEntries: BudgetSkippedLorebookEntry[];
   totalTokens: number;
   totalEntries: number;
+  semanticStatus: LorebookSemanticScanStatus;
 }
 
 export async function scanActiveLorebookEntries(
@@ -22,28 +29,35 @@ export async function scanActiveLorebookEntries(
   chatId: string,
 ): Promise<ActiveLorebookScanResult> {
   const chat = requireRecord(await storage.get("chats", chatId), "Chat");
-  const connection = await resolveGenerationConnection(storage, chat, {});
   const storedMessages = await loadChatMessages(storage, chatId);
-  const assembly = await assembleGenerationPrompt(storage, {
+  const characters = await loadCharacters(storage, chat);
+  const persona = await loadPersona(storage, chat);
+  const scan = await scanActiveLorebooks({
+    storage,
     chat,
+    characters,
+    persona,
     storedMessages,
-    connection,
     request: {},
     latestUserInput: "",
   });
-  const entries = assembly.activatedLorebookEntries.map((entry) => ({
-    id: entry.id,
-    name: entry.name,
-    content: entry.content,
-    keys: entry.matchedKeys,
-    lorebookId: entry.lorebookId,
-    order: entry.order,
-    constant: entry.constant,
-  }));
+  const entries = scan.processedLore.includedEntries.map((entry) => {
+    const event = lorebookActivatedEntryForEvent(entry);
+    return {
+      id: event.id,
+      name: event.name,
+      content: event.content,
+      keys: event.matchedKeys,
+      lorebookId: event.lorebookId,
+      order: event.order,
+      constant: event.constant,
+    };
+  });
   return {
     entries,
-    budgetSkippedEntries: assembly.budgetSkippedLorebookEntries,
+    budgetSkippedEntries: scan.budgetSkippedLorebookEntries,
     totalTokens: Math.ceil(entries.reduce((sum, entry) => sum + entry.content.length, 0) / 4),
     totalEntries: entries.length,
+    semanticStatus: scan.semanticStatus,
   };
 }

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1486,6 +1486,68 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
     expect(promptText(assembly)).toContain("LQA_ADDITIONAL_PERSONA_SOURCE_CONTENT");
   });
 
+  it("uses the generation embedding source for semantic lorebook activation", async () => {
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-semantic",
+          lorebookId: "lorebook",
+          name: "Semantic moonlit lore",
+          content: "LQA_SEMANTIC_LORE_CONTENT_SHOULD_APPEAR",
+          keys: ["LQA_KEYWORD_NOT_IN_CHAT"],
+          embedding: [1, 0],
+          enabled: true,
+        },
+      ]),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [{ role: "user", content: "No keyword appears here.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "semantic-only moonlit query",
+        embeddingSource: { embed: async () => [[1, 0]] },
+      },
+    );
+
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Semantic moonlit lore"]);
+    expect(assembly.activatedLorebookEntries[0]?.matchedKeys).toEqual(["[semantic:1.000]"]);
+    expect(promptText(assembly)).toContain("LQA_SEMANTIC_LORE_CONTENT_SHOULD_APPEAR");
+  });
+
+  it("does not request semantic embeddings for vectorized constant-only lore", async () => {
+    let embedCalls = 0;
+    const assembly = await assembleGenerationPrompt(
+      storageWithLore([
+        {
+          id: "entry-constant-vectorized",
+          lorebookId: "lorebook",
+          name: "Constant vectorized lore",
+          content: "LQA_CONSTANT_VECTORIZED_CONTENT",
+          constant: true,
+          embedding: [1, 0],
+          enabled: true,
+        },
+      ]),
+      {
+        chat: { id: "chat", mode: "roleplay" },
+        storedMessages: [{ role: "user", content: "No keyword appears here.", contextKind: "history" }],
+        connection: {},
+        request: { ...request, promptPresetId: "" },
+        latestUserInput: "semantic query should not be embedded",
+        embeddingSource: {
+          embed: async () => {
+            embedCalls += 1;
+            return [[1, 0]];
+          },
+        },
+      },
+    );
+
+    expect(embedCalls).toBe(0);
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Constant vectorized lore"]);
+    expect(promptText(assembly)).toContain("LQA_CONSTANT_VECTORIZED_CONTENT");
+  });
+
   it("applies lorebook-level scan depth to entries without an override", async () => {
     const assembly = await assembleGenerationPrompt(
       storageWithLore(
@@ -1676,7 +1738,8 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
         return baseStorage.get<T>(entity, id);
       },
       list: async <T>(entity: string, options?: { filters?: Record<string, unknown> }) => {
-        if (entity === "connections") return [{}] as T[];
+        if (entity === "connections")
+          throw new Error("active lorebook scans should not resolve generation connections");
         return baseStorage.list<T>(entity, options);
       },
       listChatMessages: async () => [],
@@ -1693,6 +1756,36 @@ describe("assembleGenerationPrompt lorebook activation settings", () => {
         chatBudget: 1,
       },
     ]);
+  });
+
+  it("reports keyword-only active scans when vectorized entries lack an embedding source", async () => {
+    const baseStorage = storageWithLore([
+      {
+        id: "entry-vectorized",
+        lorebookId: "lorebook",
+        name: "Vectorized moonlit lore",
+        content: "LQA_VECTORIZED_CONTENT_SHOULD_NOT_APPEAR",
+        keys: ["LQA_KEYWORD_NOT_IN_CHAT"],
+        embedding: [1, 0],
+        enabled: true,
+      },
+    ]);
+    const storage: StorageGateway = {
+      ...baseStorage,
+      get: async <T>(entity: string, id: string) => {
+        if (entity === "chats" && id === "chat") {
+          return { id: "chat", mode: "roleplay", metadata: {} } as T;
+        }
+        return baseStorage.get<T>(entity, id);
+      },
+      listChatMessages: async <T>() =>
+        [{ role: "user", content: "No keyword appears here.", contextKind: "history" }] as T[],
+    };
+
+    const scan = await scanActiveLorebookEntries(storage, "chat");
+
+    expect(scan.entries).toHaveLength(0);
+    expect(scan.semanticStatus).toEqual({ state: "missing_embedding_source", vectorizedEntryCount: 1 });
   });
 
   it("applies per-lorebook token budgets before prompt injection", async () => {
@@ -2185,6 +2278,58 @@ describe("assembleGenerationPrompt conversation scene awareness gates", () => {
     const prompt = assembly.messages.map((message) => message.content).join("\n\n");
     expect(prompt).toContain("A memory found only by provider vector.");
     expect(prompt).not.toContain("A memory with another vector.");
+  });
+
+  it("reuses one provider embedding query for semantic lorebook activation and memory recall", async () => {
+    const base = storageWithLore([
+      {
+        id: "semantic-lore",
+        lorebookId: "lorebook",
+        name: "Shared semantic lore",
+        content: "LQA_SHARED_EMBEDDING_LORE_CONTENT",
+        keys: ["LQA_KEYWORD_NOT_IN_CHAT"],
+        embedding: [1, 0, 0],
+        enabled: true,
+      },
+    ]);
+    const storage: StorageGateway = {
+      ...base,
+      listChatMemories: async <T>() =>
+        [
+          {
+            id: "memory-hit",
+            content: "LQA_SHARED_EMBEDDING_MEMORY_CONTENT",
+            embedding: [1, 0, 0],
+            embeddingSource: "provider",
+          },
+        ] as T[],
+    };
+    let embedCalls = 0;
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "conversation-chat",
+        mode: "conversation",
+        characterIds: [],
+        metadata: {},
+      },
+      storedMessages: [{ role: "user", content: "No keyword appears here.", contextKind: "history" }],
+      connection: {},
+      request: { ...request, promptPresetId: "" },
+      latestUserInput: "shared semantic query",
+      embeddingSource: {
+        embed: async () => {
+          embedCalls += 1;
+          return [[1, 0, 0]];
+        },
+      },
+    });
+
+    const prompt = assembly.messages.map((message) => message.content).join("\n\n");
+    expect(embedCalls).toBe(1);
+    expect(assembly.activatedLorebookEntries.map((entry) => entry.name)).toEqual(["Shared semantic lore"]);
+    expect(prompt).toContain("LQA_SHARED_EMBEDDING_LORE_CONTENT");
+    expect(prompt).toContain("LQA_SHARED_EMBEDDING_MEMORY_CONTENT");
   });
 
   it("keeps normal conversation summaries when conversation cross-chat awareness is off", async () => {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1,24 +1,9 @@
-import type { LorebookEntry, LorebookEntryTimingState, LorebookMatchingSource } from "../contracts/types/lorebook";
+import type { LorebookEntryTimingState } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
 import type { CharacterData } from "../contracts/types/character";
 import type { StorageGateway } from "../capabilities/storage";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
-import {
-  applyTokenBudgetWithSkipped,
-  injectAtDepth,
-  processActivatedEntries,
-  type BudgetSkippedActivatedEntry,
-} from "../generation-core/lorebooks/prompt-injector";
-import {
-  recursiveScan,
-  scanForActivatedEntries,
-  updateTimingStatesForScan,
-  type ActivatedEntry,
-  type EntryTimingState,
-  type ScanMessage,
-  type ScanOptions,
-} from "../generation-core/lorebooks/keyword-scanner";
-import { resolveGameLorebookScopeExclusions } from "../generation-core/lorebooks/game-lorebook-scope";
+import { injectAtDepth } from "../generation-core/lorebooks/prompt-injector";
 import { wrapContent, wrapGroup } from "../generation-core/prompt/format-engine";
 import { mergeAdjacentMessages, squashLeadingSystemMessages } from "../generation-core/prompt/merger";
 import { applyRegexScriptsToPromptMessages } from "../generation-core/regex/regex-application";
@@ -45,7 +30,6 @@ import {
   type StoredGenerationParameters,
 } from "./generate-route-utils";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection";
-import { LIMITS } from "../contracts/constants/defaults";
 import {
   bySortOrder,
   boolish,
@@ -58,6 +42,11 @@ import {
   stringArray,
   type JsonRecord,
 } from "./runtime-records";
+import {
+  lorebookActivatedEntryForEvent,
+  scanActiveLorebooks,
+  type BudgetSkippedLorebookEntry,
+} from "./active-lorebook-scanner";
 
 export interface GenerationCharacterContext {
   id: string;
@@ -89,20 +78,6 @@ export interface GenerationPersonaContext {
     attributes: Array<{ name: string; value: number }>;
     hp: { value: number; max: number };
   };
-}
-
-export interface BudgetSkippedLorebookEntry {
-  id: string;
-  name: string;
-  lorebookId: string;
-  lorebookName: string;
-  matchedKeys: string[];
-  estimatedTokens: number;
-  lorebookBudget: number;
-  lorebookUsedTokens: number;
-  chatBudget: number;
-  chatUsedTokens: number;
-  blockedBy: "lorebook" | "chat" | "both";
 }
 
 export interface PromptAssemblyResult {
@@ -308,13 +283,13 @@ function isRpgStats(value: unknown): GenerationPersonaContext["rpgStats"] | unde
   return { enabled: value.enabled, attributes, hp };
 }
 
-async function loadCharacters(storage: StorageGateway, chat: JsonRecord): Promise<GenerationCharacterContext[]> {
+export async function loadCharacters(storage: StorageGateway, chat: JsonRecord): Promise<GenerationCharacterContext[]> {
   const ids = activeCharacterIds(chat);
   const rows = await Promise.all(ids.map((id) => storage.get<JsonRecord>("characters", id)));
   return rows.filter(isRecord).map(loadCharacterContext);
 }
 
-async function loadPersona(storage: StorageGateway, chat: JsonRecord): Promise<GenerationPersonaContext | null> {
+export async function loadPersona(storage: StorageGateway, chat: JsonRecord): Promise<GenerationPersonaContext | null> {
   const personaId = readString(chat.personaId).trim();
   if (personaId) {
     const row = await storage.get<JsonRecord>("personas", personaId);
@@ -1371,6 +1346,23 @@ async function buildMemoryRecallBlock(
   ].join("\n");
 }
 
+function memoizedEmbeddingSource(
+  source: PromptAssemblyInput["embeddingSource"],
+): PromptAssemblyInput["embeddingSource"] {
+  if (!source) return null;
+  const cache = new Map<string, Promise<number[][] | null>>();
+  return {
+    embed: (texts) => {
+      const key = JSON.stringify(texts);
+      const existing = cache.get(key);
+      if (existing) return existing;
+      const embedding = source.embed(texts);
+      cache.set(key, embedding);
+      return embedding;
+    },
+  };
+}
+
 function connectedNoteTargetsChat(note: JsonRecord, chatId: string): boolean {
   const targetChatId = readString(note.targetChatId).trim();
   return !targetChatId || targetChatId === chatId;
@@ -1688,383 +1680,6 @@ function authorNotesDepthEntry(chat: JsonRecord): { content: string; role: "syst
   return { content, role: "system", depth };
 }
 
-function normalizeLorebookEntry(entry: JsonRecord): LorebookEntry {
-  return {
-    id: readString(entry.id),
-    lorebookId: readString(entry.lorebookId),
-    name: readString(entry.name) || "Entry",
-    content: readString(entry.content),
-    description: readString(entry.description),
-    keys: stringArray(entry.keys),
-    secondaryKeys: stringArray(entry.secondaryKeys),
-    selective: boolish(entry.selective, false),
-    selectiveLogic: readString(entry.selectiveLogic, "and") as LorebookEntry["selectiveLogic"],
-    constant: boolish(entry.constant, false),
-    enabled: boolish(entry.enabled, true),
-    position: readNumber(entry.position, 0),
-    role: normalizeRole(entry.role) as LorebookEntry["role"],
-    depth: readNumber(entry.depth, 0),
-    order: readNumber(entry.order ?? entry.sortOrder, 0),
-    probability: entry.probability == null ? null : readNumber(entry.probability, 100),
-    useRegex: boolish(entry.useRegex, false),
-    matchWholeWords: boolish(entry.matchWholeWords, false),
-    caseSensitive: boolish(entry.caseSensitive, false),
-    ephemeral: entry.ephemeral == null ? null : readNumber(entry.ephemeral, 0),
-    group: readString(entry.group),
-    groupWeight: entry.groupWeight == null ? null : readNumber(entry.groupWeight, 100),
-    folderId: readString(entry.folderId) || null,
-    locked: boolish(entry.locked, false),
-    preventRecursion: boolish(entry.preventRecursion, false),
-    tag: readString(entry.tag),
-    relationships: stringRecord(entry.relationships),
-    dynamicState: parseRecord(entry.dynamicState),
-    scanDepth: entry.scanDepth == null ? null : readNumber(entry.scanDepth, 0),
-    sticky: entry.sticky == null ? null : readNumber(entry.sticky, 0),
-    cooldown: entry.cooldown == null ? null : readNumber(entry.cooldown, 0),
-    delay: entry.delay == null ? null : readNumber(entry.delay, 0),
-    activationConditions: Array.isArray(entry.activationConditions) ? entry.activationConditions : [],
-    schedule: isRecord(entry.schedule) ? (entry.schedule as unknown as LorebookEntry["schedule"]) : null,
-    excludeFromVectorization: boolish(entry.excludeFromVectorization, false),
-    embedding: Array.isArray(entry.embedding)
-      ? entry.embedding.filter((item): item is number => typeof item === "number")
-      : null,
-    additionalMatchingSources: stringArray(
-      entry.additionalMatchingSources,
-    ) as LorebookEntry["additionalMatchingSources"],
-    characterFilterMode: readString(entry.characterFilterMode, "any") as LorebookEntry["characterFilterMode"],
-    characterFilterIds: stringArray(entry.characterFilterIds),
-    characterTagFilterMode: readString(entry.characterTagFilterMode, "any") as LorebookEntry["characterTagFilterMode"],
-    characterTagFilters: stringArray(entry.characterTagFilters),
-    generationTriggerFilterMode: readString(
-      entry.generationTriggerFilterMode,
-      "any",
-    ) as LorebookEntry["generationTriggerFilterMode"],
-    generationTriggerFilters: stringArray(entry.generationTriggerFilters),
-    createdAt: readString(entry.createdAt),
-    updatedAt: readString(entry.updatedAt),
-  };
-}
-
-export function lorebookAppliesToContext(
-  lorebook: JsonRecord,
-  chat: JsonRecord,
-  characters: GenerationCharacterContext[],
-  persona: GenerationPersonaContext | null,
-): boolean {
-  if (!boolish(lorebook.enabled, true)) return false;
-  const meta = parseRecord(chat.metadata);
-  const scopeExclusions = resolveGameLorebookScopeExclusions(readString(chat.mode || chat.chatMode), meta);
-  const lorebookId = readString(lorebook.id);
-  if (scopeExclusions.excludedLorebookIds.includes(lorebookId)) return false;
-  if (scopeExclusions.excludedSourceAgentIds.includes(readString(lorebook.sourceAgentId))) return false;
-  if (boolish(lorebook.isGlobal ?? lorebook.global, false)) return true;
-  const activeIds = new Set(characters.map((character) => character.id));
-  const lorebookCharacterIds = stringArray(lorebook.characterIds);
-  if (lorebookCharacterIds.some((id) => activeIds.has(id)) || activeIds.has(readString(lorebook.characterId))) {
-    return true;
-  }
-  const personaId = readString(chat.personaId);
-  if (persona && personaId) {
-    const personaIds = stringArray(lorebook.personaIds);
-    if (personaIds.includes(personaId) || readString(lorebook.personaId) === personaId) return true;
-  }
-  const chatScopedId = readString(lorebook.chatId).trim();
-  if (chatScopedId && chatScopedId === readString(chat.id).trim()) return true;
-  return stringArray(meta.activeLorebookIds ?? chat.activeLorebookIds).includes(lorebookId);
-}
-
-function joinMatchingSourceParts(parts: Array<string | undefined>): string {
-  return parts
-    .map((part) => part?.trim() ?? "")
-    .filter(Boolean)
-    .join("\n");
-}
-
-function buildAdditionalMatchingSourceText(
-  characters: GenerationCharacterContext[],
-  persona: GenerationPersonaContext | null,
-): Partial<Record<LorebookMatchingSource, string>> {
-  return {
-    character_name: joinMatchingSourceParts(characters.map((character) => character.name)),
-    character_description: joinMatchingSourceParts(characters.map((character) => character.description)),
-    character_personality: joinMatchingSourceParts(characters.map((character) => character.personality)),
-    character_scenario: joinMatchingSourceParts(characters.map((character) => character.scenario)),
-    character_tags: joinMatchingSourceParts(characters.flatMap((character) => character.tags)),
-    persona_description: persona?.description ?? "",
-    persona_tags: joinMatchingSourceParts(persona?.tags ?? []),
-  };
-}
-
-function nonNegativeInteger(value: unknown, fallback = 0): number {
-  return Math.max(0, Math.floor(readNumber(value, fallback)));
-}
-
-const MAX_LOREBOOK_RECURSION_DEPTH = 10;
-
-interface LoadedLorebookBudgetSkippedEntry {
-  activatedEntry: ActivatedEntry;
-  lorebookName: string;
-  lorebookBudget: number;
-  lorebookUsedTokens: number;
-  estimatedTokens: number;
-}
-
-interface ScannedLorebookEntries {
-  activatedEntries: ActivatedEntry[];
-  budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
-  entriesForTiming: LorebookEntry[];
-}
-
-interface LoadedActivatedLore {
-  activatedEntries: ActivatedEntry[];
-  budgetSkippedEntries: LoadedLorebookBudgetSkippedEntry[];
-  entriesForTiming: LorebookEntry[];
-  previousTimingStates: Map<string, EntryTimingState>;
-  lorebookNamesById: Map<string, string>;
-  currentMessageIndex: number;
-}
-
-function resolveLorebookTokenBudget(chat: JsonRecord, request: JsonRecord): number {
-  const meta = parseRecord(chat.metadata);
-  return nonNegativeInteger(
-    request.lorebookTokenBudget,
-    readNumber(meta.lorebookTokenBudget, LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET),
-  );
-}
-
-function resolveLorebookRecursionDepth(lorebook: JsonRecord): number {
-  return Math.min(MAX_LOREBOOK_RECURSION_DEPTH, Math.max(1, nonNegativeInteger(lorebook.maxRecursionDepth, 3)));
-}
-
-function normalizeLorebookTimingState(value: unknown): EntryTimingState | null {
-  if (!isRecord(value)) return null;
-  const stickyCount = readNumber(value.stickyCount, Number.NaN);
-  const cooldownRemaining = readNumber(value.cooldownRemaining, Number.NaN);
-  const delayRemaining = readNumber(value.delayRemaining, Number.NaN);
-  if (![stickyCount, cooldownRemaining, delayRemaining].every(Number.isFinite)) return null;
-  const lastActivatedAt =
-    value.lastActivatedAt === null || value.lastActivatedAt === undefined
-      ? null
-      : readNumber(value.lastActivatedAt, Number.NaN);
-  if (lastActivatedAt !== null && !Number.isFinite(lastActivatedAt)) return null;
-  return {
-    lastActivatedAt: lastActivatedAt === null ? null : Math.max(0, Math.trunc(lastActivatedAt)),
-    stickyCount: Math.max(0, Math.trunc(stickyCount)),
-    cooldownRemaining: Math.max(0, Math.trunc(cooldownRemaining)),
-    delayRemaining: Math.max(0, Math.trunc(delayRemaining)),
-  };
-}
-
-function lorebookTimingStateMap(value: unknown): Map<string, EntryTimingState> {
-  const states = new Map<string, EntryTimingState>();
-  for (const [entryId, state] of Object.entries(parseRecord(value))) {
-    const normalizedId = entryId.trim();
-    const normalizedState = normalizeLorebookTimingState(state);
-    if (normalizedId && normalizedState) states.set(normalizedId, normalizedState);
-  }
-  return states;
-}
-
-function serializeLorebookTimingStates(
-  states: Map<string, EntryTimingState>,
-): Record<string, LorebookEntryTimingState> {
-  return Object.fromEntries(
-    [...states.entries()]
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([entryId, state]) => [
-        entryId,
-        {
-          lastActivatedAt: state.lastActivatedAt,
-          stickyCount: state.stickyCount,
-          cooldownRemaining: state.cooldownRemaining,
-          delayRemaining: state.delayRemaining,
-        },
-      ]),
-  );
-}
-
-function lorebookTimingStatesChanged(
-  previous: Map<string, EntryTimingState>,
-  next: Map<string, EntryTimingState>,
-): boolean {
-  if (previous.size !== next.size) return true;
-  for (const [entryId, previousState] of previous) {
-    const nextState = next.get(entryId);
-    if (!nextState) return true;
-    if (
-      previousState.lastActivatedAt !== nextState.lastActivatedAt ||
-      previousState.stickyCount !== nextState.stickyCount ||
-      previousState.cooldownRemaining !== nextState.cooldownRemaining ||
-      previousState.delayRemaining !== nextState.delayRemaining
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export async function loadLorebookEntriesForActivation(
-  storage: StorageGateway,
-  lorebook: JsonRecord,
-): Promise<LorebookEntry[]> {
-  const id = readString(lorebook.id);
-  if (!id) return [];
-  const [rows, folders] = await Promise.all([
-    storage.listLorebookEntries<JsonRecord>(id),
-    storage.list<JsonRecord>("lorebook-folders", { filters: { lorebookId: id } }),
-  ]);
-  const disabledFolderIds = new Set(
-    folders
-      .filter((folder) => !boolish(folder.enabled, true))
-      .map((folder) => readString(folder.id))
-      .filter(Boolean),
-  );
-  const defaultScanDepth = nonNegativeInteger(lorebook.scanDepth, 0);
-  const excludeFromVectorization = boolish(lorebook.excludeFromVectorization, false);
-  return rows
-    .map((row) => normalizeLorebookEntry(excludeFromVectorization ? { ...row, excludeFromVectorization: true } : row))
-    .map((entry) => ({
-      ...entry,
-      scanDepth: entry.scanDepth == null ? defaultScanDepth : entry.scanDepth,
-    }))
-    .filter((entry) => entry.enabled && entry.content.trim())
-    .filter((entry) => !entry.folderId || !disabledFolderIds.has(entry.folderId));
-}
-
-function scanLorebookEntries(
-  messages: ScanMessage[],
-  entries: LorebookEntry[],
-  lorebook: JsonRecord,
-  options: ScanOptions,
-): ScannedLorebookEntries {
-  const activated = boolish(lorebook.recursiveScanning, false)
-    ? recursiveScan(messages, entries, options, resolveLorebookRecursionDepth(lorebook))
-    : scanForActivatedEntries(messages, entries, options);
-  const lorebookId = readString(lorebook.id);
-  const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
-  const lorebookBudget = nonNegativeInteger(lorebook.tokenBudget, 0);
-  const budgeted = applyTokenBudgetWithSkipped(activated, lorebookBudget);
-  return {
-    activatedEntries: budgeted.includedEntries,
-    budgetSkippedEntries: budgeted.skippedEntries.map((skipped) => ({
-      activatedEntry: skipped.activatedEntry,
-      lorebookName,
-      lorebookBudget,
-      lorebookUsedTokens: skipped.usedTokensBefore,
-      estimatedTokens: skipped.estimatedTokens,
-    })),
-    entriesForTiming: entries,
-  };
-}
-
-async function loadActivatedLore(
-  storage: StorageGateway,
-  chat: JsonRecord,
-  characters: GenerationCharacterContext[],
-  persona: GenerationPersonaContext | null,
-  storedMessages: JsonRecord[],
-): Promise<LoadedActivatedLore> {
-  const lorebooks = (await storage.list<JsonRecord>("lorebooks")).filter((book) =>
-    lorebookAppliesToContext(book, chat, characters, persona),
-  );
-  const activeCharacterIds = characters.map((character) => character.id);
-  const activeCharacterTags = characters.flatMap((character) => character.tags);
-  const meta = parseRecord(chat.metadata);
-  const gameState = parseRecord(chat.gameState ?? meta.gameState);
-  const previousTimingStates = lorebookTimingStateMap(meta.entryTimingStates);
-  const messages = storedMessages
-    .filter((message) => !hiddenFromAi(message))
-    .map((message) => ({
-      role: readString(message.role, "user"),
-      content: readString(message.content),
-    }));
-  const generationTriggers = ["chat", readString(chat.mode || chat.chatMode)].filter(Boolean);
-  const options: ScanOptions = {
-    activeCharacterIds,
-    activeCharacterTags,
-    generationTriggers,
-    gameState,
-    timingStates: previousTimingStates,
-    currentMessageIndex: messages.length,
-    additionalMatchingSourceText: buildAdditionalMatchingSourceText(characters, persona),
-  };
-  const lorebookNamesById = new Map(
-    lorebooks.map((book) => {
-      const id = readString(book.id);
-      return [id, readString(book.name, id || "Lorebook")] as const;
-    }),
-  );
-  const scanned = await Promise.all(
-    lorebooks.map(async (book) =>
-      scanLorebookEntries(messages, await loadLorebookEntriesForActivation(storage, book), book, options),
-    ),
-  );
-  return {
-    activatedEntries: scanned
-      .flatMap((result) => result.activatedEntries)
-      .sort((a, b) => a.injectionOrder - b.injectionOrder),
-    budgetSkippedEntries: scanned.flatMap((result) => result.budgetSkippedEntries),
-    entriesForTiming: scanned.flatMap((result) => result.entriesForTiming),
-    previousTimingStates,
-    lorebookNamesById,
-    currentMessageIndex: messages.length,
-  };
-}
-
-function loreForEvent(entry: ActivatedEntry) {
-  return {
-    id: entry.entry.id,
-    lorebookId: entry.entry.lorebookId,
-    name: entry.entry.name,
-    content: entry.entry.content,
-    tag: entry.matchedKeys.join(", "),
-    matchedKeys: entry.matchedKeys,
-    order: entry.entry.order,
-    constant: entry.entry.constant,
-  };
-}
-
-function budgetSkippedLoreForEvent(
-  skipped: BudgetSkippedActivatedEntry,
-  lorebookNamesById: Map<string, string>,
-  chatBudget: number,
-): BudgetSkippedLorebookEntry {
-  const entry = skipped.activatedEntry.entry;
-  return {
-    id: entry.id,
-    name: entry.name,
-    lorebookId: entry.lorebookId,
-    lorebookName: lorebookNamesById.get(entry.lorebookId) ?? entry.lorebookId,
-    matchedKeys: skipped.activatedEntry.matchedKeys,
-    estimatedTokens: skipped.estimatedTokens,
-    lorebookBudget: 0,
-    lorebookUsedTokens: 0,
-    chatBudget,
-    chatUsedTokens: skipped.usedTokensBefore,
-    blockedBy: "chat",
-  };
-}
-
-function lorebookBudgetSkippedLoreForEvent(
-  skipped: LoadedLorebookBudgetSkippedEntry,
-  chatBudget: number,
-): BudgetSkippedLorebookEntry {
-  const entry = skipped.activatedEntry.entry;
-  return {
-    id: entry.id,
-    name: entry.name,
-    lorebookId: entry.lorebookId,
-    lorebookName: skipped.lorebookName,
-    matchedKeys: skipped.activatedEntry.matchedKeys,
-    estimatedTokens: skipped.estimatedTokens,
-    lorebookBudget: skipped.lorebookBudget,
-    lorebookUsedTokens: skipped.lorebookUsedTokens,
-    chatBudget,
-    chatUsedTokens: 0,
-    blockedBy: "lorebook",
-  };
-}
-
 function sectionContent(args: {
   section: PromptSectionRecord;
   marker: MarkerConfig | null;
@@ -2110,31 +1725,25 @@ export async function assembleGenerationPrompt(
 ): Promise<PromptAssemblyResult> {
   const characters = await loadCharacters(storage, input.chat);
   const persona = await loadPersona(storage, input.chat);
-  const loadedLore = await loadActivatedLore(storage, input.chat, characters, persona, input.storedMessages);
-  const lorebookTokenBudget = resolveLorebookTokenBudget(input.chat, input.request);
-  const processedLore = processActivatedEntries(loadedLore.activatedEntries, lorebookTokenBudget);
-  const nextLorebookTimingStates = updateTimingStatesForScan(
-    loadedLore.entriesForTiming,
-    processedLore.includedEntries,
-    loadedLore.previousTimingStates,
-    loadedLore.currentMessageIndex,
-  );
-  const lorebookTimingStates = lorebookTimingStatesChanged(loadedLore.previousTimingStates, nextLorebookTimingStates)
-    ? serializeLorebookTimingStates(nextLorebookTimingStates)
-    : null;
-  const budgetSkippedLorebookEntries = [
-    ...loadedLore.budgetSkippedEntries.map((entry) => lorebookBudgetSkippedLoreForEvent(entry, lorebookTokenBudget)),
-    ...processedLore.skippedEntries.map((entry) =>
-      budgetSkippedLoreForEvent(entry, loadedLore.lorebookNamesById, lorebookTokenBudget),
-    ),
-  ];
+  const embeddingSource = memoizedEmbeddingSource(input.embeddingSource);
+  const loreScan = await scanActiveLorebooks({
+    storage,
+    chat: input.chat,
+    characters,
+    persona,
+    storedMessages: input.storedMessages,
+    request: input.request,
+    latestUserInput: input.latestUserInput,
+    embeddingSource,
+  });
+  const processedLore = loreScan.processedLore;
   const summary = chatSummaryForGeneration(input.chat);
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
     input.chat,
     input.latestUserInput,
     readNumber(input.connection.maxContext, 0) || undefined,
-    input.embeddingSource,
+    embeddingSource,
   );
   const selectedPreset = await loadSelectedPromptPreset(storage, {
     chat: input.chat,
@@ -2333,9 +1942,9 @@ export async function assembleGenerationPrompt(
     wrapFormat,
     characters,
     persona,
-    activatedLorebookEntries: processedLore.includedEntries.map(loreForEvent),
-    lorebookTimingStates,
-    budgetSkippedLorebookEntries,
+    activatedLorebookEntries: processedLore.includedEntries.map(lorebookActivatedEntryForEvent),
+    lorebookTimingStates: loreScan.lorebookTimingStates,
+    budgetSkippedLorebookEntries: loreScan.budgetSkippedLorebookEntries,
     chatSummary: summary,
     chatSummaryFingerprint: summaryFingerprint,
   };

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -6,12 +6,8 @@ import type { LorebookEntry } from "../contracts/types/lorebook";
 import type { LLMToolCall, LLMToolDefinition } from "../generation-core/llm/base-provider";
 import { lorebookEntryPassesContextFilters } from "../generation-core/lorebooks/keyword-scanner";
 import { appendChatSummaryEntryToMetadata } from "../shared/text/chat-summary-entries";
-import {
-  loadLorebookEntriesForActivation,
-  lorebookAppliesToContext,
-  type GenerationCharacterContext,
-  type GenerationPersonaContext,
-} from "./prompt-assembly";
+import { loadLorebookEntriesForActivation, lorebookAppliesToContext } from "./active-lorebook-scanner";
+import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
 import {
   boolish,
   isRecord,

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -4,6 +4,7 @@
 import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { lorebookKeys } from "../query-keys";
 import { scanActiveLorebookEntries } from "../../../../engine/generation/active-lorebooks";
+import type { LorebookSemanticScanStatus } from "../../../../engine/generation/active-lorebook-scanner";
 import {
   createLorebookEntrySchema,
   createLorebookFolderSchema,
@@ -19,6 +20,7 @@ import type { Lorebook, LorebookEntry, LorebookFolder } from "../../../../engine
 import { characterKeys } from "../../characters/query-keys";
 
 export { lorebookKeys } from "../query-keys";
+export type { LorebookSemanticScanStatus };
 
 async function transferLorebookEntries(
   sourceLorebookId: string,
@@ -463,6 +465,7 @@ interface ActiveLorebookScan {
   budgetSkippedEntries: BudgetSkippedLorebookEntry[];
   totalTokens: number;
   totalEntries: number;
+  semanticStatus: LorebookSemanticScanStatus;
 }
 
 export function useActiveLorebookEntries(chatId: string | null, enabled = false) {

--- a/src/features/runtime/visuals/components/WorldInfoPanel.tsx
+++ b/src/features/runtime/visuals/components/WorldInfoPanel.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronRight, Globe, Loader2, X } from "lucide-react";
-import { type BudgetSkippedLorebookEntry, useActiveLorebookEntries } from "../../../catalog/lorebooks/index";
+import {
+  type BudgetSkippedLorebookEntry,
+  type LorebookSemanticScanStatus,
+  useActiveLorebookEntries,
+} from "../../../catalog/lorebooks/index";
 
 function WorldInfoEntryRow({
   entry,
@@ -119,6 +123,26 @@ function BudgetSkippedEntriesNotice({ entries }: { entries: BudgetSkippedLoreboo
   );
 }
 
+function SemanticScanNotice({ status }: { status?: LorebookSemanticScanStatus | null }) {
+  if (!status || status.vectorizedEntryCount === 0 || status.state === "ready" || status.state === "not_applicable") {
+    return null;
+  }
+  const count = status.vectorizedEntryCount.toLocaleString();
+  const message =
+    status.state === "missing_embedding_source"
+      ? `${count} vectorized ${status.vectorizedEntryCount === 1 ? "entry was" : "entries were"} not semantically scanned. Keyword and constant matches are shown.`
+      : status.state === "empty_query"
+        ? `${count} vectorized ${status.vectorizedEntryCount === 1 ? "entry was" : "entries were"} not semantically scanned because there is no chat text to embed.`
+        : `${count} vectorized ${status.vectorizedEntryCount === 1 ? "entry was" : "entries were"} not semantically scanned because embedding was unavailable.`;
+
+  return (
+    <div className="mb-2 flex gap-2 rounded-lg border border-sky-500/25 bg-sky-500/10 p-2 text-xs text-sky-50/85">
+      <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0 text-sky-200" />
+      <span className="leading-relaxed">{message}</span>
+    </div>
+  );
+}
+
 export function WorldInfoPanel({
   chatId,
   isMobile,
@@ -162,6 +186,7 @@ export function WorldInfoPanel({
         </div>
       ) : entries.length === 0 ? (
         <>
+          <SemanticScanNotice status={data?.semanticStatus} />
           <BudgetSkippedEntriesNotice entries={skippedEntries} />
           <p className="py-3 text-center text-xs text-[var(--muted-foreground)]">No active entries for this chat</p>
         </>
@@ -170,6 +195,7 @@ export function WorldInfoPanel({
           <p className="mb-2 text-[0.625rem] text-[var(--muted-foreground)]">
             {entries.length} active * ~{(data?.totalTokens ?? 0).toLocaleString()} tokens
           </p>
+          <SemanticScanNotice status={data?.semanticStatus} />
           <BudgetSkippedEntriesNotice entries={skippedEntries} />
           <div className="space-y-1.5">
             {entries.map((entry) => (

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -191,7 +191,7 @@ export type RemoteRuntimeHealthCheck =
   | { status: "unreachable"; message: string; health?: RemoteRuntimeHealthPayload }
   | { status: "not-writable"; message: string; health: RemoteRuntimeHealthPayload };
 
-export function hasEmbeddedTauriRuntime(): boolean {
+function hasEmbeddedTauriRuntime(): boolean {
   if (typeof window === "undefined") return false;
   const runtimeWindow = window as unknown as { __TAURI__?: unknown; __TAURI_INTERNALS__?: unknown };
   return Boolean(runtimeWindow.__TAURI__ || runtimeWindow.__TAURI_INTERNALS__);


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Extracts lorebook activation into an engine-owned scanner so prompt assembly and Active World Info use the same contract.
- Fixes semantic lorebook activation in normal prompt assembly by wiring the generation embedding source through the scanner.
- Removes Active World Info's dependency on resolving an LLM generation connection for keyword/constant previews.

## What changed

- Added `src/engine/generation/active-lorebook-scanner.ts` for scope selection, entry loading, scanner options, per-lorebook and chat budget diagnostics, timing-state updates, and semantic scan status.
- Updated prompt assembly to call the scanner and share a per-assembly embedding cache between semantic lorebook activation and memory recall.
- Updated Active World Info to call the scanner directly and show a semantic-degrade notice when vectorized entries cannot be semantically scanned.
- Moved lorebook search-tool activation helpers to the scanner module.
- Added regression coverage for semantic activation, Active World Info without connection resolution, skipped semantic status, embedding reuse, and constant-only vectorized lore.

## Refactor impact

Primary owner:

- Engine generation.

Impact areas reviewed:

- Prompt assembly lorebook activation and prompt injection.
- Active World Info preview query path.
- Lorebook search tool entry loading.
- Memory recall embedding query path.
- Game lorebook keeper scope exclusions, timing state, token budgets, recursion, disabled folders, and entry filters through existing prompt assembly tests.

Boundary notes:

- Engine logic stays in `src/engine`; no React, Zustand, Tauri, shared API adapter, or feature internals imported into engine code.
- Feature code continues to call public catalog hooks and engine entrypoints; no raw Tauri or remote runtime calls added.
- Rust, shared API, and remote-runtime command surfaces are untouched.

Pressure points touched:

- `src/engine/generation/prompt-assembly.ts` was reduced by moving lorebook scanner/budget/timing logic into `active-lorebook-scanner.ts`.
- Active World Info UI notice touched `src/features/runtime/visuals/components/WorldInfoPanel.tsx`.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm check` successfully after the final diff.
- Ran `pnpm vitest run src/engine/generation/prompt-assembly.test.ts src/engine/generation-core/lorebooks/keyword-scanner.test.ts` successfully: 2 files, 65 tests.
- Ran `pnpm build` earlier in the slice; it passed with the existing Vite large chunk warning. Build was not rerun after the final Bunny-only test/unused-export fixes because `pnpm check` and targeted tests covered the final TypeScript/import surfaces.
- No native Tauri UI pass was run for Active World Info.
- No live provider/vectorization call was made; semantic activation is covered with mocked embedding sources.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No durable docs/source-ownership changes were needed for this internal engine refactor and small Active World Info notice.

## UI evidence

No screenshot attached. UI change is limited to the Active World Info semantic-degrade notice; native/manual UI QA remains a gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced lore scanning with semantic embedding support for improved entry matching
  * Added visual status indicators displaying semantic scan progress and results in the World Info panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->