### PR TITLE
Fix remote avatar asset routing

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -212,12 +212,22 @@ fn managed_asset_path(state: &AppState, kind: &str, path: &str) -> Result<PathBu
 }
 
 fn avatar_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {
-    let filename = avatar_asset_filename(path)?;
-    Ok(state
-        .data_dir
-        .join("avatars")
-        .join("characters")
-        .join(filename))
+    let segments = avatar_asset_path_segments(path)?;
+    let mut asset_path = state.data_dir.join("avatars");
+    if segments.len() == 1 {
+        asset_path = asset_path.join("characters").join(&segments[0]);
+    } else {
+        let collection = segments
+            .first()
+            .ok_or_else(|| AppError::not_found("Avatar asset was not found"))?;
+        if !is_avatar_asset_collection(collection) {
+            return Err(AppError::not_found("Avatar asset was not found"));
+        }
+        for segment in segments {
+            asset_path = asset_path.join(segment);
+        }
+    }
+    Ok(asset_path)
 }
 
 fn avatar_asset_filename(path: &str) -> Result<String, AppError> {
@@ -232,6 +242,28 @@ fn avatar_asset_filename(path: &str) -> Result<String, AppError> {
         return Err(AppError::not_found("Avatar asset was not found"));
     }
     Ok(filename.to_string())
+}
+
+fn avatar_asset_path_segments(path: &str) -> Result<Vec<String>, AppError> {
+    let value = path.trim();
+    if value.is_empty() {
+        return Err(AppError::not_found("Avatar asset was not found"));
+    }
+    let mut segments = Vec::new();
+    for segment in value.split('/') {
+        segments.push(avatar_asset_filename(segment)?);
+    }
+    if segments.is_empty() {
+        return Err(AppError::not_found("Avatar asset was not found"));
+    }
+    Ok(segments)
+}
+
+fn is_avatar_asset_collection(value: &str) -> bool {
+    matches!(
+        value,
+        "characters" | "personas" | "character-groups" | "persona-groups" | "npc"
+    )
 }
 
 fn content_type_for_path(path: &FsPath) -> &'static str {
@@ -1005,6 +1037,17 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 mod tests {
     use super::*;
 
+    fn test_state(label: &str) -> AppState {
+        let root = std::env::temp_dir().join(format!(
+            "marinara-http-server-{label}-{}",
+            health_probe_filename()
+        ));
+        if root.exists() {
+            std::fs::remove_dir_all(&root).expect("stale test data dir should be removed");
+        }
+        AppState::from_data_dir(root, Vec::new()).expect("test app state should initialize")
+    }
+
     fn test_security() -> SecurityConfig {
         SecurityConfig {
             cors_wildcard: false,
@@ -1114,6 +1157,50 @@ mod tests {
             avatar_asset_filename("avatar one.png").expect("valid avatar filename"),
             "avatar one.png"
         );
+    }
+
+    #[test]
+    fn avatar_asset_path_routes_known_avatar_collections() {
+        let state = test_state("avatar-collections");
+        assert_eq!(
+            avatar_asset_path(&state, "avatar.png")
+                .expect("legacy character filename should resolve"),
+            state
+                .data_dir
+                .join("avatars")
+                .join("characters")
+                .join("avatar.png")
+        );
+        assert_eq!(
+            avatar_asset_path(&state, "characters/character.png")
+                .expect("character collection should resolve"),
+            state
+                .data_dir
+                .join("avatars")
+                .join("characters")
+                .join("character.png")
+        );
+        assert_eq!(
+            avatar_asset_path(&state, "personas/persona.png")
+                .expect("persona collection should resolve"),
+            state
+                .data_dir
+                .join("avatars")
+                .join("personas")
+                .join("persona.png")
+        );
+        assert_eq!(
+            avatar_asset_path(&state, "npc/chat-1/innkeeper.png")
+                .expect("npc subpath should resolve"),
+            state
+                .data_dir
+                .join("avatars")
+                .join("npc")
+                .join("chat-1")
+                .join("innkeeper.png")
+        );
+        assert!(avatar_asset_path(&state, "sprites/mari.png").is_err());
+        assert!(avatar_asset_path(&state, "personas/../avatar.png").is_err());
     }
 
     #[test]

--- a/src/shared/api/local-file-api.test.tsx
+++ b/src/shared/api/local-file-api.test.tsx
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { avatarFileUrlFromPath } from "./local-file-api";
+import { remoteRuntimeTarget } from "./remote-runtime";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("./remote-runtime", () => ({
+  remoteHeaders: vi.fn(() => ({ "X-Marinara-CSRF": "1" })),
+  remoteRuntimeTarget: vi.fn(),
+}));
+
+vi.mock("./tauri-client", () => ({
+  invokeTauri: vi.fn(),
+}));
+
+const remoteRuntimeTargetMock = vi.mocked(remoteRuntimeTarget);
+
+describe("local file API managed avatar URLs", () => {
+  beforeEach(() => {
+    remoteRuntimeTargetMock.mockReset();
+    remoteRuntimeTargetMock.mockReturnValue({ baseUrl: "http://localhost:8787" });
+  });
+
+  it("preserves avatar collection prefixes from managed absolute paths for remote URLs", () => {
+    expect(avatarFileUrlFromPath("Current.png", "C:\\Marinara\\avatars\\personas\\Current.png")).toBe(
+      "http://localhost:8787/api/assets/avatar/personas/Current.png",
+    );
+    expect(avatarFileUrlFromPath("Created.png", "C:\\Marinara\\avatars\\characters\\Created.png")).toBe(
+      "http://localhost:8787/api/assets/avatar/characters/Created.png",
+    );
+    expect(avatarFileUrlFromPath("innkeeper.png", "/srv/marinara/avatars/npc/chat-1/innkeeper.png")).toBe(
+      "http://localhost:8787/api/assets/avatar/npc/chat-1/innkeeper.png",
+    );
+  });
+
+  it("keeps legacy filename-only remote avatar URLs when no managed path is available", () => {
+    expect(avatarFileUrlFromPath("legacy.png", null)).toBe("http://localhost:8787/api/assets/avatar/legacy.png");
+  });
+
+  it("does not derive collection-prefixed remote URLs from suspicious managed paths", () => {
+    expect(avatarFileUrlFromPath("safe.png", "C:\\Marinara\\avatars\\personas\\..\\safe.png")).toBe(
+      "http://localhost:8787/api/assets/avatar/safe.png",
+    );
+  });
+});

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -180,6 +180,41 @@ function filenameFromPath(path: string | null | undefined): string | null {
   return filename && filename !== "." && filename !== ".." ? filename : null;
 }
 
+function managedAvatarPathFromAbsolutePath(path: string | null | undefined): string | null {
+  const value = path?.trim();
+  if (!value) return null;
+  const normalized = value.replace(/\\/g, "/");
+  const lower = normalized.toLowerCase();
+  const marker = "/avatars/";
+  const markerIndex = lower.lastIndexOf(marker);
+  const relative =
+    markerIndex >= 0
+      ? normalized.slice(markerIndex + marker.length)
+      : lower.startsWith("avatars/")
+        ? normalized.slice("avatars/".length)
+        : null;
+  if (!relative) return null;
+  const segments = relative
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (segments.some((segment) => segment === "." || segment === ".." || segment.includes(":"))) {
+    return null;
+  }
+  const collection = segments[0];
+  if (!collection || !["characters", "personas", "character-groups", "persona-groups", "npc"].includes(collection)) {
+    return null;
+  }
+  return segments.join("/");
+}
+
+function avatarRemoteManagedPath(
+  filename: string | null | undefined,
+  absolutePath: string | null | undefined,
+): string | null {
+  return managedAvatarPathFromAbsolutePath(absolutePath) ?? filename?.trim() ?? filenameFromPath(absolutePath);
+}
+
 export function gameAssetFileUrlFromPath(path: string, absolutePath?: string | null): string {
   const remoteUrl = remoteManagedAssetUrl("game", path);
   if (remoteUrl) return remoteUrl;
@@ -196,7 +231,7 @@ export function avatarFileUrlFromPath(
   filename: string | null | undefined,
   absolutePath?: string | null,
 ): string | null {
-  const remoteUrl = remoteManagedAssetUrl("avatar", filename?.trim() || filenameFromPath(absolutePath));
+  const remoteUrl = remoteManagedAssetUrl("avatar", avatarRemoteManagedPath(filename, absolutePath));
   if (remoteUrl) return remoteUrl;
   return absolutePath ? filePathToAssetUrl(absolutePath) : null;
 }
@@ -225,7 +260,7 @@ export async function resolveAvatarFileUrl(
   filename: string | null | undefined,
   absolutePath?: string | null,
 ): Promise<string | null> {
-  const remoteUrl = await remoteManagedAssetResolvableUrl("avatar", filename?.trim() || filenameFromPath(absolutePath));
+  const remoteUrl = await remoteManagedAssetResolvableUrl("avatar", avatarRemoteManagedPath(filename, absolutePath));
   if (remoteUrl) return remoteUrl;
   return absolutePath ? filePathToAssetUrl(absolutePath) : null;
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1713

## Why this change

- The remote HTTP avatar asset endpoint only resolved bare filenames under `avatars/characters`, while managed persona and NPC avatar uploads are stored under `avatars/personas` and `avatars/npc`.
- In remote runtime mode, the frontend also collapsed managed avatar file paths to filename-only URLs, so persona and NPC avatar requests could not include the collection that owns the file.

## What changed

- Preserve known managed avatar collection prefixes when building remote avatar asset URLs from `avatarFilePath`.
- Route `/api/assets/avatar/<collection>/...` to allowlisted avatar collections while keeping legacy `/api/assets/avatar/<filename>` mapped to character avatars.
- Add regression coverage for character, persona, NPC, legacy filename-only, and suspicious managed-path cases.

## Refactor impact

Primary owner:

Remote runtime / Rust HTTP assets, with shared API URL construction.

Impact areas reviewed:

- `src/shared/api/local-file-api.ts`
- `src-tauri/src/http_server.rs`
- Existing avatar upload storage paths in `src-tauri/src/commands/storage/avatars.rs`

Boundary notes:

- The shared API wrapper still builds remote asset URLs; feature code does not call raw remote-runtime fetch.
- The Rust HTTP server owns filesystem resolution and keeps path traversal checks server-side.
- No schema, dependency, auth, prompt, import/export, or release metadata changes.

Pressure points touched:

- Remote runtime managed asset URL construction.
- `/api/assets/avatar/*path` HTTP asset routing.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex machine verification:

- Before fix, `cargo test --manifest-path src-tauri/Cargo.toml http_server::tests::avatar_asset_path_routes_known_avatar_collections` failed because collection-prefixed avatar paths were rejected.
- Before fix, `pnpm exec vitest run src/shared/api/local-file-api.test.ts` failed because a managed persona avatar path produced `/api/assets/avatar/Current.png` instead of `/api/assets/avatar/personas/Current.png`.
- After fix, `cargo test --manifest-path src-tauri/Cargo.toml http_server::tests::avatar_asset_path_routes_known_avatar_collections` passed.
- After fix, `pnpm exec vitest run src/shared/api/local-file-api.test.tsx` passed.
- `pnpm check` passed after the final diff and rebase.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.

Manual verification not performed:

- No Docker remote-runtime smoke was run in a live desktop-to-server setup from this machine. The endpoint/path contract is covered by focused Rust and TypeScript regression tests.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - this is a backend/shared API asset-routing fix with no visible UI state as the claim.
