### PR TITLE
Restore character legacy parity behavior

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -1,4 +1,6 @@
-use super::media_uploads::{persist_image_upload, remove_managed_record_file, safe_filename};
+use super::media_uploads::{
+    managed_record_file_path, persist_image_upload, remove_managed_record_file, safe_filename,
+};
 use super::*;
 
 pub(crate) fn update_character_avatar(
@@ -16,7 +18,7 @@ pub(crate) fn update_character_avatar(
         "avatar",
     )?;
     if collection == "characters" {
-        let snapshot_record = character_avatar_snapshot_record(&previous);
+        let snapshot_record = character_avatar_snapshot_record(state, collection, &previous);
         super::characters::create_character_version_snapshot_from_record(
             state,
             id,
@@ -40,10 +42,72 @@ pub(crate) fn update_character_avatar(
     Ok(updated)
 }
 
-fn character_avatar_snapshot_record(record: &Value) -> Value {
+pub(crate) fn remove_character_avatar(state: &AppState, id: &str) -> AppResult<Value> {
+    let previous = shared::get_required(state, "characters", id)?;
+    let patch = character_avatar_remove_patch(&previous)?;
+    if patch.is_empty() {
+        return Ok(previous);
+    }
+
+    let snapshot_record = character_avatar_snapshot_record(state, "characters", &previous);
+    super::characters::create_character_version_snapshot_from_record(
+        state,
+        id,
+        &snapshot_record,
+        "manual",
+        "Avatar removal",
+    )?;
+    let updated = state
+        .storage
+        .patch("characters", id, Value::Object(patch))?;
+    remove_avatar_file(state, "characters", &previous);
+    Ok(updated)
+}
+
+fn character_avatar_remove_patch(record: &Value) -> AppResult<Map<String, Value>> {
+    let mut patch = Map::new();
+    for field in [
+        "avatar",
+        "avatarPath",
+        "avatarFilePath",
+        "avatarFilename",
+        "avatarUpdatedAt",
+    ] {
+        if record.get(field).is_some_and(|value| !value.is_null()) {
+            patch.insert(field.to_string(), Value::Null);
+        }
+    }
+    if let Some(data) = character_data_without_avatar_crop(record)? {
+        patch.insert("data".to_string(), data);
+    }
+    Ok(patch)
+}
+
+fn character_data_without_avatar_crop(record: &Value) -> AppResult<Option<Value>> {
+    let Some(data) = record.get("data") else {
+        return Ok(None);
+    };
+    let mut data = shared::normalize_character_data_for_storage(data)?;
+    let Some(data_object) = data.as_object_mut() else {
+        unreachable!("character data normalizer only returns objects");
+    };
+    let Some(extensions) = data_object
+        .get_mut("extensions")
+        .and_then(Value::as_object_mut)
+    else {
+        return Ok(None);
+    };
+    if extensions.remove("avatarCrop").is_some() {
+        Ok(Some(data))
+    } else {
+        Ok(None)
+    }
+}
+
+fn character_avatar_snapshot_record(state: &AppState, collection: &str, record: &Value) -> Value {
     let mut snapshot = record.clone();
     if let Some(object) = snapshot.as_object_mut() {
-        if let Some(data_url) = managed_avatar_data_url(record) {
+        if let Some(data_url) = managed_avatar_data_url(state, collection, record) {
             object.insert("avatar".to_string(), Value::String(data_url.clone()));
             object.insert("avatarPath".to_string(), Value::String(data_url));
         }
@@ -53,18 +117,22 @@ fn character_avatar_snapshot_record(record: &Value) -> Value {
     snapshot
 }
 
-fn managed_avatar_data_url(record: &Value) -> Option<String> {
-    let path = record.get("avatarFilePath").and_then(Value::as_str)?;
-    let bytes = fs::read(path).ok()?;
+fn managed_avatar_data_url(state: &AppState, collection: &str, record: &Value) -> Option<String> {
+    let path = managed_record_file_path(
+        state,
+        &format!("avatars/{}", safe_filename(collection)),
+        record,
+        "avatarFilePath",
+        "avatarFilename",
+    )
+    .ok()
+    .flatten()?;
+    let bytes = fs::read(&path).ok()?;
     let mime = avatar_mime_type(
         record
             .get("avatarFilename")
             .and_then(Value::as_str)
-            .or_else(|| {
-                std::path::Path::new(path)
-                    .file_name()
-                    .and_then(|value| value.to_str())
-            }),
+            .or_else(|| path.file_name().and_then(|value| value.to_str())),
     );
     Some(format!(
         "data:{mime};base64,{}",

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -1,3 +1,4 @@
+use super::media_uploads::{managed_record_file_path, persist_image_file_copy};
 use super::shared::*;
 use super::*;
 
@@ -157,6 +158,7 @@ pub(crate) fn restore_character_version(
 
 pub(crate) fn duplicate_character(state: &AppState, character_id: &str) -> AppResult<Value> {
     let mut record = get_required(state, "characters", character_id)?;
+    let duplicate_avatar = duplicate_managed_character_avatar(state, character_id, &record)?;
     let object = record
         .as_object_mut()
         .ok_or_else(|| AppError::invalid_input("Record is not an object"))?;
@@ -166,7 +168,75 @@ pub(crate) fn duplicate_character(state: &AppState, character_id: &str) -> AppRe
             data.insert("name".to_string(), Value::String(format!("{name} (Copy)")));
         }
     }
+    match duplicate_avatar {
+        DuplicateAvatar::Copied {
+            asset_url,
+            absolute_path,
+            filename,
+        } => {
+            if object.contains_key("avatar") {
+                object.insert("avatar".to_string(), Value::String(asset_url.clone()));
+            }
+            object.insert("avatarPath".to_string(), Value::String(asset_url));
+            object.insert("avatarFilePath".to_string(), Value::String(absolute_path));
+            object.insert("avatarFilename".to_string(), Value::String(filename));
+        }
+        DuplicateAvatar::MissingManagedMetadata => {
+            object.insert("avatarFilePath".to_string(), Value::Null);
+            object.insert("avatarFilename".to_string(), Value::Null);
+        }
+        DuplicateAvatar::None => {}
+    }
     state.storage.create("characters", record)
+}
+
+enum DuplicateAvatar {
+    Copied {
+        asset_url: String,
+        absolute_path: String,
+        filename: String,
+    },
+    MissingManagedMetadata,
+    None,
+}
+
+fn duplicate_managed_character_avatar(
+    state: &AppState,
+    character_id: &str,
+    record: &Value,
+) -> AppResult<DuplicateAvatar> {
+    let avatar_path = managed_record_file_path(
+        state,
+        "avatars/characters",
+        record,
+        "avatarFilePath",
+        "avatarFilename",
+    )?;
+    let Some(avatar_path) = avatar_path else {
+        return Ok(if has_managed_avatar_metadata(record) {
+            DuplicateAvatar::MissingManagedMetadata
+        } else {
+            DuplicateAvatar::None
+        });
+    };
+
+    let filename_hint = record
+        .get("avatarFilename")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(character_id);
+    let stored = persist_image_file_copy(state, "avatars/characters", filename_hint, &avatar_path)?;
+    Ok(DuplicateAvatar::Copied {
+        asset_url: stored.asset_url,
+        absolute_path: stored.absolute_path,
+        filename: stored.filename,
+    })
+}
+
+fn has_managed_avatar_metadata(record: &Value) -> bool {
+    ["avatarFilePath", "avatarFilename"]
+        .iter()
+        .any(|field| record.get(*field).is_some_and(|value| !value.is_null()))
 }
 
 fn take_version_snapshot_options(
@@ -258,6 +328,7 @@ fn non_empty_or_default(value: &str, fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn test_state(label: &str) -> AppState {
@@ -300,6 +371,68 @@ mod tests {
             .storage
             .list("character-versions")
             .expect("versions should list")
+    }
+
+    #[test]
+    fn duplicate_character_copies_managed_avatar_file() {
+        let state = test_state("duplicate-avatar");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let source_path = avatar_dir.join("rina.png");
+        std::fs::write(&source_path, b"avatar bytes").expect("source avatar should be written");
+        let source_path_string = source_path.to_string_lossy().to_string();
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Original description",
+                        "tags": [],
+                        "character_version": "1.0"
+                    },
+                    "comment": "Original title",
+                    "avatar": "http://asset.localhost/rina.png",
+                    "avatarPath": "http://asset.localhost/rina.png",
+                    "avatarFilePath": source_path_string,
+                    "avatarFilename": "rina.png"
+                }),
+            )
+            .expect("character should be created");
+
+        let duplicate = duplicate_character(&state, "char-1").expect("character should duplicate");
+        let duplicate_path = PathBuf::from(
+            duplicate
+                .get("avatarFilePath")
+                .and_then(Value::as_str)
+                .expect("duplicate should have cloned avatar path"),
+        );
+
+        assert_ne!(duplicate["id"], "char-1");
+        assert_eq!(duplicate["data"]["name"], "Rina (Copy)");
+        assert_ne!(duplicate_path, source_path);
+        assert_eq!(
+            std::fs::read(&duplicate_path).expect("duplicate avatar should exist"),
+            b"avatar bytes".to_vec()
+        );
+        assert_eq!(
+            std::fs::read(&source_path).expect("source avatar should still exist"),
+            b"avatar bytes".to_vec()
+        );
+
+        super::super::avatars::remove_avatar_file(&state, "characters", &duplicate);
+
+        assert!(
+            !duplicate_path.exists(),
+            "removing the duplicate avatar should delete only the duplicate file"
+        );
+        assert!(
+            source_path.exists(),
+            "removing the duplicate avatar must not delete the original file"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -155,6 +155,20 @@ pub(crate) fn restore_character_version(
         .patch("characters", character_id, Value::Object(patch))
 }
 
+pub(crate) fn duplicate_character(state: &AppState, character_id: &str) -> AppResult<Value> {
+    let mut record = get_required(state, "characters", character_id)?;
+    let object = record
+        .as_object_mut()
+        .ok_or_else(|| AppError::invalid_input("Record is not an object"))?;
+    object.remove("id");
+    if let Some(data) = object.get_mut("data").and_then(Value::as_object_mut) {
+        if let Some(name) = data.get("name").and_then(Value::as_str).map(str::to_string) {
+            data.insert("name".to_string(), Value::String(format!("{name} (Copy)")));
+        }
+    }
+    state.storage.create("characters", record)
+}
+
 fn take_version_snapshot_options(
     patch: &mut Map<String, Value>,
 ) -> CharacterVersionSnapshotOptions {

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -414,9 +414,16 @@ pub async fn storage_duplicate(
     id: String,
 ) -> Result<Value, AppError> {
     let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || shared::duplicate_record(&state, &entity, &id))
+    tauri::async_runtime::spawn_blocking(move || duplicate_entity(&state, &entity, &id))
         .await
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
+}
+
+fn duplicate_entity(state: &AppState, entity: &str, id: &str) -> Result<Value, AppError> {
+    if entity == "characters" {
+        return characters::duplicate_character(state, id);
+    }
+    shared::duplicate_record(state, entity, id)
 }
 
 fn compare_json_values(left: Option<&Value>, right: Option<&Value>) -> std::cmp::Ordering {

--- a/src-tauri/src/commands/storage/commands/media.rs
+++ b/src-tauri/src/commands/storage/commands/media.rs
@@ -201,6 +201,11 @@ pub fn character_avatar_upload(
 }
 
 #[tauri::command]
+pub fn character_avatar_remove(state: State<'_, AppState>, id: String) -> Result<Value, AppError> {
+    avatars::remove_character_avatar(&state, &id)
+}
+
+#[tauri::command]
 pub fn character_restore_version(
     state: State<'_, AppState>,
     character_id: String,

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -168,7 +168,7 @@ pub(crate) fn remove_managed_record_file(
     }
 }
 
-fn managed_record_file_path(
+pub(crate) fn managed_record_file_path(
     state: &AppState,
     folder: &str,
     record: &Value,
@@ -176,25 +176,28 @@ fn managed_record_file_path(
     filename_key: &str,
 ) -> AppResult<Option<PathBuf>> {
     let managed_dir = state.data_dir.join(folder);
-    let candidate = record
+    if let Some(path) = record
+        .get(path_key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        return managed_file_candidate(PathBuf::from(path), &managed_dir);
+    }
+    let Some(filename) = record
         .get(filename_key)
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
-        .map(|filename| managed_dir.join(safe_filename(filename)))
-        .or_else(|| {
-            record
-                .get(path_key)
-                .and_then(Value::as_str)
-                .filter(|value| !value.trim().is_empty())
-                .map(PathBuf::from)
-        });
-    let Some(candidate) = candidate else {
+    else {
         return Ok(None);
     };
+    managed_file_candidate(managed_dir.join(safe_filename(filename)), &managed_dir)
+}
+
+fn managed_file_candidate(candidate: PathBuf, managed_dir: &Path) -> AppResult<Option<PathBuf>> {
     if !candidate.exists() {
         return Ok(None);
     }
-    if !is_path_inside_dir(&candidate, &managed_dir)? {
+    if !is_path_inside_dir(&candidate, managed_dir)? {
         return Ok(None);
     }
     Ok(Some(candidate))

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -678,6 +678,9 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             required_string(&args, "id")?,
             optional_value(&args, "body"),
         ),
+        "character_avatar_remove" => {
+            avatars::remove_character_avatar(state, required_string(&args, "id")?)
+        }
         "character_restore_version" => characters::restore_character_version(
             state,
             required_string(&args, "characterId")?,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -254,6 +254,7 @@ pub fn run() {
             storage_commands::media_commands::connection_save_default_parameters,
             storage_commands::media_commands::persona_activate,
             storage_commands::media_commands::character_avatar_upload,
+            storage_commands::media_commands::character_avatar_remove,
             storage_commands::media_commands::character_restore_version,
             storage_commands::media_commands::persona_avatar_upload,
             storage_commands::media_commands::npc_avatar_upload,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -62,7 +62,14 @@ export interface GenerationCharacterContext {
   mesExample?: string;
   firstMes?: string;
   postHistoryInstructions?: string;
+  depthPrompt?: GenerationCharacterDepthPrompt;
   tags: string[];
+}
+
+interface GenerationCharacterDepthPrompt {
+  prompt: string;
+  depth: number;
+  role: "system" | "user" | "assistant";
 }
 
 export interface GenerationPersonaContext {
@@ -237,7 +244,30 @@ function loadCharacterContext(record: JsonRecord): GenerationCharacterContext {
     firstMes: field(data, "first_mes") || field(data, "firstMes") || undefined,
     postHistoryInstructions:
       field(data, "post_history_instructions") || field(data, "postHistoryInstructions") || undefined,
+    depthPrompt: characterDepthPrompt(data, extensions),
     tags: stringArray(data.tags ?? record.tags),
+  };
+}
+
+function normalizeDepthPromptRole(value: unknown): "system" | "user" | "assistant" {
+  return value === "user" || value === "assistant" ? value : "system";
+}
+
+function normalizeDepthPromptDepth(value: unknown): number {
+  return Math.max(0, Math.floor(readNumber(value, 4)));
+}
+
+function characterDepthPrompt(data: JsonRecord, extensions: JsonRecord): GenerationCharacterDepthPrompt | undefined {
+  const promptValue = extensions.depth_prompt ?? data.depth_prompt;
+  const depthPrompt = parseRecord(promptValue);
+  const objectPrompt = readString(depthPrompt.prompt).trim();
+  const stringPrompt = typeof promptValue === "string" ? promptValue.trim() : "";
+  const prompt = cleanPromptText(objectPrompt || stringPrompt);
+  if (!prompt) return undefined;
+  return {
+    prompt,
+    depth: normalizeDepthPromptDepth(depthPrompt.depth ?? extensions.depth_prompt_depth ?? data.depth_prompt_depth),
+    role: normalizeDepthPromptRole(depthPrompt.role ?? extensions.depth_prompt_role ?? data.depth_prompt_role),
   };
 }
 
@@ -1633,6 +1663,21 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
   let expectedRole: "user" | "assistant" = "user";
   for (; index < messages.length; index += 1) {
     const message = messages[index]!;
+    if (message.contextKind === "injection") {
+      const previous = result[result.length - 1];
+      if (message.role !== "system" && previous?.role === message.role) {
+        mergeIntoPreviousPromptMessage(previous, message);
+        continue;
+      }
+
+      result.push(message);
+      expectedRole = message.role === "assistant" ? "user" : "assistant";
+      if (message.role === "system") {
+        expectedRole = "user";
+      }
+      continue;
+    }
+
     if (message.role === "system") {
       result.push(message);
       expectedRole = "user";
@@ -1679,6 +1724,55 @@ function authorNotesDepthEntry(chat: JsonRecord): { content: string; role: "syst
   if (!content) return null;
   const depth = Math.max(0, readNumber(meta.authorNotesDepth, 4));
   return { content, role: "system", depth };
+}
+
+function macroProfileForCharacter(
+  character: GenerationCharacterContext,
+): NonNullable<MacroContext["characterProfiles"]>[number] {
+  return {
+    name: character.name,
+    description: character.description,
+    personality: character.personality,
+    backstory: character.backstory,
+    appearance: character.appearance,
+    scenario: character.scenario,
+    example: character.mesExample,
+    systemPrompt: character.systemPrompt,
+    postHistoryInstructions: character.postHistoryInstructions,
+  };
+}
+
+function macroContextForCharacter(base: MacroContext, character: GenerationCharacterContext): MacroContext {
+  const profile = macroProfileForCharacter(character);
+  return {
+    ...base,
+    char: character.name,
+    characters: [character.name],
+    characterProfiles: [profile],
+    characterFields: {
+      description: character.description,
+      personality: character.personality,
+      backstory: character.backstory,
+      appearance: character.appearance,
+      scenario: character.scenario,
+      example: character.mesExample,
+      systemPrompt: character.systemPrompt,
+      postHistoryInstructions: character.postHistoryInstructions,
+    },
+  };
+}
+
+function characterDepthPromptEntries(
+  characters: GenerationCharacterContext[],
+  macros: MacroContext,
+): Array<{ content: string; role: "system" | "user" | "assistant"; depth: number }> {
+  return characters.flatMap((character) => {
+    const depthPrompt = character.depthPrompt;
+    if (!depthPrompt) return [];
+    const content = cleanPromptText(resolveMacros(depthPrompt.prompt, macroContextForCharacter(macros, character)));
+    if (!content.trim()) return [];
+    return [{ content, role: depthPrompt.role, depth: depthPrompt.depth }];
+  });
 }
 
 function sectionContent(args: {
@@ -1901,9 +1995,13 @@ export async function assembleGenerationPrompt(
   ]);
 
   const authorNotesEntry = authorNotesDepthEntry(input.chat);
+  const characterDepthEntries =
+    chatMode === "game" ? [] : characterDepthPromptEntries(promptCharacters, macros);
   messages = injectAtDepth(
     messages,
-    authorNotesEntry ? [...processedLore.depthEntries, authorNotesEntry] : processedLore.depthEntries,
+    authorNotesEntry
+      ? [...processedLore.depthEntries, ...characterDepthEntries, authorNotesEntry]
+      : [...processedLore.depthEntries, ...characterDepthEntries],
   );
   const regexScripts = await storage.list<JsonRecord>("regex-scripts");
   applyRegexScriptsToPromptMessages(messages, regexScripts, {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1671,10 +1671,7 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
       }
 
       result.push(message);
-      expectedRole = message.role === "assistant" ? "user" : "assistant";
-      if (message.role === "system") {
-        expectedRole = "user";
-      }
+      expectedRole = message.role === "user" ? "assistant" : "user";
       continue;
     }
 

--- a/src/features/catalog/characters/components/CharacterEditor.test.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../hooks/use-characters", () => {
     useCharacter: vi.fn(),
     useUpdateCharacter: noopMutation,
     useUploadAvatar: noopMutation,
+    useRemoveAvatar: noopMutation,
     useDeleteCharacter: noopMutation,
     useDuplicateCharacter: noopMutation,
     useCharacterGalleryImages: emptyQuery,

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -104,6 +104,7 @@ export function CharacterEditor() {
     avatarUploading,
     handleAvatarUpload,
     handleGeneratedAvatar,
+    handleRemoveAvatar: removeAvatar,
     isAvatarUploadInFlight,
     setAvatarPreview,
   } = useCharacterEditorAvatar({
@@ -139,7 +140,7 @@ export function CharacterEditor() {
   const handleSave = async () => {
     if (!characterId || !formData) return false;
     if (isAvatarUploadInFlight()) {
-      toast.error("Wait for the current avatar upload to finish before saving.");
+      toast.error("Wait for the current avatar change to finish before saving.");
       return false;
     }
     setSaving(true);
@@ -179,9 +180,24 @@ export function CharacterEditor() {
     closeDetail();
   };
 
+  const handleRemoveAvatar = async () => {
+    if (!avatarPreview && formData?.extensions.avatarCrop === undefined) return;
+    if (
+      !(await showConfirmDialog({
+        title: "Remove Avatar",
+        message: "Remove this character's avatar?",
+        confirmLabel: "Remove",
+        tone: "destructive",
+      }))
+    ) {
+      return;
+    }
+    await removeAvatar();
+  };
+
   const handleClose = useCallback(() => {
     if (avatarUploading) {
-      toast.error("Wait for the current avatar upload to finish.");
+      toast.error("Wait for the current avatar change to finish.");
       return;
     }
     if (dirty) {
@@ -193,7 +209,7 @@ export function CharacterEditor() {
 
   const forceClose = useCallback(() => {
     if (avatarUploading) {
-      toast.error("Wait for the current avatar upload to finish.");
+      toast.error("Wait for the current avatar change to finish.");
       return;
     }
     setShowUnsavedWarning(false);
@@ -290,6 +306,7 @@ export function CharacterEditor() {
         onGenerateAvatar={() => setAvatarGeneratorOpen(true)}
         onImportAsPersona={handleImportAsPersona}
         onNameChange={(name) => updateField("name", name)}
+        onRemoveAvatar={handleRemoveAvatar}
         onSave={handleSave}
         onStartChat={handleStartChat}
         onToggleFavorite={() => updateExtension("fav", !formData.extensions.fav)}

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -181,7 +181,6 @@ export function CharacterEditor() {
   };
 
   const handleRemoveAvatar = async () => {
-    if (!avatarPreview && formData?.extensions.avatarCrop === undefined) return;
     if (
       !(await showConfirmDialog({
         title: "Remove Avatar",

--- a/src/features/catalog/characters/components/CharacterEditorHeader.tsx
+++ b/src/features/catalog/characters/components/CharacterEditorHeader.tsx
@@ -3,6 +3,7 @@ import {
   ArrowLeft,
   Camera,
   Copy,
+  ImageOff,
   Loader2,
   MessageCircle,
   Save,
@@ -37,6 +38,7 @@ export function CharacterEditorHeader({
   onGenerateAvatar,
   onImportAsPersona,
   onNameChange,
+  onRemoveAvatar,
   onSave,
   onStartChat,
   onToggleFavorite,
@@ -60,6 +62,7 @@ export function CharacterEditorHeader({
   onGenerateAvatar: () => void;
   onImportAsPersona: () => void;
   onNameChange: (name: string) => void;
+  onRemoveAvatar: () => void;
   onSave: () => void | Promise<unknown>;
   onStartChat: () => void;
   onToggleFavorite: () => void;
@@ -188,6 +191,20 @@ export function CharacterEditorHeader({
               <Wand2 size="0.75rem" />
             </button>
           )}
+          {avatarPreview && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemoveAvatar();
+              }}
+              disabled={avatarUploading || saving}
+              className="absolute bottom-0.5 right-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-[var(--card)]/95 text-[var(--destructive)] opacity-0 shadow-md ring-1 ring-[var(--border)] transition-opacity hover:bg-[var(--card)] disabled:cursor-not-allowed disabled:opacity-50 group-hover:opacity-100 max-md:opacity-100"
+              title="Remove avatar"
+            >
+              <ImageOff size="0.75rem" />
+            </button>
+          )}
           <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={onAvatarUpload} />
         </div>
 
@@ -224,7 +241,7 @@ export function CharacterEditorHeader({
         )}
       >
         <Save size="0.8125rem" />
-        <span className="max-md:hidden">{avatarUploading ? "Uploading…" : saving ? "Saving…" : "Save"}</span>
+        <span className="max-md:hidden">{avatarUploading ? "Updating…" : saving ? "Saving…" : "Save"}</span>
       </button>
 
       <div className="flex w-full items-center justify-end gap-1 md:hidden">{headerActions}</div>

--- a/src/features/catalog/characters/hooks/use-character-editor-avatar.ts
+++ b/src/features/catalog/characters/hooks/use-character-editor-avatar.ts
@@ -234,9 +234,7 @@ export function useCharacterEditorAvatar({
     if (shouldClearAvatarCrop) {
       setExtensionValue("avatarCrop", undefined);
     }
-    if (fallbackDirty || shouldClearAvatarCrop) {
-      setDirtyState(fallbackDirty);
-    }
+    setDirtyState(true);
     try {
       await removeAvatar.mutateAsync(uploadCharacterId);
       if (isCurrentAvatarUpload(uploadToken, uploadCharacterId)) {

--- a/src/features/catalog/characters/hooks/use-character-editor-avatar.ts
+++ b/src/features/catalog/characters/hooks/use-character-editor-avatar.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "reac
 import { toast } from "sonner";
 
 import { generateClientId } from "../../../../shared/lib/utils";
-import { useUploadAvatar } from "./use-characters";
+import { useRemoveAvatar, useUploadAvatar } from "./use-characters";
 
 type MutableRef<T> = {
   current: T;
@@ -26,6 +26,7 @@ export function useCharacterEditorAvatar({
   setExtensionValue: (key: string, value: unknown) => void;
 }) {
   const uploadAvatar = useUploadAvatar();
+  const removeAvatar = useRemoveAvatar();
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
   const activeCharacterIdRef = useRef<string | null>(characterId);
@@ -79,7 +80,7 @@ export function useCharacterEditorAvatar({
       }
       if (!beginAvatarUpload()) {
         event.target.value = "";
-        toast.error("Wait for the current avatar upload to finish.");
+        toast.error("Wait for the current avatar change to finish.");
         return;
       }
 
@@ -156,7 +157,7 @@ export function useCharacterEditorAvatar({
         throw new Error("Wait for the current save to finish before uploading an avatar.");
       }
       if (!beginAvatarUpload()) {
-        throw new Error("Wait for the current avatar upload to finish.");
+        throw new Error("Wait for the current avatar change to finish.");
       }
       const uploadCharacterId = characterId;
       const uploadToken = generateClientId();
@@ -210,11 +211,71 @@ export function useCharacterEditorAvatar({
     ],
   );
 
+  const handleRemoveAvatar = useCallback(async () => {
+    if (!characterId) return;
+    if (saving) {
+      toast.error("Wait for the current save to finish before removing the avatar.");
+      return;
+    }
+    if (!beginAvatarUpload()) {
+      toast.error("Wait for the current avatar change to finish.");
+      return;
+    }
+    const uploadCharacterId = characterId;
+    const uploadToken = generateClientId();
+    latestAvatarUploadRef.current = { token: uploadToken, characterId: uploadCharacterId };
+    const fallbackAvatarPreview = avatarPreview;
+    const fallbackAvatarCrop = currentAvatarCrop;
+    const shouldClearAvatarCrop = fallbackAvatarCrop !== undefined;
+    const fallbackDirty = dirtyRef.current;
+    const editRevisionAtRemoveStart = editRevisionRef.current;
+
+    setAvatarPreview(null);
+    if (shouldClearAvatarCrop) {
+      setExtensionValue("avatarCrop", undefined);
+    }
+    if (fallbackDirty || shouldClearAvatarCrop) {
+      setDirtyState(fallbackDirty);
+    }
+    try {
+      await removeAvatar.mutateAsync(uploadCharacterId);
+      if (isCurrentAvatarUpload(uploadToken, uploadCharacterId)) {
+        toast.success("Character avatar removed.");
+      }
+    } catch (error) {
+      if (!isCurrentAvatarUpload(uploadToken, uploadCharacterId)) return;
+      toast.error(error instanceof Error ? error.message : "Failed to remove avatar.");
+      setAvatarPreview(fallbackAvatarPreview);
+      if (shouldClearAvatarCrop) {
+        setExtensionValue("avatarCrop", fallbackAvatarCrop);
+      }
+      if (editRevisionRef.current === editRevisionAtRemoveStart) {
+        setDirtyState(fallbackDirty);
+      }
+    } finally {
+      finishAvatarUpload(uploadToken, uploadCharacterId);
+    }
+  }, [
+    avatarPreview,
+    beginAvatarUpload,
+    characterId,
+    currentAvatarCrop,
+    dirtyRef,
+    editRevisionRef,
+    finishAvatarUpload,
+    isCurrentAvatarUpload,
+    removeAvatar,
+    saving,
+    setDirtyState,
+    setExtensionValue,
+  ]);
+
   return {
     avatarPreview,
     avatarUploading,
     handleAvatarUpload,
     handleGeneratedAvatar,
+    handleRemoveAvatar,
     isAvatarUploadInFlight,
     setAvatarPreview,
   };

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -251,7 +251,17 @@ export function useUploadAvatar() {
   return useMutation({
     mutationFn: ({ id, avatar }: { id: string; avatar: string }) => characterApi.uploadAvatar(id, avatar),
     onSuccess: (_data, variables) => {
-      invalidateCharacterRecordQueries(qc, variables.id);
+      invalidateCharacterRecordQueries(qc, variables.id, { includeVersions: true });
+    },
+  });
+}
+
+export function useRemoveAvatar() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => characterApi.removeAvatar(id),
+    onSuccess: (_data, id) => {
+      invalidateCharacterRecordQueries(qc, id, { includeVersions: true });
     },
   });
 }

--- a/src/shared/api/character-api.ts
+++ b/src/shared/api/character-api.ts
@@ -15,6 +15,7 @@ export const characterApi = {
   restoreVersion: (characterId: string, versionId: string) =>
     invokeTauri("character_restore_version", { characterId, versionId }),
   uploadAvatar: (id: string, avatar: string) => invokeTauri("character_avatar_upload", { id, body: { avatar } }),
+  removeAvatar: (id: string) => invokeTauri("character_avatar_remove", { id }),
   importEmbeddedLorebook: (id: string) =>
     invokeTauri<EmbeddedLorebookImportResult>("character_embedded_lorebook_import", { id }),
 };

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -160,6 +160,7 @@ const REMOTE_COMMANDS = new Set([
   "connection_save_default_parameters",
   "persona_activate",
   "character_avatar_upload",
+  "character_avatar_remove",
   "character_restore_version",
   "persona_avatar_upload",
   "npc_avatar_upload",


### PR DESCRIPTION
## Linked issue

N/A - local legacy parity task.

## Why this change

Restore key legacy Character behavior that regressed during the refactor while keeping the current architecture split between Rust storage, shared API wrappers, catalog UI, and React-free generation code.

## What changed

- Restore character version snapshots for normal character updates, avatar upload/removal, and restore operations, including `versionSource`, `versionReason`, and `skipVersionSnapshot` handling.
- Add avatar removal through the character API, Tauri command registration, remote runtime allowlist, editor hook, and header action.
- Guard avatar snapshot embedding/deletion so only managed avatar files are read or removed.
- Duplicate character cards with nested `data.name` updated to `(Copy)` while preserving passthrough card data.
- Reconnect character depth prompts to prompt assembly for conversation/roleplay paths, preserve injected prompt roles under strict role formatting, and suppress character depth prompts in game mode.

## Refactor impact

Primary owner:

Rust storage, shared API wrappers, catalog Character UI, and engine generation.

Impact areas reviewed:

- Character storage update/version/restore paths.
- Avatar upload/remove lifecycle and managed-file guards.
- Generic duplicate routing for character vs non-character records.
- Character editor avatar UI and mutation cache invalidation.
- Prompt assembly depth injection for conversation, roleplay, and game modes.
- Tauri command registration, HTTP dispatch, and remote runtime allowlist.

Boundary notes:

- Product prompt behavior stays in `src/engine/generation` with no React/shared-api imports.
- React editor behavior stays in `src/features/catalog/characters` and calls focused shared API wrappers.
- Runtime wrappers stay in `src/shared/api`.
- Privileged storage and file operations stay in `src-tauri`.
- Remote-capable avatar removal is wired through `remote-runtime.ts` and `src-tauri/src/http_dispatch.rs`.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration.
- `src-tauri/src/http_dispatch.rs` remote command dispatch.
- Character editor header/action surface.
- Prompt assembly strict-role and depth-injection path.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [x] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm check` passed locally after the final code diff, including line endings, architecture, TypeScript, Rust check, docs, discovery metadata, and unused-code scan.
- `pnpm build` passed locally after the final code diff.
- Native Tauri QA ran with `pnpm tauri dev --no-watch --config scratch\tauri-qa.config.json`.
- In the native Tauri WebView shell, exercised the real frontend API modules and Tauri command path for avatar upload, avatar removal, managed snapshot embedding, unmanaged avatar guard, duplicate visible-name behavior, roleplay depth prompt injection, and game-mode depth prompt suppression.
- Native QA artifact saved locally at `scratch/tauri-qa-character-parity-current.png`.
- No new test files were added as PR proof. Existing component test mock wiring was updated only so the current mocked character hook surface includes the new remove-avatar mutation.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores legacy Character behavior and adds the missing avatar removal action inside an existing editor surface; no Discover entry exists for this narrow editor action today.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Native QA screenshot exists locally at `scratch/tauri-qa-character-parity-current.png`; not uploaded here because the verified behavior was command-path/storage/prompt behavior rather than a visual layout change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar removal: Users can now remove character avatars with a confirmation prompt
  * Character duplication: Create copies of existing characters with customizable names
  * Per-character depth prompts: Added support for depth prompts in character generation

* **Improvements**
  * Improved messaging for in-flight avatar operations
  * Enhanced prompt assembly to integrate character-specific depth prompts during generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->