### PR TITLE
[codex] Restore character version snapshots

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -15,6 +15,16 @@ pub(crate) fn update_character_avatar(
         &body,
         "avatar",
     )?;
+    if collection == "characters" {
+        let snapshot_record = character_avatar_snapshot_record(&previous);
+        super::characters::create_character_version_snapshot_from_record(
+            state,
+            id,
+            &snapshot_record,
+            "manual",
+            "Avatar update",
+        )?;
+    }
     let updated = state.storage.patch(
         collection,
         id,
@@ -28,6 +38,56 @@ pub(crate) fn update_character_avatar(
     )?;
     remove_avatar_file(state, collection, &previous);
     Ok(updated)
+}
+
+fn character_avatar_snapshot_record(record: &Value) -> Value {
+    let mut snapshot = record.clone();
+    if let Some(object) = snapshot.as_object_mut() {
+        if let Some(data_url) = managed_avatar_data_url(record) {
+            object.insert("avatar".to_string(), Value::String(data_url.clone()));
+            object.insert("avatarPath".to_string(), Value::String(data_url));
+        }
+        object.insert("avatarFilePath".to_string(), Value::Null);
+        object.insert("avatarFilename".to_string(), Value::Null);
+    }
+    snapshot
+}
+
+fn managed_avatar_data_url(record: &Value) -> Option<String> {
+    let path = record.get("avatarFilePath").and_then(Value::as_str)?;
+    let bytes = fs::read(path).ok()?;
+    let mime = avatar_mime_type(
+        record
+            .get("avatarFilename")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                std::path::Path::new(path)
+                    .file_name()
+                    .and_then(|value| value.to_str())
+            }),
+    );
+    Some(format!(
+        "data:{mime};base64,{}",
+        general_purpose::STANDARD.encode(bytes)
+    ))
+}
+
+fn avatar_mime_type(filename: Option<&str>) -> &'static str {
+    let Some(filename) = filename else {
+        return "image/png";
+    };
+    match filename
+        .rsplit_once('.')
+        .map(|(_, ext)| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("webp") => "image/webp",
+        Some("gif") => "image/gif",
+        Some("avif") => "image/avif",
+        Some("svg") => "image/svg+xml",
+        _ => "image/png",
+    }
 }
 
 pub(crate) fn remove_avatar_file(state: &AppState, collection: &str, record: &Value) {
@@ -61,4 +121,81 @@ pub(crate) fn update_npc_avatar(state: &AppState, chat_id: &str, body: Value) ->
         "avatarFilePath": stored.absolute_path,
         "avatarFilename": stored.filename
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-avatars-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn character_avatar_update_snapshot_does_not_restore_deleted_file_metadata() {
+        let state = test_state("character-avatar-version");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let old_avatar_path = avatar_dir.join("old.png");
+        std::fs::write(&old_avatar_path, b"old").expect("old avatar should be written");
+        let old_avatar_path = old_avatar_path.to_string_lossy().to_string();
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Original",
+                        "character_version": "1.0"
+                    },
+                    "comment": "Original title",
+                    "avatar": "http://asset.localhost/old.png",
+                    "avatarPath": "http://asset.localhost/old.png",
+                    "avatarFilePath": old_avatar_path,
+                    "avatarFilename": "old.png"
+                }),
+            )
+            .expect("character should be created");
+
+        update_character_avatar(
+            &state,
+            "characters",
+            "char-1",
+            json!({ "avatar": "data:image/png;base64,bmV3" }),
+        )
+        .expect("avatar should update");
+
+        let versions = state
+            .storage
+            .list("character-versions")
+            .expect("versions should list");
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["avatarPath"], "data:image/png;base64,b2xk");
+        assert_eq!(versions[0]["avatarFilePath"], Value::Null);
+        assert_eq!(versions[0]["avatarFilename"], Value::Null);
+
+        let version_id = versions[0]
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("version should have id");
+        let restored =
+            super::super::characters::restore_character_version(&state, "char-1", version_id)
+                .expect("version should restore");
+
+        assert_eq!(restored["avatarPath"], "data:image/png;base64,b2xk");
+        assert_eq!(restored["avatarFilePath"], Value::Null);
+        assert_eq!(restored["avatarFilename"], Value::Null);
+    }
 }

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -1,6 +1,101 @@
 use super::shared::*;
 use super::*;
 
+const VERSION_SOURCE_FIELD: &str = "versionSource";
+const VERSION_REASON_FIELD: &str = "versionReason";
+const SKIP_VERSION_SNAPSHOT_FIELD: &str = "skipVersionSnapshot";
+const VERSIONED_CHARACTER_FIELDS: [&str; 6] = [
+    "data",
+    "comment",
+    "avatarPath",
+    "avatar",
+    "avatarFilePath",
+    "avatarFilename",
+];
+
+struct CharacterVersionSnapshotOptions {
+    source: String,
+    reason: String,
+    skip: bool,
+}
+
+impl Default for CharacterVersionSnapshotOptions {
+    fn default() -> Self {
+        Self {
+            source: "manual".to_string(),
+            reason: String::new(),
+            skip: false,
+        }
+    }
+}
+
+pub(crate) fn update_character(
+    state: &AppState,
+    character_id: &str,
+    patch: Value,
+) -> AppResult<Value> {
+    let normalized = normalize_update_patch("characters", patch)?;
+    let mut patch = ensure_object(normalized)?;
+    let options = take_version_snapshot_options(&mut patch);
+    let existing = get_required(state, "characters", character_id)?;
+    merge_partial_character_data(&existing, &mut patch)?;
+
+    if should_create_version_snapshot(&existing, &patch, &options) {
+        create_character_version_snapshot_from_record(
+            state,
+            character_id,
+            &existing,
+            &options.source,
+            &options.reason,
+        )?;
+    }
+
+    state
+        .storage
+        .patch("characters", character_id, Value::Object(patch))
+}
+
+pub(crate) fn create_character_version_snapshot_from_record(
+    state: &AppState,
+    character_id: &str,
+    record: &Value,
+    source: &str,
+    reason: &str,
+) -> AppResult<Value> {
+    let data = normalize_character_data_for_storage(
+        &record.get("data").cloned().unwrap_or_else(|| json!({})),
+    )?;
+    let version = data
+        .get("character_version")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let mut snapshot = Map::new();
+    snapshot.insert(
+        "characterId".to_string(),
+        Value::String(character_id.to_string()),
+    );
+    snapshot.insert("data".to_string(), data);
+    snapshot.insert("comment".to_string(), character_comment(record));
+    for field in ["avatarPath", "avatar", "avatarFilePath", "avatarFilename"] {
+        snapshot.insert(
+            field.to_string(),
+            record.get(field).cloned().unwrap_or(Value::Null),
+        );
+    }
+    snapshot.insert("version".to_string(), Value::String(version));
+    snapshot.insert(
+        "source".to_string(),
+        Value::String(non_empty_or_default(source, "manual")),
+    );
+    snapshot.insert("reason".to_string(), Value::String(reason.to_string()));
+
+    state
+        .storage
+        .create("character-versions", Value::Object(snapshot))
+}
+
 pub(crate) fn restore_character_version(
     state: &AppState,
     character_id: &str,
@@ -22,25 +117,310 @@ pub(crate) fn restore_character_version(
     if let Some(comment) = version.get("comment") {
         patch.insert("comment".to_string(), comment.clone());
     }
-    if version.get("avatarPath").is_some() {
+    patch.insert(
+        "avatarPath".to_string(),
+        version.get("avatarPath").cloned().unwrap_or(Value::Null),
+    );
+    for field in ["avatar", "avatarFilePath", "avatarFilename"] {
         patch.insert(
-            "avatarPath".to_string(),
-            version.get("avatarPath").cloned().unwrap_or(Value::Null),
+            field.to_string(),
+            version.get(field).cloned().unwrap_or(Value::Null),
         );
     }
-    patch.insert("versionSource".to_string(), json!("restore"));
-    patch.insert(
-        "versionReason".to_string(),
-        json!(format!(
-            "Restored {}",
-            version
-                .get("version")
-                .and_then(Value::as_str)
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or(version_id)
-        )),
+    let reason = format!(
+        "Restored {}",
+        version
+            .get("version")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(version_id)
     );
+    let existing = get_required(state, "characters", character_id)?;
+    let options = CharacterVersionSnapshotOptions {
+        source: "restore".to_string(),
+        reason,
+        skip: false,
+    };
+    if should_create_version_snapshot(&existing, &patch, &options) {
+        create_character_version_snapshot_from_record(
+            state,
+            character_id,
+            &existing,
+            &options.source,
+            &options.reason,
+        )?;
+    }
     state
         .storage
         .patch("characters", character_id, Value::Object(patch))
+}
+
+fn take_version_snapshot_options(
+    patch: &mut Map<String, Value>,
+) -> CharacterVersionSnapshotOptions {
+    let source = take_string(patch, VERSION_SOURCE_FIELD)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "manual".to_string());
+    let reason = take_string(patch, VERSION_REASON_FIELD).unwrap_or_default();
+    let skip = matches!(
+        patch.remove(SKIP_VERSION_SNAPSHOT_FIELD),
+        Some(Value::Bool(true))
+    );
+    CharacterVersionSnapshotOptions {
+        source,
+        reason,
+        skip,
+    }
+}
+
+fn take_string(patch: &mut Map<String, Value>, field: &str) -> Option<String> {
+    match patch.remove(field) {
+        Some(Value::String(value)) => Some(value),
+        _ => None,
+    }
+}
+
+fn merge_partial_character_data(existing: &Value, patch: &mut Map<String, Value>) -> AppResult<()> {
+    let Some(next_data) = patch.remove("data") else {
+        return Ok(());
+    };
+    let Value::Object(mut merged) = normalize_character_data_for_storage(
+        &existing.get("data").cloned().unwrap_or_else(|| json!({})),
+    )?
+    else {
+        unreachable!("character data normalizer only returns objects");
+    };
+    let Value::Object(next_data) = normalize_character_data_for_storage(&next_data)? else {
+        unreachable!("character data normalizer only returns objects");
+    };
+    for (key, value) in next_data {
+        merged.insert(key, value);
+    }
+    patch.insert("data".to_string(), Value::Object(merged));
+    Ok(())
+}
+
+fn should_create_version_snapshot(
+    existing: &Value,
+    patch: &Map<String, Value>,
+    options: &CharacterVersionSnapshotOptions,
+) -> bool {
+    !options.skip
+        && VERSIONED_CHARACTER_FIELDS.iter().any(|field| {
+            patch
+                .get(*field)
+                .is_some_and(|next| next != &comparable_character_field(existing, field))
+        })
+}
+
+fn comparable_character_field(record: &Value, field: &str) -> Value {
+    match field {
+        "comment" => character_comment(record),
+        "avatarPath" | "avatar" | "avatarFilePath" | "avatarFilename" => {
+            record.get(field).cloned().unwrap_or(Value::Null)
+        }
+        _ => record.get(field).cloned().unwrap_or_else(|| json!({})),
+    }
+}
+
+fn character_comment(record: &Value) -> Value {
+    Value::String(
+        record
+            .get("comment")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    )
+}
+
+fn non_empty_or_default(value: &str, fallback: &str) -> String {
+    if value.trim().is_empty() {
+        fallback.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-characters-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn create_character(state: &AppState) {
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Original description",
+                        "tags": ["ice"],
+                        "character_version": "1.0"
+                    },
+                    "comment": "Original title",
+                    "avatar": "old-avatar",
+                    "avatarPath": "old-avatar",
+                    "avatarFilePath": "C:\\Marinara\\avatars\\characters\\old.png",
+                    "avatarFilename": "old.png"
+                }),
+            )
+            .expect("character should be created");
+    }
+
+    fn character_versions(state: &AppState) -> Vec<Value> {
+        state
+            .storage
+            .list("character-versions")
+            .expect("versions should list")
+    }
+
+    #[test]
+    fn update_character_creates_previous_state_snapshot_with_source_reason() {
+        let state = test_state("snapshot-source-reason");
+        create_character(&state);
+
+        let updated = update_character(
+            &state,
+            "char-1",
+            json!({
+                "data": { "tags": ["ice", "archive"] },
+                "comment": "Updated title",
+                "avatarPath": "new-avatar",
+                "avatarFilePath": "C:\\Marinara\\avatars\\characters\\new.png",
+                "avatarFilename": "new.png",
+                "versionSource": "agent",
+                "versionReason": "Professor Mari card update"
+            }),
+        )
+        .expect("character should update");
+
+        assert_eq!(updated["data"]["name"], "Rina");
+        assert_eq!(updated["data"]["description"], "Original description");
+        assert_eq!(updated["data"]["tags"], json!(["ice", "archive"]));
+        assert!(updated.get("versionSource").is_none());
+        assert!(updated.get("versionReason").is_none());
+
+        let versions = character_versions(&state);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["characterId"], "char-1");
+        assert_eq!(versions[0]["data"]["name"], "Rina");
+        assert_eq!(versions[0]["data"]["tags"], json!(["ice"]));
+        assert_eq!(versions[0]["comment"], "Original title");
+        assert_eq!(versions[0]["avatarPath"], "old-avatar");
+        assert_eq!(
+            versions[0]["avatarFilePath"],
+            "C:\\Marinara\\avatars\\characters\\old.png"
+        );
+        assert_eq!(versions[0]["avatarFilename"], "old.png");
+        assert_eq!(versions[0]["version"], "1.0");
+        assert_eq!(versions[0]["source"], "agent");
+        assert_eq!(versions[0]["reason"], "Professor Mari card update");
+    }
+
+    #[test]
+    fn update_character_skips_snapshot_when_requested() {
+        let state = test_state("snapshot-skip");
+        create_character(&state);
+
+        let updated = update_character(
+            &state,
+            "char-1",
+            json!({
+                "data": { "name": "Rina Prime" },
+                "skipVersionSnapshot": true,
+                "versionSource": "agent",
+                "versionReason": "Skipped update"
+            }),
+        )
+        .expect("character should update");
+
+        assert_eq!(updated["data"]["name"], "Rina Prime");
+        assert!(updated.get("skipVersionSnapshot").is_none());
+        assert!(updated.get("versionSource").is_none());
+        assert!(character_versions(&state).is_empty());
+    }
+
+    #[test]
+    fn update_character_does_not_snapshot_noop_patch() {
+        let state = test_state("snapshot-noop");
+        create_character(&state);
+
+        update_character(
+            &state,
+            "char-1",
+            json!({
+                "data": { "name": "Rina" },
+                "comment": "Original title",
+                "avatarPath": "old-avatar"
+            }),
+        )
+        .expect("noop character update should succeed");
+
+        assert!(character_versions(&state).is_empty());
+    }
+
+    #[test]
+    fn restore_character_version_snapshots_current_state_and_restores_avatar_metadata() {
+        let state = test_state("restore-snapshot");
+        create_character(&state);
+        state
+            .storage
+            .create(
+                "character-versions",
+                json!({
+                    "id": "version-old",
+                    "characterId": "char-1",
+                    "data": {
+                        "name": "Old Rina",
+                        "description": "Old description",
+                        "character_version": "0.9"
+                    },
+                    "comment": "Old title",
+                    "avatarPath": "old-restored-avatar",
+                    "avatarFilePath": "C:\\Marinara\\avatars\\characters\\restored.png",
+                    "avatarFilename": "restored.png",
+                    "version": "0.9",
+                    "source": "manual",
+                    "reason": "Before edit"
+                }),
+            )
+            .expect("version should be created");
+
+        let restored = restore_character_version(&state, "char-1", "version-old")
+            .expect("version should restore");
+
+        assert_eq!(restored["data"]["name"], "Old Rina");
+        assert_eq!(restored["comment"], "Old title");
+        assert_eq!(restored["avatarPath"], "old-restored-avatar");
+        assert_eq!(
+            restored["avatarFilePath"],
+            "C:\\Marinara\\avatars\\characters\\restored.png"
+        );
+        assert_eq!(restored["avatarFilename"], "restored.png");
+        assert!(restored.get("versionSource").is_none());
+        assert!(restored.get("versionReason").is_none());
+
+        let versions = character_versions(&state);
+        assert_eq!(versions.len(), 2);
+        let restore_snapshot = versions
+            .iter()
+            .find(|version| version.get("source").and_then(Value::as_str) == Some("restore"))
+            .expect("restore snapshot should exist");
+        assert_eq!(restore_snapshot["data"]["name"], "Rina");
+        assert_eq!(restore_snapshot["reason"], "Restored 0.9");
+    }
 }

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1,4 +1,4 @@
-use super::{avatars, chats, game_state_snapshots, lorebook_images, shared};
+use super::{avatars, characters, chats, game_state_snapshots, lorebook_images, shared};
 use crate::builtins::is_protected_record;
 use crate::state::AppState;
 use marinara_core::AppError;
@@ -244,6 +244,9 @@ fn storage_update_inner(
         return Ok(shared::project_timeline_message(shared::patch_message_update(
             state, &id, patch,
         )?));
+    }
+    if entity == "characters" {
+        return characters::update_character(state, &id, patch);
     }
     let updated = state.storage.patch(
         &entity,

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1006,6 +1006,9 @@ fn storage_update(state: &AppState, args: &Map<String, Value>) -> AppResult<Valu
             optional_value(args, "patch"),
         )?));
     }
+    if entity == "characters" {
+        return characters::update_character(state, id, optional_value(args, "patch"));
+    }
     state.storage.patch(
         entity,
         id,

--- a/src/engine/contracts/types/character.ts
+++ b/src/engine/contracts/types/character.ts
@@ -122,6 +122,8 @@ export interface CharacterCardVersion {
   data: CharacterData;
   comment: string;
   avatarPath: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   version: string;
   source: "manual" | "agent" | "command" | "restore" | string;
   reason: string;

--- a/src/features/catalog/characters/hooks/use-characters.test.ts
+++ b/src/features/catalog/characters/hooks/use-characters.test.ts
@@ -6,6 +6,7 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { updateCharacterSchema } from "../../../../engine/contracts/schemas/character.schema";
+import { characterApi } from "../../../../shared/api/character-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
 import { storageApi } from "../../../../shared/api/storage-api";
 import {
@@ -16,6 +17,7 @@ import {
   useCharacterSummaries,
   useCharactersByIds,
   useCharacters,
+  useUpdateCharacter,
 } from "./use-characters";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -24,6 +26,12 @@ vi.mock("../../../../shared/api/storage-api", () => ({
   storageApi: {
     get: vi.fn(),
     list: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/character-api", () => ({
+  characterApi: {
+    update: vi.fn(),
   },
 }));
 
@@ -39,6 +47,7 @@ vi.mock("../../../../shared/api/remote-runtime", () => ({
 }));
 
 const convertFileSrcMock = vi.mocked(convertFileSrc);
+const characterUpdateMock = vi.mocked(characterApi.update);
 const remoteRuntimeTargetMock = vi.mocked(remoteRuntimeTarget);
 const storageGetMock = vi.mocked(storageApi.get);
 const storageListMock = vi.mocked(storageApi.list);
@@ -68,6 +77,7 @@ describe("character list query", () => {
     });
     storageListMock.mockResolvedValue([]);
     storageGetMock.mockResolvedValue(null);
+    characterUpdateMock.mockResolvedValue(characterRecord("char-updated", "Updated Character") as never);
     remoteRuntimeTargetMock.mockReturnValue(null);
     convertFileSrcMock.mockImplementation((path) => `asset://localhost/${encodeURIComponent(path)}`);
     (window as unknown as { __TAURI_INTERNALS__?: { convertFileSrc?: unknown } }).__TAURI_INTERNALS__ = {
@@ -83,6 +93,7 @@ describe("character list query", () => {
     queryClient.clear();
     storageGetMock.mockReset();
     storageListMock.mockReset();
+    characterUpdateMock.mockReset();
     convertFileSrcMock.mockReset();
     remoteRuntimeTargetMock.mockReset();
     delete (window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
@@ -246,6 +257,27 @@ describe("character list query", () => {
         },
       ]),
     );
+  });
+
+  it("preserves version snapshot options through update mutations", async () => {
+    const readHook = await renderHook(() => useUpdateCharacter());
+
+    await act(async () => {
+      await readHook().mutateAsync({
+        id: "char-1",
+        data: { name: "Updated" },
+        versionSource: "agent",
+        versionReason: "Professor Mari card update",
+        skipVersionSnapshot: true,
+      });
+    });
+
+    expect(characterUpdateMock).toHaveBeenCalledWith("char-1", {
+      data: { name: "Updated" },
+      versionSource: "agent",
+      versionReason: "Professor Mari card update",
+      skipVersionSnapshot: true,
+    });
   });
 
   it("normalizes managed avatar paths from character detail reads", async () => {

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -228,7 +228,7 @@ export function useUpdateCharacter() {
       versionSource?: string;
       versionReason?: string;
       skipVersionSnapshot?: boolean;
-    }) => storageApi.update("characters", id, updateCharacterSchema.parse(data)),
+    }) => characterApi.update(id, updateCharacterSchema.parse(data)),
     onSuccess: (_data, variables) => {
       invalidateCharacterRecordQueries(qc, variables.id, { includeVersions: true });
     },

--- a/src/features/catalog/characters/lib/character-import-model.test.ts
+++ b/src/features/catalog/characters/lib/character-import-model.test.ts
@@ -36,6 +36,7 @@ describe("character import model", () => {
       avatarPath: "avatars/imported.png",
       versionSource: "import",
       versionReason: "Imported updated card from Imported",
+      skipVersionSnapshot: true,
     });
     expect(plan.importedId).toBe("imported-1");
     expect(plan.updatedName).toBe("Target");

--- a/src/features/catalog/characters/lib/character-import-model.ts
+++ b/src/features/catalog/characters/lib/character-import-model.ts
@@ -22,6 +22,7 @@ type CharacterImportUpdatePatch = {
   avatarPath?: string;
   versionSource: "import";
   versionReason: string;
+  skipVersionSnapshot: true;
 };
 
 type CharacterImportVersionSnapshot = {
@@ -135,6 +136,7 @@ export function buildCharacterImportUpdatePlan(
     comment: readCharacterImportString(importedRow?.comment),
     versionSource: "import",
     versionReason: `Imported updated card from ${importedName}`,
+    skipVersionSnapshot: true,
   };
 
   const importedAvatarPath = readCharacterImportString(importedRow?.avatarPath);

--- a/src/shared/api/character-api.ts
+++ b/src/shared/api/character-api.ts
@@ -1,4 +1,5 @@
 import { invokeTauri } from "./tauri-client";
+import { storageApi } from "./storage-api";
 
 export type EmbeddedLorebookImportResult = {
   success: boolean;
@@ -7,7 +8,10 @@ export type EmbeddedLorebookImportResult = {
   reimported?: boolean;
 };
 
+export type CharacterUpdatePatch = Record<string, unknown>;
+
 export const characterApi = {
+  update: (id: string, patch: CharacterUpdatePatch) => storageApi.update("characters", id, patch),
   restoreVersion: (characterId: string, versionId: string) =>
     invokeTauri("character_restore_version", { characterId, versionId }),
   uploadAvatar: (id: string, avatar: string) => invokeTauri("character_avatar_upload", { id, body: { avatar } }),


### PR DESCRIPTION
## Linked issue

- No public issue; parity follow-up from local character-feature audit.

## Why this change

Character edits in the refactor app accepted version metadata but did not persist recoverable version snapshots, so normal editor/agent/card-update changes lost legacy rollback behavior. Avatar updates also needed snapshot-safe handling because managed avatar files are deleted after replacement.

## What changed

- Route character updates through a character-owned Rust storage path that creates `character-versions` snapshots for data/comment/avatar changes.
- Preserve `versionSource`, `versionReason`, and `skipVersionSnapshot` through the shared API/hook boundary without storing those control fields on character rows.
- Keep in-place import rollback behavior by marking its follow-up update as `skipVersionSnapshot`.
- Snapshot avatar uploads before replacement and embed previous managed avatar bytes so restore does not point at a deleted managed file.
- Add focused Rust and Vitest coverage for snapshot creation, skip/no-op behavior, restore behavior, avatar restore safety, and hook payload preservation.

## Refactor impact

Primary owner:

Rust storage, shared API, catalog character hooks.

Impact areas reviewed:

- Character editor saves and agent/card update approval path.
- Embedded and remote `storage_update` command dispatch for `characters`.
- Character avatar upload and managed file cleanup.
- Character version history restore path.
- In-place character import rollback snapshot path.

Boundary notes:

- Product/UI callers stay in `src/features/catalog/characters` and call the focused `src/shared/api/character-api.ts` wrapper.
- Snapshot persistence stays in `src-tauri/src/commands/storage/characters.rs`.
- Remote-capable `storage_update` now delegates character patches to the same Rust owner as embedded Tauri updates.
- No React, shared API, or Tauri imports were added to engine code.

Pressure points touched:

- None of the known broad UI pressure points were touched.
- `src-tauri/src/http_dispatch.rs` was touched only to route remote character updates through the character storage owner.

## Validation

- [x] `pnpm check` passes locally
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated checks run locally by Codex:

- `git diff --check` passed.
- `pnpm test -- src/features/catalog/characters/hooks/use-characters.test.ts src/features/catalog/characters/lib/character-import-model.test.ts` passed.
- `cargo test --manifest-path src-tauri\Cargo.toml update_character` passed.
- `cargo test --manifest-path src-tauri\Cargo.toml restore_character_version` passed.
- `cargo test --manifest-path src-tauri\Cargo.toml character_avatar_update_snapshot_does_not_restore_deleted_file_metadata` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.

`pnpm check` was attempted, but `check:line-endings` failed before source checks because this working tree reports repo-wide CRLF line endings in an LF-normalized tree. Those files are unrelated to this PR and were not renormalized in this change.

Native Tauri QA was not run yet.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release note assessment: no docs or changelog file was updated; this is behavior parity in existing character storage/update flows.

## UI evidence

No visible UI changes; no screenshots attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character versions now preserve avatar history; restoring previous versions automatically recovers their associated avatars
  * Character import operations optimized for improved performance

* **Improvements**
  * Version snapshots now created only when character data meaningfully changes, reducing unnecessary background operations
  * Enhanced character update system with intelligent change detection across all versioned fields, including avatars, descriptions, and metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->