### PR TITLE
Gate script custom tools

### DIFF
--- a/src-tauri/src/commands/storage/custom_tools.rs
+++ b/src-tauri/src/commands/storage/custom_tools.rs
@@ -168,7 +168,7 @@ mod tests {
             error.message
         );
         assert!(
-            error.message.contains("disabled") || error.message.contains("script executionType"),
+            error.message.contains("script executionType") && error.message.contains("disabled"),
             "error should identify the legacy script issue, got: {}",
             error.message
         );

--- a/src-tauri/src/commands/storage/custom_tools.rs
+++ b/src-tauri/src/commands/storage/custom_tools.rs
@@ -6,7 +6,7 @@ pub(crate) fn custom_tool_capabilities() -> Value {
     json!({
         "staticResults": true,
         "webhooks": true,
-        "scriptExecutionEnabled": true
+        "scriptExecutionEnabled": false
     })
 }
 
@@ -42,7 +42,7 @@ pub(crate) async fn execute_custom_tool(state: &AppState, body: Value) -> AppRes
         "script" => Err(AppError::with_details(
             "custom_tool_script_unsupported",
             format!(
-                "Custom tool '{tool_name}' uses the script executionType. Script custom tools run in the Tauri TypeScript generation runtime; native custom_tool_execute only supports static results and webhooks. Use this tool during generation, or convert it to a Webhook or Static result for direct native execution."
+                "Custom tool '{tool_name}' uses the script executionType. Script custom tools are disabled in this runtime. Convert it to a Webhook or Static result."
             ),
             json!({ "executionType": "script", "migration": "convert-to-webhook-or-static" }),
         )),
@@ -136,6 +136,17 @@ mod tests {
             .expect("storage create should succeed");
     }
 
+    #[test]
+    fn capabilities_report_script_execution_disabled() {
+        let capabilities = custom_tool_capabilities();
+        assert_eq!(
+            capabilities
+                .get("scriptExecutionEnabled")
+                .and_then(Value::as_bool),
+            Some(false)
+        );
+    }
+
     #[tokio::test]
     async fn script_execution_type_returns_actionable_error() {
         let state = test_state("script-unsupported");
@@ -157,8 +168,7 @@ mod tests {
             error.message
         );
         assert!(
-            error.message.contains("legacy script")
-                || error.message.contains("script executionType"),
+            error.message.contains("disabled") || error.message.contains("script executionType"),
             "error should identify the legacy script issue, got: {}",
             error.message
         );

--- a/src/engine/contracts/schemas/custom-tool.schema.ts
+++ b/src/engine/contracts/schemas/custom-tool.schema.ts
@@ -3,9 +3,7 @@
 // ──────────────────────────────────────────────
 import { z } from "zod";
 
-// Script tools execute in the TypeScript runtime; Rust preserves the row shape
-// and handles static/webhook tools.
-const toolExecutionTypeSchema = z.enum(["webhook", "static", "script"]);
+const toolExecutionTypeSchema = z.enum(["webhook", "static"]);
 
 export const createCustomToolSchema = z.object({
   name: z
@@ -18,7 +16,6 @@ export const createCustomToolSchema = z.object({
   executionType: toolExecutionTypeSchema.default("static"),
   webhookUrl: z.string().url().nullable().default(null),
   staticResult: z.string().nullable().default(null),
-  scriptBody: z.string().nullable().default(null),
   enabled: z.boolean().default(true),
 });
 

--- a/src/engine/contracts/types/agent.ts
+++ b/src/engine/contracts/types/agent.ts
@@ -694,10 +694,9 @@ export interface CustomTool {
   name: string;
   description: string;
   parametersSchema: ToolParameterSchema;
-  executionType: "webhook" | "static" | "script";
+  executionType: "webhook" | "static";
   webhookUrl: string | null;
   staticResult: string | null;
-  scriptBody: string | null;
   enabled: boolean;
   createdAt: string;
   updatedAt: string;

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -44,7 +44,6 @@ export interface CustomToolRecord extends JsonRecord {
   executionType: string;
   webhookUrl: string | null;
   staticResult: string | null;
-  scriptBody?: string | null;
   enabled: string | boolean;
 }
 
@@ -87,7 +86,7 @@ function customToolRecord(row: JsonRecord): CustomToolRecord | null {
   const name = readString(row.name).trim();
   if (!name || !boolish(row.enabled, false)) return null;
   const executionType = readString(row.executionType, "static");
-  if (executionType !== "static" && executionType !== "webhook" && executionType !== "script") return null;
+  if (executionType !== "static" && executionType !== "webhook") return null;
   return {
     ...row,
     name,
@@ -96,7 +95,6 @@ function customToolRecord(row: JsonRecord): CustomToolRecord | null {
     executionType,
     webhookUrl: readString(row.webhookUrl).trim() || null,
     staticResult: readString(row.staticResult),
-    scriptBody: readString(row.scriptBody),
     enabled: row.enabled as string | boolean,
   };
 }
@@ -475,81 +473,13 @@ export async function customToolExecutor(
   tool?: CustomToolRecord | null,
 ): Promise<string> {
   const name = call.function?.name || call.name;
-  if (tool?.executionType === "script") {
-    return stringifyToolResult(await executeScriptCustomTool(tool, toolArguments(call)));
-  }
+  if (!tool) return stringifyToolResult({ error: `Tool not enabled for this context: ${name}` });
   return stringifyToolResult(
     await integrations.customTools.execute({
       toolName: name,
       arguments: toolArguments(call),
     }),
   );
-}
-
-async function executeScriptCustomTool(tool: CustomToolRecord, args: JsonRecord): Promise<unknown> {
-  const scriptBody = tool.scriptBody?.trim();
-  if (!scriptBody) return { error: `No script body configured for custom tool: ${tool.name}` };
-  try {
-    // Sloppy mode lets us shadow eval/Function as parameters and mirror args onto
-    // the legacy `arguments.foo` shape used by older imported script tools.
-    const runner = new Function(
-      "args",
-      "JSON",
-      "Math",
-      "String",
-      "Number",
-      "Date",
-      "Array",
-      "parseInt",
-      "parseFloat",
-      "isNaN",
-      "isFinite",
-      "console",
-      "fetch",
-      "window",
-      "document",
-      "localStorage",
-      "sessionStorage",
-      "Function",
-      "eval",
-      `const __marinaraToolArgs = args && typeof args === "object" ? args : {};
-for (const __marinaraToolKey of Object.keys(__marinaraToolArgs)) {
-  if (__marinaraToolKey !== "length" && __marinaraToolKey !== "callee") {
-    Object.defineProperty(arguments, __marinaraToolKey, {
-      value: __marinaraToolArgs[__marinaraToolKey],
-      enumerable: true,
-      configurable: true,
-      writable: true,
-    });
-  }
-}
-${scriptBody}`,
-    );
-    const result = runner(
-      args,
-      JSON,
-      Math,
-      String,
-      Number,
-      Date,
-      Array,
-      parseInt,
-      parseFloat,
-      isNaN,
-      isFinite,
-      { log: () => undefined, warn: () => undefined, error: () => undefined },
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-    );
-    return result instanceof Promise ? await result : (result ?? { result: "OK" });
-  } catch (error) {
-    return { error: `Script error: ${error instanceof Error ? error.message : "unknown"}` };
-  }
 }
 
 // ──────────────────────────────────────────────

--- a/src/features/catalog/agents/components/ToolEditor.tsx
+++ b/src/features/catalog/agents/components/ToolEditor.tsx
@@ -32,10 +32,9 @@ import { HelpTooltip } from "../../../../shared/components/ui/HelpTooltip";
 const EXEC_TYPES = [
   { value: "static", label: "Static Result", icon: FileText, description: "Returns a fixed string when called." },
   { value: "webhook", label: "Webhook", icon: Globe, description: "Sends a POST request to an external URL." },
-  { value: "script", label: "Script", icon: Code2, description: "Runs a local JavaScript function body." },
 ] as const;
 
-type ExecType = "static" | "webhook" | "script";
+type ExecType = "static" | "webhook";
 
 // ═══════════════════════════════════════════════
 //  Main Editor
@@ -55,6 +54,7 @@ export function ToolEditor() {
   }, [toolDetailId, allTools]);
 
   const isNew = toolDetailId === "__new__";
+  const isUnsupportedScriptTool = dbTool?.executionType === "script";
 
   // ── Local state ──
   const [localName, setLocalName] = useState("");
@@ -62,7 +62,6 @@ export function ToolEditor() {
   const [localExecType, setLocalExecType] = useState<ExecType>("static");
   const [localWebhookUrl, setLocalWebhookUrl] = useState("");
   const [localStaticResult, setLocalStaticResult] = useState("");
-  const [localScriptBody, setLocalScriptBody] = useState("");
   const [localParams, setLocalParams] = useState<ParamDef[]>([]);
   const [dirty, setDirty] = useState(false);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
@@ -77,12 +76,10 @@ export function ToolEditor() {
     if (dbTool) {
       setLocalName(dbTool.name);
       setLocalDesc(dbTool.description);
-      const execType: ExecType =
-        dbTool.executionType === "webhook" ? "webhook" : dbTool.executionType === "script" ? "script" : "static";
+      const execType: ExecType = dbTool.executionType === "webhook" ? "webhook" : "static";
       setLocalExecType(execType);
       setLocalWebhookUrl(dbTool.webhookUrl ?? "");
       setLocalStaticResult(dbTool.staticResult ?? "");
-      setLocalScriptBody(dbTool.scriptBody ?? "");
       const schema = dbTool.parametersSchema ?? {};
       const props = (schema.properties as Record<string, unknown> | undefined) ?? {};
       const req: string[] = Array.isArray(schema.required)
@@ -105,7 +102,6 @@ export function ToolEditor() {
       setLocalExecType("static");
       setLocalWebhookUrl("");
       setLocalStaticResult("");
-      setLocalScriptBody("");
       setLocalParams([]);
     }
     setDirty(false);
@@ -162,10 +158,6 @@ export function ToolEditor() {
       setSaveError("Webhook URL is required for a webhook custom tool.");
       return false;
     }
-    if (localExecType === "script" && !localScriptBody.trim()) {
-      setSaveError("Script body is required for a script custom tool.");
-      return false;
-    }
     const payload = {
       name: localName,
       description: localDesc,
@@ -173,7 +165,6 @@ export function ToolEditor() {
       executionType: localExecType,
       webhookUrl: localExecType === "webhook" ? localWebhookUrl || null : null,
       staticResult: localExecType === "static" ? localStaticResult || null : null,
-      scriptBody: localExecType === "script" ? localScriptBody || null : null,
       enabled: true,
     };
 
@@ -199,7 +190,6 @@ export function ToolEditor() {
     localExecType,
     localWebhookUrl,
     localStaticResult,
-    localScriptBody,
     dbTool,
     createTool,
     updateTool,
@@ -339,6 +329,12 @@ export function ToolEditor() {
             <code className="rounded bg-[var(--secondary)] px-1">check_weather</code>). This is the identifier the AI
             will use to call this function.
           </p>
+          {isUnsupportedScriptTool && (
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+              Script custom tools are disabled in this runtime. Convert this tool to a static result or webhook before
+              saving.
+            </div>
+          )}
 
           {/* ── Description ── */}
           <FieldGroup
@@ -453,7 +449,7 @@ export function ToolEditor() {
 
           {/* ── Execution Type ── */}
           <FieldGroup label="Execution Type" icon={<Wrench size="0.875rem" className="text-[var(--primary)]" />}>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 gap-2">
               {EXEC_TYPES.map((et) => {
                 const isActive = localExecType === et.value;
                 const Icon = et.icon;
@@ -521,26 +517,6 @@ export function ToolEditor() {
             </FieldGroup>
           )}
 
-          {localExecType === "script" && (
-            <FieldGroup label="Script Body" icon={<Code2 size="0.875rem" className="text-[var(--primary)]" />}>
-              <textarea
-                value={localScriptBody}
-                onChange={(e) => {
-                  setLocalScriptBody(e.target.value);
-                  markDirty();
-                }}
-                rows={10}
-                placeholder={`const name = args.name ?? "there";\nreturn { result: \`Hello, \${name}.\` };`}
-                className="w-full resize-y rounded-xl bg-[var(--secondary)] px-4 py-3 font-mono text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-              />
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Runs locally in the Tauri app with <code className="rounded bg-[var(--secondary)] px-1">args</code>,{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">JSON</code>,{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">Math</code>, and{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">Date</code>. Return a JSON-serializable value.
-              </p>
-            </FieldGroup>
-          )}
         </div>
       </div>
     </div>

--- a/src/features/catalog/agents/components/ToolEditor.tsx
+++ b/src/features/catalog/agents/components/ToolEditor.tsx
@@ -34,6 +34,7 @@ const EXEC_TYPES = [
   { value: "webhook", label: "Webhook", icon: Globe, description: "Sends a POST request to an external URL." },
 ] as const;
 
+// Script custom tools are intentionally excluded: script execution is disabled in this runtime.
 type ExecType = "static" | "webhook";
 
 // ═══════════════════════════════════════════════

--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -17,7 +17,6 @@ export interface CustomToolRow {
   executionType: string;
   webhookUrl: string | null;
   staticResult: string | null;
-  scriptBody: string | null;
   enabled: string;
   createdAt: string;
   updatedAt: string;
@@ -34,8 +33,6 @@ export function isCustomToolSelectable(tool: CustomToolRow, _capabilities?: Cust
   if (!enabled) return false;
   if (tool.executionType === "static") return !!tool.staticResult?.trim();
   if (tool.executionType === "webhook") return !!tool.webhookUrl?.trim();
-  if (tool.executionType === "script")
-    return _capabilities?.scriptExecutionEnabled === true && !!tool.scriptBody?.trim();
   return false;
 }
 

--- a/src/features/catalog/characters/lib/character-search.ts
+++ b/src/features/catalog/characters/lib/character-search.ts
@@ -2,7 +2,7 @@ export type CharacterSearchData = Record<string, unknown> & {
   tags?: unknown;
 };
 
-export type CharacterSearchScope = "name" | "title" | "tag" | "description" | "personality";
+type CharacterSearchScope = "name" | "title" | "tag" | "description" | "personality";
 
 export type CharacterScopedSearchTerm = {
   scope: CharacterSearchScope;


### PR DESCRIPTION
## Linked issue

Refs #1791

Partial slice for the script custom-tool safety gap. Does not close #1791 because imported run metadata and cadence-status parity remain separate slices.

## Why this change

- Refactor still allowed script custom tools through the TypeScript generation runtime with `new Function`, while the native custom-tool command already rejected script execution. That left script tools selectable/executable in one runtime path despite the capability model saying script execution should be gated.

## What changed

- Removed script execution from the TypeScript custom-tool runtime and stopped loading script rows as executable custom tools.
- Limited custom-tool create/update schema and types to static results and webhooks.
- Removed the Script option and script body editor from the custom tool editor; legacy script rows show a conversion warning.
- Changed native custom-tool capabilities to report `scriptExecutionEnabled: false` and kept an actionable rejection for legacy script rows.
- Removed a stale exported character-search type so the required `pnpm check` unused-code gate passes on current refactor.

## Refactor impact

Primary owner:

- Engine generation custom-tool runtime, catalog agents UI, and Rust storage custom-tool capability.

Impact areas reviewed:

- Agent/tool selection in `AgentEditor` and chat settings via `isCustomToolSelectable`.
- Main-generation and agent-generation custom-tool dispatch through `tools-runtime.ts`.
- Native `custom_tool_execute` and `custom_tool_capabilities` behavior for static, webhook, legacy script, and unknown execution types.

Boundary notes:

- Engine still calls custom tools through the `IntegrationGateway` port, not direct Tauri APIs.
- Feature UI still uses catalog hooks and schemas for create/update.
- Native Rust command remains the privileged static/webhook executor and rejects unsupported script rows.
- Remote runtime command routing was already present for `custom_tool_execute` / `custom_tool_capabilities`; this PR does not add command surface.

Pressure points touched:

- None of the named broad pressure points. `ToolEditor.tsx` and `tools-runtime.ts` were touched narrowly to remove script execution support.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- `pnpm typecheck` passed locally.
- `cargo test --manifest-path src-tauri/Cargo.toml custom_tools --lib` passed locally.
- `pnpm check:architecture` passed locally.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed locally.
- `pnpm check` passed locally after removing the stale exported `CharacterSearchScope` type that was already failing the unused-code gate on current refactor.
- No browser or Tauri manual pass was run; this PR is a runtime/schema safety gate rather than a visual layout claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A. This removes an unsafe/unsupported execution path and does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

- No docs changes needed: current custom-tools guidance already describes ME-Refactor as static/webhook only with script execution disabled.
- This PR does not restore old staging/package-workspace/release claims.

## UI evidence

- Not added. UI impact is removal of the Script execution option plus a conversion warning for legacy script rows; no browser/Tauri screenshot pass was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Custom tools no longer support script-based execution; only webhook and static execution types are available.

* **Refactor**
  * Streamlined custom tool runtime to handle only webhook and static result types.
  * Simplified tool editor interface with 2-column execution type selector.

* **Bug Fixes**
  * Added runtime validation to prevent execution of incompatible tool types.
  * Tool editor now displays a warning banner when loading unsupported script tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->