### PR TITLE
Fix Windows Tauri dev stack overflow

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,18 @@
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let profile = std::env::var("PROFILE").unwrap_or_default();
+
+    // Windows debug builds get a small default main-thread stack. With the refactor,
+    // the app exposes enough Tauri commands that the generated invoke handler can
+    // overflow that stack while handling early frontend invokes.
+    if target_os == "windows" && profile == "debug" {
+        if target_env == "msvc" {
+            println!("cargo:rustc-link-arg-bin=marinara-engine=/STACK:16777216");
+        } else {
+            println!("cargo:rustc-link-arg-bin=marinara-engine=-Wl,--stack,16777216");
+        }
+    }
+
     tauri_build::build()
 }


### PR DESCRIPTION
## Summary
- increase the Windows debug executable stack reserve for the Tauri app
- keep release and non-Windows link behavior unchanged
- addresses dev startup stack overflow after the refactor/devtools command surface growth

## Verification
- rustfmt --check src-tauri/build.rs
- cargo check --manifest-path src-tauri/Cargo.toml --workspace
- cargo build --manifest-path src-tauri/Cargo.toml --features devtools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized stack size allocation for Windows development builds to improve stability and prevent potential issues during debugging and testing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->