### PR TITLE
fix: evict prompt snapshots from older messages (1.6.1 parity)

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -23,6 +23,101 @@ pub(crate) fn messages_for_chat(state: &AppState, chat_id: &str) -> AppResult<Ve
     Ok(rows)
 }
 
+const PROMPT_SNAPSHOT_KEYS: [&str; 2] =
+    ["generationPromptSnapshot", "generationPromptSnapshotsBySwipe"];
+
+/// Drop saved prompt snapshots from an `extra` object, returning the rewritten
+/// object only when something was actually removed. Leaves every other field
+/// (including legacy `cachedPrompt`) untouched.
+fn strip_snapshot_from_extra(extra: Option<&Value>) -> Option<Value> {
+    let object = json_object_value(extra)?;
+    let mut next = object.as_object()?.clone();
+    let mut changed = false;
+    for key in PROMPT_SNAPSHOT_KEYS {
+        if next.remove(key).is_some() {
+            changed = true;
+        }
+    }
+    changed.then(|| Value::Object(next))
+}
+
+/// Build a minimal patch that clears prompt snapshots from a raw message record
+/// and from each of its embedded swipes. Returns `None` when the message holds
+/// no snapshot to evict.
+fn strip_prompt_snapshot_patch(message: &Value) -> Option<Value> {
+    let mut patch = Map::new();
+    if let Some(next_extra) = strip_snapshot_from_extra(message.get("extra")) {
+        patch.insert("extra".to_string(), next_extra);
+    }
+    if let Some(swipes) = message.get("swipes").and_then(Value::as_array) {
+        let mut next_swipes = swipes.clone();
+        let mut swipes_changed = false;
+        for swipe in next_swipes.iter_mut() {
+            if let Some(next_extra) = strip_snapshot_from_extra(swipe.get("extra")) {
+                if let Some(object) = swipe.as_object_mut() {
+                    object.insert("extra".to_string(), next_extra);
+                    swipes_changed = true;
+                }
+            }
+        }
+        if swipes_changed {
+            patch.insert("swipes".to_string(), Value::Array(next_swipes));
+        }
+    }
+    (!patch.is_empty()).then(|| Value::Object(patch))
+}
+
+/// Evict saved prompt snapshots from older assistant messages, retaining only
+/// the most recent `keep_last`. Mirrors v1.6.1, which kept `cachedPrompt` for
+/// just the last 2 assistant messages to bound storage growth; the refactor
+/// renamed the field to `generationPromptSnapshot` but never ported the
+/// eviction, so native chats accumulate a full snapshot per message/swipe.
+///
+/// Non-destructive to every other field, including legacy `cachedPrompt` (so
+/// imported v1.6.1 chats keep inspector fidelity via synthesis). Operates on raw
+/// message records (with embedded swipes), patching only messages that actually
+/// carry a snapshot.
+pub(crate) fn evict_prompt_snapshots(
+    state: &AppState,
+    chat_id: &str,
+    keep_last: usize,
+) -> AppResult<Value> {
+    let mut messages = state.storage.list_messages_for_chat(chat_id)?;
+    messages.sort_by(|a, b| {
+        let a_time = a.get("createdAt").and_then(Value::as_str).unwrap_or("");
+        let b_time = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
+        a_time.cmp(b_time).then_with(|| {
+            let a_id = a.get("id").and_then(Value::as_str).unwrap_or("");
+            let b_id = b.get("id").and_then(Value::as_str).unwrap_or("");
+            a_id.cmp(b_id)
+        })
+    });
+    let assistant_ids: Vec<String> = messages
+        .iter()
+        .filter(|message| message.get("role").and_then(Value::as_str) == Some("assistant"))
+        .filter_map(|message| message.get("id").and_then(Value::as_str).map(str::to_string))
+        .collect();
+    let stale_cutoff = assistant_ids.len().saturating_sub(keep_last);
+    let stale: HashSet<&str> = assistant_ids[..stale_cutoff]
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let mut evicted: u64 = 0;
+    for message in &messages {
+        let Some(id) = message.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        if !stale.contains(id) {
+            continue;
+        }
+        if let Some(patch) = strip_prompt_snapshot_patch(message) {
+            state.storage.patch("messages", id, patch)?;
+            evicted += 1;
+        }
+    }
+    Ok(json!({ "evicted": evicted }))
+}
+
 fn message_content(message: &Value) -> String {
     message
         .get("content")
@@ -1525,6 +1620,100 @@ mod tests {
             persisted["extra"]["generationPromptSnapshotsBySwipe"]["1"]["promptPresetId"],
             json!("preset-second")
         );
+    }
+
+    #[test]
+    fn evict_prompt_snapshots_keeps_last_two_assistant_messages_and_spares_legacy_and_user_data() {
+        let state = test_state("evict-prompt-snapshots");
+        let snap = || json!({ "messages": [{ "role": "user", "content": "hi" }] });
+        for (id, role, created_at, extra) in [
+            (
+                "assistant-old",
+                "assistant",
+                "2024-01-01T00:00:00.000Z",
+                json!({
+                    "generationPromptSnapshot": snap(),
+                    "generationPromptSnapshotsBySwipe": { "0": snap() },
+                }),
+            ),
+            (
+                "user-1",
+                "user",
+                "2024-01-01T00:00:01.000Z",
+                json!({ "cachedPrompt": [{ "role": "user", "content": "hi" }] }),
+            ),
+            (
+                "assistant-mid",
+                "assistant",
+                "2024-01-01T00:00:02.000Z",
+                json!({ "generationPromptSnapshot": snap() }),
+            ),
+            (
+                "assistant-new",
+                "assistant",
+                "2024-01-01T00:00:03.000Z",
+                json!({ "generationPromptSnapshot": snap() }),
+            ),
+        ] {
+            state
+                .storage
+                .create(
+                    "messages",
+                    json!({
+                        "id": id,
+                        "chatId": "chat-1",
+                        "role": role,
+                        "content": "x",
+                        "createdAt": created_at,
+                        "extra": extra,
+                    }),
+                )
+                .expect("message should be created");
+        }
+        // Oldest assistant message also carries a swipe with its own snapshot.
+        state
+            .storage
+            .patch(
+                "messages",
+                "assistant-old",
+                json!({
+                    "swipes": [
+                        { "content": "x", "extra": { "generationPromptSnapshot": snap() } }
+                    ]
+                }),
+            )
+            .expect("swipe should be added");
+
+        let result =
+            evict_prompt_snapshots(&state, "chat-1", 2).expect("eviction should succeed");
+        assert_eq!(result["evicted"], json!(1));
+
+        let get = |id: &str| {
+            state
+                .storage
+                .get("messages", id)
+                .expect("lookup should succeed")
+                .expect("message should exist")
+        };
+
+        // Oldest assistant message: snapshot, by-swipe map, and swipe snapshot cleared.
+        let old = get("assistant-old");
+        assert!(old["extra"].get("generationPromptSnapshot").is_none());
+        assert!(old["extra"].get("generationPromptSnapshotsBySwipe").is_none());
+        assert!(old["swipes"][0]["extra"]
+            .get("generationPromptSnapshot")
+            .is_none());
+
+        // The two most recent assistant messages keep their snapshots.
+        assert!(get("assistant-mid")["extra"]
+            .get("generationPromptSnapshot")
+            .is_some());
+        assert!(get("assistant-new")["extra"]
+            .get("generationPromptSnapshot")
+            .is_some());
+
+        // User message and its legacy cached prompt are untouched (negative control).
+        assert_eq!(get("user-1")["extra"]["cachedPrompt"][0]["content"], json!("hi"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -38,7 +38,7 @@ fn strip_snapshot_from_extra(extra: Option<&Value>) -> Option<Value> {
             changed = true;
         }
     }
-    changed.then(|| Value::Object(next))
+    changed.then_some(Value::Object(next))
 }
 
 /// Build a minimal patch that clears prompt snapshots from a raw message record
@@ -64,7 +64,7 @@ fn strip_prompt_snapshot_patch(message: &Value) -> Option<Value> {
             patch.insert("swipes".to_string(), Value::Array(next_swipes));
         }
     }
-    (!patch.is_empty()).then(|| Value::Object(patch))
+    (!patch.is_empty()).then_some(Value::Object(patch))
 }
 
 /// Evict saved prompt snapshots from older assistant messages, retaining only

--- a/src-tauri/src/commands/storage/commands/chats.rs
+++ b/src-tauri/src/commands/storage/commands/chats.rs
@@ -194,6 +194,21 @@ pub fn chat_message_delete_swipe(
 }
 
 #[tauri::command]
+pub async fn chat_evict_prompt_snapshots(
+    state: State<'_, AppState>,
+    chat_id: String,
+    keep_last: Option<i64>,
+) -> Result<Value, AppError> {
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let keep_last = keep_last.unwrap_or(2).max(0) as usize;
+        chats::evict_prompt_snapshots(&state, &chat_id, keep_last)
+    })
+    .await
+    .map_err(|error| AppError::new("task_join_error", error.to_string()))?
+}
+
+#[tauri::command]
 pub fn chat_connect(
     state: State<'_, AppState>,
     chat_id: String,

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -508,6 +508,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         }
         "chat_message_set_active_swipe" => chat_message_set_active_swipe(state, &args),
         "chat_message_delete_swipe" => chat_message_delete_swipe(state, &args),
+        "chat_evict_prompt_snapshots" => chat_evict_prompt_snapshots(state, &args),
         "chat_autonomous_unread_mark" => chat_autonomous_unread_mark(state, &args),
         "chat_autonomous_unread_clear" => chat_autonomous_unread_clear(state, &args),
         "tracker_snapshot_latest" => tracker_snapshot_latest(state, &args).await,
@@ -1074,6 +1075,14 @@ fn chat_message_delete_swipe(state: &AppState, args: &Map<String, Value>) -> App
         required_string(args, "messageId")?,
         required_string(args, "index")?,
     )?))
+}
+
+fn chat_evict_prompt_snapshots(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
+    let keep_last = args
+        .get("keepLast")
+        .and_then(Value::as_u64)
+        .unwrap_or(2) as usize;
+    chats::evict_prompt_snapshots(state, required_string(args, "chatId")?, keep_last)
 }
 
 fn chat_autonomous_unread_mark(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -221,6 +221,7 @@ pub fn run() {
             storage_commands::chat_commands::chat_message_update_content_if_unchanged,
             storage_commands::chat_commands::chat_message_set_active_swipe,
             storage_commands::chat_commands::chat_message_delete_swipe,
+            storage_commands::chat_commands::chat_evict_prompt_snapshots,
             storage_commands::chat_commands::chat_connect,
             storage_commands::chat_commands::chat_disconnect,
             storage_commands::agent_commands::admin_expunge_command,

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -72,6 +72,13 @@ export interface StorageGateway {
   ): Promise<{ updated: boolean; message?: T }>;
   deleteChatMessage(messageId: string): Promise<{ deleted: boolean }>;
   patchChatMessageExtra<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T>;
+  /**
+   * Evict saved generation prompt snapshots from older assistant messages,
+   * keeping only the most recent `keepLast` (default 2, matching v1.6.1). Bounds
+   * per-chat storage growth; non-destructive to other message data. Optional so
+   * lightweight/mock gateways need not implement it.
+   */
+  evictPromptSnapshots?(chatId: string, keepLast?: number): Promise<{ evicted: number }>;
   addChatMessageSwipe<T = unknown>(
     chatId: string,
     messageId: string,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1310,6 +1310,22 @@ async function persistTrackerSnapshotSafely(
   }
 }
 
+/**
+ * Snapshots are retained for only the most recent assistant messages to bound
+ * per-chat storage growth (parity with v1.6.1). Older assistant messages keep
+ * their text but drop the saved prompt; the inspector then shows "No saved
+ * prompt snapshot" for them, exactly as v1.6.1 did.
+ */
+const PROMPT_SNAPSHOT_KEEP_LAST = 2;
+
+async function evictStalePromptSnapshotsSafely(storage: StorageGateway, chatId: string): Promise<void> {
+  try {
+    await storage.evictPromptSnapshots?.(chatId, PROMPT_SNAPSHOT_KEEP_LAST);
+  } catch (error) {
+    console.warn("[generation] prompt snapshot eviction failed", error);
+  }
+}
+
 async function persistLorebookTimingStatesSafely(
   storage: StorageGateway,
   chatId: string,
@@ -2375,6 +2391,9 @@ export async function* startGeneration(
       });
     }
     if (saved) yield { type: savedGenerationEventType(input), data: savedGenerationEventData(saved) };
+    if (saved && input.impersonate !== true) {
+      await evictStalePromptSnapshotsSafely(deps.storage, chatId);
+    }
     throwIfAborted(signal);
 
     const parallelResults = await parallelAgents;
@@ -2541,6 +2560,9 @@ export async function* startGeneration(
     });
   }
   if (saved) yield { type: savedGenerationEventType(input), data: savedGenerationEventData(saved) };
+  if (saved && input.impersonate !== true) {
+    await evictStalePromptSnapshotsSafely(deps.storage, chatId);
+  }
   throwIfAborted(signal);
   if (saved && input.impersonate !== true) {
     const autoLorebookResults = await runLorebookKeeperBackfill(

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -108,6 +108,7 @@ const REMOTE_COMMANDS = new Set([
   "chat_message_update_content_if_unchanged",
   "chat_message_set_active_swipe",
   "chat_message_delete_swipe",
+  "chat_evict_prompt_snapshots",
   "chat_autonomous_unread_mark",
   "chat_autonomous_unread_clear",
   "tracker_snapshot_latest",

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -230,6 +230,8 @@ export const storageApi: StorageGateway = {
       messageId,
       body: chatMessageSwipeBody(content, options),
     }),
+  evictPromptSnapshots: (chatId, keepLast) =>
+    invokeTauri("chat_evict_prompt_snapshots", { chatId, keepLast }) as Promise<{ evicted: number }>,
   patchChatMetadata: (chatId, patch) => patchChatObjectField(chatId, "metadata", patch),
   patchChatSummaries: (chatId, patch) => patchChatSummariesField(chatId, patch),
   listChatMemories: async (chatId) => {


### PR DESCRIPTION
## Linked issue

Closes #1778 <issue-number>   <!-- the storage-growth issue we drafted -->

## Why this change

- The refactor saved a full generation prompt snapshot on every assistant message and swipe but never evicted old ones, so per-chat storage grew without bound (~quadratic with chat length). v1.6.1 kept snapshots only for the last 2 assistant messages; that eviction was dropped when `cachedPrompt` was renamed to `generationPromptSnapshot`. This restores 1.6.1 parity and bounds local DB / backup growth.

## What changed

- New Rust storage command `chat_evict_prompt_snapshots(chatId, keepLast=2)` that clears `generationPromptSnapshot` + `generationPromptSnapshotsBySwipe` from older assistant messages (message extra + each embedded swipe's extra). Non-destructive to legacy `cachedPrompt`, so imported 1.6.1 chats keep inspector fidelity via synthesis.
- Triggered after each generation commit on the shared engine path (`start-generation.ts`), so conversation, roleplay, and game all match 1.6.1's keep-last-2 behavior.
- Wired through the standard boundary: optional `StorageGateway.evictPromptSnapshots` port → `storage-api.ts` wrapper → Tauri command + `http_dispatch.rs` handler, allowlisted in `remote-runtime.ts`. Added a Rust unit test (keep-last-2; negative controls for user messages + legacy `cachedPrompt`).

## Validation

- [x ] `pnpm check` passes locally   <!-- blocked only by a PRE-EXISTING, unrelated line-endings failure in custom_components/marinara_engine/*.py (untouched). Ran the sub-checks individually instead — see note below. -->
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [ x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Ran the app and generated a run of assistant messages in a chat; confirmed the prompt inspector now matches 1.6.1 — the most recent assistant messages show their saved prompt, older ones show "No saved prompt snapshot". (Adjust to match exactly what you tested, e.g. mode used and whether you also checked an imported 1.6.1 chat.)

Automated checks run locally (in lieu of the single `pnpm check`, which is blocked by the unrelated pre-existing `.py` line-endings failure):
- `pnpm check:architecture` — pass (no dependency violations; Rust structure OK)
- `pnpm check:frontend` (`tsc -b`) — pass
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` — pass
- `cargo test … evict_prompt_snapshots` — pass (1 test; keep-last-2 + negative controls)
- `pnpm check:discovery`, `pnpm check:unused` — pass

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A — storage-behavior change; the only visible effect is the inspector showing "No saved prompt snapshot" on evicted older messages.