### PR TITLE
Restore tracker parity for avatar uploads and long rows

### DIFF
--- a/src/features/catalog/characters/lib/character-search.ts
+++ b/src/features/catalog/characters/lib/character-search.ts
@@ -2,7 +2,7 @@ export type CharacterSearchData = Record<string, unknown> & {
   tags?: unknown;
 };
 
-export type CharacterSearchScope = "name" | "title" | "tag" | "description" | "personality";
+type CharacterSearchScope = "name" | "title" | "tag" | "description" | "personality";
 
 export type CharacterScopedSearchTerm = {
   scope: CharacterSearchScope;

--- a/src/features/runtime/tracker/components/CustomTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/CustomTrackerPanel.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { SlidersHorizontal, X } from "lucide-react";
 import type { CustomTrackerField } from "../../../../engine/contracts/types/game-state";
+import type { TrackerPanelSizeProfile } from "../../../../shared/stores/ui.store";
 import { cn } from "../../../../shared/lib/utils";
 import {
   appendTrackerListItem,
@@ -17,16 +18,36 @@ import {
   TrackerReadabilityVeil,
 } from "./tracker-data-sidebar.controls";
 
+function isLongCustomField(field: CustomTrackerField): boolean {
+  const name = visibleText(field.name, "");
+  const value = visibleText(field.value, "");
+  return name.length > 16 || value.length > 22 || (/\s/.test(value) && value.length > 14);
+}
+
+function shouldUseCustomFieldColumns(
+  fields: CustomTrackerField[],
+  trackerPanelSizeProfile: TrackerPanelSizeProfile,
+): boolean {
+  if (trackerPanelSizeProfile === "compact" || fields.length < 4) {
+    return false;
+  }
+  return !fields.some(isLongCustomField);
+}
+
 function CustomFieldList({
   fields,
   onUpdate,
   deleteMode = false,
+  trackerPanelSizeProfile,
 }: {
   fields: CustomTrackerField[];
   onUpdate?: (fields: CustomTrackerField[]) => void;
   deleteMode?: boolean;
+  trackerPanelSizeProfile: TrackerPanelSizeProfile;
 }) {
   if (fields.length === 0 && !onUpdate) return <EmptySection>No custom fields tracked.</EmptySection>;
+  const readableValues = trackerPanelSizeProfile !== "compact";
+  const useFieldColumns = shouldUseCustomFieldColumns(fields, trackerPanelSizeProfile);
   const updateField = (index: number, updated: CustomTrackerField) => {
     if (!onUpdate) return;
     onUpdate(replaceTrackerListItem(fields, index, updated));
@@ -42,66 +63,97 @@ function CustomFieldList({
           <EmptySection>No custom fields tracked.</EmptySection>
         </div>
       ) : (
-        <div className="grid grid-cols-1 border-t border-[var(--border)]/30 @min-[220px]:grid-cols-2 @min-[420px]:grid-cols-3">
-          {fields.map((field, index) => (
-            <div
-              key={field.customFieldId || `${field.name}-${index}`}
-              className={cn(
-                "group/field relative grid min-h-6 grid-cols-[minmax(0,1fr)_minmax(1.8rem,max-content)] items-center gap-1 border-b border-[var(--border)]/28 px-1 py-0.5 text-[0.6875rem] leading-[0.875rem]",
-                index % 2 === 0 &&
-                  !(fields.length % 2 === 1 && index === fields.length - 1) &&
-                  "@min-[220px]:border-r @min-[220px]:border-r-[var(--border)]/20",
-                fields.length % 2 === 1 && index === fields.length - 1 && "@min-[220px]:col-span-2",
-                fields.length > 2 &&
-                  index % 3 !== 2 &&
-                  "@min-[420px]:border-r @min-[420px]:border-r-[var(--border)]/20",
-                fields.length > 2 && index % 3 === 2 && "@min-[420px]:border-r-0",
-                fields.length > 2 &&
-                  fields.length % 2 === 1 &&
-                  index === fields.length - 1 &&
-                  "@min-[420px]:col-span-1",
-                deleteMode && "pr-5",
-              )}
-            >
-              {onUpdate ? (
-                <InlineEdit
-                  value={field.name}
-                  onSave={(name) => updateField(index, { ...field, name: name || "Field" })}
-                  placeholder="Field"
-                  className="min-w-0 px-0.5 py-0 font-medium"
-                  showEditHint={false}
-                />
-              ) : (
-                <span className="truncate font-medium text-[var(--muted-foreground)]">
-                  {visibleText(field.name, "Field")}
-                </span>
-              )}
-              {onUpdate ? (
-                <InlineEdit
-                  value={field.value}
-                  onSave={(value) => updateField(index, { ...field, value })}
-                  placeholder="Value"
-                  className="min-w-0 justify-end px-0.5 py-0 text-right tabular-nums"
-                  showEditHint={false}
-                />
-              ) : (
-                <span className="min-w-0 truncate text-right text-[var(--foreground)]">
-                  {visibleText(field.value, "Empty")}
-                </span>
-              )}
-              {onUpdate && deleteMode && (
-                <button
-                  type="button"
-                  onClick={() => removeField(index)}
-                  className="absolute right-1 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--primary)] active:scale-90"
-                  title="Remove field"
-                  aria-label={`Remove ${field.name || "field"}`}
-                >
-                  <X size="0.5625rem" />
-                </button>
-              )}
-            </div>
-          ))}
+        <div
+          className={cn(
+            "grid grid-cols-1 border-t border-[var(--border)]/30",
+            useFieldColumns && "@min-[300px]:grid-cols-2",
+          )}
+        >
+          {fields.map((field, index) => {
+            const allowWrap = readableValues && isLongCustomField(field);
+            const valueText = visibleText(field.value, "");
+            const valueIsLong = valueText.length > 18 || valueText.includes(" ");
+            const valueAlignment = allowWrap && valueIsLong ? "text-left" : "text-right tabular-nums";
+            return (
+              <div
+                key={field.customFieldId || `${field.name}-${index}`}
+                className={cn(
+                  "group/field relative grid min-h-6 grid-cols-[minmax(3rem,0.42fr)_minmax(0,1fr)] items-center gap-1 border-b border-[var(--border)]/28 px-1 py-0.5 text-[0.6875rem] leading-[0.875rem]",
+                  trackerPanelSizeProfile !== "compact" && "grid-cols-[minmax(3.5rem,0.42fr)_minmax(0,1fr)]",
+                  allowWrap && "min-h-8 items-start py-1 leading-[0.95rem]",
+                  useFieldColumns &&
+                    index % 2 === 0 &&
+                    !(fields.length % 2 === 1 && index === fields.length - 1) &&
+                    "@min-[300px]:border-r @min-[300px]:border-r-[var(--border)]/20",
+                  useFieldColumns &&
+                    fields.length % 2 === 1 &&
+                    index === fields.length - 1 &&
+                    "@min-[300px]:col-span-2",
+                  deleteMode && "pr-5",
+                )}
+              >
+                {onUpdate ? (
+                  <InlineEdit
+                    value={field.name}
+                    onSave={(name) => updateField(index, { ...field, name: name || "Field" })}
+                    placeholder="Field"
+                    className={cn("min-w-0 px-0.5 py-0 font-medium", allowWrap && "min-h-5")}
+                    editHintMode={allowWrap ? "overlay" : "inline"}
+                    previewLineCount={allowWrap ? 2 : undefined}
+                    scrollOnHover={!allowWrap}
+                    showEditHint={false}
+                  />
+                ) : (
+                  <span
+                    className={cn(
+                      "min-w-0 px-0.5 font-medium text-[var(--muted-foreground)]",
+                      allowWrap ? "line-clamp-2 break-words" : "truncate",
+                    )}
+                  >
+                    {visibleText(field.name, "Field")}
+                  </span>
+                )}
+                {onUpdate ? (
+                  <InlineEdit
+                    value={field.value}
+                    onSave={(value) => updateField(index, { ...field, value })}
+                    placeholder="Value"
+                    className={cn(
+                      "min-w-0 px-0.5 py-0",
+                      valueAlignment,
+                      allowWrap ? "min-h-5 justify-start leading-[1.15]" : "justify-end",
+                    )}
+                    twoLinePreview={allowWrap}
+                    editHintMode={allowWrap ? "overlay" : "inline"}
+                    previewLineCount={allowWrap ? 2 : undefined}
+                    scrollOnHover={!allowWrap}
+                    showEditHint={false}
+                  />
+                ) : (
+                  <span
+                    className={cn(
+                      "min-w-0 px-0.5 text-[var(--foreground)]",
+                      valueAlignment,
+                      allowWrap ? "line-clamp-2 break-words leading-[1.15]" : "truncate",
+                    )}
+                  >
+                    {visibleText(field.value, "Empty")}
+                  </span>
+                )}
+                {onUpdate && deleteMode && (
+                  <button
+                    type="button"
+                    onClick={() => removeField(index)}
+                    className="absolute right-1 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--primary)] active:scale-90"
+                    title="Remove field"
+                    aria-label={`Remove ${visibleText(field.name, "field")}`}
+                  >
+                    <X size="0.5625rem" />
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
@@ -114,6 +166,7 @@ export function CustomTrackerPanel({
   onUpdateFields,
   deleteMode,
   addMode,
+  trackerPanelSizeProfile,
   collapsed = false,
   onToggleCollapsed,
 }: {
@@ -122,6 +175,7 @@ export function CustomTrackerPanel({
   onUpdateFields: (fields: CustomTrackerField[]) => void;
   deleteMode: boolean;
   addMode: boolean;
+  trackerPanelSizeProfile: TrackerPanelSizeProfile;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
 }) {
@@ -145,7 +199,14 @@ export function CustomTrackerPanel({
           collapsed={collapsed}
           onToggle={onToggleCollapsed}
         />
-        {!collapsed && <CustomFieldList fields={fields} onUpdate={onUpdateFields} deleteMode={deleteMode} />}
+        {!collapsed && (
+          <CustomFieldList
+            fields={fields}
+            onUpdate={onUpdateFields}
+            deleteMode={deleteMode}
+            trackerPanelSizeProfile={trackerPanelSizeProfile}
+          />
+        )}
       </div>
     </section>
   );

--- a/src/features/runtime/tracker/components/CustomTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/CustomTrackerPanel.tsx
@@ -46,7 +46,6 @@ function CustomFieldList({
   trackerPanelSizeProfile: TrackerPanelSizeProfile;
 }) {
   if (fields.length === 0 && !onUpdate) return <EmptySection>No custom fields tracked.</EmptySection>;
-  const readableValues = trackerPanelSizeProfile !== "compact";
   const useFieldColumns = shouldUseCustomFieldColumns(fields, trackerPanelSizeProfile);
   const updateField = (index: number, updated: CustomTrackerField) => {
     if (!onUpdate) return;
@@ -70,7 +69,7 @@ function CustomFieldList({
           )}
         >
           {fields.map((field, index) => {
-            const allowWrap = readableValues && isLongCustomField(field);
+            const allowWrap = isLongCustomField(field);
             const valueText = visibleText(field.value, "");
             const valueIsLong = valueText.length > 18 || valueText.includes(" ");
             const valueAlignment = allowWrap && valueIsLong ? "text-left" : "text-right tabular-nums";

--- a/src/features/runtime/tracker/components/QuestTrackerPanel.tsx
+++ b/src/features/runtime/tracker/components/QuestTrackerPanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { QuestProgress } from "../../../../engine/contracts/types/game-state";
+import type { TrackerPanelSizeProfile } from "../../../../shared/stores/ui.store";
 import { TrackerReadabilityVeil } from "./tracker-data-sidebar.controls";
 import { QuestBoard } from "./quest-tracker/QuestBoard";
 
@@ -11,6 +12,7 @@ export function QuestTrackerPanel({
   onRemoveQuest,
   deleteMode,
   addMode,
+  trackerPanelSizeProfile,
   collapsed = false,
   onToggleCollapsed,
 }: {
@@ -21,6 +23,7 @@ export function QuestTrackerPanel({
   onRemoveQuest: (questEntryId: string) => void;
   deleteMode: boolean;
   addMode: boolean;
+  trackerPanelSizeProfile: TrackerPanelSizeProfile;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
 }) {
@@ -38,6 +41,7 @@ export function QuestTrackerPanel({
         onRemoveQuest={onRemoveQuest}
         deleteMode={deleteMode}
         addMode={addMode}
+        trackerPanelSizeProfile={trackerPanelSizeProfile}
         collapsed={collapsed}
         onToggleCollapsed={onToggleCollapsed}
       />

--- a/src/features/runtime/tracker/components/TrackerSectionList.tsx
+++ b/src/features/runtime/tracker/components/TrackerSectionList.tsx
@@ -218,6 +218,7 @@ export function TrackerSectionList({
             onRemoveQuest={removeQuest}
             deleteMode={deleteMode}
             addMode={addMode}
+            trackerPanelSizeProfile={trackerPanelSizeProfile}
             collapsed={isPanelCollapsed("quests")}
             onToggleCollapsed={() => toggleTrackerPanelSectionCollapsed("quests")}
           />
@@ -231,6 +232,7 @@ export function TrackerSectionList({
             onUpdateFields={updateCustomFields}
             deleteMode={deleteMode}
             addMode={addMode}
+            trackerPanelSizeProfile={trackerPanelSizeProfile}
             collapsed={isPanelCollapsed("custom")}
             onToggleCollapsed={() => toggleTrackerPanelSectionCollapsed("custom")}
           />

--- a/src/features/runtime/tracker/components/quest-tracker/QuestBoard.tsx
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestBoard.tsx
@@ -1,9 +1,11 @@
 import { Target } from "lucide-react";
 import type { ReactNode } from "react";
+import type { TrackerPanelSizeProfile } from "../../../../../shared/stores/ui.store";
 import type { QuestProgress } from "../../../../../engine/contracts/types/game-state";
 import { cn } from "../../../../../shared/lib/utils";
 import { AddRowButton, SectionHeader } from "../tracker-data-sidebar.controls";
 import { TRACKER_TEXT_ROW } from "../tracker-data-sidebar.constants";
+import { getQuestTextLineCount } from "./quest-layout";
 import { QuestRow } from "./QuestRow";
 
 export function QuestBoard({
@@ -14,6 +16,7 @@ export function QuestBoard({
   onRemoveQuest,
   deleteMode,
   addMode,
+  trackerPanelSizeProfile,
   collapsed = false,
   onToggleCollapsed,
 }: {
@@ -24,18 +27,20 @@ export function QuestBoard({
   onRemoveQuest: (questEntryId: string) => void;
   deleteMode: boolean;
   addMode: boolean;
+  trackerPanelSizeProfile: TrackerPanelSizeProfile;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
 }) {
   const completedQuests = quests.filter((quest) => quest.completed).length;
   const activeQuests = quests.length - completedQuests;
+  const questTextLineCount = getQuestTextLineCount(trackerPanelSizeProfile, quests.length);
 
   return (
     <div className="relative z-10 overflow-hidden pb-0.5">
       <SectionHeader
         icon={<Target size="0.6875rem" />}
         title="Quest Board"
-        badge={`${completedQuests}/${activeQuests}`}
+        badge={`${completedQuests}/${quests.length}`}
         badgeTitle={`${completedQuests} done, ${activeQuests} active`}
         action={action}
         addAction={
@@ -60,6 +65,7 @@ export function QuestBoard({
                 onRemove={() => onRemoveQuest(quest.questEntryId)}
                 deleteMode={deleteMode}
                 addMode={addMode}
+                textLineCount={questTextLineCount}
               />
             ))}
           </div>

--- a/src/features/runtime/tracker/components/quest-tracker/QuestObjectiveRow.tsx
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestObjectiveRow.tsx
@@ -9,6 +9,9 @@ type QuestObjective = QuestProgress["objectives"][number];
 export function QuestObjectiveRow({
   objective,
   objectiveGridColumns,
+  previewLineCount,
+  wrapClass,
+  wrapsText,
   onRemove,
   onToggle,
   onUpdate,
@@ -16,19 +19,29 @@ export function QuestObjectiveRow({
 }: {
   objective: QuestObjective;
   objectiveGridColumns: string;
+  previewLineCount: 2 | 3 | undefined;
+  wrapClass: string;
+  wrapsText: boolean;
   onRemove?: () => void;
   onToggle?: () => void;
   onUpdate?: (text: string) => void;
   deleteMode: boolean;
 }) {
   return (
-    <div className={cn("tracker-quest-objective-row", objectiveGridColumns)}>
+    <div
+      className={cn(
+        "tracker-quest-objective-row",
+        wrapsText ? "tracker-quest-objective-row--wrapped" : "tracker-quest-objective-row--single-line",
+        objectiveGridColumns,
+      )}
+    >
       {onToggle ? (
         <button
           type="button"
           onClick={onToggle}
           className={cn(
             "tracker-quest-objective-row__toggle",
+            wrapsText && "tracker-quest-objective-row__toggle--wrapped",
             objective.completed && "tracker-quest-objective-row__toggle--completed",
           )}
           title={objective.completed ? "Mark incomplete" : "Mark complete"}
@@ -52,8 +65,13 @@ export function QuestObjectiveRow({
           placeholder="Objective"
           title={`Objective: ${visibleText(objective.text, "Objective")}`}
           showEditHint={false}
+          previewLineCount={previewLineCount}
+          editHintMode={wrapsText ? "overlay" : "inline"}
           className={cn(
             "tracker-quest-objective-row__edit",
+            wrapsText
+              ? "tracker-quest-objective-row__edit--wrapped"
+              : "tracker-quest-objective-row__edit--single-line",
             objective.completed && "tracker-quest-objective-row__edit--completed",
           )}
         />
@@ -61,6 +79,7 @@ export function QuestObjectiveRow({
         <span
           className={cn(
             "tracker-quest-objective-row__text",
+            wrapClass,
             objective.completed && "tracker-quest-objective-row__text--completed",
           )}
         >

--- a/src/features/runtime/tracker/components/quest-tracker/QuestRow.css
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestRow.css
@@ -69,13 +69,23 @@
 .tracker-quest-row__title-edit {
   width: 100%;
   min-width: 0;
-  height: 1.25rem;
   overflow: hidden;
   padding: 0 0.125rem;
   color: color-mix(in srgb, var(--foreground) 92%, transparent);
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.tracker-quest-row__title-edit--single-line {
+  height: 1.25rem;
   line-height: 1.25rem;
+}
+
+.tracker-quest-row__title-edit--wrapped {
+  min-height: 1.25rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  line-height: 1.12;
 }
 
 .tracker-quest-row__title-edit:hover,
@@ -88,8 +98,32 @@
   overflow: hidden;
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.tracker-quest-row__text--single-line {
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tracker-quest-row__text--wrap-2,
+.tracker-quest-row__text--wrap-3 {
+  display: -webkit-box;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  -webkit-box-orient: vertical;
+}
+
+.tracker-quest-row__text--wrap-2 {
+  line-height: 1.15;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.tracker-quest-row__text--wrap-3 {
+  line-height: 1.12;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
 }
 
 .tracker-quest-row__title-edit--completed,
@@ -216,7 +250,6 @@
   position: relative;
   display: grid;
   min-height: 1rem;
-  align-items: center;
   gap: 0.25rem;
   border-radius: 2px;
   padding-right: 0.125rem;
@@ -227,24 +260,50 @@
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
 }
 
+.tracker-quest-objective-row--single-line {
+  align-items: center;
+  line-height: 1rem;
+}
+
+.tracker-quest-objective-row--wrapped {
+  align-items: start;
+  min-height: 1.25rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  line-height: 1.15;
+}
+
 .tracker-quest-objective-row:hover {
   background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.tracker-quest-objective-row__toggle--wrapped,
+.tracker-quest-objective-row--wrapped .tracker-quest-objective-row__status {
+  margin-top: 1px;
 }
 
 .tracker-quest-objective-row__edit {
   width: 100%;
   min-width: 0;
-  height: 1rem;
   overflow: hidden;
   padding: 0 0.125rem;
   font-size: 0.6875rem;
+}
+
+.tracker-quest-objective-row__edit--single-line {
+  height: 1rem;
   line-height: 1rem;
+}
+
+.tracker-quest-objective-row__edit--wrapped {
+  min-height: 1rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  line-height: 1.15;
 }
 
 .tracker-quest-objective-row__text {
   min-width: 0;
   overflow: hidden;
   color: var(--foreground);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }

--- a/src/features/runtime/tracker/components/quest-tracker/QuestRow.tsx
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestRow.tsx
@@ -11,6 +11,7 @@ import { TRACKER_BAR } from "../tracker-data-sidebar.constants";
 import { InlineEdit } from "../tracker-data-sidebar.controls";
 import { visibleText } from "../tracker-display.helpers";
 import { QuestObjectiveRow } from "./QuestObjectiveRow";
+import { getQuestTextWrapClass, type QuestTextLineCount } from "./quest-layout";
 import "./QuestRow.css";
 
 export function QuestRow({
@@ -19,12 +20,14 @@ export function QuestRow({
   onRemove,
   deleteMode = false,
   addMode = false,
+  textLineCount = 1,
 }: {
   quest: QuestProgress;
   onUpdate?: (quest: QuestProgress) => void;
   onRemove?: () => void;
   deleteMode?: boolean;
   addMode?: boolean;
+  textLineCount?: QuestTextLineCount;
 }) {
   const completed = quest.objectives.filter((objective) => objective.completed).length;
   const totalObjectives = quest.objectives.length;
@@ -34,6 +37,9 @@ export function QuestRow({
     ? "grid-cols-[0.875rem_minmax(0,1fr)_1rem]"
     : "grid-cols-[0.875rem_minmax(0,1fr)]";
   const questTitle = visibleText(quest.name, "Quest");
+  const wrapsText = textLineCount > 1;
+  const previewLineCount: 2 | 3 | undefined = textLineCount === 1 ? undefined : textLineCount;
+  const wrapClass = getQuestTextWrapClass(textLineCount);
   const updateObjective = (index: number, nextText: string) => {
     if (!onUpdate) return;
     onUpdate(updateQuestObjectiveText(quest, index, nextText));
@@ -82,8 +88,14 @@ export function QuestRow({
             placeholder="Quest"
             title={`Quest: ${questTitle}`}
             showEditHint={false}
+            fitPreview={!wrapsText}
+            previewLineCount={previewLineCount}
+            editHintMode={wrapsText ? "overlay" : "inline"}
             className={cn(
               "tracker-quest-row__title-edit",
+              wrapsText
+                ? "tracker-quest-row__title-edit--wrapped"
+                : "tracker-quest-row__title-edit--single-line",
               quest.completed && "tracker-quest-row__title-edit--completed",
             )}
           />
@@ -91,6 +103,7 @@ export function QuestRow({
           <div
             className={cn(
               "tracker-quest-row__title-static",
+              wrapClass,
               quest.completed && "tracker-quest-row__title-static--completed",
             )}
           >
@@ -136,6 +149,9 @@ export function QuestRow({
               key={objective.objectiveId || `${objective.text}-${index}`}
               objective={objective}
               objectiveGridColumns={objectiveGridColumns}
+              previewLineCount={previewLineCount}
+              wrapClass={wrapClass}
+              wrapsText={wrapsText}
               onToggle={onUpdate ? () => toggleObjective(index) : undefined}
               onUpdate={onUpdate ? (text) => updateObjective(index, text) : undefined}
               onRemove={onUpdate ? () => removeObjective(index) : undefined}

--- a/src/features/runtime/tracker/components/quest-tracker/quest-layout.ts
+++ b/src/features/runtime/tracker/components/quest-tracker/quest-layout.ts
@@ -1,0 +1,15 @@
+import type { TrackerPanelSizeProfile } from "../../../../../shared/stores/ui.store";
+
+export type QuestTextLineCount = 1 | 2 | 3;
+
+export function getQuestTextLineCount(profile: TrackerPanelSizeProfile, questCount: number): QuestTextLineCount {
+  if (profile === "expanded") return questCount <= 1 ? 3 : 2;
+  if (profile === "standard") return 2;
+  return questCount <= 1 ? 2 : 1;
+}
+
+export function getQuestTextWrapClass(lineCount: QuestTextLineCount) {
+  if (lineCount === 3) return "tracker-quest-row__text--wrap-3";
+  if (lineCount === 2) return "tracker-quest-row__text--wrap-2";
+  return "tracker-quest-row__text--single-line";
+}

--- a/src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.ts
+++ b/src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 import type { PresentCharacter } from "../../../../engine/contracts/types/game-state";
+import { makeManualTrackerRowId } from "../../../../engine/shared/game-state/tracker-row-ids";
 import { npcAvatarApi } from "../../../../shared/api/avatar-api";
 import { useAgentConfigs, useUpdateAgent, type AgentConfigRow } from "../../../catalog/agents/index";
 import { replaceTrackerListItem } from "../lib/tracker-state-edits";
@@ -83,9 +84,16 @@ export function useTrackerCharacterAvatarActions({
       const character = currentCharacters[index] ?? characters[index];
       if (!character) return;
 
-      const targetCharacterId = character.characterId;
-      const fallbackIndex = index;
-      const uploadKey = `${chatId}:${targetCharacterId || `${fallbackIndex}:${character.name}`}`;
+      const existingCharacterId = character.characterId?.trim();
+      const targetCharacterId = existingCharacterId || makeManualTrackerRowId();
+      const uploadCharacter = existingCharacterId ? character : { ...character, characterId: targetCharacterId };
+      const currentCharactersForUpload = existingCharacterId
+        ? currentCharacters
+        : replaceTrackerListItem(currentCharacters, index, uploadCharacter);
+      if (!existingCharacterId) {
+        onUpdateCharacters(currentCharactersForUpload);
+      }
+      const uploadKey = `${chatId}:${targetCharacterId}`;
       const uploadToken = avatarUploadSerialRef.current + 1;
       avatarUploadSerialRef.current = uploadToken;
       avatarUploadTokenByCharacterRef.current.set(uploadKey, uploadToken);
@@ -99,16 +107,12 @@ export function useTrackerCharacterAvatarActions({
       try {
         const dataUrl = await readFileAsDataUrl(file);
         if (!isLatestUpload()) return;
-        const response = await npcAvatarApi.upload(chatId, character.name, dataUrl);
+        const response = await npcAvatarApi.upload(chatId, uploadCharacter.name, dataUrl);
         if (!isLatestUpload()) return;
         const latestState = useGameStateStore.getState().current;
         const latestCharacters =
-          latestState?.chatId === chatId ? (latestState.presentCharacters ?? []) : currentCharacters;
-        const targetIndex = targetCharacterId
-          ? latestCharacters.findIndex((candidate) => candidate.characterId === targetCharacterId)
-          : latestCharacters[fallbackIndex]?.name === character.name
-            ? fallbackIndex
-            : -1;
+          latestState?.chatId === chatId ? (latestState.presentCharacters ?? []) : currentCharactersForUpload;
+        const targetIndex = latestCharacters.findIndex((candidate) => candidate.characterId === targetCharacterId);
         const latestCharacter = latestCharacters[targetIndex];
         if (!latestCharacter) return;
 

--- a/src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.ts
+++ b/src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { PresentCharacter } from "../../../../engine/contracts/types/game-state";
 import { npcAvatarApi } from "../../../../shared/api/avatar-api";
 import { useAgentConfigs, useUpdateAgent, type AgentConfigRow } from "../../../catalog/agents/index";
@@ -47,6 +47,8 @@ export function useTrackerCharacterAvatarActions({
   onUpdateCharacters,
   agentConfigLookupEnabled = true,
 }: UseTrackerCharacterAvatarActionsOptions) {
+  const avatarUploadSerialRef = useRef(0);
+  const avatarUploadTokenByCharacterRef = useRef(new Map<string, number>());
   const { data: agentConfigs } = useAgentConfigs(agentConfigLookupEnabled);
   const updateAgent = useUpdateAgent();
   const characterTrackerConfig = useMemo(() => {
@@ -83,19 +85,30 @@ export function useTrackerCharacterAvatarActions({
 
       const targetCharacterId = character.characterId;
       const fallbackIndex = index;
+      const uploadKey = `${chatId}:${targetCharacterId || `${fallbackIndex}:${character.name}`}`;
+      const uploadToken = avatarUploadSerialRef.current + 1;
+      avatarUploadSerialRef.current = uploadToken;
+      avatarUploadTokenByCharacterRef.current.set(uploadKey, uploadToken);
+      const isLatestUpload = () => avatarUploadTokenByCharacterRef.current.get(uploadKey) === uploadToken;
+      const clearUploadToken = () => {
+        if (isLatestUpload()) {
+          avatarUploadTokenByCharacterRef.current.delete(uploadKey);
+        }
+      };
 
       try {
         const dataUrl = await readFileAsDataUrl(file);
+        if (!isLatestUpload()) return;
         const response = await npcAvatarApi.upload(chatId, character.name, dataUrl);
+        if (!isLatestUpload()) return;
         const latestState = useGameStateStore.getState().current;
         const latestCharacters =
           latestState?.chatId === chatId ? (latestState.presentCharacters ?? []) : currentCharacters;
-        let targetIndex = targetCharacterId
+        const targetIndex = targetCharacterId
           ? latestCharacters.findIndex((candidate) => candidate.characterId === targetCharacterId)
-          : -1;
-        if (targetIndex < 0 && latestCharacters[fallbackIndex]?.name === character.name) {
-          targetIndex = fallbackIndex;
-        }
+          : latestCharacters[fallbackIndex]?.name === character.name
+            ? fallbackIndex
+            : -1;
         const latestCharacter = latestCharacters[targetIndex];
         if (!latestCharacter) return;
 
@@ -107,6 +120,8 @@ export function useTrackerCharacterAvatarActions({
         );
       } catch {
         // Avatar uploads are an optional tracker enhancement; failed uploads leave tracker data unchanged.
+      } finally {
+        clearUploadToken();
       }
     },
     [characters, chatId, onUpdateCharacters],


### PR DESCRIPTION
## Linked issue

Closes #1801

## Why this change

- The refactor tracker regressed three legacy behaviors: stale NPC avatar uploads could overwrite newer uploads, quest board badges showed completed/active instead of completed/total, and long quest/objective/custom tracker rows were truncated too aggressively.

## What changed

- Added per-character avatar upload tokens so only the latest async upload result for a character can update tracker state.
- Changed the quest board badge to completed/total while keeping the done/active tooltip.
- Added tracker-size-aware quest title/objective wrapping and a small quest layout helper.
- Updated custom tracker rows so long labels/values use readable single-column wrapping instead of forced multi-column truncation.
- De-exported an internal character search type to clear the existing unused-export PR gate.

## Refactor impact

Primary owner:

- Runtime tracker and world-state UI.

Impact areas reviewed:

- Fixed tracker side panel, roleplay HUD tracker avatar upload path, quest board rows, custom tracker rows, UI store size profile plumbing, character search unused-code gate.

Boundary notes:

- Changes stay in feature/runtime UI and world-state hooks. No engine, shared API adapter, Rust, or remote-runtime boundary changes.

Pressure points touched:

- Tracker side panel row rendering and native Tauri tracker panel QA.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [x] `pnpm check:docs` passes locally
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `pnpm typecheck`.
- Ran `pnpm check:architecture`.
- Ran `pnpm build`.
- Ran `pnpm lint:eslint`.
- Ran `pnpm check`; first run exposed an unrelated unused exported type, then passed after de-exporting that internal type.
- Ran `git diff --cached --check`.
- Ran native Tauri QA with `pnpm tauri dev --no-watch --config scratch\tauri-qa.config.json`.
- In the native WebView, seeded tracker data with one completed quest, one active long quest/objective, and long custom fields. Confirmed the expanded tracker rendered `1/2`, long quest/objective/custom text was present and wrapped, then restored QA storage and stopped Codex-owned Tauri/Vite processes.
- Avatar upload race was reviewed through the async token implementation path; a real two-file OS picker race was not manually exercised.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A. This is a tracker parity bugfix, not a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or changelog changes were made; this is a targeted bugfix with no new user-facing concept or release-process claim.

## UI evidence

- Native Tauri screenshot evidence was captured locally during QA but not committed to the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added responsive text wrapping for quest titles and objectives that adapts based on panel size and content
  * Implemented multi-column layout support for custom tracker panels
  * Updated quest badge to display completed/total counts

* **Bug Fixes**
  * Fixed race condition risk in avatar uploads for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->