### PR TITLE
chore: type preset editor rows

### DIFF
--- a/src/features/catalog/presets/components/PresetEditor.tsx
+++ b/src/features/catalog/presets/components/PresetEditor.tsx
@@ -300,8 +300,8 @@ export function PresetEditor() {
 
   const orderedSections = useMemo<PromptSectionRow[]>(() => {
     if (!data?.sections) return [];
-    const map = new Map(data.sections.map((section) => [section.id, section]));
-    return sectionOrder.map((id) => map.get(id)).filter((section): section is PromptSection => Boolean(section));
+    const map = new Map<string, PromptSectionRow>(data.sections.map((section) => [section.id, section]));
+    return sectionOrder.map((id) => map.get(id)).filter((section): section is PromptSectionRow => Boolean(section));
   }, [data?.sections, sectionOrder]);
 
   const sectionHasLorebookMarker = useMemo(() => {

--- a/src/features/catalog/presets/components/PresetEditor.tsx
+++ b/src/features/catalog/presets/components/PresetEditor.tsx
@@ -66,8 +66,44 @@ import { reviewPromptPreset } from "../../../../engine/generation/prompt-reviewe
 import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { useAgentConfigs, type AgentConfigRow } from "../../agents/index";
-import type { WrapFormat, MarkerType } from "../../../../engine/contracts/types/prompt";
+import type {
+  ChoiceBlock,
+  ChoiceOption,
+  GenerationParameters,
+  MarkerConfig,
+  WrapFormat,
+  MarkerType,
+  PromptGroup,
+  PromptSection,
+} from "../../../../engine/contracts/types/prompt";
 import { SUPPORTED_MACROS } from "../../../../engine/shared/macros/macro-engine";
+
+type PromptSectionRow = Omit<PromptSection, "enabled" | "isMarker" | "forbidOverrides" | "markerConfig"> & {
+  enabled: boolean | string;
+  isMarker: boolean | string;
+  forbidOverrides: boolean | string;
+  markerConfig: MarkerConfigRow | string | null;
+};
+
+type ChoiceBlockRow = Omit<ChoiceBlock, "multiSelect" | "randomPick"> & {
+  variable_name?: string | null;
+  multiSelect: boolean | string;
+  randomPick: boolean | string;
+};
+
+type MarkerConfigRow = Omit<MarkerConfig, "type"> & { type: MarkerType | string };
+
+type CreateSectionMutation = ReturnType<typeof useCreateSection>;
+type UpdateSectionMutation = ReturnType<typeof useUpdateSection>;
+type DeleteSectionMutation = ReturnType<typeof useDeleteSection>;
+type ReorderSectionsMutation = ReturnType<typeof useReorderSections>;
+type CreateGroupMutation = ReturnType<typeof useCreateGroup>;
+type UpdateGroupMutation = ReturnType<typeof useUpdateGroup>;
+type DeleteGroupMutation = ReturnType<typeof useDeleteGroup>;
+type CreateVariableMutation = ReturnType<typeof useCreateVariable>;
+type UpdateVariableMutation = ReturnType<typeof useUpdateVariable>;
+type DeleteVariableMutation = ReturnType<typeof useDeleteVariable>;
+type ReorderVariablesMutation = ReturnType<typeof useReorderVariables>;
 
 /** Intercept Tab in a textarea to insert 2 spaces instead of changing focus. */
 function handleTextareaTab(e: React.KeyboardEvent<HTMLTextAreaElement>, value: string, setValue: (v: string) => void) {
@@ -135,14 +171,27 @@ function readBoolFlag(value: unknown): boolean {
   return value === true || value === "true";
 }
 
-function readMarkerConfig(value: unknown) {
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readMarkerConfig(value: unknown): MarkerConfigRow | null {
   if (!value) return null;
-  if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return null;
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
   }
+  const config = readRecord(parsed);
+  if (typeof config.type !== "string") return null;
+  return config as MarkerConfigRow;
+}
+
+function markerLabel(type: string): string {
+  return type in MARKER_LABELS ? MARKER_LABELS[type as MarkerType] : "Unknown";
 }
 
 // ═══════════════════════════════════════════════
@@ -184,15 +233,15 @@ export function PresetEditor() {
   const [localDescription, setLocalDescription] = useState("");
   const [localWrapFormat, setLocalWrapFormat] = useState<WrapFormat>("xml");
   const [localAuthor, setLocalAuthor] = useState("");
-  const [localParams, setLocalParams] = useState<Record<string, unknown>>({});
+  const [localParams, setLocalParams] = useState<Partial<GenerationParameters>>({});
 
   // Populate local state when data loads
   useEffect(() => {
     if (!data) return;
-    const p = data.preset as any;
+    const p = data.preset;
     setLocalName(p.name ?? "");
     setLocalDescription(p.description ?? "");
-    setLocalWrapFormat((p.wrapFormat ?? "xml") as WrapFormat);
+    setLocalWrapFormat(p.wrapFormat ?? "xml");
     setLocalAuthor(p.author ?? "");
     setLocalParams(p.parameters ?? {});
   }, [data]);
@@ -246,21 +295,20 @@ export function PresetEditor() {
   // Parse sections in order
   const sectionOrder = useMemo(() => {
     if (!data?.preset) return [];
-    const p = data.preset as any;
-    return Array.isArray(p.sectionOrder) ? p.sectionOrder : [];
+    return Array.isArray(data.preset.sectionOrder) ? data.preset.sectionOrder : [];
   }, [data]);
 
-  const orderedSections = useMemo(() => {
+  const orderedSections = useMemo<PromptSectionRow[]>(() => {
     if (!data?.sections) return [];
-    const map = new Map((data.sections as any[]).map((s) => [s.id, s]));
-    return sectionOrder.map((id: string) => map.get(id)).filter(Boolean) as any[];
+    const map = new Map(data.sections.map((section) => [section.id, section]));
+    return sectionOrder.map((id) => map.get(id)).filter((section): section is PromptSection => Boolean(section));
   }, [data?.sections, sectionOrder]);
 
   const sectionHasLorebookMarker = useMemo(() => {
-    return orderedSections.some((section: any) => {
-      if (section.enabled !== "true" && section.enabled !== true) return false;
-      if (section.isMarker !== "true" && section.isMarker !== true) return false;
-      const config = section.markerConfig;
+    return orderedSections.some((section) => {
+      if (!readBoolFlag(section.enabled)) return false;
+      if (!readBoolFlag(section.isMarker)) return false;
+      const config = readMarkerConfig(section.markerConfig);
       return config?.type === "lorebook" || config?.type === "world_info_before" || config?.type === "world_info_after";
     });
   }, [orderedSections]);
@@ -268,8 +316,8 @@ export function PresetEditor() {
     try {
       const metadata =
         typeof activeChat?.metadata === "string"
-          ? JSON.parse(activeChat.metadata)
-          : ((activeChat?.metadata ?? {}) as any);
+          ? readRecord(JSON.parse(activeChat.metadata))
+          : readRecord(activeChat?.metadata);
       return Array.isArray(metadata.activeLorebookIds) && metadata.activeLorebookIds.length > 0;
     } catch {
       return false;
@@ -277,13 +325,13 @@ export function PresetEditor() {
   }, [activeChat?.metadata]);
 
   const groupMap = useMemo(() => {
-    if (!data?.groups) return new Map<string, any>();
-    return new Map((data.groups as any[]).map((g) => [g.id, g]));
+    if (!data?.groups) return new Map<string, PromptGroup>();
+    return new Map(data.groups.map((group) => [group.id, group]));
   }, [data?.groups]);
 
-  const choiceBlocks = useMemo(() => {
-    if (!data?.choiceBlocks) return [] as any[];
-    return data.choiceBlocks as any[];
+  const choiceBlocks = useMemo<ChoiceBlockRow[]>(() => {
+    if (!data?.choiceBlocks) return [];
+    return data.choiceBlocks;
   }, [data?.choiceBlocks]);
 
   if (!presetDetailId) return null;
@@ -627,21 +675,21 @@ function SectionsTab({
   parentChatHasLorebook,
 }: {
   presetId: string;
-  sections: any[];
-  groupMap: Map<string, any>;
-  choiceBlocks: any[];
+  sections: PromptSectionRow[];
+  groupMap: Map<string, PromptGroup>;
+  choiceBlocks: ChoiceBlockRow[];
   wrapFormat: WrapFormat;
-  onCreateSection: any;
-  onUpdateSection: any;
-  onDeleteSection: any;
-  onReorderSections: any;
-  onCreateGroup: any;
-  onUpdateGroup: any;
-  onDeleteGroup: any;
-  onCreateVariable: any;
-  onUpdateVariable: any;
-  onDeleteVariable: any;
-  onReorderVariables: any;
+  onCreateSection: CreateSectionMutation;
+  onUpdateSection: UpdateSectionMutation;
+  onDeleteSection: DeleteSectionMutation;
+  onReorderSections: ReorderSectionsMutation;
+  onCreateGroup: CreateGroupMutation;
+  onUpdateGroup: UpdateGroupMutation;
+  onDeleteGroup: DeleteGroupMutation;
+  onCreateVariable: CreateVariableMutation;
+  onUpdateVariable: UpdateVariableMutation;
+  onDeleteVariable: DeleteVariableMutation;
+  onReorderVariables: ReorderVariablesMutation;
   hasLorebookMarker: boolean;
   parentChatHasLorebook: boolean;
 }) {
@@ -801,7 +849,7 @@ function SectionsTab({
     if (sourceIdx < insertAt) insertAt--;
     if (sourceIdx === insertAt) return;
 
-    const ids = sections.map((s: any) => s.id);
+    const ids = sections.map((section) => section.id);
     const [moved] = ids.splice(sourceIdx, 1);
     ids.splice(insertAt, 0, moved);
     onReorderSections.mutate({ presetId, sectionIds: ids });
@@ -818,7 +866,7 @@ function SectionsTab({
     onReorderSections.mutate({ presetId, sectionIds });
   };
 
-  const duplicateSection = async (section: any, idx: number) => {
+  const duplicateSection = async (section: PromptSectionRow, idx: number) => {
     try {
       const created = await onCreateSection.mutateAsync({
         presetId,
@@ -836,7 +884,7 @@ function SectionsTab({
         forbidOverrides: readBoolFlag(section.forbidOverrides),
       });
       if (created?.id) {
-        const sectionIds = sections.map((s: any) => s.id);
+        const sectionIds = sections.map((existingSection) => existingSection.id);
         sectionIds.splice(idx + 1, 0, created.id);
         await onReorderSections.mutateAsync({ presetId, sectionIds });
         setExpandedSections((prev) => new Set(prev).add(created.id));
@@ -956,7 +1004,7 @@ function SectionsTab({
             </p>
           ) : (
             <div className="space-y-1">
-              {[...groupMap.values()].map((g: any) => (
+              {[...groupMap.values()].map((g) => (
                 <div
                   key={g.id}
                   className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 ring-1 ring-[var(--border)]"
@@ -991,7 +1039,7 @@ function SectionsTab({
                     </span>
                   )}
                   <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
-                    {sections.filter((s: any) => s.groupId === g.id).length} sections
+                    {sections.filter((section) => section.groupId === g.id).length} sections
                   </span>
                   <button
                     onClick={async () => {
@@ -1025,13 +1073,14 @@ function SectionsTab({
             <p className="text-xs text-[var(--muted-foreground)]">No sections yet. Add one to get started.</p>
           </div>
         ) : (
-          sections.map((section: any, idx: number) => {
+          sections.map((section, idx) => {
             const isExpanded = expandedSections.has(section.id);
-            const isEnabled = section.enabled === "true" || section.enabled === true;
-            const isMarker = section.isMarker === "true" || section.isMarker === true;
-            const role = (section.role ?? "system") as string;
+            const isEnabled = readBoolFlag(section.enabled);
+            const isMarker = readBoolFlag(section.isMarker);
+            const role = section.role ?? "system";
             const group = section.groupId ? groupMap.get(section.groupId) : null;
             const RoleIcon = ROLE_ICONS[role] ?? Settings2;
+            const markerConfig = readMarkerConfig(section.markerConfig);
             // Show drop indicator line above this card when dropIdx matches
             const showDropBefore =
               dropIdx === idx && draggingIdx !== null && draggingIdx !== idx && draggingIdx !== idx - 1;
@@ -1214,9 +1263,9 @@ function SectionsTab({
 
                       {/* Marker config */}
                       {isMarker &&
-                        section.markerConfig &&
+                        markerConfig &&
                         (() => {
-                          const mc = section.markerConfig;
+                          const mc = markerConfig;
                           const isAgentMarker = mc.type === "agent_data";
                           return isAgentMarker ? (
                             <div className="space-y-2">
@@ -1245,7 +1294,7 @@ function SectionsTab({
                             </div>
                           ) : (
                             <div className="rounded-lg bg-violet-400/5 p-3 text-xs text-violet-300">
-                              Marker type: <strong>{MARKER_LABELS[mc.type as MarkerType] ?? "Unknown"}</strong>
+                              Marker type: <strong>{markerLabel(mc.type)}</strong>
                               <p className="mt-1 text-[var(--muted-foreground)]">
                                 Content is auto-generated at assembly time from your characters, lorebooks, etc.
                               </p>
@@ -1311,7 +1360,7 @@ function SectionsTab({
                           className="rounded-lg bg-[var(--secondary)] px-2 py-1 text-xs ring-1 ring-[var(--border)]"
                         >
                           <option value="">No group</option>
-                          {[...groupMap.values()].map((g: any) => (
+                          {[...groupMap.values()].map((g) => (
                             <option key={g.id} value={g.id}>
                               {g.name}
                             </option>
@@ -1363,11 +1412,11 @@ function PresetVariablesEditor({
   onReorderVariables,
 }: {
   presetId: string;
-  variables: any[];
-  onCreateVariable: any;
-  onUpdateVariable: any;
-  onDeleteVariable: any;
-  onReorderVariables: any;
+  variables: ChoiceBlockRow[];
+  onCreateVariable: CreateVariableMutation;
+  onUpdateVariable: UpdateVariableMutation;
+  onDeleteVariable: DeleteVariableMutation;
+  onReorderVariables: ReorderVariablesMutation;
 }) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [draggingIdx, setDraggingIdx] = useState<number | null>(null);
@@ -1412,7 +1461,7 @@ function PresetVariablesEditor({
     let insertAt = target;
     if (sourceIdx < insertAt) insertAt--;
     if (sourceIdx === insertAt) return;
-    const ids = variables.map((v: any) => v.id);
+    const ids = variables.map((variable) => variable.id);
     const [moved] = ids.splice(sourceIdx, 1);
     ids.splice(insertAt, 0, moved);
     onReorderVariables.mutate({ presetId, variableIds: ids });
@@ -1472,7 +1521,7 @@ function PresetVariablesEditor({
         </div>
       ) : (
         <div className="space-y-2" onDragOver={handleContainerDragOver} onDrop={commitDrop}>
-          {variables.map((variable: any, idx: number) => {
+          {variables.map((variable, idx) => {
             const showDropBefore =
               dropIdx === idx && draggingIdx !== null && draggingIdx !== idx && draggingIdx !== idx - 1;
             const showDropAfter =
@@ -1544,11 +1593,11 @@ function VariableCard({
   isReordering,
 }: {
   presetId: string;
-  variable: any;
+  variable: ChoiceBlockRow;
   isExpanded: boolean;
   onToggle: () => void;
-  onUpdateVariable: any;
-  onDeleteVariable: any;
+  onUpdateVariable: UpdateVariableMutation;
+  onDeleteVariable: DeleteVariableMutation;
   onGripDown: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -1556,14 +1605,12 @@ function VariableCard({
   canMoveDown: boolean;
   isReordering: boolean;
 }) {
-  const opts: Array<{ id: string; label: string; value: string }> = Array.isArray(variable.options)
-    ? variable.options
-    : [];
+  const opts: ChoiceOption[] = Array.isArray(variable.options) ? variable.options : [];
 
   const varName = variable.variableName ?? variable.variable_name ?? "";
   const question = variable.question ?? "";
-  const isMultiSelect = variable.multiSelect === "true" || variable.multiSelect === true;
-  const isRandomPick = variable.randomPick === "true" || variable.randomPick === true;
+  const isMultiSelect = readBoolFlag(variable.multiSelect);
+  const isRandomPick = readBoolFlag(variable.randomPick);
   const separatorValue = variable.separator ?? ", ";
 
   // Track which option is expanded in the big editor (index or null)


### PR DESCRIPTION
## Linked issue

N/A - local lint-hardening chore.

## Why this change

- Reduce explicit `any` usage in the catalog preset editor before a future `no-explicit-any` lint gate.

## What changed

- Added typed row aliases for preset sections, groups, choice blocks, marker configs, and preset editor mutation props.
- Replaced `PresetEditor` code-level explicit `any` usage with typed rows and existing prompt contract types.
- Preserved legacy storage shapes for string booleans, JSON-string marker configs, and `variable_name`.

## Refactor impact

Primary owner:

Catalog preset editor UI.

Impact areas reviewed:

- Preset editor data loading and local state hydration.
- Section ordering, group lookup, marker display, duplicate-section payloads.
- Preset variable rendering, reorder payloads, and legacy variable-name fallback.

Boundary notes:

- Feature-only React typing cleanup.
- No engine behavior, shared API wrapper, Rust command, or remote runtime path changed.

Pressure points touched:

- None.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent-run `pnpm check` passed locally, including line endings, architecture, frontend typecheck, Rust workspace check, docs check, and unused-code check.
- Agent-run `pnpm typecheck` passed locally before the full check.
- Agent-run `pnpm check:architecture` passed locally before the full check.
- No manual Tauri/browser UI pass was run; this is a type-only cleanup with no intended UI behavior change.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- No docs or release notes needed; no user-facing behavior changed.
- This PR does not restore old staging/package-workspace/release claims.

## UI evidence

N/A - type-only catalog preset editor cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure and consistency in the preset editor component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->