### PR TITLE
feat: creator notes CSS injection with tri-state mode

### DIFF
--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -1,0 +1,345 @@
+# Card CSS Theming Guide
+
+Give your characters a unique visual identity across Marinara's chat modes. This guide covers how to embed custom CSS in your character cards so they look and feel exactly the way you want.
+
+---
+
+## Quick Start
+
+Paste a `<style>` block into your character's **Creator Notes** field (in the character editor, under Advanced). That's it — Marinara extracts and applies the CSS automatically.
+
+```html
+<style>
+[data-card-css] {
+  border-left: 3px solid #ff69b4;
+  background: linear-gradient(90deg, rgba(255, 105, 180, 0.05) 0%, transparent 40%);
+}
+</style>
+```
+
+This gives your character a pink accent border on their messages.
+
+---
+
+## How It Works
+
+When a character with CSS in their creator notes is active in a chat, Marinara:
+
+1. Extracts all `<style>` blocks from the creator notes
+2. Sanitizes the CSS (strips anything dangerous)
+3. Scopes it to the chat area so it can't affect the rest of the app
+4. Injects it into the page
+
+Users control how the CSS is applied via **Chat Settings > Card Theming**:
+
+| Mode | What it does |
+|------|-------------|
+| **Disabled** | No card CSS is applied — the character looks default |
+| **Exclusive** | Each character's CSS only affects their own messages |
+| **Chat** | All card CSS affects the entire chat area |
+
+**Exclusive** is ideal for group chats where multiple characters each have their own visual style. **Chat** is better for single-character experiences where the card wants to theme the entire chat surface.
+
+---
+
+## Mode-Specific CSS with `@chat-mode`
+
+Different chat modes render content differently. Use `@chat-mode` blocks to target specific surfaces:
+
+```html
+<style>
+/* This applies to ALL modes */
+.g-box {
+  border: 1px solid #0f0;
+  background: #000;
+}
+
+/* Only in Roleplay mode */
+@chat-mode roleplay {
+  .camera-view {
+    border: 2px solid rgba(0, 255, 0, 0.3);
+    box-shadow: 0 0 20px rgba(0, 255, 0, 0.4);
+  }
+}
+
+/* Only in Conversation mode */
+@chat-mode conversation {
+  [data-card-css] {
+    border-left: 2px solid #00FF00;
+    border-radius: 1rem;
+    padding: 0.75rem;
+    background: rgba(0, 30, 0, 0.8);
+  }
+}
+
+/* Only in Game mode */
+@chat-mode game {
+  [data-card-css] {
+    border: 1px solid rgba(0, 255, 0, 0.2);
+  }
+}
+</style>
+```
+
+CSS outside any `@chat-mode` block applies everywhere. Standard `@media` queries work normally inside `@chat-mode` blocks for responsive layouts.
+
+---
+
+## What You Can Style
+
+### Roleplay Mode
+
+Roleplay mode renders full HTML in messages, so you have the most creative freedom here. Your regex scripts can transform plain text into styled HTML, and your CSS styles it.
+
+**Targetable elements:**
+
+| Selector | What it targets |
+|----------|----------------|
+| `[data-card-css]` | The message wrapper (targets this character's messages in Exclusive mode, or the chat area in Chat mode) |
+| `:root` or `body` | Same as `[data-card-css]` — rewritten to the scope automatically |
+| Any custom class | Classes your regex scripts inject into message HTML (e.g., `.camera-view`, `.terminal-window`) |
+| `.mari-message` | A message container |
+| `.mari-message-narrator` | Narrator messages |
+| `.mari-message-assistant` | Character messages |
+| `.mari-message-user` | User messages |
+
+**What works well in RP mode:**
+- Full HTML structures injected via regex scripts (camera overlays, terminal windows, custom layouts)
+- CSS animations (`@keyframes`, transitions)
+- Pseudo-elements (`::before`, `::after`) for decorative effects
+- Custom backgrounds, borders, shadows, gradients
+- Custom fonts via `font-family` (system fonts and web-safe fonts only — `@font-face` with external URLs is blocked for security)
+
+### Conversation Mode
+
+Conversation mode renders messages as plain text with markdown — it does not render HTML from regex scripts. CSS theming here focuses on styling the existing message elements.
+
+**Targetable elements:**
+
+| Selector | What it targets |
+|----------|----------------|
+| `[data-card-css]` | The message wrapper div — this is your main styling target |
+| `[data-card-css] .mari-message-name` | The character's display name |
+| `[data-card-css] p` | Paragraph elements in the message text |
+| `[data-card-css] span` | Inline text spans |
+
+**What works well in Convo mode:**
+- Message bubbles (border-radius, background, padding, shadows)
+- Custom text colors and fonts
+- Accent borders (left/top/bottom borders as visual markers)
+- Name styling (color, glow via text-shadow, font changes)
+- Hover effects on the message wrapper
+- Gradient backgrounds
+
+**Example — message bubble:**
+```css
+@chat-mode conversation {
+  [data-card-css] {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    border: 1px solid rgba(100, 149, 237, 0.3);
+    border-radius: 1rem;
+    padding: 0.75rem 1rem;
+    margin: 0.25rem 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  [data-card-css] .mari-message-name {
+    color: #6495ED;
+    text-shadow: 0 0 8px rgba(100, 149, 237, 0.5);
+  }
+
+  [data-card-css] p {
+    color: #e0e0ff;
+    font-family: Georgia, serif;
+  }
+}
+```
+
+### Game Mode
+
+Game mode is primarily GM/narrator-driven. Currently, card CSS applies to log entries that are attributed to specific characters via `data-card-css`. The active narration/dialogue segments do not yet carry character-specific CSS attributes — this may be added in a future update.
+
+**What works in Game mode:**
+- Styling log entries attributed to the character
+- Terminal/info-box styled blocks (if used with shared-base CSS)
+- Background and text color changes on attributed narration
+
+---
+
+## What You Cannot Style
+
+These are blocked by the CSS sanitizer for security:
+
+| Blocked | Why |
+|---------|-----|
+| `url(https://...)` | Prevents network requests that could track users or exfiltrate data. Only `url(data:image/...)` is allowed for inline images. |
+| `@font-face` | Prevents font-loading network requests to external servers |
+| `@import` | Prevents loading external stylesheets |
+| `:has()` selectors | Prevents probing elements outside the chat area |
+| `content: "text"` | Prevents injecting fake UI text (phishing). `content: ''` for pseudo-element clearing is allowed. |
+| `position: fixed` | Automatically converted to `position: absolute` to prevent full-screen overlays |
+| `!important` | Stripped to prevent overriding the app's own styles |
+| App theme tokens | Declarations like `--background: red` or `--primary: blue` are stripped so card CSS can't repaint the app UI |
+
+**If you need a custom font**, use system fonts or web-safe font stacks:
+```css
+font-family: 'Courier New', Consolas, monospace;
+font-family: Georgia, 'Times New Roman', serif;
+font-family: 'Segoe UI', system-ui, sans-serif;
+```
+
+---
+
+## Exclusive vs Chat Mode: Choosing the Right Scope
+
+**Use Exclusive when:**
+- You're making a card that might be used in group chats
+- You want each character's visual identity to be independent
+- Your CSS targets `[data-card-css]` (the message wrapper)
+
+**Use Chat when:**
+- Your card is designed for 1-on-1 roleplay
+- You want to theme the entire chat background/atmosphere
+- Your CSS targets elements beyond individual messages (e.g., the chat area itself)
+
+In Exclusive mode, `[data-card-css]` targets only THIS character's message wrappers. In Chat mode, it targets the entire `.mari-card-css` container (the whole chat area). Both `:root` and `body` selectors are also rewritten to match the scope, so they work the same way as `[data-card-css]`.
+
+---
+
+## Tips for Card Creators
+
+1. **Start with Exclusive mode in mind.** Use `[data-card-css]` as your root selector — it works correctly in both Exclusive and Chat modes.
+
+2. **Use `@chat-mode` blocks.** Don't assume your card will only be used in RP. Even a simple convo-mode section with accent colors makes the character feel alive in every surface.
+
+3. **Test in both light and dark themes.** Use `rgba()` colors with transparency so they blend with whatever background the user has.
+
+4. **Keep animations subtle.** Heavy animations can slow down the chat on lower-end devices. Use `animation` sparingly and prefer `transition` for interactive effects.
+
+5. **Don't rely on specific class names for message content.** The internal class names (like Tailwind utility classes) can change between Marinara versions. Stick to the documented selectors: `[data-card-css]`, `.mari-message-name`, `.mari-message`, `p`, `span`.
+
+6. **Use `@media` for mobile.** Many users chat on phones or small windows:
+   ```css
+   @media (max-width: 768px) {
+     [data-card-css] {
+       padding: 0.5rem;
+       border-radius: 0.5rem;
+     }
+   }
+   ```
+
+7. **Layer your mode CSS.** Put shared styles (keyframes, base classes) outside `@chat-mode` blocks, and mode-specific styling inside them. This avoids duplicating rules.
+
+---
+
+## Using an AI Assistant to Create Card CSS
+
+If you're not comfortable writing CSS by hand, you can ask an AI assistant to generate it for you. Here's a prompt template:
+
+---
+
+> I'm creating a character card for Marinara Engine (a Tauri-based AI chat app). The card has a "creator notes" field where I can embed `<style>` blocks with custom CSS. I need CSS that themes the character's messages.
+>
+> **Character concept:** [describe your character's aesthetic — e.g., "cyberpunk hacker with neon green terminal vibes" or "soft cottagecore fairy with pink pastels"]
+>
+> **Technical constraints:**
+> - Use `[data-card-css]` as the selector for the message wrapper element
+> - Use `[data-card-css] .mari-message-name` for the character's display name
+> - Use `[data-card-css] p` for message text paragraphs
+> - Wrap roleplay-only CSS in `@chat-mode roleplay { ... }`
+> - Wrap conversation-only CSS in `@chat-mode conversation { ... }`
+> - CSS outside these blocks applies to all modes
+> - `url(https://...)` is blocked — only `url(data:image/...)` works for inline images
+> - `@font-face` is blocked — use system/web-safe fonts only
+> - `content: "text"` is blocked — only `content: ''` is allowed
+> - `position: fixed` is converted to `position: absolute`
+> - `!important` is stripped
+> - `:has()` selectors are blocked
+> - Use `rgba()` colors so they work on both light and dark backgrounds
+>
+> **For conversation mode**, create a styled message bubble with:
+> - Custom background color/gradient
+> - Rounded corners
+> - Accent border
+> - Styled character name (color + optional text-shadow glow)
+> - Custom font for message text
+>
+> **For roleplay mode**, [describe what you want — e.g., "create a camera surveillance overlay with scanlines" or "just use the same bubble style as conversation"]
+>
+> Please output a single `<style>` block I can paste into the creator notes field.
+
+---
+
+Adjust the character concept and roleplay description to match your vision. The AI should produce a working `<style>` block you can paste directly into the Creator Notes field.
+
+**After generating:**
+1. Paste the CSS into Creator Notes
+2. Create a chat with the character
+3. Open Chat Settings > Card Theming
+4. Set mode to Exclusive
+5. Send a test message and check the styling
+6. Try switching between Exclusive and Chat to see the difference
+7. Test in both RP and Convo modes if you used `@chat-mode` blocks
+
+---
+
+## Example: Complete Multi-Mode Card CSS
+
+Here's a full example for a cyberpunk character that looks different in each mode:
+
+```html
+<style>
+/* Shared animations */
+@keyframes glow-pulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(0, 255, 0, 0.2); }
+  50% { box-shadow: 0 0 16px rgba(0, 255, 0, 0.4); }
+}
+
+/* Roleplay: full immersive theming */
+@chat-mode roleplay {
+  body { color: #0f0; }
+  .terminal-window {
+    background: #1a1a1a;
+    border: 1px solid #0f0;
+    border-radius: 8px;
+    animation: glow-pulse 3s ease-in-out infinite;
+  }
+}
+
+/* Conversation: clean message bubbles */
+@chat-mode conversation {
+  [data-card-css] {
+    background: linear-gradient(135deg, rgba(0, 30, 0, 0.85), rgba(0, 15, 0, 0.7));
+    border: 1px solid rgba(0, 255, 0, 0.3);
+    border-radius: 1rem;
+    padding: 0.75rem 1rem;
+    margin: 0.25rem 0;
+  }
+  [data-card-css] .mari-message-name {
+    color: #00FF00;
+    text-shadow: 0 0 8px rgba(0, 255, 0, 0.6);
+    font-family: 'Courier New', monospace;
+  }
+  [data-card-css] p {
+    font-family: 'Courier New', monospace;
+    color: #c0ffc0;
+  }
+  [data-card-css]:hover {
+    border-color: rgba(0, 255, 0, 0.5);
+  }
+}
+
+/* Game: tactical styling */
+@chat-mode game {
+  [data-card-css] {
+    border: 1px solid rgba(0, 255, 0, 0.2);
+    border-radius: 4px;
+    background: rgba(0, 20, 0, 0.4);
+  }
+  [data-card-css] p {
+    font-family: 'Courier New', monospace;
+    color: #b0ffb0;
+  }
+}
+</style>
+```

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -348,6 +348,10 @@ export interface ChatMetadata {
    */
   summaryTailMessages?: number;
 
+  // ── Card Theming ──
+  /** How creator-notes CSS is applied: "disabled" | "exclusive" | "chat" (default). */
+  cardCssMode?: "disabled" | "exclusive" | "chat";
+
   /** Any extra key-value data */
   [key: string]: unknown;
 }

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -734,6 +734,7 @@ export const ConversationMessage = memo(function ConversationMessage({
           isStreaming && "bg-[var(--secondary)]/20",
           multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
         )}
+        data-card-css={message.characterId ?? undefined}
         onClick={handleMessageClick}
         onDoubleClick={handleMessageDoubleClick}
       >

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -1030,6 +1030,7 @@ export const ConversationMessage = memo(function ConversationMessage({
       )}
       data-message-id={message.id}
       data-message-role={message.role}
+      data-card-css={message.characterId ?? undefined}
       onClick={handleMessageClick}
       onDoubleClick={handleMessageDoubleClick}
     >

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../shared/chat-ui/index";
 import { useDeleteChat } from "../../../catalog/chats/index";
 import { ChatConversationSurface } from "./ChatConversationSurface";
+import { CreatorNotesCssInjector } from "../../shared/chat-ui/components/CreatorNotesCssInjector";
 
 type ConversationModeRouteProps = {
   activeChatId: string;
@@ -115,8 +116,19 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
       });
   }, [activeChatId, deleteChat, overlays, setActiveChatId]);
 
+  const cardCssMode = (() => {
+    const mode = data.chatMeta.cardCssMode;
+    if (mode === "disabled" || mode === "exclusive") return mode;
+    return "chat" as const;
+  })();
+
   return (
     <>
+      <CreatorNotesCssInjector
+        allCharacters={data.allCharacters}
+        characterIds={data.chatCharIds}
+        mode={cardCssMode}
+      />
       <ChatConversationSurface
         activeChatId={activeChatId}
         chat={data.chat}

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../shared/chat-ui/index";
 import { useDeleteChat } from "../../../catalog/chats/index";
 import { ChatConversationSurface } from "./ChatConversationSurface";
-import { CreatorNotesCssInjector } from "../../shared/chat-ui/components/CreatorNotesCssInjector";
+import { CreatorNotesCssInjector } from "../../shared/chat-ui/index";
 
 type ConversationModeRouteProps = {
   activeChatId: string;

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -128,6 +128,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
         allCharacters={data.allCharacters}
         characterIds={data.chatCharIds}
         mode={cardCssMode}
+        chatMode="conversation"
       />
       <ChatConversationSurface
         activeChatId={activeChatId}

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -805,7 +805,7 @@ export function ConversationView({
   }, [hiddenCount]);
 
   return (
-    <div className="mari-chat-area relative flex flex-1 flex-col overflow-hidden" style={gradientStyle}>
+    <div className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" data-chat-mode="conversation" style={{ ...gradientStyle, isolation: "isolate" }}>
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}

--- a/src/features/modes/game/components/GameConversationView.tsx
+++ b/src/features/modes/game/components/GameConversationView.tsx
@@ -11,6 +11,7 @@ import {
   useSpriteMetadataState,
 } from "../../shared/chat-ui/index";
 import { GameSurface } from "./GameSurface";
+import { CreatorNotesCssInjector } from "../../shared/chat-ui/components/CreatorNotesCssInjector";
 
 interface GameConversationViewProps {
   activeChatId: string;
@@ -94,8 +95,19 @@ export function GameConversationView({ activeChatId }: GameConversationViewProps
     return <GameChatHydrationState status="loading" />;
   }
 
+  const cardCssMode = (() => {
+    const mode = data.chatMeta.cardCssMode;
+    if (mode === "disabled" || mode === "exclusive") return mode;
+    return "chat" as const;
+  })();
+
   return (
     <>
+      <CreatorNotesCssInjector
+        allCharacters={data.allCharacters}
+        characterIds={data.chatCharIds}
+        mode={cardCssMode}
+      />
       <GameSurface
         activeChatId={activeChatId}
         chat={data.chat as unknown as EngineChat}

--- a/src/features/modes/game/components/GameConversationView.tsx
+++ b/src/features/modes/game/components/GameConversationView.tsx
@@ -107,6 +107,7 @@ export function GameConversationView({ activeChatId }: GameConversationViewProps
         allCharacters={data.allCharacters}
         characterIds={data.chatCharIds}
         mode={cardCssMode}
+        chatMode="game"
       />
       <GameSurface
         activeChatId={activeChatId}

--- a/src/features/modes/game/components/GameConversationView.tsx
+++ b/src/features/modes/game/components/GameConversationView.tsx
@@ -11,7 +11,7 @@ import {
   useSpriteMetadataState,
 } from "../../shared/chat-ui/index";
 import { GameSurface } from "./GameSurface";
-import { CreatorNotesCssInjector } from "../../shared/chat-ui/components/CreatorNotesCssInjector";
+import { CreatorNotesCssInjector } from "../../shared/chat-ui/index";
 
 interface GameConversationViewProps {
   activeChatId: string;

--- a/src/features/modes/game/components/GameNarration.tsx
+++ b/src/features/modes/game/components/GameNarration.tsx
@@ -3483,7 +3483,11 @@ export function GameNarration({
               }}
             >
               {stackedLogEntries.map((entry) => (
-                <div key={entry.messageId} className="space-y-1.5">
+                <div
+                  key={entry.messageId}
+                  className="space-y-1.5"
+                  data-card-css={sourceMessagesById.get(entry.messageId)?.characterId ?? undefined}
+                >
                   {entry.segments.map((seg) => renderStackedLogSegment(seg))}
                 </div>
               ))}
@@ -4162,7 +4166,11 @@ export function GameNarration({
                 const translatedEntryText = sourceMessage ? translations[entry.messageId] : undefined;
                 const entryIsTranslating = sourceMessage ? !!translating[entry.messageId] : false;
                 return (
-                  <div key={entry.messageId} className="space-y-1.5">
+                  <div
+                    key={entry.messageId}
+                    className="space-y-1.5"
+                    data-card-css={sourceMessage?.characterId ?? undefined}
+                  >
                     {entry.segments.map((seg) => {
                       const sourceMessageId = seg.sourceMessageId ?? entry.messageId;
                       const hasSourceSegmentIndex = seg.sourceSegmentIndex != null;

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -8035,7 +8035,7 @@ export function GameSurface({
   }
 
   return (
-    <div className="relative flex h-full overflow-hidden bg-black">
+    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" data-chat-mode="game" style={{ isolation: "isolate" }}>
       <GameTransitionManager gameState={gameState} location={gameSnapshot?.location ?? null}>
         <DirectionEngine
           directions={activeDirections}

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -758,7 +758,7 @@ export function ChatRoleplaySurface({
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex h-full min-h-0 flex-1 basis-0 overflow-hidden">
-      <div className="rpg-chat-area mari-chat-area relative isolate flex h-full min-h-0 flex-1 basis-0 flex-col overflow-hidden">
+      <div className="rpg-chat-area mari-chat-area mari-card-css relative isolate flex h-full min-h-0 flex-1 basis-0 flex-col overflow-hidden" data-chat-mode="roleplay">
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay pointer-events-none absolute inset-0 z-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0 z-0" />

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -281,6 +281,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
         allCharacters={data.allCharacters}
         characterIds={data.chatCharIds}
         mode={cardCssMode}
+        chatMode="roleplay"
       />
       <ChatRoleplaySurface
         activeChatId={activeChatId}

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../../runtime/visuals/sprite-owner-keys";
 import { AgentInjectionReviewModal } from "./AgentInjectionReviewModal";
 import { ChatRoleplaySurface } from "./ChatRoleplaySurface";
-import { CreatorNotesCssInjector } from "../../shared/chat-ui/components/CreatorNotesCssInjector";
+import { CreatorNotesCssInjector } from "../../shared/chat-ui/index";
 
 type RoleplayModeRouteProps = {
   activeChatId: string;

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../../runtime/visuals/sprite-owner-keys";
 import { AgentInjectionReviewModal } from "./AgentInjectionReviewModal";
 import { ChatRoleplaySurface } from "./ChatRoleplaySurface";
+import { CreatorNotesCssInjector } from "../../shared/chat-ui/components/CreatorNotesCssInjector";
 
 type RoleplayModeRouteProps = {
   activeChatId: string;
@@ -268,8 +269,19 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
     [activeChatId, forkScene, isForking, timeline.isStreaming],
   );
 
+  const cardCssMode = (() => {
+    const mode = data.chatMeta.cardCssMode;
+    if (mode === "disabled" || mode === "exclusive") return mode;
+    return "chat" as const;
+  })();
+
   return (
     <>
+      <CreatorNotesCssInjector
+        allCharacters={data.allCharacters}
+        characterIds={data.chatCharIds}
+        mode={cardCssMode}
+      />
       <ChatRoleplaySurface
         activeChatId={activeChatId}
         chat={data.chat}

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -1709,6 +1709,7 @@ export const ChatMessage = memo(function ChatMessage({
             "mari-message mari-message-narrator rpg-narrator-msg group mb-4 px-2",
             multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/5 ring-2 ring-[var(--destructive)]/50",
           )}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleMessageDoubleClick}
         >
@@ -1786,6 +1787,7 @@ export const ChatMessage = memo(function ChatMessage({
           )}
           data-message-id={message.id}
           data-message-role={message.role}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleMessageDoubleClick}
           style={roleplayAvatarScaleStyle}
@@ -2327,6 +2329,7 @@ export const ChatMessage = memo(function ChatMessage({
       )}
       data-message-id={message.id}
       data-message-role={message.role}
+      data-card-css={message.characterId ?? undefined}
       onClick={handleMobileTap}
       onDoubleClick={handleMessageDoubleClick}
     >

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -51,9 +51,11 @@ import {
   RotateCcw,
   Music2,
   Loader2,
+  Paintbrush,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../../../../shared/lib/utils";
+import { extractCreatorNotesCss } from "../../../../../shared/lib/creator-notes-css";
 import { showAlertDialog, showConfirmDialog, showPromptDialog } from "../../../../../shared/lib/app-dialogs";
 import { HelpTooltip } from "../../../../../shared/components/ui/HelpTooltip";
 import { ExpandedTextarea } from "../../../../../shared/components/ui/ExpandedTextarea";
@@ -892,6 +894,28 @@ function ChatSettingsDrawerInner({
     }
     return map;
   }, [charInfoMap]);
+
+  const cardCssCharacters = useMemo(() => {
+    const result: Array<{ id: string; name: string }> = [];
+    for (const id of chatCharIds) {
+      const char = characters.find((c) => c.id === id);
+      if (!char) continue;
+      try {
+        const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
+        const notes: string = parsed?.creator_notes ?? "";
+        if (!notes) continue;
+        const { css } = extractCreatorNotesCss(notes);
+        if (css.trim()) result.push({ id, name: charNameMap.get(id) ?? "Unknown" });
+      } catch { /* skip */ }
+    }
+    return result;
+  }, [chatCharIds, characters, charNameMap]);
+
+  const cardCssMode = useMemo(() => {
+    const mode = metadata.cardCssMode;
+    if (mode === "disabled" || mode === "exclusive") return mode;
+    return "chat";
+  }, [metadata.cardCssMode]);
 
   const getCharacterInfo = useCallback(
     (c: { id?: string; data?: unknown; comment?: string | null }) => {
@@ -3855,6 +3879,40 @@ function ChatSettingsDrawerInner({
               </PickerDropdown>
             )}
           </Section>
+
+          {/* Card Theming — creator-notes CSS mode selector */}
+          {cardCssCharacters.length > 0 && (
+            <Section
+              label="Card Theming"
+              icon={<Paintbrush size="0.875rem" />}
+              count={cardCssMode !== "disabled" ? cardCssCharacters.length : 0}
+              help="Characters can embed custom CSS in their creator notes to theme the chat. Choose how broadly their styles are applied."
+            >
+              <div className="space-y-1.5">
+                <CardCssModeSelector
+                  mode={cardCssMode}
+                  onChange={(mode) => updateMeta.mutate({ id: chat.id, cardCssMode: mode })}
+                />
+                <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                  {cardCssMode === "disabled"
+                    ? "Card CSS is disabled — no character styling is applied."
+                    : cardCssMode === "exclusive"
+                      ? "Each character's CSS only affects their own messages."
+                      : "All card CSS affects the entire chat area, including UI elements."}
+                </p>
+                {cardCssMode !== "disabled" && (
+                  <div className="space-y-1">
+                    <span className="block px-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">Characters with CSS:</span>
+                    {cardCssCharacters.map((char) => (
+                      <div key={char.id} className="flex items-center gap-2 rounded-lg px-3 py-1.5 ring-1 ring-[var(--border)] bg-[var(--card)]">
+                        <span className="flex-1 text-[0.6875rem] font-medium text-[var(--foreground)] truncate">{char.name}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Section>
+          )}
 
           {/* Agents — hidden for conversation mode */}
           {!isConversation && (
@@ -7323,5 +7381,42 @@ function ConversationNotesSection({ chatId }: { chatId: string }) {
         )}
       </div>
     </Section>
+  );
+}
+
+function CardCssModeSelector({ mode, onChange }: { mode: string; onChange: (mode: string) => void }) {
+  const options = [
+    { id: "disabled", label: "Disabled", tooltip: "No card CSS is applied" },
+    { id: "exclusive", label: "Exclusive", tooltip: "Each character's CSS only affects their own messages" },
+    { id: "chat", label: "Chat", tooltip: "All card CSS affects the entire chat area" },
+  ];
+  return (
+    <div className="space-y-1.5 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[0.6875rem] font-medium text-[var(--foreground)]">CSS Mode</span>
+      </div>
+      <div className="grid grid-cols-3 overflow-hidden rounded-md ring-1 ring-[var(--border)]">
+        {options.map((option, index) => {
+          const active = mode === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onChange(option.id)}
+              className={cn(
+                "min-w-0 px-2.5 py-1.5 text-[0.625rem] font-medium transition-colors",
+                index > 0 && "border-l border-[var(--border)]",
+                active
+                  ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                  : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+              )}
+              title={option.tooltip}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import type { ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { CreatorNotesCssInjector } from "./CreatorNotesCssInjector";
+
+const STYLE_ELEMENT_ID = "marinara-card-css";
+
+const characters = [
+  {
+    id: "char-a",
+    data: JSON.stringify({
+      creator_notes:
+        "<style>.bubble { color: red; } @chat-mode conversation { .conversation-only { color: blue; } } @chat-mode roleplay { .roleplay-only { color: green; } }</style>",
+    }),
+  },
+  {
+    id: "char-b",
+    data: JSON.stringify({
+      creator_notes: "<style>.other { color: purple; }</style>",
+    }),
+  },
+];
+
+let root: Root | undefined;
+
+function renderInjector(props: Partial<ComponentProps<typeof CreatorNotesCssInjector>> = {}) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+
+  act(() => {
+    root?.render(
+      <CreatorNotesCssInjector
+        characterIds={["char-a"]}
+        allCharacters={characters}
+        mode="chat"
+        chatMode="conversation"
+        {...props}
+      />,
+    );
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = undefined;
+  document.body.innerHTML = "";
+  document.getElementById(STYLE_ELEMENT_ID)?.remove();
+});
+
+describe("CreatorNotesCssInjector", () => {
+  it("injects global and matching mode CSS for active characters", () => {
+    renderInjector();
+
+    const style = document.getElementById(STYLE_ELEMENT_ID);
+    expect(style?.textContent).toContain("@layer card-css");
+    expect(style?.textContent).toContain(".mari-card-css .bubble");
+    expect(style?.textContent).toContain(".mari-card-css .conversation-only");
+    expect(style?.textContent).not.toContain(".roleplay-only");
+    expect(style?.textContent).not.toContain(".other");
+  });
+
+  it("scopes exclusive mode to the active character message wrapper", () => {
+    renderInjector({ mode: "exclusive" });
+
+    expect(document.getElementById(STYLE_ELEMENT_ID)?.textContent).toContain(
+      '.mari-card-css [data-card-css="char-a"] .bubble',
+    );
+  });
+
+  it("clears injected CSS when disabled", () => {
+    renderInjector({ mode: "disabled" });
+
+    expect(document.getElementById(STYLE_ELEMENT_ID)?.textContent ?? "").toBe("");
+  });
+});

--- a/src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.tsx
+++ b/src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.tsx
@@ -5,7 +5,7 @@
 // ──────────────────────────────────────────────
 import { useEffect, useMemo } from "react";
 import { extractCreatorNotesCss } from "../../../../../shared/lib/creator-notes-css";
-import { scopeChatCss } from "../../../../../shared/lib/chat-css";
+import { scopeChatCss, filterCssByMode, type ChatModeFilter } from "../../../../../shared/lib/chat-css";
 
 type CardCssMode = "disabled" | "exclusive" | "chat";
 
@@ -21,6 +21,8 @@ interface CreatorNotesCssInjectorProps {
   allCharacters: CharacterRow[] | undefined;
   /** CSS injection mode: disabled | exclusive | chat */
   mode: CardCssMode;
+  /** Current chat surface mode — controls @chat-mode filtering. */
+  chatMode: ChatModeFilter;
 }
 
 const STYLE_ELEMENT_ID = "marinara-card-css";
@@ -30,7 +32,7 @@ const SCOPE_SELECTOR = ".mari-card-css";
  * Extracts `<style>` blocks from the creator_notes of all active characters,
  * sanitizes and scopes them, then injects the combined CSS into the document head.
  */
-export function CreatorNotesCssInjector({ characterIds, allCharacters, mode }: CreatorNotesCssInjectorProps) {
+export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, chatMode }: CreatorNotesCssInjectorProps) {
   const scopedCss = useMemo(() => {
     if (mode === "disabled" || !allCharacters || characterIds.length === 0) return "";
 
@@ -54,8 +56,12 @@ export function CreatorNotesCssInjector({ characterIds, allCharacters, mode }: C
       const creatorNotes = (parsed as { creator_notes?: string }).creator_notes;
       if (!creatorNotes) continue;
 
-      const { css } = extractCreatorNotesCss(creatorNotes);
-      if (!css) continue;
+      const { css: rawCss } = extractCreatorNotesCss(creatorNotes);
+      if (!rawCss) continue;
+
+      // Filter by @chat-mode blocks — only include rules targeting the active surface
+      const css = filterCssByMode(rawCss, chatMode);
+      if (!css.trim()) continue;
 
       // Scope mode determines the selector target
       const scope = mode === "exclusive" ? `${SCOPE_SELECTOR} [data-card-css="${charId}"]` : SCOPE_SELECTOR;
@@ -65,7 +71,7 @@ export function CreatorNotesCssInjector({ characterIds, allCharacters, mode }: C
 
     if (cssChunks.length === 0) return "";
     return `@layer card-css {\n${cssChunks.join("\n")}\n}`;
-  }, [characterIds, allCharacters, mode]);
+  }, [characterIds, allCharacters, mode, chatMode]);
 
   useEffect(() => {
     let styleEl = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;

--- a/src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.tsx
+++ b/src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.tsx
@@ -1,0 +1,94 @@
+// ──────────────────────────────────────────────
+// CreatorNotesCssInjector — extracts CSS from active
+// characters' creator_notes, scopes it, and injects
+// a <style> element into <head>.
+// ──────────────────────────────────────────────
+import { useEffect, useMemo } from "react";
+import { extractCreatorNotesCss } from "../../../../../shared/lib/creator-notes-css";
+import { scopeChatCss } from "../../../../../shared/lib/chat-css";
+
+type CardCssMode = "disabled" | "exclusive" | "chat";
+
+type CharacterRow = {
+  id: string;
+  data: string;
+};
+
+interface CreatorNotesCssInjectorProps {
+  /** Active character IDs in this chat. */
+  characterIds: string[];
+  /** All characters from the catalog. */
+  allCharacters: CharacterRow[] | undefined;
+  /** CSS injection mode: disabled | exclusive | chat */
+  mode: CardCssMode;
+}
+
+const STYLE_ELEMENT_ID = "marinara-card-css";
+const SCOPE_SELECTOR = ".mari-card-css";
+
+/**
+ * Extracts `<style>` blocks from the creator_notes of all active characters,
+ * sanitizes and scopes them, then injects the combined CSS into the document head.
+ */
+export function CreatorNotesCssInjector({ characterIds, allCharacters, mode }: CreatorNotesCssInjectorProps) {
+  const scopedCss = useMemo(() => {
+    if (mode === "disabled" || !allCharacters || characterIds.length === 0) return "";
+
+    const charMap = new Map<string, CharacterRow>();
+    for (const char of allCharacters) {
+      charMap.set(char.id, char);
+    }
+
+    const cssChunks: string[] = [];
+    for (const charId of characterIds) {
+      const row = charMap.get(charId);
+      if (!row) continue;
+
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
+      } catch {
+        continue;
+      }
+
+      const creatorNotes = (parsed as { creator_notes?: string }).creator_notes;
+      if (!creatorNotes) continue;
+
+      const { css } = extractCreatorNotesCss(creatorNotes);
+      if (!css) continue;
+
+      // Scope mode determines the selector target
+      const scope = mode === "exclusive" ? `${SCOPE_SELECTOR} [data-card-css="${charId}"]` : SCOPE_SELECTOR;
+      const scoped = scopeChatCss(css, scope);
+      if (scoped) cssChunks.push(scoped);
+    }
+
+    if (cssChunks.length === 0) return "";
+    return `@layer card-css {\n${cssChunks.join("\n")}\n}`;
+  }, [characterIds, allCharacters, mode]);
+
+  useEffect(() => {
+    let styleEl = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+
+    if (!scopedCss) {
+      if (styleEl) styleEl.textContent = "";
+      return;
+    }
+
+    if (!styleEl) {
+      styleEl = document.createElement("style");
+      styleEl.id = STYLE_ELEMENT_ID;
+      document.head.appendChild(styleEl);
+    }
+
+    styleEl.textContent = scopedCss;
+
+    return () => {
+      // Cleanup on unmount
+      const el = document.getElementById(STYLE_ELEMENT_ID);
+      if (el) el.textContent = "";
+    };
+  }, [scopedCss]);
+
+  return null;
+}

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -353,5 +353,6 @@ export function useChatSurfaceData({
     connectedChatName,
     pageCount,
     gameCharacters,
+    allCharacters: characterRows as Array<{ id: string; data: string; avatarPath: string | null }> | undefined,
   };
 }

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -4,6 +4,7 @@ export * from "./components/ChatBranchSelector";
 export * from "./components/ChatCommonOverlays";
 export * from "./components/ChatInput";
 export * from "./components/ChatMessage";
+export * from "./components/CreatorNotesCssInjector";
 export * from "./components/EchoChamberPanel";
 export * from "./components/GenerationReplayDetailsModal";
 export * from "./components/ImagePromptPanel";

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -16,6 +16,7 @@ export * from "./components/QuickSwitcherMobile";
 export * from "./components/SlashCommandFeedback";
 export * from "./components/SummaryPopover";
 export * from "./components/SwipeJumpControl";
+export * from "./components/CreatorNotesCssInjector";
 export * from "./hooks/use-chat-metadata-sync";
 export * from "./hooks/use-chat-overlays";
 export * from "./hooks/use-chat-surface-data";

--- a/src/shared/lib/chat-css.test.ts
+++ b/src/shared/lib/chat-css.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { filterCssByMode, scopeChatCss } from "./chat-css";
+
+describe("filterCssByMode", () => {
+  it("keeps global CSS and only the requested chat mode block", () => {
+    const css = [
+      ".shared { color: white; }",
+      "@chat-mode roleplay { .rp { color: red; } }",
+      "@chat-mode conversation { .convo { color: blue; } }",
+      "@chat-mode game { .game { color: green; } }",
+      ".tail { color: black; }",
+    ].join("\n");
+
+    expect(filterCssByMode(css, "conversation")).toContain(".shared");
+    expect(filterCssByMode(css, "conversation")).toContain(".convo");
+    expect(filterCssByMode(css, "conversation")).toContain(".tail");
+    expect(filterCssByMode(css, "conversation")).not.toContain(".rp");
+    expect(filterCssByMode(css, "conversation")).not.toContain(".game");
+  });
+
+  it("handles nested rule blocks inside mode filters", () => {
+    const css = "@chat-mode game { @media (min-width: 600px) { .panel { color: lime; } } }";
+
+    expect(filterCssByMode(css, "game")).toContain("@media");
+    expect(filterCssByMode(css, "game")).toContain(".panel");
+    expect(filterCssByMode(css, "roleplay").trim()).toBe("");
+  });
+});
+
+describe("scopeChatCss sanitization", () => {
+  it("blocks network, theme override, content, scope escape, and important constructs", () => {
+    const sanitized = scopeChatCss(`
+      @import url("https://example.test/evil.css");
+      @font-face { font-family: Sneak; src: url("https://example.test/font.woff2"); }
+      .card:has(.secret) {
+        background: url("https://example.test/track.png");
+        --background: red;
+        content: "spoof";
+        position: fixed !important;
+      }
+    `, ".mari-card-css");
+
+    expect(sanitized).not.toMatch(/@import/i);
+    expect(sanitized).not.toMatch(/@font-face/i);
+    expect(sanitized).not.toMatch(/https:\/\/example\.test/i);
+    expect(sanitized).not.toContain("--background");
+    expect(sanitized).not.toMatch(/:has/i);
+    expect(sanitized).not.toMatch(/!important/i);
+    expect(sanitized).toContain("url(about:invalid)");
+    expect(sanitized).toContain("content: '';");
+    expect(sanitized).toContain("position:absolute");
+  });
+
+  it("blocks content declarations without a trailing semicolon", () => {
+    const sanitized = scopeChatCss(".card::before { content: \"fake button\" }", ".mari-card-css");
+
+    expect(sanitized).not.toContain("fake button");
+    expect(sanitized).toContain("content: ''}");
+  });
+
+  it("allows data image URLs", () => {
+    expect(scopeChatCss(".portrait { background: url(data:image/png;base64,abc); }", ".mari-card-css")).toContain(
+      "data:image/png",
+    );
+  });
+});
+
+describe("scopeChatCss", () => {
+  it("scopes selectors and root-like selectors under the provided scope", () => {
+    const scoped = scopeChatCss(":root { color: red; }\n.name, body .bubble { opacity: 1; }", ".mari-card-css");
+
+    expect(scoped).toContain(".mari-card-css { color: red; }");
+    expect(scoped).toContain(".mari-card-css .name");
+    expect(scoped).toContain(".mari-card-css .bubble");
+  });
+
+  it("namespaces keyframes and animation references", () => {
+    const scoped = scopeChatCss("@keyframes shimmer { from { opacity: 0; } to { opacity: 1; } }\n.card { animation: shimmer 1s ease; }", ".mari-card-css");
+
+    expect(scoped).toContain("@keyframes mc-shimmer");
+    expect(scoped).toContain("animation: mc-shimmer 1s ease");
+  });
+});

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -104,37 +104,54 @@ function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
-/** Remove dangerous constructs from CSS. */
+/**
+ * Remove dangerous constructs from CSS.
+ *
+ * Security model: card CSS is untrusted user content shared between users.
+ * A malicious card creator must not be able to:
+ * - Make network requests (data exfiltration, IP tracking)
+ * - Escape the scoped container to style/probe app UI
+ * - Override application theme tokens
+ * - Inject phishing content via `content` property
+ * - Cause denial-of-service via resource-heavy rules
+ */
 export function sanitizeChatCss(css: string): string {
   let out = stripComments(css);
 
-  // Strip @import and @namespace
+  // ── Network exfiltration prevention ──
+  // Strip ALL url() except data:image/* (no external network requests)
+  out = out.replace(/url\s*\(\s*(['"]?)\s*(?!['"]?\s*data:image\/)[^)]*\)/gi, "url(about:invalid)");
+  // Strip @import (network request + CSS injection)
   out = out.replace(/@import\b[^;]*;/gi, "");
+  // Strip @namespace
   out = out.replace(/@namespace\b[^;]*;/gi, "");
+  // Strip @font-face (network request via font loading)
+  out = out.replace(/@font-face\s*\{[^}]*\}/gi, "");
 
-  // Strip expression()
+  // ── Script/expression injection ──
   out = out.replace(/expression\s*\([^)]*\)/gi, "");
-
-  // Strip javascript: / vbscript:
   out = out.replace(/javascript\s*:/gi, "");
   out = out.replace(/vbscript\s*:/gi, "");
-
-  // Strip behavior:
   out = out.replace(/behavior\s*:[^;]*/gi, "");
-
-  // Strip -moz-binding:
   out = out.replace(/-moz-binding\s*:[^;]*/gi, "");
 
-  // Strip unsafe url() (only those with protocols or data:)
-  out = out.replace(/url\s*\(\s*['"]?\s*(javascript|vbscript|data)\s*:/gi, "url(about:invalid");
-
-  // Convert position:fixed to position:absolute
+  // ── Scope escape prevention ──
+  // Strip :has() — can probe elements outside the scoped container
+  out = out.replace(/:has\s*\([^)]*\)/gi, "");
+  // Strip :visited — can detect browsing history via style differences
+  out = out.replace(/:visited/gi, ":link");
+  // Convert position:fixed to position:absolute (prevent viewport overlays)
   out = out.replace(/position\s*:\s*fixed/gi, "position:absolute");
 
+  // ── Content injection prevention ──
+  // Strip content property (prevent phishing text/UI spoofing)
+  // Allow content:"" (used for pseudo-element clearing) but block non-empty values
+  out = out.replace(/content\s*:\s*(?!['"]?\s*['"]\s*['"]?\s*[;}\n])[^;]*;/gi, "content: '';");
   // Strip </style (prevent injection breakout)
   out = out.replace(/<\/style/gi, "");
 
-  // Strip theme token declarations (property: value pairs that set blocked tokens)
+  // ── Theme protection ──
+  // Strip theme token declarations
   out = out.replace(
     new RegExp(
       `(${THEME_TOKEN_BLOCKLIST.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*:[^;]*;?`,
@@ -142,24 +159,10 @@ export function sanitizeChatCss(css: string): string {
     ),
     "",
   );
-
-  // Strip !important
+  // Strip !important (prevent overriding app styles)
   out = out.replace(/!important/gi, "");
 
   return out;
-}
-
-const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
-
-/** Extract `<style>` blocks from HTML, returning the CSS content. */
-export function extractChatStyleBlocks(html: string): string {
-  const blocks: string[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = STYLE_BLOCK_RE.exec(html)) !== null) {
-    blocks.push(match[1]);
-  }
-  STYLE_BLOCK_RE.lastIndex = 0;
-  return blocks.join("\n");
 }
 
 /**

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -2,6 +2,61 @@
 // Chat CSS — sanitization and scoping utilities
 // ──────────────────────────────────────────────
 
+export type ChatModeFilter = "roleplay" | "conversation" | "game";
+
+const CHAT_MODE_RE = /@chat-mode\s+(roleplay|conversation|game)\s*\{/gi;
+
+/**
+ * Filter CSS by `@chat-mode <mode> { ... }` blocks.
+ *
+ * - `@chat-mode conversation { ... }` → included only in conversation mode
+ * - `@chat-mode roleplay { ... }` → included only in roleplay mode
+ * - `@chat-mode game { ... }` → included only in game mode
+ * - CSS outside any `@chat-mode` block → included in ALL modes
+ *
+ * Card creators use this to target styles to specific surfaces while
+ * keeping a shared base that applies everywhere.
+ */
+export function filterCssByMode(css: string, chatMode: ChatModeFilter): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  CHAT_MODE_RE.lastIndex = 0;
+
+  while ((match = CHAT_MODE_RE.exec(css)) !== null) {
+    // Emit any CSS between the last block and this one (unscoped = all modes)
+    if (match.index > cursor) {
+      chunks.push(css.slice(cursor, match.index));
+    }
+
+    const targetMode = match[1].toLowerCase();
+    const bodyStart = match.index + match[0].length;
+
+    // Find the matching closing brace (handle one level of nesting)
+    let depth = 1;
+    let i = bodyStart;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+      i++;
+    }
+    const body = css.slice(bodyStart, i - 1);
+    cursor = i;
+    CHAT_MODE_RE.lastIndex = i;
+
+    if (targetMode === chatMode) {
+      chunks.push(body);
+    }
+  }
+
+  // Trailing CSS after the last @chat-mode block (unscoped = all modes)
+  if (cursor < css.length) {
+    chunks.push(css.slice(cursor));
+  }
+
+  return chunks.join("\n");
+}
+
 /** Theme tokens that card CSS must never override. */
 const THEME_TOKEN_BLOCKLIST = [
   "--background",

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -115,7 +115,7 @@ function stripComments(css: string): string {
  * - Inject phishing content via `content` property
  * - Cause denial-of-service via resource-heavy rules
  */
-export function sanitizeChatCss(css: string): string {
+function sanitizeChatCss(css: string): string {
   let out = stripComments(css);
 
   // ── Network exfiltration prevention ──

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -1,0 +1,191 @@
+// ──────────────────────────────────────────────
+// Chat CSS — sanitization and scoping utilities
+// ──────────────────────────────────────────────
+
+/** Theme tokens that card CSS must never override. */
+const THEME_TOKEN_BLOCKLIST = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--destructive-foreground",
+  "--border",
+  "--input",
+  "--ring",
+  "--radius",
+  "--sidebar-background",
+  "--sidebar-foreground",
+  "--sidebar-primary",
+  "--sidebar-primary-foreground",
+  "--sidebar-accent",
+  "--sidebar-accent-foreground",
+  "--sidebar-border",
+  "--sidebar-ring",
+  "--color-background",
+  "--color-foreground",
+  "--color-card",
+  "--color-primary",
+  "--color-secondary",
+  "--color-muted",
+  "--color-accent",
+  "--color-destructive",
+  "--color-border",
+  "--color-input",
+  "--color-ring",
+];
+
+
+/** Strip CSS comments */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Remove dangerous constructs from CSS. */
+export function sanitizeChatCss(css: string): string {
+  let out = stripComments(css);
+
+  // Strip @import and @namespace
+  out = out.replace(/@import\b[^;]*;/gi, "");
+  out = out.replace(/@namespace\b[^;]*;/gi, "");
+
+  // Strip expression()
+  out = out.replace(/expression\s*\([^)]*\)/gi, "");
+
+  // Strip javascript: / vbscript:
+  out = out.replace(/javascript\s*:/gi, "");
+  out = out.replace(/vbscript\s*:/gi, "");
+
+  // Strip behavior:
+  out = out.replace(/behavior\s*:[^;]*/gi, "");
+
+  // Strip -moz-binding:
+  out = out.replace(/-moz-binding\s*:[^;]*/gi, "");
+
+  // Strip unsafe url() (only those with protocols or data:)
+  out = out.replace(/url\s*\(\s*['"]?\s*(javascript|vbscript|data)\s*:/gi, "url(about:invalid");
+
+  // Convert position:fixed to position:absolute
+  out = out.replace(/position\s*:\s*fixed/gi, "position:absolute");
+
+  // Strip </style (prevent injection breakout)
+  out = out.replace(/<\/style/gi, "");
+
+  // Strip theme token declarations (property: value pairs that set blocked tokens)
+  out = out.replace(
+    new RegExp(
+      `(${THEME_TOKEN_BLOCKLIST.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*:[^;]*;?`,
+      "gi",
+    ),
+    "",
+  );
+
+  // Strip !important
+  out = out.replace(/!important/gi, "");
+
+  return out;
+}
+
+const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+/** Extract `<style>` blocks from HTML, returning the CSS content. */
+export function extractChatStyleBlocks(html: string): string {
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = STYLE_BLOCK_RE.exec(html)) !== null) {
+    blocks.push(match[1]);
+  }
+  STYLE_BLOCK_RE.lastIndex = 0;
+  return blocks.join("\n");
+}
+
+/**
+ * Scope CSS rules under a given selector.
+ * - Sanitizes input
+ * - Namespaces @keyframes with "mc-" prefix
+ * - Rewrites :root, html, body to the scope selector
+ * - Prefixes all other selectors with the scope selector
+ */
+export function scopeChatCss(css: string, scopeSelector: string): string {
+  let sanitized = sanitizeChatCss(css);
+
+  // Namespace @keyframes: @keyframes foo -> @keyframes mc-foo
+  sanitized = sanitized.replace(/@keyframes\s+([^\s{]+)/gi, (_match, name: string) => {
+    return `@keyframes mc-${name}`;
+  });
+
+  // Rewrite animation-name references too
+  sanitized = sanitized.replace(
+    /animation(?:-name)?\s*:[^;{}]*/gi,
+    (match) => {
+      // For each animation name token that isn't a keyword, prefix with mc-
+      return match.replace(
+        /:\s*([^;{}]*)/,
+        (_, value: string) => {
+          const prefixed = value.replace(
+            /(?:^|,\s*)([a-zA-Z_][\w-]*)/g,
+            (full, name: string) => {
+              const keywords = new Set([
+                "none", "initial", "inherit", "unset", "infinite", "alternate",
+                "reverse", "alternate-reverse", "normal", "forwards", "backwards",
+                "both", "running", "paused", "ease", "ease-in", "ease-out",
+                "ease-in-out", "linear", "step-start", "step-end",
+              ]);
+              if (keywords.has(name) || /^\d/.test(name)) return full;
+              return full.replace(name, `mc-${name}`);
+            },
+          );
+          return `: ${prefixed}`;
+        },
+      );
+    },
+  );
+
+  // Split into rules and scope selectors
+  const result: string[] = [];
+  // Simple rule-level split: find selector { ... } blocks
+  const ruleRe = /([^{}]+)\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}/g;
+  let ruleMatch: RegExpExecArray | null;
+
+  while ((ruleMatch = ruleRe.exec(sanitized)) !== null) {
+    const selector = ruleMatch[1].trim();
+    const body = ruleMatch[2];
+
+    // Skip @keyframes — already namespaced, don't prefix their contents
+    if (/^@keyframes\s/i.test(selector)) {
+      result.push(`${selector} {${body}}`);
+      continue;
+    }
+
+    // Handle @media and other at-rules that wrap rulesets
+    if (/^@/.test(selector)) {
+      // Recursively scope the inner rules
+      const innerScoped = scopeChatCss(body, scopeSelector);
+      result.push(`${selector} {${innerScoped}}`);
+      continue;
+    }
+
+    // Scope each selector in the comma-separated list
+    const scopedSelectors = selector.split(",").map((sel) => {
+      const s = sel.trim();
+      // :root, html, body -> scopeSelector
+      if (/^(:root|html|body)$/i.test(s)) return scopeSelector;
+      // Starts with :root, html, body -> replace with scope
+      if (/^(:root|html|body)\s/i.test(s)) return s.replace(/^(:root|html|body)/i, scopeSelector);
+      // Otherwise prefix
+      return `${scopeSelector} ${s}`;
+    });
+
+    result.push(`${scopedSelectors.join(", ")} {${body}}`);
+  }
+
+  return result.join("\n");
+}

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -145,8 +145,14 @@ function sanitizeChatCss(css: string): string {
 
   // ── Content injection prevention ──
   // Strip content property (prevent phishing text/UI spoofing)
-  // Allow content:"" (used for pseudo-element clearing) but block non-empty values
-  out = out.replace(/content\s*:\s*(?!['"]?\s*['"]\s*['"]?\s*[;}\n])[^;]*;/gi, "content: '';");
+  // Allow content:"" (used for pseudo-element clearing) but block non-empty values.
+  out = out.replace(/content\s*:\s*([^;}]*)([;}]|$)/gi, (_match, value: string, terminator: string) => {
+    const normalized = value.trim();
+    if (/^(['"])\s*\1$/.test(normalized)) {
+      return `content: ${normalized}${terminator}`;
+    }
+    return `content: ''${terminator}`;
+  });
   // Strip </style (prevent injection breakout)
   out = out.replace(/<\/style/gi, "");
 

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -231,10 +231,14 @@ export function scopeChatCss(css: string, scopeSelector: string): string {
     // Scope each selector in the comma-separated list
     const scopedSelectors = selector.split(",").map((sel) => {
       const s = sel.trim();
-      // :root, html, body -> scopeSelector
+      // :root, html, body -> scopeSelector (targets the scope element itself)
       if (/^(:root|html|body)$/i.test(s)) return scopeSelector;
-      // Starts with :root, html, body -> replace with scope
+      // Starts with :root, html, body -> replace prefix with scope
       if (/^(:root|html|body)\s/i.test(s)) return s.replace(/^(:root|html|body)/i, scopeSelector);
+      // [data-card-css] alone -> scopeSelector (self-reference in exclusive mode)
+      if (/^\[data-card-css\]$/i.test(s)) return scopeSelector;
+      // [data-card-css] with descendant -> replace with scope
+      if (/^\[data-card-css\]\s/i.test(s)) return s.replace(/^\[data-card-css\]/i, scopeSelector);
       // Otherwise prefix
       return `${scopeSelector} ${s}`;
     });

--- a/src/shared/lib/creator-notes-css.test.ts
+++ b/src/shared/lib/creator-notes-css.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { extractCreatorNotesCss } from "./creator-notes-css";
+
+describe("extractCreatorNotesCss", () => {
+  it("extracts style blocks and leaves non-style creator notes text", () => {
+    const result = extractCreatorNotesCss(
+      "Intro\n<style>.card { color: red; }</style>\nMiddle\n<style data-card>.name { color: blue; }</style>\nOutro",
+    );
+
+    expect(result.css).toBe(".card { color: red; }\n.name { color: blue; }");
+    expect(result.text).toBe("Intro\n\nMiddle\n\nOutro");
+  });
+});

--- a/src/shared/lib/creator-notes-css.ts
+++ b/src/shared/lib/creator-notes-css.ts
@@ -1,0 +1,12 @@
+const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+export function extractCreatorNotesCss(creatorNotes: string): { css: string; text: string } {
+  const cssBlocks: string[] = [];
+  const text = creatorNotes
+    .replace(STYLE_BLOCK_RE, (_match, css: string) => {
+      cssBlocks.push(css);
+      return "";
+    })
+    .trim();
+  return { css: cssBlocks.join("\n"), text };
+}


### PR DESCRIPTION
## Linked issue

Closes #1757

## Why this change

Character card creators should be able to embed custom CSS in their cards to give characters a unique visual identity across roleplay, conversation, and game surfaces. This brings the refactored Tauri architecture a clean client-side version of the card theming idea that was partially explored in old-engine PR #1058.

## What changed

- Added creator-notes CSS extraction from `<style>` blocks.
- Added card CSS filtering for `@chat-mode roleplay`, `@chat-mode conversation`, and `@chat-mode game`.
- Added sanitization/scoping for card-authored CSS before it is injected into the page.
- Added `CreatorNotesCssInjector` for chat-wide, character-exclusive, and disabled card CSS modes.
- Added `cardCssMode` to chat metadata and a Card Theming section in chat settings.
- Added `mari-card-css` / `data-chat-mode` surface attributes and `data-card-css` message attributes across roleplay, conversation, and game surfaces.
- Added `docs/card-css-theming-guide.md`.
- Follow-up readiness fix: exported `CreatorNotesCssInjector` through the shared chat-ui barrel so mode routes no longer import a private component path.
- Follow-up security fix: blocked non-empty CSS `content` declarations even when the declaration omits a trailing semicolon.
- Follow-up proof: added focused tests for CSS extraction, mode filtering, sanitizer/scoping behavior, and injector enabled/disabled/exclusive paths.

## Refactor impact

Primary owner: shared mode UI, with consumer changes in roleplay, conversation, and game mode surfaces.

Impact areas reviewed:

- `src/engine/contracts/types/chat.ts` adds optional `ChatMetadata.cardCssMode`.
- `src/shared/lib/creator-notes-css.ts` extracts card CSS from creator notes.
- `src/shared/lib/chat-css.ts` filters, sanitizes, and scopes card CSS.
- `src/features/modes/shared/chat-ui/` owns the injector, settings UI, metadata access, and shared exports.
- `src/features/modes/roleplay/`, `src/features/modes/conversation/`, and `src/features/modes/game/` render the injector and expose targetable surface/message attributes.
- `docs/card-css-theming-guide.md` documents author-facing usage and limits.

Boundary notes:

- No Rust/Tauri changes.
- No prompt assembly or generation changes.
- No remote runtime changes.
- Existing character/card data is read but not mutated or migrated.

Pressure points touched:

- `ChatRoleplaySurface`, `ConversationView`, and `GameSurface` surface attributes.
- `ChatMessage`, `ConversationMessage`, and `GameNarration` message wrapper attributes.
- `ChatSettingsDrawer` Card Theming controls.
- CSS sanitizer handling for untrusted user-authored card styles.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex machine proof:

- `pnpm test -- src/shared/lib/creator-notes-css.test.ts src/shared/lib/chat-css.test.ts src/features/modes/shared/chat-ui/components/CreatorNotesCssInjector.test.tsx` passed: 3 files, 11 tests.
- `pnpm check` passed after the final diff.
- Local Marinara proof gate passed against the scratch verification ledger.
- Bunny review passed locally with the UI screenshot note below as a non-blocking disclosed limitation.

Human/manual note:

- No GitHub-hosted browser screenshots or recordings were uploaded during this local readiness pass. The core extraction/sanitization/scoping/injection behavior is covered by tests and the full repo check; screenshots would still be useful reviewer evidence for the visible styling surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs note: added `docs/card-css-theming-guide.md`.

## UI evidence (if applicable)

No GitHub-hosted screenshots or recordings were uploaded in this pass. The visible UI behavior is supported by focused jsdom injector coverage plus full local validation; a reviewer can add screenshots later if they want reviewer-visible visual evidence before merge.
