### PR TITLE
Add durable tracker row IDs

### DIFF
--- a/src/engine/contracts/types/game-state.ts
+++ b/src/engine/contracts/types/game-state.ts
@@ -67,6 +67,7 @@ export interface PresentCharacter {
 
 /** A numeric stat for a character. */
 export interface CharacterStat {
+  statId: string;
   name: string;
   value: number;
   max: number;
@@ -75,6 +76,7 @@ export interface CharacterStat {
 
 /** A user-defined custom tracker field. */
 export interface CustomTrackerField {
+  customFieldId: string;
   name: string;
   value: string;
 }
@@ -109,6 +111,7 @@ export interface RPGAttributes {
 
 /** An item in the player's inventory. */
 export interface InventoryItem {
+  inventoryItemId: string;
   name: string;
   description: string;
   quantity: number;
@@ -116,11 +119,18 @@ export interface InventoryItem {
   location: string;
 }
 
+/** A quest objective row. */
+export interface QuestObjective {
+  objectiveId: string;
+  text: string;
+  completed: boolean;
+}
+
 /** Quest progress data tracked in game state. */
 export interface QuestProgress {
   questEntryId: string;
   name: string;
   currentStage: number;
-  objectives: Array<{ text: string; completed: boolean }>;
+  objectives: QuestObjective[];
   completed: boolean;
 }

--- a/src/engine/generation/tracker-snapshots.test.ts
+++ b/src/engine/generation/tracker-snapshots.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StorageGateway } from "../capabilities/storage";
+import type { AgentResult, AgentResultType } from "../contracts/types/agent";
+import { getTrackerSnapshotForTarget, persistTrackerSnapshotForTurn } from "./tracker-snapshots";
+
+function agentResult(agentType: string, data: Record<string, unknown>): AgentResult {
+  const resultTypes: Record<string, AgentResultType> = {
+    "character-tracker": "character_tracker_update",
+    "persona-stats": "persona_stats_update",
+    "custom-tracker": "custom_tracker_update",
+    quest: "quest_update",
+  };
+  return {
+    agentId: agentType,
+    agentType,
+    type: resultTypes[agentType] ?? "game_state_update",
+    data,
+    tokensUsed: 0,
+    durationMs: 0,
+    success: true,
+    error: null,
+  };
+}
+
+describe("tracker snapshot row id normalization", () => {
+  it("defaults missing nested tracker row ids before saving agent snapshots", async () => {
+    const savedSnapshots: Record<string, unknown>[] = [];
+    const storage = {
+      list: vi.fn(async () => []),
+      get: vi.fn(async () => ({ id: "chat-1", gameState: null })),
+      saveTrackerSnapshot: vi.fn(async (_chatId: string, snapshot: Record<string, unknown>) => {
+        savedSnapshots.push(snapshot);
+        return snapshot;
+      }),
+      update: vi.fn(async () => null),
+    } as unknown as StorageGateway;
+
+    const saved = await persistTrackerSnapshotForTurn(
+      storage,
+      "chat-1",
+      { messageId: "assistant-1", swipeIndex: 0 },
+      [
+        agentResult("character-tracker", {
+          presentCharacters: [
+            {
+              characterId: "char-1",
+              name: "Mira",
+              stats: [
+                { name: "HP", value: 6, max: 10, color: "#f00" },
+                { name: "HP", value: 4, max: 10, color: "#0f0" },
+              ],
+            },
+          ],
+        }),
+        agentResult("persona-stats", {
+          stats: [{ name: "Energy", value: 3, max: 5, color: "#00f" }],
+          inventory: [{ name: "Potion", description: "", quantity: 2, location: "on_person" }],
+        }),
+        agentResult("custom-tracker", {
+          fields: [{ name: "Status", value: "Alert" }],
+        }),
+        agentResult("quest", {
+          updates: [{ action: "create", questName: "Find the door", objectives: ["Search the room"] }],
+        }),
+      ],
+    );
+
+    const snapshot = savedSnapshots[0]!;
+    expect(snapshot.presentCharacters).toEqual([
+      expect.objectContaining({
+        stats: [
+          expect.objectContaining({ statId: "character-stat-hp-1" }),
+          expect.objectContaining({ statId: "character-stat-hp-2" }),
+        ],
+      }),
+    ]);
+    expect(snapshot.personaStats).toEqual([expect.objectContaining({ statId: "persona-stat-energy-1" })]);
+    expect((snapshot.playerStats as Record<string, unknown>).inventory).toEqual([
+      expect.objectContaining({ inventoryItemId: "inventory-item-potion-1" }),
+    ]);
+    expect((snapshot.playerStats as Record<string, unknown>).customTrackerFields).toEqual([
+      expect.objectContaining({ customFieldId: "custom-field-status-1" }),
+    ]);
+    expect(((snapshot.playerStats as Record<string, unknown>).activeQuests as Array<Record<string, unknown>>)[0]?.objectives).toEqual([
+      expect.objectContaining({ objectiveId: "quest-objective-search-the-room-1" }),
+    ]);
+    expect(saved?.presentCharacters[0]?.stats[1]?.statId).toBe("character-stat-hp-2");
+  });
+
+  it("normalizes legacy no-id rows when reading tracker snapshots", async () => {
+    const storage = {
+      list: vi.fn(async () => [
+        {
+          id: "snapshot-1",
+          chatId: "chat-1",
+          kind: "tracker",
+          messageId: "assistant-1",
+          swipeIndex: 0,
+          presentCharacters: [
+            { characterId: "char-1", name: "Mira", stats: [{ name: "HP", value: 6, max: 10, color: "#f00" }] },
+          ],
+          recentEvents: [],
+          playerStats: {
+            stats: [],
+            attributes: null,
+            skills: {},
+            inventory: [{ name: "Potion", description: "", quantity: 1, location: "on_person" }],
+            activeQuests: [
+              {
+                questEntryId: "quest-1",
+                name: "Quest",
+                currentStage: 0,
+                objectives: [{ text: "Search", completed: false }],
+                completed: false,
+              },
+            ],
+            customTrackerFields: [{ name: "Status", value: "Alert" }],
+            status: "",
+          },
+          personaStats: [{ name: "Energy", value: 3, max: 5, color: "#00f" }],
+          createdAt: "2026-05-31T00:00:00.000Z",
+        },
+      ]),
+    } as unknown as StorageGateway;
+
+    const snapshot = await getTrackerSnapshotForTarget(storage, "chat-1", { messageId: "assistant-1", swipeIndex: 0 });
+
+    expect(snapshot?.presentCharacters[0]?.stats[0]?.statId).toBe("character-stat-hp-1");
+    expect(snapshot?.personaStats?.[0]?.statId).toBe("persona-stat-energy-1");
+    expect(snapshot?.playerStats?.inventory[0]?.inventoryItemId).toBe("inventory-item-potion-1");
+    expect(snapshot?.playerStats?.customTrackerFields?.[0]?.customFieldId).toBe("custom-field-status-1");
+    expect(snapshot?.playerStats?.activeQuests[0]?.objectives[0]?.objectiveId).toBe("quest-objective-search-1");
+  });
+});

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -16,6 +16,7 @@ import {
   parseInventoryItem,
   parseStat,
 } from "../shared/game-state/player-stats";
+import { normalizeGameStateTrackerRows } from "../shared/game-state/tracker-row-ids";
 
 export interface TrackerSnapshotTurnTarget {
   messageId: string;
@@ -116,7 +117,7 @@ function parsePresentCharacter(value: unknown): PresentCharacter | null {
 
 function normalizeGameState(value: unknown, chatId: string, target: TrackerSnapshotTurnTarget): GameState {
   const record = parseRecord(value);
-  return {
+  return normalizeGameStateTrackerRows({
     id: readString(record.id),
     chatId,
     messageId: target.messageId,
@@ -141,7 +142,7 @@ function normalizeGameState(value: unknown, chatId: string, target: TrackerSnaps
     committed: record.committed === undefined ? undefined : boolish(record.committed, false),
     manualOverrides: parseManualOverrides(record.manualOverrides),
     createdAt: readString(record.createdAt) || nowIso(),
-  };
+  });
 }
 
 function trackerSnapshotTargetFromRecord(value: unknown): TrackerSnapshotTurnTarget | null {

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -3,6 +3,7 @@ import type {
   CustomTrackerField,
   InventoryItem,
   PlayerStats,
+  QuestObjective,
   QuestProgress,
   RPGAttributes,
 } from "../../contracts/types/game-state";
@@ -15,7 +16,6 @@ import {
   readString,
 } from "../../generation/runtime-records";
 
-type QuestObjective = QuestProgress["objectives"][number];
 type QuestUpdateAction = "create" | "update" | "complete" | "fail";
 
 interface NormalizedQuestUpdate {
@@ -35,10 +35,10 @@ const RPG_ATTRIBUTE_KEYS: RpgAttributeKey[] = ["str", "dex", "con", "int", "wis"
  */
 const NESTED_QUEST_KEYS = ["quests", "activeQuests", "groups", "items", "children"] as const;
 
-function parseQuestObjective(value: unknown): { text: string; completed: boolean } | null {
+function parseQuestObjective(value: unknown): QuestObjective | null {
   if (typeof value === "string") {
     const text = value.trim();
-    return text ? { text, completed: false } : null;
+    return text ? { objectiveId: "", text, completed: false } : null;
   }
   const record = parseRecord(value);
   const text = firstString(record.text, record.description, record.objective, record.name, record.title);
@@ -47,6 +47,7 @@ function parseQuestObjective(value: unknown): { text: string; completed: boolean
     .trim()
     .toLowerCase();
   return {
+    objectiveId: readString(record.objectiveId).trim(),
     text,
     completed: boolish(record.completed, status === "complete" || status === "completed" || status === "done"),
   };
@@ -139,7 +140,7 @@ export function parseStat(value: unknown): CharacterStat | null {
   const max = Math.max(1, readNumber(record.max, 100));
   const valueNumber = Math.min(max, Math.max(0, readNumber(record.value, max)));
   const color = readString(record.color).trim() || "#8b5cf6";
-  return { name, value: valueNumber, max, color };
+  return { statId: readString(record.statId).trim(), name, value: valueNumber, max, color };
 }
 
 export function parseInventoryItem(value: unknown): InventoryItem | null {
@@ -147,6 +148,7 @@ export function parseInventoryItem(value: unknown): InventoryItem | null {
   const name = readString(record.name).trim();
   if (!name) return null;
   return {
+    inventoryItemId: readString(record.inventoryItemId).trim(),
     name,
     description: readString(record.description).trim(),
     quantity: Math.max(0, readNumber(record.quantity, 1)),
@@ -158,7 +160,7 @@ export function parseCustomTrackerField(value: unknown): CustomTrackerField | nu
   const record = parseRecord(value);
   const name = readString(record.name).trim();
   if (!name) return null;
-  return { name, value: readString(record.value).trim() };
+  return { customFieldId: readString(record.customFieldId).trim(), name, value: readString(record.value).trim() };
 }
 
 function parseRpgAttributes(value: unknown): RPGAttributes | null {

--- a/src/engine/shared/game-state/tracker-row-ids.test.ts
+++ b/src/engine/shared/game-state/tracker-row-ids.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { GameState } from "../../contracts/types/game-state";
+import { normalizeGameStateTrackerRows } from "./tracker-row-ids";
+
+function gameStateWithPlayerStats(playerStats: NonNullable<GameState["playerStats"]>): GameState {
+  return {
+    id: "state-1",
+    chatId: "chat-1",
+    messageId: "message-1",
+    swipeIndex: 0,
+    date: null,
+    time: null,
+    location: null,
+    weather: null,
+    temperature: null,
+    presentCharacters: [],
+    recentEvents: [],
+    playerStats,
+    personaStats: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+describe("normalizeGameStateTrackerRows", () => {
+  it("generates distinct quest ids for duplicate legacy quest names", () => {
+    const normalized = normalizeGameStateTrackerRows(
+      gameStateWithPlayerStats({
+        stats: [],
+        attributes: null,
+        skills: {},
+        inventory: [],
+        activeQuests: [
+          {
+            questEntryId: "",
+            name: "Find the key",
+            currentStage: 0,
+            objectives: [],
+            completed: false,
+          },
+          {
+            questEntryId: "",
+            name: "Find the key",
+            currentStage: 1,
+            objectives: [],
+            completed: false,
+          },
+        ],
+        status: "",
+      }),
+    );
+
+    const questIds = normalized.playerStats?.activeQuests.map((quest) => quest.questEntryId) ?? [];
+
+    expect(questIds).toHaveLength(2);
+    expect(questIds[0]).toMatch(/^manual-/);
+    expect(questIds[1]).toMatch(/^manual-/);
+    expect(new Set(questIds).size).toBe(2);
+  });
+});

--- a/src/engine/shared/game-state/tracker-row-ids.ts
+++ b/src/engine/shared/game-state/tracker-row-ids.ts
@@ -1,0 +1,142 @@
+import type {
+  CharacterStat,
+  CustomTrackerField,
+  GameState,
+  InventoryItem,
+  PlayerStats,
+  PresentCharacter,
+  QuestObjective,
+  QuestProgress,
+} from "../../contracts/types/game-state";
+
+type TrackerRowFamily =
+  | "character-stat"
+  | "player-stat"
+  | "persona-stat"
+  | "inventory-item"
+  | "custom-field"
+  | "quest-objective";
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function slugTrackerLabel(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "row";
+}
+
+function makeDefaultTrackerRowId(family: TrackerRowFamily, label: string, index: number): string {
+  return `${family}-${slugTrackerLabel(label)}-${index + 1}`;
+}
+
+export function makeManualTrackerRowId(): string {
+  const id =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
+  return `manual-${id}`;
+}
+
+function normalizeCharacterStats(
+  stats: readonly Partial<CharacterStat>[] | null | undefined,
+  family: Extract<TrackerRowFamily, "character-stat" | "player-stat" | "persona-stat">,
+): CharacterStat[] {
+  return (stats ?? []).map((stat, index) => {
+    const name = readString(stat.name) || "Stat";
+    return {
+      statId: readString(stat.statId) || makeDefaultTrackerRowId(family, name, index),
+      name,
+      value: typeof stat.value === "number" && Number.isFinite(stat.value) ? stat.value : 0,
+      max: typeof stat.max === "number" && Number.isFinite(stat.max) ? stat.max : 100,
+      color: readString(stat.color) || "var(--primary)",
+    };
+  });
+}
+
+function normalizeInventoryItems(items: readonly Partial<InventoryItem>[] | null | undefined): InventoryItem[] {
+  return (items ?? []).map((item, index) => {
+    const name = readString(item.name) || "Item";
+    return {
+      inventoryItemId: readString(item.inventoryItemId) || makeDefaultTrackerRowId("inventory-item", name, index),
+      name,
+      description: readString(item.description),
+      quantity: typeof item.quantity === "number" && Number.isFinite(item.quantity) ? item.quantity : 1,
+      location: readString(item.location) || "on_person",
+    };
+  });
+}
+
+function normalizeCustomTrackerFields(
+  fields: readonly Partial<CustomTrackerField>[] | null | undefined,
+): CustomTrackerField[] {
+  return (fields ?? []).map((field, index) => {
+    const name = readString(field.name) || "Field";
+    return {
+      customFieldId: readString(field.customFieldId) || makeDefaultTrackerRowId("custom-field", name, index),
+      name,
+      value: readString(field.value),
+    };
+  });
+}
+
+function normalizeQuestObjectives(
+  objectives: readonly Partial<QuestObjective>[] | null | undefined,
+): QuestObjective[] {
+  return (objectives ?? []).map((objective, index) => {
+    const text = readString(objective.text) || "Objective";
+    return {
+      objectiveId: readString(objective.objectiveId) || makeDefaultTrackerRowId("quest-objective", text, index),
+      text,
+      completed: objective.completed === true,
+    };
+  });
+}
+
+function normalizeQuestProgressRows(quests: readonly Partial<QuestProgress>[] | null | undefined): QuestProgress[] {
+  return (quests ?? []).map((quest) => {
+    const name = readString(quest.name) || "Quest";
+    return {
+      questEntryId: readString(quest.questEntryId) || name,
+      name,
+      currentStage: typeof quest.currentStage === "number" && Number.isFinite(quest.currentStage) ? quest.currentStage : 0,
+      objectives: normalizeQuestObjectives(quest.objectives),
+      completed: quest.completed === true,
+    };
+  });
+}
+
+function normalizePlayerStatsTrackerRows(playerStats: PlayerStats | null | undefined): PlayerStats | null {
+  if (!playerStats) return null;
+  return {
+    ...playerStats,
+    stats: normalizeCharacterStats(playerStats.stats, "player-stat"),
+    inventory: normalizeInventoryItems(playerStats.inventory),
+    activeQuests: normalizeQuestProgressRows(playerStats.activeQuests),
+    customTrackerFields: playerStats.customTrackerFields
+      ? normalizeCustomTrackerFields(playerStats.customTrackerFields)
+      : undefined,
+  };
+}
+
+function normalizePresentCharacterTrackerRows(
+  characters: readonly PresentCharacter[] | null | undefined,
+): PresentCharacter[] {
+  return (characters ?? []).map((character) => ({
+    ...character,
+    stats: normalizeCharacterStats(character.stats, "character-stat"),
+  }));
+}
+
+export function normalizeGameStateTrackerRows(state: GameState): GameState {
+  return {
+    ...state,
+    presentCharacters: normalizePresentCharacterTrackerRows(state.presentCharacters),
+    playerStats: normalizePlayerStatsTrackerRows(state.playerStats),
+    personaStats: state.personaStats ? normalizeCharacterStats(state.personaStats, "persona-stat") : null,
+  };
+}

--- a/src/engine/shared/game-state/tracker-row-ids.ts
+++ b/src/engine/shared/game-state/tracker-row-ids.ts
@@ -101,7 +101,7 @@ function normalizeQuestProgressRows(quests: readonly Partial<QuestProgress>[] | 
   return (quests ?? []).map((quest) => {
     const name = readString(quest.name) || "Quest";
     return {
-      questEntryId: readString(quest.questEntryId) || name,
+      questEntryId: readString(quest.questEntryId) || makeManualTrackerRowId(),
       name,
       currentStage: typeof quest.currentStage === "number" && Number.isFinite(quest.currentStage) ? quest.currentStage : 0,
       objectives: normalizeQuestObjectives(quest.objectives),

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -1082,29 +1082,42 @@ function addInventoryUnit<T extends { name: string; quantity: number }>(items: T
   return addedToExisting ? updated : [...updated, { name, quantity: 1 } as T];
 }
 
-function addDetailedInventoryUnit(items: InventoryItem[], itemName: string): InventoryItem[] {
+function addDetailedInventoryUnit(items: InventoryItem[], itemName: string, inventoryItemId?: string): InventoryItem[] {
   const name = normalizeInventoryName(itemName);
   if (!name) return items;
 
-  let addedToExisting = false;
-  const updated = items.map((item) => {
-    if (item.name.trim().toLowerCase() !== name.toLowerCase()) return item;
-    addedToExisting = true;
-    return { ...item, quantity: item.quantity + 1 };
-  });
+  const targetItemId = inventoryItemId?.trim();
+  if (targetItemId) {
+    let addedToExisting = false;
+    const updated = items.map((item) => {
+      if (item.inventoryItemId !== targetItemId) return item;
+      addedToExisting = true;
+      return { ...item, quantity: item.quantity + 1 };
+    });
 
-  return addedToExisting
-    ? updated
-    : [
-        ...updated,
-        {
-          inventoryItemId: makeManualTrackerRowId(),
-          name,
-          description: "",
-          quantity: 1,
-          location: "on_person",
-        },
-      ];
+    if (addedToExisting) return updated;
+  }
+
+  const normalizedName = name.toLowerCase();
+  const matchingIndexes = items
+    .map((item, index) => (item.name.trim().toLowerCase() === normalizedName ? index : -1))
+    .filter((index) => index >= 0);
+
+  if (matchingIndexes.length === 1) {
+    const targetIndex = matchingIndexes[0]!;
+    return items.map((item, index) => (index === targetIndex ? { ...item, quantity: item.quantity + 1 } : item));
+  }
+
+  return [
+    ...items,
+    {
+      inventoryItemId: makeManualTrackerRowId(),
+      name,
+      description: "",
+      quantity: 1,
+      location: "on_person",
+    },
+  ];
 }
 
 function normalizeInventoryName(value: string): string {

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -13,6 +13,7 @@ import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useGameStateStore } from "../../../runtime/world-state/index";
 import { useGameStatePatcher } from "../../../runtime/world-state/index";
 import type { GameStatePatchField, GameStatePatchValue } from "../../../runtime/world-state/types";
+import { makeManualTrackerRowId } from "../../../../engine/shared/game-state/tracker-row-ids";
 import {
   useSyncGameState,
   useCreateGame,
@@ -114,7 +115,7 @@ import type {
   HudWidget,
   SkillCheckResult,
 } from "../../../../engine/contracts/types/game";
-import type { GameState } from "../../../../engine/contracts/types/game-state";
+import type { GameState, InventoryItem } from "../../../../engine/contracts/types/game-state";
 import type {
   SceneAnalysis,
   SceneIllustrationRequest,
@@ -1079,6 +1080,31 @@ function addInventoryUnit<T extends { name: string; quantity: number }>(items: T
   });
 
   return addedToExisting ? updated : [...updated, { name, quantity: 1 } as T];
+}
+
+function addDetailedInventoryUnit(items: InventoryItem[], itemName: string): InventoryItem[] {
+  const name = normalizeInventoryName(itemName);
+  if (!name) return items;
+
+  let addedToExisting = false;
+  const updated = items.map((item) => {
+    if (item.name.trim().toLowerCase() !== name.toLowerCase()) return item;
+    addedToExisting = true;
+    return { ...item, quantity: item.quantity + 1 };
+  });
+
+  return addedToExisting
+    ? updated
+    : [
+        ...updated,
+        {
+          inventoryItemId: makeManualTrackerRowId(),
+          name,
+          description: "",
+          quantity: 1,
+          location: "on_person",
+        },
+      ];
 }
 
 function normalizeInventoryName(value: string): string {
@@ -5130,7 +5156,13 @@ export function GameSurface({
           ...currentPlayerStats,
           inventory: [
             ...currentPlayerStats.inventory,
-            { name: addedItemName, description: "", quantity: 1, location: "on_person" },
+            {
+              inventoryItemId: makeManualTrackerRowId(),
+              name: addedItemName,
+              description: "",
+              quantity: 1,
+              location: "on_person",
+            },
           ],
         }
       : null;
@@ -5188,7 +5220,7 @@ export function GameSurface({
       const nextPlayerStats = currentPlayerStats
         ? {
             ...currentPlayerStats,
-            inventory: addInventoryUnit(currentPlayerStats.inventory, normalizedItemName),
+            inventory: addDetailedInventoryUnit(currentPlayerStats.inventory, normalizedItemName),
           }
         : null;
       const shouldPatchGameState =

--- a/src/features/modes/roleplay/components/RoleplayHUD.tsx
+++ b/src/features/modes/roleplay/components/RoleplayHUD.tsx
@@ -16,7 +16,9 @@ import { useChat } from "../../../catalog/chats/index";
 import { useTrackerStateController } from "../../../runtime/world-state/index";
 import { discardPendingGameStatePatch } from "../../../runtime/world-state/index";
 import {
-  mergeNamedTrackerListUpdate,
+  mergeCharacterStatListUpdate,
+  mergeCustomTrackerFieldListUpdate,
+  mergeInventoryItemListUpdate,
   mergePresentCharacterListUpdate,
   mergeQuestProgressListUpdate,
 } from "../../../runtime/world-state/index";
@@ -212,7 +214,7 @@ export function RoleplayHUD({
   const personaStatus = playerStats?.status ?? "";
   const updatePersonaStats = useCallback(
     (bars: CharacterStat[]) => {
-      patchField("personaStats", mergeNamedTrackerListUpdate(personaStatBars, getSnapshot().personaStats, bars));
+      patchField("personaStats", mergeCharacterStatListUpdate(personaStatBars, getSnapshot().personaStats, bars));
     },
     [getSnapshot, patchField, personaStatBars],
   );
@@ -227,7 +229,7 @@ export function RoleplayHUD({
   );
   const updateInventory = useCallback(
     (items: InventoryItem[]) => {
-      patchPlayerStats("inventory", mergeNamedTrackerListUpdate(inventory, getSnapshot().inventory, items));
+      patchPlayerStats("inventory", mergeInventoryItemListUpdate(inventory, getSnapshot().inventory, items));
     },
     [getSnapshot, inventory, patchPlayerStats],
   );
@@ -241,7 +243,7 @@ export function RoleplayHUD({
     (fields: CustomTrackerField[]) => {
       patchPlayerStats(
         "customTrackerFields",
-        mergeNamedTrackerListUpdate(customTrackerFields, getSnapshot().customTrackerFields, fields),
+        mergeCustomTrackerFieldListUpdate(customTrackerFields, getSnapshot().customTrackerFields, fields),
       );
     },
     [customTrackerFields, getSnapshot, patchPlayerStats],

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -702,7 +702,7 @@ function parseStat(value: unknown): CharacterStat | null {
   const max = Math.max(1, readNumber(record.max, 100));
   const valueNumber = Math.min(max, Math.max(0, readNumber(record.value, max)));
   const color = readString(record.color).trim() || "#8b5cf6";
-  return { name, value: valueNumber, max, color };
+  return { statId: readString(record.statId).trim(), name, value: valueNumber, max, color };
 }
 
 function parseInventoryItem(value: unknown): InventoryItem | null {
@@ -710,6 +710,7 @@ function parseInventoryItem(value: unknown): InventoryItem | null {
   const name = readString(record.name).trim();
   if (!name) return null;
   return {
+    inventoryItemId: readString(record.inventoryItemId).trim(),
     name,
     description: readString(record.description).trim(),
     quantity: Math.max(0, readNumber(record.quantity, 1)),
@@ -749,7 +750,7 @@ function parseCustomTrackerField(value: unknown): CustomTrackerField | null {
   const record = parseMaybeRecord(value);
   const name = readString(record.name).trim();
   if (!name) return null;
-  return { name, value: readString(record.value).trim() };
+  return { customFieldId: readString(record.customFieldId).trim(), name, value: readString(record.value).trim() };
 }
 
 function gameStatePatchFromAgentResult(result: AgentResult, chatId: string): Record<string, unknown> | null {

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -50,7 +50,12 @@ import {
   type GenerationReplay,
 } from "../../../../engine/generation/generation-replay";
 import { readNonNegativeInteger } from "../../../../engine/generation/runtime-records";
-import { applyQuestUpdatesToPlayerStats } from "../../../../engine/shared/game-state/player-stats";
+import {
+  applyQuestUpdatesToPlayerStats,
+  parseCustomTrackerField,
+  parseInventoryItem,
+  parseStat,
+} from "../../../../engine/shared/game-state/player-stats";
 import type { AgentDebugEntry } from "../../../../engine/contracts/types/agent";
 import type { IntegrationGateway } from "../../../../engine/capabilities/integrations";
 
@@ -648,15 +653,6 @@ function readNullableString(value: unknown): string | null {
   return null;
 }
 
-function readNumber(value: unknown, fallback: number): number {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return fallback;
-}
-
 function trackerTargetFromMessagePayload(value: unknown): WorldStateTarget | null {
   const record = parseMaybeRecord(value);
   const messageId = readString(record.id).trim();
@@ -695,29 +691,6 @@ async function refreshGameStateFromStorage(chatId: string, target?: WorldStateTa
   }
 }
 
-function parseStat(value: unknown): CharacterStat | null {
-  const record = parseMaybeRecord(value);
-  const name = readString(record.name).trim();
-  if (!name) return null;
-  const max = Math.max(1, readNumber(record.max, 100));
-  const valueNumber = Math.min(max, Math.max(0, readNumber(record.value, max)));
-  const color = readString(record.color).trim() || "#8b5cf6";
-  return { statId: readString(record.statId).trim(), name, value: valueNumber, max, color };
-}
-
-function parseInventoryItem(value: unknown): InventoryItem | null {
-  const record = parseMaybeRecord(value);
-  const name = readString(record.name).trim();
-  if (!name) return null;
-  return {
-    inventoryItemId: readString(record.inventoryItemId).trim(),
-    name,
-    description: readString(record.description).trim(),
-    quantity: Math.max(0, readNumber(record.quantity, 1)),
-    location: readString(record.location).trim() || "on_person",
-  };
-}
-
 function parsePresentCharacter(value: unknown): PresentCharacter | null {
   const record = parseMaybeRecord(value);
   const name = readString(record.name).trim();
@@ -744,13 +717,6 @@ function parsePresentCharacter(value: unknown): PresentCharacter | null {
       : [],
     thoughts: readNullableString(record.thoughts),
   };
-}
-
-function parseCustomTrackerField(value: unknown): CustomTrackerField | null {
-  const record = parseMaybeRecord(value);
-  const name = readString(record.name).trim();
-  if (!name) return null;
-  return { customFieldId: readString(record.customFieldId).trim(), name, value: readString(record.value).trim() };
 }
 
 function gameStatePatchFromAgentResult(result: AgentResult, chatId: string): Record<string, unknown> | null {

--- a/src/features/runtime/tracker/components/CustomTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/CustomTrackerPanel.tsx
@@ -45,7 +45,7 @@ function CustomFieldList({
         <div className="grid grid-cols-1 border-t border-[var(--border)]/30 @min-[220px]:grid-cols-2 @min-[420px]:grid-cols-3">
           {fields.map((field, index) => (
             <div
-              key={`${field.name}-${index}`}
+              key={field.customFieldId || `${field.name}-${index}`}
               className={cn(
                 "group/field relative grid min-h-6 grid-cols-[minmax(0,1fr)_minmax(1.8rem,max-content)] items-center gap-1 border-b border-[var(--border)]/28 px-1 py-0.5 text-[0.6875rem] leading-[0.875rem]",
                 index % 2 === 0 &&

--- a/src/features/runtime/tracker/components/PersonaTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/PersonaTrackerPanel.tsx
@@ -267,7 +267,7 @@ export function PersonaInventoryPanel({
         ) : (
           inventory.map((item, index) => (
             <PersonaInventoryRow
-              key={`${item.name}-${index}`}
+              key={item.inventoryItemId || `${item.name}-${index}`}
               item={item}
               onUpdate={(updated) => onUpdateInventoryItem(index, updated)}
               onRemove={() => onRemoveInventoryItem(index)}

--- a/src/features/runtime/tracker/components/TrackerSectionList.tsx
+++ b/src/features/runtime/tracker/components/TrackerSectionList.tsx
@@ -88,6 +88,7 @@ export function TrackerSectionList({
   } = useTrackerMutations({
     activeChatId,
     agentConfigLookupEnabled,
+    customTrackerFields,
     inventory,
     personaStats,
     presentCharacters,

--- a/src/features/runtime/tracker/components/quest-tracker/QuestRow.tsx
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestRow.tsx
@@ -133,7 +133,7 @@ export function QuestRow({
           />
           {quest.objectives.map((objective, index) => (
             <QuestObjectiveRow
-              key={`${objective.text}-${index}`}
+              key={objective.objectiveId || `${objective.text}-${index}`}
               objective={objective}
               objectiveGridColumns={objectiveGridColumns}
               onToggle={onUpdate ? () => toggleObjective(index) : undefined}

--- a/src/features/runtime/tracker/components/tracker-data-sidebar.stats.tsx
+++ b/src/features/runtime/tracker/components/tracker-data-sidebar.stats.tsx
@@ -326,7 +326,7 @@ export function StatList({
       >
         {stats.map((stat, index) => (
           <StatBar
-            key={`${stat.name}-${index}`}
+            key={stat.statId || `${stat.name}-${index}`}
             stat={stat}
             onUpdateName={onUpdate && editableName ? (name) => updateStat(index, { ...stat, name }) : undefined}
             onUpdateValue={onUpdate ? (value) => updateStat(index, { ...stat, value }) : undefined}

--- a/src/features/runtime/tracker/hooks/use-tracker-mutations.ts
+++ b/src/features/runtime/tracker/hooks/use-tracker-mutations.ts
@@ -14,13 +14,14 @@ import {
   createManualInventoryItem,
   createManualPresentCharacter,
   createManualQuest,
+  mergeCharacterStatListUpdate,
+  mergeCustomTrackerFieldListUpdate,
+  mergeInventoryItemListItemUpdate,
   mergePresentCharacterListItemUpdate,
   mergeQuestProgressListItemUpdate,
-  mergeTrackerListItemUpdate,
-  mergeTrackerListUpdate,
+  removeInventoryItemListItem,
   removePresentCharacterListItem,
   removeQuestProgressListItem,
-  removeTrackerListItem,
 } from "../../world-state/index";
 import { getCharacterFeatureKey } from "../components/tracker-character.helpers";
 
@@ -32,6 +33,7 @@ export function useTrackerMutations({
   activeChatId,
   agentConfigLookupEnabled,
   getSnapshot,
+  customTrackerFields,
   inventory,
   personaStats,
   presentCharacters,
@@ -43,6 +45,7 @@ export function useTrackerMutations({
   activeChatId: string | null;
   agentConfigLookupEnabled: boolean;
   getSnapshot: TrackerStateController["getSnapshot"];
+  customTrackerFields: TrackerStateController["customTrackerFields"];
   inventory: InventoryItem[];
   personaStats: TrackerStateController["personaStats"];
   presentCharacters: PresentCharacter[];
@@ -60,6 +63,7 @@ export function useTrackerMutations({
   const getLatestPresentCharacters = useCallback(() => getSnapshot().presentCharacters, [getSnapshot]);
   const getLatestInventory = useCallback(() => getSnapshot().inventory, [getSnapshot]);
   const getLatestPersonaStats = useCallback(() => getSnapshot().personaStats, [getSnapshot]);
+  const getLatestCustomTrackerFields = useCallback(() => getSnapshot().customTrackerFields, [getSnapshot]);
   const getLatestQuests = useCallback(() => getSnapshot().quests, [getSnapshot]);
   const {
     autoGenerateCharacterAvatars,
@@ -122,16 +126,16 @@ export function useTrackerMutations({
 
   const updateInventoryItem = useCallback(
     (index: number, item: InventoryItem) => {
-      updateInventory(mergeTrackerListItemUpdate(inventory, getLatestInventory(), index, item));
+      updateInventory(mergeInventoryItemListItemUpdate(inventory, getLatestInventory(), index, item));
     },
     [getLatestInventory, inventory, updateInventory],
   );
 
   const removeInventoryItem = useCallback(
     (index: number) => {
-      updateInventory(removeTrackerListItem(getLatestInventory(), index));
+      updateInventory(removeInventoryItemListItem(inventory, getLatestInventory(), index));
     },
-    [getLatestInventory, updateInventory],
+    [getLatestInventory, inventory, updateInventory],
   );
 
   const addInventoryItem = useCallback(() => {
@@ -181,7 +185,7 @@ export function useTrackerMutations({
 
   const updatePersonaStats = useCallback(
     (stats: CharacterStat[]) => {
-      patchField("personaStats", mergeTrackerListUpdate(personaStats, getLatestPersonaStats(), stats));
+      patchField("personaStats", mergeCharacterStatListUpdate(personaStats, getLatestPersonaStats(), stats));
     },
     [getLatestPersonaStats, patchField, personaStats],
   );
@@ -203,7 +207,10 @@ export function useTrackerMutations({
     toggleAutoGenerateCharacterAvatars,
     updateCharacter,
     updateCustomFields: (fields: TrackerStateController["customTrackerFields"]) =>
-      patchPlayerStats("customTrackerFields", fields),
+      patchPlayerStats(
+        "customTrackerFields",
+        mergeCustomTrackerFieldListUpdate(customTrackerFields, getLatestCustomTrackerFields(), fields),
+      ),
     updateInventoryItem,
     updatePersonaStats,
     updateQuest,

--- a/src/features/runtime/world-state/lib/tracker-state-edits.test.ts
+++ b/src/features/runtime/world-state/lib/tracker-state-edits.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { CharacterStat, CustomTrackerField, InventoryItem, QuestProgress } from "../../../../engine/contracts/types/game-state";
+import {
+  mergeCharacterStatListUpdate,
+  mergeCustomTrackerFieldListUpdate,
+  mergeInventoryItemListItemUpdate,
+  mergeQuestProgressListItemUpdate,
+} from "./tracker-state-edits";
+
+function stat(overrides: Partial<CharacterStat>): CharacterStat {
+  return {
+    statId: "stat-id",
+    name: "HP",
+    value: 10,
+    max: 10,
+    color: "#fff",
+    ...overrides,
+  };
+}
+
+function legacyStat(overrides: Omit<Partial<CharacterStat>, "statId">): CharacterStat {
+  return { name: "HP", value: 10, max: 10, color: "#fff", ...overrides } as CharacterStat;
+}
+
+describe("tracker list durable row ids", () => {
+  it("uses statId to update the intended duplicate character stat", () => {
+    const previous = [stat({ statId: "hp-a", value: 10 }), stat({ statId: "hp-b", value: 5 })];
+    const latest = [stat({ statId: "hp-a", value: 8 }), stat({ statId: "hp-b", value: 5 })];
+    const next = [previous[0]!, stat({ statId: "hp-b", value: 7 })];
+
+    expect(mergeCharacterStatListUpdate(previous, latest, next)).toEqual([
+      stat({ statId: "hp-a", value: 8 }),
+      stat({ statId: "hp-b", value: 7 }),
+    ]);
+  });
+
+  it("uses statId to update the intended duplicate persona stat after latest rows reorder", () => {
+    const previous = [
+      stat({ statId: "energy-a", name: "Energy", value: 2 }),
+      stat({ statId: "energy-b", name: "Energy", value: 3 }),
+    ];
+    const latest = [previous[1]!, previous[0]!];
+    const next = [stat({ statId: "energy-a", name: "Energy", value: 4 }), previous[1]!];
+
+    expect(mergeCharacterStatListUpdate(previous, latest, next)).toEqual([
+      previous[1]!,
+      stat({ statId: "energy-a", name: "Energy", value: 4 }),
+    ]);
+  });
+
+  it("uses inventoryItemId to update the intended duplicate inventory item after latest rows reorder", () => {
+    const itemA: InventoryItem = {
+      inventoryItemId: "potion-a",
+      name: "Potion",
+      description: "",
+      quantity: 1,
+      location: "on_person",
+    };
+    const itemB: InventoryItem = {
+      inventoryItemId: "potion-b",
+      name: "Potion",
+      description: "",
+      quantity: 1,
+      location: "on_person",
+    };
+
+    expect(mergeInventoryItemListItemUpdate([itemA, itemB], [itemB, itemA], 0, { ...itemA, quantity: 3 })).toEqual([
+      itemB,
+      { ...itemA, quantity: 3 },
+    ]);
+  });
+
+  it("uses customFieldId to update the intended duplicate custom field", () => {
+    const fieldA: CustomTrackerField = { customFieldId: "field-a", name: "Status", value: "agent-updated" };
+    const fieldB: CustomTrackerField = { customFieldId: "field-b", name: "Status", value: "old" };
+
+    expect(
+      mergeCustomTrackerFieldListUpdate(
+        [{ ...fieldA, value: "old" }, fieldB],
+        [fieldA, fieldB],
+        [{ ...fieldA, value: "old" }, { ...fieldB, value: "manual" }],
+      ),
+    ).toEqual([fieldA, { ...fieldB, value: "manual" }]);
+  });
+
+  it("uses objectiveId to update the intended duplicate quest objective", () => {
+    const previousQuest: QuestProgress = {
+      questEntryId: "quest-1",
+      name: "Find the door",
+      currentStage: 0,
+      objectives: [
+        { objectiveId: "objective-a", text: "Search the room", completed: false },
+        { objectiveId: "objective-b", text: "Search the room", completed: false },
+      ],
+      completed: false,
+    };
+    const latestQuest: QuestProgress = {
+      ...previousQuest,
+      objectives: [previousQuest.objectives[1]!, previousQuest.objectives[0]!],
+    };
+    const nextQuest: QuestProgress = {
+      ...previousQuest,
+      objectives: [previousQuest.objectives[0]!, { ...previousQuest.objectives[1]!, completed: true }],
+    };
+
+    expect(mergeQuestProgressListItemUpdate([previousQuest], [latestQuest], 0, nextQuest)[0]?.objectives).toEqual([
+      { ...previousQuest.objectives[1]!, completed: true },
+      previousQuest.objectives[0]!,
+    ]);
+  });
+
+  it("falls back to legacy visible keys for no-id rows", () => {
+    const previous = [legacyStat({ name: "HP", value: 10 })];
+    const latest = [legacyStat({ name: "HP", value: 8 })];
+    const next = [legacyStat({ name: "HP", value: 6 })];
+
+    expect(mergeCharacterStatListUpdate(previous, latest, next)).toEqual([legacyStat({ name: "HP", value: 6 })]);
+  });
+});

--- a/src/features/runtime/world-state/lib/tracker-state-edits.ts
+++ b/src/features/runtime/world-state/lib/tracker-state-edits.ts
@@ -3,13 +3,17 @@ import type {
   CustomTrackerField,
   InventoryItem,
   PresentCharacter,
+  QuestObjective,
   QuestProgress,
 } from "../../../../engine/contracts/types/game-state";
+import { makeManualTrackerRowId } from "../../../../engine/shared/game-state/tracker-row-ids";
 
 type TrackerItemMerger<T extends object> = (previous: T | undefined, latest: T | undefined, next: T) => T;
 type TrackerItemKeyGetter<T> = (item: T | undefined) => string | null | undefined;
 type NamedTrackerItem = { name?: string | null };
-type QuestObjective = QuestProgress["objectives"][number];
+type StatTrackerItem = { statId?: string | null; name?: string | null };
+type InventoryTrackerItem = { inventoryItemId?: string | null; name?: string | null };
+type CustomTrackerItem = { customFieldId?: string | null; name?: string | null };
 
 export function replaceTrackerListItem<T>(items: readonly T[], index: number, item: T): T[] {
   if (index < 0 || index >= items.length) return [...items];
@@ -32,18 +36,6 @@ function mergeChangedTrackerFields<T extends object>(previous: T | undefined, la
     }
   }
   return merged;
-}
-
-export function mergeTrackerListItemUpdate<T extends object>(
-  previousItems: readonly T[],
-  latestItems: readonly T[],
-  index: number,
-  nextItem: T,
-  mergeItem: TrackerItemMerger<T> = mergeChangedTrackerFields,
-): T[] {
-  const latestItem = latestItems[index];
-  if (!latestItem && index >= latestItems.length) return [...latestItems];
-  return replaceTrackerListItem(latestItems, index, mergeItem(previousItems[index], latestItem, nextItem));
 }
 
 function getLatestListIndexByKey<T>(
@@ -134,7 +126,7 @@ function getAppendedListItem<T>(
   return nextItems[nextItems.length - 1];
 }
 
-export function mergeTrackerListUpdate<T extends object>(
+function mergeTrackerListUpdate<T extends object>(
   previousItems: readonly T[],
   latestItems: readonly T[],
   nextItems: readonly T[],
@@ -166,25 +158,82 @@ function namedTrackerItemKey(item: NamedTrackerItem | undefined) {
   return item?.name?.trim() || null;
 }
 
+function trackerIdKey(value: string | null | undefined) {
+  return value?.trim() || null;
+}
+
+function trackerKeyWithLegacyFallback(id: string | null | undefined, legacyKey: string | null | undefined) {
+  const durableId = trackerIdKey(id);
+  if (durableId) return `id:${durableId}`;
+  return legacyKey ? `legacy:${legacyKey}` : null;
+}
+
+function statTrackerItemKey(item: StatTrackerItem | undefined) {
+  return trackerKeyWithLegacyFallback(item?.statId, namedTrackerItemKey(item));
+}
+
+function inventoryTrackerItemKey(item: InventoryTrackerItem | undefined) {
+  return trackerKeyWithLegacyFallback(item?.inventoryItemId, namedTrackerItemKey(item));
+}
+
+function customTrackerItemKey(item: CustomTrackerItem | undefined) {
+  return trackerKeyWithLegacyFallback(item?.customFieldId, namedTrackerItemKey(item));
+}
+
 function questObjectiveKey(item: QuestObjective | undefined) {
-  return item?.text?.trim() || null;
+  return trackerKeyWithLegacyFallback(item?.objectiveId, item?.text?.trim() || null);
 }
 
 function makeManualTrackerId() {
-  const id =
-    typeof globalThis.crypto?.randomUUID === "function"
-      ? globalThis.crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
-  return `manual-${id}`;
+  return makeManualTrackerRowId();
 }
 
-export function mergeNamedTrackerListUpdate<T extends NamedTrackerItem & object>(
-  previousItems: readonly T[],
-  latestItems: readonly T[],
-  nextItems: readonly T[],
-  mergeItem: TrackerItemMerger<T> = mergeChangedTrackerFields,
-): T[] {
-  return mergeTrackerListUpdate(previousItems, latestItems, nextItems, mergeItem, namedTrackerItemKey);
+export function mergeCharacterStatListUpdate(
+  previousItems: readonly CharacterStat[],
+  latestItems: readonly CharacterStat[],
+  nextItems: readonly CharacterStat[],
+): CharacterStat[] {
+  return mergeTrackerListUpdate(previousItems, latestItems, nextItems, mergeChangedTrackerFields, statTrackerItemKey);
+}
+
+export function mergeInventoryItemListUpdate(
+  previousItems: readonly InventoryItem[],
+  latestItems: readonly InventoryItem[],
+  nextItems: readonly InventoryItem[],
+): InventoryItem[] {
+  return mergeTrackerListUpdate(previousItems, latestItems, nextItems, mergeChangedTrackerFields, inventoryTrackerItemKey);
+}
+
+export function mergeInventoryItemListItemUpdate(
+  previousItems: readonly InventoryItem[],
+  latestItems: readonly InventoryItem[],
+  index: number,
+  nextItem: InventoryItem,
+): InventoryItem[] {
+  return mergeKeyedTrackerListItemUpdate(
+    previousItems,
+    latestItems,
+    index,
+    nextItem,
+    inventoryTrackerItemKey,
+    mergeChangedTrackerFields,
+  );
+}
+
+export function removeInventoryItemListItem(
+  previousItems: readonly InventoryItem[],
+  latestItems: readonly InventoryItem[],
+  index: number,
+): InventoryItem[] {
+  return removeKeyedTrackerListItem(previousItems, latestItems, index, inventoryTrackerItemKey);
+}
+
+export function mergeCustomTrackerFieldListUpdate(
+  previousItems: readonly CustomTrackerField[],
+  latestItems: readonly CustomTrackerField[],
+  nextItems: readonly CustomTrackerField[],
+): CustomTrackerField[] {
+  return mergeTrackerListUpdate(previousItems, latestItems, nextItems, mergeChangedTrackerFields, customTrackerItemKey);
 }
 
 function mergeTrackerRecordUpdate<T>(
@@ -213,7 +262,7 @@ function mergePresentCharacterUpdate(
   if (!previous) return merged;
 
   if (!Object.is(previous.stats, next.stats)) {
-    merged.stats = mergeNamedTrackerListUpdate(previous.stats ?? [], latest?.stats ?? [], next.stats ?? []);
+    merged.stats = mergeCharacterStatListUpdate(previous.stats ?? [], latest?.stats ?? [], next.stats ?? []);
   }
 
   if (!Object.is(previous.customFields, next.customFields)) {
@@ -362,6 +411,7 @@ export function createManualPresentCharacter(options: Partial<PresentCharacter> 
 
 export function createManualInventoryItem(options: Partial<InventoryItem> = {}): InventoryItem {
   return {
+    inventoryItemId: options.inventoryItemId ?? makeManualTrackerId(),
     name: options.name ?? "New Item",
     description: options.description ?? "",
     quantity: options.quantity ?? 1,
@@ -371,6 +421,7 @@ export function createManualInventoryItem(options: Partial<InventoryItem> = {}):
 
 function createManualQuestObjective(options: Partial<QuestProgress["objectives"][number]> = {}) {
   return {
+    objectiveId: options.objectiveId ?? makeManualTrackerId(),
     text: options.text ?? "New objective",
     completed: options.completed ?? false,
   };
@@ -388,6 +439,7 @@ export function createManualQuest(options: Partial<QuestProgress> = {}): QuestPr
 
 export function createManualCustomTrackerField(options: Partial<CustomTrackerField> = {}): CustomTrackerField {
   return {
+    customFieldId: options.customFieldId ?? makeManualTrackerId(),
     name: options.name ?? "New Field",
     value: options.value ?? "",
   };
@@ -395,6 +447,7 @@ export function createManualCustomTrackerField(options: Partial<CustomTrackerFie
 
 export function createManualCharacterStat(options: Partial<CharacterStat> = {}): CharacterStat {
   return {
+    statId: options.statId ?? makeManualTrackerId(),
     name: options.name ?? "New Stat",
     value: options.value ?? 0,
     max: options.max ?? 100,

--- a/src/features/runtime/world-state/stores/world-state.store.ts
+++ b/src/features/runtime/world-state/stores/world-state.store.ts
@@ -4,6 +4,7 @@
 import { create } from "zustand";
 import type { GameState } from "../../../../engine/contracts/types/game-state";
 import { coerceGameStateTextFields } from "../../../../engine/shared/game-state/game-state-text";
+import { normalizeGameStateTrackerRows } from "../../../../engine/shared/game-state/tracker-row-ids";
 
 interface GameStateStore {
   current: GameState | null;
@@ -28,7 +29,10 @@ const flushPatchCallbacks = new Map<string, () => Promise<void>>();
 
 function normalizeGameState(state: GameState | null): GameState | null {
   if (!state) return null;
-  return { ...state, ...coerceGameStateTextFields(state as unknown as Record<string, unknown>) };
+  return normalizeGameStateTrackerRows({
+    ...state,
+    ...coerceGameStateTextFields(state as unknown as Record<string, unknown>),
+  });
 }
 
 function buildFlushPatch() {


### PR DESCRIPTION
## Linked issue

Closes #1528

## Why this change

- Nested tracker rows were still reconciled by visible labels like `name` or `text`, so duplicate stat names, inventory item names, custom field names, or quest objective text could cause manual edits and agent snapshot merges to target the wrong row.

## What changed

- Added durable nested tracker row IDs for character/player/persona stats, inventory items, custom tracker fields, and quest objectives.
- Added engine-owned normalization/defaulting so legacy snapshots and generated agent output without IDs remain readable and are saved/current-state normalized.
- Updated tracker merge paths to prefer durable IDs while retaining visible-key fallback for legacy/no-id rows.
- Updated manual tracker row creation and game inventory additions to assign `manual-*` IDs.
- Added focused coverage for duplicate labels, legacy no-id fallback, and snapshot normalization/defaulting.

## Refactor impact

Primary owner:

world-state / engine generation

Impact areas reviewed:

- Engine game-state contract and tracker snapshot persistence
- Shared player-stat parsing
- Runtime tracker merge helpers and tracker UI row keys
- Roleplay HUD tracker widgets and game inventory sync path

Boundary notes:

- Engine/shared game-state normalization stays React-free.
- Feature code continues using runtime/world-state helpers rather than raw storage or Tauri APIs.
- No Rust storage migration is included; snapshots remain JSON-compatible and normalize at read/save/current-state boundaries.

Pressure points touched:

- `GameSurface` inventory tracker sync
- Roleplay HUD tracker widget merge paths
- Runtime tracker panel row identity and keys

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex verification run from clean worktree `C:\tmp\Marinara-Engine-issue-1528`:

- `pnpm test src/features/runtime/world-state/lib/tracker-state-edits.test.ts` passed.
- `pnpm test src/engine/generation/tracker-snapshots.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed, including line endings, architecture, frontend typecheck, Rust check, docs, and unused-code check.
- Bunny review pass completed locally for the current diff.

Manual browser/Tauri verification was not run because this is a data-contract and merge-logic change, not a visible UI layout claim.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made; this is a tracker state contract/compatibility implementation.

## UI evidence

N/A. No visual UI behavior or layout claim; row keys changed only to preserve identity after the new durable IDs are present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker system reliability and consistency across quest objectives, inventory items, character statistics, and custom fields.
  * Enhanced game state persistence and data recovery capabilities with improved support for legacy save data.
  * More stable and reliable synchronization of tracker updates throughout the game interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->