### PR TITLE
Type game DTO handoffs

### DIFF
--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -92,7 +92,7 @@ import {
   advanceTime as advanceGameTime,
   type GameTime,
 } from "../../../../engine/modes/game/world/time.service";
-import { generateWeather, inferBiome, type WeatherState } from "../../../../engine/modes/game/world/weather.service";
+import { generateWeather, inferBiome, type Season, type WeatherState } from "../../../../engine/modes/game/world/weather.service";
 import { parsePartyDialogue } from "../lib/party-dialogue-parser";
 
 export interface CreateGameResponse {
@@ -1045,7 +1045,15 @@ function playerAttributes(meta: Record<string, unknown>): Partial<RPGAttributes>
   const cards = Array.isArray(meta.gameCharacterCards) ? meta.gameCharacterCards : [];
   const first = asRecord(cards[0]);
   const rpgStats = asRecord(first.rpgStats);
-  return mapSheetAttributesToRPG(Array.isArray(rpgStats.attributes) ? (rpgStats.attributes as any[]) : undefined);
+  return mapSheetAttributesToRPG(
+    Array.isArray(rpgStats.attributes)
+      ? (rpgStats.attributes as ReadonlyArray<{ name: string; value: number }>)
+      : undefined,
+  );
+}
+
+function isWeatherSeason(value: unknown): value is Season {
+  return value === "spring" || value === "summer" || value === "autumn" || value === "winter";
 }
 
 function replaceFirstUnresolvedSkillCheckTag(content: string, resolvedTag: string): string {
@@ -1886,13 +1894,13 @@ export const gameApi = {
     mechanics?: CombatMechanic[];
     elementPreset?: string;
   }) {
-    const combatants = data.combatants.map((combatant) => ({ ...combatant })) as any[];
+    const combatants: Array<Omit<Combatant, "sprite">> = data.combatants.map((combatant) => ({ ...combatant }));
     const result = resolveCombatRound(
       combatants,
       data.round,
       "normal",
       data.elementPreset,
-      data.playerAction as any,
+      data.playerAction,
       data.mechanics,
     );
     return { result, combatants: combatants as Combatant[] };
@@ -1958,7 +1966,7 @@ export const gameApi = {
     const chat = await getChat(data.chatId);
     const forced = data.type
       ? ({ type: data.type, temperature: 20, description: "", wind: "calm", visibility: "clear" } as WeatherState)
-      : generateWeather(inferBiome(data.location ?? ""), (data.season as any) ?? "summer");
+      : generateWeather(inferBiome(data.location ?? ""), isWeatherSeason(data.season) ? data.season : "summer");
     const changed =
       Boolean(data.type) ||
       Math.random() <

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1964,9 +1964,21 @@ export const gameApi = {
     type?: string;
   }): Promise<{ changed: boolean; weather: WeatherState; sessionChat: Chat }> {
     const chat = await getChat(data.chatId);
-    const forced = data.type
-      ? ({ type: data.type, temperature: 20, description: "", wind: "calm", visibility: "clear" } as WeatherState)
-      : generateWeather(inferBiome(data.location ?? ""), isWeatherSeason(data.season) ? data.season : "summer");
+    let forced: WeatherState;
+    if (data.type) {
+      forced = { type: data.type, temperature: 20, description: "", wind: "calm", visibility: "clear" } as WeatherState;
+    } else {
+      const biome = inferBiome(data.location ?? "");
+      const season = isWeatherSeason(data.season) ? data.season : "summer";
+      if (data.season && season === "summer" && data.season !== "summer") {
+        console.warn("[game] Invalid weather season; defaulting to summer", {
+          season: data.season,
+          biome,
+          location: data.location ?? "",
+        });
+      }
+      forced = generateWeather(biome, season);
+    }
     const changed =
       Boolean(data.type) ||
       Math.random() <

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -207,6 +207,8 @@ type GameAssetGenerationOptions = {
   showSuccessToast?: boolean;
 };
 
+type GameAssetManifestMap = Record<string, { path: string; absolutePath?: string }> | null;
+
 type GameSpotifyCandidatesResponse = {
   enabled: boolean;
   tracks: SceneSpotifyTrackCandidate[];
@@ -3955,7 +3957,11 @@ export function GameSurface({
     runSceneAnalysis(sceneContext);
   };
 
-  function applyInlineTags(gmTags: ReturnType<typeof parseGmTags>, assetMap: any, msg: { id: string }) {
+  function applyInlineTags(
+    gmTags: ReturnType<typeof parseGmTags>,
+    assetMap: GameAssetManifestMap,
+    msg: { id: string },
+  ) {
     const sceneAnalysisState: GameActiveState =
       gmTags.combatEncounter || gmTags.stateChange === "combat"
         ? "combat"

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -24,6 +24,7 @@ import type {
   GameSetupConfig,
   Combatant,
   CombatPlayerAction,
+  GameNpc,
   HudWidget,
   GameBlueprint,
 } from "../../../../engine/contracts/types/game";
@@ -488,6 +489,9 @@ function finiteNumber(value: unknown): number | null {
   return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
 }
 
+type LegacyInventoryItem = { name: string; slot?: string | number; quantity?: number };
+type LegacyInventoryConfig = Omit<HudWidget["config"], "items"> & { items?: LegacyInventoryItem[] };
+
 function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
   return widgets.map((w) => {
     if (isNumericHudWidgetType(w.type)) {
@@ -508,8 +512,9 @@ function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
       }
     }
 
-    if (w.type === "inventory_grid" && !w.config.contents && Array.isArray((w.config as any).items)) {
-      const items = (w.config as any).items as Array<{ name: string; slot?: string | number; quantity?: number }>;
+    const inventoryConfig = w.config as LegacyInventoryConfig;
+    if (w.type === "inventory_grid" && !w.config.contents && Array.isArray(inventoryConfig.items)) {
+      const items = inventoryConfig.items;
       return {
         ...w,
         config: {
@@ -565,7 +570,7 @@ export function useSyncGameState(activeChatId: string, chatMeta: Record<string, 
       useGameModeStore.getState().setCurrentMap(chatMeta.gameMap as GameMap);
     }
     if (Array.isArray(chatMeta.gameNpcs)) {
-      useGameModeStore.getState().setNpcs(chatMeta.gameNpcs as any[]);
+      useGameModeStore.getState().setNpcs(chatMeta.gameNpcs as GameNpc[]);
     }
     if (chatMeta.gameSessionNumber) {
       useGameModeStore.getState().setSessionNumber(chatMeta.gameSessionNumber as number);
@@ -675,7 +680,7 @@ export function useUpdateReputation() {
     mutationFn: (data: { chatId: string; actions: Array<{ npcId: string; action: string; modifier?: number }> }) =>
       gameApi.updateReputation(data),
     onSuccess: (res, variables) => {
-      store.getState().setNpcs(res.npcs as any[]);
+      store.getState().setNpcs(res.npcs as GameNpc[]);
       publishSessionChat(qc, res.sessionChat);
       qc.invalidateQueries({ queryKey: chatKeys.detail(variables.chatId) });
       qc.invalidateQueries({ queryKey: [...gameKeys.all, "journal", variables.chatId] });


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Continues the explicit-any cleanup chore by narrowing game-mode DTO and asset-map handoffs.

## What changed

- Typed game character RPG attribute mapping inputs instead of passing an untyped array.
- Typed combat round handoff data and player actions at the game API boundary.
- Added a weather season guard before calling the weather generator.
- Typed legacy inventory widget normalization, NPC store handoffs, and inline scene asset maps.

## Refactor impact

Primary owner:

game mode

Impact areas reviewed:

- Game API DTO handoffs
- Game hook metadata/store sync
- GameSurface inline asset/audio tag processing

Boundary notes:

- Feature-layer game code still calls existing game-owned hooks/APIs and React-free engine services through existing imports.
- No shared API, Rust, remote runtime, storage schema, or cross-mode boundary changes.

Pressure points touched:

- GameSurface: type-only annotation for inline tag asset map.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm check` passed locally.
- Focused game explicit-any grep now only hits prompt prose.
- No browser or Tauri manual QA run; this is a type-only cleanup.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Type-only internal cleanup; no user-discoverable feature changed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A; no visible UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety across game API and component modules by replacing generic type casting with proper typed declarations, improving code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->