### PR TITLE
Replace UI explicit any usage

### DIFF
--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -60,6 +60,10 @@ import { useStartNewChat } from "./useStartNewChat";
 
 type ChatSortOption = "newest" | "oldest" | "name-asc" | "name-desc";
 export type ChatSidebarTab = "conversation" | "roleplay" | "game";
+type ChatSidebarRow = {
+  chat: NonNullable<ReturnType<typeof useChatSummaries>["data"]>[number];
+  branchCount: number;
+};
 
 function getChatTags(chat: { metadata?: { tags?: unknown } | null }): string[] {
   return Array.isArray(chat.metadata?.tags)
@@ -351,7 +355,7 @@ export function ChatSidebar({
     });
 
     const seenGroups = new Set<string>();
-    const result: { chat: (typeof sorted)[number]; branchCount: number }[] = [];
+    const result: ChatSidebarRow[] = [];
     const activeFilteredChat = activeChat ? sorted.find((chat) => chat.id === activeChat.id) : undefined;
 
     for (const chat of sorted) {
@@ -625,7 +629,7 @@ export function ChatSidebar({
   );
 
   // ── Chat row renderer (shared between unfiled + folder sections) ──
-  const renderChatRow = ({ chat, branchCount }: (typeof displayChats)[number]) => {
+  const renderChatRow = ({ chat, branchCount }: ChatSidebarRow) => {
     const cfg = MODE_CONFIG[chat.mode] ?? MODE_CONFIG.conversation;
     const isActive = activeChatId === chat.id || (chat.groupId != null && chat.groupId === activeGroupId);
     const isSelected = selectedChatIds.has(chat.id);
@@ -1369,8 +1373,8 @@ function FolderRow({
   onDelete,
 }: {
   folder: ChatFolder;
-  entries: { chat: any; branchCount: number }[];
-  renderChatRow: (entry: any) => React.ReactNode;
+  entries: ChatSidebarRow[];
+  renderChatRow: (entry: ChatSidebarRow) => React.ReactNode;
   onToggleCollapse: (folder: ChatFolder) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;

--- a/src/engine/modes/game/prompts/gm-prompts.ts
+++ b/src/engine/modes/game/prompts/gm-prompts.ts
@@ -379,7 +379,7 @@ function buildCompactInventoryLine(items: Array<{ name: string; quantity: number
 
 function buildWidgetSummaryLines(widgets: HudWidget[]): string[] {
   return widgets.map((widget) => {
-    const config = (widget.config ?? {}) as Record<string, any>;
+    const config = widget.config ?? {};
     if (widget.type === "stat_block" && Array.isArray(config.stats) && config.stats.length > 0) {
       const stats = config.stats.map((stat) => `${stat.name}=${stat.value}`).join(", ");
       return `- ${widget.id} (${widget.type}): ${stats}`;

--- a/src/features/catalog/agents/regex-application.ts
+++ b/src/features/catalog/agents/regex-application.ts
@@ -6,6 +6,10 @@ type RegexPlacement = "ai_output" | "user_input";
 
 export type ScopedRegexMode = "disabled" | "exclusive" | "chat";
 
+export function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
+  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
+}
+
 interface ApplyRegexOptions {
   depth?: number;
   resolveMacros?: (value: string) => string;

--- a/src/features/catalog/characters/components/CharacterListRow.tsx
+++ b/src/features/catalog/characters/components/CharacterListRow.tsx
@@ -20,6 +20,10 @@ export type CharacterListRowAssigningGroup = {
   memberIds: string[];
 };
 
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
 export function CharacterListRow({
   character,
   hasActiveChat,
@@ -56,7 +60,8 @@ export function CharacterListRow({
   const charName = getText(character.parsed.name) || "Unnamed";
   const charTitle = getCharacterTitle({ name: charName, comment: character.comment });
   const charTags = getCharacterTags(character);
-  const charNameColor = (character.parsed.extensions?.nameColor as string) || undefined;
+  const extensions = readRecord(character.parsed.extensions);
+  const charNameColor = typeof extensions.nameColor === "string" ? extensions.nameColor : undefined;
   const avatarUrl = characterAvatarUrl(character);
   const isInTargetGroup = assigningGroup?.memberIds.includes(character.id) ?? false;
   const previewMetadata = getCharacterPreviewMetadata(character);
@@ -136,7 +141,7 @@ export function CharacterListRow({
               avatarFilePath={character.avatarFilePath}
               avatarFilename={character.avatarFilename}
               alt={charName}
-              crop={character.parsed.extensions?.avatarCrop}
+              crop={extensions.avatarCrop}
             />
           </div>
         ) : (

--- a/src/features/catalog/characters/hooks/use-characters-panel-data.ts
+++ b/src/features/catalog/characters/hooks/use-characters-panel-data.ts
@@ -11,6 +11,10 @@ import {
 } from "../lib/characters-panel-model";
 import type { CharacterScopedSearchTerm } from "../lib/character-search";
 
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
 export function useCharactersPanelData({
   assigningToGroup,
   excludedTags,
@@ -38,11 +42,12 @@ export function useCharactersPanelData({
       { name: string; comment?: string | null; avatarPath: string | null; avatarCrop?: unknown }
     >();
     for (const character of parsedCharacters) {
+      const extensions = readRecord(character.parsed.extensions);
       map.set(character.id, {
-        name: character.parsed.name ?? "Unknown",
+        name: typeof character.parsed.name === "string" ? character.parsed.name : "Unknown",
         comment: character.comment,
         avatarPath: characterAvatarUrl(character),
-        avatarCrop: character.parsed.extensions?.avatarCrop,
+        avatarCrop: extensions.avatarCrop,
       });
     }
     return map;

--- a/src/features/catalog/characters/lib/characters-panel-model.ts
+++ b/src/features/catalog/characters/lib/characters-panel-model.ts
@@ -10,7 +10,7 @@ import {
 
 export type CharacterRow = {
   id: string;
-  data: CharacterSearchData & Record<string, any>;
+  data: CharacterSearchData & Record<string, unknown>;
   comment?: string | null;
   avatarPath?: string | null;
   avatarFilePath?: string | null;
@@ -27,7 +27,7 @@ type GroupRow = {
   avatarPath?: string | null;
 };
 
-export type ParsedCharacterRow = CharacterRow & { parsed: Record<string, any> };
+export type ParsedCharacterRow = CharacterRow & { parsed: Record<string, unknown> };
 
 export type ParsedGroupRow = Omit<GroupRow, "characterIds"> & {
   characterIds: string[];
@@ -39,6 +39,18 @@ export type SortOption = "name-asc" | "name-desc" | "newest" | "oldest" | "favor
 export type FavoriteFilter = "all" | "favorites" | "non-favorites";
 
 const UNGROUPED_CHARACTER_GROUP_ID = "__ungrouped-characters__";
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function characterExtensions(char: ParsedCharacterRow): Record<string, unknown> {
+  return readRecord(char.parsed.extensions);
+}
 
 export function parseCharacterRows(characters: unknown): ParsedCharacterRow[] {
   if (!characters) return [];
@@ -56,10 +68,8 @@ export function getCharacterPreviewMetadata(char: ParsedCharacterRow): string | 
   const parts: string[] = [];
   const creator = typeof char.parsed.creator === "string" ? char.parsed.creator.trim() : "";
   const version = typeof char.parsed.character_version === "string" ? char.parsed.character_version.trim() : "";
-  const importMetadata =
-    char.parsed.extensions?.importMetadata && typeof char.parsed.extensions.importMetadata === "object"
-      ? (char.parsed.extensions.importMetadata as Record<string, unknown>)
-      : {};
+  const extensions = characterExtensions(char);
+  const importMetadata = readRecord(extensions.importMetadata);
   const cardMetadata =
     importMetadata.card && typeof importMetadata.card === "object"
       ? (importMetadata.card as Record<string, unknown>)
@@ -94,9 +104,9 @@ export function filterCharacterRows({
 }): ParsedCharacterRow[] {
   let list = characters;
   if (favoriteFilter === "favorites") {
-    list = list.filter((c) => c.parsed.extensions?.fav);
+    list = list.filter((c) => characterExtensions(c).fav);
   } else if (favoriteFilter === "non-favorites") {
-    list = list.filter((c) => !c.parsed.extensions?.fav);
+    list = list.filter((c) => !characterExtensions(c).fav);
   }
   if (includedTags.size > 0) {
     list = list.filter((c) => countIncludedTagMatches(c.parsed, includedTags) > 0);
@@ -139,11 +149,11 @@ export function sortCharacterRows(
   switch (sort) {
     case "name-asc":
       return list.sort(
-        (a, b) => compareIncludedTagMatches(a, b) || (a.parsed.name ?? "").localeCompare(b.parsed.name ?? ""),
+        (a, b) => compareIncludedTagMatches(a, b) || readString(a.parsed.name).localeCompare(readString(b.parsed.name)),
       );
     case "name-desc":
       return list.sort(
-        (a, b) => compareIncludedTagMatches(a, b) || (b.parsed.name ?? "").localeCompare(a.parsed.name ?? ""),
+        (a, b) => compareIncludedTagMatches(a, b) || readString(b.parsed.name).localeCompare(readString(a.parsed.name)),
       );
     case "newest":
       return list.sort(
@@ -155,12 +165,12 @@ export function sortCharacterRows(
       );
     case "favorites":
       return list.sort((a, b) => {
-        const aFav = a.parsed.extensions?.fav ? 1 : 0;
-        const bFav = b.parsed.extensions?.fav ? 1 : 0;
+        const aFav = characterExtensions(a).fav ? 1 : 0;
+        const bFav = characterExtensions(b).fav ? 1 : 0;
         if (bFav !== aFav) return bFav - aFav;
         const tagMatchDiff = compareIncludedTagMatches(a, b);
         if (tagMatchDiff !== 0) return tagMatchDiff;
-        return (a.parsed.name ?? "").localeCompare(b.parsed.name ?? "");
+        return readString(a.parsed.name).localeCompare(readString(b.parsed.name));
       });
     default:
       return list;
@@ -181,7 +191,7 @@ export function parseCharacterGroups(groups: unknown, parsedCharacters: ParsedCh
   });
   const ungroupedMemberIds = parsedCharacters
     .filter((char) => !assignedIds.has(char.id))
-    .sort((a, b) => (a.parsed.name ?? "").localeCompare(b.parsed.name ?? ""))
+    .sort((a, b) => readString(a.parsed.name).localeCompare(readString(b.parsed.name)))
     .map((char) => char.id);
   if (ungroupedMemberIds.length === 0) return realGroups;
   return [

--- a/src/features/modes/conversation/components/ChatConversationSurface.tsx
+++ b/src/features/modes/conversation/components/ChatConversationSurface.tsx
@@ -37,7 +37,7 @@ type ConversationSurfaceProps = {
   characterMap: CharacterMap;
   characterNames: string[];
   personaInfo?: PersonaInfo;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   chatCharIds: string[];
   enabledAgentTypes?: Set<string>;
   connectedChatName?: string;

--- a/src/features/modes/conversation/components/ConversationAutonomousEffects.tsx
+++ b/src/features/modes/conversation/components/ConversationAutonomousEffects.tsx
@@ -12,7 +12,7 @@ type ConversationAutonomousEffectsProps = {
   chatId: string;
   messages: Message[] | undefined;
   characterMap: CharacterMap;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
 };
 
 export function ConversationAutonomousEffects({

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -26,7 +26,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useGenerate } from "../../../runtime/generation/index";
-import { useApplyRegex, type ScopedRegexMode } from "../../../catalog/agents/regex-application";
+import { readScopedRegexMode, useApplyRegex } from "../../../catalog/agents/regex-application";
 import {
   useCreateMessage,
   useDeleteMessage,
@@ -87,10 +87,6 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yaml",
   "yml",
 ]);
-
-function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
-  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
-}
 
 const SAVED_STATUS_LIMIT = 12;
 const SAVED_STATUS_MAX_LENGTH = 120;

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -26,7 +26,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useGenerate } from "../../../runtime/generation/index";
-import { useApplyRegex } from "../../../catalog/agents/regex-application";
+import { useApplyRegex, type ScopedRegexMode } from "../../../catalog/agents/regex-application";
 import {
   useCreateMessage,
   useDeleteMessage,
@@ -87,6 +87,10 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yaml",
   "yml",
 ]);
+
+function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
+  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
+}
 
 const SAVED_STATUS_LIMIT = 12;
 const SAVED_STATUS_MAX_LENGTH = 120;
@@ -568,7 +572,10 @@ export function ConversationInput({
       const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
       const streamMeta = parseChatMetadata(activeChatData?.metadata);
       // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-      let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros, scopedMode: streamMeta.scopedRegexMode });
+      let message = applyToUserInput(raw, {
+        resolveMacros: resolveInputMacros,
+        scopedMode: readScopedRegexMode(streamMeta.scopedRegexMode),
+      });
       // Input translation for streaming path too
       if (streamMeta.translateInput && message.trim()) {
         try {
@@ -673,7 +680,10 @@ export function ConversationInput({
     const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
     const chatMeta = parseChatMetadata(activeChat?.metadata);
     // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-    let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros, scopedMode: chatMeta.scopedRegexMode });
+    let message = applyToUserInput(raw, {
+      resolveMacros: resolveInputMacros,
+      scopedMode: readScopedRegexMode(chatMeta.scopedRegexMode),
+    });
 
     // Input translation: translate user's message before sending
     if (chatMeta.translateInput && message.trim()) {
@@ -872,7 +882,7 @@ export function ConversationInput({
     const postOnlyMeta = parseChatMetadata(activeChatData?.metadata);
     let message = applyToUserInput(raw, {
       resolveMacros: resolveInputMacros,
-      scopedMode: postOnlyMeta.scopedRegexMode,
+      scopedMode: readScopedRegexMode(postOnlyMeta.scopedRegexMode),
     });
 
     if (postOnlyMeta.translateInput && message.trim()) {

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -62,7 +62,7 @@ function nameColorStyle(color?: string): CSSProperties | undefined {
 const IMAGE_URL_RE = /^https?:\/\/\S+\.(?:gif|png|jpe?g|webp)(?:\?[^\s]*)?$/i;
 const MESSAGE_EDIT_GESTURE_IGNORE_SELECTOR =
   "button, a, textarea, input, select, label, [role='button'], [contenteditable='true'], .mari-message-actions";
-type ConversationMessageExtra = Partial<MessageExtra> & { hiddenFromAi?: unknown };
+type ConversationMessageExtra = Partial<MessageExtra> & { hiddenFromAI?: unknown; hiddenFromAi?: unknown };
 const EMPTY_MESSAGE_EXTRA: ConversationMessageExtra = {};
 
 function HiddenFromAIConversationButton({

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -258,20 +258,10 @@ function groupConsecutiveSegments(segments: SpeakerSegment[]): GroupedSegment[] 
   return groups;
 }
 
-interface MessageData {
-  id: string;
-  chatId: string;
-  role: "user" | "assistant" | "system" | "narrator";
-  characterId: string | null;
-  content: string;
-  activeSwipeIndex: number;
-  swipeCount?: number;
-  extra: ConversationMessageExtra | string;
-  createdAt: string;
-}
+type ConversationMessageData = Omit<Message, "extra"> & { extra: ConversationMessageExtra | string };
 
 interface ConversationMessageProps {
-  message: MessageData;
+  message: ConversationMessageData;
   isStreaming?: boolean;
   isGrouped?: boolean;
   hideActions?: boolean;

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -90,16 +90,18 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
 
   const connectedChatId = (data.chat as unknown as { connectedChatId?: string | null } | null | undefined)
     ?.connectedChatId;
-  const activeSceneChat = data.chatMeta.activeSceneChatId
-    ? data.chatList.find((item) => item.id === data.chatMeta.activeSceneChatId)
+  const activeSceneChatId =
+    typeof data.chatMeta.activeSceneChatId === "string" ? data.chatMeta.activeSceneChatId : null;
+  const activeSceneChat = activeSceneChatId
+    ? data.chatList.find((item) => item.id === activeSceneChatId)
     : undefined;
   const activeSceneMeta = parseChatMetadata(activeSceneChat?.metadata);
   const hasActiveLinkedScene = activeSceneChat && activeSceneMeta.sceneStatus === "active";
   const sceneInfo =
-    data.chatMeta.activeSceneChatId && hasActiveLinkedScene
+    activeSceneChatId && hasActiveLinkedScene
       ? {
           variant: "origin" as const,
-          sceneChatId: data.chatMeta.activeSceneChatId,
+          sceneChatId: activeSceneChatId,
           sceneChatName: getChatDisplayName(activeSceneChat),
         }
       : undefined;

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -58,7 +58,7 @@ interface ConversationViewProps {
   characterMap: CharacterMap;
   characterNames: string[];
   personaInfo?: PersonaInfo;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   chatName?: string;
   chatGroupId?: string | null;
   chatCharIds: string[];
@@ -105,6 +105,10 @@ function formatDaySeparator(dateStr: string): string {
 function getDayKey(dateStr: string): string {
   const d = new Date(dateStr);
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function chatMetaString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
 }
 
 /** Check if a message's content uses "Name: text" format with known chat-member character names */
@@ -1035,7 +1039,7 @@ export function ConversationView({
             elements.push(
               <ConversationMessage
                 key={item.key}
-                message={displayMsg as any}
+                message={displayMsg}
                 isStreaming={hasStreamContent}
                 isGrouped={isGrouped}
                 onDelete={onDelete}
@@ -1046,7 +1050,7 @@ export function ConversationView({
                 onToggleHiddenFromAI={onToggleHiddenFromAI}
                 isLastAssistantMessage={msg.id === lastAssistantMessageId}
                 characterMap={characterMap}
-                personaInfo={personaInfo as any}
+                personaInfo={personaInfo}
                 chatCharacterIds={chatCharIds}
                 messageIndex={item.index + 1}
                 messageOrderIndex={item.index}
@@ -1133,7 +1137,7 @@ export function ConversationView({
           activeChatCharIds.length > 1
             ? chatMeta.groupResponseOrder === "manual"
               ? "manual"
-              : (chatMeta.groupResponseOrder ?? "sequential")
+              : chatMetaString(chatMeta.groupResponseOrder, "sequential")
             : undefined
         }
         chatCharacters={
@@ -1222,7 +1226,7 @@ function SplitMessageGroup({
       <div className="group relative">
         <ConversationMessage
           key={firstItem.key}
-          message={{ ...msg, content: "" } as any}
+          message={{ ...msg, content: "" }}
           isStreaming={false}
           isGrouped={firstItem.isGrouped}
           noHoverGroup
@@ -1236,7 +1240,7 @@ function SplitMessageGroup({
           isLastAssistantMessage={false}
           characterMap={characterMap}
           chatCharacterIds={chatCharacterIds}
-          personaInfo={personaInfo as any}
+          personaInfo={personaInfo}
         />
         <div className="space-y-2 pl-14 pr-4 -mt-1">
           <textarea
@@ -1298,7 +1302,7 @@ function SplitMessageGroup({
             return (
               <ConversationMessage
                 key={firstItem.key}
-                message={{ ...firstItem.msg, content: "", extra: regenExtra } as any}
+                message={{ ...firstItem.msg, content: "", extra: regenExtra }}
                 isStreaming={false}
                 isGrouped={firstItem.isGrouped}
                 hideActions
@@ -1312,7 +1316,7 @@ function SplitMessageGroup({
                 isLastAssistantMessage={false}
                 characterMap={characterMap}
                 chatCharacterIds={chatCharacterIds}
-                personaInfo={personaInfo as any}
+                personaInfo={personaInfo}
               />
             );
           }
@@ -1324,7 +1328,7 @@ function SplitMessageGroup({
           return (
             <ConversationMessage
               key={firstItem.key}
-              message={dMsg as any}
+              message={dMsg}
               isStreaming
               isGrouped={firstItem.isGrouped}
               hideActions={false}
@@ -1340,7 +1344,7 @@ function SplitMessageGroup({
               isLastAssistantMessage={firstItem.msg.id === lastAssistantMessageId}
               characterMap={characterMap}
               chatCharacterIds={chatCharacterIds}
-              personaInfo={personaInfo as any}
+              personaInfo={personaInfo}
               messageIndex={firstItem.index + 1}
             />
           );
@@ -1352,7 +1356,7 @@ function SplitMessageGroup({
           return (
             <ConversationMessage
               key={gi.key}
-              message={msg as any}
+              message={msg}
               isStreaming={false}
               isGrouped={grp}
               hideActions={isChild}
@@ -1368,7 +1372,7 @@ function SplitMessageGroup({
               isLastAssistantMessage={msg.id === lastAssistantMessageId}
               characterMap={characterMap}
               chatCharacterIds={chatCharacterIds}
-              personaInfo={personaInfo as any}
+              personaInfo={personaInfo}
               messageIndex={gi.index + 1}
             />
           );

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -247,6 +247,29 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+function sheetAttributes(value: unknown): ReadonlyArray<{ name: string; value: number }> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const attrs = value
+    .map((item) => {
+      const record = asRecord(item);
+      const name = typeof record.name === "string" ? record.name : "";
+      const parsedValue = Number(record.value);
+      return name && Number.isFinite(parsedValue) ? { name, value: parsedValue } : null;
+    })
+    .filter((item): item is { name: string; value: number } => item !== null);
+  return attrs.length ? attrs : undefined;
+}
+
+const WEATHER_SEASONS = new Set<Season>(["spring", "summer", "autumn", "winter"]);
+
+function isWeatherSeason(value: unknown): value is Season {
+  return typeof value === "string" && WEATHER_SEASONS.has(value as Season);
+}
+
+function weatherSeason(value: unknown): Season {
+  return isWeatherSeason(value) ? value : "summer";
+}
+
 function chatMeta(chat: Chat | null | undefined): Record<string, unknown> {
   return asRecord(chat?.metadata);
 }
@@ -1045,15 +1068,7 @@ function playerAttributes(meta: Record<string, unknown>): Partial<RPGAttributes>
   const cards = Array.isArray(meta.gameCharacterCards) ? meta.gameCharacterCards : [];
   const first = asRecord(cards[0]);
   const rpgStats = asRecord(first.rpgStats);
-  return mapSheetAttributesToRPG(
-    Array.isArray(rpgStats.attributes)
-      ? (rpgStats.attributes as ReadonlyArray<{ name: string; value: number }>)
-      : undefined,
-  );
-}
-
-function isWeatherSeason(value: unknown): value is Season {
-  return value === "spring" || value === "summer" || value === "autumn" || value === "winter";
+  return mapSheetAttributesToRPG(sheetAttributes(rpgStats.attributes));
 }
 
 function replaceFirstUnresolvedSkillCheckTag(content: string, resolvedTag: string): string {
@@ -1969,7 +1984,7 @@ export const gameApi = {
       forced = { type: data.type, temperature: 20, description: "", wind: "calm", visibility: "clear" } as WeatherState;
     } else {
       const biome = inferBiome(data.location ?? "");
-      const season = isWeatherSeason(data.season) ? data.season : "summer";
+      const season = weatherSeason(data.season);
       if (data.season && season === "summer" && data.season !== "summer") {
         console.warn("[game] Invalid weather season; defaulting to summer", {
           season: data.season,

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -252,7 +252,7 @@ function sheetAttributes(value: unknown): ReadonlyArray<{ name: string; value: n
   const attrs = value
     .map((item) => {
       const record = asRecord(item);
-      const name = typeof record.name === "string" ? record.name : "";
+      const name = typeof record.name === "string" ? record.name.trim() : "";
       const parsedValue = Number(record.value);
       return name && Number.isFinite(parsedValue) ? { name, value: parsedValue } : null;
     })
@@ -262,12 +262,14 @@ function sheetAttributes(value: unknown): ReadonlyArray<{ name: string; value: n
 
 const WEATHER_SEASONS = new Set<Season>(["spring", "summer", "autumn", "winter"]);
 
-function isWeatherSeason(value: unknown): value is Season {
-  return typeof value === "string" && WEATHER_SEASONS.has(value as Season);
+function isWeatherSeason(value: unknown): boolean {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return WEATHER_SEASONS.has(normalized as Season);
 }
 
 function weatherSeason(value: unknown): Season {
-  return isWeatherSeason(value) ? value : "summer";
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return isWeatherSeason(normalized) ? (normalized as Season) : "summer";
 }
 
 function chatMeta(chat: Chat | null | undefined): Record<string, unknown> {

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -489,8 +489,25 @@ function finiteNumber(value: unknown): number | null {
   return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
 }
 
-type LegacyInventoryItem = { name: string; slot?: string | number; quantity?: number };
-type LegacyInventoryConfig = Omit<HudWidget["config"], "items"> & { items?: LegacyInventoryItem[] };
+type LegacyInventoryGridItem = { name: string; slot?: string; quantity?: number };
+
+function legacyInventoryGridItems(value: unknown): LegacyInventoryGridItem[] | null {
+  if (!Array.isArray(value)) return null;
+  const items: LegacyInventoryGridItem[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name : "";
+    if (!name) continue;
+    const slot = typeof record.slot === "string" ? record.slot : undefined;
+    items.push({
+      name,
+      ...(slot ? { slot } : {}),
+      quantity: finiteNumber(record.quantity) ?? 1,
+    });
+  }
+  return items;
+}
 
 function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
   return widgets.map((w) => {
@@ -512,18 +529,13 @@ function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
       }
     }
 
-    const inventoryConfig = w.config as LegacyInventoryConfig;
-    if (w.type === "inventory_grid" && !w.config.contents && Array.isArray(inventoryConfig.items)) {
-      const items = inventoryConfig.items;
+    const legacyItems = legacyInventoryGridItems((w.config as HudWidget["config"] & { items?: unknown }).items);
+    if (w.type === "inventory_grid" && !w.config.contents && legacyItems) {
       return {
         ...w,
         config: {
           ...w.config,
-          contents: items.map((i) => ({
-            name: i.name,
-            slot: typeof i.slot === "string" ? i.slot : undefined,
-            quantity: i.quantity ?? 1,
-          })),
+          contents: legacyItems,
         },
       };
     }
@@ -680,7 +692,7 @@ export function useUpdateReputation() {
     mutationFn: (data: { chatId: string; actions: Array<{ npcId: string; action: string; modifier?: number }> }) =>
       gameApi.updateReputation(data),
     onSuccess: (res, variables) => {
-      store.getState().setNpcs(res.npcs as GameNpc[]);
+      store.getState().setNpcs(res.npcs);
       publishSessionChat(qc, res.sessionChat);
       qc.invalidateQueries({ queryKey: chatKeys.detail(variables.chatId) });
       qc.invalidateQueries({ queryKey: [...gameKeys.all, "journal", variables.chatId] });

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -491,6 +491,11 @@ function finiteNumber(value: unknown): number | null {
 
 type LegacyInventoryGridItem = { name: string; slot?: string; quantity?: number };
 
+function positiveInventoryQuantity(value: unknown): number {
+  const quantity = finiteNumber(value) ?? 1;
+  return Math.max(1, Math.floor(quantity));
+}
+
 function legacyInventoryGridItems(value: unknown): LegacyInventoryGridItem[] | null {
   if (!Array.isArray(value)) return null;
   const items: LegacyInventoryGridItem[] = [];
@@ -503,7 +508,7 @@ function legacyInventoryGridItems(value: unknown): LegacyInventoryGridItem[] | n
     items.push({
       name,
       ...(slot ? { slot } : {}),
-      quantity: finiteNumber(record.quantity) ?? 1,
+      quantity: positiveInventoryQuantity(record.quantity),
     });
   }
   return items;

--- a/src/features/modes/roleplay/components/ChatRoleplayPanels.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplayPanels.tsx
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { PenLine, X } from "lucide-react";
 import { useUpdateChatMetadata } from "../../../catalog/chats/index";
 
+function readAuthorNotesDepth(value: unknown): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 4;
+}
+
 export function AuthorNotesPanel({
   chatId,
   chatMeta,
@@ -9,31 +14,33 @@ export function AuthorNotesPanel({
   onClose,
 }: {
   chatId: string;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   isMobile: boolean;
   onClose: () => void;
 }) {
-  const [notes, setNotes] = useState((chatMeta.authorNotes as string) ?? "");
-  const [depthStr, setDepthStr] = useState(String((chatMeta.authorNotesDepth as number) ?? 4));
+  const authorNotes = typeof chatMeta.authorNotes === "string" ? chatMeta.authorNotes : "";
+  const authorNotesDepth = readAuthorNotesDepth(chatMeta.authorNotesDepth);
+  const [notes, setNotes] = useState(authorNotes);
+  const [depthStr, setDepthStr] = useState(String(authorNotesDepth));
   const updateMeta = useUpdateChatMetadata();
 
   const latestRef = useRef({ notes, depthStr });
   latestRef.current = { notes, depthStr };
   const baselineRef = useRef({
-    notes: (chatMeta.authorNotes as string) ?? "",
-    depth: (chatMeta.authorNotesDepth as number) ?? 4,
+    notes: authorNotes,
+    depth: authorNotesDepth,
   });
   const mutateRef = useRef(updateMeta.mutate);
   mutateRef.current = updateMeta.mutate;
 
   useEffect(() => {
-    setNotes((chatMeta.authorNotes as string) ?? "");
-    setDepthStr(String((chatMeta.authorNotesDepth as number) ?? 4));
+    setNotes(authorNotes);
+    setDepthStr(String(authorNotesDepth));
     baselineRef.current = {
-      notes: (chatMeta.authorNotes as string) ?? "",
-      depth: (chatMeta.authorNotesDepth as number) ?? 4,
+      notes: authorNotes,
+      depth: authorNotesDepth,
     };
-  }, [chatMeta.authorNotes, chatMeta.authorNotesDepth]);
+  }, [authorNotes, authorNotesDepth]);
 
   // Outside-click closes the popover via mousedown, which unmounts the
   // textarea before its onBlur (the only save trigger) can fire. Flush

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -398,7 +398,17 @@ function SummaryButton({
   );
 }
 
-function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMeta: Record<string, any> }) {
+function metadataString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function metadataStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMeta: Record<string, unknown> }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
@@ -500,7 +510,7 @@ type RoleplaySurfaceProps = {
   activeChatId: string;
   chat: ChatData | null | undefined;
   allChats: Array<{ id: string; name: string; metadata?: string | Record<string, unknown> | null }> | undefined;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   chatMode: string;
   isRoleplay: boolean;
   centerCompact: boolean;
@@ -736,7 +746,7 @@ export function ChatRoleplaySurface({
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
   const inactiveCharacterIdSet = useMemo(
-    () => new Set(Array.isArray(chatMeta.inactiveCharacterIds) ? chatMeta.inactiveCharacterIds : []),
+    () => new Set(metadataStringArray(chatMeta.inactiveCharacterIds)),
     [chatMeta.inactiveCharacterIds],
   );
   const activeChatCharIds = useMemo(
@@ -831,7 +841,7 @@ export function ChatRoleplaySurface({
                   <ToolbarMenu>
                     <SummaryButton
                       chatId={chat?.id ?? null}
-                      summary={chatMeta.summary ?? null}
+                      summary={metadataString(chatMeta.summary) || null}
                       summaryContextSize={summaryContextSize}
                       totalMessageCount={totalMessageCount}
                       onContextSizeChange={onSummaryContextSizeChange}
@@ -901,7 +911,7 @@ export function ChatRoleplaySurface({
                         />
                         <SummaryButton
                           chatId={chat?.id ?? null}
-                          summary={chatMeta.summary ?? null}
+                          summary={metadataString(chatMeta.summary) || null}
                           summaryContextSize={summaryContextSize}
                           totalMessageCount={totalMessageCount}
                           onContextSizeChange={onSummaryContextSizeChange}
@@ -942,7 +952,7 @@ export function ChatRoleplaySurface({
                       />
                       <SummaryButton
                         chatId={chat?.id ?? null}
-                        summary={chatMeta.summary ?? null}
+                        summary={metadataString(chatMeta.summary) || null}
                         summaryContextSize={summaryContextSize}
                         totalMessageCount={totalMessageCount}
                         onContextSizeChange={onSummaryContextSizeChange}
@@ -1115,7 +1125,7 @@ export function ChatRoleplaySurface({
                 {chatMeta.sceneStatus === "active" && (
                   <EndSceneBar
                     sceneChatId={activeChatId}
-                    originChatId={chatMeta.sceneOriginChatId}
+                    originChatId={metadataString(chatMeta.sceneOriginChatId) || undefined}
                     onConclude={onConcludeScene}
                     onAbandon={onAbandonScene}
                     onFork={onForkScene}
@@ -1125,8 +1135,8 @@ export function ChatRoleplaySurface({
                 {isConcludedScene && (
                   <SceneBanner
                     variant="scene"
-                    originChatId={chatMeta.sceneOriginChatId}
-                    description={chatMeta.sceneDescription}
+                    originChatId={metadataString(chatMeta.sceneOriginChatId) || undefined}
+                    description={metadataString(chatMeta.sceneDescription) || undefined}
                   />
                 )}
                 {!isConcludedScene && combatAgentEnabled && (
@@ -1148,7 +1158,7 @@ export function ChatRoleplaySurface({
                     characterNames={activeCharacterNames}
                     groupResponseOrder={
                       activeChatCharIds.length > 1 && groupChatMode === "individual"
-                        ? (chatMeta.groupResponseOrder ?? "sequential")
+                        ? metadataString(chatMeta.groupResponseOrder, "sequential")
                         : undefined
                     }
                     chatCharacters={activeChatCharIds

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -404,7 +404,9 @@ function metadataString(value: unknown, fallback = ""): string {
 
 function metadataStringArray(value: unknown): string[] {
   return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    ? value
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter((item): item is string => item.length > 0)
     : [];
 }
 

--- a/src/features/modes/roleplay/components/EncounterModal.tsx
+++ b/src/features/modes/roleplay/components/EncounterModal.tsx
@@ -38,6 +38,14 @@ import type { Lorebook } from "../../../../engine/contracts/types/lorebook";
 // Sub-components
 // ──────────────────────────────────────────────
 
+const NARRATIVE_TENSE_OPTIONS = ["present", "past"] as const satisfies readonly NarrativeStyle["tense"][];
+const NARRATIVE_PERSON_OPTIONS = ["first", "second", "third"] as const satisfies readonly NarrativeStyle["person"][];
+const NARRATIVE_MODE_OPTIONS = ["omniscient", "limited"] as const satisfies readonly NarrativeStyle["narration"][];
+
+function selectNarrativeOption<T extends string>(nextValue: string, options: readonly T[], fallback: T): T {
+  return (options as readonly string[]).includes(nextValue) ? (nextValue as T) : fallback;
+}
+
 function HPBar({ current, max, isParty }: { current: number; max: number; isParty?: boolean }) {
   const pct = Math.max(0, Math.min(100, (current / max) * 100));
   const isDead = current <= 0;
@@ -286,7 +294,12 @@ function NarrativeSelect({
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <select
           value={value.tense}
-          onChange={(e) => onChange({ ...value, tense: e.target.value as any })}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              tense: selectNarrativeOption(e.target.value, NARRATIVE_TENSE_OPTIONS, value.tense),
+            })
+          }
           className="rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 py-1.5 text-xs text-[var(--foreground)]"
         >
           <option value="present">Present Tense</option>
@@ -294,7 +307,12 @@ function NarrativeSelect({
         </select>
         <select
           value={value.person}
-          onChange={(e) => onChange({ ...value, person: e.target.value as any })}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              person: selectNarrativeOption(e.target.value, NARRATIVE_PERSON_OPTIONS, value.person),
+            })
+          }
           className="rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 py-1.5 text-xs text-[var(--foreground)]"
         >
           <option value="first">First Person</option>
@@ -303,7 +321,12 @@ function NarrativeSelect({
         </select>
         <select
           value={value.narration}
-          onChange={(e) => onChange({ ...value, narration: e.target.value as any })}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              narration: selectNarrativeOption(e.target.value, NARRATIVE_MODE_OPTIONS, value.narration),
+            })
+          }
           className="rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 py-1.5 text-xs text-[var(--foreground)]"
         >
           <option value="omniscient">Omniscient</option>

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -62,6 +62,10 @@ function normalizeMessageSpriteExpressions(value: unknown): Record<string, strin
   return expressions;
 }
 
+function metadataString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
 function resolveExpressionAvatarSpriteUrl(sprites: Map<string, string> | undefined, expression: string): string | null {
   const normalizedExpression = expression.trim().toLowerCase();
   if (!normalizedExpression) return null;
@@ -191,7 +195,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
   if (renderMessages?.length) hasAnimatedRef.current = true;
 
   const groupChatMode: string | undefined =
-    data.chatCharIds.length > 1 ? (data.chatMeta.groupChatMode ?? "merged") : undefined;
+    data.chatCharIds.length > 1 ? metadataString(data.chatMeta.groupChatMode, "merged") : undefined;
   const msgPayload = useMemo(() => {
     const messages = renderMessages ?? [];
     const start = Math.max(0, messages.length - SPRITE_OVERLAY_MESSAGE_SCAN_LIMIT);

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -39,16 +39,20 @@ export function RecentChats() {
     if (!recentCharacters) return map;
     for (const char of recentCharacters as Array<{
       id: string;
-      data: Record<string, any>;
+      data: Record<string, unknown>;
       avatarPath?: string | null;
       avatarFilePath?: string | null;
       avatarFilename?: string | null;
     }>) {
       const parsed = char.data ?? {};
+      const extensions =
+        parsed.extensions && typeof parsed.extensions === "object" && !Array.isArray(parsed.extensions)
+          ? (parsed.extensions as Record<string, unknown>)
+          : {};
       map.set(char.id, {
-        name: parsed.name ?? "Unknown",
+        name: typeof parsed.name === "string" ? parsed.name : "Unknown",
         avatarUrl: characterAvatarUrl(char),
-        avatarCrop: parsed.extensions?.avatarCrop ?? null,
+        avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
       });
     }
     return map;

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -7,7 +7,7 @@ import { MessageSquare, BookOpen } from "lucide-react";
 import { useRecentChatSummaries, type ChatListItem } from "../../../catalog/chats/index";
 import { characterAvatarUrl, useCharacterSummariesByIds } from "../../../catalog/characters/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
-import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
 
 const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: string }> = {
   conversation: {
@@ -21,6 +21,17 @@ const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: str
     label: "Roleplay",
   },
 };
+
+function readAvatarCrop(value: unknown): AvatarCropValue | null {
+  if (!value) return null;
+  if (typeof value === "string") return parseAvatarCropJson(value);
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  try {
+    return parseAvatarCropJson(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
 
 export function RecentChats() {
   const { data: recentChats } = useRecentChatSummaries(3);
@@ -52,7 +63,7 @@ export function RecentChats() {
       map.set(char.id, {
         name: typeof parsed.name === "string" ? parsed.name : "Unknown",
         avatarUrl: characterAvatarUrl(char),
-        avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
+        avatarCrop: readAvatarCrop(extensions.avatarCrop),
       });
     }
     return map;

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -21,7 +21,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import { useGenerate } from "../../../../runtime/generation/index";
-import { useApplyRegex, type ScopedRegexMode } from "../../../../catalog/agents/regex-application";
+import { readScopedRegexMode, useApplyRegex } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
 import { characterKeys } from "../../../../catalog/characters/index";
 import { personaKeys } from "../../../../catalog/personas/index";
@@ -74,10 +74,6 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yaml",
   "yml",
 ]);
-
-function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
-  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
-}
 
 function getFileExtension(fileName: string): string {
   const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -21,7 +21,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import { useGenerate } from "../../../../runtime/generation/index";
-import { useApplyRegex } from "../../../../catalog/agents/regex-application";
+import { useApplyRegex, type ScopedRegexMode } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
 import { characterKeys } from "../../../../catalog/characters/index";
 import { personaKeys } from "../../../../catalog/personas/index";
@@ -74,6 +74,10 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yaml",
   "yml",
 ]);
+
+function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
+  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
+}
 
 function getFileExtension(fileName: string): string {
   const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
@@ -572,7 +576,10 @@ export const ChatInput = memo(function ChatInput({
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     const chatMeta = parseChatMetadata(chat?.metadata);
-    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros, scopedMode: chatMeta.scopedRegexMode });
+    let message = applyToUserInput(normalized, {
+      resolveMacros: resolveInputMacros,
+      scopedMode: readScopedRegexMode(chatMeta.scopedRegexMode),
+    });
 
     // Input translation: translate user's message before sending
     if (chatMeta.translateInput && message.trim()) {
@@ -750,7 +757,10 @@ export const ChatInput = memo(function ChatInput({
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     const chatMeta2 = parseChatMetadata(chat?.metadata);
-    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros, scopedMode: chatMeta2.scopedRegexMode });
+    let message = applyToUserInput(normalized, {
+      resolveMacros: resolveInputMacros,
+      scopedMode: readScopedRegexMode(chatMeta2.scopedRegexMode),
+    });
 
     if (chatMeta2.translateInput && message.trim()) {
       try {

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
@@ -7,10 +7,18 @@ import type { MessageWithSwipes } from "../types";
 
 type UseChatMetadataSyncOptions = {
   chat: Chat | null | undefined;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   messages: MessageWithSwipes[] | undefined;
   messagePageCount: number;
 };
+
+function metadataString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function metadataTranslationProvider(value: unknown): "ai" | "deeplx" | "deepl" | "google" {
+  return value === "ai" || value === "deeplx" || value === "deepl" || value === "google" ? value : "google";
+}
 
 export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount }: UseChatMetadataSyncOptions) {
   const chatBackground = useUIStore((state) => state.chatBackground);
@@ -19,11 +27,11 @@ export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount
   useEffect(() => {
     if (!chat?.id) return;
     useTranslationStore.getState().setConfig({
-      provider: chatMeta.translationProvider ?? "google",
-      targetLanguage: chatMeta.translationTargetLang ?? "en",
-      connectionId: chatMeta.translationConnectionId,
-      deeplApiKey: chatMeta.translationDeeplApiKey,
-      deeplxUrl: chatMeta.translationDeeplxUrl,
+      provider: metadataTranslationProvider(chatMeta.translationProvider),
+      targetLanguage: metadataString(chatMeta.translationTargetLang) ?? "en",
+      connectionId: metadataString(chatMeta.translationConnectionId),
+      deeplApiKey: metadataString(chatMeta.translationDeeplApiKey),
+      deeplxUrl: metadataString(chatMeta.translationDeeplxUrl),
     });
   }, [
     chat?.id,

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -14,7 +14,7 @@ import { useActivePersona, usePersona } from "../../../../catalog/personas/index
 import { ApiError } from "../../../../../shared/api/api-errors";
 import { getConnectedChatDisplayName, parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";
-import { parseAvatarCropJson } from "../../../../../shared/lib/utils";
+import { parseAvatarCropJson, type AvatarCropValue } from "../../../../../shared/lib/utils";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import type { CharacterMap, MessageWithSwipes, PersonaInfo } from "../types";
 
@@ -31,7 +31,7 @@ type UseChatSurfaceDataOptions = {
 
 type CharacterRow = {
   id: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   comment?: string | null;
   avatarPath: string | null;
   avatarFilePath?: string | null;
@@ -69,8 +69,27 @@ function parseChatCharacterIds(chat: Chat | null | undefined): string[] {
   return Array.isArray(raw) ? raw.filter((id): id is string => typeof id === "string") : [];
 }
 
-function parseCharacterData(data: Record<string, any>): Record<string, any> {
+function parseCharacterData(data: Record<string, unknown>): Record<string, unknown> {
   return data && typeof data === "object" ? data : {};
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readAvatarCrop(value: unknown): AvatarCropValue | null {
+  if (!value) return null;
+  if (typeof value === "string") return parseAvatarCropJson(value);
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  try {
+    return parseAvatarCropJson(JSON.stringify(value));
+  } catch {
+    return null;
+  }
 }
 
 function normalizeIds(ids: Array<string | null | undefined>): string[] {
@@ -105,9 +124,11 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
-function collectGameCharacterIds(chatMeta: Record<string, any>): string[] {
+function collectGameCharacterIds(chatMeta: Record<string, unknown>): string[] {
   const setup =
-    chatMeta.gameSetupConfig && typeof chatMeta.gameSetupConfig === "object" ? chatMeta.gameSetupConfig : {};
+    chatMeta.gameSetupConfig && typeof chatMeta.gameSetupConfig === "object" && !Array.isArray(chatMeta.gameSetupConfig)
+      ? (chatMeta.gameSetupConfig as Record<string, unknown>)
+      : {};
   const ids: Array<string | null | undefined> = [
     typeof setup.gmCharacterId === "string" ? setup.gmCharacterId : null,
     ...stringArray(setup.partyCharacterIds),
@@ -249,23 +270,31 @@ export function useChatSurfaceData({
     for (const character of (characterRows ?? []) as CharacterRow[]) {
       try {
         const parsed = parseCharacterData(character.data);
+        const extensions = readRecord(parsed.extensions);
+        const conversationStatus = readString(extensions.conversationStatus);
         map.set(character.id, {
-          name: parsed.name ?? "Unknown",
-          description: parsed.description ?? "",
-          personality: parsed.personality ?? "",
-          backstory: parsed.extensions?.backstory ?? "",
-          appearance: parsed.extensions?.appearance ?? "",
-          scenario: parsed.scenario ?? "",
-          example: parsed.mes_example ?? "",
-          systemPrompt: parsed.system_prompt ?? parsed.systemPrompt ?? "",
-          postHistoryInstructions: parsed.post_history_instructions ?? parsed.postHistoryInstructions ?? "",
+          name: readString(parsed.name, "Unknown"),
+          description: readString(parsed.description),
+          personality: readString(parsed.personality),
+          backstory: readString(extensions.backstory),
+          appearance: readString(extensions.appearance),
+          scenario: readString(parsed.scenario),
+          example: readString(parsed.mes_example),
+          systemPrompt: readString(parsed.system_prompt) || readString(parsed.systemPrompt),
+          postHistoryInstructions:
+            readString(parsed.post_history_instructions) || readString(parsed.postHistoryInstructions),
           avatarUrl: characterAvatarUrl(character),
-          nameColor: parsed.extensions?.nameColor || undefined,
-          dialogueColor: parsed.extensions?.dialogueColor || undefined,
-          boxColor: parsed.extensions?.boxColor || undefined,
-          avatarCrop: parsed.extensions?.avatarCrop || null,
-          conversationStatus: parsed.extensions?.conversationStatus || undefined,
-          conversationActivity: parsed.extensions?.conversationActivity || undefined,
+          nameColor: readString(extensions.nameColor) || undefined,
+          dialogueColor: readString(extensions.dialogueColor) || undefined,
+          boxColor: readString(extensions.boxColor) || undefined,
+          avatarCrop: readAvatarCrop(extensions.avatarCrop),
+          conversationStatus:
+            conversationStatus === "idle" || conversationStatus === "dnd" || conversationStatus === "offline"
+              ? conversationStatus
+              : conversationStatus === "online"
+                ? "online"
+                : undefined,
+          conversationActivity: readString(extensions.conversationActivity) || undefined,
         });
       } catch {
         map.set(character.id, { name: "Unknown", avatarUrl: null });
@@ -303,20 +332,21 @@ export function useChatSurfaceData({
         ? (characterRows as CharacterRow[]).map((character) => {
             try {
               const parsed = parseCharacterData(character.data);
+              const extensions = readRecord(parsed.extensions);
               const display = parseCharacterDisplayData(character);
               return {
                 id: character.id,
                 name: display.name,
                 comment: display.comment,
                 avatarUrl: characterAvatarUrl(character) ?? undefined,
-                avatarCrop: parsed.extensions?.avatarCrop || null,
-                nameColor: parsed.extensions?.nameColor || undefined,
-                dialogueColor: parsed.extensions?.dialogueColor || undefined,
-                description: parsed.description ?? "",
-                personality: parsed.personality ?? "",
-                backstory: parsed.extensions?.backstory ?? "",
-                appearance: parsed.extensions?.appearance ?? "",
-                tags: parsed.tags ?? [],
+                avatarCrop: readAvatarCrop(extensions.avatarCrop),
+                nameColor: readString(extensions.nameColor) || undefined,
+                dialogueColor: readString(extensions.dialogueColor) || undefined,
+                description: readString(parsed.description),
+                personality: readString(parsed.personality),
+                backstory: readString(extensions.backstory),
+                appearance: readString(extensions.appearance),
+                tags: stringArray(parsed.tags),
               };
             } catch {
               return { id: character.id, name: "Unknown" };

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -69,8 +69,8 @@ function parseChatCharacterIds(chat: Chat | null | undefined): string[] {
   return Array.isArray(raw) ? raw.filter((id): id is string => typeof id === "string") : [];
 }
 
-function parseCharacterData(data: Record<string, unknown>): Record<string, unknown> {
-  return data && typeof data === "object" ? data : {};
+function parseCharacterData(data: unknown): Record<string, unknown> {
+  return data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>) : {};
 }
 
 function readRecord(value: unknown): Record<string, unknown> {

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -38,9 +38,9 @@ type UseChatTimelineActionsOptions = {
   refreshWorldStateOnTimelineChange?: boolean;
 };
 
-function readMessageExtra(message: MessageWithSwipes): Record<string, any> {
+function readMessageExtra(message: MessageWithSwipes): Record<string, unknown> {
   return message.extra && typeof message.extra === "object" && !Array.isArray(message.extra)
-    ? (message.extra as Record<string, any>)
+    ? (message.extra as unknown as Record<string, unknown>)
     : {};
 }
 
@@ -625,8 +625,10 @@ export function useChatTimelineActions({
       if (!prev || !curr) return false;
       if (prev.role !== curr.role || prev.characterId !== curr.characterId) return false;
       if (prev.role === "user" && curr.role === "user") {
-        const prevId = readMessageExtra(prev).personaSnapshot?.personaId;
-        const currId = readMessageExtra(curr).personaSnapshot?.personaId;
+        const prevSnapshot = readRecord(readMessageExtra(prev).personaSnapshot);
+        const currSnapshot = readRecord(readMessageExtra(curr).personaSnapshot);
+        const prevId = readString(prevSnapshot.personaId);
+        const currId = readString(currSnapshot.personaId);
         if (prevId && currId && prevId !== currId) return false;
       }
       return true;

--- a/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.ts
@@ -8,7 +8,7 @@ import type { MessageWithSwipes } from "../types";
 
 type UseSpriteMetadataStateOptions = {
   chat: Chat | null | undefined;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   messages?: MessageWithSwipes[] | undefined;
 };
 
@@ -18,10 +18,16 @@ function normalizeSpriteDisplayValue(value: unknown, fallback: number, min: numb
   return Math.max(min, Math.min(max, numeric));
 }
 
-function readMessageExtra(message: MessageWithSwipes): Record<string, any> {
+function readMessageExtra(message: MessageWithSwipes): Record<string, unknown> {
   return message.extra && typeof message.extra === "object" && !Array.isArray(message.extra)
-    ? (message.extra as Record<string, any>)
+    ? (message.extra as unknown as Record<string, unknown>)
     : {};
+}
+
+function stringRecord(value: unknown): Record<string, string> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  return entries.length ? Object.fromEntries(entries) : null;
 }
 
 export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMetadataStateOptions) {
@@ -48,8 +54,9 @@ export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMe
         const message = messages[index]!;
         if (message.role === "assistant") {
           const extra = readMessageExtra(message);
-          if (extra.spriteExpressions && Object.keys(extra.spriteExpressions).length > 0) {
-            return extra.spriteExpressions as Record<string, string>;
+          const spriteExpressions = stringRecord(extra.spriteExpressions);
+          if (spriteExpressions && Object.keys(spriteExpressions).length > 0) {
+            return spriteExpressions;
           }
           break;
         }

--- a/src/shared/lib/chat-display.ts
+++ b/src/shared/lib/chat-display.ts
@@ -7,17 +7,19 @@ export type ChatDisplaySource = {
 
 const PLACEHOLDER_BRANCH_NAME = "New Branch";
 
-export function parseChatMetadata(raw: unknown): Record<string, any> {
+export function parseChatMetadata(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
   if (typeof raw === "string") {
     try {
       const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, any>) : {};
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
     } catch {
       return {};
     }
   }
-  return typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, any>) : {};
+  return typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
 }
 
 export function getChatDisplayName(chat: ChatDisplaySource | null | undefined): string {


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Remove remaining explicit `any` usage across the UI cleanup slice so stricter linting can move forward without weakening runtime guards.

## What changed

- Narrowed chat metadata, character metadata, sprite expression metadata, and conversation message props from `any` to `unknown` plus local readers.
- Replaced game HUD, weather, RPG attribute, and related metadata casts with typed helpers.
- Preserved author-notes depth compatibility for numeric-string metadata while removing the explicit `any` cast.

## Refactor impact

Primary owner:

- Shared mode UI, roleplay mode, conversation mode, game mode, catalog character UI, app shell, and shared chat display helpers.

Impact areas reviewed:

- Chat metadata parsing and metadata sync.
- Character row parsing and preview metadata.
- Roleplay author notes, scene metadata, and group response metadata.
- Conversation input regex mode handling and message props.
- Game API utility readers and HUD widget normalization.

Boundary notes:

- No new cross-layer imports.
- Engine touch is limited to game prompt HUD config typing.
- Feature code continues to use existing catalog/shared API hooks.
- No Rust or remote-runtime path changes.

Pressure points touched:

- Shared mode UI hooks were touched for metadata narrowing only.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [x] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [x] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

Validation evidence:

- `pnpm typecheck` passed before rebase.
- `pnpm check:architecture` passed before rebase.
- `pnpm check` passed after rebase onto `origin/refactor`.

### Manual verification notes

- Not run; this is a typed metadata cleanup with command-line validation.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal type cleanup and metadata compatibility guard only; no new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes:

- No docs changes needed; no changelog file exists and this does not add user-facing discovery or release content.

## UI evidence

- Not applicable; no visual UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety and validation logic across chat, character management, and game systems to enhance code reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->