### PR TITLE
Fix legacy sidecar embedding selection

### DIFF
--- a/src-tauri/src/commands/storage/prompts.rs
+++ b/src-tauri/src/commands/storage/prompts.rs
@@ -2,6 +2,8 @@ use super::shared::*;
 use super::*;
 use marinara_security::is_allowed_outbound_url;
 
+const LEGACY_LOCAL_SIDECAR_CONNECTION_ID: &str = "__local_sidecar__";
+
 pub(crate) async fn vectorize_lorebook(
     state: &AppState,
     lorebook_id: &str,
@@ -99,6 +101,9 @@ pub(crate) fn resolve_embedding_connection_for_id(
     state: &AppState,
     connection_id: &str,
 ) -> AppResult<(String, Value)> {
+    if is_legacy_local_sidecar_connection_id(connection_id) {
+        return Err(legacy_local_sidecar_embedding_error());
+    }
     let connection = get_required(state, "connections", connection_id)?;
     if let Some(embedding_connection_id) = connection
         .get("embeddingConnectionId")
@@ -106,6 +111,9 @@ pub(crate) fn resolve_embedding_connection_for_id(
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
+        if is_legacy_local_sidecar_connection_id(embedding_connection_id) {
+            return Err(legacy_local_sidecar_embedding_error());
+        }
         let embedding_connection = get_required(state, "connections", embedding_connection_id)?;
         if is_openai_chatgpt_connection(&embedding_connection) {
             return Err(openai_chatgpt_embedding_error());
@@ -120,8 +128,13 @@ pub(crate) fn resolve_embedding_connection_for_id(
 
 pub(crate) fn resolve_default_embedding_connection(state: &AppState) -> AppResult<(String, Value)> {
     let connections = state.storage.list("connections")?;
-    let selected = connections
+    let embedding_candidates = connections
         .iter()
+        .filter(|connection| !is_legacy_local_sidecar_connection(connection))
+        .collect::<Vec<_>>();
+    let selected = embedding_candidates
+        .iter()
+        .copied()
         .find(|connection| {
             connection
                 .get("isDefault")
@@ -130,19 +143,20 @@ pub(crate) fn resolve_default_embedding_connection(state: &AppState) -> AppResul
                 && has_embedding_model(connection)
         })
         .or_else(|| {
-            connections
+            embedding_candidates
                 .iter()
+                .copied()
                 .find(|connection| has_embedding_model(connection))
         })
         .or_else(|| {
-            connections.iter().find(|connection| {
+            embedding_candidates.iter().copied().find(|connection| {
                 connection
                     .get("isDefault")
                     .and_then(Value::as_bool)
                     .unwrap_or(false)
             })
         })
-        .or_else(|| connections.first())
+        .or_else(|| embedding_candidates.first().copied())
         .ok_or_else(|| AppError::invalid_input("No embedding connection is configured"))?;
     let connection_id = selected
         .get("id")
@@ -165,10 +179,22 @@ pub(crate) fn embedding_model(connection: &Value, explicit: Option<&str>) -> App
 
 fn has_embedding_model(connection: &Value) -> bool {
     !is_openai_chatgpt_connection(connection)
+        && !is_legacy_local_sidecar_connection(connection)
         && connection
             .get("embeddingModel")
             .and_then(Value::as_str)
             .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn is_legacy_local_sidecar_connection(connection: &Value) -> bool {
+    connection
+        .get("id")
+        .and_then(Value::as_str)
+        .is_some_and(is_legacy_local_sidecar_connection_id)
+}
+
+fn is_legacy_local_sidecar_connection_id(connection_id: &str) -> bool {
+    connection_id.trim() == LEGACY_LOCAL_SIDECAR_CONNECTION_ID
 }
 
 fn is_openai_chatgpt_connection(connection: &Value) -> bool {
@@ -258,6 +284,12 @@ pub(crate) async fn embed_text(connection: &Value, model: &str, text: &str) -> A
 fn openai_chatgpt_embedding_error() -> AppError {
     AppError::invalid_input(
         "OpenAI (ChatGPT) does not support embeddings through Codex auth. Configure a separate embedding connection.",
+    )
+}
+
+fn legacy_local_sidecar_embedding_error() -> AppError {
+    AppError::invalid_input(
+        "Local Model (sidecar) embeddings are retired in the refactor. Configure a normal embedding-capable connection.",
     )
 }
 
@@ -763,6 +795,41 @@ mod tests {
         assert!(error.message.contains("does not support embeddings"));
     }
 
+    #[test]
+    fn resolve_embedding_connection_rejects_legacy_local_sidecar_id() {
+        let state = test_state("legacy-sidecar-embedding-rejected");
+
+        let error = resolve_embedding_connection_for_id(&state, LEGACY_LOCAL_SIDECAR_CONNECTION_ID)
+            .expect_err("legacy sidecar should not be used for embeddings");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("retired in the refactor"));
+    }
+
+    #[test]
+    fn resolve_embedding_connection_rejects_legacy_local_sidecar_as_dedicated_connection() {
+        let state = test_state("legacy-sidecar-dedicated-embedding-rejected");
+        state
+            .storage
+            .create(
+                "connections",
+                json!({
+                    "id": "chat-connection",
+                    "name": "Chat",
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "embeddingConnectionId": LEGACY_LOCAL_SIDECAR_CONNECTION_ID
+                }),
+            )
+            .expect("chat connection should insert");
+
+        let error = resolve_embedding_connection_for_id(&state, "chat-connection")
+            .expect_err("legacy sidecar dedicated connection should not be used for embeddings");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("retired in the refactor"));
+    }
+
     #[tokio::test]
     async fn embed_text_rejects_openai_chatgpt_before_provider_call() {
         let connection = json!({
@@ -856,6 +923,71 @@ mod tests {
             embedding_model(&connection, None).unwrap(),
             "local-embedding"
         );
+    }
+
+    #[test]
+    fn resolve_default_embedding_connection_skips_legacy_local_sidecar_candidate() {
+        let state = test_state("default-skips-legacy-sidecar");
+        state
+            .storage
+            .create(
+                "connections",
+                json!({
+                    "id": LEGACY_LOCAL_SIDECAR_CONNECTION_ID,
+                    "name": "Local Model (sidecar)",
+                    "provider": "custom",
+                    "model": "local-sidecar",
+                    "embeddingModel": "local-sidecar",
+                    "isDefault": true
+                }),
+            )
+            .expect("legacy sidecar connection should insert");
+        state
+            .storage
+            .create(
+                "connections",
+                json!({
+                    "id": "embedding-connection",
+                    "name": "Embeddings",
+                    "provider": "custom",
+                    "model": "chat-model",
+                    "embeddingModel": "text-embedding-3-small"
+                }),
+            )
+            .expect("embedding connection should insert");
+
+        let (id, connection) = resolve_default_embedding_connection(&state).unwrap();
+
+        assert_eq!(id, "embedding-connection");
+        assert_eq!(
+            embedding_model(&connection, None).unwrap(),
+            "text-embedding-3-small"
+        );
+    }
+
+    #[test]
+    fn resolve_default_embedding_connection_rejects_only_legacy_local_sidecar() {
+        let state = test_state("default-only-legacy-sidecar");
+        state
+            .storage
+            .create(
+                "connections",
+                json!({
+                    "id": LEGACY_LOCAL_SIDECAR_CONNECTION_ID,
+                    "name": "Local Model (sidecar)",
+                    "provider": "custom",
+                    "model": "local-sidecar",
+                    "embeddingModel": "local-sidecar",
+                    "isDefault": true
+                }),
+            )
+            .expect("legacy sidecar connection should insert");
+
+        let error = resolve_default_embedding_connection(&state)
+            .expect_err("legacy sidecar should not be selected as default embedding connection");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("No embedding connection"));
     }
 
     #[tokio::test]

--- a/src/features/catalog/lorebooks/components/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/LorebookEditor.tsx
@@ -94,6 +94,7 @@ import { ExportFormatDialog, type ExportFormatChoice } from "../../../../shared/
 // state is independent across books.
 // ──────────────────────────────────────────────
 const FOLDER_COLLAPSE_KEY_PREFIX = "lorebook-folder-collapsed:";
+const LEGACY_LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";
 
 function readCollapsedFolderIds(lorebookId: string | null): Set<string> {
   if (!lorebookId || typeof window === "undefined") return new Set();
@@ -2171,7 +2172,10 @@ function VectorizeSection({
   const unvectorizeEntries = useBulkUnvectorizeLorebookEntries();
   const { data: rawConnections } = useConnections();
   const connections = (rawConnections ?? []) as Array<{ id: string; name: string; embeddingModel?: string }>;
-  const embeddingConnections = connections.filter((c) => c.embeddingModel);
+  const embeddingConnections = connections.filter(
+    (c) =>
+      c.id !== LEGACY_LOCAL_SIDECAR_CONNECTION_ID && typeof c.embeddingModel === "string" && c.embeddingModel.trim(),
+  );
   const [selectedConnectionId, setSelectedConnectionId] = useState<string>("");
   const [vectorizing, setVectorizing] = useState(false);
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);

--- a/src/features/shell/connections/components/ConnectionEditor.tsx
+++ b/src/features/shell/connections/components/ConnectionEditor.tsx
@@ -97,6 +97,7 @@ const DEFAULT_CACHING_AT_DEPTH = 5;
 const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
+const LEGACY_LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";
 
 const OPENAI_CHATGPT_SETUP_STEPS = [
   { label: "Install Codex CLI", command: "npm i -g @openai/codex" },
@@ -426,12 +427,17 @@ export function ConnectionEditor() {
   const embeddingConnectionOptions = useMemo(
     () =>
       ((allConnections ?? []) as Record<string, unknown>[]).filter(
-        (c) => c.id !== connectionDetailId && c.provider !== "image_generation" && c.provider !== "openai_chatgpt",
+        (c) =>
+          c.id !== connectionDetailId &&
+          c.id !== LEGACY_LOCAL_SIDECAR_CONNECTION_ID &&
+          c.provider !== "image_generation" &&
+          c.provider !== "openai_chatgpt",
       ),
     [allConnections, connectionDetailId],
   );
   const selectedEmbeddingConnectionId =
     localEmbeddingConnectionId &&
+    localEmbeddingConnectionId !== LEGACY_LOCAL_SIDECAR_CONNECTION_ID &&
     (allConnections === undefined || embeddingConnectionOptions.some((c) => c.id === localEmbeddingConnectionId))
       ? localEmbeddingConnectionId
       : "";


### PR DESCRIPTION
## Linked issue

Closes #1747

## Why this change

- In v1.6.1, lorebook vectorization could expose the synthetic Local Model sidecar embedding option (`__local_sidecar__`). In the refactor, the old managed sidecar runtime is retired, so that legacy id must not be offered or routed as an embedding-capable connection.

## What changed

- Reject the legacy `__local_sidecar__` id before Rust embedding resolution reaches provider transport.
- Exclude the retired sidecar id from default embedding connection selection while preserving real embedding-capable connection fallback behavior.
- Hide stale `__local_sidecar__` rows from lorebook vectorization and connection embedding override dropdowns.
- Added focused Rust regression coverage for direct sidecar id, dedicated embedding override, default resolver skip, and only-sidecar cases.

## Refactor impact

Primary owner:

Rust storage / catalog connections and lorebook vectorization

Impact areas reviewed:

- `src-tauri/src/commands/storage/prompts.rs` embedding resolver and lorebook vectorization path
- `src/features/catalog/lorebooks/components/LorebookEditor.tsx` Semantic Search embedding picker
- `src/features/shell/connections/components/ConnectionEditor.tsx` embedding override picker

Boundary notes:

- Product behavior stays in the Rust storage/provider boundary for actual embedding resolution.
- React feature code only filters stale picker options; it does not add provider logic or raw runtime calls.
- No engine import boundary changes.

Pressure points touched:

- Lorebook vectorization command path
- Connection embedding override UI
- Legacy/refactor compatibility for retired Local Model sidecar id

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

Codex-run proof:

- `cargo test --manifest-path src-tauri/Cargo.toml legacy_local_sidecar -- --nocapture` passed, 4 tests.
- `pnpm check` passed locally.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification.json` passed.
- Bunny pass on the current diff before opening the PR: no blocking findings.

### Manual verification notes

- No human-only manual verification is required for the core claim. This is a provider/connection contract fix, proven with focused resolver tests and the full pre-PR gate.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed: the refactor docs already state the old managed sidecar is retired and normal embedding-capable connections should be used.

## UI evidence

N/A. The visible symptom is the stale Local Model sidecar appearing as an embedding/vectorization choice, but the core fix is the embedding resolver contract plus picker filtering. The behavior is covered by Rust regression tests, TypeScript typecheck, and `pnpm check`.
