### PR TITLE
Fix Spotify DJ malformed scene fallback

### DIFF
--- a/src/engine/modes/game/scene/game-scene-analysis.service.test.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LlmGateway, LlmRequest } from "../../../capabilities/llm";
+import type { StorageGateway } from "../../../capabilities/storage";
+import { analyzeGameScene } from "./game-scene-analysis.service";
+
+async function* emptyStream() {
+  // Test double for the streaming side of the LLM port.
+}
+
+describe("analyzeGameScene", () => {
+  it("uses the game scene analyzer prompt and post-processes model output", async () => {
+    const requests: LlmRequest[] = [];
+    const llm = {
+      complete: vi.fn(async (request: LlmRequest) => {
+        requests.push(request);
+        return JSON.stringify({
+          background: "castle hall",
+          weather: "cold",
+          timeOfDay: "null",
+          spotifyTrack: "spotify:track:good",
+          segmentEffects: [
+            {
+              segment: 0,
+              background: "old castle hallway",
+              sfx: ["door slam"],
+              directions: [
+                { effect: "flash", duration: 1 },
+                { effect: "screen_shake", duration: 1 },
+              ],
+            },
+          ],
+          directions: [{ effect: "bad_effect", duration: 3 }],
+        });
+      }),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The party steps into the old castle as the doors slam shut.",
+        context: {
+          currentState: "dialogue",
+          availableBackgrounds: ["backgrounds:castle:hall"],
+          availableSfx: ["sfx:door-slam"],
+          currentBackground: null,
+          currentWeather: "cloudy",
+          currentTimeOfDay: "night",
+          trackedNpcs: [{ id: "npc-1", name: "Ari" }],
+          characterNames: ["Ari"],
+          useSpotifyMusic: true,
+          availableSpotifyTracks: [{ uri: "spotify:track:good", name: "Storm Hall", artist: "Mari" }],
+        },
+      },
+    );
+
+    expect(requests[0]?.connectionId).toBe("scene-conn");
+    expect(requests[0]?.messages).toHaveLength(2);
+    expect(requests[0]?.messages[0]).toMatchObject({ role: "system" });
+    expect(requests[0]?.messages[1]?.content).toContain("BACKGROUND OPTIONS: <backgrounds:castle:hall>");
+    expect(requests[0]?.messages[1]?.content).toContain("SPOTIFY TRACK OPTIONS:");
+    expect(result.background).toBe("backgrounds:castle:hall");
+    expect(result.weather).toBe("frost");
+    expect(result.timeOfDay).toBeNull();
+    expect(result.spotifyTrack).toEqual({ uri: "spotify:track:good", name: "Storm Hall", artist: "Mari", album: null });
+    expect(result.segmentEffects?.[0]?.background).toBe("backgrounds:castle:hall");
+    expect(result.segmentEffects?.[0]?.sfx).toEqual(["sfx:door-slam"]);
+    expect(result.segmentEffects?.[0]?.directions).toEqual([{ effect: "flash", duration: 1 }]);
+    expect(result.directions).toEqual([]);
+  });
+
+  it("drops malformed nested scene fields without losing valid analysis", async () => {
+    const llm = {
+      complete: vi.fn(async () =>
+        JSON.stringify({
+          background: "castle hall",
+          weather: "cold",
+          segmentEffects: [
+            {
+              segment: 0,
+              background: "old castle hallway",
+              sfx: [null, "door slam", { bad: true }],
+              directions: [null, { effect: "flash", duration: 1 }],
+            },
+          ],
+        }),
+      ),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The party steps into the old castle as the doors slam shut.",
+        context: {
+          availableBackgrounds: ["backgrounds:castle:hall"],
+          availableSfx: ["sfx:door-slam"],
+        },
+      },
+    );
+
+    expect(result.background).toBe("backgrounds:castle:hall");
+    expect(result.weather).toBe("frost");
+    expect(result.segmentEffects?.[0]?.background).toBe("backgrounds:castle:hall");
+    expect(result.segmentEffects?.[0]?.sfx).toEqual(["sfx:door-slam"]);
+    expect(result.segmentEffects?.[0]?.directions).toEqual([{ effect: "flash", duration: 1 }]);
+  });
+
+  it("falls back to the first Spotify candidate when scene analysis JSON is malformed", async () => {
+    const llm = {
+      complete: vi.fn(async () => "{ not valid json"),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The battle starts.",
+        context: {
+          useSpotifyMusic: true,
+          availableSpotifyTracks: [
+            { uri: "spotify:track:first", name: "First Track", artist: "Mari", album: "Fallbacks" },
+            { uri: "spotify:track:second", name: "Second Track", artist: "Mari" },
+          ],
+        },
+      },
+    );
+
+    expect(result.spotifyTrack).toEqual({
+      uri: "spotify:track:first",
+      name: "First Track",
+      artist: "Mari",
+      album: "Fallbacks",
+    });
+  });
+
+  it("does not fall back when valid scene analysis explicitly returns no Spotify track", async () => {
+    const llm = {
+      complete: vi.fn(async () => JSON.stringify({ spotifyTrack: null })),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The party rests quietly.",
+        context: {
+          useSpotifyMusic: true,
+          availableSpotifyTracks: [{ uri: "spotify:track:first", name: "First Track", artist: "Mari" }],
+        },
+      },
+    );
+
+    expect(result.spotifyTrack).toBeNull();
+  });
+
+  it("keeps default null analysis when malformed scene analysis has no Spotify candidates", async () => {
+    const llm = {
+      complete: vi.fn(async () => "{ not valid json"),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The party rests quietly.",
+        context: {
+          useSpotifyMusic: true,
+          availableSpotifyTracks: [],
+        },
+      },
+    );
+
+    expect(result.background).toBeNull();
+    expect(result.spotifyTrack).toBeNull();
+    expect(result.reputationChanges).toEqual([]);
+    expect(result.segmentEffects).toEqual([]);
+    expect(result.directions).toEqual([]);
+  });
+
+  it("does not fall back to Spotify candidates when Spotify music is disabled", async () => {
+    const llm = {
+      complete: vi.fn(async () => "{ not valid json"),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The party rests quietly.",
+        context: {
+          useSpotifyMusic: false,
+          availableSpotifyTracks: [{ uri: "spotify:track:first", name: "First Track", artist: "Mari" }],
+        },
+      },
+    );
+
+    expect(result.spotifyTrack).toBeNull();
+  });
+});

--- a/src/engine/modes/game/scene/game-scene-analysis.service.test.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.test.ts
@@ -152,6 +152,44 @@ describe("analyzeGameScene", () => {
     });
   });
 
+  it("normalizes malformed Spotify candidate metadata before falling back", async () => {
+    const llm = {
+      complete: vi.fn(async () => "{ not valid json"),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    const result = await analyzeGameScene(
+      { storage, llm },
+      {
+        chatId: "chat-1",
+        narration: "The battle starts.",
+        context: {
+          useSpotifyMusic: true,
+          availableSpotifyTracks: [
+            {
+              uri: "spotify:track:first",
+              name: 123,
+              artist: null,
+              album: { title: "Fallbacks" },
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.spotifyTrack).toEqual({
+      uri: "spotify:track:first",
+      name: null,
+      artist: null,
+      album: null,
+    });
+  });
+
   it("does not fall back when valid scene analysis explicitly returns no Spotify track", async () => {
     const llm = {
       complete: vi.fn(async () => JSON.stringify({ spotifyTrack: null })),

--- a/src/engine/modes/game/scene/game-scene-analysis.service.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.ts
@@ -121,13 +121,27 @@ function sanitizeGameSceneAnalysis(parsed: JsonRecord): SceneAnalysis {
   } as SceneAnalysis;
 }
 
-function parseObject(raw: string): JsonRecord {
+function parseObject(raw: string): JsonRecord | null {
   try {
     const parsed = parseGameJsonish(raw);
-    return isRecord(parsed) ? parsed : {};
+    return isRecord(parsed) ? parsed : null;
   } catch {
-    return {};
+    return null;
   }
+}
+
+function malformedJsonFallback(sceneContext: SceneAnalyzerContext): SceneAnalysis {
+  const fallback = defaultGameSceneAnalysis();
+  const track = sceneContext.useSpotifyMusic ? sceneContext.availableSpotifyTracks?.[0] : null;
+  if (track) {
+    fallback.spotifyTrack = {
+      uri: track.uri,
+      name: track.name,
+      artist: track.artist,
+      album: track.album ?? null,
+    };
+  }
+  return fallback;
 }
 
 function readNullableString(value: unknown): string | null {
@@ -226,7 +240,9 @@ export async function analyzeGameScene(
       ],
       parameters: { maxTokens: 1200, temperature: 0.2 },
     });
-    return postProcessSceneResult(sanitizeGameSceneAnalysis(parseObject(raw)), scenePostProcessContext(sceneContext));
+    const parsed = parseObject(raw);
+    const analysis = parsed ? sanitizeGameSceneAnalysis(parsed) : malformedJsonFallback(sceneContext);
+    return postProcessSceneResult(analysis, scenePostProcessContext(sceneContext));
   } catch {
     return defaultGameSceneAnalysis();
   }

--- a/src/engine/modes/game/scene/game-scene-analysis.service.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.ts
@@ -133,12 +133,13 @@ function parseObject(raw: string): JsonRecord | null {
 function malformedJsonFallback(sceneContext: SceneAnalyzerContext): SceneAnalysis {
   const fallback = defaultGameSceneAnalysis();
   const track = sceneContext.useSpotifyMusic ? sceneContext.availableSpotifyTracks?.[0] : null;
-  if (track) {
+  const uri = readString(track?.uri).trim();
+  if (uri) {
     fallback.spotifyTrack = {
-      uri: track.uri,
-      name: track.name,
-      artist: track.artist,
-      album: track.album ?? null,
+      uri,
+      name: readNullableString(track?.name),
+      artist: readNullableString(track?.artist),
+      album: readNullableString(track?.album),
     };
   }
   return fallback;
@@ -151,6 +152,23 @@ function readNullableString(value: unknown): string | null {
 
 function readRecordArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value.filter(isRecord) as T[]) : [];
+}
+
+function normalizeSpotifyTrackCandidates(value: unknown): NonNullable<SceneAnalyzerContext["availableSpotifyTracks"]> {
+  return readRecordArray<NonNullable<SceneAnalyzerContext["availableSpotifyTracks"]>[number]>(value)
+    .map((track): NonNullable<SceneAnalyzerContext["availableSpotifyTracks"]>[number] | null => {
+      const uri = readString(track.uri).trim();
+      if (!uri) return null;
+      const candidate: NonNullable<SceneAnalyzerContext["availableSpotifyTracks"]>[number] = {
+        uri,
+        name: readString(track.name).trim(),
+        artist: readString(track.artist).trim(),
+      };
+      const album = readNullableString(track.album);
+      if (album) candidate.album = album;
+      return candidate;
+    })
+    .filter((track): track is NonNullable<SceneAnalyzerContext["availableSpotifyTracks"]>[number] => track !== null);
 }
 
 function readGameActiveState(value: unknown): SceneAnalyzerContext["currentState"] {
@@ -175,9 +193,7 @@ function normalizeSceneAnalyzerContext(value: unknown): SceneAnalyzerContext {
     currentMusic: readNullableString(context.currentMusic),
     recentMusic: stringArray(context.recentMusic),
     useSpotifyMusic: boolish(context.useSpotifyMusic, false),
-    availableSpotifyTracks: readRecordArray<NonNullable<SceneAnalyzerContext["availableSpotifyTracks"]>[number]>(
-      context.availableSpotifyTracks,
-    ),
+    availableSpotifyTracks: normalizeSpotifyTrackCandidates(context.availableSpotifyTracks),
     currentSpotifyTrack: readNullableString(context.currentSpotifyTrack),
     recentSpotifyTracks: stringArray(context.recentSpotifyTracks),
     currentAmbient: readNullableString(context.currentAmbient),

--- a/src/engine/modes/game/scene/scene-postprocess.ts
+++ b/src/engine/modes/game/scene/scene-postprocess.ts
@@ -102,9 +102,9 @@ function sanitizeSpotifyTrack(
 
   return {
     uri: candidate.uri,
-    name: candidate.name,
-    artist: candidate.artist,
-    album: candidate.album ?? null,
+    name: sanitizeString(candidate.name),
+    artist: sanitizeString(candidate.artist),
+    album: sanitizeString(candidate.album),
   };
 }
 


### PR DESCRIPTION
﻿## Linked issue

Closes #1540

## Why this change

- Game Spotify DJ scene analysis could return malformed JSON and lose playback selection even when valid Spotify candidate tracks were already fetched.

## What changed

- Distinguish malformed scene-analysis JSON from valid empty analysis.
- Fall back to the first Spotify candidate only when game Spotify music is enabled and parsing fails.
- Added regression coverage for malformed output, explicit null selection, no-candidate fallback, and Spotify-disabled fallback.

## Refactor impact

Primary owner:

Engine game scene analysis.

Impact areas reviewed:

- Game mode Spotify scene music selection.
- Game surface playback consumer path.

Boundary notes:

- Kept the fix in `src/engine`.
- Did not change generic agent executor behavior.
- Did not add a UI-only fallback.

Pressure points touched:

- Game scene analysis service.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex ran:
- `pnpm test src/engine/modes/game/scene/game-scene-analysis.service.test.ts`
- `pnpm typecheck`
- `pnpm check`

No browser/Tauri manual verification was run; this is engine logic covered by unit tests.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scene analysis robustness by better handling malformed responses from the AI model.
  * Enhanced fallback logic for music selection when scene analysis data is incomplete or invalid.

* **Tests**
  * Added comprehensive test coverage for scene analysis, including edge cases for data validation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->