### PR TITLE
Restore home screen animations

### DIFF
--- a/src/features/modes/router/components/ModeHomeSurface.tsx
+++ b/src/features/modes/router/components/ModeHomeSurface.tsx
@@ -43,6 +43,8 @@ export function ModeHomeSurface() {
     [connections, createChat],
   );
 
+  const showEmptyStateEffects = true;
+
   return (
     <>
       <div
@@ -51,14 +53,19 @@ export function ModeHomeSurface() {
       >
         <div className="flex w-full max-w-2xl flex-col items-center gap-3 py-2 sm:gap-4 sm:py-3 lg:pt-4 lg:pb-5">
           <div className="relative">
-            <div className="flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl shadow-xl shadow-orange-500/20 sm:h-20 sm:w-20">
+            <div
+              className={cn(
+                "flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl shadow-xl shadow-orange-500/20 sm:h-20 sm:w-20",
+                showEmptyStateEffects && "animate-pulse-ring bunny-glow",
+              )}
+            >
               <img
-                src="/logo.png"
+                src={showEmptyStateEffects ? "/logo-splash.gif" : "/logo.png"}
                 alt="Marinara Engine"
                 width={80}
                 height={80}
                 decoding="async"
-                className="h-full w-full object-contain p-1.5 sm:p-2"
+                className={cn("h-full w-full", showEmptyStateEffects ? "object-cover" : "object-contain p-1.5 sm:p-2")}
               />
             </div>
           </div>
@@ -70,7 +77,9 @@ export function ModeHomeSurface() {
             </p>
           </div>
 
-          <div className="flex flex-wrap justify-center gap-2 sm:gap-3">
+          <div
+            className={cn("flex flex-wrap justify-center gap-2 sm:gap-3", showEmptyStateEffects && "stagger-children")}
+          >
             <QuickStartCard
               icon={<MessageSquare size="1.125rem" />}
               label="Conversation"
@@ -100,7 +109,9 @@ export function ModeHomeSurface() {
           <RecentChats />
           <HomeFaq />
 
-          <div className="h-px w-48 rounded-[1px] bg-[var(--border)]/40" />
+          <div
+            className={cn("w-48", showEmptyStateEffects ? "retro-divider" : "h-px rounded-[1px] bg-[var(--border)]/40")}
+          />
 
           <div className="flex w-full max-w-2xl flex-col items-center gap-2">
             <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 text-center text-[0.625rem] leading-tight text-[var(--muted-foreground)]/55 sm:text-xs">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1059,6 +1059,7 @@ body {
   flex: 0 0 auto;
   border-radius: 0.18rem;
   filter: drop-shadow(0 0 0.25rem color-mix(in srgb, var(--primary) 22%, transparent));
+  animation: mari-title-heartbeat 2.4s ease-in-out infinite;
 }
 
 .mari-title-word {
@@ -1108,6 +1109,20 @@ body {
   }
   70% {
     transform: translateY(-1px) rotate(-4deg) scale(1.08);
+  }
+}
+
+@keyframes mari-title-heartbeat {
+  0%,
+  64%,
+  100% {
+    transform: scale(1);
+  }
+  72% {
+    transform: scale(1.22);
+  }
+  82% {
+    transform: scale(0.98);
   }
 }
 
@@ -1505,13 +1520,27 @@ summary[class*="cursor-pointer"],
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
 }
 
+@keyframes twinkle-glow {
+  0%,
+  100% {
+    opacity: 0.6;
+    filter: blur(0);
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.2;
+    filter: blur(0.5px);
+    transform: scale(0.9);
+  }
+}
+
 .y2k-star,
 .y2k-star-md,
 .y2k-star-lg {
   position: fixed;
   pointer-events: none;
   border-radius: 50%;
-  opacity: 0.55;
+  animation: twinkle-glow 4s ease-in-out infinite;
 }
 
 .y2k-star {
@@ -1530,7 +1559,7 @@ summary[class*="cursor-pointer"],
   box-shadow:
     0 0 10px 4px rgba(212, 173, 252, 0.6),
     0 0 20px 8px rgba(212, 173, 252, 0.3);
-  opacity: 0.45;
+  animation-duration: 5s;
 }
 
 .y2k-star-lg {
@@ -1540,7 +1569,7 @@ summary[class*="cursor-pointer"],
   box-shadow:
     0 0 12px 5px rgba(255, 228, 245, 0.7),
     0 0 24px 10px rgba(255, 228, 245, 0.4);
-  opacity: 0.5;
+  animation-duration: 6s;
 }
 
 @keyframes pulse-glow {


### PR DESCRIPTION
## Linked issue

Closes #

## Why this change

- PR #1745 intentionally made the no-chat home screen static to prove that continuous WebView2 animation was contributing to idle CPU usage.
- That fix reduced CPU, but it was a visual parity downgrade versus old staging, where the home screen could keep its branded ambient animation.
- This revert restores the home animation behavior so the next performance pass can target the real high-CPU mode surfaces, especially Game Mode, without sacrificing home-screen flair as the final product direction.

## What changed

- Reverted PR #1745 / commit `b46090b0`.
- Restored `/logo-splash.gif` on the home screen.
- Restored the home logo pulse/glow, staggered quick-start cards, animated retro divider, title heartbeat, and twinkling ambient stars.

## Refactor impact

Primary owner:

- app shell / mode home surface

Impact areas reviewed:

- no-chat home surface
- global shell/home animation CSS
- visual parity with pre-static home behavior

Boundary notes:

- React/UI and CSS-only revert.
- No engine, shared API, Rust/Tauri command, storage, schema, dependency, release, or version changes.

Pressure points touched:

- `ModeHomeSurface`
- global shell/home decor CSS

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm typecheck` in a clean worktree.
- Codex ran `pnpm build` in the same worktree. Build passed with existing warnings:
  - generated CSS minify warning for `[file:line]`
  - existing large chunk warning
- Codex built the Windows pre-alpha Tauri artifact with `pnpm tauri build --ci --no-sign --config src-tauri/tauri.prealpha.conf.json`; first attempt failed with a generic Tauri wrapper error during the long Rust build, retry completed successfully and produced MSI/NSIS bundles.
- Static/source verification confirms the restored home animation hooks:
  - `/logo-splash.gif`
  - `animate-pulse-ring bunny-glow`
  - `stagger-children`
  - `retro-divider`
  - `mari-title-heartbeat`
  - `twinkle-glow`
- Packaged-app screenshot capture was attempted, but Windows captured the transparent Tauri shell/background rather than reliable WebView content, so no screenshot evidence is attached.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No reliable screenshot attached; source/static verification and Tauri package build are the proof for this visual revert.