### PR TITLE
Fix reasoning icon for provider metadata

### DIFF
--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -27,7 +27,11 @@ import { resolveMessageMacros } from "../../../../shared/lib/chat-macros";
 import { useTranslate } from "../../../../shared/hooks/use-translate";
 import { storageApi } from "../../../../shared/api/storage-api";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "../../shared/chat-ui/types";
-import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "../../shared/chat-ui/index";
+import {
+  GenerationReplayDetailsModal,
+  hasGenerationReplayDetails,
+  readStoredThinking,
+} from "../../shared/chat-ui/index";
 import { ImagePromptPanel } from "../../shared/chat-ui/index";
 import { SwipeJumpControl } from "../../shared/chat-ui/index";
 
@@ -566,7 +570,7 @@ export const ConversationMessage = memo(function ConversationMessage({
     prevContentRef.current = renderedContent;
   }, [renderedContent, segmentCount]);
 
-  const thinking = extra?.thinking;
+  const thinking = readStoredThinking(extra);
   const swipeCount = message.swipeCount ?? 0;
   const hasSwipes = swipeCount > 1;
 

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -75,6 +75,7 @@ import type {
 import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./GenerationReplayDetailsModal";
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import { SwipeJumpControl } from "./SwipeJumpControl";
+import { readStoredThinking } from "../lib/message-thinking";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
@@ -1139,7 +1140,7 @@ export const ChatMessage = memo(function ChatMessage({
   }, [message.extra]);
   const isConversationStart = !!extra.isConversationStart;
   const isHiddenFromAI = extra.hiddenFromAI === true || extra.hiddenFromAi === true;
-  const thinking = extra.thinking as string | undefined;
+  const thinking = readStoredThinking(extra);
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
   const promptSnapshotsBySwipe =
     extra.generationPromptSnapshotsBySwipe &&

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -24,3 +24,4 @@ export * from "./hooks/use-chat-transcript-shortcuts";
 export * from "./hooks/use-chat-tts-autoplay";
 export * from "./hooks/use-streaming-tts";
 export * from "./hooks/use-sprite-metadata-state";
+export * from "./lib/message-thinking";

--- a/src/features/modes/shared/chat-ui/lib/message-thinking.test.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-thinking.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { readStoredThinking } from "./message-thinking";
+
+describe("readStoredThinking", () => {
+  it("prefers normalized app thinking metadata", () => {
+    expect(
+      readStoredThinking({
+        thinking: "app thinking",
+        reasoning_content: "provider reasoning",
+        reasoning: "fallback reasoning",
+      }),
+    ).toBe("app thinking");
+  });
+
+  it("falls back to provider reasoning_content metadata", () => {
+    expect(readStoredThinking({ reasoning_content: "ollama reasoning" })).toBe("ollama reasoning");
+  });
+
+  it("falls back to provider reasoning metadata", () => {
+    expect(readStoredThinking({ reasoning: "provider reasoning" })).toBe("provider reasoning");
+  });
+
+  it("skips blank higher-priority fields", () => {
+    expect(readStoredThinking({ thinking: "   ", reasoning_content: "provider reasoning" })).toBe(
+      "provider reasoning",
+    );
+  });
+
+  it("ignores non-string metadata", () => {
+    expect(readStoredThinking({ reasoning_content: ["provider reasoning"] })).toBeNull();
+  });
+});

--- a/src/features/modes/shared/chat-ui/lib/message-thinking.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-thinking.ts
@@ -1,0 +1,16 @@
+const STORED_THINKING_KEYS = ["thinking", "reasoning_content", "reasoning"] as const;
+
+export function readStoredThinking(extra: unknown): string | null {
+  if (!extra || typeof extra !== "object" || Array.isArray(extra)) return null;
+
+  const record = extra as Record<string, unknown>;
+  for (const key of STORED_THINKING_KEYS) {
+    const value = record[key];
+    if (typeof value !== "string") continue;
+
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1708

## Why this change

- Provider reasoning can already be stored on messages as `extra.thinking`, `extra.reasoning_content`, or `extra.reasoning`, but the message action UI only checked `extra.thinking`. Messages with provider-shaped reasoning metadata could therefore hide the View thoughts action even though the reasoning content was present.

## What changed

- Added a shared `readStoredThinking` helper that resolves stored reasoning in the existing priority order: app-normalized `thinking`, provider `reasoning_content`, then provider `reasoning`.
- Updated shared chat/roleplay and conversation message renderers to use the helper for the brain/View thoughts action and modal.
- Added focused Vitest coverage for app-normalized reasoning, provider reasoning aliases, blank fallback behavior, and non-string negative control.

## Refactor impact

Primary owner:

- shared mode UI

Impact areas reviewed:

- Shared chat message actions
- Conversation message actions
- Existing message extra reasoning fields and active-swipe metadata aliases

Boundary notes:

- Feature/UI-only change. No engine imports from features, no storage writes, no provider transport changes, no dependency/schema/version changes.
- The conversation renderer imports the helper through the shared chat-ui public barrel to satisfy package boundaries.

Pressure points touched:

- Shared mode UI message action rendering.
- Conversation message action rendering.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

Codex-run verification:

- `pnpm test src/features/modes/shared/chat-ui/lib/message-thinking.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`
- Bunny pass before push: focused diff, clean refactor branch, proof gate passed, `pnpm check` passed.

### Manual verification notes

- Android/Termux Ollama/Gemma was not available in this environment, so the reporter's exact provider/runtime path was not manually exercised.
- Browser screenshot evidence was not captured; the core UI condition is covered by the focused metadata reader test and both renderers now consume that helper.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No browser screenshot attached. The changed path is the message action's stored-reasoning condition, verified by focused unit coverage plus `pnpm check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thinking/reasoning content extraction by centralizing logic into a shared helper that checks multiple field names in priority order, making "View thoughts" and "Model Thoughts" features more robust across different model response formats.

* **Tests**
  * Added comprehensive test coverage for the thinking content extraction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->