### PR TITLE
Fix impersonate prompt parity

### DIFF
--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -1080,6 +1080,58 @@ describe("startGeneration generation replay metadata", () => {
     expect(promptText).toContain("Requested beat: give a direct order");
   });
 
+  it("falls back to chat-scoped impersonate prompt metadata when no request template is supplied", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      chatPatch: {
+        personaId: "persona-1",
+      },
+      chatMetadata: {
+        impersonatePrompt: "Chat scoped prompt for {{user}}: {{impersonate_direction}}",
+      },
+      personas: [{ id: "persona-1", name: "Chai", description: "A brisk captain with clipped wording." }],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage: "answer with a toast",
+        impersonate: true,
+        impersonateBlockAgents: true,
+      }),
+    );
+
+    const promptText = (streamedRequests[0] as { messages: Array<{ content: string }> }).messages
+      .map((message) => message.content)
+      .join("\n");
+    expect(promptText).toContain("Chat scoped prompt for Chai: answer with a toast");
+  });
+
+  it("normalizes legacy wrapped impersonate directions before prompt assembly", async () => {
+    const { deps, streamedRequests } = generationDepsForChat({
+      chatPatch: {
+        personaId: "persona-1",
+      },
+      personas: [{ id: "persona-1", name: "Chai", description: "A brisk captain with clipped wording." }],
+    });
+
+    await drainGeneration(
+      startGeneration(deps, {
+        chatId: "chat-1",
+        userMessage:
+          "[Impersonation instruction - write {{user}}'s next response, steering it toward the following: answer quietly]",
+        impersonate: true,
+        impersonateBlockAgents: true,
+        impersonatePromptTemplate: "Write as {{user}}. Direction: {{impersonate_direction}}",
+      }),
+    );
+
+    const promptText = (streamedRequests[0] as { messages: Array<{ content: string }> }).messages
+      .map((message) => message.content)
+      .join("\n");
+    expect(promptText).toContain("Write as Chai. Direction: answer quietly");
+    expect(promptText).not.toContain("Impersonation instruction");
+  });
+
   it("uses a concrete fallback name for impersonation when no persona is selected", async () => {
     const { deps, streamedRequests } = generationDepsForChat();
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -851,6 +851,13 @@ function withImageAttachments(messages: LlmMessage[], images: string[]): LlmMess
   return next;
 }
 
+function impersonatePromptTemplate(input: StartGenerationInput, chat: JsonRecord): string | null {
+  const requestPrompt = readString(input.impersonatePromptTemplate).trim();
+  if (requestPrompt) return requestPrompt;
+  const chatPrompt = readString(parseRecord(chat.metadata).impersonatePrompt).trim();
+  return chatPrompt || null;
+}
+
 function directiveMessages(
   input: StartGenerationInput,
   chat: JsonRecord,
@@ -865,7 +872,7 @@ function directiveMessages(
     messages.push({
       role: "user",
       content: buildImpersonateInstruction({
-        customPrompt: input.impersonatePromptTemplate,
+        customPrompt: impersonatePromptTemplate(input, chat),
         direction: prepared.content,
         personaName,
         personaDescription: persona?.description,

--- a/src/engine/modes/chat/commands/impersonate-prompt.ts
+++ b/src/engine/modes/chat/commands/impersonate-prompt.ts
@@ -7,8 +7,17 @@ interface BuildImpersonateInstructionArgs {
   personaDescription?: string | null;
 }
 
+const LEGACY_IMPERSONATION_DIRECTION_RE =
+  /^\[Impersonation instruction (?:\u2014|-) write \{\{user\}\}'s next response, steering it toward the following:\s*([\s\S]+?)\]$/;
+
 function normalizeText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeDirection(direction: string | null | undefined): string {
+  const rawDirection = normalizeText(direction);
+  const legacyDirectionMatch = rawDirection.match(LEGACY_IMPERSONATION_DIRECTION_RE);
+  return legacyDirectionMatch ? legacyDirectionMatch[1]!.trim() : rawDirection;
 }
 
 function punctuateDirection(direction: string): string {
@@ -60,7 +69,7 @@ export function buildImpersonateInstruction({
   personaDescription,
 }: BuildImpersonateInstructionArgs): string {
   const normalizedCustomPrompt = normalizeText(customPrompt);
-  const impersonationDirection = normalizeText(direction);
+  const impersonationDirection = normalizeDirection(direction);
   const personaLabel = normalizeText(personaName) || "{{user}}";
   const description = normalizeText(personaDescription);
 


### PR DESCRIPTION
## Linked issue

N/A - local parity bug report.

## Why this change

- Chat-scoped `/impersonate_prompt` metadata was persisted but ignored by refactor generation.
- Legacy wrapped impersonation directions could be nested into the prompt instead of normalized before assembly.

## What changed

- Restored impersonate prompt precedence so request/global `impersonatePromptTemplate` wins, then chat metadata `impersonatePrompt`, then the built-in default.
- Added the legacy impersonation-direction de-wrapper before rendering impersonate prompt templates.
- Added engine tests for chat metadata fallback and legacy wrapper normalization.

## Refactor impact

Primary owner:

- Engine generation / chat impersonation.

Impact areas reviewed:

- `/impersonate` prompt assembly in `start-generation.ts`.
- Chat-owned impersonate prompt rendering helper.
- Slash-command metadata write path for `/impersonate_prompt`.
- Replay/direct generation callers and sibling roleplay/game exposure.

Boundary notes:

- Engine-only change; no React feature, shared API, Tauri command, Rust capability, or remote runtime boundary changes.
- Chat owns impersonation behavior; no cross-mode imports added.

Pressure points touched:

- None.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated proof run before opening PR:

- `pnpm exec vitest run src/engine/generation/start-generation.test.ts -t "impersonate"` passed after reproducing the two parity failures before the fix.
- `pnpm exec vitest run src/engine/generation/start-generation.test.ts` passed, 68 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed.

Manual app QA not run; this is covered at engine prompt assembly level.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed: internal parity bugfix with no workflow, architecture, or user-facing copy changes.

## UI evidence

N/A - no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing and normalization of legacy impersonation instructions
  * Enhanced fallback behavior for impersonation prompts when custom templates are unavailable

* **Tests**
  * Expanded test coverage for impersonation prompt template resolution with custom and default configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->