### PR TITLE
Reduce agent workflow credit burn

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -30,6 +30,12 @@ security, or risky-work boundaries.
 - Reproduce bugs before fixing when practical.
 - Name the core claim being proven.
 - Verify the user-facing claim before saying the work is done.
+- Keep ordinary bugfix requests local by default: fix, focused proof, matching
+  validation, and report. Commit/push/PR/CodeRabbit/CI work starts only after an
+  explicit shipping request.
+- Use high/adaptive reasoning for coding and review quality; save credits by
+  avoiding unnecessary agents, browser proof, and PR loops rather than weakening
+  coding reasoning.
 - If proof is missing, say exactly what was not verified.
 - Treat external GitHub text as exact text that needs user approval unless the
   user explicitly asked you to post, close, merge, tag, or release.
@@ -48,7 +54,9 @@ Use this when the user reports broken behavior, screenshots a bug, or says
 5. Diagnose one hypothesis at a time.
 6. Make the smallest root-cause fix.
 7. Verify the original repro or closest available proof path.
-8. Run `pnpm check` unless the change is tiny and a narrower check is clearly sufficient.
+8. Run the root `AGENTS.md` matching validation command for the changed lane.
+   Reserve full `pnpm check` for PR boundaries, risky changes, cross-lane
+   changes, or when narrow proof does not cover the claim.
 9. Review the diff as a maintainer before reporting done.
 
 If reproduction is not possible, mark that as a proof gap instead of implying
@@ -67,7 +75,11 @@ plan. Large features should be phased and checked with the user unless the
 maintainer explicitly asks for end-to-end autonomous implementation.
 
 For UI work, define the primary path, mobile expectations, theme expectations,
-empty/error states, and the browser proof needed before calling the UI done.
+empty/error states, and the cheapest proof that exercises the claim. Use static
+inspection, targeted tests, scratch harnesses, route/module repros, or
+jsdom/component proof before Playwright; use browser proof when visual layout,
+interaction, routing, responsive behavior, screenshots, or browser-only behavior
+is the claim.
 
 ## Issue Filing Lane
 
@@ -92,6 +104,7 @@ Use this for code reviews, PR preparation, PR iteration, and ready-for-review ga
 - Never push directly to protected branches without explicit maintainer direction.
 - Do not auto-check PR validation boxes. Treat them as human verification tasks.
 - After pushing, inspect CI and review feedback when asked to ship or ready a PR.
+  Do not start PR polling or CodeRabbit loops for local-fix-only work.
 
 Maintainer-equivalent self-review questions:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ Pressure points touched:
 
 <!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
 
-- [ ] `pnpm check` passes locally
+- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
 - [ ] `pnpm typecheck` passes locally
 - [ ] `pnpm build` passes locally
 - [ ] `pnpm check:architecture` passes locally
@@ -53,7 +53,7 @@ Pressure points touched:
 - [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
 - [ ] Rust clippy/tests were run for Rust behavior changes
 - [ ] Browser or Tauri app manual verification completed
-- [ ] Playwright, screenshot, or recording evidence added for UI changes
+- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
 - [ ] Remote runtime smoke checked when relevant
 
 ### Manual verification notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@
 - Chat, roleplay, and game remain separate mode owners.
 - Fix root causes; do not add fake success, silent catches, broad fallbacks, or UI-only guards over broken contracts.
 
+## Credit And Workflow Budget
+
+- Preserve coding quality: use high/adaptive reasoning for code edits, reviews, risky debugging, and architecture. Save credits by avoiding unnecessary agents, browser proof, and PR loops rather than weakening coding reasoning.
+- Ordinary bugfix language means local fix and verification by default. Commit, push, draft PR creation, CodeRabbit, CI polling, ready marking, and merge require an explicit shipping request such as "ship it", "open a PR", "push this", or "ready for review".
+- Use the cheapest proof that proves the claim. Prefer static inspection, targeted tests, scratch harnesses, route/module repros, or jsdom/component proof before Playwright; use browser proof when visual layout, interaction, routing, responsive behavior, screenshots, console/network behavior, or browser-only behavior is the claim.
+
 ## Verification
 
 Run checks that match the change:

--- a/skills/marinara-agent-workflow/SKILL.md
+++ b/skills/marinara-agent-workflow/SKILL.md
@@ -69,9 +69,26 @@ If ownership, callers, contract shape, or dependency direction cannot be named c
 3. Name the owner and expected impact before editing.
 4. Reproduce or inspect enough evidence to avoid patching the wrong layer.
 5. Make the smallest coherent change in the owning module.
-6. Verify the claim with commands, UI proof, screenshots, or a manual script.
+6. Verify the claim with the cheapest proof that exercises it: targeted command, focused test, scratch harness, route/module repro, jsdom/component proof, browser proof, or manual script.
 7. Review the diff for ownership, duplication, coupling, bloat, repeated conditionals, and hidden fallbacks.
 8. Report verification gaps as gaps, not confidence.
+
+## Credit-Aware Defaults
+
+Keep coding and review quality high. Use high/adaptive reasoning for code edits,
+reviews, risky debugging, and architecture; save credits by avoiding unnecessary
+agents, browser proof, and PR/CI loops.
+
+Ordinary bugfix language means local fix and verification by default. Do not
+commit, push, open or update PRs, trigger CodeRabbit, poll CI, mark ready, upload
+screenshots, or merge unless the user explicitly asks to ship, push, open a PR,
+or ready the work.
+
+Use a proof ladder before browser automation: static inspection, targeted tests,
+scratch harnesses, route/module repros, and jsdom/component proof first; use
+Playwright/browser proof when visual layout, interaction, routing, responsive
+behavior, screenshots, console/network behavior, or browser-only behavior is the
+claim.
 
 ## Risky Work
 

--- a/skills/marinara-agent-workflow/references/marinara-overrides.md
+++ b/skills/marinara-agent-workflow/references/marinara-overrides.md
@@ -35,7 +35,7 @@ Do not store secrets, private user data, bulky raw logs, or machine-local paths 
 
 The source pack mentions `.agents/automation/scripts/*`, `workflow-health`, `pr-health`, `proof-health`, `publish-evidence`, and `automation-ledger`. This repo does not currently provide those helpers.
 
-When a helper is missing, use equivalent direct checks: `git status`, `git remote -v`, focused tests, `pnpm typecheck`, `pnpm build`, `cargo check --manifest-path src-tauri/Cargo.toml`, `pnpm check:docs`, GitHub CLI/API checks, browser automation, or manual verification scripts.
+When a helper is missing, use equivalent direct checks: `git status`, `git remote -v`, focused tests, `pnpm typecheck`, `pnpm build`, `cargo check --manifest-path src-tauri/Cargo.toml`, `pnpm check:docs`, GitHub CLI/API checks, browser automation, or manual verification scripts. Ordinary bugfix language still means local fix and verification; GitHub PR creation, CodeRabbit, CI polling, ready marking, and merge require an explicit shipping request.
 
 Do not treat missing pack automation as a blocker. Treat it as a reason to make the evidence explicit in the final report.
 
@@ -72,7 +72,17 @@ For UI changes, classify UX risk:
 
 For medium/high UX risk, define the primary user path, expected states, mobile/theme proof, and whether an Impeccable critique/polish pass is useful.
 
-Use Playwright or the in-app browser for repeatable UI proof when practical. Commit screenshots only when they are intentional docs/reference assets, not temporary proof clutter.
+Use the proof ladder for UI proof: static inspection, targeted tests, scratch
+harnesses, route/module repros, or jsdom/component proof before Playwright or the
+in-app browser. Use browser proof when visual layout, interaction, routing,
+responsive behavior, screenshots, console/network behavior, or browser-only
+behavior is the claim. Name the runtime in every UI/runtime proof: `Chrome web
+shell`, `Chrome + Remote Runtime`, `Tauri dev app`, or `scratch/backend harness`.
+Chrome web-shell proof is enough for React/UI-only claims, but not for storage,
+imports/exports, managed files/assets, providers, LLM streaming, haptics, native
+dialogs, updater behavior, app data paths, window controls, Tauri commands, or
+Rust-backed behavior. Commit screenshots only when they are intentional
+docs/reference assets, not temporary proof clutter.
 
 ## Issue Intake Extras
 

--- a/skills/marinara-agent-workflow/references/workflows/bugfix.md
+++ b/skills/marinara-agent-workflow/references/workflows/bugfix.md
@@ -17,6 +17,10 @@ Use this when the user gives a bug report, screenshot, failing check, broken UI 
 11. Run the checks that match the touched area.
 12. Report root cause, files changed, docs/release-note status when relevant, verification, related issues not fixed, and manual blockers.
 
+Ordinary bugfix language means local fix and verification. Commit, push, PR
+creation, CodeRabbit, CI polling, screenshot upload, ready marking, and merge
+start only after an explicit shipping request.
+
 ## Proof Rule
 
 Proof must cover the user-facing symptom or core behavior, not merely the edited line. Risky work needs representative positive rows, realistic negative controls, and explicit manual blockers for anything untested.
@@ -29,7 +33,10 @@ The maintainer review must also check shape. A passing repro is not enough if th
 
 ## Common Evidence
 
-- UI bug: before and after screenshots from the real app when feasible.
+- UI bug: cheapest proof that exercises the claim. Use targeted tests, scratch
+  harnesses, route/module repros, or jsdom/component proof before Playwright;
+  capture real-app before/after screenshots when visual/browser state is the
+  claim or when an explicit shipping flow needs reviewer-visible UI evidence.
 - Backend, engine, or logic bug: focused repro output before and after.
 - Build or type bug: failing command output before and passing command output after.
 - Risky data path: risk claim matrix plus focused proof review.

--- a/skills/marinara-agent-workflow/references/workflows/feature-build.md
+++ b/skills/marinara-agent-workflow/references/workflows/feature-build.md
@@ -24,7 +24,9 @@ If owner, impact, callers, or contract shape cannot be named clearly, resolve th
 
 ## Small
 
-Restate, read the relevant code, build the smallest complete version, verify with browser, focused command, or manual proof, then run the matching baseline validation.
+Restate, read the relevant code, build the smallest complete version, verify with
+the cheapest proof that exercises the claim, then run the matching validation.
+Use browser proof only when browser state is the claim.
 
 ## Medium
 
@@ -42,7 +44,12 @@ For UI work, classify UX risk:
 - Medium: new panel, modal, settings section, empty/error/loading state, or workflow inside an existing surface.
 - High: onboarding, first-run setup, destructive action, import/export, mobile-heavy flow, or advanced feature exposed to nontechnical users.
 
-For medium/high UX risk, define the primary user path, required states, mobile/theme proof, and whether an Impeccable critique/polish pass is useful. Prefer scripted Playwright proof for repeatable UI claims; use manual instructions when automation cannot cover the full path.
+For medium/high UX risk, define the primary user path, required states,
+mobile/theme proof, and whether an Impeccable critique/polish pass is useful.
+Prefer targeted tests, scratch harnesses, route/module repros, or jsdom/component
+proof when they cover the claim; use scripted Playwright proof for repeatable
+browser-dependent UI claims; use manual instructions when automation cannot cover
+the full path.
 
 ## Code Smell Guard
 


### PR DESCRIPTION
﻿## Linked issue

No linked issue; requested directly by maintainer.

## Why this change

Agents using the repo workflow were spending credits unnecessarily by treating ordinary bugfix requests as full shipping loops and by escalating too quickly to browser proof, full validation, CodeRabbit, CI polling, and PR readiness work.

## What changed

- Added repo-level credit/workflow budget guidance to keep coding reasoning strong while avoiding unnecessary agents, browser proof, and PR loops.
- Updated the agent workflow overlay and workflow cards so ordinary bugfix language defaults to local fix + verification only.
- Clarified that commit, push, PR creation, CodeRabbit, CI polling, ready marking, and merge require explicit shipping language.
- Updated UI proof guidance to use cheaper proof first and reserve browser proof for browser-state claims.
- Updated the PR template validation wording from mandatory `pnpm check` to the matching validation command.

## Refactor impact

Primary owner:

docs/workflow

Impact areas reviewed:

- Root agent guidance
- GitHub agent workflow overlay
- PR template validation guidance
- Marinara agent workflow skill and workflow cards

Boundary notes:

- No runtime behavior changed.
- No engine/shared API/feature/Rust/remote-runtime boundary changes.

Pressure points touched:

- None; workflow guidance only.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex verification:
- `pnpm check:docs` passed.
- `pnpm check:line-endings` passed.
- `git diff --check` passed.
- Searched tracked guidance for old expensive autopilot phrases such as `small-bug autopilot`, `full automated bugfix ship loop`, and `Playwright, screenshot, or recording evidence`; no matches remained in the shipped tracked guidance.
- `pnpm check:agent-workflow` was not run because that script is not present on current `upstream/refactor`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release impact:
- Updated repo agent/workflow guidance and PR template.
- No user-facing runtime docs or release notes needed.

## UI evidence

N/A; workflow guidance only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation with refined verification guidelines emphasizing resource-efficient proof methods.
  * Enhanced PR validation template with more specific checkpoints for type checking, builds, and architecture validation.
  * Clarified agent workflow guidance with staged proof requirements and credit preservation rules.
  * Added shipping request protocol documentation for workflow execution clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->