### PR TITLE
Add explicit Vite vendor chunk policy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,30 @@ import tailwindcss from "@tailwindcss/vite";
 import { fileURLToPath, URL } from "node:url";
 
 const host = process.env.TAURI_DEV_HOST;
+const vendorChunkGroups: Record<string, string[]> = {
+  "vendor-react": ["react", "react-dom"],
+  "vendor-runtime": ["@tanstack/react-query", "zustand", "zod", "clsx", "tailwind-merge"],
+  "vendor-ui": ["framer-motion", "motion", "@dnd-kit", "dompurify", "sonner"],
+  "vendor-tauri": [
+    "@tauri-apps/api",
+    "@tauri-apps/plugin-dialog",
+    "@tauri-apps/plugin-notification",
+    "@tauri-apps/plugin-opener",
+  ],
+};
+
+function manualVendorChunk(id: string) {
+  const normalizedId = id.replace(/\\/g, "/");
+  if (!normalizedId.includes("/node_modules/")) return undefined;
+
+  for (const [chunkName, packages] of Object.entries(vendorChunkGroups)) {
+    if (packages.some((packageName) => normalizedId.includes(`/node_modules/${packageName}/`))) {
+      return chunkName;
+    }
+  }
+
+  return undefined;
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -37,8 +61,13 @@ export default defineConfig(async () => ({
   },
 
   build: {
-    // Refactor's largest lazy JS chunk is intentionally below 800 kB raw, and `pnpm perf:size`
-    // tracks aggregate JS/CSS transfer budgets. Keep Vite noisy only for new outsized chunks.
-    chunkSizeWarningLimit: 800,
+    // The largest remaining JS chunk is lazy Game mode route code; keep
+    // startup/vendor leakage visible while allowing that intentional split.
+    chunkSizeWarningLimit: 650,
+    rollupOptions: {
+      output: {
+        manualChunks: manualVendorChunk,
+      },
+    },
   },
 }));


### PR DESCRIPTION
## Linked issue

Closes #1577

## Why this change

- Split stable framework/vendor code out of the startup entry so Vite chunk warnings are meaningful again and future startup leakage is easier to spot.

## What changed

- Added an explicit function-based `manualChunks` policy for React, runtime utilities, UI support libraries, and Tauri helper packages.
- Lowered the Vite chunk warning limit to `650` with an inline note that the largest remaining JS chunk is lazy Game mode route code.

## Refactor impact

Primary owner:

- app shell / build tooling

Impact areas reviewed:

- Vite production bundle output
- startup entry chunk size
- lazy Game mode route chunk size
- existing Tauri/Vite asset pipeline assumptions

Boundary notes:

- No runtime API, engine, shared API, Rust, schema, storage, or user-facing behavior changes.
- The policy only groups selected packages from `node_modules`; it does not add a broad vendor fallback or pull `lucide-react` into a shared startup chunk.

Pressure points touched:

- Vite build output only.
- `GameSurface` remains a lazy route chunk.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm build` passed and emitted explicit `vendor-react`, `vendor-runtime`, `vendor-ui`, and `vendor-tauri` chunks.
- Largest observed JS chunks after the policy: startup `index` about `270.63 kB`; lazy `GameSurface` about `640.63 kB`.
- `pnpm check` passed locally.
- `pnpm test:ui:run tests/e2e/app.spec.ts` passed locally.
- Tauri desktop smoke was not run in this agent session.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize dependency bundling and improve chunk size management for enhanced application distribution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->