### PR TITLE
Add game startup entrypoint for notification shell

### DIFF
--- a/src/features/modes/game/startup.ts
+++ b/src/features/modes/game/startup.ts
@@ -1,0 +1,5 @@
+import { useGameModeStore } from "./stores/game-mode.store";
+
+export function useSetGameSetupActive() {
+  return useGameModeStore((state) => state.setSetupActive);
+}

--- a/src/features/shell/notifications/components/ChatNotificationBubbles.tsx
+++ b/src/features/shell/notifications/components/ChatNotificationBubbles.tsx
@@ -9,7 +9,7 @@
 import { useState } from "react";
 import { X, MessageCircle } from "lucide-react";
 import { useChatStore } from "../../../../shared/stores/chat.store";
-import { useGameModeStore } from "../../../modes/game";
+import { useSetGameSetupActive } from "../../../modes/game/startup";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
@@ -22,7 +22,7 @@ export function ChatNotificationBubbles() {
   const setShouldOpenWizard = useChatStore((s) => s.setShouldOpenWizard);
   const setShouldOpenWizardInShortcutMode = useChatStore((s) => s.setShouldOpenWizardInShortcutMode);
   const setPendingNewChatMode = useChatStore((s) => s.setPendingNewChatMode);
-  const setSetupActive = useGameModeStore((s) => s.setSetupActive);
+  const setSetupActive = useSetGameSetupActive();
   const closeAllDetails = useUIStore((s) => s.closeAllDetails);
   const [mobileExpanded, setMobileExpanded] = useState(false);
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1575

## Why this change

- Shell notification bubbles still imported `useGameModeStore` through the broad game mode barrel, which can couple notification startup code to game route/runtime exports that should stay behind lazy mode boundaries.

## What changed

- Added a narrow game-owned startup entrypoint for the game setup-active action.
- Updated chat notification bubbles to import that focused entrypoint instead of `features/modes/game`.

## Refactor impact

Primary owner:

App shell and game mode startup boundaries.

Impact areas reviewed:

- Chat notification navigation.
- Game mode public entrypoints.
- AppShell startup import boundaries already narrowed by the prior chat-side entrypoint work.

Boundary notes:

- UI code remains in `src/features`.
- No engine, shared API, Rust command, storage, or remote runtime behavior changes.
- The new entrypoint exposes an existing game store selector without creating a new broad compatibility barrel.

Pressure points touched:

- `src/features/shell/notifications/components/ChatNotificationBubbles.tsx`
- `src/features/modes/game/startup.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex ran:

- `pnpm check`
- `pnpm build`

`pnpm build` passed. It still reports the broader existing Vite large-chunk warning, which remains tracked by the broader chunk strategy issues. No browser/Tauri manual smoke was run for notification navigation.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed; this is an internal import-boundary cleanup.

## UI evidence

N/A. This changes startup import boundaries, not intended visuals.