### PR TITLE
[codex] Tighten Lorebook Keeper target resolution

### DIFF
--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -154,7 +154,7 @@ export interface ChatMetadata {
   agentOverrides: Record<string, boolean>;
   /** Agent IDs scoped to this chat. Non-empty = only these agents run; empty = use globally-enabled agents. */
   activeAgentIds: string[];
-  /** Explicit target lorebook for the Lorebook Keeper in this chat. Null/omitted = auto-pick. */
+  /** Explicit target lorebook for the Lorebook Keeper in this chat. Null/omitted = use a scoped active lorebook when available. */
   lorebookKeeperTargetLorebookId?: string | null;
   /** How many assistant responses behind the latest available one Lorebook Keeper should read from. */
   lorebookKeeperReadBehindMessages?: number;

--- a/src/engine/generation-core/lorebooks/lorebook-keeper-target.ts
+++ b/src/engine/generation-core/lorebooks/lorebook-keeper-target.ts
@@ -1,0 +1,129 @@
+import {
+  resolveActiveLorebookScopeReasons,
+  type ActiveLorebookScopeContext,
+  type ActiveLorebookScopeLorebook,
+  type ActiveLorebookScopeReason,
+} from "./active-lorebook-scope";
+
+type LorebookKeeperTargetSource = "configured" | "proposed" | "active";
+
+export interface LorebookKeeperTarget {
+  id: string;
+  name: string;
+  source: LorebookKeeperTargetSource;
+}
+
+export interface LorebookKeeperTargetContext extends ActiveLorebookScopeContext {
+  proposedLorebookId?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseRecord(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+}
+
+function stringArray(value: unknown): string[] {
+  return parseArray(value)
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function targetFromLorebook(
+  lorebook: ActiveLorebookScopeLorebook | undefined,
+  source: LorebookKeeperTargetSource,
+): LorebookKeeperTarget | null {
+  const id = readString(lorebook?.id);
+  if (!id) return null;
+  return {
+    id,
+    name: readString(lorebook?.name, "Lorebook"),
+    source,
+  };
+}
+
+function targetableAutoReasons(reasons: readonly ActiveLorebookScopeReason[]): boolean {
+  return reasons.some((reason) => reason.reason !== "global");
+}
+
+function activeTargetFromIds(
+  ids: readonly string[],
+  lorebookById: Map<string, ActiveLorebookScopeLorebook>,
+  context: ActiveLorebookScopeContext,
+  source: LorebookKeeperTargetSource,
+): LorebookKeeperTarget | null {
+  for (const id of ids) {
+    const lorebook = lorebookById.get(id);
+    if (!lorebook) continue;
+    if (!targetableAutoReasons(resolveActiveLorebookScopeReasons(lorebook, context))) continue;
+    const target = targetFromLorebook(lorebook, source);
+    if (target) return target;
+  }
+  return null;
+}
+
+export function resolveLorebookKeeperTarget(
+  lorebooks: readonly ActiveLorebookScopeLorebook[],
+  context: LorebookKeeperTargetContext,
+): LorebookKeeperTarget | null {
+  const lorebookById = new Map(
+    lorebooks
+      .map((lorebook) => [readString(lorebook.id), lorebook] as const)
+      .filter(([id]) => id.length > 0),
+  );
+  const chat = context.chat ?? {};
+  const metadata = parseRecord(chat.metadata);
+  const configuredLorebookId = readString(metadata.lorebookKeeperTargetLorebookId);
+  const configuredTarget = targetFromLorebook(lorebookById.get(configuredLorebookId), "configured");
+  if (configuredTarget) return configuredTarget;
+
+  const proposedTarget = activeTargetFromIds(
+    [readString(context.proposedLorebookId)],
+    lorebookById,
+    context,
+    "proposed",
+  );
+  if (proposedTarget) return proposedTarget;
+
+  const selectedTarget = activeTargetFromIds(
+    stringArray(metadata.activeLorebookIds ?? chat.activeLorebookIds),
+    lorebookById,
+    context,
+    "active",
+  );
+  if (selectedTarget) return selectedTarget;
+
+  return activeTargetFromIds(
+    lorebooks.map((lorebook) => readString(lorebook.id)),
+    lorebookById,
+    context,
+    "active",
+  );
+}

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -40,6 +40,7 @@ import {
   type GameStateForScanning,
 } from "../generation-core/lorebooks/keyword-scanner";
 import { resolveGameLorebookScopeExclusions } from "../generation-core/lorebooks/game-lorebook-scope";
+import { resolveLorebookKeeperTarget } from "../generation-core/lorebooks/lorebook-keeper-target";
 import { buildSpriteExpressionChoices } from "../modes/game/prompts/sprite.service";
 import { applyAllSegmentEdits } from "../modes/game/state/segment-edits";
 import { llmParameters } from "./context";
@@ -790,9 +791,39 @@ function skippedDanglingConnectionResult(agent: JsonRecord, connectionId: string
   };
 }
 
+function skippedLorebookKeeperTargetResult(agent: JsonRecord): AgentResult {
+  const name = readString(agent.name) || "Lorebook Keeper";
+  return {
+    agentId: readString(agent.id) || "lorebook-keeper",
+    agentType: "lorebook-keeper",
+    type: "lorebook_update",
+    data: {
+      code: "missing_lorebook_keeper_target",
+      agentName: name,
+    },
+    tokensUsed: 0,
+    durationMs: 0,
+    success: false,
+    error:
+      "Lorebook Keeper needs a target lorebook. Choose a Target Lorebook in Chat Settings or activate a chat, character, or persona lorebook for this chat.",
+  };
+}
+
 function suppressAgentForTurn(input: GenerationAgentRuntimeInput, type: string): boolean {
   const isRegeneration = !!readString(input.regenerateMessageId).trim();
   return isRegeneration && type === "echo-chamber";
+}
+
+async function resolveLorebookKeeperRuntimeTarget(
+  storage: StorageGateway,
+  input: GenerationAgentRuntimeInput,
+): Promise<ReturnType<typeof resolveLorebookKeeperTarget>> {
+  const lorebooks = await storage.list<JsonRecord>("lorebooks");
+  return resolveLorebookKeeperTarget(lorebooks, {
+    chat: input.chat,
+    characters: input.characters.map((character) => ({ id: character.id })),
+    persona: readString(input.chat.personaId) ? { id: input.chat.personaId } : null,
+  });
 }
 
 async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput): Promise<ResolvedAgentsResult> {
@@ -834,6 +865,10 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     if (suppressAgentForTurn(input, type)) continue;
     const id = readString(agent.id) || type;
     const settings = agentSettings(agent);
+    if (type === "lorebook-keeper" && !(await resolveLorebookKeeperRuntimeTarget(deps.storage, input))) {
+      skippedResults.push(skippedLorebookKeeperTargetResult(agent));
+      continue;
+    }
     const builtInAgent = isBuiltInAgent(agent);
     if (!input.bypassCustomAgentActivation && !builtInAgent) {
       const activation = matchCustomAgentActivation(settings, activationMessages);
@@ -934,21 +969,12 @@ function lorebookKeeperActiveForContext(input: GenerationAgentRuntimeInput): boo
 
 async function loadLorebookKeeperEntries(
   storage: StorageGateway,
-  chatMeta: JsonRecord,
+  input: GenerationAgentRuntimeInput,
 ): Promise<Array<{ id: string; name: string; content: string; keys: string[]; locked: boolean }> | null> {
-  const configuredLorebookId = readString(chatMeta.lorebookKeeperTargetLorebookId).trim();
-  const activeLorebookIds = stringSet(chatMeta.activeLorebookIds);
-  let lorebookId = configuredLorebookId || [...activeLorebookIds][0] || "";
+  const target = await resolveLorebookKeeperRuntimeTarget(storage, input);
 
-  if (!lorebookId) {
-    const lorebook = (await storage.list<JsonRecord>("lorebooks").catch(() => [])).find((row) =>
-      boolish(row.enabled, true),
-    );
-    lorebookId = readString(lorebook?.id).trim();
-  }
-
-  if (!lorebookId) return null;
-  const entries = await storage.list<JsonRecord>("lorebook-entries", { filters: { lorebookId } }).catch(() => []);
+  if (!target) return null;
+  const entries = await storage.listLorebookEntries<JsonRecord>(target.id).catch(() => []);
   return entries.map((entry) => ({
     id: readString(entry.id).trim(),
     name: readString(entry.name).trim() || "Unnamed",
@@ -1111,7 +1137,7 @@ async function buildAgentContext(
   if (secretPlotState) memory._secretPlotState = secretPlotState;
   memory._spotifyDjConstraints = buildSpotifyDjConstraints(chatMode, chatMeta);
   if (lorebookKeeperActiveForContext(input)) {
-    const existingLorebookEntries = await loadLorebookKeeperEntries(deps.storage, chatMeta);
+    const existingLorebookEntries = await loadLorebookKeeperEntries(deps.storage, input);
     if (existingLorebookEntries) memory._existingLorebookEntries = existingLorebookEntries;
   }
   const context: AgentContext = {

--- a/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../engine/contracts/schemas/lorebook.schema";
 import type { Chat } from "../../../../engine/contracts/types/chat";
 import type { Lorebook, LorebookEntry } from "../../../../engine/contracts/types/lorebook";
+import { resolveLorebookKeeperTarget } from "../../../../engine/generation-core/lorebooks/lorebook-keeper-target";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { parseChatMetadata } from "../../../../shared/lib/chat-display";
 import type { PendingLorebookUpdate } from "../../../../shared/stores/agent.store";
@@ -100,21 +101,17 @@ async function lorebooksForUpdate(queryClient: QueryClient): Promise<Lorebook[]>
   return storageApi.list<Lorebook>("lorebooks").catch(() => []);
 }
 
-async function resolveTargetLorebook(
-  queryClient: QueryClient,
-  chatId: string,
+function resolveTargetLorebook(
+  chat: Chat | null,
+  lorebooks: Lorebook[],
   rawUpdate: Record<string, unknown>,
-): Promise<{ id: string; name: string } | null> {
-  const explicitLorebookId = readString(rawUpdate.lorebookId);
-  const chat = await chatForUpdate(queryClient, chatId);
-  const metadata = parseChatMetadata(chat?.metadata);
-  const metadataLorebookId = readString(metadata.lorebookKeeperTargetLorebookId);
-  const activeLorebookIds = stringArray(metadata.activeLorebookIds);
-  const lorebooks = await lorebooksForUpdate(queryClient);
-  const targetId = explicitLorebookId || metadataLorebookId || activeLorebookIds[0] || lorebooks[0]?.id || "";
-  if (!targetId) return null;
-  const lorebook = lorebooks.find((item) => item.id === targetId);
-  return { id: targetId, name: lorebook?.name || "Lorebook" };
+): { id: string; name: string } | null {
+  return resolveLorebookKeeperTarget(lorebooks, {
+    chat,
+    characters: (chat?.characterIds ?? []).map((id) => ({ id })),
+    persona: chat?.personaId ? { id: chat.personaId } : null,
+    proposedLorebookId: rawUpdate.lorebookId,
+  });
 }
 
 function normalizeRawLorebookUpdate(raw: unknown): Record<string, unknown> | null {
@@ -149,9 +146,11 @@ export async function buildPendingLorebookUpdates(
   if (updates.length === 0) return [];
 
   const timestamp = Date.now();
+  const chat = await chatForUpdate(queryClient, chatId);
+  const lorebooks = await lorebooksForUpdate(queryClient);
   const pending: PendingLorebookUpdate[] = [];
   for (const rawUpdate of updates) {
-    const target = await resolveTargetLorebook(queryClient, chatId, rawUpdate);
+    const target = resolveTargetLorebook(chat, lorebooks, rawUpdate);
     if (!target) continue;
     const action = readString(rawUpdate.action).toLowerCase() as PendingLorebookUpdate["action"];
     pending.push({

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -4141,8 +4141,8 @@ function ChatSettingsDrawerInner({
                           <span>Lorebook Keeper</span>
                         </div>
                         <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                          Pick a chat-specific target lorebook and optionally keep Lorebook Keeper a few assistant
-                          replies behind the latest canon before it writes.
+                          Pick a chat-specific target lorebook. If blank, Keeper uses a scoped active lorebook and skips
+                          writing when none is available.
                         </p>
                       </div>
                       <button
@@ -4173,7 +4173,7 @@ function ChatSettingsDrawerInner({
                           }
                           className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)]"
                         >
-                          <option value="">Auto-select first writable lorebook</option>
+                          <option value="">Use scoped active lorebook</option>
                           {((lorebooks ?? []) as Array<{ id: string; name: string }>).map((lorebook) => (
                             <option key={lorebook.id} value={lorebook.id}>
                               {lorebook.name}


### PR DESCRIPTION
## Linked issue

Not linked.

## Why this change

- Lorebook Keeper could fall back to an unqualified first enabled lorebook when no explicit target was set, which risked writing updates into a broad/default book.
- The no-target path could also silently drop generated proposals after a successful agent run.

## What changed

- Added an engine-owned Lorebook Keeper target resolver for configured target, proposed scoped target, and scoped active target selection.
- Routed Lorebook Keeper agent context and pending update application through that resolver.
- Removed the first-enabled lorebook fallback from the write path.
- Added a preflight skip result when Lorebook Keeper has no writable target, avoiding an unnecessary LLM call and surfacing the configuration issue.
- Updated Chat Settings copy for the target selector and added focused resolver/runtime/update tests.

## Refactor impact

Primary owner:

engine generation and generation-core lorebook targeting, with small catalog update-flow and shared chat settings UI touchpoints.

Impact areas reviewed:

- Lorebook Keeper agent prompt context and result flow.
- Pending Lorebook Keeper update review/apply path.
- Chat metadata target contract.
- Active lorebook scope resolver behavior.

Boundary notes:

- Target selection lives in React-free `src/engine/generation-core/lorebooks`.
- Feature code consumes the focused engine resolver for pending update application.
- No shared API, Tauri command, Rust, or remote-runtime routing changes.

Pressure points touched:

- Shared mode UI: `ChatSettingsDrawer` copy only.
- No `ModeSurface`, `GameSurface`, Tauri command registration, or import modules touched.

## Validation

- [x] `pnpm check` passes locally
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Playwright, screenshot, or recording evidence added for UI changes
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Agent-run validation:

- `pnpm vitest run src/engine/generation-core/lorebooks/lorebook-keeper-target.test.ts src/features/catalog/lorebooks/lib/lorebook-keeper-updates.test.ts src/engine/generation/agent-runner.test.ts` passed: 3 files, 46 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm build` passed; Vite reported existing large chunk warnings and an existing CSS minify warning.
- `git diff --check` passed.
- `pnpm check` passed after fixing an unused exported type.

Not run: native Tauri UI pass, live provider call, or manual Lorebook Keeper review/apply flow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release files changed; this is a focused engine behavior fix with small settings copy adjustment.

## UI evidence

Not added. Visible UI impact is limited to target selector copy; no native UI pass was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling when no target lorebook is available for the Lorebook Keeper agent.

* **Documentation**
  * Updated Lorebook Keeper UI help text and labels to reflect scoped lorebook selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->