### PR TITLE
Decide bundle warning policy

### DIFF
--- a/src/features/modes/game/lib/game-tag-parser.ts
+++ b/src/features/modes/game/lib/game-tag-parser.ts
@@ -27,7 +27,7 @@ interface SkillCheckTag {
   disadvantage?: boolean;
   resolvedResult?: SkillCheckResult;
   /**
-   * Player-submitted d20 echoed by the GM when a `[dice:1d20]` was rolled
+   * Player-submitted d20 echoed by the GM when a dice:1d20 tag was rolled
    * before the check. Forwarded to the server resolver so the sheet's
    * attribute modifier is applied on top of the player's number.
    */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,8 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
+@source "../../index.html";
+@source "../app";
+@source "../features";
+@source "../shared";
 @import "./themes/sillytavern.css";
 
 /* World state & tracker widgets: equal flex sizing on mobile */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,4 +35,10 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+
+  build: {
+    // Refactor's largest lazy JS chunk is intentionally below 800 kB raw, and `pnpm perf:size`
+    // tracks aggregate JS/CSS transfer budgets. Keep Vite noisy only for new outsized chunks.
+    chunkSizeWarningLimit: 800,
+  },
 }));


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1532

## Why this change

- `pnpm build` was still noisy after the earlier chunk-splitting work because Vite's default 500 kB raw chunk warning was below the intentionally measured current lazy chunk sizes.
- Tailwind was also scanning non-UI text and comments, producing invalid arbitrary-property CSS for examples like `[file:line]` and `[dice:1d20]`.

## What changed

- Set Vite's `chunkSizeWarningLimit` to 800 kB with a comment tying the threshold to the measured refactor chunks and existing `pnpm perf:size` transfer budgets.
- Switched Tailwind to explicit source registration for the app UI surfaces instead of repository-wide automatic source detection.
- Reworded one game tag parser comment so it no longer looks like a Tailwind arbitrary property candidate.

## Refactor impact

Primary owner:

Build/frontend styling configuration.

Impact areas reviewed:

- Vite production build output
- Tailwind source scanning
- Game tag parser comment-only reference

Boundary notes:

- No engine behavior changed.
- No shared API, Tauri/Rust, storage, remote runtime, schema, dependency, or version files changed.

Pressure points touched:

- Global stylesheet Tailwind import/source scan policy
- Vite build warning policy

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm build`: passed with no Vite large-chunk warning and no esbuild CSS warning.
- Codex checked generated CSS for the false `file:line` and `dice:1d20` arbitrary-property selectors: none found.
- Codex ran `pnpm perf:size`: passed with JS 1.09 MB / 1.7 MB and CSS 53.12 kB / 250 kB.
- Codex ran `pnpm check`: passed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. Build/style pipeline hygiene only; no visible UI behavior changed.
