### PR TITLE
Remove explicit any types from UI cleanup paths

### DIFF
--- a/src/engine/agents-runtime/pipeline/agent-pipeline.ts
+++ b/src/engine/agents-runtime/pipeline/agent-pipeline.ts
@@ -92,6 +92,16 @@ function shouldExecuteIndividually(agent: ResolvedAgent): boolean {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getAgentResultText(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (isRecord(data) && typeof data.text === "string") return data.text;
+  return "";
+}
+
 async function executeResolvedAgent(agent: ResolvedAgent, context: AgentContext): Promise<AgentResult> {
   const agentContext = buildAgentContext(agent, context);
   if (agent.type === "knowledge-retrieval") {
@@ -282,7 +292,7 @@ async function runPreGenerationAgents(
 
     // prose-guardian & director produce text to inject
     if (result.type === "context_injection" || result.type === "director_event") {
-      const text = typeof result.data === "string" ? result.data : ((result.data as any)?.text ?? "");
+      const text = getAgentResultText(result.data);
       const agentName = agents.find((agent) => agent.type === result.agentType)?.name;
       if (text) injections.push({ agentType: result.agentType, agentName, text });
     }

--- a/src/engine/contracts/types/agent.ts
+++ b/src/engine/contracts/types/agent.ts
@@ -180,9 +180,8 @@ export interface AgentContext {
   streaming?: boolean;
   /** Whether agent runtime diagnostics should emit to the debug sink and console. */
   debugMode?: boolean;
-  /** Abort signal — when triggered, agent execution should stop. Typed as `any` to avoid DOM/Node lib dependency. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  signal?: any;
+  /** Abort signal — when triggered, agent execution should stop. */
+  signal?: AbortSignal;
 }
 
 /** Built-in agent type identifiers. */

--- a/src/features/catalog/characters/components/CharacterEditor.tsx
+++ b/src/features/catalog/characters/components/CharacterEditor.tsx
@@ -11,6 +11,7 @@ import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useStartChatFromCharacter } from "../hooks/use-start-chat-from-character";
 import { useConnections } from "../../connections/index";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
+import { getErrorMessage } from "../../../../shared/lib/error-message";
 import type { CharacterData } from "../../../../engine/contracts/types/character";
 import type { ImageGenerationConnectionOption } from "../../../../shared/types/image-generation";
 import { useCharacterEditorAvatar } from "../hooks/use-character-editor-avatar";
@@ -155,9 +156,9 @@ export function CharacterEditor() {
         setDirtyState(false);
       }
       return true;
-    } catch (err: any) {
+    } catch (err) {
       console.error("[CharacterEditor] Save failed:", err);
-      toast.error(err?.message ?? "Failed to save character. Check the console for details.");
+      toast.error(getErrorMessage(err, "Failed to save character. Check the console for details."));
       return false;
     } finally {
       setSaving(false);

--- a/src/features/catalog/characters/components/CharacterSpritesTab.tsx
+++ b/src/features/catalog/characters/components/CharacterSpritesTab.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../sprites/index";
 import { SpriteGenerationModal } from "../../../../shared/components/ui/SpriteGenerationModal";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
+import { getErrorMessage } from "../../../../shared/lib/error-message";
 import { downloadBlob, loadUrlBlob } from "../../../../shared/lib/url-blob";
 import {
   DEFAULT_EXPRESSIONS,
@@ -98,10 +99,6 @@ export function CharacterSpritesTab({
     (stored: string) => displaySpriteExpressionForCategory(stored, category),
     [category],
   );
-  const getSpriteErrorMessage = useCallback(
-    (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback),
-    [],
-  );
 
   const handleDeleteSingleSprite = useCallback(async () => {
     if (!deleteSpriteRequest) return;
@@ -110,11 +107,11 @@ export function CharacterSpritesTab({
       await deleteSprite.mutateAsync({ characterId, expression: deleteSpriteRequest.expression });
       setDeleteSpriteRequest(null);
     } catch (error) {
-      toast.error(getSpriteErrorMessage(error, "Failed to delete sprite."));
+      toast.error(getErrorMessage(error, "Failed to delete sprite."));
     } finally {
       setDeletingSprites(null);
     }
-  }, [characterId, deleteSprite, deleteSpriteRequest, getSpriteErrorMessage]);
+  }, [characterId, deleteSprite, deleteSpriteRequest]);
 
   const handleDeleteVisibleSprites = useCallback(async () => {
     if (visibleSprites.length === 0) return;
@@ -211,8 +208,8 @@ export function CharacterSpritesTab({
       if (result.failed.length > 0) {
         toast.warning(`${result.failed.length} sprite${result.failed.length === 1 ? "" : "s"} could not be cleaned.`);
       }
-    } catch (err: any) {
-      toast.error(err?.message || "Failed to clean saved sprites.");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to clean saved sprites."));
     } finally {
       setCleaningSprites(false);
     }
@@ -236,8 +233,8 @@ export function CharacterSpritesTab({
       } else {
         setLastCleanupRestorePointId(null);
       }
-    } catch (err: any) {
-      toast.error(err?.message || "Failed to restore sprite cleanup point.");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to restore sprite cleanup point."));
     } finally {
       setRestoringCleanup(false);
     }
@@ -257,12 +254,12 @@ export function CharacterSpritesTab({
         toast.success(`Framed ${displayExpression(framingSprite.expression)} sprite.`);
         setFramingSprite(null);
       } catch (error) {
-        toast.error(getSpriteErrorMessage(error, "Failed to save framed sprite."));
+        toast.error(getErrorMessage(error, "Failed to save framed sprite."));
       } finally {
         setSavingFrame(false);
       }
     },
-    [characterId, displayExpression, framingSprite, getSpriteErrorMessage, uploadSprite],
+    [characterId, displayExpression, framingSprite, uploadSprite],
   );
 
   const handleApplyWandCleanup = useCallback(
@@ -279,12 +276,12 @@ export function CharacterSpritesTab({
         toast.success(`Cleaned ${displayExpression(wandCleanupSprite.expression)} sprite.`);
         setWandCleanupSprite(null);
       } catch (error) {
-        toast.error(getSpriteErrorMessage(error, "Failed to save cleaned sprite."));
+        toast.error(getErrorMessage(error, "Failed to save cleaned sprite."));
       } finally {
         setSavingWandCleanup(false);
       }
     },
-    [characterId, displayExpression, getSpriteErrorMessage, uploadSprite, wandCleanupSprite],
+    [characterId, displayExpression, uploadSprite, wandCleanupSprite],
   );
 
   return (

--- a/src/features/catalog/personas/components/sprites/PersonaSpritesTab.tsx
+++ b/src/features/catalog/personas/components/sprites/PersonaSpritesTab.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 
 import { SpriteGenerationModal } from "../../../../../shared/components/ui/SpriteGenerationModal";
 import { showAlertDialog, showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
+import { getErrorMessage } from "../../../../../shared/lib/error-message";
 import { cn } from "../../../../../shared/lib/utils";
 import { downloadBlob, loadUrlBlob } from "../../../../../shared/lib/url-blob";
 import {
@@ -86,10 +87,6 @@ export function PersonaSpritesTab({
   const cleanupEngineReason = spriteCapabilities?.cleanupEngine?.reason ?? "Sprite cleanup is not available.";
 
   const displayExpression = useCallback((stored: string) => displaySpriteExpression(stored, category), [category]);
-  const getErrorMessage = useCallback(
-    (error: unknown, fallback: string) => (error instanceof Error ? error.message : fallback),
-    [],
-  );
 
   const startUpload = useCallback((expression: string) => {
     if (!expression) return;
@@ -187,7 +184,7 @@ export function PersonaSpritesTab({
         toast.error("No sprites could be imported.");
       }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to import sprites.");
+      toast.error(getErrorMessage(error, "Failed to import sprites."));
     } finally {
       setFolderProgress(null);
       event.target.value = "";
@@ -209,7 +206,7 @@ export function PersonaSpritesTab({
     } finally {
       setDeletingSprites(null);
     }
-  }, [deleteSprite, deleteSpriteRequest, getErrorMessage, personaId]);
+  }, [deleteSprite, deleteSpriteRequest, personaId]);
 
   const handleDeleteVisibleSprites = useCallback(async () => {
     if (visibleSprites.length === 0) return;
@@ -255,7 +252,7 @@ export function PersonaSpritesTab({
         toast.error(getErrorMessage(error, "Failed to download sprite."));
       }
     },
-    [downloadSpriteFile, getErrorMessage],
+    [downloadSpriteFile],
   );
 
   const handleExportSprites = useCallback(
@@ -326,8 +323,8 @@ export function PersonaSpritesTab({
       if (result.failed.length > 0) {
         toast.warning(`${result.failed.length} sprite${result.failed.length === 1 ? "" : "s"} could not be cleaned.`);
       }
-    } catch (err: any) {
-      toast.error(err?.message || "Failed to clean saved sprites.");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to clean saved sprites."));
     } finally {
       setCleaningSprites(false);
     }
@@ -352,8 +349,8 @@ export function PersonaSpritesTab({
       } else {
         setLastCleanupRestorePointId(null);
       }
-    } catch (err: any) {
-      toast.error(err?.message || "Failed to restore sprite cleanup point.");
+    } catch (err) {
+      toast.error(getErrorMessage(err, "Failed to restore sprite cleanup point."));
     } finally {
       setRestoringCleanup(false);
     }
@@ -379,7 +376,7 @@ export function PersonaSpritesTab({
         setSavingFrame(false);
       }
     },
-    [displayExpression, framingSprite, getErrorMessage, personaId, uploadSprite],
+    [displayExpression, framingSprite, personaId, uploadSprite],
   );
 
   const handleApplyWandCleanup = useCallback(
@@ -402,7 +399,7 @@ export function PersonaSpritesTab({
         setSavingWandCleanup(false);
       }
     },
-    [displayExpression, getErrorMessage, personaId, uploadSprite, wandCleanupSprite],
+    [displayExpression, personaId, uploadSprite, wandCleanupSprite],
   );
 
   return (

--- a/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
+++ b/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
@@ -11,6 +11,7 @@ import { useUpdateChatMetadata } from "../../chats/index";
 import { CheckCircle2, Circle, CheckSquare2, Square, Sparkles, ListChecks, Shuffle, Save } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
 import type { ChoiceBlock, ChoiceOption } from "../../../../engine/contracts/types/prompt";
+import { isRecord, normalizeChoiceSelections, type ChoiceSelections } from "../lib/choice-selections";
 
 interface ChoiceSelectionModalProps {
   open: boolean;
@@ -18,7 +19,7 @@ interface ChoiceSelectionModalProps {
   presetId: string | null;
   chatId: string;
   /** Existing selections to pre-populate (variableName → value or values) */
-  existingChoices?: Record<string, string | string[]>;
+  existingChoices?: ChoiceSelections;
 }
 
 interface VariableData {
@@ -28,12 +29,6 @@ interface VariableData {
   options: ChoiceOption[];
   multiSelect: boolean;
   randomPick: boolean;
-}
-
-type ChoiceSelections = Record<string, string | string[]>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 function stringField(value: unknown, fallback: string): string {
@@ -57,16 +52,6 @@ function legacyField(block: ChoiceBlock, field: string): unknown {
   return (block as unknown as Record<string, unknown>)[field];
 }
 
-function normalizeChoiceSelections(value: unknown): ChoiceSelections {
-  if (!isRecord(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value).filter(
-      (entry): entry is [string, string | string[]] =>
-        typeof entry[1] === "string" || (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")),
-    ),
-  );
-}
-
 export function ChoiceSelectionModal({
   open,
   onClose,
@@ -74,8 +59,7 @@ export function ChoiceSelectionModal({
   chatId,
   existingChoices = {},
 }: ChoiceSelectionModalProps) {
-  const { data } = usePresetFull(presetId);
-  const isLoading = !data && !!presetId;
+  const { data, isError, isLoading } = usePresetFull(presetId);
   const updateMetadata = useUpdateChatMetadata();
   const updatePreset = useUpdatePreset();
 
@@ -99,7 +83,7 @@ export function ChoiceSelectionModal({
   }, [data?.choiceBlocks]);
 
   // Parse saved default choices from preset
-  const defaultChoices = useMemo<Record<string, string | string[]>>(() => {
+  const defaultChoices = useMemo<ChoiceSelections>(() => {
     if (!data?.preset) return {};
     const preset = data.preset as unknown as Record<string, unknown>;
     return normalizeChoiceSelections(preset.defaultChoices ?? preset.default_choices);
@@ -107,9 +91,9 @@ export function ChoiceSelectionModal({
 
   // Base selections derived from existing choices / defaults / first option.
   // Pure derivation — no setState, no flicker on open.
-  const baseSelections = useMemo<Record<string, string | string[]>>(() => {
+  const baseSelections = useMemo<ChoiceSelections>(() => {
     if (!variables.length) return {};
-    const initial: Record<string, string | string[]> = {};
+    const initial: ChoiceSelections = {};
     for (const v of variables) {
       const existing = existingChoices[v.variableName];
       const saved = defaultChoices[v.variableName];
@@ -128,7 +112,7 @@ export function ChoiceSelectionModal({
 
   // User overrides (only written when user clicks an option).
   // Reset when modal re-opens so stale overrides don't persist.
-  const [overrides, setOverrides] = useState<Record<string, string | string[]>>({});
+  const [overrides, setOverrides] = useState<ChoiceSelections>({});
   const prevOpenRef = useRef(false);
   useEffect(() => {
     if (open && !prevOpenRef.current) {
@@ -138,11 +122,11 @@ export function ChoiceSelectionModal({
   }, [open]);
 
   useEffect(() => {
-    if (!open || isLoading || !presetId) return;
-    if (variables.length === 0) {
+    if (!open || !presetId || isLoading) return;
+    if (isError || variables.length === 0) {
       onClose();
     }
-  }, [open, isLoading, onClose, presetId, variables.length]);
+  }, [isError, isLoading, onClose, open, presetId, variables.length]);
 
   // Merged view: base + user overrides
   const selections = useMemo(() => ({ ...baseSelections, ...overrides }), [baseSelections, overrides]);

--- a/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
+++ b/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
@@ -10,6 +10,7 @@ import { usePresetFull, useUpdatePreset } from "../hooks/use-presets";
 import { useUpdateChatMetadata } from "../../chats/index";
 import { CheckCircle2, Circle, CheckSquare2, Square, Sparkles, ListChecks, Shuffle, Save } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
+import type { ChoiceBlock, ChoiceOption } from "../../../../engine/contracts/types/prompt";
 
 interface ChoiceSelectionModalProps {
   open: boolean;
@@ -20,12 +21,6 @@ interface ChoiceSelectionModalProps {
   existingChoices?: Record<string, string | string[]>;
 }
 
-interface ChoiceOption {
-  id: string;
-  label: string;
-  value: string;
-}
-
 interface VariableData {
   id: string;
   variableName: string;
@@ -33,6 +28,43 @@ interface VariableData {
   options: ChoiceOption[];
   multiSelect: boolean;
   randomPick: boolean;
+}
+
+type ChoiceSelections = Record<string, string | string[]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function boolishChoice(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function isChoiceOption(value: unknown): value is ChoiceOption {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.label === "string" &&
+    typeof value.value === "string"
+  );
+}
+
+function legacyField(block: ChoiceBlock, field: string): unknown {
+  return (block as unknown as Record<string, unknown>)[field];
+}
+
+function normalizeChoiceSelections(value: unknown): ChoiceSelections {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string | string[]] =>
+        typeof entry[1] === "string" || (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")),
+    ),
+  );
 }
 
 export function ChoiceSelectionModal({
@@ -52,15 +84,16 @@ export function ChoiceSelectionModal({
   // Parse variables from preset data
   const variables = useMemo<VariableData[]>(() => {
     if (!data?.choiceBlocks) return [];
-    return (data.choiceBlocks as any[]).map((cb: any) => {
-      const opts: ChoiceOption[] = Array.isArray(cb.options) ? cb.options : [];
+    return data.choiceBlocks.map((cb) => {
+      const rawOptions = legacyField(cb, "options");
+      const options: ChoiceOption[] = Array.isArray(rawOptions) ? rawOptions.filter(isChoiceOption) : [];
       return {
         id: cb.id,
-        variableName: cb.variableName ?? cb.variable_name ?? "unknown",
-        question: cb.question ?? "Choose an option",
-        options: opts,
-        multiSelect: cb.multiSelect === "true" || cb.multiSelect === true || cb.multi_select === "true",
-        randomPick: cb.randomPick === "true" || cb.randomPick === true || cb.random_pick === "true",
+        variableName: stringField(cb.variableName, stringField(legacyField(cb, "variable_name"), "unknown")),
+        question: stringField(cb.question, "Choose an option"),
+        options,
+        multiSelect: boolishChoice(cb.multiSelect) || boolishChoice(legacyField(cb, "multi_select")),
+        randomPick: boolishChoice(cb.randomPick) || boolishChoice(legacyField(cb, "random_pick")),
       };
     });
   }, [data?.choiceBlocks]);
@@ -68,10 +101,8 @@ export function ChoiceSelectionModal({
   // Parse saved default choices from preset
   const defaultChoices = useMemo<Record<string, string | string[]>>(() => {
     if (!data?.preset) return {};
-    return ((data.preset as any).defaultChoices ?? (data.preset as any).default_choices ?? {}) as Record<
-      string,
-      string | string[]
-    >;
+    const preset = data.preset as unknown as Record<string, unknown>;
+    return normalizeChoiceSelections(preset.defaultChoices ?? preset.default_choices);
   }, [data?.preset]);
 
   // Base selections derived from existing choices / defaults / first option.

--- a/src/features/catalog/presets/components/PresetsPanel.tsx
+++ b/src/features/catalog/presets/components/PresetsPanel.tsx
@@ -25,6 +25,33 @@ type PresetRow = {
   sectionOrder?: string | string[];
 };
 
+type PresetChoices = Record<string, string | string[]>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizePresetChoices(value: unknown): PresetChoices {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string | string[]] =>
+        typeof entry[1] === "string" || (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")),
+    ),
+  );
+}
+
+function getPresetChoices(metadata: unknown): PresetChoices {
+  if (typeof metadata === "string") {
+    try {
+      return getPresetChoices(JSON.parse(metadata));
+    } catch {
+      return {};
+    }
+  }
+  return normalizePresetChoices(isRecord(metadata) ? metadata.presetChoices : undefined);
+}
+
 export function PresetsPanel() {
   const { data: presets, isLoading } = usePresets();
   const deletePreset = useDeletePreset();
@@ -415,11 +442,7 @@ export function PresetsPanel() {
           onClose={() => setChoiceModalPresetId(null)}
           presetId={choiceModalPresetId}
           chatId={activeChat.id}
-          existingChoices={
-            typeof activeChat.metadata === "string"
-              ? (JSON.parse(activeChat.metadata).presetChoices ?? {})
-              : ((activeChat.metadata as any)?.presetChoices ?? {})
-          }
+          existingChoices={getPresetChoices(activeChat.metadata)}
         />
       )}
     </div>

--- a/src/features/catalog/presets/components/PresetsPanel.tsx
+++ b/src/features/catalog/presets/components/PresetsPanel.tsx
@@ -14,6 +14,7 @@ import { ChoiceSelectionModal } from "./ChoiceSelectionModal";
 import { Plus, Download, FileText, Trash2, Check, Copy, Search, Code2, Hash, Star } from "lucide-react";
 import { cn } from "../../../../shared/lib/utils";
 import { boolish } from "../../../../engine/generation/runtime-records";
+import { isRecord, normalizeChoiceSelections, type ChoiceSelections } from "../lib/choice-selections";
 
 type PresetRow = {
   id: string;
@@ -25,21 +26,7 @@ type PresetRow = {
   sectionOrder?: string | string[];
 };
 
-type PresetChoices = Record<string, string | string[]>;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
-}
-
-function normalizePresetChoices(value: unknown): PresetChoices {
-  if (!isRecord(value)) return {};
-  return Object.fromEntries(
-    Object.entries(value).filter(
-      (entry): entry is [string, string | string[]] =>
-        typeof entry[1] === "string" || (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")),
-    ),
-  );
-}
+type PresetChoices = ChoiceSelections;
 
 function getPresetChoices(metadata: unknown): PresetChoices {
   if (typeof metadata === "string") {
@@ -49,7 +36,7 @@ function getPresetChoices(metadata: unknown): PresetChoices {
       return {};
     }
   }
-  return normalizePresetChoices(isRecord(metadata) ? metadata.presetChoices : undefined);
+  return normalizeChoiceSelections(isRecord(metadata) ? metadata.presetChoices : undefined);
 }
 
 export function PresetsPanel() {

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -197,11 +197,16 @@ export function usePresetFull(id: string | null) {
     queryFn: async (): Promise<PresetFullData> => {
       const preset = await storageApi.get<PromptPreset>("prompts", id!);
       if (!preset) throw new Error("Preset not found");
+      const [sections, groups, choiceBlocks] = await Promise.all([
+        listPromptNested<PromptSection>(id!, "sections"),
+        listPromptNested<PromptGroup>(id!, "groups"),
+        listPromptNested<ChoiceBlock>(id!, "variables"),
+      ]);
       return {
         preset,
-        sections: await listPromptNested<PromptSection>(id!, "sections"),
-        groups: await listPromptNested<PromptGroup>(id!, "groups"),
-        choiceBlocks: await listPromptNested<ChoiceBlock>(id!, "variables"),
+        sections,
+        groups,
+        choiceBlocks,
       };
     },
     enabled: !!id,

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -34,6 +34,13 @@ export type PromptPresetSummary = Pick<PromptPreset, "id" | "name" | "isDefault"
   default?: boolean | string;
 };
 
+export interface PresetFullData {
+  preset: PromptPreset;
+  sections: PromptSection[];
+  groups: PromptGroup[];
+  choiceBlocks: ChoiceBlock[];
+}
+
 const PRESET_SUMMARY_OPTIONS = {
   fields: ["id", "name", "isDefault", "default"],
 };
@@ -187,12 +194,16 @@ export function usePresetSummaries() {
 export function usePresetFull(id: string | null) {
   return useQuery({
     queryKey: presetKeys.full(id ?? ""),
-    queryFn: async () => ({
-      preset: (await storageApi.get<PromptPreset>("prompts", id!))!,
-      sections: await listPromptNested<PromptSection>(id!, "sections"),
-      groups: await listPromptNested<PromptGroup>(id!, "groups"),
-      choiceBlocks: await listPromptNested<ChoiceBlock>(id!, "variables"),
-    }),
+    queryFn: async (): Promise<PresetFullData> => {
+      const preset = await storageApi.get<PromptPreset>("prompts", id!);
+      if (!preset) throw new Error("Preset not found");
+      return {
+        preset,
+        sections: await listPromptNested<PromptSection>(id!, "sections"),
+        groups: await listPromptNested<PromptGroup>(id!, "groups"),
+        choiceBlocks: await listPromptNested<ChoiceBlock>(id!, "variables"),
+      };
+    },
     enabled: !!id,
     staleTime: 5 * 60_000,
     refetchOnMount: "always",
@@ -373,7 +384,7 @@ export function useReorderSections() {
       reorderPromptNested<PromptSection>(presetId, "sections", sectionIds),
     onMutate: async ({ presetId, sectionIds }) => {
       await qc.cancelQueries({ queryKey: presetKeys.full(presetId) });
-      const prev = qc.getQueryData(presetKeys.full(presetId)) as any;
+      const prev = qc.getQueryData<PresetFullData>(presetKeys.full(presetId));
       if (prev?.preset?.sectionOrder) {
         qc.setQueryData(presetKeys.full(presetId), {
           ...prev,
@@ -445,11 +456,11 @@ export function useReorderVariables() {
       reorderPromptNested<ChoiceBlock>(presetId, "variables", variableIds),
     onMutate: async ({ presetId, variableIds }) => {
       await qc.cancelQueries({ queryKey: presetKeys.full(presetId) });
-      const prev = qc.getQueryData(presetKeys.full(presetId)) as any;
+      const prev = qc.getQueryData<PresetFullData>(presetKeys.full(presetId));
       if (prev?.choiceBlocks) {
         const idOrder = new Map(variableIds.map((id, i) => [id, i]));
         const sorted = [...prev.choiceBlocks].sort(
-          (a: any, b: any) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0),
+          (a, b) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0),
         );
         qc.setQueryData(presetKeys.full(presetId), { ...prev, choiceBlocks: sorted });
       }

--- a/src/features/catalog/presets/lib/choice-selections.ts
+++ b/src/features/catalog/presets/lib/choice-selections.ts
@@ -1,0 +1,15 @@
+export type ChoiceSelections = Record<string, string | string[]>;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeChoiceSelections(value: unknown): ChoiceSelections {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string | string[]] =>
+        typeof entry[1] === "string" || (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")),
+    ),
+  );
+}

--- a/src/features/modes/roleplay/hooks/use-scene.ts
+++ b/src/features/modes/roleplay/hooks/use-scene.ts
@@ -26,6 +26,21 @@ import type {
   ScenePlanResponse,
   SceneFullPlan,
 } from "../../../../engine/contracts/types/scene";
+import type { Chat } from "../../../../engine/contracts/types/chat";
+
+type CachedChatWithLegacyMetadata = Omit<Chat, "metadata"> & {
+  metadata: Chat["metadata"] | Record<string, unknown> | string;
+};
+
+function parseMetadataRecord(metadata: CachedChatWithLegacyMetadata["metadata"]): Record<string, unknown> {
+  if (typeof metadata !== "string") return { ...metadata };
+  try {
+    const parsed = JSON.parse(metadata);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? { ...parsed } : {};
+  } catch {
+    return {};
+  }
+}
 
 /** Provides scene lifecycle mutations and the scene-to-roleplay fork action. */
 export function useScene() {
@@ -123,9 +138,9 @@ export function useScene() {
 
         // Optimistically clear scene pointer from the cached origin chat
         // so the banner disappears immediately (invalidation refetches async).
-        qc.setQueryData(chatKeys.detail(res.originChatId), (old: any) => {
+        qc.setQueryData<CachedChatWithLegacyMetadata | undefined>(chatKeys.detail(res.originChatId), (old) => {
           if (!old) return old;
-          const meta = typeof old.metadata === "string" ? JSON.parse(old.metadata) : { ...(old.metadata ?? {}) };
+          const meta = parseMetadataRecord(old.metadata);
           delete meta.activeSceneChatId;
           delete meta.sceneBusyCharIds;
           return { ...old, metadata: meta };

--- a/src/features/modes/roleplay/hooks/use-scene.ts
+++ b/src/features/modes/roleplay/hooks/use-scene.ts
@@ -33,7 +33,8 @@ type CachedChatWithLegacyMetadata = Omit<Chat, "metadata"> & {
 };
 
 function parseMetadataRecord(metadata: CachedChatWithLegacyMetadata["metadata"]): Record<string, unknown> {
-  if (typeof metadata !== "string") return { ...metadata };
+  if (typeof metadata === "object" && metadata !== null && !Array.isArray(metadata)) return { ...metadata };
+  if (typeof metadata !== "string") return {};
   try {
     const parsed = JSON.parse(metadata);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? { ...parsed } : {};

--- a/src/features/shell/connections/components/ConnectionsPanel.tsx
+++ b/src/features/shell/connections/components/ConnectionsPanel.tsx
@@ -157,7 +157,7 @@ function ConnectionRow({
           onClick={(e) => {
             e.stopPropagation();
             duplicateConnection.mutate(conn.id, {
-              onSuccess: (data: any) => {
+              onSuccess: (data) => {
                 if (data?.id) openConnectionDetail(data.id);
               },
             });

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3161,7 +3161,7 @@ function ImportButton({
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      let data: { success?: boolean; error?: string; chatId?: string };
+      let data: ImportButtonResult;
       let importEmbeddedLorebook: boolean | undefined;
 
       // "auto" mode: send binary files (PNG) as multipart, JSON files as JSON body

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -3138,6 +3138,12 @@ function ImportSettings() {
   );
 }
 
+type ImportButtonResult = {
+  success?: boolean;
+  error?: string;
+  chatId?: string;
+};
+
 function ImportButton({
   label,
   accept,
@@ -3149,7 +3155,7 @@ function ImportButton({
   accept: string;
   endpoint: string;
   mode?: "file" | "json" | "auto";
-  onImported?: (data: any) => void;
+  onImported?: (data: ImportButtonResult) => void;
 }) {
   const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/shared/components/ui/SpriteFrameEditor.tsx
+++ b/src/shared/components/ui/SpriteFrameEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Crop, Loader2, RotateCcw, X } from "lucide-react";
 import { cropSpriteDataUrl, type SpriteFrameAdjustments } from "../../lib/sprite-frame-crop";
+import { getErrorMessage } from "../../lib/error-message";
 
 type SpriteFrameAdjustmentKey = keyof SpriteFrameAdjustments;
 
@@ -53,10 +54,10 @@ export function SpriteFrameEditor({ imageUrl, label, applying = false, onApply, 
           setError(null);
         }
       })
-      .catch((err: any) => {
+      .catch((err) => {
         if (!cancelled) {
           setPreviewUrl(imageUrl);
-          setError(err?.message || "Frame preview failed");
+          setError(getErrorMessage(err, "Frame preview failed"));
         }
       });
 
@@ -87,8 +88,8 @@ export function SpriteFrameEditor({ imageUrl, label, applying = false, onApply, 
     setError(null);
     try {
       await onApply(await cropSpriteDataUrl(imageUrl, frame));
-    } catch (err: any) {
-      setError(err?.message || "Failed to frame sprite");
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to frame sprite"));
     }
   }, [frame, imageUrl, onApply]);
 

--- a/src/shared/components/ui/SpriteGenerationModal.tsx
+++ b/src/shared/components/ui/SpriteGenerationModal.tsx
@@ -8,6 +8,7 @@ import { X, Loader2, Check, ImagePlus, Sparkles, ArrowLeft, Crop, RotateCcw } fr
 import { Modal } from "./Modal";
 import { cn } from "../../lib/utils";
 import { cropSpriteDataUrl, type SpriteFrameAdjustments } from "../../lib/sprite-frame-crop";
+import { getErrorMessage } from "../../lib/error-message";
 import { useUIStore } from "../../stores/ui.store";
 import { spriteApi, type SpriteOwnerType } from "../../api/image-generation-api";
 import { ImagePromptReviewModal, type ImagePromptOverride, type ImagePromptReviewItem } from "./ImagePromptReviewModal";
@@ -339,15 +340,7 @@ function imageDataUrl(base64: string): string {
 }
 
 function getGenerationErrorMessage(err: unknown): string {
-  if (
-    err &&
-    typeof err === "object" &&
-    "message" in err &&
-    typeof (err as { message?: unknown }).message === "string"
-  ) {
-    return (err as { message: string }).message;
-  }
-  return "Image generation failed";
+  return getErrorMessage(err, "Image generation failed");
 }
 
 function createGeneratedSpritesFromResult(
@@ -956,8 +949,8 @@ export function SpriteGenerationModal({
         })),
       );
       setCleanupApplied(true);
-    } catch (err: any) {
-      setError(err?.message || "Failed to apply background cleanup");
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to apply background cleanup"));
     } finally {
       setCleanupApplying(false);
     }
@@ -1024,8 +1017,8 @@ export function SpriteGenerationModal({
         ),
       );
       handleCloseCellFrame();
-    } catch (err: any) {
-      setError(err?.message || "Failed to frame sprite");
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to frame sprite"));
     } finally {
       setFrameApplying(false);
     }
@@ -1145,8 +1138,8 @@ export function SpriteGenerationModal({
       setActiveFrameIndex(null);
       setFrameAdjustments(DEFAULT_SPRITE_FRAME_ADJUSTMENTS);
       setFramePreviewUrl(null);
-    } catch (err: any) {
-      setError(err?.message || "Failed to adjust sprite slices");
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to adjust sprite slices"));
     } finally {
       setSliceApplying(false);
     }
@@ -1210,8 +1203,8 @@ export function SpriteGenerationModal({
       setFailedMatchedBatch(null);
       setGenerationProgress(null);
       handleCloseCellFrame();
-    } catch (err: any) {
-      setError(err?.message || "Failed to save sprites");
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to save sprites"));
     } finally {
       setSaving(false);
     }

--- a/src/shared/components/ui/sprite-wand-cleanup/useSpriteCleanupEditor.ts
+++ b/src/shared/components/ui/sprite-wand-cleanup/useSpriteCleanupEditor.ts
@@ -10,6 +10,7 @@ import {
   type WheelEvent,
 } from "react";
 import { applyBrushLine, applyBrushStamp } from "./sprite-cleanup-brush";
+import { getErrorMessage } from "../../../lib/error-message";
 import { canvasPointFromClient, loadImageToCanvas } from "./sprite-cleanup-canvas";
 import {
   brushActionLabels,
@@ -183,9 +184,9 @@ export function useSpriteCleanupEditor({ imageUrl, applying, onApply }: UseSprit
           setLoading(false);
           requestAnimationFrame(fitCanvasToStage);
         })
-        .catch((err: any) => {
+        .catch((err) => {
           if (cancelled) return;
-          setError(err?.message || "Sprite image could not be loaded");
+          setError(getErrorMessage(err, "Sprite image could not be loaded"));
           setLoading(false);
         });
     };
@@ -619,8 +620,8 @@ export function useSpriteCleanupEditor({ imageUrl, applying, onApply }: UseSprit
     try {
       setError(null);
       await onApply(canvas.toDataURL("image/png"));
-    } catch (err: any) {
-      setError(err?.message || "Failed to save sprite cleanup");
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to save sprite cleanup"));
     }
   }, [onApply]);
 

--- a/src/shared/lib/error-message.ts
+++ b/src/shared/lib/error-message.ts
@@ -1,0 +1,13 @@
+function hasMessage(value: unknown): value is { message: string } {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    "message" in value &&
+    typeof (value as { message?: unknown }).message === "string" &&
+    (value as { message: string }).message.length > 0
+  );
+}
+
+export function getErrorMessage(error: unknown, fallback: string): string {
+  return hasMessage(error) ? error.message : fallback;
+}

--- a/src/shared/lib/error-message.ts
+++ b/src/shared/lib/error-message.ts
@@ -1,11 +1,7 @@
 function hasMessage(value: unknown): value is { message: string } {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    "message" in value &&
-    typeof (value as { message?: unknown }).message === "string" &&
-    (value as { message: string }).message.length > 0
-  );
+  if (!value || typeof value !== "object" || !("message" in value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.message === "string" && candidate.message.length > 0;
 }
 
 export function getErrorMessage(error: unknown, fallback: string): string {


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Reduce remaining explicit `any` usage before stricter linting by replacing local casts with typed guards and shared error-message helpers.

## What changed

- Added a shared helper for reading messages from unknown errors.
- Typed sprite generation, cleanup, and frame-editing error paths.
- Replaced preset choice casts with guarded parsing and typed preset query data.
- Removed related explicit `any` callbacks/casts in character save, shell settings/connections, roleplay scene cache updates, and agent pipeline result handling.
- Tightened the agent context abort signal type.

## Refactor impact

Primary owner:

Catalog UI, shared UI helpers, shell UI, roleplay hook, and engine agent contracts.

Impact areas reviewed:

- Preset choice parsing and chat metadata choice application
- Character/persona sprite generation and cleanup error paths
- Agent pipeline result text extraction and abort signal typing
- Roleplay scene cached metadata updates
- Shell settings import and duplicate connection callbacks

Boundary notes:

- Engine changes stay React-free and do not import feature or shared API adapters.
- Shared helper is feature-neutral under `src/shared/lib`.
- Feature changes stay in React UI owners; no new raw Tauri/runtime calls.
- Rust and remote runtime not touched.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm check` passed locally.
- `pnpm typecheck` passed locally before the full gate.
- `pnpm check:architecture` passed locally before the full gate.
- `git diff --check` passed locally.
- Targeted touched-area explicit-`any` grep returned no hits.
- Browser/Tauri manual verification not run; no visible UI behavior change claimed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal type-safety cleanup only; no new discoverable user feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes needed; this is internal type-safety cleanup and does not change user-facing documentation or release claims.

## UI evidence

N/A; no visible UI behavior change claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message consistency and clarity across character sprites, personas, and preset operations.
  * Enhanced data validation for preset choices and metadata to prevent processing errors.

* **Refactor**
  * Standardized internal error handling with improved type safety throughout the application, reducing potential runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->