### PR TITLE
Fix Mari custom tool_choice compatibility

### DIFF
--- a/src-tauri/src/commands/storage/mari.rs
+++ b/src-tauri/src/commands/storage/mari.rs
@@ -152,7 +152,11 @@ impl ChatProvider for MarinaraLlmProvider {
                 .iter()
                 .map(autoagents_message_to_marinara)
                 .collect(),
-            parameters: mari_request_parameters(messages, tools.unwrap_or_default()),
+            parameters: mari_request_parameters(
+                &self.connection,
+                messages,
+                tools.unwrap_or_default(),
+            ),
             tools: tools
                 .unwrap_or_default()
                 .iter()
@@ -173,7 +177,11 @@ impl ChatProvider for MarinaraLlmProvider {
     }
 }
 
-fn mari_request_parameters(messages: &[ChatMessage], tools: &[Tool]) -> Value {
+fn mari_request_parameters(
+    connection: &marinara_llm::LlmConnection,
+    messages: &[ChatMessage],
+    tools: &[Tool],
+) -> Value {
     let mut parameters = json!({
                 "temperature": 0.4,
                 "maxTokens": 2048,
@@ -188,17 +196,21 @@ fn mari_request_parameters(messages: &[ChatMessage], tools: &[Tool]) -> Value {
         .map(|message| message.content.as_str())
         .unwrap_or_default();
     if !tools.is_empty() && !has_tool_result && looks_like_codebase_question(latest_user) {
-        parameters["toolChoice"] = json!({
-            "type": "function",
-            "function": { "name": "search_marinara_code" }
-        });
+        parameters["toolChoice"] = mari_forced_tool_choice(connection, "search_marinara_code");
     } else if !tools.is_empty() && !has_tool_result && looks_like_library_question(latest_user) {
-        parameters["toolChoice"] = json!({
-            "type": "function",
-            "function": { "name": "read_marinara_library" }
-        });
+        parameters["toolChoice"] = mari_forced_tool_choice(connection, "read_marinara_library");
     }
     parameters
+}
+
+fn mari_forced_tool_choice(connection: &marinara_llm::LlmConnection, tool_name: &str) -> Value {
+    if connection.provider == "custom" {
+        return json!("required");
+    }
+    json!({
+        "type": "function",
+        "function": { "name": tool_name }
+    })
 }
 
 #[async_trait]
@@ -1424,6 +1436,82 @@ fn looks_like_encoded_blob(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_connection(provider: &str) -> marinara_llm::LlmConnection {
+        marinara_llm::LlmConnection {
+            provider: provider.to_string(),
+            model: "test-model".to_string(),
+            api_key: String::new(),
+            base_url: String::new(),
+            openrouter_provider: None,
+            enable_caching: false,
+            caching_at_depth: None,
+            max_tokens_override: None,
+            claude_fast_mode: false,
+        }
+    }
+
+    fn text_message(content: &str) -> ChatMessage {
+        ChatMessage {
+            role: ChatRole::User,
+            message_type: MessageType::Text,
+            content: content.to_string(),
+        }
+    }
+
+    fn test_tool(name: &str) -> Tool {
+        Tool {
+            tool_type: "function".to_string(),
+            function: autoagents::llm::chat::FunctionTool {
+                name: name.to_string(),
+                description: "Test tool".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+            },
+        }
+    }
+
+    #[test]
+    fn professor_mari_custom_connections_use_string_tool_choice() {
+        let connection = test_connection("custom");
+        let messages = [text_message("What does src/app/shell/AppShell.tsx do?")];
+        let tools = [test_tool("search_marinara_code")];
+
+        let parameters = mari_request_parameters(&connection, &messages, &tools);
+
+        assert_eq!(parameters["toolChoice"], json!("required"));
+    }
+
+    #[test]
+    fn professor_mari_known_openai_connections_keep_exact_tool_choice() {
+        let connection = test_connection("openai");
+        let messages = [text_message("What does src/app/shell/AppShell.tsx do?")];
+        let tools = [test_tool("search_marinara_code")];
+
+        let parameters = mari_request_parameters(&connection, &messages, &tools);
+
+        assert_eq!(
+            parameters["toolChoice"],
+            json!({
+                "type": "function",
+                "function": { "name": "search_marinara_code" }
+            })
+        );
+    }
+
+    #[test]
+    fn professor_mari_custom_library_questions_use_string_tool_choice() {
+        let connection = test_connection("custom");
+        let messages = [text_message("What personas are in my library?")];
+        let tools = [test_tool("read_marinara_library")];
+
+        let parameters = mari_request_parameters(&connection, &messages, &tools);
+
+        assert_eq!(parameters["toolChoice"], json!("required"));
+    }
 
     fn prompt_with_attachment(attachment: MariAttachment) -> String {
         prompt_with_attachments(vec![attachment])


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1704

## Why this change

- Professor Mari forced a specific function tool with OpenAI object-form `tool_choice` for all native-tool providers. LM Studio's OpenAI-compatible local server rejects that object form and only accepts string values such as `"required"`, which made Mari fail before the model saw codebase/library requests.

## What changed

- Pass the selected LLM connection into Mari's request-parameter builder.
- Use `tool_choice: "required"` for `custom` connections so LM Studio-compatible endpoints get the broadly accepted string form.
- Keep exact object-form tool selection for known OpenAI-style providers such as `openai`.
- Add Rust regression coverage for custom codebase, custom library, and OpenAI exact-tool behavior.

## Refactor impact

Primary owner:

Rust storage / Professor Mari provider bridge.

Impact areas reviewed:

- `src-tauri/src/commands/storage/mari.rs`
- `src-tauri/crates/llm/src/lib.rs` tool-choice pass-through behavior
- Professor Mari codebase and library forced-tool paths

Boundary notes:

- The fix stays in the Rust Professor Mari request-shaping layer. It does not change React UI, engine TypeScript, shared API wrappers, persisted connection schema, or the Rust LLM transport contract.

Pressure points touched:

- Professor Mari ReAct `chat_with_tools` request parameters.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

Codex-run verification:

- `node scratch\repro-1704-tool-choice.mjs`
  - Before fix: reproduced object-form `tool_choice` assignments for `search_marinara_code` and `read_marinara_library`.
  - After fix: passes, confirming custom Professor Mari requests use string `tool_choice: "required"`.
- `cargo test --manifest-path src-tauri\Cargo.toml professor_mari -- --nocapture` passed: 10 passed.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.
- `pnpm check` passed after rebasing onto current `upstream/refactor`.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny pass before opening: focused one-file diff, no blocking findings.

### Manual verification notes

- Not manually tested against a live LM Studio server in this environment. The core request-shape claim is covered by the Rust regression tests and scratch repro.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note files were changed.

## UI evidence

N/A. This is a backend/provider request-shape fix with no visible UI state change.
