### PR TITLE
[codex] Extract active lorebook scope reasons

### DIFF
--- a/src/engine/generation-core/lorebooks/active-lorebook-scope.test.ts
+++ b/src/engine/generation-core/lorebooks/active-lorebook-scope.test.ts
@@ -57,6 +57,28 @@ describe("active lorebook scope", () => {
     expect(reason?.reason).toBe("global");
   });
 
+  it("uses persona context id when chat persona id is unavailable", () => {
+    const reasons = resolveActiveLorebookScopeReasons(
+      {
+        id: "book",
+        enabled: true,
+        personaIds: ["persona-from-context"],
+      },
+      {
+        chat: { id: "chat-1", mode: "roleplay" },
+        characters: [],
+        persona: { id: "persona-from-context" },
+      },
+    );
+
+    expect(reasons).toMatchObject([
+      {
+        reason: "persona",
+        matchedIds: ["persona-from-context"],
+      },
+    ]);
+  });
+
   it("excludes disabled Game Lorebook Keeper books in game scope", () => {
     const disabledKeeperContext = {
       chat: {

--- a/src/engine/generation-core/lorebooks/active-lorebook-scope.test.ts
+++ b/src/engine/generation-core/lorebooks/active-lorebook-scope.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  activeLorebookScopeReasonLabels,
+  resolveActiveLorebookScopeReason,
+  resolveActiveLorebookScopeReasons,
+} from "./active-lorebook-scope";
+
+describe("active lorebook scope", () => {
+  it("resolves all active reasons from the shared scope contract", () => {
+    const reasons = resolveActiveLorebookScopeReasons(
+      {
+        id: "book",
+        name: "Scope Book",
+        enabled: true,
+        isGlobal: true,
+        characterIds: ["char-1", "other-char"],
+        personaIds: ["persona-1"],
+        chatId: "chat-1",
+      },
+      {
+        chat: {
+          id: "chat-1",
+          mode: "roleplay",
+          personaId: "persona-1",
+          metadata: { activeLorebookIds: ["book"] },
+        },
+        characters: [{ id: "char-1" }],
+        persona: { id: "persona-1" },
+      },
+    );
+
+    expect(reasons.map((reason) => reason.reason)).toEqual([
+      "global",
+      "character",
+      "persona",
+      "chat",
+      "selected",
+    ]);
+    expect(activeLorebookScopeReasonLabels(reasons)).toEqual(["Global", "Character", "Persona", "Chat"]);
+  });
+
+  it("keeps scanner primary reason order stable", () => {
+    const reason = resolveActiveLorebookScopeReason(
+      {
+        id: "book",
+        enabled: true,
+        isGlobal: true,
+        characterIds: ["char-1"],
+      },
+      {
+        chat: { id: "chat-1", mode: "roleplay" },
+        characters: [{ id: "char-1" }],
+        persona: null,
+      },
+    );
+
+    expect(reason?.reason).toBe("global");
+  });
+
+  it("excludes disabled Game Lorebook Keeper books in game scope", () => {
+    const disabledKeeperContext = {
+      chat: {
+        id: "game-chat",
+        mode: "game",
+        metadata: {
+          gameLorebookKeeperEnabled: false,
+          gameLorebookKeeperLorebookId: "keeper-book",
+        },
+      },
+      characters: [],
+      persona: null,
+    };
+
+    expect(
+      resolveActiveLorebookScopeReasons(
+        { id: "keeper-book", enabled: true, isGlobal: true },
+        disabledKeeperContext,
+      ),
+    ).toEqual([]);
+    expect(
+      resolveActiveLorebookScopeReasons(
+        {
+          id: "source-book",
+          enabled: true,
+          isGlobal: true,
+          sourceAgentId: "game-lorebook-keeper",
+        },
+        disabledKeeperContext,
+      ),
+    ).toEqual([]);
+    expect(
+      resolveActiveLorebookScopeReasons(
+        {
+          id: "source-book",
+          enabled: true,
+          isGlobal: true,
+          sourceAgentId: "game-lorebook-keeper",
+        },
+        {
+          ...disabledKeeperContext,
+          chat: {
+            ...disabledKeeperContext.chat,
+            metadata: { gameLorebookKeeperEnabled: true },
+          },
+        },
+      ).map((reason) => reason.reason),
+    ).toEqual(["global"]);
+  });
+});

--- a/src/engine/generation-core/lorebooks/active-lorebook-scope.ts
+++ b/src/engine/generation-core/lorebooks/active-lorebook-scope.ts
@@ -167,11 +167,15 @@ export function resolveActiveLorebookScopeReasons(
     });
   }
 
-  const personaId = readString(chat.personaId);
-  if (context.persona && personaId) {
+  const activePersonaIds = [readString(chat.personaId), readString(context.persona?.id)].filter(
+    (id, index, ids) => id && ids.indexOf(id) === index,
+  );
+  if (context.persona && activePersonaIds.length > 0) {
     const personaIds = stringArray(lorebook.personaIds);
-    if (personaIds.includes(personaId) || readString(lorebook.personaId) === personaId) {
-      reasons.push({ lorebookId, lorebookName, reason: "persona", matchedIds: [personaId] });
+    const lorebookPersonaId = readString(lorebook.personaId);
+    const matchedPersonaIds = activePersonaIds.filter((id) => personaIds.includes(id) || lorebookPersonaId === id);
+    if (matchedPersonaIds.length > 0) {
+      reasons.push({ lorebookId, lorebookName, reason: "persona", matchedIds: matchedPersonaIds });
     }
   }
 

--- a/src/engine/generation-core/lorebooks/active-lorebook-scope.ts
+++ b/src/engine/generation-core/lorebooks/active-lorebook-scope.ts
@@ -1,0 +1,204 @@
+import {
+  resolveGameLorebookScopeExclusions,
+  type LorebookScopeExclusions,
+} from "./game-lorebook-scope";
+
+type ActiveLorebookScopeReasonType = "global" | "character" | "persona" | "chat" | "selected";
+export type ActiveLorebookScopeReasonLabel = "Global" | "Character" | "Persona" | "Chat";
+
+export interface ActiveLorebookScopeReason {
+  lorebookId: string;
+  lorebookName: string;
+  reason: ActiveLorebookScopeReasonType;
+  matchedIds: string[];
+}
+
+export interface ActiveLorebookScopeLorebook {
+  id?: unknown;
+  name?: unknown;
+  enabled?: unknown;
+  isGlobal?: unknown;
+  global?: unknown;
+  characterId?: unknown;
+  characterIds?: unknown;
+  personaId?: unknown;
+  personaIds?: unknown;
+  chatId?: unknown;
+  sourceAgentId?: unknown;
+}
+
+interface ActiveLorebookScopeChatContext {
+  id?: unknown;
+  mode?: unknown;
+  chatMode?: unknown;
+  metadata?: unknown;
+  activeLorebookIds?: unknown;
+  personaId?: unknown;
+}
+
+interface ActiveLorebookScopeCharacterContext {
+  id: string;
+}
+
+interface ActiveLorebookScopePersonaContext {
+  id?: unknown;
+  name?: unknown;
+  description?: unknown;
+}
+
+export interface ActiveLorebookScopeContext {
+  chat: ActiveLorebookScopeChatContext | null | undefined;
+  characters: ActiveLorebookScopeCharacterContext[];
+  persona: ActiveLorebookScopePersonaContext | null | undefined;
+  scopeExclusions?: LorebookScopeExclusions;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseRecord(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+}
+
+function stringArray(value: unknown): string[] {
+  return parseArray(value)
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function boolish(value: unknown, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return fallback;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  }
+  return fallback;
+}
+
+function activeLorebookScopeReasonLabel(reason: ActiveLorebookScopeReasonType): ActiveLorebookScopeReasonLabel {
+  switch (reason) {
+    case "global":
+      return "Global";
+    case "character":
+      return "Character";
+    case "persona":
+      return "Persona";
+    case "chat":
+    case "selected":
+      return "Chat";
+  }
+}
+
+export function activeLorebookScopeReasonLabels(
+  reasons: readonly ActiveLorebookScopeReason[],
+): ActiveLorebookScopeReasonLabel[] {
+  const labels: ActiveLorebookScopeReasonLabel[] = [];
+  for (const reason of reasons) {
+    const label = activeLorebookScopeReasonLabel(reason.reason);
+    if (!labels.includes(label)) labels.push(label);
+  }
+  return labels;
+}
+
+export function resolveActiveLorebookScopeReasons(
+  lorebook: ActiveLorebookScopeLorebook,
+  context: ActiveLorebookScopeContext,
+): ActiveLorebookScopeReason[] {
+  if (!boolish(lorebook.enabled, true)) return [];
+  const chat = context.chat ?? {};
+  const metadata = parseRecord(chat.metadata);
+  const lorebookId = readString(lorebook.id);
+  const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
+  const scopeExclusions =
+    context.scopeExclusions ??
+    resolveGameLorebookScopeExclusions(readString(chat.mode ?? chat.chatMode), metadata);
+
+  if (scopeExclusions.excludedLorebookIds.includes(lorebookId)) return [];
+  if (scopeExclusions.excludedSourceAgentIds.includes(readString(lorebook.sourceAgentId))) return [];
+
+  const reasons: ActiveLorebookScopeReason[] = [];
+  if (boolish(lorebook.isGlobal ?? lorebook.global, false)) {
+    reasons.push({ lorebookId, lorebookName, reason: "global", matchedIds: [] });
+  }
+
+  const activeCharacterIds = new Set(
+    context.characters.map((character) => character.id.trim()).filter(Boolean),
+  );
+  const lorebookCharacterIds = stringArray(lorebook.characterIds);
+  const matchedCharacterIds = [
+    ...lorebookCharacterIds.filter((id) => activeCharacterIds.has(id)),
+    readString(lorebook.characterId),
+  ].filter((id, index, ids) => id && activeCharacterIds.has(id) && ids.indexOf(id) === index);
+  if (matchedCharacterIds.length > 0) {
+    reasons.push({
+      lorebookId,
+      lorebookName,
+      reason: "character",
+      matchedIds: matchedCharacterIds,
+    });
+  }
+
+  const personaId = readString(chat.personaId);
+  if (context.persona && personaId) {
+    const personaIds = stringArray(lorebook.personaIds);
+    if (personaIds.includes(personaId) || readString(lorebook.personaId) === personaId) {
+      reasons.push({ lorebookId, lorebookName, reason: "persona", matchedIds: [personaId] });
+    }
+  }
+
+  const chatId = readString(chat.id);
+  const chatScopedId = readString(lorebook.chatId);
+  if (chatScopedId && chatScopedId === chatId) {
+    reasons.push({ lorebookId, lorebookName, reason: "chat", matchedIds: [chatId] });
+  }
+
+  const selectedLorebookIds = stringArray(metadata.activeLorebookIds ?? chat.activeLorebookIds);
+  if (selectedLorebookIds.includes(lorebookId)) {
+    reasons.push({ lorebookId, lorebookName, reason: "selected", matchedIds: [lorebookId] });
+  }
+
+  return reasons;
+}
+
+export function resolveActiveLorebookScopeReason(
+  lorebook: ActiveLorebookScopeLorebook,
+  context: ActiveLorebookScopeContext,
+): ActiveLorebookScopeReason | null {
+  return resolveActiveLorebookScopeReasons(lorebook, context)[0] ?? null;
+}
+
+export function lorebookAppliesToContext(
+  lorebook: ActiveLorebookScopeLorebook,
+  context: ActiveLorebookScopeContext,
+): boolean {
+  return resolveActiveLorebookScopeReasons(lorebook, context).length > 0;
+}

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -11,6 +11,11 @@ import {
   type LorebookScopeExclusions,
 } from "../generation-core/lorebooks/game-lorebook-scope";
 import {
+  lorebookAppliesToContext as lorebookAppliesToActiveScopeContext,
+  resolveActiveLorebookScopeReason,
+  type ActiveLorebookScopeReason,
+} from "../generation-core/lorebooks/active-lorebook-scope";
+import {
   recursiveScan,
   scanForActivatedEntries,
   updateTimingStatesForScan,
@@ -61,15 +66,6 @@ export interface BudgetSkippedLorebookEntry {
   chatBudget: number;
   chatUsedTokens: number;
   blockedBy: "lorebook" | "chat" | "both";
-}
-
-type ActiveLorebookScopeReasonType = "global" | "character" | "persona" | "chat" | "selected";
-
-interface ActiveLorebookScopeReason {
-  lorebookId: string;
-  lorebookName: string;
-  reason: ActiveLorebookScopeReasonType;
-  matchedIds: string[];
 }
 
 export interface LorebookSemanticScanStatus {
@@ -213,64 +209,13 @@ function normalizeLorebookEntry(entry: JsonRecord): LorebookEntry {
   };
 }
 
-function resolveActiveLorebookScopeReason(
-  lorebook: JsonRecord,
-  chat: JsonRecord,
-  characters: LorebookActivationCharacterContext[],
-  persona: LorebookActivationPersonaContext | null,
-  scopeExclusions: LorebookScopeExclusions = resolveGameLorebookScopeExclusions(
-    readString(chat.mode || chat.chatMode),
-    parseRecord(chat.metadata),
-  ),
-): ActiveLorebookScopeReason | null {
-  if (!boolish(lorebook.enabled, true)) return null;
-  const lorebookId = readString(lorebook.id);
-  const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
-  if (scopeExclusions.excludedLorebookIds.includes(lorebookId)) return null;
-  if (scopeExclusions.excludedSourceAgentIds.includes(readString(lorebook.sourceAgentId))) return null;
-  if (boolish(lorebook.isGlobal ?? lorebook.global, false)) {
-    return { lorebookId, lorebookName, reason: "global", matchedIds: [] };
-  }
-
-  const activeIds = new Set(characters.map((character) => character.id));
-  const lorebookCharacterIds = stringArray(lorebook.characterIds);
-  const matchedCharacterIds = [
-    ...lorebookCharacterIds.filter((id) => activeIds.has(id)),
-    readString(lorebook.characterId),
-  ].filter((id, index, ids) => id && activeIds.has(id) && ids.indexOf(id) === index);
-  if (matchedCharacterIds.length > 0) {
-    return { lorebookId, lorebookName, reason: "character", matchedIds: matchedCharacterIds };
-  }
-
-  const personaId = readString(chat.personaId);
-  if (persona && personaId) {
-    const personaIds = stringArray(lorebook.personaIds);
-    if (personaIds.includes(personaId) || readString(lorebook.personaId) === personaId) {
-      return { lorebookId, lorebookName, reason: "persona", matchedIds: [personaId] };
-    }
-  }
-
-  const chatId = readString(chat.id).trim();
-  const chatScopedId = readString(lorebook.chatId).trim();
-  if (chatScopedId && chatScopedId === chatId) {
-    return { lorebookId, lorebookName, reason: "chat", matchedIds: [chatId] };
-  }
-
-  const meta = parseRecord(chat.metadata);
-  if (stringArray(meta.activeLorebookIds ?? chat.activeLorebookIds).includes(lorebookId)) {
-    return { lorebookId, lorebookName, reason: "selected", matchedIds: [lorebookId] };
-  }
-
-  return null;
-}
-
 export function lorebookAppliesToContext(
   lorebook: JsonRecord,
   chat: JsonRecord,
   characters: LorebookActivationCharacterContext[],
   persona: LorebookActivationPersonaContext | null,
 ): boolean {
-  return !!resolveActiveLorebookScopeReason(lorebook, chat, characters, persona);
+  return lorebookAppliesToActiveScopeContext(lorebook, { chat, characters, persona });
 }
 
 function joinMatchingSourceParts(parts: Array<string | undefined>): string {
@@ -482,7 +427,12 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
   const scopedLorebooks = (await input.storage.list<JsonRecord>("lorebooks"))
     .map((book) => ({
       book,
-      reason: resolveActiveLorebookScopeReason(book, input.chat, input.characters, input.persona, scopeExclusions),
+      reason: resolveActiveLorebookScopeReason(book, {
+        chat: input.chat,
+        characters: input.characters,
+        persona: input.persona,
+        scopeExclusions,
+      }),
     }))
     .filter((entry): entry is { book: JsonRecord; reason: ActiveLorebookScopeReason } => !!entry.reason);
   const lorebooks = scopedLorebooks.map((entry) => entry.book);

--- a/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
+++ b/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
@@ -32,6 +32,7 @@ import { useLorebooks, useDeleteLorebook, useUpdateLorebook, useUploadLorebookIm
 import { useCharacterSummariesByIds } from "../../characters/index";
 import { usePersonaSummaries } from "../../personas/index";
 import type { Lorebook, LorebookCategory } from "../../../../engine/contracts/types/lorebook";
+import { resolveActiveLorebookScopeReasons } from "../../../../engine/generation-core/lorebooks/active-lorebook-scope";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";
 import { exportApi } from "../../../../shared/api/export-api";
@@ -75,19 +76,15 @@ export function LorebooksPanel() {
 
   // Active chat context for the "Active" filter
   const activeChat = useChatStore((s) => s.activeChat);
-  const activeChatMetadata = activeChat?.metadata;
-  const activeLorebookIds: string[] = useMemo(() => {
-    if (!activeChatMetadata) return [];
-    try {
-      const meta = typeof activeChatMetadata === "string" ? JSON.parse(activeChatMetadata) : activeChatMetadata;
-      return Array.isArray(meta.activeLorebookIds) ? meta.activeLorebookIds : [];
-    } catch {
-      return [];
-    }
-  }, [activeChatMetadata]);
   const activeCharacterIds = useMemo(() => getChatCharacterIds(activeChat), [activeChat]);
-  const activePersonaId = activeChat?.personaId ?? null;
-  const activeChatId = activeChat?.id ?? null;
+  const activeLorebookScopeContext = useMemo(
+    () => ({
+      chat: activeChat,
+      characters: activeCharacterIds.map((id) => ({ id })),
+      persona: activeChat?.personaId ? { id: activeChat.personaId } : null,
+    }),
+    [activeChat, activeCharacterIds],
+  );
 
   // When "active" category is selected, fetch all lorebooks (no category filter) — we filter client-side
   const { data: lorebooks, isLoading } = useLorebooks(
@@ -206,19 +203,8 @@ export function LorebooksPanel() {
     if (!lorebooks) return [];
     let list = lorebooks as Lorebook[];
     // "Active" filter: show lorebooks active in the current chat
-    // Mirrors native lorebook filtering: global + pinned + character-linked + persona-linked + chat-scoped.
     if (activeCategory === "active") {
-      list = list.filter(
-        (lb) =>
-          lb.enabled &&
-          (lb.isGlobal ||
-            activeLorebookIds.includes(lb.id) ||
-            (Array.isArray(lb.characterIds) && lb.characterIds.some((id) => activeCharacterIds.includes(id))) ||
-            (lb.characterId && activeCharacterIds.includes(lb.characterId)) ||
-            (Array.isArray(lb.personaIds) && lb.personaIds.includes(activePersonaId ?? "")) ||
-            (lb.personaId && lb.personaId === activePersonaId) ||
-            (lb.chatId && lb.chatId === activeChatId)),
-      );
+      list = list.filter((lb) => resolveActiveLorebookScopeReasons(lb, activeLorebookScopeContext).length > 0);
     }
     if (activeTag) {
       list = list.filter((lb) => parseTags(lb).includes(activeTag));
@@ -236,10 +222,7 @@ export function LorebooksPanel() {
   }, [
     lorebooks,
     activeCategory,
-    activeLorebookIds,
-    activeCharacterIds,
-    activePersonaId,
-    activeChatId,
+    activeLorebookScopeContext,
     searchQuery,
     activeTag,
     getCharacterNames,

--- a/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
+++ b/src/features/catalog/lorebooks/components/LorebooksPanel.tsx
@@ -33,10 +33,12 @@ import { useCharacterSummariesByIds } from "../../characters/index";
 import { usePersonaSummaries } from "../../personas/index";
 import type { Lorebook, LorebookCategory } from "../../../../engine/contracts/types/lorebook";
 import { resolveActiveLorebookScopeReasons } from "../../../../engine/generation-core/lorebooks/active-lorebook-scope";
+import { resolveGameLorebookScopeExclusions } from "../../../../engine/generation-core/lorebooks/game-lorebook-scope";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";
 import { exportApi } from "../../../../shared/api/export-api";
 import { getChatCharacterIds } from "../../../../shared/lib/chat-macros";
+import { parseChatMetadata } from "../../../../shared/lib/chat-display";
 import { ExportFormatDialog, type ExportFormatChoice } from "../../../../shared/components/ui/ExportFormatDialog";
 import { resolveManagedLocalAssetUrl } from "../../../../shared/api/local-file-api";
 
@@ -82,6 +84,7 @@ export function LorebooksPanel() {
       chat: activeChat,
       characters: activeCharacterIds.map((id) => ({ id })),
       persona: activeChat?.personaId ? { id: activeChat.personaId } : null,
+      scopeExclusions: resolveGameLorebookScopeExclusions(activeChat?.mode, parseChatMetadata(activeChat?.metadata)),
     }),
     [activeChat, activeCharacterIds],
   );

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -166,6 +166,7 @@ import {
   resolveActiveLorebookScopeReasons,
   type ActiveLorebookScopeReasonLabel,
 } from "../../../../../engine/generation-core/lorebooks/active-lorebook-scope";
+import { resolveGameLorebookScopeExclusions } from "../../../../../engine/generation-core/lorebooks/game-lorebook-scope";
 import {
   isCustomToolSelectable,
   useCustomToolCapabilities,
@@ -570,8 +571,9 @@ function ChatSettingsDrawerInner({
       chat,
       characters: chatCharIds.map((id) => ({ id })),
       persona: chat.personaId ? { id: chat.personaId } : null,
+      scopeExclusions: resolveGameLorebookScopeExclusions(chatMode, metadata),
     }),
-    [chat, chatCharIds],
+    [chat, chatCharIds, chatMode, metadata],
   );
   const activeLorebooks = useMemo<ActiveLorebookView[]>(() => {
     const lorebookList = (lorebooks ?? []) as Lorebook[];

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -162,6 +162,11 @@ import { boolish as isEnabledFlag } from "../../../../../engine/generation/runti
 import type { CharacterGroup } from "../../../../../engine/contracts/types/character";
 import type { Lorebook } from "../../../../../engine/contracts/types/lorebook";
 import {
+  activeLorebookScopeReasonLabels,
+  resolveActiveLorebookScopeReasons,
+  type ActiveLorebookScopeReasonLabel,
+} from "../../../../../engine/generation-core/lorebooks/active-lorebook-scope";
+import {
   isCustomToolSelectable,
   useCustomToolCapabilities,
   useCustomTools,
@@ -237,7 +242,7 @@ type AvailableAgent = {
   builtIn: boolean;
 };
 
-type LorebookActiveReason = "Global" | "Character" | "Persona" | "Chat";
+type LorebookActiveReason = ActiveLorebookScopeReasonLabel;
 
 type ActiveLorebookView = Lorebook & {
   activeReasons: LorebookActiveReason[];
@@ -560,52 +565,26 @@ function ChatSettingsDrawerInner({
   const gameLorebookKeeperEnabled = metadata.gameLorebookKeeperEnabled === true;
   const gameLorebookKeeperLorebookId =
     typeof metadata.gameLorebookKeeperLorebookId === "string" ? metadata.gameLorebookKeeperLorebookId : null;
+  const activeLorebookScopeContext = useMemo(
+    () => ({
+      chat,
+      characters: chatCharIds.map((id) => ({ id })),
+      persona: chat.personaId ? { id: chat.personaId } : null,
+    }),
+    [chat, chatCharIds],
+  );
   const activeLorebooks = useMemo<ActiveLorebookView[]>(() => {
-    const pinnedIds = new Set(activeLorebookIds);
     const lorebookList = (lorebooks ?? []) as Lorebook[];
 
     return lorebookList.flatMap((lorebook) => {
-      if (
-        isGame &&
-        !gameLorebookKeeperEnabled &&
-        (lorebook.id === gameLorebookKeeperLorebookId || lorebook.sourceAgentId === "game-lorebook-keeper")
-      ) {
-        return [];
-      }
-
-      const reasons: LorebookActiveReason[] = [];
-      const isPinned = pinnedIds.has(lorebook.id);
-
-      if (lorebook.enabled !== false) {
-        if (isPinned) reasons.push("Chat");
-        if (lorebook.isGlobal) reasons.push("Global");
-        if (
-          lorebook.characterIds?.some((id) => chatCharIds.includes(id)) ||
-          (lorebook.characterId && chatCharIds.includes(lorebook.characterId))
-        ) {
-          reasons.push("Character");
-        }
-        if (
-          chat.personaId &&
-          (lorebook.personaIds?.includes(chat.personaId) || lorebook.personaId === chat.personaId)
-        ) {
-          reasons.push("Persona");
-        }
-        if (lorebook.chatId === chat.id && !reasons.includes("Chat")) reasons.push("Chat");
-      }
+      const reasons = activeLorebookScopeReasonLabels(
+        resolveActiveLorebookScopeReasons(lorebook, activeLorebookScopeContext),
+      );
+      const isPinned = activeLorebookIds.includes(lorebook.id);
 
       return reasons.length > 0 ? [{ ...lorebook, activeReasons: reasons, isPinned }] : [];
     });
-  }, [
-    activeLorebookIds,
-    chat.id,
-    chat.personaId,
-    chatCharIds,
-    gameLorebookKeeperEnabled,
-    gameLorebookKeeperLorebookId,
-    isGame,
-    lorebooks,
-  ]);
+  }, [activeLorebookIds, activeLorebookScopeContext, lorebooks]);
   const activeLorebookIdSet = useMemo(() => new Set(activeLorebooks.map((lorebook) => lorebook.id)), [activeLorebooks]);
   const lorebookTokenBudget =
     typeof metadata.lorebookTokenBudget === "number" && Number.isFinite(metadata.lorebookTokenBudget)
@@ -1322,47 +1301,8 @@ function ChatSettingsDrawerInner({
       }
     });
   }, [currentPromptPresetFull?.sections]);
-  const hasScopedOrGlobalLorebooks = useMemo(() => {
-    return (
-      (lorebooks ?? []) as Array<{
-        id: string;
-        enabled?: boolean;
-        isGlobal?: boolean;
-        characterId?: string | null;
-        characterIds?: string[];
-        personaId?: string | null;
-        personaIds?: string[];
-        chatId?: string | null;
-        sourceAgentId?: string | null;
-      }>
-    ).some(
-      (lorebook) =>
-        lorebook.enabled !== false &&
-        !(
-          isGame &&
-          !gameLorebookKeeperEnabled &&
-          (lorebook.id === gameLorebookKeeperLorebookId || lorebook.sourceAgentId === "game-lorebook-keeper")
-        ) &&
-        (lorebook.isGlobal ||
-          activeLorebookIds.includes(lorebook.id) ||
-          lorebook.characterIds?.some((id) => chatCharIds.includes(id)) ||
-          (lorebook.characterId && chatCharIds.includes(lorebook.characterId)) ||
-          (chat.personaId && lorebook.personaIds?.includes(chat.personaId)) ||
-          (lorebook.personaId && lorebook.personaId === chat.personaId) ||
-          (lorebook.chatId && lorebook.chatId === chat.id)),
-    );
-  }, [
-    activeLorebookIds,
-    chat.id,
-    chat.personaId,
-    chatCharIds,
-    gameLorebookKeeperEnabled,
-    gameLorebookKeeperLorebookId,
-    isGame,
-    lorebooks,
-  ]);
   const showLorebookMarkerWarning =
-    !!chat.promptPresetId && hasScopedOrGlobalLorebooks && !currentPromptPresetHasLorebookMarker;
+    !!chat.promptPresetId && activeLorebooks.length > 0 && !currentPromptPresetHasLorebookMarker;
 
   const setPreset = (presetId: string | null) => {
     updateChat.mutate(


### PR DESCRIPTION
## Linked issue

None.

## Why this change

- Lorebook active-scope behavior was duplicated between engine prompt activation, the Lorebooks panel Active filter, and Chat Settings.
- The duplicate UI logic could drift from engine rules, especially around Game Lorebook Keeper exclusions.

## What changed

- Added an engine-owned active lorebook scope/reason helper in `src/engine/generation-core/lorebooks/active-lorebook-scope.ts`.
- Routed prompt assembly scanner scope checks through the shared helper without changing prompt order.
- Updated the Lorebooks panel Active filter and Chat Settings active lorebook/marker-warning logic to consume the shared helper.
- Added focused tests covering reason ordering, label folding, and disabled Game Lorebook Keeper exclusions.

## Refactor impact

Primary owner:

- Engine generation-core lorebook scope contract.

Impact areas reviewed:

- Prompt-time lorebook activation scanner.
- Lorebooks panel Active filter.
- Chat Settings active lorebook list and prompt-marker warning.
- Game Lorebook Keeper exclusion behavior.

Boundary notes:

- Product scope behavior stays in `src/engine/generation-core`.
- React feature code imports deterministic engine helper only; no engine import from React/shared APIs/Tauri.
- No shared API, Rust, Tauri command, or remote runtime changes.

Pressure points touched:

- Shared mode UI: `ChatSettingsDrawer.tsx` now delegates active lorebook scope math to the engine helper.

## Validation

<!-- Checkboxes intentionally left unchecked for human verification per template. Commands below were run locally by Codex. -->

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

Commands run:

- `pnpm vitest run src/engine/generation-core/lorebooks/active-lorebook-scope.test.ts src/engine/generation/prompt-assembly.test.ts src/engine/generation-core/lorebooks/keyword-scanner.test.ts` passed: 3 files, 69 tests.
- `pnpm check` passed.
- `pnpm build` passed; Vite reported existing large chunk warnings plus an existing CSS minify warning about `file` not being a known CSS property.

### Manual verification notes

- Native Tauri UI pass was not run for the Lorebooks panel Active filter or Chat Settings active lorebook list.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- No docs/changelog update made; this is an internal refactor with unchanged user-facing copy and no public workflow change.

## UI evidence

- Not captured; no visual layout change intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced lorebook scope reasoning with clear categorization: global, character, persona, chat, and selected contexts.

* **Tests**
  * Added comprehensive test suite for lorebook scope resolution to ensure accurate scope matching and consistent behavior.

* **Refactor**
  * Consolidated duplicate scope-resolution logic across multiple components into a centralized utility for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

