### PR TITLE
Fix tracker panel chat scrollbar overlap

### DIFF
--- a/src/app/shell/AppShell.tsx
+++ b/src/app/shell/AppShell.tsx
@@ -697,6 +697,12 @@ export function AppShell() {
         ? "var(--tracker-panel-mobile-width)"
         : `${Math.round(trackerPanelWidth * 0.62)}px`
       : "0px";
+  const trackerPanelScrollAvoidance =
+    trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
+      ? isMobile
+        ? "var(--tracker-panel-mobile-width)"
+        : `${trackerPanelWidth + TRACKER_PANEL_HUD_GAP}px`
+      : "0px";
   const trackerPanelHudClearance =
     trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets && trackerPanelSurfaceAvailable
       ? isMobile
@@ -1058,6 +1064,10 @@ export function AppShell() {
                   "--tracker-panel-mobile-width": mobileTrackerPanelWidth,
                   "--tracker-chat-avoid-left": trackerPanelSide === "left" ? trackerPanelChatAvoidance : "0px",
                   "--tracker-chat-avoid-right": trackerPanelSide === "right" ? trackerPanelChatAvoidance : "0px",
+                  "--tracker-chat-scroll-avoid-left":
+                    trackerPanelSide === "left" ? trackerPanelScrollAvoidance : "0px",
+                  "--tracker-chat-scroll-avoid-right":
+                    trackerPanelSide === "right" ? trackerPanelScrollAvoidance : "0px",
                   "--tracker-panel-hud-clear-left": trackerPanelSide === "left" ? trackerPanelHudClearance : "0px",
                   "--tracker-panel-hud-clear-right": trackerPanelSide === "right" ? trackerPanelHudClearance : "0px",
                 } as CSSProperties

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -91,6 +91,8 @@ const PANEL_BACKDROP =
   "fixed inset-0 z-[9999] flex items-center justify-center p-4 max-md:pt-[max(1rem,env(safe-area-inset-top))]";
 const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
   "pl-[var(--tracker-chat-avoid-left)] pr-[var(--tracker-chat-avoid-right)] transition-[padding] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]";
+const TRACKER_SCROLL_AVOIDANCE_CLASS =
+  "transition-[padding] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]";
 const PANEL_CONTAINER =
   "relative max-h-[calc(100dvh-4rem)] w-full max-w-sm overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 shadow-2xl shadow-black/40 animate-message-in";
 
@@ -971,7 +973,11 @@ export function ChatRoleplaySurface({
             )}
 
             <div
-              className={cn("relative z-10 min-h-0 flex-1 basis-0 overflow-hidden", TRACKER_FOREGROUND_AVOIDANCE_CLASS)}
+              className={cn("relative z-10 min-h-0 flex-1 basis-0 overflow-hidden", TRACKER_SCROLL_AVOIDANCE_CLASS)}
+              style={{
+                paddingLeft: "var(--tracker-chat-scroll-avoid-left)",
+                paddingRight: "var(--tracker-chat-scroll-avoid-right)",
+              }}
             >
               <div
                 ref={scrollRef}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1695

## Why this change

- The fixed tracker panel can sit over the roleplay chat's native scrollbar gutter. The existing chat avoidance padding only moved foreground content partway away from the tracker, so the scroll container itself could still extend under the panel and paint the scrollbar through tracker cards.

## What changed

- Added a full-width tracker scroll avoidance value in `AppShell` that matches the tracker panel width plus HUD gap.
- Applied that full scroll avoidance only to the roleplay transcript scroll shell, leaving the existing narrower foreground/input avoidance behavior unchanged.

## Refactor impact

Primary owner:

- App shell / roleplay mode UI.

Impact areas reviewed:

- `src/app/shell/AppShell.tsx`
- `src/features/modes/roleplay/components/ChatRoleplaySurface.tsx`

Boundary notes:

- Client-only layout fix. No engine, shared API, Rust, storage, remote-runtime, dependency, schema, or prompt pipeline changes.

Pressure points touched:

- `AppShell` tracker-panel CSS variables.
- Roleplay transcript scroll shell.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm typecheck`.
- Codex ran full `pnpm check` after rebasing onto current `upstream/refactor`; it passed line endings, architecture, frontend typecheck, Rust cargo check, docs, and unused-code checks.
- Codex ran `node scratch/prove-1695-scrollbar-geometry.mjs` against the local Vite app. The proof reproduced the old geometry with the chat scroll edge overlapping the tracker by 122px, then verified the fixed geometry with the chat scroll edge stopping 16px before the tracker.
- Full desktop/Tauri roleplay visual verification is still pending. In this web-shell, creating the roleplay repro chat is blocked by the app's "Remote Runtime required" setup state, so this PR is intentionally opened as a draft.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Geometry proof gist: https://gist.github.com/cha1latte/0f07f9296cea4a2dcf876321aa1266f6
- Local screenshot artifacts from the proof run: `scratch/issue-1695-before.png`, `scratch/issue-1695-after.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout spacing to prevent content from being obscured by the tracker panel, with optimized adjustments for both mobile and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->