### PR TITLE
Type conversation attachment rendering

### DIFF
--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -378,6 +378,18 @@ export interface Message {
   extra: MessageExtra;
 }
 
+/** Persisted attachment rendered with a message or carried into generation. */
+export interface MessageAttachment {
+  type?: string | null;
+  url?: string | null;
+  data?: string | null;
+  filename?: string | null;
+  name?: string | null;
+  prompt?: string | null;
+  galleryId?: string | null;
+  [key: string]: unknown;
+}
+
 /** Additional data attached to a message. */
 export interface MessageExtra {
   /** Display-formatted text (may differ from raw content) */
@@ -396,6 +408,8 @@ export interface MessageExtra {
   reasoning?: string | null;
   /** Provider-shaped reasoning content from OpenAI-compatible streaming deltas. */
   reasoning_content?: string | null;
+  /** User-provided or generated attachments rendered with the message. */
+  attachments?: MessageAttachment[] | null;
   /** Per-swipe sprite expressions from the Expression Engine agent */
   spriteExpressions?: Record<string, string> | null;
   /** Per-swipe CYOA choices from the CYOA Choices agent */
@@ -404,6 +418,11 @@ export interface MessageExtra {
   personaSnapshot?: {
     personaId: string;
     name: string;
+    description?: string | null;
+    personality?: string | null;
+    backstory?: string | null;
+    appearance?: string | null;
+    scenario?: string | null;
     avatarUrl?: string | null;
     /** JSON-encoded AvatarCrop captured at send time so re-edits don't restyle past messages. */
     avatarCrop?: string | null;

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -378,6 +378,8 @@ export interface Message {
   extra: MessageExtra;
 }
 
+export type MessageAttachmentExtraValue = string | number | boolean | null | undefined;
+
 /** Persisted attachment rendered with a message or carried into generation. */
 export interface MessageAttachment {
   type?: string | null;
@@ -387,7 +389,7 @@ export interface MessageAttachment {
   name?: string | null;
   prompt?: string | null;
   galleryId?: string | null;
-  [key: string]: unknown;
+  [key: string]: MessageAttachmentExtraValue;
 }
 
 /** Additional data attached to a message. */

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -30,6 +30,10 @@ import type { CharacterMap, MessageSelectionToggle, PeekPromptOptions, PersonaIn
 import {
   GenerationReplayDetailsModal,
   hasGenerationReplayDetails,
+  isImageMessageAttachment,
+  messageAttachmentImageAlt,
+  messageAttachmentImageSource,
+  messageAttachmentsFromExtra,
   readStoredThinking,
   resolvePromptSnapshotFromExtra,
 } from "../../shared/chat-ui/index";
@@ -58,6 +62,8 @@ function nameColorStyle(color?: string): CSSProperties | undefined {
 const IMAGE_URL_RE = /^https?:\/\/\S+\.(?:gif|png|jpe?g|webp)(?:\?[^\s]*)?$/i;
 const MESSAGE_EDIT_GESTURE_IGNORE_SELECTOR =
   "button, a, textarea, input, select, label, [role='button'], [contenteditable='true'], .mari-message-actions";
+type ConversationMessageExtra = Partial<MessageExtra> & { hiddenFromAi?: unknown };
+const EMPTY_MESSAGE_EXTRA: ConversationMessageExtra = {};
 
 function HiddenFromAIConversationButton({
   canCollapse,
@@ -260,21 +266,7 @@ interface MessageData {
   content: string;
   activeSwipeIndex: number;
   swipeCount?: number;
-  extra: {
-    displayText: string | null;
-    isGenerated: boolean;
-    tokenCount: number | null;
-    generationInfo: {
-      model?: string;
-      tokensIn?: number;
-      tokensOut?: number;
-      duration?: number;
-    } | null;
-    isConversationStart?: boolean;
-    thinking?: string | null;
-    generationReplay?: MessageExtra["generationReplay"];
-    attachments?: Array<{ type: string; url: string; filename?: string; prompt?: string; galleryId?: string }>;
-  };
+  extra: ConversationMessageExtra | string;
   createdAt: string;
 }
 
@@ -363,9 +355,10 @@ export const ConversationMessage = memo(function ConversationMessage({
 
   // Parse extra early so we can access persona snapshot
   const extra = useMemo(() => {
-    if (!message.extra) return {} as Record<string, any>;
-    return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
+    if (!message.extra) return EMPTY_MESSAGE_EXTRA;
+    return typeof message.extra === "string" ? (JSON.parse(message.extra) as ConversationMessageExtra) : message.extra;
   }, [message.extra]);
+  const attachments = useMemo(() => messageAttachmentsFromExtra(extra), [extra]);
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
   const activePromptSnapshot = useMemo(
     () => resolvePromptSnapshotFromExtra(extra, message.activeSwipeIndex),
@@ -471,8 +464,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   const qc = useQueryClient();
   const handleRemoveAttachment = useCallback(
     async (index: number) => {
-      const current = (extra.attachments as any[]) ?? [];
-      const updated = current.filter((_: any, i: number) => i !== index);
+      const updated = attachments.filter((_, i) => i !== index);
       // Optimistic: update the infinite query cache immediately so the image disappears
       const msgKey = chatKeys.messages(message.chatId);
       qc.setQueryData<InfiniteData<Message[]>>(msgKey, (old) => {
@@ -493,7 +485,7 @@ export const ConversationMessage = memo(function ConversationMessage({
       });
       qc.invalidateQueries({ queryKey: msgKey });
     },
-    [extra.attachments, message.chatId, message.id, qc],
+    [attachments, message.chatId, message.id, qc],
   );
 
   // Build name→character lookup for speaker tag resolution.
@@ -885,25 +877,25 @@ export const ConversationMessage = memo(function ConversationMessage({
 
         {/* Image attachments (selfies, illustrations) */}
         {!isHiddenCollapsed &&
-          extra.attachments &&
-          extra.attachments.length > 0 &&
+          attachments.length > 0 &&
           !IMAGE_URL_RE.test(renderedContent.trim()) && (
             <div className="ml-14 mt-1.5 flex flex-col items-start gap-2">
-              {extra.attachments.map((att: any, i: number) =>
-                att.type === "image" || att.type?.startsWith("image/") ? (
+              {attachments.map((att, i) => {
+                const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
+                return imageSource ? (
                   <div key={i} className="group/att relative inline-block">
                     <button
                       type="button"
                       onClick={(e) => {
                         e.stopPropagation();
-                        setImageLightbox({ url: att.url || att.data, prompt: att.prompt });
+                        setImageLightbox({ url: imageSource, prompt: att.prompt });
                       }}
                       className="block cursor-zoom-in rounded-lg text-left"
                       title="Open image"
                     >
                       <img
-                        src={att.url || att.data}
-                        alt={att.filename || att.name || "image"}
+                        src={imageSource}
+                        alt={messageAttachmentImageAlt(att)}
                         className="max-h-80 max-w-full rounded-lg"
                         loading="lazy"
                       />
@@ -916,8 +908,8 @@ export const ConversationMessage = memo(function ConversationMessage({
                       <X size="0.875rem" />
                     </button>
                   </div>
-                ) : null,
-              )}
+                ) : null;
+              })}
             </div>
           )}
 
@@ -1203,25 +1195,25 @@ export const ConversationMessage = memo(function ConversationMessage({
 
         {/* Image attachments (selfies, illustrations) — skip when content is already an image URL */}
         {!isHiddenCollapsed &&
-          extra.attachments &&
-          extra.attachments.length > 0 &&
+          attachments.length > 0 &&
           !IMAGE_URL_RE.test(renderedContent.trim()) && (
             <div className="mt-1.5 flex flex-col items-center gap-2">
-              {extra.attachments.map((att: any, i: number) =>
-                att.type === "image" || att.type?.startsWith("image/") ? (
+              {attachments.map((att, i) => {
+                const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
+                return imageSource ? (
                   <div key={i} className="group/att relative inline-block">
                     <button
                       type="button"
                       onClick={(e) => {
                         e.stopPropagation();
-                        setImageLightbox({ url: att.url || att.data, prompt: att.prompt });
+                        setImageLightbox({ url: imageSource, prompt: att.prompt });
                       }}
                       className="block cursor-zoom-in rounded-lg text-left"
                       title="Open image"
                     >
                       <img
-                        src={att.url || att.data}
-                        alt={att.filename || att.name || "image"}
+                        src={imageSource}
+                        alt={messageAttachmentImageAlt(att)}
                         className="max-h-80 max-w-full rounded-lg"
                         loading="lazy"
                       />
@@ -1234,8 +1226,8 @@ export const ConversationMessage = memo(function ConversationMessage({
                       <X size="0.875rem" />
                     </button>
                   </div>
-                ) : null,
-              )}
+                ) : null;
+              })}
             </div>
           )}
 

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -33,7 +33,7 @@ import {
   Pause,
   Play,
 } from "lucide-react";
-import type { Message, MessageSwipe } from "../../../../../engine/contracts/types/chat";
+import type { Message, MessageExtra, MessageSwipe } from "../../../../../engine/contracts/types/chat";
 import {
   memo,
   useState,
@@ -77,12 +77,20 @@ import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./Gene
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import { SwipeJumpControl } from "./SwipeJumpControl";
 import { readStoredThinking } from "../lib/message-thinking";
+import {
+  isImageMessageAttachment,
+  messageAttachmentImageAlt,
+  messageAttachmentImageSource,
+  messageAttachmentsFromExtra,
+} from "../lib/message-attachments";
 import { resolvePromptSnapshotFromExtra } from "../lib/prompt-snapshot";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
 const MESSAGE_EDIT_GESTURE_IGNORE_SELECTOR =
   "button, a, textarea, input, select, label, [role='button'], [contenteditable='true'], .mari-message-actions";
+type ChatMessageExtra = Partial<MessageExtra> & { hiddenFromAi?: unknown };
+const EMPTY_CHAT_MESSAGE_EXTRA: ChatMessageExtra = {};
 
 function formatEditableMessageText(value: string, quoteFormat: QuoteFormat): string {
   return formatTextQuotes(value, quoteFormat);
@@ -1136,9 +1144,12 @@ export const ChatMessage = memo(function ChatMessage({
   }, [showActions]);
 
   // Parse message extra for conversation start flag
-  const extra = useMemo<Record<string, any>>(() => {
-    return message.extra && typeof message.extra === "object" && !Array.isArray(message.extra) ? message.extra : {};
+  const extra = useMemo<ChatMessageExtra>(() => {
+    return message.extra && typeof message.extra === "object" && !Array.isArray(message.extra)
+      ? (message.extra as ChatMessageExtra)
+      : EMPTY_CHAT_MESSAGE_EXTRA;
   }, [message.extra]);
+  const attachments = useMemo(() => messageAttachmentsFromExtra(extra), [extra]);
   const isConversationStart = !!extra.isConversationStart;
   const isHiddenFromAI = extra.hiddenFromAI === true || extra.hiddenFromAi === true;
   const thinking = readStoredThinking(extra);
@@ -1172,8 +1183,7 @@ export const ChatMessage = memo(function ChatMessage({
   const qc = useQueryClient();
   const handleRemoveAttachment = useCallback(
     async (index: number) => {
-      const current = (extra.attachments as any[]) ?? [];
-      const updated = current.filter((_: any, i: number) => i !== index);
+      const updated = attachments.filter((_, i) => i !== index);
       // Optimistic: update the infinite query cache immediately so the image disappears
       const msgKey = chatKeys.messages(message.chatId);
       qc.setQueryData<InfiniteData<Message[]>>(msgKey, (old) => {
@@ -1194,7 +1204,7 @@ export const ChatMessage = memo(function ChatMessage({
       });
       qc.invalidateQueries({ queryKey: msgKey });
     },
-    [extra.attachments, message.chatId, message.id, qc],
+    [attachments, message.chatId, message.id, qc],
   );
 
   const genLabel = useMemo(
@@ -1409,9 +1419,9 @@ export const ChatMessage = memo(function ChatMessage({
         }
       : personaInfo
     : charInfo;
-  const dialogueColor = msgColors?.dialogueColor;
-  const boxBgColor = msgColors?.boxColor;
-  const msgNameColor = msgColors?.nameColor;
+  const dialogueColor = msgColors?.dialogueColor ?? undefined;
+  const boxBgColor = msgColors?.boxColor ?? undefined;
+  const msgNameColor = msgColors?.nameColor ?? undefined;
   const roleplayBubbleBg = boxBgColor ? boxBgColor : isUser ? userBubbleBg : assistantBubbleBg;
 
   // Build speaker → dialogueColor map for group chat speaker tag coloring
@@ -2058,21 +2068,22 @@ export const ChatMessage = memo(function ChatMessage({
             </div>
 
             {/* Image attachments (illustrations, selfies) */}
-            {!editing && extra.attachments?.length > 0 && !IMAGE_URL_RE.test(message.content.trim()) && (
+            {!editing && attachments.length > 0 && !IMAGE_URL_RE.test(message.content.trim()) && (
               <div className="mt-1.5 flex flex-col items-center gap-2 px-3 pb-2">
-                {extra.attachments.map((att: any, i: number) =>
-                  att.type === "image" || att.type?.startsWith("image/") ? (
+                {attachments.map((att, i) => {
+                  const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
+                  return imageSource ? (
                     <div key={i} className="group/att relative inline-block">
                       <button
                         type="button"
-                        onClick={() => openImageLightbox(att.url || att.data, att.prompt)}
+                        onClick={() => openImageLightbox(imageSource, att.prompt)}
                         className="block"
                         title="Open image"
-                        aria-label={`Open ${att.filename || att.name || "image"}`}
+                        aria-label={`Open ${messageAttachmentImageAlt(att)}`}
                       >
                         <img
-                          src={att.url || att.data}
-                          alt={att.filename || att.name || "image"}
+                          src={imageSource}
+                          alt={messageAttachmentImageAlt(att)}
                           className="max-h-80 max-w-full rounded-lg"
                           loading="lazy"
                           decoding="async"
@@ -2088,8 +2099,8 @@ export const ChatMessage = memo(function ChatMessage({
                         <X size="0.875rem" />
                       </button>
                     </div>
-                  ) : null,
-                )}
+                  ) : null;
+                })}
               </div>
             )}
 
@@ -2498,21 +2509,22 @@ export const ChatMessage = memo(function ChatMessage({
           </div>
 
           {/* Image attachments (illustrations, selfies) */}
-          {!editing && extra.attachments?.length > 0 && !IMAGE_URL_RE.test(message.content.trim()) && (
+          {!editing && attachments.length > 0 && !IMAGE_URL_RE.test(message.content.trim()) && (
             <div className="mt-1.5 flex flex-col items-center gap-2 px-3 pb-2">
-              {extra.attachments.map((att: any, i: number) =>
-                att.type === "image" || att.type?.startsWith("image/") ? (
+              {attachments.map((att, i) => {
+                const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
+                return imageSource ? (
                   <div key={i} className="group/att relative inline-block">
                     <button
                       type="button"
-                      onClick={() => openImageLightbox(att.url || att.data, att.prompt)}
+                      onClick={() => openImageLightbox(imageSource, att.prompt)}
                       className="block"
                       title="Open image"
-                      aria-label={`Open ${att.filename || att.name || "image"}`}
+                      aria-label={`Open ${messageAttachmentImageAlt(att)}`}
                     >
                       <img
-                        src={att.url || att.data}
-                        alt={att.filename || att.name || "image"}
+                        src={imageSource}
+                        alt={messageAttachmentImageAlt(att)}
                         className="max-h-80 max-w-full rounded-lg"
                         loading="lazy"
                         decoding="async"
@@ -2528,8 +2540,8 @@ export const ChatMessage = memo(function ChatMessage({
                       <X size="0.875rem" />
                     </button>
                   </div>
-                ) : null,
-              )}
+                ) : null;
+              })}
             </div>
           )}
 

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -27,4 +27,5 @@ export * from "./hooks/use-chat-tts-autoplay";
 export * from "./hooks/use-streaming-tts";
 export * from "./hooks/use-sprite-metadata-state";
 export * from "./lib/message-thinking";
+export * from "./lib/message-attachments";
 export * from "./lib/prompt-snapshot";

--- a/src/features/modes/shared/chat-ui/lib/message-attachments.test.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-attachments.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { messageAttachmentsFromExtra } from "./message-attachments";
+
+describe("messageAttachmentsFromExtra", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps records with known attachment fields and scalar extension fields", () => {
+    expect(
+      messageAttachmentsFromExtra({
+        attachments: [{ type: "image", url: "data:image/png;base64,abc", width: 512, pinned: true }],
+      }),
+    ).toEqual([{ type: "image", url: "data:image/png;base64,abc", width: 512, pinned: true }]);
+  });
+
+  it("drops malformed attachment entries and reports the count", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(
+      messageAttachmentsFromExtra({
+        attachments: [null, "image", {}, { type: 42 }, { type: "image", metadata: { width: 512 } }],
+      }),
+    ).toEqual([]);
+    expect(warn).toHaveBeenCalledWith("[chat-ui] Dropped malformed message attachment(s)", {
+      dropped: 5,
+      total: 5,
+    });
+  });
+
+  it("reports non-array attachment payloads without logging the payload contents", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(messageAttachmentsFromExtra({ attachments: "private-data" })).toEqual([]);
+    expect(warn).toHaveBeenCalledWith("[chat-ui] Ignored malformed message attachments payload", {
+      reason: "not-array",
+    });
+  });
+});

--- a/src/features/modes/shared/chat-ui/lib/message-attachments.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-attachments.ts
@@ -1,0 +1,27 @@
+import type { MessageAttachment } from "../../../../../engine/contracts/types/chat";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isMessageAttachment(value: unknown): value is MessageAttachment {
+  return isRecord(value);
+}
+
+export function messageAttachmentsFromExtra(extra: { attachments?: unknown } | null | undefined): MessageAttachment[] {
+  return Array.isArray(extra?.attachments) ? extra.attachments.filter(isMessageAttachment) : [];
+}
+
+export function isImageMessageAttachment(attachment: MessageAttachment): boolean {
+  return attachment.type === "image" || attachment.type?.startsWith("image/") === true;
+}
+
+export function messageAttachmentImageSource(attachment: MessageAttachment): string | null {
+  const source = attachment.url ?? attachment.data;
+  return typeof source === "string" && source.length > 0 ? source : null;
+}
+
+export function messageAttachmentImageAlt(attachment: MessageAttachment): string {
+  const alt = attachment.filename ?? attachment.name;
+  return typeof alt === "string" && alt.trim().length > 0 ? alt : "image";
+}

--- a/src/features/modes/shared/chat-ui/lib/message-attachments.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-attachments.ts
@@ -1,15 +1,54 @@
-import type { MessageAttachment } from "../../../../../engine/contracts/types/chat";
+import type { MessageAttachment, MessageAttachmentExtraValue } from "../../../../../engine/contracts/types/chat";
+
+const MESSAGE_ATTACHMENT_KEYS = ["type", "url", "data", "filename", "name", "prompt", "galleryId"] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function hasOwnKey(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function isKnownAttachmentValue(value: unknown): value is string | null | undefined {
+  return value == null || typeof value === "string";
+}
+
+function isAttachmentExtraValue(value: unknown): value is MessageAttachmentExtraValue {
+  return value == null || ["string", "number", "boolean"].includes(typeof value);
+}
+
+function hasKnownAttachmentField(record: Record<string, unknown>): boolean {
+  return MESSAGE_ATTACHMENT_KEYS.some((key) => hasOwnKey(record, key) && isKnownAttachmentValue(record[key]));
+}
+
+function hasValidKnownAttachmentFields(record: Record<string, unknown>): boolean {
+  return MESSAGE_ATTACHMENT_KEYS.every((key) => !hasOwnKey(record, key) || isKnownAttachmentValue(record[key]));
+}
+
 function isMessageAttachment(value: unknown): value is MessageAttachment {
-  return isRecord(value);
+  return (
+    isRecord(value) &&
+    hasKnownAttachmentField(value) &&
+    hasValidKnownAttachmentFields(value) &&
+    Object.values(value).every(isAttachmentExtraValue)
+  );
 }
 
 export function messageAttachmentsFromExtra(extra: { attachments?: unknown } | null | undefined): MessageAttachment[] {
-  return Array.isArray(extra?.attachments) ? extra.attachments.filter(isMessageAttachment) : [];
+  const attachments = extra?.attachments;
+  if (attachments == null) return [];
+  if (!Array.isArray(attachments)) {
+    console.warn("[chat-ui] Ignored malformed message attachments payload", { reason: "not-array" });
+    return [];
+  }
+
+  const valid = attachments.filter(isMessageAttachment);
+  const dropped = attachments.length - valid.length;
+  if (dropped > 0) {
+    console.warn("[chat-ui] Dropped malformed message attachment(s)", { dropped, total: attachments.length });
+  }
+  return valid;
 }
 
 export function isImageMessageAttachment(attachment: MessageAttachment): boolean {


### PR DESCRIPTION
## Linked issue

N/A - local chore from the explicit-any cleanup queue.

## Why this change

- Remove attachment-related explicit `any` usage from conversation and shared chat message rendering.
- Make persisted message attachment data visible in the chat message contract.

## What changed

- Added a `MessageAttachment` contract and typed `MessageExtra.attachments`.
- Added shared chat-ui attachment helpers for reading image sources and alt text.
- Updated conversation and shared chat message renderers to use typed attachment arrays for rendering, lightbox open, and removal.

## Refactor impact

Primary owner:

- Shared chat UI and conversation message UI.

Impact areas reviewed:

- Conversation message rendering.
- Shared chat message rendering.
- Message extra contract shape.
- Shared chat-ui public exports.

Boundary notes:

- Engine contract now names the persisted attachment shape.
- Feature UI continues to use `storageApi.patchChatMessageExtra` for attachment removal.
- No Tauri, Rust storage implementation, remote runtime, or generation behavior changes.

Pressure points touched:

- Shared mode UI.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm check` passed locally. This includes line endings, architecture, frontend typecheck, Rust check, docs, discovery metadata, and unused-code checks.
- Target explicit-any grep for `ConversationMessage.tsx` and `ChatMessage.tsx` returned no hits.
- No browser or Tauri manual QA was run; this is type cleanup around existing attachment rendering.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this is internal type cleanup for existing message attachment rendering.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not added; no visual behavior change claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced message attachments with metadata support
  * Expanded persona context capture including personality, backstory, appearance, and scenario details
  * Improved attachment handling and display across chat modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->