### PR TITLE
Add configurable OpenAI TTS voice lookup path

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -114,6 +114,7 @@ fn default_config() -> Value {
         "enabled": false,
         "source": "openai",
         "baseUrl": "https://api.openai.com/v1",
+        "voicesPath": "",
         "apiKey": "",
         "voice": "alloy",
         "model": "tts-1",
@@ -221,6 +222,7 @@ async fn voices(state: &AppState) -> AppResult<Value> {
         .get(openai_voices_url(
             &base,
             config.get("model").and_then(Value::as_str),
+            config.get("voicesPath").and_then(Value::as_str),
         ))
         .headers(openai_headers(api_key)?)
         .send()
@@ -485,8 +487,17 @@ fn configured_base_url(config: &Value) -> String {
 /// providers can return the right catalog. If URL parsing fails, return the
 /// raw legacy endpoint and let the provider request fail through the existing
 /// fallback path.
-fn openai_voices_url(base: &str, model: Option<&str>) -> String {
-    let raw_url = format!("{base}/audio/voices");
+fn openai_voices_url(base: &str, model: Option<&str>, voices_path: Option<&str>) -> String {
+    let configured_path = voices_path
+        .map(str::trim)
+        .unwrap_or("")
+        .trim_start_matches('/');
+    let path = if configured_path.is_empty() {
+        "audio/voices"
+    } else {
+        configured_path
+    };
+    let raw_url = format!("{base}/{path}");
     let Ok(mut url) = reqwest::Url::parse(&raw_url) else {
         return raw_url;
     };
@@ -817,7 +828,10 @@ mod tests {
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
     }
 
-    async fn serve_model_gated_voices(expected_model: &'static str) -> String {
+    async fn serve_model_gated_voices(
+        expected_path_prefix: &'static str,
+        expected_model: &'static str,
+    ) -> String {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("test voice server should bind");
@@ -837,11 +851,15 @@ mod tests {
             let request = String::from_utf8_lossy(&buffer[..bytes]);
             let path = request.lines().next().unwrap_or_default();
             let encoded_model = expected_model.replace('/', "%2F");
+            let has_expected_path = path.starts_with(expected_path_prefix);
             let has_model = path.contains(&format!("model={encoded_model}"));
-            let (status, body) = if has_model {
+            let (status, body) = if has_expected_path && has_model {
                 ("200 OK", r#"{"voices":["af_heart"]}"#)
             } else {
-                ("400 Bad Request", r#"{"error":"missing model"}"#)
+                (
+                    "404 Not Found",
+                    r#"{"error":"unexpected voice lookup route"}"#,
+                )
             };
             let response = format!(
                 "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -931,7 +949,7 @@ mod tests {
     async fn openai_compatible_voice_lookup_passes_configured_model() {
         let state = test_state("openai-voices-model");
         let model = "mlx-community/Kokoro-82M-bf16";
-        let base_url = serve_model_gated_voices(model).await;
+        let base_url = serve_model_gated_voices("GET /v1/audio/voices?", model).await;
         state
             .storage
             .upsert_with_id(
@@ -942,6 +960,37 @@ mod tests {
                         "enabled": true,
                         "source": "openai",
                         "baseUrl": base_url,
+                        "apiKey": "",
+                        "model": model
+                    }
+                }),
+            )
+            .expect("TTS settings should be stored");
+
+        let result = voices(&state).await.expect("voice lookup should complete");
+
+        assert_eq!(result["fromProvider"], true);
+        assert_eq!(result["fallback"], false);
+        assert!(result.get("providerError").is_none());
+        assert_eq!(result["voices"], json!(["af_heart"]));
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_voice_lookup_uses_configured_path() {
+        let state = test_state("openai-voices-path");
+        let model = "mlx-community/Kokoro-82M-bf16";
+        let base_url = serve_model_gated_voices("GET /v1/voices?", model).await;
+        state
+            .storage
+            .upsert_with_id(
+                "app-settings",
+                TTS_SETTINGS_KEY,
+                json!({
+                    "value": {
+                        "enabled": true,
+                        "source": "openai",
+                        "baseUrl": base_url,
+                        "voicesPath": "/voices",
                         "apiKey": "",
                         "model": model
                     }
@@ -1056,7 +1105,8 @@ mod tests {
         assert_eq!(
             openai_voices_url(
                 "http://127.0.0.1:8081/v1",
-                Some(" mlx-community/Kokoro-82M-bf16 ")
+                Some(" mlx-community/Kokoro-82M-bf16 "),
+                None,
             ),
             "http://127.0.0.1:8081/v1/audio/voices?model=mlx-community%2FKokoro-82M-bf16"
         );
@@ -1065,8 +1115,16 @@ mod tests {
     #[test]
     fn openai_voices_url_omits_blank_model() {
         assert_eq!(
-            openai_voices_url("http://127.0.0.1:8081/v1", Some("  ")),
+            openai_voices_url("http://127.0.0.1:8081/v1", Some("  "), None),
             "http://127.0.0.1:8081/v1/audio/voices"
+        );
+    }
+
+    #[test]
+    fn openai_voices_url_uses_configured_path() {
+        assert_eq!(
+            openai_voices_url("http://127.0.0.1:8081/v1", Some("tts-1"), Some(" /voices ")),
+            "http://127.0.0.1:8081/v1/voices?model=tts-1"
         );
     }
 }

--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -103,6 +103,8 @@ export const ttsConfigSchema = z.object({
   enabled: z.boolean().default(false),
   source: ttsSourceSchema.default("openai"),
   baseUrl: z.string().default("https://api.openai.com/v1"),
+  /** OpenAI-compatible voice catalog path. Empty preserves the legacy /audio/voices route. */
+  voicesPath: z.string().default(""),
   /** Plain text on write; masked "••••••" on read when a key is saved */
   apiKey: z.string().default(""),
   voice: z.string().default("alloy"),

--- a/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-streaming-tts.test.tsx
@@ -12,6 +12,7 @@ const baseConfig: TTSConfig = {
   enabled: true,
   source: "openai",
   baseUrl: "https://api.openai.com/v1",
+  voicesPath: "",
   apiKey: "",
   voice: "alloy",
   narratorVoiceEnabled: false,

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -299,6 +299,7 @@ export function TTSConfigCard() {
   const [enabled, setEnabled] = useState(false);
   const [source, setSource] = useState<TTSSource>("openai");
   const [baseUrl, setBaseUrl] = useState("https://api.openai.com/v1");
+  const [voicesPath, setVoicesPath] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [model, setModel] = useState("tts-1");
   const [voice, setVoice] = useState("alloy");
@@ -335,6 +336,7 @@ export function TTSConfigCard() {
   } = useTTSVoices(
     savedSource,
     savedConfig?.baseUrl ?? TTS_SOURCE_DEFAULTS[savedSource].baseUrl,
+    savedConfig?.voicesPath ?? "",
     savedConfig?.enabled ?? false,
   );
 
@@ -344,6 +346,7 @@ export function TTSConfigCard() {
     setEnabled(savedConfig.enabled);
     setSource(savedConfig.source ?? "openai");
     setBaseUrl(savedConfig.baseUrl);
+    setVoicesPath(savedConfig.voicesPath ?? "");
     setApiKey(savedConfig.apiKey); // masked value from server
     setModel(savedConfig.model);
     setVoice(savedConfig.voice);
@@ -390,6 +393,7 @@ export function TTSConfigCard() {
     enabled,
     source,
     baseUrl,
+    voicesPath,
     apiKey: apiKey === TTS_API_KEY_MASK ? TTS_API_KEY_MASK : apiKey,
     model,
     voice,
@@ -452,6 +456,7 @@ export function TTSConfigCard() {
 
     setSource(nextSource);
     setBaseUrl(defaults.baseUrl);
+    setVoicesPath("");
     setApiKey(nextApiKey);
     setModel(defaults.model);
     setVoice(defaults.voice);
@@ -467,6 +472,7 @@ export function TTSConfigCard() {
     mark({
       source: nextSource,
       baseUrl: defaults.baseUrl,
+      voicesPath: "",
       apiKey: nextApiKey,
       model: defaults.model,
       voice: defaults.voice,
@@ -766,6 +772,23 @@ export function TTSConfigCard() {
               />
             </div>
           </FieldRow>
+
+          {source === "openai" && (
+            <FieldRow
+              label="Voice Lookup Path"
+              help="Optional path used to fetch provider voices. Leave blank for the default /audio/voices route."
+            >
+              <input
+                value={voicesPath}
+                onChange={(e) => {
+                  setVoicesPath(e.target.value);
+                  mark({ voicesPath: e.target.value });
+                }}
+                className={cn(INPUT_CLS, "font-mono")}
+                placeholder="/audio/voices"
+              />
+            </FieldRow>
+          )}
 
           {/* API Key */}
           <FieldRow

--- a/src/shared/hooks/use-tts.ts
+++ b/src/shared/hooks/use-tts.ts
@@ -7,7 +7,8 @@ import type { TTSConfig, TTSSource } from "../../engine/contracts/types/tts";
 
 const KEYS = {
   config: ["tts", "config"] as const,
-  voices: (source: TTSSource, baseUrl: string) => ["tts", "voices", source, baseUrl] as const,
+  voices: (source: TTSSource, baseUrl: string, voicesPath: string) =>
+    ["tts", "voices", source, baseUrl, voicesPath] as const,
 };
 
 // ── Config ───────────────────────────────────────
@@ -41,9 +42,9 @@ export function useUpdateTTSConfig() {
 
 // ── Voices ───────────────────────────────────────
 
-export function useTTSVoices(source: TTSSource, baseUrl: string, enabled: boolean) {
+export function useTTSVoices(source: TTSSource, baseUrl: string, voicesPath: string, enabled: boolean) {
   return useQuery({
-    queryKey: KEYS.voices(source, baseUrl),
+    queryKey: KEYS.voices(source, baseUrl, voicesPath),
     queryFn: () => ttsApi.voices(),
     enabled: enabled && Boolean(baseUrl),
     staleTime: 5 * 60_000,


### PR DESCRIPTION
## Linked issue

Closes #1592

## Why this change

- OpenAI-compatible TTS providers do not share a standard voice-list endpoint. Marinara hardcoded `/audio/voices`, so self-hosted or custom-compatible providers using paths like `/voices` or `/v1/voices` could not return live voice catalogs.

## What changed

- Added optional `voicesPath` to the TTS config contract, defaulting to blank so existing configs keep `/audio/voices`.
- Updated OpenAI-compatible voice lookup to use the configured path when present while preserving model query handling.
- Added a Connections panel input for the OpenAI-compatible voice lookup path.
- Added focused Rust regression coverage for default and configured voice lookup routes.

## Refactor impact

Primary owner:

Rust storage integrations / TTS configuration.

Impact areas reviewed:

- `src-tauri` TTS voice lookup
- shared TTS config schema
- Connections TTS settings card
- TTS voice query cache key
- existing streaming TTS config test fixture

Boundary notes:

- Engine contract remains React-free.
- Feature UI continues through shared TTS hooks/API wrappers.
- Provider URL construction remains in the Rust TTS integration boundary.

Pressure points touched:

- Connections panel TTS settings card
- `tts_voices` Rust command path

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex verification run:

- `cargo test --manifest-path src-tauri/Cargo.toml openai_compatible_voice_lookup -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml openai_voices_url -- --nocapture`
- `pnpm test -- src\features\modes\shared\chat-ui\hooks\use-streaming-tts.test.tsx`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `node scratch\issue-1592-ui-proof.mjs`
- `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Local Playwright proof captured the OpenAI-compatible TTS settings card showing the new `Voice Lookup Path` field with `/audio/voices` placeholder at `scratch/issue-1592-tts-voices-path.png`. Not embedded here because local scratch files are not GitHub-renderable PR evidence.
