### PR TITLE
Make home idle state static

### DIFF
--- a/src/features/modes/router/components/ModeHomeSurface.tsx
+++ b/src/features/modes/router/components/ModeHomeSurface.tsx
@@ -43,8 +43,6 @@ export function ModeHomeSurface() {
     [connections, createChat],
   );
 
-  const showEmptyStateEffects = true;
-
   return (
     <>
       <div
@@ -53,19 +51,14 @@ export function ModeHomeSurface() {
       >
         <div className="flex w-full max-w-2xl flex-col items-center gap-3 py-2 sm:gap-4 sm:py-3 lg:pt-4 lg:pb-5">
           <div className="relative">
-            <div
-              className={cn(
-                "flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl shadow-xl shadow-orange-500/20 sm:h-20 sm:w-20",
-                showEmptyStateEffects && "animate-pulse-ring bunny-glow",
-              )}
-            >
+            <div className="flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl shadow-xl shadow-orange-500/20 sm:h-20 sm:w-20">
               <img
-                src={showEmptyStateEffects ? "/logo-splash.gif" : "/logo.png"}
+                src="/logo.png"
                 alt="Marinara Engine"
                 width={80}
                 height={80}
                 decoding="async"
-                className={cn("h-full w-full", showEmptyStateEffects ? "object-cover" : "object-contain p-1.5 sm:p-2")}
+                className="h-full w-full object-contain p-1.5 sm:p-2"
               />
             </div>
           </div>
@@ -77,9 +70,7 @@ export function ModeHomeSurface() {
             </p>
           </div>
 
-          <div
-            className={cn("flex flex-wrap justify-center gap-2 sm:gap-3", showEmptyStateEffects && "stagger-children")}
-          >
+          <div className="flex flex-wrap justify-center gap-2 sm:gap-3">
             <QuickStartCard
               icon={<MessageSquare size="1.125rem" />}
               label="Conversation"
@@ -109,9 +100,7 @@ export function ModeHomeSurface() {
           <RecentChats />
           <HomeFaq />
 
-          <div
-            className={cn("w-48", showEmptyStateEffects ? "retro-divider" : "h-px rounded-[1px] bg-[var(--border)]/40")}
-          />
+          <div className="h-px w-48 rounded-[1px] bg-[var(--border)]/40" />
 
           <div className="flex w-full max-w-2xl flex-col items-center gap-2">
             <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 text-center text-[0.625rem] leading-tight text-[var(--muted-foreground)]/55 sm:text-xs">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1059,7 +1059,6 @@ body {
   flex: 0 0 auto;
   border-radius: 0.18rem;
   filter: drop-shadow(0 0 0.25rem color-mix(in srgb, var(--primary) 22%, transparent));
-  animation: mari-title-heartbeat 2.4s ease-in-out infinite;
 }
 
 .mari-title-word {
@@ -1109,20 +1108,6 @@ body {
   }
   70% {
     transform: translateY(-1px) rotate(-4deg) scale(1.08);
-  }
-}
-
-@keyframes mari-title-heartbeat {
-  0%,
-  64%,
-  100% {
-    transform: scale(1);
-  }
-  72% {
-    transform: scale(1.22);
-  }
-  82% {
-    transform: scale(0.98);
   }
 }
 
@@ -1520,27 +1505,13 @@ summary[class*="cursor-pointer"],
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
 }
 
-@keyframes twinkle-glow {
-  0%,
-  100% {
-    opacity: 0.6;
-    filter: blur(0);
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.2;
-    filter: blur(0.5px);
-    transform: scale(0.9);
-  }
-}
-
 .y2k-star,
 .y2k-star-md,
 .y2k-star-lg {
   position: fixed;
   pointer-events: none;
   border-radius: 50%;
-  animation: twinkle-glow 4s ease-in-out infinite;
+  opacity: 0.55;
 }
 
 .y2k-star {
@@ -1559,7 +1530,7 @@ summary[class*="cursor-pointer"],
   box-shadow:
     0 0 10px 4px rgba(212, 173, 252, 0.6),
     0 0 20px 8px rgba(212, 173, 252, 0.3);
-  animation-duration: 5s;
+  opacity: 0.45;
 }
 
 .y2k-star-lg {
@@ -1569,7 +1540,7 @@ summary[class*="cursor-pointer"],
   box-shadow:
     0 0 12px 5px rgba(255, 228, 245, 0.7),
     0 0 24px 10px rgba(255, 228, 245, 0.4);
-  animation-duration: 6s;
+  opacity: 0.5;
 }
 
 @keyframes pulse-glow {


### PR DESCRIPTION
## Linked issue

Closes #

## Why this change

- The Tauri/WebView2 pre-release was burning CPU while sitting on the no-chat home shell.
- Profiling showed the hot owner was WebView GPU/renderer work from always-on home/shell animation, not Rust, Tauri, or backend runtime work.
- A static home state keeps the app branded while avoiding continuous idle paint work.

## What changed

- Swapped the idle home logo from `/logo-splash.gif` to static `/logo.png`.
- Removed idle use of home pulse/glow/stagger/divider animations from `ModeHomeSurface`.
- Removed always-on title heartbeat and Y2K star twinkle animation from global shell decor, keeping static glow/opacity.

## Refactor impact

Primary owner:

- app shell / mode home surface

Impact areas reviewed:

- no-chat home surface
- shell ambient decor CSS
- reduced-motion behavior
- mode-specific/game/roleplay animation utilities left in place

Boundary notes:

- React/UI and CSS-only change.
- No engine, shared API, Rust/Tauri command, storage, schema, dependency, or release/version changes.

Pressure points touched:

- `ModeHomeSurface`
- global shell/home decor CSS

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm typecheck` and `pnpm build` in a clean worktree.
- Codex also built the Windows pre-alpha Tauri artifact with `pnpm tauri build --ci --no-sign --config src-tauri/tauri.prealpha.conf.json` during local verification.
- Copied-profile CPU harness on the packaged build:
  - idle after load: 0.025% avg total CPU
  - navigation: 0.036% avg total CPU
  - chat workflow: 0.026% avg total CPU
  - open idle 3 minutes: 0.019% avg total CPU
- Baseline #4.1 open-idle app-tree CPU was about 4.371% total CPU, so this drops idle usage well under the <1% target.
- Packaged-app smoke screenshot showed the home surface still branded with quick-start cards, FAQ row, and footer links.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Local screenshot artifact: `scratch/cpu-fix-smoke/fixed-tauri-home.png`
- Local CPU finding note: `scratch/cpu-compare/fixed-static-home-cpu-finding.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed animation effects (heartbeat and twinkling) from title icon and star elements.
  * Simplified empty state UI and quick start card styling for a cleaner, static appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->