### PR TITLE
Fix agent enabled state

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -605,6 +605,10 @@ function builtInAgentFallback(type: string): JsonRecord | null {
   };
 }
 
+function agentConfigEnabled(agent: JsonRecord): boolean {
+  return boolish(agent.enabled, true);
+}
+
 function positiveInteger(value: unknown, fallback: number, max: number): number {
   const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
   if (!Number.isFinite(parsed) || parsed < 1) return fallback;
@@ -832,9 +836,14 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
   const activationMessages = activationScanMessages(input);
   const requestedAgentTypes = input.agentTypes ?? null;
   const explicitAgentTypes = requestedAgentTypes ?? scopedAgentIds;
-  const rows = (await deps.storage.list<JsonRecord>("agents")).filter((agent) => {
+  const agentRows = await deps.storage.list<JsonRecord>("agents");
+  const configuredBuiltInTypes = new Set(
+    agentRows.map(builtInAgentType).filter((type) => BUILT_IN_AGENT_TYPES.has(type)),
+  );
+  const rows = agentRows.filter((agent) => {
     const type = builtInAgentType(agent);
     const id = readString(agent.id);
+    if (!agentConfigEnabled(agent)) return false;
     const requestedExplicitly = requestedAgentTypes && (requestedAgentTypes.has(type) || requestedAgentTypes.has(id));
     const scopedToChat = scopedAgentIds.size > 0 && (scopedAgentIds.has(type) || scopedAgentIds.has(id));
     if (
@@ -846,12 +855,13 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     }
     if (requestedAgentTypes && requestedAgentTypes.size > 0) return Boolean(requestedExplicitly);
     if (scopedAgentIds.size > 0) return scopedToChat;
-    return boolish(agent.enabled, false);
+    return true;
   });
   const resolvedBuiltInTypes = new Set(rows.map(builtInAgentType).filter((type) => BUILT_IN_AGENT_TYPES.has(type)));
   const fallbackRows = [...explicitAgentTypes]
     .filter((type) => BUILT_IN_AGENT_TYPES.has(type))
     .filter((type) => !resolvedBuiltInTypes.has(type))
+    .filter((type) => !configuredBuiltInTypes.has(type))
     .filter((type) => requestedAgentTypes || type !== "lorebook-keeper")
     .map(builtInAgentFallback)
     .filter((agent): agent is JsonRecord => !!agent);

--- a/src/engine/generation/sprite-expression-validation.ts
+++ b/src/engine/generation/sprite-expression-validation.ts
@@ -16,7 +16,7 @@ export interface SpriteExpressionEntry {
   transition?: unknown;
 }
 
-export interface ExpressionValidationWarning {
+interface ExpressionValidationWarning {
   message: string;
 }
 

--- a/src/features/catalog/agents/components/AgentEditor.test.tsx
+++ b/src/features/catalog/agents/components/AgentEditor.test.tsx
@@ -42,7 +42,19 @@ vi.mock("../hooks/use-agents", () => {
       detail: (id: string) => ["agents", id],
       customRuns: (id: string) => ["agents", "runs", "custom", id],
     },
-    agentCreditLabel: (value: unknown) => (typeof value === "string" && value.trim() ? value.trim() : "Marinara Dev Team"),
+    agentConfigEnabled: (value: unknown, fallback = true) => {
+      if (typeof value === "boolean") return value;
+      if (typeof value === "number") return value !== 0;
+      if (typeof value === "string") {
+        const normalized = value.trim().toLowerCase();
+        if (["true", "1", "yes", "on"].includes(normalized)) return true;
+        if (["false", "0", "no", "off"].includes(normalized)) return false;
+        if (!normalized) return fallback;
+      }
+      return fallback;
+    },
+    agentCreditLabel: (value: unknown) =>
+      typeof value === "string" && value.trim() ? value.trim() : "Marinara Dev Team",
     useAgentConfigs: () => ({ data: agentHookMocks.configs }),
     useUpdateAgent: () => agentHookMocks.updateAgent,
     useCreateAgent: () => agentHookMocks.createAgent,

--- a/src/features/catalog/agents/components/AgentEditor.tsx
+++ b/src/features/catalog/agents/components/AgentEditor.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import {
+  agentConfigEnabled,
   agentCreditLabel,
   agentKeys,
   useAgentConfigs,
@@ -200,6 +201,7 @@ export function AgentEditor() {
   // ── Local editable state ──
   const [localName, setLocalName] = useState("");
   const [localDescription, setLocalDescription] = useState("");
+  const [localEnabled, setLocalEnabled] = useState(true);
   const [localPhase, setLocalPhase] = useState<AgentPhase>("post_processing");
   const [localConnectionId, setLocalConnectionId] = useState("");
   const [localImageConnectionId, setLocalImageConnectionId] = useState("");
@@ -255,6 +257,7 @@ export function AgentEditor() {
     if (dbConfig) {
       setLocalName(builtIn ? builtIn.name : dbConfig.name);
       setLocalDescription(dbConfig.description);
+      setLocalEnabled(agentConfigEnabled(dbConfig.enabled, true));
       setLocalPhase(dbConfig.phase as AgentPhase);
       setLocalConnectionId(dbConfig.connectionId ?? "");
       const settings = dbConfig.settings
@@ -291,6 +294,7 @@ export function AgentEditor() {
     } else if (builtIn) {
       setLocalName(builtIn.name);
       setLocalDescription(builtIn.description);
+      setLocalEnabled(true);
       setLocalPhase(builtIn.phase);
       setLocalConnectionId("");
       setLocalImageConnectionId("");
@@ -317,6 +321,7 @@ export function AgentEditor() {
       // Brand new custom agent — start empty
       setLocalName("New Agent");
       setLocalDescription("");
+      setLocalEnabled(true);
       setLocalPhase("post_processing");
       setLocalConnectionId("");
       setLocalImageConnectionId("");
@@ -374,7 +379,7 @@ export function AgentEditor() {
     if (!agentConfigs) return false;
     if (!isKnowledgeRouterAgent && !isKnowledgeRetrievalAgent) return false;
     const rows = agentConfigs as AgentConfigRow[];
-    const enabledTypes = new Set(rows.filter((c) => c.enabled === "true").map((c) => c.type));
+    const enabledTypes = new Set(rows.filter((c) => agentConfigEnabled(c.enabled, true)).map((c) => c.type));
     return enabledTypes.has("knowledge-router") && enabledTypes.has("knowledge-retrieval");
   }, [agentConfigs, isKnowledgeRetrievalAgent, isKnowledgeRouterAgent]);
 
@@ -497,7 +502,7 @@ export function AgentEditor() {
       description: localDescription,
       credit: agentCreditLabel(dbConfig?.credit ?? builtIn?.credit ?? DEFAULT_AGENT_CREDIT),
       phase: savedPhase,
-      enabled: true,
+      enabled: localEnabled,
       connectionId: localConnectionId || null,
       promptTemplate: localPrompt,
       settings: {
@@ -560,6 +565,7 @@ export function AgentEditor() {
     agentDetailId,
     localName,
     localDescription,
+    localEnabled,
     localPhase,
     localResultType,
     localActivationKeywordsText,
@@ -775,6 +781,41 @@ export function AgentEditor() {
             <div className="rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)]">
               {displayedCredit}
             </div>
+          </FieldGroup>
+
+          <FieldGroup
+            label="Agent Status"
+            icon={<Sparkles size="0.875rem" className="text-[var(--primary)]" />}
+            help="Disabled agents stay configured but do not run globally or when selected for a chat."
+          >
+            <button
+              type="button"
+              onClick={() => {
+                setLocalEnabled((value) => !value);
+                markDirty();
+              }}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-xl p-3 text-left text-sm ring-1 transition-all",
+                localEnabled
+                  ? "bg-emerald-500/10 text-[var(--foreground)] ring-emerald-400/35"
+                  : "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-[var(--border)] hover:bg-[var(--accent)]",
+              )}
+              aria-pressed={localEnabled}
+            >
+              {localEnabled ? (
+                <ToggleRight size="1.25rem" className="shrink-0 text-emerald-400" />
+              ) : (
+                <ToggleLeft size="1.25rem" className="shrink-0 text-[var(--muted-foreground)]" />
+              )}
+              <span className="min-w-0 flex-1">
+                <span className="block font-medium">{localEnabled ? "Enabled" : "Disabled"}</span>
+                <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)]">
+                  {localEnabled
+                    ? "This agent can run when generation allows it."
+                    : "This agent is preserved but skipped."}
+                </span>
+              </span>
+            </button>
           </FieldGroup>
 
           {/* ── Pipeline Phase ── */}

--- a/src/features/catalog/agents/components/AgentsPanel.tsx
+++ b/src/features/catalog/agents/components/AgentsPanel.tsx
@@ -18,7 +18,14 @@ import {
   ToggleRight,
 } from "lucide-react";
 import { useUIStore } from "../../../../shared/stores/ui.store";
-import { useAgentConfigs, useDeleteAgent, type AgentConfigRow } from "../hooks/use-agents";
+import {
+  agentConfigEnabled,
+  useAgentConfigs,
+  useCreateAgent,
+  useDeleteAgent,
+  useUpdateAgent,
+  type AgentConfigRow,
+} from "../hooks/use-agents";
 import { useCustomTools, useDeleteCustomTool, type CustomToolRow } from "../hooks/use-custom-tools";
 import {
   useRegexScripts,
@@ -28,7 +35,13 @@ import {
   useReorderRegexScripts,
   type RegexScriptRow,
 } from "../hooks/use-regex-scripts";
-import { BUILT_IN_AGENTS, type AgentCategory } from "../../../../engine/contracts/types/agent";
+import {
+  BUILT_IN_AGENTS,
+  DEFAULT_AGENT_TOOLS,
+  getDefaultBuiltInAgentSettings,
+  type AgentCategory,
+  type AgentPhase,
+} from "../../../../engine/contracts/types/agent";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";
 
@@ -36,6 +49,8 @@ export function AgentsPanel() {
   const { data: agentConfigs, isLoading } = useAgentConfigs();
   const { data: customTools } = useCustomTools();
   const { data: regexScripts } = useRegexScripts();
+  const createAgent = useCreateAgent();
+  const updateAgent = useUpdateAgent();
   const deleteAgent = useDeleteAgent();
   const deleteTool = useDeleteCustomTool();
   const deleteRegex = useDeleteRegexScript();
@@ -124,26 +139,34 @@ export function AgentsPanel() {
   );
   const configByType = new Map(((agentConfigs ?? []) as AgentConfigRow[]).map((config) => [config.type, config]));
 
-  const statusAgents = [
-    ...BUILT_IN_AGENTS.map((agent) => ({
-      id: agent.id,
-      type: agent.id,
-      name: agent.name,
-      description: agent.description,
-      category: agent.category,
-      enabled: configByType.get(agent.id)?.enabled !== "false",
-      custom: false,
-    })),
+  const statusAgents: AgentPanelRow[] = [
+    ...BUILT_IN_AGENTS.map((agent) => {
+      const config = configByType.get(agent.id);
+      return {
+        id: agent.id,
+        type: agent.id,
+        name: agent.name,
+        description: agent.description,
+        category: agent.category,
+        phase: agent.phase,
+        enabled: config ? agentConfigEnabled(config.enabled, true) : true,
+        configId: config?.id,
+        custom: false,
+      };
+    }),
     ...customAgents.map((agent) => ({
       id: agent.id,
       type: agent.type,
       name: agent.name,
       description: agent.description,
       category: "custom" as const,
-      enabled: agent.enabled !== "false",
+      phase: agent.phase as AgentPhase,
+      enabled: agentConfigEnabled(agent.enabled, true),
+      configId: agent.id,
       custom: true,
     })),
   ];
+  const statusAgentByType = new Map(statusAgents.map((agent) => [agent.type, agent]));
 
   const activeAgents = statusAgents.filter((agent) => agent.enabled);
   const inactiveAgents = statusAgents.filter((agent) => !agent.enabled);
@@ -159,6 +182,31 @@ export function AgentsPanel() {
 
   const handleCreateRegex = () => {
     openRegexDetail("__new__");
+  };
+
+  const handleToggleAgentEnabled = async (agent: AgentPanelRow) => {
+    const enabled = !agent.enabled;
+    const config = agent.configId
+      ? ((agentConfigs ?? []) as AgentConfigRow[]).find((row) => row.id === agent.configId)
+      : null;
+    if (config) {
+      await updateAgent.mutateAsync({ id: config.id, enabled });
+      return;
+    }
+    if (agent.custom) return;
+    await createAgent.mutateAsync({
+      type: agent.type,
+      name: agent.name,
+      description: agent.description,
+      phase: agent.phase,
+      enabled,
+      connectionId: null,
+      promptTemplate: "",
+      settings: {
+        ...getDefaultBuiltInAgentSettings(agent.type),
+        enabledTools: DEFAULT_AGENT_TOOLS[agent.type] ?? [],
+      },
+    });
   };
 
   const handleRegexDrop = (targetId: string) => {
@@ -394,14 +442,19 @@ export function AgentsPanel() {
                 ) : (
                   agents.map((agent) =>
                     renderAgentCard({
-                      id: agent.id,
-                      type: agent.id,
-                      name: agent.name,
-                      description: agent.description,
-                      category: agent.category,
-                      enabled: configByType.get(agent.id)?.enabled !== "false",
-                      custom: false,
+                      ...(statusAgentByType.get(agent.id) ?? {
+                        id: agent.id,
+                        type: agent.id,
+                        name: agent.name,
+                        description: agent.description,
+                        category: agent.category,
+                        phase: agent.phase,
+                        enabled: true,
+                        custom: false,
+                      }),
                       openAgentDetail,
+                      onToggleEnabled: handleToggleAgentEnabled,
+                      toggleDisabled: createAgent.isPending || updateAgent.isPending,
                     }),
                   )
                 )}
@@ -418,14 +471,28 @@ export function AgentsPanel() {
             {!activeAgents.length ? (
               <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No active agents.</p>
             ) : (
-              activeAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail }))
+              activeAgents.map((agent) =>
+                renderAgentCard({
+                  ...agent,
+                  openAgentDetail,
+                  onToggleEnabled: handleToggleAgentEnabled,
+                  toggleDisabled: createAgent.isPending || updateAgent.isPending,
+                }),
+              )
             )}
           </PanelSection>
           <PanelSection title="Disabled Agents" icon={<Sparkles size="0.8125rem" />}>
             {!inactiveAgents.length ? (
               <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No inactive agents.</p>
             ) : (
-              inactiveAgents.map((agent) => renderAgentCard({ ...agent, openAgentDetail }))
+              inactiveAgents.map((agent) =>
+                renderAgentCard({
+                  ...agent,
+                  openAgentDetail,
+                  onToggleEnabled: handleToggleAgentEnabled,
+                  toggleDisabled: createAgent.isPending || updateAgent.isPending,
+                }),
+              )
             )}
           </PanelSection>
         </>
@@ -457,7 +524,7 @@ export function AgentsPanel() {
                   key={agent.id}
                   className={cn(
                     "flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]",
-                    agent.enabled === "false" && "opacity-55",
+                    !agentConfigEnabled(agent.enabled, true) && "opacity-55",
                   )}
                 >
                   <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
@@ -466,6 +533,30 @@ export function AgentsPanel() {
                     <div className="text-[0.625rem] text-[var(--muted-foreground)] line-clamp-2">
                       {agent.description || "No description"}
                     </div>
+                  </button>
+                  <button
+                    className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)] disabled:opacity-50"
+                    title={agentConfigEnabled(agent.enabled, true) ? "Disable agent" : "Enable agent"}
+                    disabled={updateAgent.isPending}
+                    onClick={() =>
+                      void handleToggleAgentEnabled({
+                        id: agent.id,
+                        type: agent.type,
+                        name: agent.name,
+                        description: agent.description,
+                        category: "custom",
+                        phase: agent.phase as AgentPhase,
+                        enabled: agentConfigEnabled(agent.enabled, true),
+                        configId: agent.id,
+                        custom: true,
+                      })
+                    }
+                  >
+                    {agentConfigEnabled(agent.enabled, true) ? (
+                      <ToggleRight size="0.8125rem" />
+                    ) : (
+                      <ToggleLeft size="0.8125rem" />
+                    )}
                   </button>
                   <button
                     className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"
@@ -567,31 +658,43 @@ export function AgentsPanel() {
   );
 }
 
+type AgentPanelRow = {
+  id: string;
+  type: string;
+  name: string;
+  description: string;
+  category: AgentCategory | "custom";
+  phase: AgentPhase;
+  enabled: boolean;
+  configId?: string;
+  custom: boolean;
+};
+
 function renderAgentCard({
   id,
   type,
   name,
   description,
   category,
+  phase,
   enabled,
+  configId,
   custom,
   openAgentDetail,
-}: {
-  id: string;
-  type: string;
-  name: string;
-  description: string;
-  category: AgentCategory | "custom";
-  enabled: boolean;
-  custom: boolean;
+  onToggleEnabled,
+  toggleDisabled,
+}: AgentPanelRow & {
   openAgentDetail: (id: string) => void;
+  onToggleEnabled: (agent: AgentPanelRow) => void | Promise<void>;
+  toggleDisabled: boolean;
 }) {
-  void enabled;
-
   return (
     <div
       key={id}
-      className="flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]"
+      className={cn(
+        "flex items-start gap-2.5 rounded-lg p-2 transition-colors hover:bg-[var(--sidebar-accent)]",
+        !enabled && "opacity-60",
+      )}
     >
       <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
       <button className="min-w-0 flex-1 text-left" onClick={() => openAgentDetail(custom ? id : type)}>
@@ -599,9 +702,39 @@ function renderAgentCard({
         <div className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)] line-clamp-2">
           {description || "No description"}
         </div>
-        <div className="mt-1 text-[0.5625rem] uppercase tracking-wide text-[var(--muted-foreground)]/80">
-          {custom ? "custom" : category}
+        <div className="mt-1 flex flex-wrap items-center gap-1">
+          <span className="text-[0.5625rem] uppercase tracking-wide text-[var(--muted-foreground)]/80">
+            {custom ? "custom" : category}
+          </span>
+          <span
+            className={cn(
+              "rounded px-1 py-0.5 text-[0.5rem] uppercase tracking-wide",
+              enabled ? "bg-emerald-500/10 text-emerald-400" : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
+            )}
+          >
+            {enabled ? "enabled" : "disabled"}
+          </span>
         </div>
+      </button>
+      <button
+        className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)] disabled:opacity-50"
+        title={enabled ? "Disable agent" : "Enable agent"}
+        disabled={toggleDisabled}
+        onClick={() =>
+          void onToggleEnabled({
+            id,
+            type,
+            name,
+            description,
+            category,
+            phase,
+            enabled,
+            configId,
+            custom,
+          })
+        }
+      >
+        {enabled ? <ToggleRight size="0.8125rem" /> : <ToggleLeft size="0.8125rem" />}
       </button>
       <button
         className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)]"

--- a/src/features/catalog/agents/components/AgentsPanel.tsx
+++ b/src/features/catalog/agents/components/AgentsPanel.tsx
@@ -133,43 +133,53 @@ export function AgentsPanel() {
     event.target.value = ""; // reset file input
   };
 
-  // Custom agents = DB entries whose type doesn't match any built-in
-  const customAgents = ((agentConfigs ?? []) as AgentConfigRow[]).filter(
-    (c) => !BUILT_IN_AGENTS.some((b) => b.id === c.type),
-  );
-  const configByType = new Map(((agentConfigs ?? []) as AgentConfigRow[]).map((config) => [config.type, config]));
+  const agentConfigRows = useMemo(() => ((agentConfigs ?? []) as AgentConfigRow[]), [agentConfigs]);
+  const builtInAgentTypes = useMemo(() => new Set(BUILT_IN_AGENTS.map((agent) => agent.id)), []);
 
-  const statusAgents: AgentPanelRow[] = [
-    ...BUILT_IN_AGENTS.map((agent) => {
-      const config = configByType.get(agent.id);
-      return {
+  // Custom agents = DB entries whose type doesn't match any built-in
+  const customAgents = useMemo(
+    () => agentConfigRows.filter((config) => !builtInAgentTypes.has(config.type)),
+    [agentConfigRows, builtInAgentTypes],
+  );
+  const configByType = useMemo(
+    () => new Map(agentConfigRows.map((config) => [config.type, config])),
+    [agentConfigRows],
+  );
+
+  const statusAgents: AgentPanelRow[] = useMemo(
+    () => [
+      ...BUILT_IN_AGENTS.map((agent) => {
+        const config = configByType.get(agent.id);
+        return {
+          id: agent.id,
+          type: agent.id,
+          name: agent.name,
+          description: agent.description,
+          category: agent.category,
+          phase: agent.phase,
+          enabled: config ? agentConfigEnabled(config.enabled, true) : true,
+          configId: config?.id,
+          custom: false,
+        };
+      }),
+      ...customAgents.map((agent) => ({
         id: agent.id,
-        type: agent.id,
+        type: agent.type,
         name: agent.name,
         description: agent.description,
-        category: agent.category,
-        phase: agent.phase,
-        enabled: config ? agentConfigEnabled(config.enabled, true) : true,
-        configId: config?.id,
-        custom: false,
-      };
-    }),
-    ...customAgents.map((agent) => ({
-      id: agent.id,
-      type: agent.type,
-      name: agent.name,
-      description: agent.description,
-      category: "custom" as const,
-      phase: agent.phase as AgentPhase,
-      enabled: agentConfigEnabled(agent.enabled, true),
-      configId: agent.id,
-      custom: true,
-    })),
-  ];
-  const statusAgentByType = new Map(statusAgents.map((agent) => [agent.type, agent]));
+        category: "custom" as const,
+        phase: agent.phase as AgentPhase,
+        enabled: agentConfigEnabled(agent.enabled, true),
+        configId: agent.id,
+        custom: true,
+      })),
+    ],
+    [configByType, customAgents],
+  );
+  const statusAgentByType = useMemo(() => new Map(statusAgents.map((agent) => [agent.type, agent])), [statusAgents]);
 
-  const activeAgents = statusAgents.filter((agent) => agent.enabled);
-  const inactiveAgents = statusAgents.filter((agent) => !agent.enabled);
+  const activeAgents = useMemo(() => statusAgents.filter((agent) => agent.enabled), [statusAgents]);
+  const inactiveAgents = useMemo(() => statusAgents.filter((agent) => !agent.enabled), [statusAgents]);
 
   const handleCreateAgent = () => {
     // Create a new custom agent immediately in DB then open editor
@@ -187,12 +197,13 @@ export function AgentsPanel() {
   const handleToggleAgentEnabled = async (agent: AgentPanelRow) => {
     const enabled = !agent.enabled;
     const config = agent.configId
-      ? ((agentConfigs ?? []) as AgentConfigRow[]).find((row) => row.id === agent.configId)
+      ? agentConfigRows.find((row) => row.id === agent.configId)
       : null;
     if (config) {
       await updateAgent.mutateAsync({ id: config.id, enabled });
       return;
     }
+    // Custom agents are persisted rows, so this handler should never synthesize them.
     if (agent.custom) return;
     await createAgent.mutateAsync({
       type: agent.type,
@@ -537,6 +548,8 @@ export function AgentsPanel() {
                   <button
                     className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)] disabled:opacity-50"
                     title={agentConfigEnabled(agent.enabled, true) ? "Disable agent" : "Enable agent"}
+                    aria-label={agentConfigEnabled(agent.enabled, true) ? "Disable agent" : "Enable agent"}
+                    aria-pressed={agentConfigEnabled(agent.enabled, true)}
                     disabled={updateAgent.isPending}
                     onClick={() =>
                       void handleToggleAgentEnabled({
@@ -719,6 +732,8 @@ function renderAgentCard({
       <button
         className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--primary)] disabled:opacity-50"
         title={enabled ? "Disable agent" : "Enable agent"}
+        aria-label={enabled ? "Disable agent" : "Enable agent"}
+        aria-pressed={enabled}
         disabled={toggleDisabled}
         onClick={() =>
           void onToggleEnabled({

--- a/src/features/catalog/agents/hooks/use-agents.ts
+++ b/src/features/catalog/agents/hooks/use-agents.ts
@@ -2,10 +2,7 @@
 // Hooks: Agent Configs (React Query)
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  createAgentConfigSchema,
-  updateAgentConfigSchema,
-} from "../../../../engine/contracts/schemas/agent.schema";
+import { createAgentConfigSchema, updateAgentConfigSchema } from "../../../../engine/contracts/schemas/agent.schema";
 import { BUILT_IN_AGENTS, DEFAULT_AGENT_CREDIT } from "../../../../engine/contracts/types/agent";
 import { agentApi } from "../../../../shared/api/agent-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -22,7 +19,7 @@ export interface AgentConfigRow {
   description: string;
   credit?: string;
   phase: string;
-  enabled: string;
+  enabled?: boolean | number | string | null;
   connectionId: string | null;
   promptTemplate: string;
   settings: string;
@@ -50,6 +47,18 @@ const builtInAgentTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 
 export function agentCreditLabel(value: unknown): string {
   return typeof value === "string" && value.trim() ? value.trim() : DEFAULT_AGENT_CREDIT;
+}
+
+export function agentConfigEnabled(value: unknown, fallback = true): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+    if (!normalized) return fallback;
+  }
+  return fallback;
 }
 
 function normalizeAgentUpdatePayload(data: Record<string, unknown>): Record<string, unknown> {

--- a/src/features/modes/roleplay/components/RoleplayHUD.tsx
+++ b/src/features/modes/roleplay/components/RoleplayHUD.tsx
@@ -11,7 +11,7 @@ import { agentApi } from "../../../../shared/api/agent-api";
 import { roleplayTrackerApi } from "../api/roleplay-tracker-api";
 import { useGameStateStore } from "../../../runtime/world-state/index";
 import { useAgentStore } from "../../../../shared/stores/agent.store";
-import { useAgentConfigs } from "../../../catalog/agents/index";
+import { agentConfigEnabled, useAgentConfigs } from "../../../catalog/agents/index";
 import { useChat } from "../../../catalog/chats/index";
 import { useTrackerStateController } from "../../../runtime/world-state/index";
 import { discardPendingGameStatePatch } from "../../../runtime/world-state/index";
@@ -99,8 +99,8 @@ export function RoleplayHUD({
   const globalEnabledAgentTypes = useMemo(() => {
     const set = new Set<string>();
     if (agentConfigs) {
-      for (const a of agentConfigs as Array<{ type: string; enabled: string }>) {
-        if (a.enabled === "true") set.add(a.type);
+      for (const a of agentConfigs as Array<{ type: string; enabled?: unknown }>) {
+        if (agentConfigEnabled(a.enabled, true)) set.add(a.type);
       }
     }
     return set;

--- a/src/features/modes/roleplay/components/RoleplayHUDActionsMenu.tsx
+++ b/src/features/modes/roleplay/components/RoleplayHUDActionsMenu.tsx
@@ -13,7 +13,12 @@ import {
 } from "lucide-react";
 import { BUILT_IN_AGENTS } from "../../../../engine/contracts/types/agent";
 import type { Message } from "../../../../engine/contracts/types/chat";
-import { useUpdateAgentRunData, type AgentConfigRow, type AgentRunRow } from "../../../catalog/agents/index";
+import {
+  agentConfigEnabled,
+  useUpdateAgentRunData,
+  type AgentConfigRow,
+  type AgentRunRow,
+} from "../../../catalog/agents/index";
 import {
   formatAgentFailureDetail,
   formatAgentFailureTitle,
@@ -413,7 +418,8 @@ function hasActiveInjectableCustomAgent(configs: AgentConfigRow[], enabledAgentT
   const builtInTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
   return configs.some((config) => {
     if (builtInTypes.has(config.type)) return false;
-    if (enabledAgentTypes ? !enabledAgentTypes.has(config.type) : config.enabled !== "true") return false;
+    if (!agentConfigEnabled(config.enabled, true)) return false;
+    if (enabledAgentTypes && !enabledAgentTypes.has(config.type)) return false;
     const settings = parseAgentSettings(config.settings);
     return settings.injectAsSection === true;
   });
@@ -429,7 +435,8 @@ function getLatestInjectableCustomRuns(
     configs
       .filter((config) => {
         if (builtInTypes.has(config.type)) return false;
-        if (enabledAgentTypes ? !enabledAgentTypes.has(config.type) : config.enabled !== "true") return false;
+        if (!agentConfigEnabled(config.enabled, true)) return false;
+        if (enabledAgentTypes && !enabledAgentTypes.has(config.type)) return false;
         const settings = parseAgentSettings(config.settings);
         return settings.injectAsSection === true;
       })

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -4,6 +4,7 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useEncounterStore } from "../../../../shared/stores/encounter.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { spriteApi } from "../../../../shared/api/image-generation-api";
+import { agentConfigEnabled, useAgentConfigs, type AgentConfigRow } from "../../../catalog/agents/index";
 import { spriteKeys, type SpriteInfo } from "../../../catalog/sprites/index";
 import {
   type ExpressionAvatarResolver,
@@ -83,6 +84,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
     fallbackChatMode,
     personaFallback: "active-persona",
   });
+  const { data: agentConfigs } = useAgentConfigs();
   const { chatBackground, updateMeta } = useChatMetadataSync({
     chat: data.chat,
     chatMeta: data.chatMeta,
@@ -94,9 +96,17 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
     const set = new Set<string>();
     const activeAgentIds: string[] = Array.isArray(data.chatMeta.activeAgentIds) ? data.chatMeta.activeAgentIds : [];
     if (!data.chatMeta.enableAgents && activeAgentIds.length === 0) return set;
-    for (const id of activeAgentIds) set.add(id);
+    const enabledById = new Map<string, boolean>();
+    for (const config of (agentConfigs ?? []) as AgentConfigRow[]) {
+      const enabled = agentConfigEnabled(config.enabled, true);
+      enabledById.set(config.id, enabled);
+      enabledById.set(config.type, enabled);
+    }
+    for (const id of activeAgentIds) {
+      if (enabledById.get(id) !== false) set.add(id);
+    }
     return set;
-  }, [data.chatMeta.activeAgentIds, data.chatMeta.enableAgents]);
+  }, [agentConfigs, data.chatMeta.activeAgentIds, data.chatMeta.enableAgents]);
   const agentsUiEnabled = Boolean(data.chatMeta.enableAgents) || enabledAgentTypes.size > 0;
   const expressionAgentEnabled = enabledAgentTypes.has("expression");
   const combatAgentEnabled = enabledAgentTypes.has("combat");

--- a/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
+++ b/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
@@ -9,7 +9,7 @@ import { X, Trash2 } from "lucide-react";
 import { useAgentStore } from "../../../../../shared/stores/agent.store";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import type { EchoChamberSide } from "../../../../../shared/stores/ui.store";
-import { useAgentConfigs } from "../../../../catalog/agents/index";
+import { agentConfigEnabled, useAgentConfigs } from "../../../../catalog/agents/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { useChat } from "../../../../catalog/chats/index";
 import { agentApi } from "../../../../../shared/api/agent-api";
@@ -88,8 +88,8 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     }
     // Fallback: check global agent config
     if (!agentConfigs) return false;
-    const cfg = (agentConfigs as Array<{ type: string; enabled: string }>).find((a) => a.type === "echo-chamber");
-    return cfg?.enabled === "true";
+    const cfg = (agentConfigs as Array<{ type: string; enabled?: unknown }>).find((a) => a.type === "echo-chamber");
+    return agentConfigEnabled(cfg?.enabled, false);
   }, [chat, agentConfigs]);
 
   // ── Timed reveal: show one more message every 30 s ──

--- a/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
+++ b/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
@@ -89,7 +89,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     // Fallback: check global agent config
     if (!agentConfigs) return false;
     const cfg = (agentConfigs as Array<{ type: string; enabled?: unknown }>).find((a) => a.type === "echo-chamber");
-    return agentConfigEnabled(cfg?.enabled, false);
+    return cfg ? agentConfigEnabled(cfg.enabled, true) : false;
   }, [chat, agentConfigs]);
 
   // ── Timed reveal: show one more message every 30 s ──


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1791

## Why this change

- Agent enabled/disabled state was not preserved consistently after the refactor. The editor saved agents as enabled, the Agents panel did not expose or toggle the stored state, and some runtime paths could still run configured agents that had been disabled.

## What changed

- Added shared agent enabled-state normalization for boolean, numeric, and legacy string values.
- Preserved enabled state in the Agent Editor and added an Agent Status control.
- Surfaced enabled/disabled badges and toggles in the Agents panel for built-in and custom agents.
- Filtered disabled agents in roleplay HUD/action UI, Echo Chamber visibility, and engine generation resolution so disabled configured agents do not run through global, scoped, or explicitly requested paths.

## Refactor impact

Primary owner:

Catalog agents, shared mode UI, roleplay mode, and engine generation.

Impact areas reviewed:

- Agent config storage shape and React Query hooks.
- Agent editor save payloads.
- Agents panel category/status views and built-in fallback config creation.
- Roleplay HUD actions and per-chat active agent filtering.
- Echo Chamber global enable fallback.
- Engine agent resolution for requested, scoped, global, and built-in fallback agents.

Boundary notes:

- React UI changes stay in `src/features`.
- Runtime execution filtering stays in `src/engine/generation`.
- No new raw Tauri invokes, remote runtime fetches, Rust commands, or cross-layer imports were added.

Pressure points touched:

- Shared mode UI: `EchoChamberPanel`.
- Roleplay mode route/HUD action surfaces.
- Engine generation agent resolution.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm typecheck` passed.
- Targeted eslint passed for the touched agent, roleplay HUD/action, Echo Chamber, and engine generation files.
- `pnpm exec vitest run src/features/catalog/agents/components/AgentEditor.test.tsx src/features/catalog/agents/components/AgentsPanel.test.tsx` passed.
- `git diff --check` passed.
- `pnpm check` passed, including line endings, architecture, TypeScript, Rust workspace check, docs, discovery metadata, and unused-code checks.
- Native Tauri QA passed with `pnpm tauri dev --no-watch --config scratch\tauri-qa.config.json`: Agents panel rendered status badges, Continuity Checker disabled/re-enabled from the panel, editor opened with Agent Status = Disabled, editor save restored Enabled, and By Status grouped the disabled row with an Enable agent control.
- Live-provider native QA passed with LM Studio Gemma 4: the app selected `QA LM Studio Gemma 4` for a fresh Conversation chat, sent through the native composer, and rendered a model response containing `LIVE_PROVIDER_QA_PASS` and `LIVE_PROVIDER_QA_PASS_2`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A: this restores and wires existing agent enabled/disabled behavior rather than adding a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed: this is a focused bugfix for existing agent configuration behavior and does not change contributor workflow, setup, architecture docs, or public release claims.

## UI evidence

- Native Tauri screenshots were captured locally during QA for the Agents panel/editor/status-tab and live LM Studio response paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now be enabled and disabled through the UI.
  * Added Agent Status section in the agent editor to toggle individual agent enablement.
  * Agent enable/disable settings are now persisted and respected across the application.

* **Bug Fixes**
  * Improved agent configuration handling for consistent enabled/disabled state interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->