### PR TITLE
Card CSS theming: avatar override, typing indicator, message grouping

### DIFF
--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -102,13 +102,14 @@ Roleplay mode renders full HTML in messages, so you have the most creative freed
 | `.mari-message-narrator` | Narrator messages |
 | `.mari-message-assistant` | Character messages |
 | `.mari-message-user` | User messages |
+| `[data-grouped]` | Present on consecutive messages from the same character (grouped/continuation messages) |
 
 **What works well in RP mode:**
 - Full HTML structures injected via regex scripts (camera overlays, terminal windows, custom layouts)
 - CSS animations (`@keyframes`, transitions)
 - Pseudo-elements (`::before`, `::after`) for decorative effects
 - Custom backgrounds, borders, shadows, gradients
-- Custom fonts via `font-family` (system fonts and web-safe fonts only — `@font-face` with external URLs is blocked for security)
+- Custom fonts via `font-family` (system/web-safe fonts, or embedded `@font-face` with font `data:` URIs; external font URLs are blocked for security)
 
 ### Conversation Mode
 
@@ -118,10 +119,17 @@ Conversation mode renders messages as plain text with markdown — it does not r
 
 | Selector | What it targets |
 |----------|----------------|
-| `[data-card-css]` | The message wrapper div — this is your main styling target |
+| `[data-card-css]` | The message wrapper div — your main styling target |
+| `[data-card-css] .mari-message-body` | The message "bubble" container — background, border, corners, shadows |
+| `[data-card-css] .mari-message-meta` | The header row that holds the name + timestamp |
 | `[data-card-css] .mari-message-name` | The character's display name |
+| `[data-card-css] .mari-message-timestamp` | The message timestamp |
+| `[data-card-css] .mari-message-content` | The container around the message text |
+| `[data-card-css] .mari-message-avatar` | The avatar column; `.mari-message-avatar > div` is the avatar circle (override `border-radius` to reshape it) |
 | `[data-card-css] p` | Paragraph elements in the message text |
 | `[data-card-css] span` | Inline text spans |
+| `[data-card-css] .mari-typing-indicator` | The "(name) is typing…" indicator (see **Typing Indicator** below) |
+| `[data-grouped]` | Present on consecutive messages from the same character — use `[data-card-css]:not([data-grouped])` for first-in-group styling |
 
 **What works well in Convo mode:**
 - Message bubbles (border-radius, background, padding, shadows)
@@ -155,6 +163,66 @@ Conversation mode renders messages as plain text with markdown — it does not r
 }
 ```
 
+#### Typing Indicator
+
+While a character is generating a reply, Marinara shows a "*(name) is typing…*" indicator, and it's fully themeable. If the message it belongs to already has a bubble on screen (for example, during **regeneration**), the indicator renders **inside that bubble**; otherwise it appears as a **standalone row** below the messages. Both expose the same hooks:
+
+| Selector | What it targets |
+|----------|----------------|
+| `[data-card-css] .mari-typing-indicator` | The indicator row / container |
+| `[data-card-css] .mari-typing-dots` | The animated dots wrapper — style the individual dots with `.mari-typing-dots span` |
+| `[data-card-css] .mari-typing-text` | The "(name) is typing…" label |
+
+The character's name is also exposed on the indicator as a `data-typing-name` attribute, so you can compose your own label with `content: attr(data-typing-name)`.
+
+> **Scoping note:** on the *standalone* row, `data-card-css` sits **on** the `.mari-typing-indicator` element itself. Target the row with **no space** (`[data-card-css].mari-typing-indicator`) and its children **with a space** (`[data-card-css] .mari-typing-text`). The descendant selectors also match the in-bubble version.
+
+```css
+@chat-mode conversation {
+  /* Recolor / restyle the default label and dots */
+  [data-card-css] .mari-typing-text { color: #c77b92; font-style: italic; font-family: 'Courier New', monospace; }
+  [data-card-css] .mari-typing-dots span { background: #e3a8bd; }
+
+  /* OR replace the label text entirely (including the character's name) */
+  [data-card-css] .mari-typing-text { display: none; }
+  [data-card-css].mari-typing-indicator::after {
+    content: attr(data-typing-name) " is cooking up a reply…";
+    font-style: italic;
+    color: #c77b92;
+  }
+}
+```
+
+> **Group chats (Exclusive mode):** when several characters generate at once, the standalone
+> indicator normally combines their names into one row (e.g. *"Aria, Bryn are typing…"*), which
+> a single character's CSS can't meaningfully restyle. In **Exclusive** card-CSS mode, any
+> character whose CSS targets these hooks (`.mari-typing-*` or `data-typing-name`) is instead
+> given **its own row**, sorted alphabetically, so each custom label renders in isolation;
+> characters without typing CSS stay grouped in the shared row above them. This split only
+> applies in Exclusive mode — Chat mode scopes all card CSS to the shared `.mari-card-css`, so a
+> typing rule there would affect every row identically.
+
+#### Avatar
+
+The avatar is a 40px circle by default — but `border-radius` (and the rest) is yours to override:
+
+```css
+@chat-mode conversation {
+  [data-card-css] .mari-message-avatar > div {
+    border-radius: 8px;            /* square it off — 0 = sharp corners, 50% = back to a circle */
+    box-shadow: 0 0 0 3px #fff;    /* white "sticker" border */
+    transform: scale(1.2);         /* enlarge slightly */
+  }
+}
+```
+
+You can also **swap the avatar image itself**, per character, without any CSS: the editor's **Colors** tab has a **Conversation Avatar** control to set it to an emoji, one of the character's **sprites**, a **gallery** image, or **hide** it entirely (Conversation mode only — Roleplay is unaffected). This pairs nicely with the CSS above — e.g. choose a gallery image, then square it off and add a sticker border. (Sprite/Gallery require a saved character with assets already uploaded; Emoji works any time. The chosen image is center-cropped to the circle/square, so pick a roughly square source for the cleanest result.)
+
+#### Editing & multi-paragraph messages
+
+- **While a message is being edited, its card CSS is turned off** so the edit box uses the app's plain style. You don't need to design for the editing state — only the normal display.
+- **A multi-paragraph reply renders as a single `.mari-message-body`**, not several stacked bubbles — so your borders, corners, and `::after` stickers wrap the whole reply cleanly. Use `[data-card-css]:not([data-grouped])` for the first message in a run and `[data-grouped]` for continuations.
+
 ### Game Mode
 
 Game mode is primarily GM/narrator-driven. Currently, card CSS applies to log entries that are attributed to specific characters via `data-card-css`. The active narration/dialogue segments do not yet carry character-specific CSS attributes — this may be added in a future update.
@@ -172,17 +240,24 @@ These are blocked by the CSS sanitizer for security:
 
 | Blocked | Why |
 |---------|-----|
-| `url(https://...)` | Prevents network requests that could track users or exfiltrate data. Only `url(data:image/...)` is allowed for inline images. |
-| `@font-face` | Prevents font-loading network requests to external servers |
+| `url(https://...)` | Prevents network requests that could track users or exfiltrate data. Only `url(data:...)` is allowed for inline images and embedded fonts. |
+| `@font-face` with external URLs | `@font-face` blocks that reference external URLs are stripped. Blocks using only `data:` URIs (base64-embedded fonts) are allowed; the embedded family name is automatically namespaced (e.g. `Inter` → an internal `mc-font-*` name) so it can't override fonts used elsewhere in the app, and your own `font-family` references are rewritten to match. Only font `data:` URIs — `font/*`, `application/font*`, `application/x-font*` — are valid as `@font-face` sources. (The wider `url(data:...)` allowlist that also permits `image/*` applies to general `url()` usage, not font sources.) |
 | `@import` | Prevents loading external stylesheets |
 | `:has()` selectors | Prevents probing elements outside the chat area |
-| `content: "text"` | Prevents injecting fake UI text (phishing). `content: ''` for pseudo-element clearing is allowed. |
+| `content: "text"` with HTML | `content` text is allowed for decorative labels (e.g., window titles in themed cards) but `<` and `>` characters are stripped and text is capped at 200 characters to prevent UI spoofing. CSS functions such as `attr()` and `counter()` are also permitted (e.g. `content: attr(data-typing-name)`). |
 | `position: fixed` | Automatically converted to `position: absolute` to prevent full-screen overlays |
 | `!important` | Stripped to prevent overriding the app's own styles |
 | App theme tokens | Declarations like `--background: red` or `--primary: blue` are stripped so card CSS can't repaint the app UI |
 
-**If you need a custom font**, use system fonts or web-safe font stacks:
+**Custom fonts:** You can embed fonts directly in your card CSS using base64-encoded `@font-face` blocks with `data:` URIs. External font URLs (like Google Fonts) are blocked for security. You can also use system fonts or web-safe font stacks:
 ```css
+/* Embedded font (base64) — works */
+@font-face {
+  font-family: 'MyPixelFont';
+  src: url(data:font/woff2;base64,d09GMgABAAAAA...) format('woff2');
+}
+
+/* System / web-safe fonts — always works */
 font-family: 'Courier New', Consolas, monospace;
 font-family: Georgia, 'Times New Roman', serif;
 font-family: 'Segoe UI', system-ui, sans-serif;
@@ -230,6 +305,10 @@ In Exclusive mode, `[data-card-css]` targets only THIS character's message wrapp
 
 7. **Layer your mode CSS.** Put shared styles (keyframes, base classes) outside `@chat-mode` blocks, and mode-specific styling inside them. This avoids duplicating rules.
 
+8. **Theme the "typing…" state.** Style `.mari-typing-text` and `.mari-typing-dots span` so the "(name) is typing…" indicator matches your card — or replace the label entirely with `content: attr(data-typing-name) "…"`. It shows both in-bubble (during regeneration) and as a standalone row, so a little styling here goes a long way.
+
+9. **Reshape the avatar.** The avatar circle is just an overridable `border-radius` on `.mari-message-avatar > div`. Pair it with the per-character **Conversation Avatar** setting (emoji / sprite / gallery / hide) in the editor's Colors tab for a fully custom look.
+
 ---
 
 ## Using an AI Assistant to Create Card CSS
@@ -244,14 +323,18 @@ If you're not comfortable writing CSS by hand, you can ask an AI assistant to ge
 >
 > **Technical constraints:**
 > - Use `[data-card-css]` as the selector for the message wrapper element
+> - Use `[data-card-css] .mari-message-body` for the message bubble (background / border / corners) and `[data-card-css] .mari-message-content` for the text area
 > - Use `[data-card-css] .mari-message-name` for the character's display name
+> - Use `[data-card-css] .mari-message-avatar > div` for the avatar circle (override `border-radius` to reshape it)
 > - Use `[data-card-css] p` for message text paragraphs
+> - Style the "typing…" indicator via `[data-card-css] .mari-typing-text` and `[data-card-css] .mari-typing-dots span` (the character name is available as `attr(data-typing-name)` for custom label text)
 > - Wrap roleplay-only CSS in `@chat-mode roleplay { ... }`
 > - Wrap conversation-only CSS in `@chat-mode conversation { ... }`
 > - CSS outside these blocks applies to all modes
-> - `url(https://...)` is blocked — only `url(data:image/...)` works for inline images
-> - `@font-face` is blocked — use system/web-safe fonts only
-> - `content: "text"` is blocked — only `content: ''` is allowed
+> - `url(https://...)` is blocked — only `url(data:...)` works for inline images and embedded fonts
+> - `@font-face` with external URLs is blocked — use base64-embedded `data:` URIs or system/web-safe fonts
+> - `content: "text"` is allowed for decorative labels but `<>` chars are stripped and text is capped at 200 chars
+> - `[data-grouped]` is present on continuation messages from the same character — use `:not([data-grouped])` to target first-in-group
 > - `position: fixed` is converted to `position: absolute`
 > - `!important` is stripped
 > - `:has()` selectors are blocked

--- a/src/engine/contracts/types/character.ts
+++ b/src/engine/contracts/types/character.ts
@@ -51,7 +51,25 @@ export interface CharacterExtensions {
   rpgStats?: RPGStatsConfig;
   /** Marinara Engine: Conversation-mode availability status */
   conversationStatus?: "online" | "idle" | "dnd" | "offline";
+  /** Marinara Engine: Conversation-mode avatar override (Default / Hide / Emoji / Sprite / Gallery) */
+  conversationAvatar?: ConversationAvatarOverride;
   [key: string]: unknown;
+}
+
+/** Marinara Engine: Conversation-mode avatar override modes. */
+export type ConversationAvatarMode = "default" | "hide" | "emoji" | "sprite" | "gallery";
+
+/** Marinara Engine: per-character avatar override applied only in Conversation mode. */
+export interface ConversationAvatarOverride {
+  mode: ConversationAvatarMode;
+  /**
+   * Reference for the chosen mode:
+   * - "emoji": the emoji glyph to display
+   * - "sprite": the sprite expression key (resolved to an image at render time)
+   * - "gallery": the character-gallery image id (resolved to an image at render time)
+   * Unused for "default" and "hide".
+   */
+  value?: string;
 }
 
 /** RPG stats configuration attached to a character card. */

--- a/src/features/catalog/characters/components/CharacterColorsTab.tsx
+++ b/src/features/catalog/characters/components/CharacterColorsTab.tsx
@@ -7,15 +7,18 @@ import { extractColorsFromImage } from "../../../../shared/lib/avatar-color-extr
 import { parseTrackerCardColorConfig } from "../../../../shared/lib/tracker-card-colors";
 import { cn } from "../../../../shared/lib/utils";
 import { CharacterEditorSectionHeader } from "./CharacterEditorSectionHeader";
+import { ConversationAvatarControl, parseConversationAvatarOverride } from "./ConversationAvatarControl";
 
 export function CharacterColorsTab({
   formData,
   updateExtension,
   avatarUrl,
+  characterId,
 }: {
   formData: CharacterData;
   updateExtension: (key: string, value: unknown) => void;
   avatarUrl: string | null;
+  characterId: string | null;
 }) {
   const nameColor = (formData.extensions.nameColor as string) ?? "";
   const dialogueColor = (formData.extensions.dialogueColor as string) ?? "";
@@ -149,6 +152,12 @@ export function CharacterColorsTab({
         onChange={(value) => updateExtension("trackerCardColors", value)}
         chatColors={{ nameColor, dialogueColor, boxColor }}
         entityLabel="Character"
+      />
+
+      <ConversationAvatarControl
+        characterId={characterId}
+        value={parseConversationAvatarOverride(formData.extensions.conversationAvatar)}
+        onChange={(next) => updateExtension("conversationAvatar", next)}
       />
     </div>
   );

--- a/src/features/catalog/characters/components/CharacterEditorTabContent.tsx
+++ b/src/features/catalog/characters/components/CharacterEditorTabContent.tsx
@@ -122,7 +122,12 @@ export function CharacterEditorTabContent({
           <CharacterGalleryTab characterId={characterId} characterName={formData.name} />
         )}
         {activeTab === "colors" && (
-          <CharacterColorsTab formData={formData} updateExtension={updateExtension} avatarUrl={avatarPreview} />
+          <CharacterColorsTab
+            formData={formData}
+            updateExtension={updateExtension}
+            avatarUrl={avatarPreview}
+            characterId={characterId ?? null}
+          />
         )}
         {activeTab === "stats" && <CharacterStatsTab formData={formData} updateExtension={updateExtension} />}
         {activeTab === "lorebook" && <CharacterLorebookTab characterId={characterId} formData={formData} />}

--- a/src/features/catalog/characters/components/CharacterMetadataTab.tsx
+++ b/src/features/catalog/characters/components/CharacterMetadataTab.tsx
@@ -1,7 +1,9 @@
-import { Tag, X } from "lucide-react";
+import { useState } from "react";
+import { Maximize2, Tag, X } from "lucide-react";
 
 import type { CharacterData } from "../../../../engine/contracts/types/character";
 import { AvatarCropWidget } from "../../../../shared/components/ui/AvatarCropWidget";
+import { ExpandedTextarea } from "../../../../shared/components/ui/ExpandedTextarea";
 import { HelpTooltip } from "../../../../shared/components/ui/HelpTooltip";
 import type { AvatarCrop } from "../../../../shared/lib/utils";
 import { CharacterEditorSectionHeader as SectionHeader } from "./CharacterEditorSectionHeader";
@@ -32,10 +34,11 @@ export function CharacterMetadataTab({
   removeAllTags: () => void;
   avatarPreview: string | null;
 }) {
+  const [expandedCreatorNotes, setExpandedCreatorNotes] = useState(false);
+  const creatorNotesId = "character-creator-notes";
   // Read the saved source-rectangle crop and write the same current shape on edit.
   const savedCrop = (formData.extensions.avatarCrop as AvatarCrop | undefined) ?? null;
-  const talkativeness =
-    typeof formData.extensions.talkativeness === "number" ? formData.extensions.talkativeness : 0.5;
+  const talkativeness = typeof formData.extensions.talkativeness === "number" ? formData.extensions.talkativeness : 0.5;
 
   return (
     <div className="space-y-5">
@@ -161,19 +164,42 @@ export function CharacterMetadataTab({
         </div>
       </div>
 
-      <label className="block space-y-1.5">
-        <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
-          Creator Notes{" "}
-          <HelpTooltip text="Private notes about this character — tips for use, known quirks, recommended settings. Not sent to the AI." />
-        </span>
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor={creatorNotesId}
+            className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]"
+          >
+            Creator Notes{" "}
+            <HelpTooltip text="Private notes about this character — tips for use, known quirks, recommended settings. Not sent to the AI." />
+          </label>
+          <button
+            type="button"
+            onClick={() => setExpandedCreatorNotes(true)}
+            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            title="Expand editor"
+          >
+            <Maximize2 size="0.875rem" />
+          </button>
+        </div>
         <textarea
+          id={creatorNotesId}
           value={formData.creator_notes}
           onChange={(event) => updateField("creator_notes", event.target.value)}
           rows={4}
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder="Notes about this character, intended use, tips for best results…"
         />
-      </label>
+      </div>
+
+      <ExpandedTextarea
+        open={expandedCreatorNotes}
+        onClose={() => setExpandedCreatorNotes(false)}
+        title="Creator Notes"
+        value={formData.creator_notes}
+        onChange={(value) => updateField("creator_notes", value)}
+        placeholder="Notes about this character, intended use, tips for best results…"
+      />
     </div>
   );
 }

--- a/src/features/catalog/characters/components/ConversationAvatarControl.tsx
+++ b/src/features/catalog/characters/components/ConversationAvatarControl.tsx
@@ -1,0 +1,207 @@
+import type { ConversationAvatarMode, ConversationAvatarOverride } from "../../../../engine/contracts/types/character";
+import { useEffect, useState } from "react";
+import { cn } from "../../../../shared/lib/utils";
+import { useSprites } from "../../sprites/index";
+import { useCharacterGalleryImages } from "../hooks/use-characters";
+import { CharacterEditorSectionHeader } from "./CharacterEditorSectionHeader";
+
+/**
+ * Defensively parse an open-ended `extensions.conversationAvatar` bag into a known-good
+ * override. Imported cards, stale saves, or hand-edited extensions can carry an unknown
+ * mode or malformed value; anything that doesn't match a supported mode (or "default",
+ * which means "no override") collapses to `undefined` so the control falls back to its
+ * default state instead of an impossible one. The type annotation alone is not a parser.
+ */
+export function parseConversationAvatarOverride(value: unknown): ConversationAvatarOverride | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const mode = (value as { mode?: unknown }).mode;
+  if (mode === "hide") return { mode };
+  if (mode === "emoji" || mode === "sprite" || mode === "gallery") {
+    const raw = (value as { value?: unknown }).value;
+    return { mode, value: typeof raw === "string" && raw ? raw : undefined };
+  }
+  // "default" or any unrecognized mode ⇒ no override.
+  return undefined;
+}
+
+const MODES: { mode: ConversationAvatarMode; label: string; hint: string }[] = [
+  { mode: "default", label: "Default", hint: "Use the character's normal avatar" },
+  { mode: "hide", label: "Hide", hint: "Show no avatar in Conversation mode" },
+  { mode: "emoji", label: "Emoji", hint: "Show an emoji instead of an avatar" },
+  { mode: "sprite", label: "Sprite", hint: "Pick one of this character's sprites" },
+  { mode: "gallery", label: "Gallery", hint: "Pick one of this character's gallery images" },
+];
+
+type GridItem = { key: string; src: string; label: string; selected: boolean };
+
+function isAssetMode(mode: ConversationAvatarMode | undefined): mode is "sprite" | "gallery" {
+  return mode === "sprite" || mode === "gallery";
+}
+
+/**
+ * Per-character avatar override for Conversation mode. Stored on the character card's
+ * extensions as `{ mode, value }`; "default" clears the override entirely.
+ */
+export function ConversationAvatarControl({
+  characterId,
+  value,
+  onChange,
+}: {
+  characterId: string | null;
+  value: ConversationAvatarOverride | undefined;
+  onChange: (next: ConversationAvatarOverride | undefined) => void;
+}) {
+  const [draftMode, setDraftMode] = useState<ConversationAvatarMode>(value?.mode ?? "default");
+  const mode: ConversationAvatarMode = draftMode;
+
+  useEffect(() => {
+    const nextMode = value?.mode ?? "default";
+    const isDraftingDifferentAssetMode = isAssetMode(draftMode) && draftMode !== value?.mode;
+    if (!isDraftingDifferentAssetMode) {
+      setDraftMode(nextMode);
+    }
+  }, [draftMode, value]);
+
+  const selectMode = (next: ConversationAvatarMode) => {
+    setDraftMode(next);
+    if (next === "default") {
+      onChange(undefined);
+      return;
+    }
+    if (next === value?.mode) return;
+    if (next === "sprite" || next === "gallery") {
+      onChange(undefined);
+      return;
+    }
+    onChange({ mode: next, value: undefined });
+  };
+
+  // Only fetch the asset list for the active mode (passing null disables the query).
+  const { data: sprites, isLoading: spritesLoading } = useSprites(mode === "sprite" ? characterId : null);
+  const { data: gallery, isLoading: galleryLoading } = useCharacterGalleryImages(
+    mode === "gallery" ? characterId : null,
+  );
+
+  return (
+    <div className="space-y-3">
+      <CharacterEditorSectionHeader
+        title="Conversation Avatar"
+        subtitle="Override the avatar shown next to this character's messages in Conversation mode. Roleplay mode is unaffected."
+      />
+
+      <div className="flex flex-wrap gap-1.5">
+        {MODES.map((m) => (
+          <button
+            key={m.mode}
+            type="button"
+            onClick={() => selectMode(m.mode)}
+            title={m.hint}
+            className={cn(
+              "rounded-lg px-3 py-1.5 text-xs font-medium transition-all",
+              mode === m.mode
+                ? "bg-purple-500/20 text-purple-300 ring-1 ring-purple-400/40"
+                : "bg-white/5 text-[var(--muted-foreground)] hover:bg-white/10",
+            )}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      {mode === "emoji" && (
+        <div className="flex items-center gap-3">
+          <input
+            value={value?.value ?? ""}
+            onChange={(e) => onChange({ mode: "emoji", value: e.target.value })}
+            maxLength={8}
+            placeholder="🥞"
+            aria-label="Avatar emoji"
+            className="w-20 rounded-lg border border-[var(--border)] bg-black/30 px-3 py-2 text-center text-2xl outline-none focus:ring-1 focus:ring-purple-400/40"
+          />
+          <span className="text-[0.6875rem] text-[var(--muted-foreground)]">
+            Type or paste an emoji to use as the avatar.
+          </span>
+        </div>
+      )}
+
+      {mode === "sprite" && (
+        <AssetGrid
+          loading={spritesLoading}
+          emptyText={
+            characterId ? "No sprites uploaded for this character yet." : "Save the character first to use its sprites."
+          }
+          items={(sprites ?? []).map((s) => ({
+            key: s.expression,
+            src: s.url,
+            label: s.expression,
+            selected: value?.value === s.expression,
+          }))}
+          onSelect={(key) => {
+            setDraftMode("sprite");
+            onChange({ mode: "sprite", value: key });
+          }}
+        />
+      )}
+
+      {mode === "gallery" && (
+        <AssetGrid
+          loading={galleryLoading}
+          emptyText={
+            characterId
+              ? "No gallery images for this character yet."
+              : "Save the character first to use its gallery images."
+          }
+          items={(gallery ?? []).map((g, i) => ({
+            key: g.id,
+            src: g.url,
+            // Fall back to a deterministic name so assistive tech never gets an empty
+            // button title / image alt when a gallery image has no prompt.
+            label: g.prompt || `Gallery image ${i + 1}`,
+            selected: value?.value === g.id,
+          }))}
+          onSelect={(key) => {
+            setDraftMode("gallery");
+            onChange({ mode: "gallery", value: key });
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function AssetGrid({
+  loading,
+  emptyText,
+  items,
+  onSelect,
+}: {
+  loading: boolean;
+  emptyText: string;
+  items: GridItem[];
+  onSelect: (key: string) => void;
+}) {
+  if (loading) {
+    return <p className="text-[0.6875rem] text-[var(--muted-foreground)]">Loading…</p>;
+  }
+  if (items.length === 0) {
+    return <p className="text-[0.6875rem] text-[var(--muted-foreground)]">{emptyText}</p>;
+  }
+  return (
+    <div className="grid max-h-56 grid-cols-4 gap-2 overflow-y-auto sm:grid-cols-6">
+      {items.map((it) => (
+        <button
+          key={it.key}
+          type="button"
+          onClick={() => onSelect(it.key)}
+          title={it.label}
+          className={cn(
+            "relative aspect-square overflow-hidden rounded-lg bg-black/30 ring-1 transition-all",
+            it.selected ? "ring-2 ring-purple-400" : "ring-[var(--border)] hover:ring-purple-400/50",
+          )}
+        >
+          <img src={it.src} alt={it.label} loading="lazy" className="h-full w-full object-cover" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/modes/conversation/components/ChatConversationSurface.tsx
+++ b/src/features/modes/conversation/components/ChatConversationSurface.tsx
@@ -39,6 +39,7 @@ type ConversationSurfaceProps = {
   personaInfo?: PersonaInfo;
   chatMeta: Record<string, unknown>;
   chatCharIds: string[];
+  typingStyledCharacterIds?: Set<string>;
   enabledAgentTypes?: Set<string>;
   connectedChatName?: string;
   sceneInfo?: SceneInfo;
@@ -105,6 +106,7 @@ export function ChatConversationSurface({
   personaInfo,
   chatMeta,
   chatCharIds,
+  typingStyledCharacterIds,
   enabledAgentTypes,
   connectedChatName,
   sceneInfo,
@@ -174,6 +176,7 @@ export function ChatConversationSurface({
           chatName={chat?.name}
           chatGroupId={chat?.groupId ?? null}
           chatCharIds={chatCharIds}
+          typingStyledCharacterIds={typingStyledCharacterIds}
           onDelete={onDelete}
           onRegenerate={onRegenerate}
           onEdit={onEdit}

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message, MessageExtra } from "../../../../engine/contracts/types/chat";
+import type { ConversationAvatarOverride } from "../../../../engine/contracts/types/character";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { cn, copyToClipboard, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks } from "../../../../shared/lib/markdown";
@@ -83,6 +84,28 @@ function readGenerationDurationMs(generationInfo: unknown): number | null {
   if (typeof record.durationMs === "number" && record.durationMs > 0) return record.durationMs;
   if (typeof record.duration === "number" && record.duration > 0) return record.duration * 1000;
   return null;
+}
+
+/**
+ * Resolve a character's Conversation-mode avatar override into a renderable form.
+ * `fallbackUrl` is the character's normal avatar (used for "default", or as a fallback
+ * when a sprite/gallery reference couldn't be resolved).
+ */
+function resolveConversationAvatar(
+  info: { conversationAvatar?: ConversationAvatarOverride; conversationAvatarSrc?: string | null } | null | undefined,
+  fallbackUrl: string | null,
+): { hide: boolean; emoji: string | null; url: string | null; isOverride: boolean } {
+  const override = info?.conversationAvatar;
+  if (!override || override.mode === "default") {
+    return { hide: false, emoji: null, url: fallbackUrl, isOverride: false };
+  }
+  if (override.mode === "hide") return { hide: true, emoji: null, url: null, isOverride: true };
+  if (override.mode === "emoji") {
+    return { hide: false, emoji: override.value?.trim() || null, url: null, isOverride: true };
+  }
+  // "sprite" | "gallery": prefer the resolved src; fall back to the real avatar if unresolved.
+  const resolved = info?.conversationAvatarSrc ?? null;
+  return { hide: false, emoji: null, url: resolved ?? fallbackUrl, isOverride: !!resolved };
 }
 
 function HiddenFromAIConversationButton({
@@ -307,6 +330,10 @@ interface ConversationMessageProps {
   multiSelectMode?: boolean;
   isSelected?: boolean;
   onToggleSelect?: (toggle: MessageSelectionToggle) => void;
+  /** When true, omit the data-card-css hook so the message renders vanilla (used while editing). */
+  suppressCardCss?: boolean;
+  /** When set and the body is empty, shows "X is typing..." inside the message body (CSS hooks: .mari-typing-*). */
+  typingLabel?: string;
 }
 
 export const ConversationMessage = memo(function ConversationMessage({
@@ -332,8 +359,12 @@ export const ConversationMessage = memo(function ConversationMessage({
   multiSelectMode,
   isSelected,
   onToggleSelect,
+  suppressCardCss,
+  typingLabel,
 }: ConversationMessageProps) {
   const [editing, setEditing] = useState(false);
+  // Drop the card-CSS hook while editing (or when asked to) so the edit view renders vanilla.
+  const cardCssId = editing || suppressCardCss ? undefined : (message.characterId ?? undefined);
   const [editValue, setEditValue] = useState(message.content);
   const [editSaving, setEditSaving] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
@@ -449,6 +480,8 @@ export const ConversationMessage = memo(function ConversationMessage({
     ? (msgPersona?.name ?? personaInfo?.name ?? "You")
     : (primaryCharInfo?.name ?? "Assistant");
   const nameColor = isUser ? (msgPersona?.nameColor ?? personaInfo?.nameColor) : charInfo?.nameColor;
+  // Conversation-mode avatar override (Default / Hide / Emoji / Sprite / Gallery). User messages are never overridden.
+  const conversationAvatar = resolveConversationAvatar(isUser ? null : charInfo, avatarUrl);
   const renderedContent = useMemo(
     () =>
       resolveMessageMacros(message.content, {
@@ -767,7 +800,8 @@ export const ConversationMessage = memo(function ConversationMessage({
           isStreaming && "bg-[var(--secondary)]/20",
           multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
         )}
-        data-card-css={message.characterId ?? undefined}
+        data-card-css={cardCssId}
+        data-grouped={isGrouped || undefined}
         onClick={handleMessageClick}
         onDoubleClick={handleMessageDoubleClick}
       >
@@ -797,6 +831,7 @@ export const ConversationMessage = memo(function ConversationMessage({
           const segAvatarCropStyle = getAvatarCropStyle(segChar?.avatarCrop);
           const segName = segChar?.name ?? grp.speaker ?? "";
           const segColor = segChar?.nameColor;
+          const segAvatarOverride = resolveConversationAvatar(segChar, segAvatar);
           const isFirst = i === 0;
           const combinedText = grp.lines.join("\n");
 
@@ -830,21 +865,27 @@ export const ConversationMessage = memo(function ConversationMessage({
                     <div className="flex gap-4">
                       {/* Avatar */}
                       <div className="w-10 flex-shrink-0">
-                        <div className="relative h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
-                          {segAvatar ? (
-                            <img
-                              src={segAvatar}
-                              alt={segName}
-                              loading="lazy"
-                              className="h-full w-full object-cover"
-                              style={segAvatarCropStyle}
-                            />
-                          ) : (
-                            <div className="flex h-full w-full items-center justify-center text-sm font-bold text-[var(--muted-foreground)]">
-                              {segName[0]?.toUpperCase()}
-                            </div>
-                          )}
-                        </div>
+                        {!segAvatarOverride.hide && (
+                          <div className="relative h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
+                            {segAvatarOverride.emoji ? (
+                              <div className="flex h-full w-full items-center justify-center text-2xl leading-none">
+                                {segAvatarOverride.emoji}
+                              </div>
+                            ) : segAvatarOverride.url ? (
+                              <img
+                                src={segAvatarOverride.url}
+                                alt={segName}
+                                loading="lazy"
+                                className="h-full w-full object-cover"
+                                style={segAvatarOverride.isOverride ? undefined : segAvatarCropStyle}
+                              />
+                            ) : (
+                              <div className="flex h-full w-full items-center justify-center text-sm font-bold text-[var(--muted-foreground)]">
+                                {segName[0]?.toUpperCase()}
+                              </div>
+                            )}
+                          </div>
+                        )}
                         {isFirst && (showActions || forceShowActions || showMessageNumbers) && messageIndex != null && (
                           <span className="mt-0.5 block text-center text-[0.5rem] font-medium text-[var(--muted-foreground)] select-none">
                             #{messageIndex}
@@ -1083,7 +1124,8 @@ export const ConversationMessage = memo(function ConversationMessage({
       )}
       data-message-id={message.id}
       data-message-role={message.role}
-      data-card-css={message.characterId ?? undefined}
+      data-card-css={cardCssId}
+      data-grouped={isGrouped || undefined}
       onClick={handleMessageClick}
       onDoubleClick={handleMessageDoubleClick}
     >
@@ -1105,10 +1147,24 @@ export const ConversationMessage = memo(function ConversationMessage({
 
       {/* Avatar column — fixed 40px width */}
       <div className="mari-message-avatar w-10 flex-shrink-0">
-        {!isGrouped && (
+        {!isGrouped && !conversationAvatar.hide && (
           <>
             <div className="relative h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
-              {avatarUrl ? (
+              {/* Emoji and resolved sprite/gallery overrides render directly; the normal avatar
+                  goes through the file-path/thumbnail-aware resolver with crop styling. */}
+              {conversationAvatar.emoji ? (
+                <div className="flex h-full w-full items-center justify-center text-2xl leading-none">
+                  {conversationAvatar.emoji}
+                </div>
+              ) : conversationAvatar.isOverride && conversationAvatar.url ? (
+                <img
+                  src={conversationAvatar.url}
+                  alt={displayName}
+                  loading="lazy"
+                  decoding="async"
+                  className="h-full w-full object-cover"
+                />
+              ) : avatarUrl ? (
                 <ResolvedAvatarImage
                   src={avatarUrl}
                   avatarFilePath={avatarFilePath}
@@ -1201,11 +1257,22 @@ export const ConversationMessage = memo(function ConversationMessage({
           <div
             className={cn(
               "mari-message-content text-[0.9375rem] leading-relaxed break-words whitespace-pre-wrap",
-              isStreaming && !renderedContent && "py-1",
+              (isStreaming || typingLabel) && !renderedContent && "py-1",
             )}
             style={messageTextStyle}
           >
-            {isStreaming && !renderedContent ? (
+            {!renderedContent && typingLabel ? (
+              <div className="mari-typing-indicator flex items-center gap-2" data-typing-name={displayName}>
+                <span className="mari-typing-dots flex items-center gap-1">
+                  <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:0ms]" />
+                  <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:150ms]" />
+                  <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:300ms]" />
+                </span>
+                <span className="mari-typing-text text-[0.8125rem] italic text-[var(--text-secondary)]">
+                  {typingLabel}
+                </span>
+              </div>
+            ) : isStreaming && !renderedContent ? (
               <div className="flex items-center gap-1">
                 <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:0ms]" />
                 <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:150ms]" />

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { getChatDisplayName, parseChatMetadata } from "../../../../shared/lib/chat-display";
+import { extractCreatorNotesCss } from "../../../../shared/lib/creator-notes-css";
+import { cssTargetsTypingIndicator, filterCssByMode } from "../../../../shared/lib/chat-css";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import {
@@ -16,6 +18,7 @@ import {
 import { useDeleteChat } from "../../../catalog/chats/index";
 import { ChatConversationSurface } from "./ChatConversationSurface";
 import { CreatorNotesCssInjector } from "../../shared/chat-ui/index";
+import { useConversationAvatarOverrides } from "../hooks/use-conversation-avatar-overrides";
 
 type ConversationModeRouteProps = {
   activeChatId: string;
@@ -32,6 +35,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     fallbackChatMode: "conversation",
     personaFallback: "active-persona",
   });
+  const conversationCharacterMap = useConversationAvatarOverrides(data.characterMap);
   const { chatBackground } = useChatMetadataSync({
     chat: data.chat,
     chatMeta: data.chatMeta,
@@ -85,7 +89,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     chatId: activeChatId,
     mode: "conversation",
     messages: data.messages,
-    characterMap: data.characterMap,
+    characterMap: conversationCharacterMap,
     isStreaming: timeline.isStreaming,
   });
 
@@ -147,6 +151,34 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     return "chat" as const;
   })();
 
+  // Which active characters carry card CSS that targets the typing indicator? Their typing
+  // row is rendered separately (so per-character text/styling applies in isolation) instead
+  // of being merged into the combined "A, B are typing…" row. This only differentiates in
+  // exclusive mode — chat mode scopes all card CSS to the shared `.mari-card-css`, so a typing
+  // rule would apply to every row identically and splitting would be meaningless.
+  const typingStyledCharacterIds = useMemo(() => {
+    const set = new Set<string>();
+    if (cardCssMode !== "exclusive" || !data.allCharacters) return set;
+    const byId = new Map(data.allCharacters.map((c) => [c.id, c]));
+    for (const id of data.chatCharIds) {
+      const row = byId.get(id);
+      if (!row) continue;
+      let parsed: Record<string, unknown>;
+      try {
+        const raw = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+        parsed = raw as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const notes = parsed.creator_notes;
+      if (typeof notes !== "string" || !notes) continue;
+      const { css } = extractCreatorNotesCss(notes);
+      if (css && cssTargetsTypingIndicator(filterCssByMode(css, "conversation"))) set.add(id);
+    }
+    return set;
+  }, [cardCssMode, data.allCharacters, data.chatCharIds]);
+
   return (
     <>
       <CreatorNotesCssInjector
@@ -165,11 +197,12 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
         fetchNextPage={data.fetchNextPage}
         pageCount={data.pageCount}
         totalMessageCount={data.totalMessageCount}
-        characterMap={data.characterMap}
+        characterMap={conversationCharacterMap}
         characterNames={data.characterNames}
         personaInfo={data.personaInfo}
         chatMeta={data.chatMeta}
         chatCharIds={data.chatCharIds}
+        typingStyledCharacterIds={typingStyledCharacterIds}
         enabledAgentTypes={agentThoughtBubbleTypes}
         connectedChatName={data.connectedChatName}
         sceneInfo={sceneInfo}

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -78,6 +78,8 @@ interface ConversationViewProps {
   chatName?: string;
   chatGroupId?: string | null;
   chatCharIds: string[];
+  /** Active characters whose card CSS targets the typing indicator (exclusive mode only). */
+  typingStyledCharacterIds?: Set<string>;
   onDelete: (messageId: string) => void;
   onRegenerate: (messageId: string) => void;
   onEdit: (messageId: string, content: string) => void | Promise<void>;
@@ -126,6 +128,42 @@ function getDayKey(dateStr: string): string {
 
 function chatMetaString(value: unknown, fallback: string): string {
   return typeof value === "string" ? value : fallback;
+}
+
+/**
+ * A single "… is/are typing…" row. CSS hooks: `.mari-typing-indicator` (row),
+ * `.mari-typing-dots` (the dots), `.mari-typing-text` (the label). `data-card-css`
+ * scopes the row to a character in exclusive mode; `data-typing-name` exposes the
+ * name(s) for `content: attr(data-typing-name)`.
+ */
+function TypingIndicatorRow({ names, cardCssId }: { names: string[]; cardCssId?: string }) {
+  const label = names.join(", ");
+  const verb = label.includes(",") || label.includes(" & ") ? "are" : "is";
+  return (
+    <div
+      className="mari-typing-indicator flex items-center gap-2 px-4 py-1.5 text-[0.8125rem] text-[var(--text-secondary)]"
+      data-card-css={cardCssId}
+      data-typing-name={label}
+    >
+      <span className="mari-typing-dots flex gap-0.5">
+        <span
+          className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
+          style={{ animationDelay: "0ms" }}
+        />
+        <span
+          className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
+          style={{ animationDelay: "150ms" }}
+        />
+        <span
+          className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
+          style={{ animationDelay: "300ms" }}
+        />
+      </span>
+      <span className="mari-typing-text italic">
+        {label} {verb} typing...
+      </span>
+    </div>
+  );
 }
 
 /** Check if a message's content uses "Name: text" format with known chat-member character names */
@@ -343,6 +381,7 @@ export function ConversationView({
   chatName,
   chatGroupId,
   chatCharIds,
+  typingStyledCharacterIds,
   onDelete,
   onRegenerate,
   onEdit,
@@ -394,6 +433,79 @@ export function ConversationView({
   const liveTypingVerb = liveTypingName.includes(",") || liveTypingName.includes(" & ") ? "are" : "is";
   const showTypingIndicator =
     isStreaming && !delayedCharacterInfo && (!regenerateMessageId || (!streamBuffer && !thinkingBuffer));
+  const liveTypingLabel = `${liveTypingName} ${liveTypingVerb} typing...`;
+
+  // ── Group typing rows ──
+  // Characters whose card CSS targets the typing indicator (exclusive mode) get their own
+  // row so their custom text/styling applies in isolation; everyone else shares one combined
+  // "A, B are typing…" row. The styled set is derived in ConversationModeRoute (empty unless
+  // exclusive card-CSS mode is active, so chat/disabled modes keep the single combined row).
+  //
+  // We only split when the indicator can be tied to concrete character ids: the single
+  // streaming character, or the explicit `typingCharacterName` mapped back to ids. Returning
+  // `null` means "render one combined row from `liveTypingName`" — we never invent typists
+  // from the full active roster when the runtime told us a specific (sub)set is typing.
+  const typingParticipants = useMemo<Array<{ id: string; name: string }> | null>(() => {
+    if (streamingCharacterId) {
+      const name = characterMap.get(streamingCharacterId)?.name;
+      return name ? [{ id: streamingCharacterId, name }] : null;
+    }
+    const nameToIds = new Map<string, string[]>();
+    for (const id of activeChatCharIds) {
+      const name = characterMap.get(id)?.name;
+      if (name) nameToIds.set(name, [...(nameToIds.get(name) ?? []), id]);
+    }
+    if (typingCharacterName) {
+      // The typing event lists the actual responders by name; only split if every name maps
+      // to one concrete id (dedup by id). Duplicate display names are ambiguous, so keep the
+      // explicit label as one row instead of attributing CSS to the wrong card.
+      const names = typingCharacterName
+        .split(",")
+        .map((n) => n.trim())
+        .filter(Boolean);
+      if (names.length === 0 || names.some((name) => (nameToIds.get(name)?.length ?? 0) !== 1)) return null;
+      const seen = new Set<string>();
+      const participants: Array<{ id: string; name: string }> = [];
+      for (const name of names) {
+        const id = nameToIds.get(name)![0]!;
+        if (!seen.has(id)) {
+          seen.add(id);
+          participants.push({ id, name });
+        }
+      }
+      return participants;
+    }
+    // No streaming id and no explicit label → fall back to the active roster (matches the
+    // pre-split `liveTypingName` fallback, which also listed every active character).
+    const fromActive = activeChatCharIds
+      .map((id) => ({ id, name: characterMap.get(id)?.name }))
+      .filter((p): p is { id: string; name: string } => !!p.name);
+    return fromActive.length > 0 ? fromActive : null;
+  }, [streamingCharacterId, typingCharacterName, activeChatCharIds, characterMap]);
+  const { typingStyledRows, typingPlainNames, typingPlainCardCssId } = useMemo(() => {
+    // Couldn't resolve concrete participants → one combined row with the explicit live label.
+    if (!typingParticipants) {
+      return {
+        typingStyledRows: [] as Array<{ id: string; name: string }>,
+        typingPlainNames: [liveTypingName],
+        typingPlainCardCssId: streamingCharacterId ?? activeChatCharIds[0] ?? undefined,
+      };
+    }
+    const styled: Array<{ id: string; name: string }> = [];
+    const plain: Array<{ id: string; name: string }> = [];
+    for (const p of typingParticipants) {
+      if (typingStyledCharacterIds?.has(p.id)) styled.push(p);
+      else plain.push(p);
+    }
+    styled.sort((a, b) => a.name.localeCompare(b.name));
+    plain.sort((a, b) => a.name.localeCompare(b.name));
+    return {
+      typingStyledRows: styled,
+      typingPlainNames: plain.map((p) => p.name),
+      typingPlainCardCssId: streamingCharacterId ?? plain[0]?.id ?? activeChatCharIds[0] ?? undefined,
+    };
+  }, [typingParticipants, typingStyledCharacterIds, streamingCharacterId, activeChatCharIds, liveTypingName]);
+
   const isPageActive = usePageActivity();
 
   // ── Periodic status refresh (every 60s) ──
@@ -561,8 +673,7 @@ export function ConversationView({
   const isOptimistic = newestMsgId?.startsWith("__optimistic_");
   useEffect(() => {
     const previousTail = previousTailRef.current;
-    const tailMessageChanged =
-      !!newestMsgId && !!previousTail.messageId && previousTail.messageId !== newestMsgId;
+    const tailMessageChanged = !!newestMsgId && !!previousTail.messageId && previousTail.messageId !== newestMsgId;
     const streamingStarted = isStreaming && !previousTail.isStreaming;
     if (transcriptWindowStart !== null && !isLoadingMoreRef.current && (tailMessageChanged || streamingStarted)) {
       setTranscriptWindowStart(null);
@@ -929,6 +1040,24 @@ export function ConversationView({
     }
   }, [hiddenCount]);
 
+  // When the message currently generating has a bubble in the list, render the typing
+  // indicator inside that bubble; otherwise it falls back to the standalone row below.
+  // ConversationMessage only renders typingLabel when its body is empty, so we may only
+  // route into a bubble that will actually be empty at render time:
+  //   • regeneration — the target bubble's content is cleared while we wait, or
+  //   • a deliberately-empty placeholder message.
+  // A brand-new generation otherwise targets lastAssistantMessageId (the previous, NON-empty
+  // assistant message); routing into it would swallow the indicator and show no feedback, so
+  // we leave the standalone row alive in that case.
+  const typingTargetId = showTypingIndicator ? (regenerateMessageId ?? lastAssistantMessageId) : null;
+  const typingLabelInMessage =
+    !!typingTargetId &&
+    renderedItems.some((item) => {
+      if (item.type !== "message") return false;
+      if (!(item.msg.id === typingTargetId || item.key.startsWith(typingTargetId + "__"))) return false;
+      return regenerateMessageId != null || (item.msg.content ?? "").trim() === "";
+    });
+
   return (
     <div
       className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
@@ -1137,6 +1266,7 @@ export function ConversationView({
                   onPeekPrompt={onPeekPrompt}
                   onToggleHiddenFromAI={onToggleHiddenFromAI}
                   onBranch={onBranch}
+                  typingLabel={typingLabelInMessage && item.msg.id === typingTargetId ? liveTypingLabel : undefined}
                 />,
               );
               i = j;
@@ -1147,8 +1277,8 @@ export function ConversationView({
             const { msg, isGrouped } = item;
             const isRegenerating = isStreaming && regenerateMessageId === msg.id;
             // During regeneration, don't pass isStreaming until content arrives — the
-            // "X is typing..." indicator at the bottom provides visual feedback instead
-            // of showing bouncing dots inside the message bubble.
+            // "X is typing..." indicator inside the message body provides feedback, and the
+            // old content is cleared while waiting so the indicator shows in an empty bubble.
             const hasStreamContent = isRegenerating && (!!streamBuffer || !!thinkingBuffer);
             // Strip old-swipe attachments during regeneration so a previous
             // illustration doesn't linger while new text is streaming in.
@@ -1157,7 +1287,7 @@ export function ConversationView({
                   const parsed = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
                   return {
                     ...msg,
-                    content: streamBuffer || (thinkingBuffer ? "Thinking..." : msg.content),
+                    content: streamBuffer || (thinkingBuffer ? "Thinking..." : ""),
                     extra: { ...parsed, attachments: null, thinking: thinkingBuffer || parsed.thinking },
                   };
                 })()
@@ -1184,6 +1314,7 @@ export function ConversationView({
                 multiSelectMode={multiSelectMode}
                 isSelected={selectedMessageIds?.has(msg.id)}
                 onToggleSelect={onToggleSelectMessage}
+                typingLabel={typingLabelInMessage && msg.id === typingTargetId ? liveTypingLabel : undefined}
               />,
             );
             i++;
@@ -1213,27 +1344,26 @@ export function ConversationView({
           </div>
         )}
 
-        {/* Typing indicator — shown when generation is actively running */}
-        {showTypingIndicator && (
-          <div className="flex items-center gap-2 px-4 py-1.5 text-[0.8125rem] text-[var(--text-secondary)]">
-            <span className="flex gap-0.5">
-              <span
-                className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
-                style={{ animationDelay: "0ms" }}
-              />
-              <span
-                className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
-                style={{ animationDelay: "150ms" }}
-              />
-              <span
-                className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
-                style={{ animationDelay: "300ms" }}
-              />
-            </span>
-            <span className="italic">
-              {liveTypingName} {liveTypingVerb} typing...
-            </span>
-          </div>
+        {/* Typing indicator — shown when generation is actively running.
+            CSS-targetable per character via data-card-css. Hooks:
+              .mari-typing-indicator  — the row
+              .mari-typing-dots        — the bouncing dots (style `.mari-typing-dots span`)
+              .mari-typing-text        — the "X is typing..." label
+            data-typing-name carries the character name (usable as content: attr(data-typing-name)).
+            In group chats, characters whose card CSS targets these hooks (exclusive mode) get
+            their own row so their custom text applies in isolation; the rest share one row. */}
+        {showTypingIndicator && !typingLabelInMessage && (
+          <>
+            {/* Combined row for characters without typing-targeted CSS (shown first). When no
+                concrete participants resolve, this carries the single live typing label. */}
+            {typingPlainNames.length > 0 && (
+              <TypingIndicatorRow names={typingPlainNames} cardCssId={typingPlainCardCssId} />
+            )}
+            {/* One row per character whose card CSS targets the typing indicator (alphabetical). */}
+            {typingStyledRows.map((p) => (
+              <TypingIndicatorRow key={p.id} names={[p.name]} cardCssId={p.id} />
+            ))}
+          </>
         )}
 
         {/* Scene banner — inline at bottom of messages (origin variant only) */}
@@ -1319,6 +1449,7 @@ function SplitMessageGroup({
   onPeekPrompt,
   onToggleHiddenFromAI,
   onBranch,
+  typingLabel,
 }: {
   items: Array<{ key: string; msg: Message; isGrouped: boolean; index: number }>;
   isStreaming: boolean;
@@ -1336,6 +1467,7 @@ function SplitMessageGroup({
   onPeekPrompt: (options?: PeekPromptOptions) => void;
   onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
   onBranch: (messageId: string) => void;
+  typingLabel?: string;
 }) {
   const [showActions, setShowActions] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -1358,15 +1490,18 @@ function SplitMessageGroup({
     setEditing(false);
   }, [editValue, fullContent, messageId, onEdit]);
 
+  const groupCharacterId = items[0]!.msg.characterId ?? undefined;
+
   if (editing) {
     // Show the first message header + a single textarea for the full content
     const firstItem = items[0]!;
     const { msg } = firstItem;
     return (
-      <div className="group relative">
+      <div className="mari-message-group group relative">
         <ConversationMessage
           key={firstItem.key}
           message={{ ...msg, content: "" }}
+          suppressCardCss
           isStreaming={false}
           isGrouped={firstItem.isGrouped}
           noHoverGroup
@@ -1420,11 +1555,15 @@ function SplitMessageGroup({
   }
 
   return (
-    <div className="group relative" onClick={() => setShowActions((v) => !v)}>
+    <div
+      className="mari-message-group group relative"
+      data-card-css-group={groupCharacterId}
+      onClick={() => setShowActions((v) => !v)}
+    >
       {(() => {
         // During regeneration, the split lines all belong to the same message ID.
         // Collapse them into a single ConversationMessage showing the streamed content
-        // (or "X is typing…" via the indicator below) rather than repeating dots/content per line.
+        // (or the in-bubble "X is typing…" label) rather than repeating dots/content per line.
         const firstItem = items[0]!;
         const isRegen = isStreaming && regenerateMessageId === firstItem.msg.id;
         // Strip old-swipe attachments during regeneration so a previous
@@ -1437,8 +1576,7 @@ function SplitMessageGroup({
             })()
           : undefined;
         if (isRegen) {
-          // While waiting for content, don't render — the "X is typing..." indicator
-          // at the bottom of the message list provides the visual feedback.
+          // While waiting for content, show the "X is typing..." label inside the (empty) bubble.
           if (!streamBuffer && !thinkingBuffer) {
             return (
               <ConversationMessage
@@ -1459,6 +1597,7 @@ function SplitMessageGroup({
                 characterMap={characterMap}
                 chatCharacterIds={chatCharacterIds}
                 personaInfo={personaInfo}
+                typingLabel={typingLabel}
               />
             );
           }
@@ -1493,34 +1632,42 @@ function SplitMessageGroup({
           );
         }
 
-        return items.map((gi) => {
-          const { msg, isGrouped: grp } = gi;
-          const isChild = !/(?:__block0|__line0)$/.test(gi.key);
-          return (
-            <ConversationMessage
-              key={gi.key}
-              message={msg}
-              isStreaming={false}
-              isGrouped={grp}
-              hideActions={isChild}
-              noHoverGroup
-              forceShowActions={showActions}
-              onDelete={onDelete}
-              onRegenerate={onRegenerate}
-              onEdit={onEdit}
-              onSetActiveSwipe={onSetActiveSwipe}
-              onPeekPrompt={onPeekPrompt}
-              onToggleHiddenFromAI={isChild ? undefined : onToggleHiddenFromAI}
-              onBranch={isChild ? undefined : onBranch}
-              onEditClick={handleStartEdit}
-              isLastAssistantMessage={msg.id === lastAssistantMessageId}
-              characterMap={characterMap}
-              chatCharacterIds={chatCharacterIds}
-              personaInfo={personaInfo}
-              messageIndex={gi.index + 1}
-            />
-          );
-        });
+        // Combine all split paragraphs into a single ConversationMessage so that
+        // card CSS can style one seamless container (continuous borders, corners, stickers).
+        // The stagger animation still works: as hidden blocks become visible the items
+        // array grows and the combined content expands inside the same message body.
+        const lastItem = items[items.length - 1]!;
+        const combinedContent = items.map((gi) => gi.msg.content).join("\n\n");
+        const combinedMsg = {
+          ...firstItem.msg,
+          content: combinedContent,
+          // The last block carries the real extras (attachments, generationInfo, etc.)
+          extra: lastItem.msg.extra,
+        };
+        return (
+          <ConversationMessage
+            key={firstItem.key}
+            message={combinedMsg}
+            isStreaming={false}
+            isGrouped={firstItem.isGrouped}
+            hideActions={false}
+            noHoverGroup
+            forceShowActions={showActions}
+            onDelete={onDelete}
+            onRegenerate={onRegenerate}
+            onEdit={onEdit}
+            onSetActiveSwipe={onSetActiveSwipe}
+            onPeekPrompt={onPeekPrompt}
+            onToggleHiddenFromAI={onToggleHiddenFromAI}
+            onBranch={onBranch}
+            onEditClick={handleStartEdit}
+            isLastAssistantMessage={firstItem.msg.id === lastAssistantMessageId}
+            characterMap={characterMap}
+            chatCharacterIds={chatCharacterIds}
+            personaInfo={personaInfo}
+            messageIndex={firstItem.index + 1}
+          />
+        );
       })()}
     </div>
   );

--- a/src/features/modes/conversation/hooks/use-conversation-avatar-overrides.ts
+++ b/src/features/modes/conversation/hooks/use-conversation-avatar-overrides.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { spriteApi } from "../../../../shared/api/image-generation-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import type { CharacterMap } from "../../shared/chat-ui/types";
+
+type AvatarOverrideRef = { charId: string; mode: "sprite" | "gallery"; value: string };
+type SpriteRow = { expression: string; url: string };
+type GalleryRow = { id: string; url?: string | null; filePath?: string | null };
+
+function collectAvatarOverrideRefs(characterMap: CharacterMap): AvatarOverrideRef[] {
+  const refs: AvatarOverrideRef[] = [];
+  characterMap.forEach((info, id) => {
+    const override = info.conversationAvatar;
+    if (override && (override.mode === "sprite" || override.mode === "gallery") && override.value) {
+      refs.push({ charId: id, mode: override.mode, value: override.value });
+    }
+  });
+  return refs;
+}
+
+export function useConversationAvatarOverrides(baseCharacterMap: CharacterMap): CharacterMap {
+  const avatarOverrideRefs = useMemo(() => collectAvatarOverrideRefs(baseCharacterMap), [baseCharacterMap]);
+  const { data: resolvedAvatarOverrides } = useQuery({
+    queryKey: ["conversation-avatar-override", avatarOverrideRefs],
+    enabled: avatarOverrideRefs.length > 0,
+    // Keep this always-stale rather than caching for minutes: the queryFn degrades sprite/gallery
+    // lookup failures into empty results, and a sprite/gallery asset can change in place without
+    // altering {charId, mode, value}. A non-zero staleTime would pin a transient fallback or a
+    // stale URL; staleTime 0 lets a remount/refocus re-resolve.
+    staleTime: 0,
+    queryFn: async () => {
+      const result: Record<string, string> = {};
+      const spriteCharIds = Array.from(
+        new Set(avatarOverrideRefs.filter((ref) => ref.mode === "sprite").map((ref) => ref.charId)),
+      );
+      const galleryCharIds = Array.from(
+        new Set(avatarOverrideRefs.filter((ref) => ref.mode === "gallery").map((ref) => ref.charId)),
+      );
+      const spriteLists = new Map<string, SpriteRow[]>();
+      const galleryLists = new Map<string, GalleryRow[]>();
+
+      await Promise.all([
+        ...spriteCharIds.map(async (characterId) => {
+          try {
+            spriteLists.set(characterId, await spriteApi.list<SpriteRow[]>(characterId, { ownerType: "character" }));
+          } catch {
+            spriteLists.set(characterId, []);
+          }
+        }),
+        ...galleryCharIds.map(async (characterId) => {
+          try {
+            galleryLists.set(
+              characterId,
+              await storageApi.list<GalleryRow>("character-gallery", { filters: { characterId } }),
+            );
+          } catch {
+            galleryLists.set(characterId, []);
+          }
+        }),
+      ]);
+
+      for (const ref of avatarOverrideRefs) {
+        if (ref.mode === "sprite") {
+          const src = spriteLists.get(ref.charId)?.find((sprite) => sprite.expression === ref.value)?.url;
+          if (src) result[ref.charId] = src;
+          continue;
+        }
+        const image = galleryLists.get(ref.charId)?.find((galleryImage) => galleryImage.id === ref.value);
+        const src = (image?.url || image?.filePath || "").trim();
+        if (src) result[ref.charId] = src;
+      }
+
+      return result;
+    },
+  });
+
+  return useMemo(() => {
+    if (!resolvedAvatarOverrides || Object.keys(resolvedAvatarOverrides).length === 0) return baseCharacterMap;
+    const next: CharacterMap = new Map(baseCharacterMap);
+    for (const [characterId, src] of Object.entries(resolvedAvatarOverrides)) {
+      const info = next.get(characterId);
+      if (info) next.set(characterId, { ...info, conversationAvatarSrc: src });
+    }
+    return next;
+  }, [baseCharacterMap, resolvedAvatarOverrides]);
+}

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -1963,6 +1963,7 @@ export const ChatMessage = memo(function ChatMessage({
           data-message-id={message.id}
           data-message-role={message.role}
           data-card-css={message.characterId ?? undefined}
+          data-grouped={isGrouped || undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleMessageDoubleClick}
           style={roleplayAvatarScaleStyle}
@@ -2529,6 +2530,7 @@ export const ChatMessage = memo(function ChatMessage({
       data-message-id={message.id}
       data-message-role={message.role}
       data-card-css={message.characterId ?? undefined}
+      data-grouped={isGrouped || undefined}
       onClick={handleMobileTap}
       onDoubleClick={handleMessageDoubleClick}
     >

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx
@@ -2,22 +2,25 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatSurfaceData } from "./use-chat-surface-data";
 
-const catalogMocks = vi.hoisted(() => ({
+const mocks = vi.hoisted(() => ({
+  useChat: vi.fn(),
   useChatMessages: vi.fn(),
+  useCharacterSummariesByIds: vi.fn(),
 }));
 
 vi.mock("../../../../catalog/chats/index", () => ({
-  useChat: () => ({ data: undefined, error: null }),
+  useChat: mocks.useChat,
   useChatMessageCount: () => ({ data: undefined }),
-  useChatMessages: catalogMocks.useChatMessages,
+  useChatMessages: mocks.useChatMessages,
 }));
 
 vi.mock("../../../../catalog/characters/index", () => ({
   characterAvatarUrl: () => null,
-  useCharacterSummariesByIds: () => ({ data: [] }),
+  useCharacterSummariesByIds: mocks.useCharacterSummariesByIds,
 }));
 
 vi.mock("../../../../catalog/personas/index", () => ({
@@ -27,11 +30,13 @@ vi.mock("../../../../catalog/personas/index", () => ({
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-function Harness() {
+type Mode = "conversation" | "roleplay" | "game";
+
+function Harness({ fallbackChatMode = "conversation" }: { fallbackChatMode?: Mode }) {
   useChatSurfaceData({
     activeChatId: "chat-1",
     messagePageSize: 20,
-    fallbackChatMode: "conversation",
+    fallbackChatMode,
     personaFallback: "active-persona",
   });
   return null;
@@ -40,9 +45,17 @@ function Harness() {
 describe("useChatSurfaceData", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let client: QueryClient;
 
   beforeEach(() => {
-    catalogMocks.useChatMessages.mockReturnValue({
+    mocks.useChat.mockReturnValue({
+      data: undefined,
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+    mocks.useChatMessages.mockReturnValue({
       data: undefined,
       isLoading: true,
       fetchNextPage: vi.fn(),
@@ -50,9 +63,11 @@ describe("useChatSurfaceData", () => {
       isFetchingNextPage: false,
       refetch: vi.fn(),
     });
+    mocks.useCharacterSummariesByIds.mockReturnValue({ data: [] });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   });
 
   afterEach(() => {
@@ -60,14 +75,25 @@ describe("useChatSurfaceData", () => {
       root.unmount();
     });
     container.remove();
-    catalogMocks.useChatMessages.mockReset();
+    client.clear();
+    vi.clearAllMocks();
   });
 
-  it("starts loading messages as soon as an active chat id exists", () => {
-    act(() => {
-      root.render(<Harness />);
+  async function render(props: { fallbackChatMode?: Mode } = {}) {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <Harness {...props} />
+        </QueryClientProvider>,
+      );
     });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
 
-    expect(catalogMocks.useChatMessages).toHaveBeenCalledWith("chat-1", 20, true);
+  it("starts loading messages as soon as an active chat id exists", async () => {
+    await render();
+    expect(mocks.useChatMessages).toHaveBeenCalledWith("chat-1", 20, true);
   });
 });

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -266,7 +266,7 @@ export function useChatSurfaceData({
     [chatCharIds, chatMeta, messages],
   );
   const { data: characterRows } = useCharacterSummariesByIds(neededCharacterIds, neededCharacterIds.length > 0);
-  const characterMap: CharacterMap = useMemo(() => {
+  const baseCharacterMap: CharacterMap = useMemo(() => {
     const map: CharacterMap = new Map();
     for (const character of (characterRows ?? []) as CharacterRow[]) {
       try {
@@ -298,6 +298,13 @@ export function useChatSurfaceData({
                 ? "online"
                 : undefined,
           conversationActivity: readString(extensions.conversationActivity) || undefined,
+          conversationAvatar: (() => {
+            const rec = readRecord(extensions.conversationAvatar);
+            const mode = readString(rec.mode);
+            return mode === "hide" || mode === "emoji" || mode === "sprite" || mode === "gallery"
+              ? { mode, value: readString(rec.value) || undefined }
+              : undefined;
+          })(),
         });
       } catch {
         map.set(character.id, { name: "Unknown", avatarUrl: null });
@@ -305,6 +312,8 @@ export function useChatSurfaceData({
     }
     return map;
   }, [characterRows]);
+
+  const characterMap = baseCharacterMap;
 
   const characterNames = useMemo(
     () => chatCharIds.map((id) => characterMap.get(id)?.name).filter((name): name is string => !!name),

--- a/src/features/runtime/visuals/types.ts
+++ b/src/features/runtime/visuals/types.ts
@@ -1,4 +1,5 @@
 import type { AvatarCropValue } from "../../../shared/lib/utils";
+import type { ConversationAvatarOverride } from "../../../engine/contracts/types/character";
 
 export type CharacterMap = Map<
   string,
@@ -21,6 +22,10 @@ export type CharacterMap = Map<
     avatarCrop?: AvatarCropValue | null;
     conversationStatus?: "online" | "idle" | "dnd" | "offline";
     conversationActivity?: string;
+    /** Conversation-mode avatar override (raw reference; sprite/gallery resolved into conversationAvatarSrc) */
+    conversationAvatar?: ConversationAvatarOverride;
+    /** Resolved image src for sprite/gallery override modes (filled during map build); undefined otherwise */
+    conversationAvatarSrc?: string | null;
   }
 >;
 

--- a/src/features/shell/discovery/discovery-entries.json
+++ b/src/features/shell/discovery/discovery-entries.json
@@ -44,6 +44,17 @@
     "coverage": "core"
   },
   {
+    "id": "conversation-avatar",
+    "title": "Conversation Avatar",
+    "category": "Library",
+    "summary": "Override a character's avatar in Conversation mode — show an emoji, one of its sprites, a gallery image, or hide it entirely.",
+    "keywords": ["avatar", "conversation avatar", "emoji avatar", "sprite avatar", "gallery avatar", "profile picture", "hide avatar", "character appearance", "card css"],
+    "audience": "Users theming how a character looks next to their messages in Conversation mode.",
+    "where": "Character editor > Colors tab > Conversation Avatar.",
+    "actions": [{ "type": "open-panel", "panel": "characters", "label": "Open Characters" }],
+    "coverage": "advanced"
+  },
+  {
     "id": "personas",
     "title": "Personas",
     "category": "Library",

--- a/src/shared/lib/chat-css.test.ts
+++ b/src/shared/lib/chat-css.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from "vitest";
+import { cssTargetsTypingIndicator, filterCssByMode, scopeChatCss } from "./chat-css";
+
+describe("filterCssByMode", () => {
+  it("keeps global CSS and only the requested chat mode block", () => {
+    const css = [
+      ".shared { color: white; }",
+      "@chat-mode roleplay { .rp { color: red; } }",
+      "@chat-mode conversation { .convo { color: blue; } }",
+      "@chat-mode game { .game { color: green; } }",
+      ".tail { color: black; }",
+    ].join("\n");
+
+    expect(filterCssByMode(css, "conversation")).toContain(".shared");
+    expect(filterCssByMode(css, "conversation")).toContain(".convo");
+    expect(filterCssByMode(css, "conversation")).toContain(".tail");
+    expect(filterCssByMode(css, "conversation")).not.toContain(".rp");
+    expect(filterCssByMode(css, "conversation")).not.toContain(".game");
+  });
+
+  it("handles nested rule blocks inside mode filters", () => {
+    const css = "@chat-mode game { @media (min-width: 600px) { .panel { color: lime; } } }";
+
+    expect(filterCssByMode(css, "game")).toContain("@media");
+    expect(filterCssByMode(css, "game")).toContain(".panel");
+    expect(filterCssByMode(css, "roleplay").trim()).toBe("");
+  });
+
+  it("ignores braces inside strings and comments when skipping another mode", () => {
+    const css = [
+      '@chat-mode game { .game::before { content: "}"; } /* } */ .leak { color: red; } }',
+      "@chat-mode conversation { .convo { color: blue; } }",
+    ].join("\n");
+    const filtered = filterCssByMode(css, "conversation");
+
+    expect(filtered).toContain(".convo");
+    expect(filtered).not.toContain(".leak");
+    expect(filtered).not.toContain('content: "}"');
+  });
+});
+
+describe("scopeChatCss sanitization", () => {
+  it("blocks network, theme override, scope escape, and important constructs", () => {
+    const sanitized = scopeChatCss(`
+      @import url("https://example.test/evil.css");
+      @font-face { font-family: Sneak; src: url("https://example.test/font.woff2"); }
+      .card:has(.secret) {
+        background: url("https://example.test/track.png");
+        --background: red;
+        content: "spoof";
+        position: fixed !important;
+      }
+    `, ".mari-card-css");
+
+    expect(sanitized).not.toMatch(/@import/i);
+    expect(sanitized).not.toMatch(/@font-face/i);
+    expect(sanitized).not.toMatch(/https:\/\/example\.test/i);
+    expect(sanitized).not.toContain("--background");
+    expect(sanitized).not.toMatch(/:has/i);
+    expect(sanitized).not.toMatch(/!important/i);
+    expect(sanitized).toContain("url(about:invalid)");
+    expect(sanitized).toContain("position:absolute");
+  });
+
+  it("neutralizes escaped url() so it can't tunnel under the network guard", () => {
+    // `\75rl(...)` parses as url(...) in the engine; the function name is decoded before the guard.
+    const sanitized = scopeChatCss(".x { background: \\75rl(https://tracker.test/pixel); }", ".mari-card-css");
+    expect(sanitized).not.toMatch(/tracker\.test/i);
+    expect(sanitized).toContain("url(about:invalid)");
+  });
+
+  it("preserves benign escapes outside function names (only function-name tokens are decoded)", () => {
+    // An escaped slash in a class name (e.g. a "w-1/2"-style utility class) must survive intact.
+    expect(scopeChatCss(".w-1\\/2 { color: red }", ".mari-card-css")).toContain(".w-1\\/2");
+    // An escaped code point inside a content string is preserved, not rewritten.
+    expect(scopeChatCss('.card::before { content: "\\2014" }', ".mari-card-css")).toContain('"\\2014"');
+  });
+
+  it("does not decode function-name escapes that live inside a content string", () => {
+    // `\75rl(` here is decorative text, not a real url() call — it must stay literal, not become "url(".
+    const sanitized = scopeChatCss('.card::before { content: "\\75rl(" }', ".mari-card-css");
+    expect(sanitized).toContain('"\\75rl("');
+    expect(sanitized).not.toContain('"url("');
+  });
+
+  it("allows sanitized content text (no HTML-like chars)", () => {
+    const sanitized = scopeChatCss('.card::before { content: "Hello World" }', ".mari-card-css");
+    expect(sanitized).toContain('content: "Hello World"');
+  });
+
+  it("strips HTML-like characters from content text", () => {
+    const sanitized = scopeChatCss('.card::before { content: "<button>Click me</button>" }', ".mari-card-css");
+    expect(sanitized).not.toContain("<button>");
+    expect(sanitized).not.toContain("</button>");
+    expect(sanitized).toContain('content: "buttonClick me/button"');
+  });
+
+  it("keeps semicolons inside quoted content values", () => {
+    const sanitized = scopeChatCss('.card::before { content: "A; B"; color: red }', ".mari-card-css");
+    expect(sanitized).toContain('content: "A; B";');
+    expect(sanitized).toContain("color: red");
+  });
+
+  it("caps content text length at 200 characters", () => {
+    const longText = "A".repeat(300);
+    const sanitized = scopeChatCss(`.card::before { content: "${longText}" }`, ".mari-card-css");
+    expect(sanitized).toContain("A".repeat(200));
+    expect(sanitized).not.toContain("A".repeat(201));
+  });
+
+  it("allows empty content strings", () => {
+    const sanitized = scopeChatCss(".card::before { content: '' }", ".mari-card-css");
+    expect(sanitized).toContain("content: ''");
+  });
+
+  it("allows CSS content functions", () => {
+    const sanitized = scopeChatCss('.card::before { content: counter(section) }', ".mari-card-css");
+    expect(sanitized).toContain("content: counter(section)");
+  });
+
+  it("sanitizes quoted text segments beside allowed CSS content functions", () => {
+    const sanitized = scopeChatCss(
+      '.card::before { content: attr(data-typing-name) "<button>fake</button>" }',
+      ".mari-card-css",
+    );
+    expect(sanitized).toContain('content: attr(data-typing-name) "buttonfake/button"');
+    expect(sanitized).not.toContain("<button>");
+    expect(sanitized).not.toContain("</button>");
+  });
+
+  it("preserves content: attr(data-typing-name) (the documented typing-label pattern)", () => {
+    const sanitized = scopeChatCss(
+      ".mari-typing-indicator::after { content: attr(data-typing-name) }",
+      ".mari-card-css",
+    );
+    expect(sanitized).toContain("attr(data-typing-name)");
+    // and the selector is still scoped under the card root
+    expect(sanitized).toContain(".mari-card-css .mari-typing-indicator::after");
+  });
+
+  it("falls back to empty string for unrecognized content values", () => {
+    const sanitized = scopeChatCss(".card::before { content: something-weird }", ".mari-card-css");
+    expect(sanitized).toContain("content: ''");
+  });
+
+  it("allows data image URLs", () => {
+    expect(scopeChatCss(".portrait { background: url(data:image/png;base64,abc); }", ".mari-card-css")).toContain(
+      "data:image/png",
+    );
+  });
+
+  it("allows @font-face with data: URIs only", () => {
+    const css = '@font-face { font-family: MyFont; src: url(data:font/woff2;base64,abc); }';
+    const sanitized = scopeChatCss(css, ".mari-card-css");
+    expect(sanitized).toMatch(/@font-face/i);
+    expect(sanitized).toContain("data:font/woff2");
+  });
+
+  it("strips @font-face blocks with external URLs", () => {
+    const css = '@font-face { font-family: Sneak; src: url("https://evil.test/font.woff2"); }';
+    const sanitized = scopeChatCss(css, ".mari-card-css");
+    expect(sanitized).not.toMatch(/@font-face/i);
+  });
+
+  it("strips @font-face blocks whose source is a non-font data: URI (e.g. image)", () => {
+    // image/* data URIs are allowed for general url() use but are NOT valid font sources;
+    // the whole @font-face block is dropped so the documented font-only contract holds.
+    const css = '@font-face { font-family: Sneak; src: url(data:image/png;base64,abc); }';
+    const sanitized = scopeChatCss(css, ".mari-card-css");
+    expect(sanitized).not.toMatch(/@font-face/i);
+  });
+
+  it("strips @font-face blocks with local() / no data: url source (no vacuous pass)", () => {
+    // local() references an installed font (non-data, fingerprintable) and there's no data:
+    // url at all — must not survive the font-data-only contract.
+    expect(scopeChatCss('@font-face { font-family: Sneak; src: local("Inter"); }', ".mari-card-css")).not.toMatch(
+      /@font-face/i,
+    );
+    // local() mixed with a valid data: font is still rejected (any non-data source disqualifies).
+    expect(
+      scopeChatCss(
+        '@font-face { font-family: Sneak; src: local("Inter"), url(data:font/woff2;base64,abc); }',
+        ".mari-card-css",
+      ),
+    ).not.toMatch(/@font-face/i);
+  });
+
+  it("strips @font-face blocks that hide local() behind escaped function names", () => {
+    // `l\6f cal(...)` parses as local(...); the function name is decoded before the gate runs,
+    // so the escaped source is caught even alongside a valid data: font url.
+    const css = '@font-face { font-family: Sneak; src: l\\6f cal("Inter"), url(data:font/woff2;base64,abc); }';
+    expect(scopeChatCss(css, ".mari-card-css")).not.toMatch(/@font-face/i);
+  });
+
+  it("allows data: URIs with application/font MIME types", () => {
+    const css = '.icon { background: url(data:application/font-woff2;base64,abc); }';
+    const sanitized = scopeChatCss(css, ".mari-card-css");
+    expect(sanitized).toContain("data:application/font-woff2");
+  });
+
+  it("strips broad data:application/octet-stream urls (fonts/images only)", () => {
+    const sanitized = scopeChatCss(".x { background: url(data:application/octet-stream;base64,abc); }", ".mari-card-css");
+    expect(sanitized).not.toContain("octet-stream");
+    expect(sanitized).toContain("url(about:invalid)");
+  });
+
+  it("namespaces @font-face families and rewrites references so embedded fonts can't leak app-wide", () => {
+    const css =
+      '@font-face { font-family: "Inter"; src: url(data:font/woff2;base64,abc); }\n.label { font-family: "Inter", sans-serif; }';
+    const sanitized = scopeChatCss(css, ".mari-card-css");
+    // the embedded family is renamed to a namespaced one
+    expect(sanitized).toContain("mc-font-Inter");
+    // and no bare app-family "Inter" is ever declared (which would otherwise override app UI)
+    expect(sanitized).not.toMatch(/font-family:\s*["']?Inter["']?\s*[;,}]/i);
+    // the reference still resolves to the namespaced family and keeps the fallback
+    expect(sanitized).toContain("sans-serif");
+  });
+
+  it("salts @font-face names so two cards embedding the same family can't collide globally", () => {
+    const cardA =
+      '@font-face { font-family: "Inter"; src: url(data:font/woff2;base64,AAA); }\n.label { font-family: "Inter"; }';
+    const cardB =
+      '@font-face { font-family: "Inter"; src: url(data:font/woff2;base64,BBB); }\n.label { font-family: "Inter"; }';
+    const a = scopeChatCss(cardA, ".mari-card-css");
+    const b = scopeChatCss(cardB, ".mari-card-css");
+    const nameA = a.match(/mc-font-Inter-[a-z0-9]+/i)?.[0];
+    const nameB = b.match(/mc-font-Inter-[a-z0-9]+/i)?.[0];
+    expect(nameA).toBeTruthy();
+    expect(nameB).toBeTruthy();
+    expect(nameA).not.toBe(nameB);
+  });
+
+  it("keeps multiple faces of one family grouped under a single salted name within a card", () => {
+    const css =
+      '@font-face { font-family: "Inter"; font-weight: 400; src: url(data:font/woff2;base64,AAA); }\n' +
+      '@font-face { font-family: "Inter"; font-weight: 700; src: url(data:font/woff2;base64,BBB); }\n' +
+      '.label { font-family: "Inter", sans-serif; }';
+    const out = scopeChatCss(css, ".mari-card-css");
+    const names = [...out.matchAll(/mc-font-Inter-[a-z0-9]+/gi)].map((m) => m[0]);
+    // 2 @font-face declarations + 1 reference, all rewritten to the same salted family name
+    expect(names.length).toBe(3);
+    expect(new Set(names).size).toBe(1);
+  });
+});
+
+describe("scopeChatCss", () => {
+  it("scopes selectors and root-like selectors under the provided scope", () => {
+    const scoped = scopeChatCss(":root { color: red; }\n.name, body .bubble { opacity: 1; }", ".mari-card-css");
+
+    expect(scoped).toContain(".mari-card-css { color: red; }");
+    expect(scoped).toContain(".mari-card-css .name");
+    expect(scoped).toContain(".mari-card-css .bubble");
+  });
+
+  it("namespaces keyframes and animation references", () => {
+    const scoped = scopeChatCss("@keyframes shimmer { from { opacity: 0; } to { opacity: 1; } }\n.card { animation: shimmer 1s ease; }", ".mari-card-css");
+
+    expect(scoped).toContain("@keyframes mc-shimmer");
+    expect(scoped).toContain("animation: mc-shimmer 1s ease");
+  });
+
+  it("scopes chained selectors on [data-card-css] in exclusive mode", () => {
+    const exclusiveScope = '.mari-card-css [data-card-css="char-123"]';
+    const scoped = scopeChatCss(
+      '[data-card-css]:not([data-grouped]) .body { color: red; }\n[data-card-css][data-grouped] .body { color: blue; }',
+      exclusiveScope,
+    );
+
+    expect(scoped).toContain('.mari-card-css [data-card-css="char-123"]:not([data-grouped]) .body');
+    expect(scoped).toContain('.mari-card-css [data-card-css="char-123"][data-grouped] .body');
+    // Must NOT create nested [data-card-css] descendant selectors
+    expect(scoped).not.toContain('] [data-card-css]:');
+    expect(scoped).not.toContain('] [data-card-css][');
+  });
+
+  it("scopes chained selectors on [data-card-css] as descendant in chat mode", () => {
+    const chatScope = ".mari-card-css";
+    const scoped = scopeChatCss(
+      '[data-card-css]:not([data-grouped]) .body { color: red; }\n[data-card-css][data-grouped] .body { color: blue; }',
+      chatScope,
+    );
+
+    expect(scoped).toContain(".mari-card-css [data-card-css]:not([data-grouped]) .body");
+    expect(scoped).toContain(".mari-card-css [data-card-css][data-grouped] .body");
+  });
+
+  it("scopes chained class selectors on [data-card-css] in exclusive mode", () => {
+    const exclusiveScope = '.mari-card-css [data-card-css="char-123"]';
+    const scoped = scopeChatCss(
+      "[data-card-css].mari-message-group { border-left: 2px solid pink; }",
+      exclusiveScope,
+    );
+
+    expect(scoped).toContain('.mari-card-css [data-card-css="char-123"].mari-message-group');
+  });
+
+  it("scopes chained class selectors on [data-card-css] as descendant in chat mode", () => {
+    const chatScope = ".mari-card-css";
+    const scoped = scopeChatCss(
+      "[data-card-css].mari-message-group { border-left: 2px solid pink; }",
+      chatScope,
+    );
+
+    expect(scoped).toContain(".mari-card-css [data-card-css].mari-message-group");
+  });
+});
+
+describe("cssTargetsTypingIndicator", () => {
+  it("detects the .mari-typing-* selector hooks", () => {
+    expect(cssTargetsTypingIndicator(".mari-typing-text { color: red; }")).toBe(true);
+    expect(cssTargetsTypingIndicator(".mari-typing-dots span { background: pink; }")).toBe(true);
+    expect(cssTargetsTypingIndicator(".mari-typing-indicator { gap: 4px; }")).toBe(true);
+  });
+
+  it("detects data-typing-name usage (e.g. content: attr(data-typing-name))", () => {
+    expect(
+      cssTargetsTypingIndicator('.mari-typing-indicator::after { content: attr(data-typing-name); }'),
+    ).toBe(true);
+  });
+
+  it("returns false for CSS that doesn't touch the typing indicator", () => {
+    expect(cssTargetsTypingIndicator(".mari-message-content { color: red; } .name { font-weight: 700; }")).toBe(
+      false,
+    );
+  });
+
+  it("ignores typing hooks that only appear inside comments", () => {
+    // A comment mentioning the hook must NOT count as an active selector.
+    expect(cssTargetsTypingIndicator("/* tweak .mari-typing-text later */ .name { color: red; }")).toBe(false);
+    expect(cssTargetsTypingIndicator("/* uses data-typing-name */ .bubble { opacity: 1; }")).toBe(false);
+  });
+
+  it("ignores typing hooks that only appear inside decorative strings", () => {
+    expect(cssTargetsTypingIndicator('.label::after { content: ".mari-typing-text"; }')).toBe(false);
+    expect(cssTargetsTypingIndicator('.label::after { content: "data-typing-name"; }')).toBe(false);
+  });
+
+  it("composes with filterCssByMode so only the active surface's typing rules count", () => {
+    const css = [
+      "@chat-mode roleplay { .mari-typing-text { color: lime; } }",
+      "@chat-mode conversation { .bubble { color: white; } }",
+    ].join("\n");
+    // The typing rule lives in the roleplay block, so it must not register for conversation…
+    expect(cssTargetsTypingIndicator(filterCssByMode(css, "conversation"))).toBe(false);
+    // …but it does for roleplay.
+    expect(cssTargetsTypingIndicator(filterCssByMode(css, "roleplay"))).toBe(true);
+  });
+
+  it("detects a conversation-scoped typing rule under the conversation filter", () => {
+    const css = "@chat-mode conversation { .mari-typing-text::after { content: ' is cooking…'; } }";
+    expect(cssTargetsTypingIndicator(filterCssByMode(css, "conversation"))).toBe(true);
+    expect(cssTargetsTypingIndicator(filterCssByMode(css, "game"))).toBe(false);
+  });
+});

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -6,6 +6,54 @@ export type ChatModeFilter = "roleplay" | "conversation" | "game";
 
 const CHAT_MODE_RE = /@chat-mode\s+(roleplay|conversation|game)\s*\{/gi;
 
+function findCssBlockEnd(css: string, bodyStart: number): { end: number; closed: boolean } {
+  let depth = 1;
+  let i = bodyStart;
+  let quote: string | null = null;
+  let escaped = false;
+  let inComment = false;
+
+  while (i < css.length && depth > 0) {
+    const ch = css[i]!;
+    const next = css[i + 1];
+    if (inComment) {
+      if (ch === "*" && next === "/") {
+        inComment = false;
+        i += 2;
+      } else {
+        i++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inComment = true;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    i++;
+  }
+
+  return { end: i, closed: depth === 0 };
+}
+
 /**
  * Filter CSS by `@chat-mode <mode> { ... }` blocks.
  *
@@ -32,17 +80,10 @@ export function filterCssByMode(css: string, chatMode: ChatModeFilter): string {
     const targetMode = match[1].toLowerCase();
     const bodyStart = match.index + match[0].length;
 
-    // Find the matching closing brace (handle one level of nesting)
-    let depth = 1;
-    let i = bodyStart;
-    while (i < css.length && depth > 0) {
-      if (css[i] === "{") depth++;
-      else if (css[i] === "}") depth--;
-      i++;
-    }
-    const body = css.slice(bodyStart, i - 1);
-    cursor = i;
-    CHAT_MODE_RE.lastIndex = i;
+    const block = findCssBlockEnd(css, bodyStart);
+    const body = css.slice(bodyStart, block.closed ? block.end - 1 : block.end);
+    cursor = block.end;
+    CHAT_MODE_RE.lastIndex = block.end;
 
     if (targetMode === chatMode) {
       chunks.push(body);
@@ -55,6 +96,21 @@ export function filterCssByMode(css: string, chatMode: ChatModeFilter): string {
   }
 
   return chunks.join("\n");
+}
+
+/**
+ * Heuristic: does this card CSS reference the typing-indicator hooks?
+ * Used to decide whether a character's typing row should render on its own
+ * (so its `.mari-typing-*` / `data-typing-name` rules apply in isolation) rather
+ * than being folded into the combined "A, B are typing…" row. Callers should pass
+ * the CSS already filtered to the active surface via `filterCssByMode`.
+ *
+ * Comments are stripped first so an explanatory note that merely mentions
+ * `.mari-typing` or `data-typing-name` can't be mistaken for a real selector and
+ * trigger a spurious per-character row.
+ */
+export function cssTargetsTypingIndicator(css: string): boolean {
+  return /\.mari-typing|data-typing-name/i.test(stripQuotedStrings(stripComments(css)));
 }
 
 /** Theme tokens that card CSS must never override. */
@@ -98,21 +154,138 @@ const THEME_TOKEN_BLOCKLIST = [
   "--color-ring",
 ];
 
-
 /** Strip CSS comments */
 function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
+/** Replace quoted CSS strings with empty quotes so heuristic scanners ignore decorative text. */
+function stripQuotedStrings(css: string): string {
+  return css.replace(/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g, (match) => match[0]! + match[0]!);
+}
+
+function sanitizeContentText(text: string): string {
+  const stripped = text.replace(/[<>]/g, "");
+  return stripped.length > 200 ? stripped.slice(0, 200) : stripped;
+}
+
+function sanitizeContentQuotedSegments(value: string): string {
+  return value.replace(/(['"])((?:\\.|(?!\1)[\s\S])*)\1/g, (_match, quote: string, text: string) => {
+    return `${quote}${sanitizeContentText(text)}${quote}`;
+  });
+}
+
+const CONTENT_TOKEN_RE =
+  /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|(?:counter|counters|attr)\s*\([^)]*\)|open-quote|close-quote|no-open-quote|no-close-quote|none|normal)\s*/gi;
+
+function isAllowedContentExpression(value: string): boolean {
+  return value.replace(CONTENT_TOKEN_RE, "").trim().length === 0;
+}
+
+function matchContentPropertyColon(css: string, index: number): number | null {
+  if (css.slice(index, index + "content".length).toLowerCase() !== "content") return null;
+  if (index > 0 && /[-_A-Za-z0-9]/.test(css[index - 1]!)) return null;
+  let cursor = index + "content".length;
+  while (cursor < css.length && /\s/.test(css[cursor]!)) cursor++;
+  return css[cursor] === ":" ? cursor : null;
+}
+
+function findDeclarationEnd(css: string, valueStart: number): { valueEnd: number; terminator: string } {
+  let quote: string | null = null;
+  let escaped = false;
+  for (let cursor = valueStart; cursor < css.length; cursor++) {
+    const ch = css[cursor]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ";" || ch === "}") return { valueEnd: cursor, terminator: ch };
+  }
+  return { valueEnd: css.length, terminator: "" };
+}
+
+function sanitizeContentDeclarationValue(value: string, terminator: string): string {
+  const normalized = value.trim();
+  // Allow empty string content (pseudo-element clearing)
+  if (/^(['"])\s*\1$/.test(normalized)) {
+    return `content: ${normalized}${terminator}`;
+  }
+  // Allow quoted text with sanitization
+  const quoted = normalized.match(/^(['"])(.*)\1$/);
+  if (quoted) {
+    return `content: "${sanitizeContentText(quoted[2])}"${terminator}`;
+  }
+  // Allow CSS functions like counter(), attr(), etc.
+  if (isAllowedContentExpression(normalized)) {
+    return `content: ${sanitizeContentQuotedSegments(normalized)}${terminator}`;
+  }
+  return `content: ''${terminator}`;
+}
+
+function sanitizeContentDeclarations(css: string): string {
+  let result = "";
+  let lastAppend = 0;
+  let cursor = 0;
+  let quote: string | null = null;
+  let escaped = false;
+
+  while (cursor < css.length) {
+    const ch = css[cursor]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      cursor++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      cursor++;
+      continue;
+    }
+
+    const colonIndex = matchContentPropertyColon(css, cursor);
+    if (colonIndex !== null) {
+      const valueStart = colonIndex + 1;
+      const { valueEnd, terminator } = findDeclarationEnd(css, valueStart);
+      result += css.slice(lastAppend, cursor);
+      result += sanitizeContentDeclarationValue(css.slice(valueStart, valueEnd), terminator);
+      cursor = valueEnd + (terminator ? 1 : 0);
+      lastAppend = cursor;
+      continue;
+    }
+    cursor++;
+  }
+
+  return result + css.slice(lastAppend);
+}
+
 /** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
 function decodeCssEscapes(input: string): string {
-  return input.replace(/\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g, (_m, hex: string | undefined, ch: string | undefined) => {
-    if (hex) {
-      const cp = parseInt(hex, 16);
-      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
-    }
-    return ch ?? "";
-  });
+  return input.replace(
+    /\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g,
+    (_m, hex: string | undefined, ch: string | undefined) => {
+      if (hex) {
+        const cp = parseInt(hex, 16);
+        return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+      }
+      return ch ?? "";
+    },
+  );
 }
 
 // Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
@@ -167,14 +340,31 @@ function sanitizeChatCss(css: string): string {
   out = canonicalizeKeywordEscapes(out);
 
   // ── Network exfiltration prevention ──
-  // Strip ALL url() except data:image/* (no external network requests)
-  out = out.replace(/url\s*\(\s*(['"]?)\s*(?!['"]?\s*data:image\/)[^)]*\)/gi, "url(about:invalid)");
+  // Strip ALL url() except data: URIs for images and fonts (no external network requests).
+  // Allowed MIME prefixes are intentionally narrow: image/*, font/*, and the font-specific
+  // application/font* and application/x-font* (no generic application/octet-stream).
+  out = out.replace(
+    /url\s*\(\s*(['"]?)\s*(?!['"]?\s*data:(?:image\/|font\/|application\/(?:font|x-font)))[^)]*\)/gi,
+    "url(about:invalid)",
+  );
   // Strip @import (network request + CSS injection)
   out = out.replace(/@import\b[^;]*;/gi, "");
   // Strip @namespace
   out = out.replace(/@namespace\b[^;]*;/gi, "");
-  // Strip @font-face (network request via font loading)
-  out = out.replace(/@font-face\s*\{[^}]*\}/gi, "");
+  // Keep an @font-face block only if every source is a FONT data: URI. The block must carry
+  // at least one url() (an empty url() set would otherwise pass vacuously), every url() must
+  // be a font data: URI, and local() sources are rejected — they reference installed fonts
+  // (non-data, usable for fingerprinting) and fall outside the documented "embedded data:
+  // fonts only" contract. External URLs were already neutralized to url(about:invalid) above,
+  // and image/* data URIs (allowed for general url() use) are not valid font sources.
+  out = out.replace(/@font-face\s*\{[^}]*\}/gi, (block) => {
+    const urls = block.match(/url\s*\([^)]*\)/gi) ?? [];
+    const allFontData =
+      urls.length > 0 &&
+      urls.every((u) => /url\s*\(\s*(['"]?)\s*data:(?:font\/|application\/(?:font|x-font))/i.test(u));
+    const hasLocalSource = /\blocal\s*\(/i.test(block);
+    return allFontData && !hasLocalSource ? block : "";
+  });
 
   // ── Script/expression injection ──
   out = out.replace(/expression\s*\([^)]*\)/gi, "");
@@ -192,15 +382,9 @@ function sanitizeChatCss(css: string): string {
   out = out.replace(/position\s*:\s*fixed/gi, "position:absolute");
 
   // ── Content injection prevention ──
-  // Strip content property (prevent phishing text/UI spoofing)
-  // Allow content:"" (used for pseudo-element clearing) but block non-empty values.
-  out = out.replace(/content\s*:\s*([^;}]*)([;}]|$)/gi, (_match, value: string, terminator: string) => {
-    const normalized = value.trim();
-    if (/^(['"])\s*\1$/.test(normalized)) {
-      return `content: ${normalized}${terminator}`;
-    }
-    return `content: ''${terminator}`;
-  });
+  // Allow content property with sanitized text (for decorative labels in card CSS).
+  // Strip HTML-like characters and cap length to prevent phishing/UI spoofing.
+  out = sanitizeContentDeclarations(out);
   // Strip </style (prevent injection breakout)
   out = out.replace(/<\/style/gi, "");
 
@@ -220,6 +404,20 @@ function sanitizeChatCss(css: string): string {
 }
 
 /**
+ * Stable, short, non-cryptographic hash (FNV-1a, base36). Used only to salt
+ * generated identifiers so they can't collide between independent card CSS
+ * specimens — it does not need to be secure, just deterministic.
+ */
+function hashCss(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
  * Scope CSS rules under a given selector.
  * - Sanitizes input
  * - Namespaces @keyframes with "mc-" prefix
@@ -235,31 +433,82 @@ export function scopeChatCss(css: string, scopeSelector: string): string {
   });
 
   // Rewrite animation-name references too
-  sanitized = sanitized.replace(
-    /animation(?:-name)?\s*:[^;{}]*/gi,
-    (match) => {
-      // For each animation name token that isn't a keyword, prefix with mc-
-      return match.replace(
-        /:\s*([^;{}]*)/,
-        (_, value: string) => {
-          const prefixed = value.replace(
-            /(?:^|,\s*)([a-zA-Z_][\w-]*)/g,
-            (full, name: string) => {
-              const keywords = new Set([
-                "none", "initial", "inherit", "unset", "infinite", "alternate",
-                "reverse", "alternate-reverse", "normal", "forwards", "backwards",
-                "both", "running", "paused", "ease", "ease-in", "ease-out",
-                "ease-in-out", "linear", "step-start", "step-end",
-              ]);
-              if (keywords.has(name) || /^\d/.test(name)) return full;
-              return full.replace(name, `mc-${name}`);
-            },
-          );
-          return `: ${prefixed}`;
-        },
-      );
-    },
-  );
+  sanitized = sanitized.replace(/animation(?:-name)?\s*:[^;{}]*/gi, (match) => {
+    // For each animation name token that isn't a keyword, prefix with mc-
+    return match.replace(/:\s*([^;{}]*)/, (_, value: string) => {
+      const prefixed = value.replace(/(?:^|,\s*)([a-zA-Z_][\w-]*)/g, (full, name: string) => {
+        const keywords = new Set([
+          "none",
+          "initial",
+          "inherit",
+          "unset",
+          "infinite",
+          "alternate",
+          "reverse",
+          "alternate-reverse",
+          "normal",
+          "forwards",
+          "backwards",
+          "both",
+          "running",
+          "paused",
+          "ease",
+          "ease-in",
+          "ease-out",
+          "ease-in-out",
+          "linear",
+          "step-start",
+          "step-end",
+        ]);
+        if (keywords.has(name) || /^\d/.test(name)) return full;
+        return full.replace(name, `mc-${name}`);
+      });
+      return `: ${prefixed}`;
+    });
+  });
+
+  // Namespace @font-face families so an embedded font can't override an app-wide
+  // family (e.g. "Inter") outside the card. We rewrite the declared family in each
+  // kept @font-face block to a unique "mc-font-*" name, then rewrite the
+  // font-family / font references that point at it — mirroring @keyframes handling.
+  //
+  // @font-face rules are global (they can't be scoped under a selector), so the
+  // namespaced name is salted with a per-card hash (scope + source). Without the
+  // salt, two different cards that both embed `font-family: Inter` would both map to
+  // `mc-font-Inter` and silently clobber each other in the global cascade. The salt
+  // is stable per card, so multiple faces of the same family within one card
+  // (regular/bold/italic) still share a name and remain a single family.
+  const fontSalt = hashCss(`${scopeSelector}\\0${css}`);
+  const fontFamilyMap = new Map<string, string>();
+  sanitized = sanitized.replace(/@font-face\s*\{([^}]*)\}/gi, (_block, body: string) => {
+    const newBody = body.replace(
+      /(font-family\s*:\s*)("[^"]*"|'[^']*'|[^;]+)/i,
+      (_decl, prefix: string, rawValue: string) => {
+        const name = rawValue
+          .trim()
+          .replace(/^['"]|['"]$/g, "")
+          .trim();
+        if (!name) return `${prefix}${rawValue}`;
+        const namespaced = `mc-font-${name.replace(/[^a-zA-Z0-9_-]+/g, "-")}-${fontSalt}`;
+        fontFamilyMap.set(name.toLowerCase(), namespaced);
+        return `${prefix}"${namespaced}"`;
+      },
+    );
+    return `@font-face {${newBody}}`;
+  });
+  if (fontFamilyMap.size > 0) {
+    sanitized = sanitized.replace(/\bfont(?:-family)?\s*:\s*([^;{}]+)/gi, (decl: string, value: string) => {
+      let next = value;
+      for (const [orig, namespaced] of fontFamilyMap) {
+        const escaped = orig.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // quoted family occurrences: 'Inter' / "Inter"
+        next = next.replace(new RegExp(`(['"])${escaped}\\1`, "gi"), `"${namespaced}"`);
+        // unquoted single-token occurrences in a family list
+        next = next.replace(new RegExp(`(^|,|\\s)${escaped}(?=\\s*(?:,|$))`, "gi"), `$1"${namespaced}"`);
+      }
+      return decl.slice(0, decl.length - value.length) + next;
+    });
+  }
 
   // Split into rules and scope selectors
   const result: string[] = [];
@@ -277,6 +526,12 @@ export function scopeChatCss(css: string, scopeSelector: string): string {
       continue;
     }
 
+    // Skip @font-face — contains declarations, not nested rules
+    if (/^@font-face$/i.test(selector)) {
+      result.push(`${selector} {${body}}`);
+      continue;
+    }
+
     // Handle @media and other at-rules that wrap rulesets
     if (/^@/.test(selector)) {
       // Recursively scope the inner rules
@@ -290,12 +545,19 @@ export function scopeChatCss(css: string, scopeSelector: string): string {
       const s = sel.trim();
       // :root, html, body -> scopeSelector (targets the scope element itself)
       if (/^(:root|html|body)$/i.test(s)) return scopeSelector;
-      // Starts with :root, html, body -> replace prefix with scope
-      if (/^(:root|html|body)\s/i.test(s)) return s.replace(/^(:root|html|body)/i, scopeSelector);
+      // Starts with :root, html, body (descendant or chained) -> replace prefix with scope
+      if (/^(:root|html|body)[\s:.[]/i.test(s)) return s.replace(/^(:root|html|body)/i, scopeSelector);
       // [data-card-css] alone -> scopeSelector (self-reference in exclusive mode)
       if (/^\[data-card-css\]$/i.test(s)) return scopeSelector;
       // [data-card-css] with descendant -> replace with scope
       if (/^\[data-card-css\]\s/i.test(s)) return s.replace(/^\[data-card-css\]/i, scopeSelector);
+      // [data-card-css] with chained pseudo-classes or attribute selectors
+      // e.g. [data-card-css]:not([data-grouped]), [data-card-css][data-grouped]
+      // In exclusive mode the scope IS the element, so chain on it.
+      // In chat mode the scope is a container, so keep as descendant (default).
+      if (/^\[data-card-css\][:[.]/.test(s) && scopeSelector.includes("[data-card-css=")) {
+        return s.replace(/^\[data-card-css\]/i, scopeSelector);
+      }
       // Otherwise prefix
       return `${scopeSelector} ${s}`;
     });


### PR DESCRIPTION
## Linked issue

Closes #1967

## Why this change

- Card creators want real per-character identity in **Conversation** mode, but the card-CSS surface exposed almost nothing beyond the message wrapper: no themeable "typing?" indicator, no way to restyle or replace the avatar, and multi-paragraph replies rendered as several separate boxes that CSS couldn't treat as one container.
- The CSS sanitizer also blocked common, harmless decorative needs (`content` text, embedded `@font-face` fonts) and mis-scoped chained `[data-card-css]` selectors in Exclusive mode.

## What changed

**Card CSS sanitizer + scoping (`src/shared/lib/chat-css.ts`)**
- Allow `content: "text"` after sanitization (strip `<>`, cap at 200 chars); allow CSS functions (`attr()`, `counter()`, quote keywords); unrecognized values still fall back to `''`.
- Allow `@font-face` blocks that reference only `data:` URIs (base64-embedded fonts); external-URL blocks are still stripped. Expanded the `url()` data-allowlist to also cover `data:font/*` and `data:application/font*`.
- Fixed selector scoping for chained `[data-card-css]` selectors (e.g. `[data-card-css]:not([data-grouped])`, `[data-card-css].mari-typing-indicator`) so they chain onto the element in Exclusive mode and fall back to descendant in Chat mode.

**Message structure + grouping**
- Added `data-grouped` to conversation and roleplay message wrappers, so card CSS can target first-in-group (`[data-card-css]:not([data-grouped])`) vs. continuations (`[data-grouped]`).
- Conversation: collapsed split (multi-paragraph) assistant replies into a single `.mari-message-body` so card CSS styles one seamless container (continuous borders/corners/decorations); added `mari-message-group` / `data-card-css-group` hooks.

**Themeable typing indicator**
- The "(character) is typing?" indicator is now CSS-targetable via `.mari-typing-indicator` / `.mari-typing-dots` / `.mari-typing-text`, scoped per character through `data-card-css`, with the character's name exposed as `data-typing-name` (usable as `content: attr(data-typing-name)` for custom labels).
- It renders **inside** the generating message's bubble when that message has one on screen (e.g. during regeneration), otherwise as the standalone row below the list.

**Per-character Conversation avatar override (new user-facing feature)**
- New `extensions.conversationAvatar` (`{ mode: default | hide | emoji | sprite | gallery, value? }`) with a `ConversationAvatarOverride` contract type.
- New **Conversation Avatar** control in the character editor's *Colors* tab (`ConversationAvatarControl`) to choose the mode and pick an emoji / sprite / gallery image.
- Sprite/gallery references are resolved to image URLs centrally in `use-chat-surface-data` (a single batched query, gated so it only fetches when an override is actually set) and rendered in `ConversationMessage` for both the single and grouped-speaker avatar paths. Conversation-mode only ? other modes ignore the field.

**Other**
- Card CSS is now suppressed while a message is being **edited**, so the edit box renders in the app's plain style.
- Expandable **Creator Notes** editor in the character metadata tab.
- Updated `docs/card-css-theming-guide.md` with the new selector hooks, the typing-indicator section, the avatar control, edit-mode/grouping behavior, new tips, and a refreshed AI-prompt template.

## Refactor impact

Primary owner: chat mode (conversation) + shared chat-ui

Impact areas reviewed:

- `src/shared/lib/chat-css.ts` ? sanitizer + selector scoping
- `src/features/modes/conversation/components/ConversationView.tsx`, `ConversationMessage.tsx` ? conversation rendering, grouping, avatar override, typing indicator
- `src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts` ? **shared** CharacterMap builder (used by all chat modes); added a conversation-only avatar field + sprite/gallery resolution
- `src/features/modes/shared/chat-ui/components/ChatMessage.tsx` ? roleplay `data-grouped`
- `src/features/catalog/characters/components/*` ? character-editor *Colors* tab wiring + new `ConversationAvatarControl`
- `src/engine/contracts/types/character.ts`, `src/features/runtime/visuals/types.ts` ? new optional types

Boundary notes:

- **Engine contract:** `character.ts` gains an *optional* `conversationAvatar` extension field ? backward-compatible, no migration, ignored by older readers.
- **Shared hook:** `use-chat-surface-data` is shared across conversation/roleplay/game. The added `conversationAvatar` / `conversationAvatarSrc` map fields and the resolution query are gated (only fetch when a sprite/gallery override exists) and are ignored by the roleplay/game renderers, so those surfaces are unchanged.
- No Rust, storage, imports, or remote-runtime boundaries touched.

Pressure points touched:

- Shared mode UI: `use-chat-surface-data.ts` (CharacterMap construction) and `ChatMessage.tsx` (RP wrapper). **Not** touched: ModeSurface, GameSurface, `src-tauri/src/lib.rs` command registration, import modules.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Run locally on the merged branch (now up to date with `refactor`):

- `pnpm typecheck` (tsc -b) ? pass
- `pnpm build` (tsc -b + vite) ? pass
- `pnpm lint:eslint` ? pass
- `pnpm check:architecture` (depcruise + rust-structure) ? pass
- `pnpm check:unused` (knip) ? pass
- `pnpm check:docs` ? pass
- `pnpm check:discovery` ? pass (38 entries; the new `conversation-avatar` entry validates)
- `pnpm check:line-endings` ? fails only on pre-existing `custom_components/marinara_engine/*.py` (CRLF in a local Windows working tree); those files aren't touched by this PR and the check passes on an LF checkout such as CI.
- `pnpm check:rust` (cargo) ? not run locally; this PR makes no Rust changes (the Rust deltas here come from the merged `refactor` base and are validated upstream).
- Contributor manually playtested Conversation / Roleplay / Game modes ? avatar override modes (emoji/sprite/gallery/hide), the themeable + in-bubble typing indicator, grouping, and a multi-mode showcase theme.

## Feature Discoverability

Check exactly one:

- [x] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Added a discovery entry (`conversation-avatar`, Library category) for the per-character **Conversation Avatar** control in `src/features/shell/discovery/discovery-entries.json`; its action opens the Characters panel. The card-CSS theming hooks themselves are documented in `docs/card-css-theming-guide.md`.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated `docs/card-css-theming-guide.md`

## Proof

Core claim:

- The Conversation avatar override (hide / emoji / sprite / gallery), the per-character group typing-row split, and the card-CSS theming hooks render correctly, and the risky surfaces they touch stay safe: untrusted card CSS cannot make network requests, escape its scope, override app theme tokens, spoof UI via `content`, or leak embedded fonts app-wide; and the avatar-resolution query stays gated and bounded so it can't regress chat into lag.

Verification run:

- On the post-`refactor`-merge head: `pnpm typecheck` (clean), `pnpm test` (23 files / 97 passed), `pnpm build` (clean), `pnpm lint:eslint`, `pnpm check:architecture`, `pnpm check:unused`, `pnpm check:docs`, `pnpm check:discovery` ? all pass locally. (`check:line-endings` flags only pre-existing CRLF in `custom_components/**/*.py`, unrelated to this PR; no Rust changes.)

Evidence:

- Sanitizer (`pnpm test` covers `chat-css`): the `url()` / `@import` / `@font-face` / `:has()` / `position:fixed` / theme-token / `content` guards; the `@font-face` data-font-only contract (external, `image/*`, non-font, `local()`, and source-less blocks all rejected); `@keyframes` + `@font-face` family namespacing with a per-card salt; and escaped-function-name canonicalization (`\75rl(` ? `url(`, `lo\63al(` ? `local(`).
- Avatar query (`use-chat-surface-data` suite): resolution is gated (no fetch without an override or outside Conversation mode), resolves once with no per-render refetch, and revalidates exactly once on remount.
- Typing-CSS detection: `cssTargetsTypingIndicator` covered for styled / unstyled / comment-only inputs and `@chat-mode` surface filtering.

Risk coverage:

- Positive rows: sprite / gallery / emoji avatar overrides resolve and render; per-character typing rows render in Exclusive mode; data-font `@font-face` is kept; benign card CSS (escaped selectors, `content` strings) is preserved.
- Negative controls: external/escaped `url()` ? `url(about:invalid)`; `image/*` / non-font / `local()` / source-less / escaped `@font-face` stripped; theme-token and `!important` overrides stripped; `:has()` removed; the avatar query stays disabled with no override and in Roleplay/Game.
- Untested/manual blockers: visual rendering across Conversation/Roleplay/GM surfaces is covered by the screenshots under UI evidence (author playtest); not asserted by automated UI tests.

Manual verification requested:

- Author playtested the avatar selector, Conversation/Roleplay/GM card-CSS rendering, and the typing indicator across modes (see UI evidence below).

## UI evidence

Conversation Avatar selector
<img width="1603" height="1310" alt="image" src="https://github.com/user-attachments/assets/213dc340-9571-44db-8fbe-900344cdf8d6" />

Convo mode example (Chat-scoped)
<img width="2560" height="1368" alt="image" src="https://github.com/user-attachments/assets/a2a21176-8e2c-49ae-9c91-10ce985adc72" />

Convo mode examples (Character-scoped)
<img width="2560" height="1368" alt="image" src="https://github.com/user-attachments/assets/8202f6b7-0e58-4756-883f-f712ac64ab66" />
<img width="1603" height="326" alt="image" src="https://github.com/user-attachments/assets/4b04b753-9cbe-40ca-8a8c-838f8caa2f3e" />
<img width="2560" height="1367" alt="image" src="https://github.com/user-attachments/assets/982b93a8-7bc8-4ee2-907a-d7d36b19d05e" />

RP mode example (Chat-scoped)
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/3597d1d3-b530-4a1f-8716-201f2bcd321e" />

RP mode example (Character-scoped)
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/6339972e-7a54-491f-98d3-e300f88396ec" />

GM mode example (Chat-scoped)
<img width="2560" height="1364" alt="image" src="https://github.com/user-attachments/assets/321a8b35-6fb3-4ada-948b-183869bc6755" />

