### PR TITLE
fix: enable BYPASS_AUTH_DOCKER in docker-compose for host browser access

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ With Docker Compose:
 docker compose up --build
 ```
 
+The Compose file is intended for same-machine browser access by default. It binds
+the host port to `127.0.0.1:8787` and enables the Docker bridge auth bypass so a
+host browser can reach the container through the mapped local port. For LAN or
+reverse-proxy access, intentionally change the bind address and configure
+`BASIC_AUTH_USER`/`BASIC_AUTH_PASS`, `IP_ALLOWLIST`, or another explicit remote
+access opt-in.
+
 ## Developer Docs
 
 Open the static docs directly:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # use API-key auth or a credentials file in CLAUDE_CONFIG_DIR.
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/data/claude-config}
+      BYPASS_AUTH_DOCKER: "true"
     ports:
       - "8787:8787"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       CLAUDE_CONFIG_DIR: ${CLAUDE_CONFIG_DIR:-/data/claude-config}
       BYPASS_AUTH_DOCKER: "true"
     ports:
-      - "8787:8787"
+      - "127.0.0.1:8787:8787"
     volumes:
       - marinara-server-data:/data
 

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -285,8 +285,14 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         <h2>Run The Remote Runtime With Docker</h2>
         <p>Build and start the Rust API server with Docker Compose:</p>
         <pre><code>docker compose up --build</code></pre>
-        <p>The compose service exposes:</p>
+        <p>The compose service is intended for same-machine browser access by default and exposes:</p>
         <pre><code>http://127.0.0.1:8787</code></pre>
+        <p>
+          The default Compose port binding is limited to <code>127.0.0.1</code>. For LAN or
+          reverse-proxy access, intentionally change the bind address and configure
+          <code>BASIC_AUTH_USER</code>/<code>BASIC_AUTH_PASS</code>, <code>IP_ALLOWLIST</code>, or another
+          explicit remote access opt-in.
+        </p>
         <p>To build directly from GitHub, use Docker's remote git context:</p>
         <pre><code>docker build -t marinara-engine-server https://github.com/Pasta-Devs/Marinara-Engine.git#refactor
 docker run --rm -p 8787:8787 -v marinara-server-data:/data marinara-engine-server</code></pre>


### PR DESCRIPTION
## Linked issue

Fixes #1750

## Why this change

When running `marinara-server` via `docker compose up`, requests from the host browser arrive at the container from the Docker gateway IP (`172.17.0.1`), not loopback. The security middleware treated this as a non-loopback remote access attempt and returned a 403 before the CORS layer could add browser-readable headers, so the browser surfaced the failure as a CORS error instead of an auth/configuration error.

The fix should preserve same-machine Docker browser access without making unauthenticated remote runtime access broadly available on every host interface.

## What changed

- Added `BYPASS_AUTH_DOCKER: "true"` to the Compose service so host-browser requests that arrive through the Docker bridge can pass the runtime auth gate.
- Changed the Compose port mapping to `127.0.0.1:8787:8787` so the default Compose setup is same-machine only instead of host-wide.
- Documented the localhost-only Compose default and the need to intentionally configure bind/auth settings for LAN or reverse-proxy access.

## Refactor impact

Primary owner: remote runtime / Docker deployment

Impact areas reviewed:
- `docker-compose.yml`
- `README.md`
- `docs/developer/run-build.html`

Boundary notes:
- No engine, shared API, feature, or Tauri command source boundaries changed.
- The auth behavior remains owned by the Rust remote runtime; this PR only changes the Docker deployment wrapper and docs around that runtime.

Pressure points touched:
- Remote runtime Docker deployment and auth exposure defaults.
- No ModeSurface, GameSurface, shared mode UI, command registration, or import modules touched.

## Validation

- [x] Matching validation command passes locally (focused validation: `pnpm check:docs`, `pnpm check:architecture`, `cargo check --manifest-path src-tauri/Cargo.toml --workspace`, and Docker remote-runtime smoke)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [x] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `docker compose config` and confirmed the published port resolves to `host_ip: 127.0.0.1`, `published: "8787"`, `target: 8787`.
- Ran `docker compose build --progress plain`; image `marinara-engine-server:local` built successfully.
- Ran `docker compose up -d`; container `marinara-engine-server` started successfully.
- Confirmed `GET http://127.0.0.1:8787/health` returned `{"ok":true,"runtime":"marinara-server","writable":true}` with HTTP 200.
- Confirmed browser-origin `POST http://127.0.0.1:8787/api/invoke` with `Origin: http://localhost:1420`, `X-Marinara-CSRF: 1`, and a `storage_list` payload returned `[]` with HTTP 200.
- Confirmed `docker ps` showed `127.0.0.1:8787->8787/tcp`, not `0.0.0.0:8787->8787/tcp`.
- Ran `docker compose down` after the smoke test to stop and remove the test container/network.
- Ran `node D:\dev\Marinara-Engine\.agents\automation\scripts\proof-health.mjs C:\tmp\marinara-pr-1742\scratch\pr-1742-docker-auth-ledger.json`; proof health reported ready for risky auth/network work.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [x] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence (if applicable)

N/A — no visible UI changes. This is Docker remote-runtime network/auth behavior; runtime proof is captured in the manual verification notes.
