### PR TITLE
Add gallery image prompt regeneration

### DIFF
--- a/src/features/catalog/gallery/hooks/use-gallery.test.tsx
+++ b/src/features/catalog/gallery/hooks/use-gallery.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Chat } from "../../../../engine/contracts/types/chat";
+import { imageGenerationApi } from "../../../../shared/api/image-generation-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import type { ChatImage } from "../../../../shared/types/gallery";
+import { galleryKeys } from "../query-keys";
+import { useRegenerateGalleryImage } from "./use-gallery";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../../../../shared/api/image-generation-api", () => ({
+  galleryApi: {
+    uploadChat: vi.fn(),
+  },
+  imageGenerationApi: {
+    generate: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    create: vi.fn(),
+  },
+}));
+
+const generateMock = vi.mocked(imageGenerationApi.generate);
+const createMock = vi.mocked(storageApi.create);
+
+function chat(overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: "chat-1",
+    name: "Test chat",
+    mode: "conversation",
+    characterIds: [],
+    groupId: null,
+    personaId: null,
+    promptPresetId: null,
+    connectionId: null,
+    connectedChatId: null,
+    folderId: null,
+    sortOrder: 0,
+    createdAt: "2026-05-31T00:00:00.000Z",
+    updatedAt: "2026-05-31T00:00:00.000Z",
+    metadata: {
+      summary: null,
+      tags: [],
+      enableAgents: false,
+      agentOverrides: {},
+      activeAgentIds: [],
+      activeToolIds: [],
+      presetChoices: {},
+      imageGenConnectionId: "image-connection-1",
+    },
+    ...overrides,
+  };
+}
+
+function image(overrides: Partial<ChatImage> = {}): ChatImage {
+  return {
+    id: "gallery-1",
+    chatId: "chat-1",
+    url: "asset://gallery-1.png",
+    prompt: " rainy neon street ",
+    provider: "old_provider",
+    model: "old-model",
+    width: 640,
+    height: 832,
+    createdAt: "2026-05-31T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("gallery hooks", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    generateMock.mockReset();
+    createMock.mockReset();
+  });
+
+  async function renderHook<TValue>(useHook: () => TValue): Promise<TValue> {
+    let value: TValue | undefined;
+
+    function Probe() {
+      value = useHook();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        createElement(QueryClientProvider, {
+          client: queryClient,
+          children: createElement(Probe),
+        }),
+      );
+    });
+
+    if (!value) throw new Error("Hook did not render");
+    return value;
+  }
+
+  it("regenerates a gallery image from its saved prompt and stores the new image", async () => {
+    const regenerate = await renderHook(() => useRegenerateGalleryImage(chat()));
+    queryClient.setQueryData(galleryKeys.images("chat-1"), [image()]);
+    generateMock.mockResolvedValue({
+      image: "data:image/webp;base64,new-image",
+      mimeType: "image/webp",
+      provider: "new_provider",
+      model: "new-model",
+    });
+    createMock.mockResolvedValue({ id: "gallery-2" });
+
+    await act(async () => {
+      await regenerate.mutateAsync(image());
+    });
+
+    expect(generateMock).toHaveBeenCalledWith({
+      connectionId: "image-connection-1",
+      prompt: "rainy neon street",
+      width: 640,
+      height: 832,
+    });
+    expect(createMock).toHaveBeenCalledWith(
+      "gallery",
+      expect.objectContaining({
+        chatId: "chat-1",
+        filename: expect.stringMatching(/^regenerated_\d+\.webp$/),
+        prompt: "rainy neon street",
+        provider: "new_provider",
+        model: "new-model",
+        width: 640,
+        height: 832,
+        sourceGalleryId: "gallery-1",
+        url: "data:image/webp;base64,new-image",
+      }),
+    );
+    expect(queryClient.getQueryState(galleryKeys.images("chat-1"))?.isInvalidated).toBe(true);
+  });
+
+  it("uses the game image connection when regenerating game gallery images", async () => {
+    const regenerate = await renderHook(() =>
+      useRegenerateGalleryImage(
+        chat({
+          mode: "game",
+          metadata: {
+            summary: null,
+            tags: [],
+            enableAgents: false,
+            agentOverrides: {},
+            activeAgentIds: [],
+            activeToolIds: [],
+            presetChoices: {},
+            imageGenConnectionId: "conversation-image-connection",
+            gameImageConnectionId: "game-image-connection",
+          },
+        }),
+      ),
+    );
+    generateMock.mockResolvedValue({ base64: "new-image", mimeType: "image/png" });
+    createMock.mockResolvedValue({ id: "gallery-2" });
+
+    await act(async () => {
+      await regenerate.mutateAsync(image({ width: null, height: null }));
+    });
+
+    expect(generateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: "game-image-connection",
+        width: 1024,
+        height: 1024,
+      }),
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      "gallery",
+      expect.objectContaining({
+        url: "data:image/png;base64,new-image",
+      }),
+    );
+  });
+
+  it("rejects images without a saved prompt before calling the provider", async () => {
+    const regenerate = await renderHook(() => useRegenerateGalleryImage(chat()));
+
+    await act(async () => {
+      await expect(regenerate.mutateAsync(image({ prompt: " " }))).rejects.toThrow(
+        "This image does not have a saved prompt to regenerate.",
+      );
+    });
+
+    expect(generateMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/catalog/gallery/hooks/use-gallery.test.tsx
+++ b/src/features/catalog/gallery/hooks/use-gallery.test.tsx
@@ -126,7 +126,10 @@ describe("gallery hooks", () => {
 
   it("regenerates a gallery image from its saved prompt and stores the new image", async () => {
     const regenerate = await renderHook(() => useRegenerateGalleryImage(chat()));
-    queryClient.setQueryData(galleryKeys.images("chat-1"), [image()]);
+    const activeGalleryKey = galleryKeys.images("chat-1", ["chat-1"]);
+    const otherGalleryKey = galleryKeys.images("other-chat", ["other-chat"]);
+    queryClient.setQueryData(activeGalleryKey, [image()]);
+    queryClient.setQueryData(otherGalleryKey, []);
     generateMock.mockResolvedValue({
       image: "data:image/webp;base64,new-image",
       mimeType: "image/webp",
@@ -159,27 +162,51 @@ describe("gallery hooks", () => {
         url: "data:image/webp;base64,new-image",
       }),
     );
-    expect(queryClient.getQueryState(galleryKeys.images("chat-1"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(activeGalleryKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(otherGalleryKey)?.isInvalidated).toBe(false);
   });
 
   it("uses the game image connection when regenerating game gallery images", async () => {
+    const gameChat = chat({
+      mode: "game",
+      groupId: "game-1",
+      metadata: {
+        summary: null,
+        tags: [],
+        enableAgents: false,
+        agentOverrides: {},
+        activeAgentIds: [],
+        activeToolIds: [],
+        presetChoices: {},
+        imageGenConnectionId: "conversation-image-connection",
+        gameImageConnectionId: "game-image-connection",
+        gameId: "game-1",
+      },
+    });
+    const activeGalleryKey = galleryKeys.images("chat-1", ["chat-2", "chat-1"]);
+    const unrelatedGalleryKey = galleryKeys.images("other-chat", ["other-chat"]);
+    queryClient.setQueryData(galleryKeys.gameSessions("game-1"), [
+      chat({
+        id: "chat-2",
+        mode: "game",
+        groupId: "game-1",
+        metadata: {
+          summary: null,
+          tags: [],
+          enableAgents: false,
+          agentOverrides: {},
+          activeAgentIds: [],
+          activeToolIds: [],
+          presetChoices: {},
+          gameId: "game-1",
+        },
+      }),
+    ]);
+    queryClient.setQueryData(activeGalleryKey, []);
+    queryClient.setQueryData(unrelatedGalleryKey, []);
+
     const regenerate = await renderHook(() =>
-      useRegenerateGalleryImage(
-        chat({
-          mode: "game",
-          metadata: {
-            summary: null,
-            tags: [],
-            enableAgents: false,
-            agentOverrides: {},
-            activeAgentIds: [],
-            activeToolIds: [],
-            presetChoices: {},
-            imageGenConnectionId: "conversation-image-connection",
-            gameImageConnectionId: "game-image-connection",
-          },
-        }),
-      ),
+      useRegenerateGalleryImage(gameChat),
     );
     generateMock.mockResolvedValue({ base64: "new-image", mimeType: "image/png" });
     createMock.mockResolvedValue({ id: "gallery-2" });
@@ -201,6 +228,8 @@ describe("gallery hooks", () => {
         url: "data:image/png;base64,new-image",
       }),
     );
+    expect(queryClient.getQueryState(activeGalleryKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(unrelatedGalleryKey)?.isInvalidated).toBe(false);
   });
 
   it("rejects images without a saved prompt before calling the provider", async () => {

--- a/src/features/catalog/gallery/hooks/use-gallery.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.ts
@@ -127,6 +127,11 @@ export function useUploadGalleryImage(chatId: string | null) {
 
 export function useRegenerateGalleryImage(chat: Chat | null) {
   const queryClient = useQueryClient();
+  const gameId = getGameGalleryScopeId(chat);
+  const gameSessions = queryClient.getQueryData<Chat[]>(galleryKeys.gameSessions(gameId)) ?? [];
+  const galleryChatIds = getGalleryChatIds(chat, gameSessions);
+  const activeGalleryQueryKey = galleryKeys.images(chat?.id ?? null, galleryChatIds);
+
   return useMutation({
     mutationFn: async (image: ChatImage) => {
       if (!chat?.id) throw new Error("Open a chat before regenerating gallery images.");
@@ -172,7 +177,7 @@ export function useRegenerateGalleryImage(chat: Chat | null) {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: galleryKeys.all });
+      queryClient.invalidateQueries({ queryKey: activeGalleryQueryKey });
     },
     meta: { chatId: chat?.id ?? null },
   });

--- a/src/features/catalog/gallery/hooks/use-gallery.ts
+++ b/src/features/catalog/gallery/hooks/use-gallery.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { galleryKeys } from "../query-keys";
-import { galleryApi } from "../../../../shared/api/image-generation-api";
+import { galleryApi, imageGenerationApi } from "../../../../shared/api/image-generation-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import type { Chat } from "../../../../engine/contracts/types/chat";
 import type { ChatImage } from "../../../../shared/types/gallery";
@@ -8,6 +8,30 @@ import type { ChatImage } from "../../../../shared/types/gallery";
 function imageCreatedAt(image: ChatImage) {
   const timestamp = typeof image.createdAt === "string" ? Date.parse(image.createdAt) : NaN;
   return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function readTrimmed(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function imageExtension(mimeType: string | null | undefined): string {
+  const normalized = mimeType?.toLowerCase() ?? "";
+  if (normalized.includes("jpeg") || normalized.includes("jpg")) return "jpg";
+  if (normalized.includes("webp")) return "webp";
+  return "png";
+}
+
+function imageDimension(value: number | null | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.round(value) : fallback;
+}
+
+function imageConnectionId(chat: Chat | null): string {
+  if (!chat) return "";
+  return (
+    readTrimmed(chat.metadata?.gameImageConnectionId) ||
+    readTrimmed(chat.metadata?.imageGenConnectionId) ||
+    readTrimmed(chat.metadata?.illustrationImageConnectionId)
+  );
 }
 
 function getGameGalleryScopeId(chat: Chat | null): string | null {
@@ -98,6 +122,59 @@ export function useUploadGalleryImage(chatId: string | null) {
       }
     },
     meta: { chatId },
+  });
+}
+
+export function useRegenerateGalleryImage(chat: Chat | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (image: ChatImage) => {
+      if (!chat?.id) throw new Error("Open a chat before regenerating gallery images.");
+
+      const prompt = readTrimmed(image.prompt);
+      if (!prompt) throw new Error("This image does not have a saved prompt to regenerate.");
+
+      const connectionId = imageConnectionId(chat);
+      if (!connectionId) throw new Error("Choose an image generation connection in chat settings first.");
+
+      const width = imageDimension(image.width, 1024);
+      const height = imageDimension(image.height, 1024);
+      const generated = await imageGenerationApi.generate<{
+        base64?: string;
+        mimeType?: string;
+        image?: string;
+        provider?: string;
+        model?: string;
+      }>({
+        connectionId,
+        prompt,
+        width,
+        height,
+      });
+      const mimeType = generated.mimeType || "image/png";
+      const imageUrl =
+        readTrimmed(generated.image) ||
+        (readTrimmed(generated.base64) ? `data:${mimeType};base64,${readTrimmed(generated.base64)}` : "");
+      if (!imageUrl) throw new Error("Image provider returned no image data.");
+
+      const filename = `regenerated_${Date.now()}.${imageExtension(mimeType)}`;
+      return storageApi.create<ChatImage>("gallery", {
+        chatId: chat.id,
+        filePath: filename,
+        filename,
+        url: imageUrl,
+        prompt,
+        provider: generated.provider ?? image.provider ?? "image_generation",
+        model: generated.model ?? image.model ?? null,
+        width,
+        height,
+        sourceGalleryId: image.id,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: galleryKeys.all });
+    },
+    meta: { chatId: chat?.id ?? null },
   });
 }
 

--- a/src/features/modes/shared/chat-ui/components/ChatGallery.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatGallery.tsx
@@ -15,8 +15,14 @@ import {
   Sparkles,
   Pin,
   Minimize2,
+  RotateCcw,
 } from "lucide-react";
-import { useGalleryImages, useUploadGalleryImage, useDeleteGalleryImage } from "../../../../catalog/gallery/index";
+import {
+  useGalleryImages,
+  useUploadGalleryImage,
+  useDeleteGalleryImage,
+  useRegenerateGalleryImage,
+} from "../../../../catalog/gallery/index";
 import { useGalleryStore } from "../../../../../shared/stores/gallery.store";
 import { ImageUploadDropzone } from "../../../../../shared/components/ui/ImageUploadDropzone";
 import { ImagePromptPanel } from "./ImagePromptPanel";
@@ -46,6 +52,7 @@ export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
   const { data: images, isLoading } = useGalleryImages(chat);
   const upload = useUploadGalleryImage(chat.id);
   const remove = useDeleteGalleryImage(chat.id);
+  const regenerate = useRegenerateGalleryImage(chat);
   const [lightbox, setLightbox] = useState<ChatImage | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [illustratePending, setIllustratePending] = useState(false);
@@ -53,6 +60,7 @@ export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
   const pinImage = useGalleryStore((s) => s.pinImage);
   const lightboxPrompt = lightbox?.prompt?.trim() ?? "";
   const lightboxMeta = lightbox ? formatImageMeta(lightbox) : "";
+  const regeneratingImageId = regenerate.isPending ? regenerate.variables?.id : null;
 
   const handleUpload = useCallback(
     (files: File[]) => {
@@ -84,6 +92,20 @@ export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
     setConfirmDeleteId(null);
     if (lightbox?.id === id) setLightbox(null);
   };
+
+  const handleRegenerate = useCallback(
+    (image: ChatImage) => {
+      regenerate.mutate(image, {
+        onSuccess: () => {
+          toast.success("Image regenerated from the saved prompt.");
+        },
+        onError: (error) => {
+          toast.error(error instanceof Error ? error.message : "Failed to regenerate image.");
+        },
+      });
+    },
+    [regenerate],
+  );
 
   return (
     <div className="flex flex-col gap-3 p-4">
@@ -179,6 +201,23 @@ export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
                     >
                       <Pin size="0.75rem" />
                     </button>
+                    {img.prompt?.trim() && (
+                      <button
+                        type="button"
+                        onClick={() => handleRegenerate(img)}
+                        disabled={regenerate.isPending}
+                        aria-label="Regenerate image from prompt"
+                        aria-busy={regeneratingImageId === img.id}
+                        className="rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30 disabled:cursor-wait disabled:opacity-60"
+                        title="Regenerate from prompt"
+                      >
+                        {regeneratingImageId === img.id ? (
+                          <Loader2 size="0.75rem" className="animate-spin" />
+                        ) : (
+                          <RotateCcw size="0.75rem" />
+                        )}
+                      </button>
+                    )}
                   </div>
                   <button
                     type="button"
@@ -253,6 +292,23 @@ export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
                 >
                   <Minimize2 size="0.875rem" />
                 </button>
+                {lightboxPrompt && (
+                  <button
+                    type="button"
+                    onClick={() => handleRegenerate(lightbox)}
+                    disabled={regenerate.isPending}
+                    aria-label="Regenerate image from prompt"
+                    aria-busy={regeneratingImageId === lightbox.id}
+                    className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80 disabled:cursor-wait disabled:opacity-60"
+                    title="Regenerate from prompt"
+                  >
+                    {regeneratingImageId === lightbox.id ? (
+                      <Loader2 size="0.875rem" className="animate-spin" />
+                    ) : (
+                      <RotateCcw size="0.875rem" />
+                    )}
+                  </button>
+                )}
                 <a
                   href={lightbox.url}
                   download
@@ -271,6 +327,22 @@ export function ChatGallery({ chat, onIllustrate }: ChatGalleryProps) {
                 </button>
               </div>
             </div>
+            {lightboxPrompt && (
+              <button
+                type="button"
+                onClick={() => handleRegenerate(lightbox)}
+                disabled={regenerate.isPending}
+                aria-busy={regeneratingImageId === lightbox.id}
+                className="flex min-h-9 items-center justify-center gap-2 rounded-lg bg-white/10 px-3 text-xs font-medium text-white transition-colors hover:bg-white/15 disabled:cursor-wait disabled:opacity-60"
+              >
+                {regeneratingImageId === lightbox.id ? (
+                  <Loader2 size="0.875rem" className="animate-spin" />
+                ) : (
+                  <RotateCcw size="0.875rem" />
+                )}
+                <span>{regeneratingImageId === lightbox.id ? "Regenerating..." : "Regenerate from prompt"}</span>
+              </button>
+            )}
             <ImagePromptPanel prompt={lightboxPrompt} meta={lightboxMeta} className="w-full max-w-3xl" />
           </div>
         </div>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1573

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

Adds a focused way to retry an existing generated gallery image from its saved prompt, so users do not need to spend a new chat message just to regenerate the same image prompt.

## What changed

<!-- List the key changes in this PR. -->

- Added a shared chat gallery regeneration mutation that reuses the saved prompt, current chat image connection, and existing dimensions where available.
- Added regenerate controls on prompted gallery images in the grid overlay and lightbox.
- Added focused hook tests for prompt reuse, game image connection selection, fallback dimensions, gallery writes, cache invalidation, and promptless-image rejection.

## Refactor impact

Primary owner:

shared mode UI / catalog gallery

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Impact areas reviewed:

- Chat gallery image grid and lightbox controls.
- Gallery query invalidation for conversation, roleplay, and game gallery scopes.
- Image generation API and storage API call boundaries.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

The feature code stays in `src/features` and uses existing focused shared API wrappers (`imageGenerationApi`, `storageApi`) instead of raw Tauri invokes. Engine and Rust storage behavior are not changed.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Shared chat gallery UI (`ChatGallery`)
- Catalog gallery hooks (`use-gallery`)

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

Codex-run validation:
- `pnpm exec vitest run src/features/catalog/gallery/hooks/use-gallery.test.tsx` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app/runtime, step by step. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Provider-backed manual check still needed before ready-for-review: open a chat with an image generation connection, open a prompted gallery image, click "Regenerate from prompt", and confirm the new image appears in the gallery.
- Browser visual pass still needed before ready-for-review because Codex did not run the full app with a configured image provider.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed for this focused UI affordance.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

Not added yet. The PR should stay draft until a provider-backed browser pass can capture the gallery regenerate control and successful regenerated image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Gallery images can now be regenerated from their saved prompts via a dedicated button in the image overlay and lightbox view
  * Loading indicators and success/error feedback display during regeneration
  * Regenerated images are automatically added to your gallery collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->