### PR TITLE
chore: tighten discovery metadata PR gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,6 +71,7 @@ Check exactly one:
 - [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.
 
 Reason:
+
 -
 
 ## Docs and release impact

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -63,6 +63,16 @@ Pressure points touched:
 
 -
 
+## Feature Discoverability
+
+Check exactly one:
+
+- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
+- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.
+
+Reason:
+-
+
 ## Docs and release impact
 
 - [ ] No docs changes needed
@@ -70,7 +80,6 @@ Pressure points touched:
 - [ ] Updated `CONTRIBUTING.md`
 - [ ] Updated `docs/developer/`
 - [ ] Updated repo skills or `AGENTS.md`
-- [ ] Updated Feature Discoverability / marked N/A in notes
 - [ ] Confirmed this PR does not restore old staging/package-workspace/release claims
 
 ## UI evidence

--- a/scripts/check-discovery-metadata.mjs
+++ b/scripts/check-discovery-metadata.mjs
@@ -137,6 +137,70 @@ function getArgValue(name) {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
+async function readPullRequestBodyFromEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) return "";
+
+  try {
+    const event = JSON.parse((await readFile(eventPath, "utf8")).replace(/^\uFEFF/, ""));
+    return typeof event.pull_request?.body === "string" ? event.pull_request.body : "";
+  } catch {
+    return "";
+  }
+}
+
+function checkboxChecked(line) {
+  return /\[\s*x\s*\]/i.test(line);
+}
+
+function cleanReasonLine(line) {
+  return line
+    .replace(/^[-*]\s*/, "")
+    .replace(/^<!--.*-->$/, "")
+    .trim();
+}
+
+function readFeatureDiscoverabilityReason(body) {
+  const lines = body.split(/\r?\n/);
+  const reasonIndex = lines.findIndex((line) => /^#{0,6}\s*(feature discoverability\s+)?reason\s*:/i.test(line.trim()));
+  if (reasonIndex < 0) return "";
+
+  const inlineReason = cleanReasonLine(lines[reasonIndex].replace(/^#{0,6}\s*(feature discoverability\s+)?reason\s*:/i, ""));
+  if (inlineReason && inlineReason !== "-") return inlineReason;
+
+  for (const line of lines.slice(reasonIndex + 1)) {
+    if (/^#{1,6}\s+/.test(line)) break;
+    const reason = cleanReasonLine(line);
+    if (reason && reason !== "-") return reason;
+  }
+  return "";
+}
+
+function parseFeatureDiscoverabilityDecision(body) {
+  const decision = { updated: false, na: false, reason: readFeatureDiscoverabilityReason(body) };
+  const lines = body.split(/\r?\n/);
+  let inFeatureDiscoverabilitySection = false;
+  for (const line of lines) {
+    if (/^#{1,6}\s+feature discoverability\s*$/i.test(line.trim())) {
+      inFeatureDiscoverabilitySection = true;
+      continue;
+    }
+    if (inFeatureDiscoverabilitySection && /^#{1,6}\s+/.test(line.trim())) {
+      inFeatureDiscoverabilitySection = false;
+    }
+    if (!/\[\s*[ x]\s*\]/i.test(line)) continue;
+    const normalized = line.toLowerCase();
+    const isFeatureDiscoverabilityLine =
+      inFeatureDiscoverabilitySection ||
+      normalized.includes("feature discoverability") ||
+      normalized.includes("src/features/shell/discovery");
+    if (!isFeatureDiscoverabilityLine || !checkboxChecked(line)) continue;
+    if (/\bn\/?a\b/i.test(line)) decision.na = true;
+    else decision.updated = true;
+  }
+  return decision;
+}
+
 function gitChangedFiles(base) {
   const output = execFileSync("git", ["diff", "--name-only", `${base}...HEAD`], { encoding: "utf8" });
   return output
@@ -175,18 +239,46 @@ if (errors.length > 0) {
 
 const prAware = process.argv.includes("--pr-aware");
 const changedFrom = getArgValue("--changed-from") ?? (prAware ? `origin/${process.env.GITHUB_BASE_REF || "refactor"}` : undefined);
+const pullRequestBody = await readPullRequestBodyFromEvent();
+const featureDiscoverabilityDecision = parseFeatureDiscoverabilityDecision(pullRequestBody);
+const featureDiscoverabilityDecisionCount =
+  Number(featureDiscoverabilityDecision.updated) + Number(featureDiscoverabilityDecision.na);
+const allowMissingDiscovery =
+  process.argv.includes("--allow-missing") ||
+  process.env.DISCOVERY_CHECK_ALLOW_MISSING === "1" ||
+  (featureDiscoverabilityDecision.na && hasText(featureDiscoverabilityDecision.reason));
 
 if (changedFrom) {
   const changed = gitChangedFiles(changedFrom);
   const userFacing = changed.filter(isLikelyUserFacingPath);
   const discoveryTouched = changed.some(isDiscoveryMetadataPath);
-  if (userFacing.length > 0 && !discoveryTouched && process.env.DISCOVERY_CHECK_ALLOW_MISSING !== "1") {
+  if (userFacing.length > 0 && pullRequestBody && featureDiscoverabilityDecisionCount !== 1) {
+    console.error("Feature Discoverability must check exactly one option in the PR body.");
+    console.error("- Updated src/features/shell/discovery/ metadata");
+    console.error("- N/A with a short reason");
+    process.exit(1);
+  }
+  if (
+    userFacing.length > 0 &&
+    !discoveryTouched &&
+    featureDiscoverabilityDecision.na &&
+    !hasText(featureDiscoverabilityDecision.reason)
+  ) {
+    console.error("Feature Discoverability N/A requires a non-empty Reason in the PR body.");
+    process.exit(1);
+  }
+  if (userFacing.length > 0 && !discoveryTouched && !allowMissingDiscovery) {
     console.error(
       `Discovery metadata was not updated, but ${userFacing.length} likely user-facing file(s) changed relative to ${changedFrom}.`,
     );
     for (const path of userFacing.slice(0, 12)) console.error(`- ${path}`);
-    console.error("Update src/features/shell/discovery/ or rerun with DISCOVERY_CHECK_ALLOW_MISSING=1 for an intentional N/A.");
+    console.error(
+      "Update src/features/shell/discovery/ or mark Feature Discoverability as N/A in the PR body with a reason.",
+    );
     process.exit(1);
+  }
+  if (userFacing.length > 0 && !discoveryTouched && allowMissingDiscovery) {
+    console.log("Discovery metadata not updated; accepted explicit Feature Discoverability N/A marker.");
   }
   console.log(`Checked ${registry.length} discovery entries and ${changed.length} changed file(s).`);
 } else {


### PR DESCRIPTION
## Linked issue

Refs #1765

## Why this change

- The discovery PR gate correctly catches user-facing changes without Discover metadata, but contributors and automation need a clearer way to mark intentional N/A cases without treating N/A as a free pass.

## What changed

- Added a dedicated Feature Discoverability section to the PR template with "check exactly one" guidance.
- Updated the discovery metadata checker to accept missing Discover metadata only when the PR body explicitly checks N/A and includes a non-empty reason.
- Kept registry validation mandatory.

## Refactor impact

Primary owner:

- docs/workflow

Impact areas reviewed:

- Discovery metadata CI gate
- PR template guidance for contributors and automation

Boundary notes:

- Workflow-only change; no product runtime behavior changes.

Pressure points touched:

- PR template
- `scripts/check-discovery-metadata.mjs`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex ran `pnpm check:discovery`.
- Codex ran `pnpm check:docs`.
- Codex verified PR-aware discovery behavior against a #1765-style diff:
  - no Feature Discoverability choice fails
  - N/A without a reason fails
  - N/A with a reason passes

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, helper automation, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:
- Workflow-only PR gate/template change; no new user-facing product surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pull request processes and validation workflows to improve development efficiency and metadata tracking consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->