### PR TITLE
Document PR proof file policy

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -41,6 +41,9 @@ security, or risky-work boundaries.
   user explicitly asked you to post, close, merge, tag, or release.
 - Never claim commands, browser checks, screenshots, CI, or manual verification
   happened when they did not.
+- Do not submit `*.test.ts` or `*.test.tsx` files in PRs as proof. Use existing
+  checks, command output, scratch/local-only harnesses, app/browser/Tauri proof,
+  or manual verification notes instead.
 
 ## Bugfix Lane
 
@@ -109,6 +112,8 @@ Use this for code reviews, PR preparation, PR iteration, and ready-for-review ga
 - Before pushing, opening, or handing off a PR, run `pnpm check` after the final
   diff. It includes the unused-code check; if it fails, stop and report whether
   the failure is in-scope or pre-existing instead of waiting for CI to block it.
+- Do not add or carry `*.test.ts` or `*.test.tsx` files as PR proof artifacts.
+  If a local repro needs one, keep it out of the submitted diff.
 - Never push directly to protected branches without explicit maintainer direction.
 - Do not auto-check PR validation boxes. Treat them as human verification tasks.
 - After pushing, inspect CI and review feedback when asked to ship or ready a PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,6 +44,7 @@ Pressure points touched:
 ## Validation
 
 <!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
+<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->
 
 - [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
 - [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Use the tiny local bug path for narrow, low-risk, machine-provable fixes: no full ledger by default, just a short claim/proof/validation/files/risk/vault receipt. Escalate to the full workflow as soon as the bug is nontrivial, PR-affecting, cross-boundary, storage/import/export/prompt/provider/security-sensitive, browser-evidence-dependent, or uncertain.
 - Before local bugfix edits, name only the cheap gate: core claim, likely owner/lane, risk level, and proof target. Broaden the gate only after a hypothesis is falsified or a risk boundary appears.
 - Use the cheapest proof that proves the claim. Prefer static inspection, targeted tests, scratch harnesses, route/module repros, or jsdom/component proof before Playwright; use browser proof when visual layout, interaction, routing, responsive behavior, screenshots, console/network behavior, or browser-only behavior is the claim.
+- Do not submit `*.test.ts` or `*.test.tsx` files in PRs as proof. Use existing tests, scratch/local-only harnesses, command output, app/browser/Tauri proof, or manual verification notes instead.
 - When available, keep `workflow-health.mjs` for nontrivial Marinara work, PR work, issue selection, and risky workflow changes. Do not spend it on a tiny one-file local bug unless repo policy or visible risk requires it.
 
 ## Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,9 @@ This is the general pre-PR gate for line endings, architecture, TypeScript,
 Rust compile, docs, and unused-code checks. Run additional targeted proof when
 the change needs it, such as focused tests, lint, build, size checks, clippy,
 Rust tests, native Tauri QA, or browser checks.
+Do not submit `*.test.ts` or `*.test.tsx` files in a PR as proof; validation
+belongs in existing checks, command output, local-only scratch harnesses,
+app/browser/Tauri verification, or manual verification notes.
 
 Leave PR template checkboxes unchecked until a human has actually verified each item. If an AI agent drafts a PR body, treat the checkboxes as a to-do list, not as proof.
 

--- a/skills/marinara-agent-workflow/SKILL.md
+++ b/skills/marinara-agent-workflow/SKILL.md
@@ -97,6 +97,11 @@ Playwright/browser proof when visual layout, interaction, routing, responsive
 behavior, screenshots, console/network behavior, or browser-only behavior is the
 claim.
 
+Do not submit `*.test.ts` or `*.test.tsx` files in PRs as proof. Existing tests
+and local-only scratch harnesses can still inform a fix, but submitted PR proof
+must cite checks, command output, app/browser/Tauri verification, or manual
+verification notes instead.
+
 ## Risky Work
 
 Treat these as risky: storage, migrations, import/export, installers, user data, prompt assembly, provider transport, auth/secrets, destructive actions, cross-entrypoint behavior, legacy compatibility, and new abstractions.

--- a/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
+++ b/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
@@ -30,6 +30,10 @@ Before push or PR creation:
 such as focused tests, lint, build, size checks, clippy, native Tauri QA, or
 browser checks when the change needs them.
 
+Do not submit `*.test.ts` or `*.test.tsx` files as PR proof. If a repro needs
+one locally, keep it out of the submitted diff and cite the command output,
+existing checks, app/browser/Tauri proof, or manual verification notes instead.
+
 If `pnpm check` fails, do not push or mark the PR ready. Classify the failure as
 in-scope or pre-existing/unrelated, fix in-scope failures, and report unrelated
 failures clearly instead of letting CI be the first place they appear.


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- PR proof policy now needs to make clear that `*.test.ts` and `*.test.tsx` files are not submitted as proof artifacts.

## What changed

- Added the policy to root contributor guidance, workflow guidance, and PR shipping guidance.
- Added a validation note to the pull request template so submitted PRs cite checks, command output, app/runtime proof, or manual notes instead.

## Refactor impact

Primary owner:

- Repo guidance and workflow documentation

Impact areas reviewed:

- Contributor validation guidance
- Pull request template validation instructions
- Workflow and review guidance

Boundary notes:

- No engine, shared API, feature, Rust command, or remote-runtime boundaries changed.

Pressure points touched:

- None

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm check` passed.
- `git diff --check` passed.
- `pnpm check:line-endings` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Docs and workflow guidance only; no user-discoverable app behavior changed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [x] Updated `CONTRIBUTING.md`
- [x] Updated `docs/developer/`
- [x] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A