### PR TITLE
Fix terminal LLM stream cleanup

### DIFF
--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -17,6 +17,12 @@ const OPENAI_CHATGPT_REFRESH_URL: &str = "https://auth.openai.com/oauth/token";
 const OPENAI_CHATGPT_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const APP_VERSION: &str = "1.6.1";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SseBlockStatus {
+    Continue,
+    Complete,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LlmMessage {
     pub role: String,
@@ -840,16 +846,23 @@ async fn stream_openai_compatible(
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
     let mut tool_calls = OpenAiToolCallAccumulator::default();
+    let mut completed = false;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|error| {
             AppError::new("llm_stream_error", provider_transport_error_message(error))
         })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
-            process_openai_sse_block(&block, emit, &mut tool_calls)?;
+            if process_openai_sse_block(&block, emit, &mut tool_calls)? == SseBlockStatus::Complete {
+                completed = true;
+                break;
+            }
+        }
+        if completed {
+            break;
         }
     }
-    if !buffer.trim().is_empty() {
+    if !completed && !buffer.trim().is_empty() {
         process_openai_sse_block(&buffer, emit, &mut tool_calls)?;
     }
     for tool_call in tool_calls.into_tool_calls() {
@@ -1053,16 +1066,23 @@ async fn stream_openai_responses(
     }
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
+    let mut completed = false;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|error| {
             AppError::new("llm_stream_error", provider_transport_error_message(error))
         })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
-            process_openai_responses_sse_block(&block, emit)?;
+            if process_openai_responses_sse_block(&block, emit)? == SseBlockStatus::Complete {
+                completed = true;
+                break;
+            }
+        }
+        if completed {
+            break;
         }
     }
-    if !buffer.trim().is_empty() {
+    if !completed && !buffer.trim().is_empty() {
         process_openai_responses_sse_block(&buffer, emit)?;
     }
     Ok(())
@@ -1071,7 +1091,7 @@ async fn stream_openai_responses(
 fn process_openai_responses_sse_block(
     block: &str,
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
-) -> AppResult<()> {
+) -> AppResult<SseBlockStatus> {
     let event_name = block
         .lines()
         .find_map(|line| line.trim_start().strip_prefix("event:"))
@@ -1083,8 +1103,11 @@ fn process_openai_responses_sse_block(
         .map(str::trim)
         .collect::<Vec<_>>()
         .join("\n");
-    if payload.is_empty() || payload == "[DONE]" {
-        return Ok(());
+    if payload.is_empty() {
+        return Ok(SseBlockStatus::Continue);
+    }
+    if payload == "[DONE]" {
+        return Ok(SseBlockStatus::Complete);
     }
     let value: Value = serde_json::from_str(&payload)
         .map_err(|error| AppError::new("llm_stream_parse_error", error.to_string()))?;
@@ -1121,6 +1144,7 @@ fn process_openai_responses_sse_block(
             {
                 emit(json!({ "type": "usage", "data": usage }))?;
             }
+            return Ok(SseBlockStatus::Complete);
         }
         "response.failed" | "response.incomplete" | "error" => {
             return Err(AppError::with_details(
@@ -1131,7 +1155,7 @@ fn process_openai_responses_sse_block(
         }
         _ => {}
     }
-    Ok(())
+    Ok(SseBlockStatus::Continue)
 }
 
 #[derive(Default)]
@@ -1211,15 +1235,18 @@ fn process_openai_sse_block(
     block: &str,
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
     tool_calls: &mut OpenAiToolCallAccumulator,
-) -> AppResult<()> {
+) -> AppResult<SseBlockStatus> {
     let payload = block
         .lines()
         .filter_map(|line| line.trim_start().strip_prefix("data:"))
         .map(str::trim)
         .collect::<Vec<_>>()
         .join("\n");
-    if payload.is_empty() || payload == "[DONE]" {
-        return Ok(());
+    if payload.is_empty() {
+        return Ok(SseBlockStatus::Continue);
+    }
+    if payload == "[DONE]" {
+        return Ok(SseBlockStatus::Complete);
     }
     let value: Value = serde_json::from_str(&payload)
         .map_err(|error| AppError::new("llm_stream_parse_error", error.to_string()))?;
@@ -1227,7 +1254,7 @@ fn process_openai_sse_block(
         emit(json!({ "type": "usage", "data": usage }))?;
     }
     let Some(choices) = value.get("choices").and_then(Value::as_array) else {
-        return Ok(());
+        return Ok(SseBlockStatus::Continue);
     };
     for choice in choices {
         let delta = choice.get("delta").unwrap_or(choice);
@@ -1245,7 +1272,7 @@ fn process_openai_sse_block(
             }
         }
     }
-    Ok(())
+    Ok(SseBlockStatus::Continue)
 }
 
 fn openai_message(message: &LlmMessage) -> Value {
@@ -2075,16 +2102,23 @@ async fn stream_anthropic(
 
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
+    let mut completed = false;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|error| {
             AppError::new("llm_stream_error", provider_transport_error_message(error))
         })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
-            process_anthropic_sse_block(&block, emit)?;
+            if process_anthropic_sse_block(&block, emit)? == SseBlockStatus::Complete {
+                completed = true;
+                break;
+            }
+        }
+        if completed {
+            break;
         }
     }
-    if !buffer.trim().is_empty() {
+    if !completed && !buffer.trim().is_empty() {
         process_anthropic_sse_block(&buffer, emit)?;
     }
     Ok(())
@@ -2107,7 +2141,7 @@ fn emit_anthropic_usage(
 fn process_anthropic_sse_block(
     block: &str,
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
-) -> AppResult<()> {
+) -> AppResult<SseBlockStatus> {
     let event_name = block
         .lines()
         .find_map(|line| line.trim_start().strip_prefix("event:"))
@@ -2119,8 +2153,11 @@ fn process_anthropic_sse_block(
         .map(str::trim)
         .collect::<Vec<_>>()
         .join("\n");
-    if payload.is_empty() || payload == "[DONE]" {
-        return Ok(());
+    if payload.is_empty() {
+        return Ok(SseBlockStatus::Continue);
+    }
+    if payload == "[DONE]" {
+        return Ok(SseBlockStatus::Complete);
     }
     let value: Value = serde_json::from_str(&payload)
         .map_err(|error| AppError::new("llm_stream_parse_error", error.to_string()))?;
@@ -2186,9 +2223,10 @@ fn process_anthropic_sse_block(
                 redact_sensitive_json(error),
             ));
         }
+        "message_stop" => return Ok(SseBlockStatus::Complete),
         _ => {}
     }
-    Ok(())
+    Ok(SseBlockStatus::Continue)
 }
 
 fn anthropic_endpoint(base: &str, path: &str) -> String {
@@ -2397,16 +2435,23 @@ async fn stream_google(
 
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
+    let mut completed = false;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|error| {
             AppError::new("llm_stream_error", provider_transport_error_message(error))
         })?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
         while let Some(block) = take_sse_block(&mut buffer) {
-            process_google_sse_block(&block, emit)?;
+            if process_google_sse_block(&block, emit)? == SseBlockStatus::Complete {
+                completed = true;
+                break;
+            }
+        }
+        if completed {
+            break;
         }
     }
-    if !buffer.trim().is_empty() {
+    if !completed && !buffer.trim().is_empty() {
         process_google_sse_block(&buffer, emit)?;
     }
     Ok(())
@@ -2415,15 +2460,18 @@ async fn stream_google(
 fn process_google_sse_block(
     block: &str,
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
-) -> AppResult<()> {
+) -> AppResult<SseBlockStatus> {
     let payload = block
         .lines()
         .filter_map(|line| line.trim_start().strip_prefix("data:"))
         .map(str::trim)
         .collect::<Vec<_>>()
         .join("\n");
-    if payload.is_empty() || payload == "[DONE]" {
-        return Ok(());
+    if payload.is_empty() {
+        return Ok(SseBlockStatus::Continue);
+    }
+    if payload == "[DONE]" {
+        return Ok(SseBlockStatus::Complete);
     }
     let value: Value = serde_json::from_str(&payload)
         .map_err(|error| AppError::new("llm_stream_parse_error", error.to_string()))?;
@@ -2438,7 +2486,7 @@ fn process_google_sse_block(
         emit(json!({ "type": "usage", "data": usage }))?;
     }
     let Some(candidates) = value.get("candidates").and_then(Value::as_array) else {
-        return Ok(());
+        return Ok(SseBlockStatus::Continue);
     };
     for candidate in candidates {
         let Some(parts) = candidate
@@ -2466,8 +2514,16 @@ fn process_google_sse_block(
                 emit(json!({ "type": "token", "text": text, "data": text }))?;
             }
         }
+        if candidate
+            .get("finishReason")
+            .and_then(Value::as_str)
+            .filter(|reason| !reason.is_empty())
+            .is_some()
+        {
+            return Ok(SseBlockStatus::Complete);
+        }
     }
-    Ok(())
+    Ok(SseBlockStatus::Continue)
 }
 
 async fn read_error_response_details(response: reqwest::Response) -> AppResult<Value> {
@@ -2738,13 +2794,13 @@ mod tests {
             Ok(())
         };
 
-        process_openai_sse_block(
+        let first_status = process_openai_sse_block(
             r#"data: {"choices":[{"delta":{"content":"Rolling...","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"roll_dice","arguments":"{\"notation\""}}]}}]}"#,
             &mut emit,
             &mut tool_calls,
         )
         .expect("first chunk should parse");
-        process_openai_sse_block(
+        let status = process_openai_sse_block(
             r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"1d20\"}"}}]}}]}"#,
             &mut emit,
             &mut tool_calls,
@@ -2758,6 +2814,43 @@ mod tests {
         assert_eq!(calls[0]["id"], "call_1");
         assert_eq!(calls[0]["function"]["name"], "roll_dice");
         assert_eq!(calls[0]["function"]["arguments"], r#"{"notation":"1d20"}"#);
+        assert_eq!(first_status, SseBlockStatus::Continue);
+        assert_eq!(status, SseBlockStatus::Continue);
+    }
+
+    #[test]
+    fn openai_chat_stream_done_block_is_terminal() {
+        let mut emitted = Vec::new();
+        let mut tool_calls = OpenAiToolCallAccumulator::default();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let status = process_openai_sse_block("data: [DONE]", &mut emit, &mut tool_calls)
+            .expect("DONE chunk should parse");
+
+        assert_eq!(status, SseBlockStatus::Complete);
+        assert!(emitted.is_empty());
+    }
+
+    #[test]
+    fn openai_responses_completed_event_is_terminal() {
+        let mut emitted = Vec::new();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let status = process_openai_responses_sse_block(
+            r#"event: response.completed
+data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":2}}}"#,
+            &mut emit,
+        )
+        .expect("response.completed should parse");
+
+        assert_eq!(status, SseBlockStatus::Complete);
+        assert_eq!(emitted[0]["type"], json!("usage"));
     }
 
     #[test]
@@ -2929,7 +3022,7 @@ mod tests {
             Ok(())
         };
 
-        process_google_sse_block(
+        let status = process_google_sse_block(
             r#"data: {"candidates":[{"content":{"parts":[{"text":"pondering","thought":true},{"text":"hello"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}"#,
             &mut emit,
         )
@@ -2942,6 +3035,28 @@ mod tests {
         );
         assert_eq!(
             emitted[2],
+            json!({ "type": "token", "text": "hello", "data": "hello" })
+        );
+        assert_eq!(status, SseBlockStatus::Continue);
+    }
+
+    #[test]
+    fn google_stream_finish_reason_is_terminal_after_tokens() {
+        let mut emitted = Vec::new();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let status = process_google_sse_block(
+            r#"data: {"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}]}"#,
+            &mut emit,
+        )
+        .expect("Gemini terminal block should parse");
+
+        assert_eq!(status, SseBlockStatus::Complete);
+        assert_eq!(
+            emitted[0],
             json!({ "type": "token", "text": "hello", "data": "hello" })
         );
     }
@@ -3083,7 +3198,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","
             &mut emit,
         )
         .expect("thinking delta should parse");
-        process_anthropic_sse_block(
+        let status = process_anthropic_sse_block(
             r#"event: content_block_delta
 data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}"#,
             &mut emit,
@@ -3099,6 +3214,26 @@ data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text
             emitted[2],
             json!({ "type": "token", "text": "hello", "data": "hello" })
         );
+        assert_eq!(status, SseBlockStatus::Continue);
+    }
+
+    #[test]
+    fn anthropic_stream_message_stop_is_terminal() {
+        let mut emitted = Vec::new();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let status = process_anthropic_sse_block(
+            r#"event: message_stop
+data: {"type":"message_stop"}"#,
+            &mut emit,
+        )
+        .expect("message_stop should parse");
+
+        assert_eq!(status, SseBlockStatus::Complete);
+        assert!(emitted.is_empty());
     }
 
     #[test]

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -1271,6 +1271,14 @@ fn process_openai_sse_block(
                 emit(json!({ "type": "token", "text": content, "data": content }))?;
             }
         }
+        if choice
+            .get("finish_reason")
+            .and_then(Value::as_str)
+            .filter(|reason| !reason.is_empty())
+            .is_some()
+        {
+            return Ok(SseBlockStatus::Complete);
+        }
     }
     Ok(SseBlockStatus::Continue)
 }
@@ -2489,29 +2497,28 @@ fn process_google_sse_block(
         return Ok(SseBlockStatus::Continue);
     };
     for candidate in candidates {
-        let Some(parts) = candidate
+        if let Some(parts) = candidate
             .get("content")
             .and_then(|content| content.get("parts"))
             .and_then(Value::as_array)
-        else {
-            continue;
-        };
-        for part in parts {
-            let Some(text) = part
-                .get("text")
-                .and_then(Value::as_str)
-                .filter(|text| !text.is_empty())
-            else {
-                continue;
-            };
-            if part
-                .get("thought")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-            {
-                emit(json!({ "type": "thinking", "text": text, "data": text }))?;
-            } else {
-                emit(json!({ "type": "token", "text": text, "data": text }))?;
+        {
+            for part in parts {
+                let Some(text) = part
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.is_empty())
+                else {
+                    continue;
+                };
+                if part
+                    .get("thought")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    emit(json!({ "type": "thinking", "text": text, "data": text }))?;
+                } else {
+                    emit(json!({ "type": "token", "text": text, "data": text }))?;
+                }
             }
         }
         if candidate
@@ -2835,6 +2842,29 @@ mod tests {
     }
 
     #[test]
+    fn openai_chat_stream_finish_reason_is_terminal() {
+        let mut emitted = Vec::new();
+        let mut tool_calls = OpenAiToolCallAccumulator::default();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let status = process_openai_sse_block(
+            r#"data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}"#,
+            &mut emit,
+            &mut tool_calls,
+        )
+        .expect("finish_reason chunk should parse");
+
+        assert_eq!(status, SseBlockStatus::Complete);
+        assert_eq!(
+            emitted[0],
+            json!({ "type": "token", "text": "done", "data": "done" })
+        );
+    }
+
+    #[test]
     fn openai_responses_completed_event_is_terminal() {
         let mut emitted = Vec::new();
         let mut emit = |value: Value| {
@@ -3059,6 +3089,24 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
             emitted[0],
             json!({ "type": "token", "text": "hello", "data": "hello" })
         );
+    }
+
+    #[test]
+    fn google_stream_finish_reason_is_terminal_without_parts() {
+        let mut emitted = Vec::new();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let status = process_google_sse_block(
+            r#"data: {"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"totalTokenCount":3}}"#,
+            &mut emit,
+        )
+        .expect("Gemini terminal metadata block should parse");
+
+        assert_eq!(status, SseBlockStatus::Complete);
+        assert_eq!(emitted[0], json!({ "type": "usage", "data": { "totalTokenCount": 3 } }));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -161,10 +161,16 @@ impl AppState {
 }
 
 fn prune_expired_llm_stream_cancellations(cancellations: &mut LlmStreamCancellations) {
-    let now = Instant::now();
-    cancellations
-        .pending
-        .retain(|_, created_at| now.duration_since(*created_at) < LLM_STREAM_PENDING_CANCEL_TTL);
+    prune_expired_llm_stream_cancellations_with_now(cancellations, Instant::now());
+}
+
+fn prune_expired_llm_stream_cancellations_with_now(
+    cancellations: &mut LlmStreamCancellations,
+    now: Instant,
+) {
+    cancellations.pending.retain(|_, created_at| {
+        now.saturating_duration_since(*created_at) < LLM_STREAM_PENDING_CANCEL_TTL
+    });
 }
 
 fn migrate_storage_json_fields(storage: &FileStorage) -> AppResult<()> {
@@ -687,6 +693,64 @@ mod tests {
             .expect("clock should be after epoch")
             .as_nanos();
         TempRoot(std::env::temp_dir().join(format!("marinara-state-{test_name}-{suffix}")))
+    }
+
+    #[test]
+    fn llm_stream_pending_cancellations_inside_ttl_are_retained() {
+        let now = Instant::now();
+        let mut cancellations = LlmStreamCancellations::default();
+        cancellations.pending.insert(
+            "recent".to_string(),
+            now - LLM_STREAM_PENDING_CANCEL_TTL + Duration::from_millis(1),
+        );
+
+        prune_expired_llm_stream_cancellations_with_now(&mut cancellations, now);
+
+        assert!(cancellations.pending.contains_key("recent"));
+    }
+
+    #[test]
+    fn llm_stream_pending_cancellations_older_than_ttl_are_pruned() {
+        let now = Instant::now();
+        let mut cancellations = LlmStreamCancellations::default();
+        cancellations.pending.insert(
+            "expired".to_string(),
+            now - LLM_STREAM_PENDING_CANCEL_TTL - Duration::from_millis(1),
+        );
+
+        prune_expired_llm_stream_cancellations_with_now(&mut cancellations, now);
+
+        assert!(!cancellations.pending.contains_key("expired"));
+    }
+
+    #[test]
+    fn llm_stream_pending_cancellations_with_future_timestamps_do_not_panic() {
+        let now = Instant::now();
+        let mut cancellations = LlmStreamCancellations::default();
+        cancellations
+            .pending
+            .insert("future".to_string(), now + Duration::from_secs(1));
+
+        prune_expired_llm_stream_cancellations_with_now(&mut cancellations, now);
+
+        assert!(cancellations.pending.contains_key("future"));
+    }
+
+    #[test]
+    fn register_llm_stream_starts_cancelled_for_recent_pending_entry() {
+        let root = temp_root("llm-stream-pending-cancel");
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+
+        assert!(!state
+            .cancel_llm_stream("stream-1")
+            .expect("cancel should register pending"));
+
+        let cancellation = state
+            .register_llm_stream("stream-1")
+            .expect("stream should register");
+
+        assert!(*cancellation.borrow());
+        state.unregister_llm_stream("stream-1");
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Manager};
 use tokio::sync::watch;
 
@@ -29,8 +30,10 @@ pub struct AppState {
 #[derive(Default)]
 struct LlmStreamCancellations {
     active: HashMap<String, watch::Sender<bool>>,
-    pending: HashSet<String>,
+    pending: HashMap<String, Instant>,
 }
+
+const LLM_STREAM_PENDING_CANCEL_TTL: Duration = Duration::from_secs(60);
 
 impl AppState {
     pub fn new(app: &AppHandle) -> AppResult<Self> {
@@ -123,7 +126,8 @@ impl AppState {
                 "LLM stream cancellation registry is unavailable",
             )
         })?;
-        let starts_cancelled = cancellations.pending.remove(stream_id);
+        prune_expired_llm_stream_cancellations(&mut cancellations);
+        let starts_cancelled = cancellations.pending.remove(stream_id).is_some();
         let (tx, rx) = watch::channel(starts_cancelled);
         cancellations.active.insert(stream_id.to_string(), tx);
         Ok(rx)
@@ -137,27 +141,30 @@ impl AppState {
     }
 
     pub fn cancel_llm_stream(&self, stream_id: &str) -> AppResult<bool> {
-        let cancellations = self.llm_stream_cancellations.lock().map_err(|_| {
+        let mut cancellations = self.llm_stream_cancellations.lock().map_err(|_| {
             AppError::new(
                 "llm_stream_cancel_error",
                 "LLM stream cancellation registry is unavailable",
             )
         })?;
+        prune_expired_llm_stream_cancellations(&mut cancellations);
         if let Some(tx) = cancellations.active.get(stream_id) {
             let _ = tx.send(true);
             Ok(true)
         } else {
-            drop(cancellations);
-            let mut cancellations = self.llm_stream_cancellations.lock().map_err(|_| {
-                AppError::new(
-                    "llm_stream_cancel_error",
-                    "LLM stream cancellation registry is unavailable",
-                )
-            })?;
-            cancellations.pending.insert(stream_id.to_string());
+            cancellations
+                .pending
+                .insert(stream_id.to_string(), Instant::now());
             Ok(false)
         }
     }
+}
+
+fn prune_expired_llm_stream_cancellations(cancellations: &mut LlmStreamCancellations) {
+    let now = Instant::now();
+    cancellations
+        .pending
+        .retain(|_, created_at| now.duration_since(*created_at) < LLM_STREAM_PENDING_CANCEL_TTL);
 }
 
 fn migrate_storage_json_fields(storage: &FileStorage) -> AppResult<()> {

--- a/src/shared/api/llm-api.test.ts
+++ b/src/shared/api/llm-api.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LlmChunk, LlmRequest } from "../../engine/capabilities/llm";
 import { useUIStore } from "../stores/ui.store";
-import { llmApi } from "./llm-api";
+import { llmApi, TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS } from "./llm-api";
 import { invokeTauri } from "./tauri-client";
 
 vi.mock("./tauri-client", () => ({
@@ -47,6 +47,7 @@ describe("llmApi stream cancellation", () => {
     warn.mockRestore();
     invokeMock.mockReset();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("cancels remote streams against the target captured when streaming started", async () => {
@@ -180,6 +181,7 @@ describe("llmApi stream cancellation", () => {
   });
 
   it("cancels local native cleanup if the terminal event arrives before the native command settles", async () => {
+    vi.useFakeTimers();
     invokeMock.mockImplementation((command) => {
       if (command === "llm_stream_channel") {
         return pendingCommand();
@@ -196,6 +198,7 @@ describe("llmApi stream cancellation", () => {
     await expect(doneEvent).resolves.toMatchObject({ done: false, value: { type: "done" } });
     const final = iterator.next();
     await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS);
     await expect(final).resolves.toMatchObject({ done: true });
     expect(invokeMock).toHaveBeenCalledWith(
       "llm_stream_cancel",

--- a/src/shared/api/llm-api.test.ts
+++ b/src/shared/api/llm-api.test.ts
@@ -179,13 +179,10 @@ describe("llmApi stream cancellation", () => {
     );
   });
 
-  it("waits for native cleanup when the terminal event arrives before the native command settles", async () => {
-    let settleCommand: (() => void) | undefined;
+  it("cancels local native cleanup if the terminal event arrives before the native command settles", async () => {
     invokeMock.mockImplementation((command) => {
       if (command === "llm_stream_channel") {
-        return new Promise<void>((resolve) => {
-          settleCommand = resolve;
-        });
+        return pendingCommand();
       }
       if (command === "llm_stream_cancel") return Promise.resolve();
       return Promise.reject(new Error(`Unexpected command: ${command}`));
@@ -199,14 +196,8 @@ describe("llmApi stream cancellation", () => {
     await expect(doneEvent).resolves.toMatchObject({ done: false, value: { type: "done" } });
     const final = iterator.next();
     await Promise.resolve();
-    expect(invokeMock).not.toHaveBeenCalledWith(
-      "llm_stream_cancel",
-      expect.objectContaining({ streamId: expect.any(String) }),
-    );
-
-    settleCommand?.();
     await expect(final).resolves.toMatchObject({ done: true });
-    expect(invokeMock).not.toHaveBeenCalledWith(
+    expect(invokeMock).toHaveBeenCalledWith(
       "llm_stream_cancel",
       expect.objectContaining({ streamId: expect.any(String) }),
     );

--- a/src/shared/api/llm-api.test.ts
+++ b/src/shared/api/llm-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { LlmRequest } from "../../engine/capabilities/llm";
+import type { LlmChunk, LlmRequest } from "../../engine/capabilities/llm";
 import { useUIStore } from "../stores/ui.store";
 import { llmApi } from "./llm-api";
 import { invokeTauri } from "./tauri-client";
@@ -24,6 +24,13 @@ function pendingCommand(): Promise<void> {
 
 function sseChunk(event: unknown): Uint8Array {
   return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+function sentChannel(): { onmessage: (event: LlmChunk) => void } {
+  const streamCall = vi.mocked(invokeTauri).mock.calls.find(([command]) => command === "llm_stream_channel");
+  const args = streamCall?.[1] as { onEvent?: { onmessage?: (event: LlmChunk) => void } } | undefined;
+  if (!args?.onEvent?.onmessage) throw new Error("llm_stream_channel onEvent was not registered");
+  return { onmessage: args.onEvent.onmessage };
 }
 
 describe("llmApi stream cancellation", () => {
@@ -149,5 +156,46 @@ describe("llmApi stream cancellation", () => {
       expect.objectContaining({ streamId: expect.any(String) }),
     );
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("cancels a local stream when the consumer closes the generator early", async () => {
+    invokeMock.mockImplementation((command) => {
+      if (command === "llm_stream_channel") return pendingCommand();
+      if (command === "llm_stream_cancel") return Promise.resolve();
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+    const iterator = llmApi.stream(request);
+
+    const first = iterator.next();
+    await Promise.resolve();
+    sentChannel().onmessage({ type: "token", text: "hello" });
+
+    await expect(first).resolves.toMatchObject({ done: false, value: { type: "token", text: "hello" } });
+    await iterator.return(undefined);
+
+    expect(invokeMock).toHaveBeenCalledWith(
+      "llm_stream_cancel",
+      expect.objectContaining({ streamId: expect.any(String) }),
+    );
+  });
+
+  it("cancels a local stream if the terminal event arrives before the native command settles", async () => {
+    invokeMock.mockImplementation((command) => {
+      if (command === "llm_stream_channel") return pendingCommand();
+      if (command === "llm_stream_cancel") return Promise.resolve();
+      return Promise.reject(new Error(`Unexpected command: ${command}`));
+    });
+    const iterator = llmApi.stream(request);
+
+    const doneEvent = iterator.next();
+    await Promise.resolve();
+    sentChannel().onmessage({ type: "done" });
+
+    await expect(doneEvent).resolves.toMatchObject({ done: false, value: { type: "done" } });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+    expect(invokeMock).toHaveBeenCalledWith(
+      "llm_stream_cancel",
+      expect.objectContaining({ streamId: expect.any(String) }),
+    );
   });
 });

--- a/src/shared/api/llm-api.test.ts
+++ b/src/shared/api/llm-api.test.ts
@@ -94,6 +94,25 @@ describe("llmApi stream cancellation", () => {
     await expect(next).resolves.toMatchObject({ done: true });
   });
 
+  it("does not yield remote done events", async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(new Response(stream, { status: 200 })));
+    useUIStore.getState().setRemoteRuntimeUrl("http://127.0.0.1:8787");
+    const iterator = llmApi.stream(request);
+
+    const next = iterator.next();
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    streamController!.enqueue(sseChunk({ type: "done" }));
+    streamController!.close();
+
+    await expect(next).resolves.toMatchObject({ done: true });
+  });
+
   it("logs local cancel command failures without changing abort behavior", async () => {
     invokeMock.mockImplementation((command) => {
       if (command === "llm_stream_channel") return pendingCommand();
@@ -180,7 +199,7 @@ describe("llmApi stream cancellation", () => {
     );
   });
 
-  it("cancels local native cleanup if the terminal event arrives before the native command settles", async () => {
+  it("does not yield local done events and cancels native cleanup if the command stays unsettled", async () => {
     vi.useFakeTimers();
     invokeMock.mockImplementation((command) => {
       if (command === "llm_stream_channel") {
@@ -195,11 +214,9 @@ describe("llmApi stream cancellation", () => {
     await Promise.resolve();
     sentChannel().onmessage({ type: "done" });
 
-    await expect(doneEvent).resolves.toMatchObject({ done: false, value: { type: "done" } });
-    const final = iterator.next();
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS);
-    await expect(final).resolves.toMatchObject({ done: true });
+    await expect(doneEvent).resolves.toMatchObject({ done: true });
     expect(invokeMock).toHaveBeenCalledWith(
       "llm_stream_cancel",
       expect.objectContaining({ streamId: expect.any(String) }),

--- a/src/shared/api/llm-api.test.ts
+++ b/src/shared/api/llm-api.test.ts
@@ -179,9 +179,14 @@ describe("llmApi stream cancellation", () => {
     );
   });
 
-  it("cancels a local stream if the terminal event arrives before the native command settles", async () => {
+  it("waits for native cleanup when the terminal event arrives before the native command settles", async () => {
+    let settleCommand: (() => void) | undefined;
     invokeMock.mockImplementation((command) => {
-      if (command === "llm_stream_channel") return pendingCommand();
+      if (command === "llm_stream_channel") {
+        return new Promise<void>((resolve) => {
+          settleCommand = resolve;
+        });
+      }
       if (command === "llm_stream_cancel") return Promise.resolve();
       return Promise.reject(new Error(`Unexpected command: ${command}`));
     });
@@ -192,8 +197,16 @@ describe("llmApi stream cancellation", () => {
     sentChannel().onmessage({ type: "done" });
 
     await expect(doneEvent).resolves.toMatchObject({ done: false, value: { type: "done" } });
-    await expect(iterator.next()).resolves.toMatchObject({ done: true });
-    expect(invokeMock).toHaveBeenCalledWith(
+    const final = iterator.next();
+    await Promise.resolve();
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "llm_stream_cancel",
+      expect.objectContaining({ streamId: expect.any(String) }),
+    );
+
+    settleCommand?.();
+    await expect(final).resolves.toMatchObject({ done: true });
+    expect(invokeMock).not.toHaveBeenCalledWith(
       "llm_stream_cancel",
       expect.objectContaining({ streamId: expect.any(String) }),
     );

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -11,7 +11,7 @@ function createStreamId(): string {
 
 const activeTauriStreamIds = new Set<string>();
 let unloadCancellationInstalled = false;
-const TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS = 250;
+export const TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS = 250;
 
 function wait(ms: number): Promise<false> {
   return new Promise((resolve) => {

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -61,7 +61,10 @@ export const llmApi: LlmGateway = {
       if (signal?.aborted) abort();
       signal?.addEventListener("abort", abort, { once: true });
       try {
-        yield* streamRemoteLlm(streamId, request, remoteTarget, signal);
+        for await (const event of streamRemoteLlm(streamId, request, remoteTarget, signal)) {
+          if (event.type === "done") continue;
+          yield event;
+        }
       } finally {
         signal?.removeEventListener("abort", abort);
       }
@@ -116,6 +119,7 @@ export const llmApi: LlmGateway = {
         commandSettled = true;
       },
       (error) => {
+        // A native command rejection is fatal; prefer surfacing it over yielding already-buffered partial tokens.
         commandSettled = true;
         failure = error;
         completed = true;
@@ -134,11 +138,13 @@ export const llmApi: LlmGateway = {
         }
         const event = queue.shift()!;
         if (event.type === "error") throw new Error(String(event.text ?? event.data ?? "LLM stream failed"));
+        if (event.type === "done") continue;
         yield event;
       }
       if (commandSettled) {
         await command;
       } else if (terminalEventReceived) {
+        // command handles native success and rejection, so this race only distinguishes settled cleanup from timeout.
         const cleanedUp = await Promise.race([command.then(() => true), wait(TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS)]);
         if (!cleanedUp) cancelNativeStream();
       } else {

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -66,14 +66,21 @@ export const llmApi: LlmGateway = {
     let completed = false;
     let failure: unknown = null;
     let wake: (() => void) | null = null;
+    let commandSettled = false;
+    let cancelRequested = false;
 
     const notify = () => {
       wake?.();
       wake = null;
     };
+    const cancelNativeStream = () => {
+      if (cancelRequested || commandSettled) return;
+      cancelRequested = true;
+      void ignoreLlmStreamCancelFailure("tauri", streamId, invokeTauri("llm_stream_cancel", { streamId }));
+    };
     const abort = () => {
       failure = new DOMException("The operation was aborted.", "AbortError");
-      void ignoreLlmStreamCancelFailure("tauri", streamId, invokeTauri("llm_stream_cancel", { streamId }));
+      cancelNativeStream();
       notify();
     };
 
@@ -93,11 +100,17 @@ export const llmApi: LlmGateway = {
       streamId,
       request,
       onEvent,
-    }).catch((error) => {
-      failure = error;
-      completed = true;
-      notify();
-    });
+    }).then(
+      () => {
+        commandSettled = true;
+      },
+      (error) => {
+        commandSettled = true;
+        failure = error;
+        completed = true;
+        notify();
+      },
+    );
 
     try {
       while (!completed || queue.length > 0) {
@@ -112,10 +125,12 @@ export const llmApi: LlmGateway = {
         if (event.type === "error") throw new Error(String(event.text ?? event.data ?? "LLM stream failed"));
         yield event;
       }
-      await command;
+      if (commandSettled) await command;
+      else cancelNativeStream();
       if (failure) throw failure;
     } finally {
       signal?.removeEventListener("abort", abort);
+      cancelNativeStream();
       activeTauriStreamIds.delete(streamId);
     }
   },

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -68,6 +68,7 @@ export const llmApi: LlmGateway = {
     let wake: (() => void) | null = null;
     let commandSettled = false;
     let cancelRequested = false;
+    let terminalEventReceived = false;
 
     const notify = () => {
       wake?.();
@@ -91,7 +92,10 @@ export const llmApi: LlmGateway = {
       const text =
         typeof event.text === "string" ? event.text : typeof event.data === "string" ? event.data : undefined;
       const normalized = text === undefined ? event : { ...event, text };
-      if (normalized.type === "done" || normalized.type === "error") completed = true;
+      if (normalized.type === "done" || normalized.type === "error") {
+        terminalEventReceived = true;
+        completed = true;
+      }
       queue.push(normalized);
       notify();
     });
@@ -125,7 +129,7 @@ export const llmApi: LlmGateway = {
         if (event.type === "error") throw new Error(String(event.text ?? event.data ?? "LLM stream failed"));
         yield event;
       }
-      if (commandSettled) await command;
+      if (commandSettled || terminalEventReceived) await command;
       else cancelNativeStream();
       if (failure) throw failure;
     } finally {

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -11,6 +11,13 @@ function createStreamId(): string {
 
 const activeTauriStreamIds = new Set<string>();
 let unloadCancellationInstalled = false;
+const TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS = 250;
+
+function wait(ms: number): Promise<false> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(() => resolve(false), ms);
+  });
+}
 
 function cancelActiveTauriStreams() {
   for (const streamId of activeTauriStreamIds) {
@@ -129,8 +136,14 @@ export const llmApi: LlmGateway = {
         if (event.type === "error") throw new Error(String(event.text ?? event.data ?? "LLM stream failed"));
         yield event;
       }
-      if (commandSettled || terminalEventReceived) await command;
-      else cancelNativeStream();
+      if (commandSettled) {
+        await command;
+      } else if (terminalEventReceived) {
+        const cleanedUp = await Promise.race([command.then(() => true), wait(TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS)]);
+        if (!cleanedUp) cancelNativeStream();
+      } else {
+        cancelNativeStream();
+      }
       if (failure) throw failure;
     } finally {
       signal?.removeEventListener("abort", abort);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1716

## Why this change

- Local LLM streaming could finish at the provider level while the native streaming command remained unsettled, leaving the frontend waiting on native cleanup instead of completing the generator.
- Some provider terminal chunks were not treated as terminal unless the stream also sent a separate `[DONE]`-style marker.

## What changed

- Treat OpenAI-compatible chat `finish_reason` chunks as terminal while preserving emitted token content.
- Treat Gemini `finishReason` chunks as terminal even when the terminal metadata block does not include content parts.
- Add a short Tauri cleanup grace period after a terminal stream event, then cancel native cleanup if the command remains unsettled.
- Update targeted TS and Rust tests for the terminal-event cleanup path.

## Refactor impact

Primary owner:

shared API, Rust LLM provider transport

Impact areas reviewed:

- Tauri LLM stream channel cleanup and cancellation.
- OpenAI-compatible chat stream SSE parsing.
- Google/Gemini stream SSE parsing.
- Remote runtime stream path for boundary impact.

Boundary notes:

- Frontend behavior stays in `src/shared/api/llm-api.ts`.
- Provider SSE parsing stays in `src-tauri/crates/llm`.
- No feature code or engine mode ownership changed.

Pressure points touched:

- `llm_stream_channel` cleanup behavior through the shared API wrapper.
- Rust LLM stream parser terminal handling.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [x] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm exec vitest run src/shared/api/llm-api.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm openai_chat_stream_finish_reason_is_terminal`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm google_stream_finish_reason_is_terminal_without_parts`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm check:architecture`
- Live provider, browser/Tauri, and remote runtime smoke checks were not run.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced LLM streaming: improved detection of stream completion across all providers (OpenAI, Anthropic, Google)
  * Improved cancellation handling: better cleanup and timeout management for stopping streams

<!-- end of auto-generated comment: release notes by coderabbit.ai -->