### PR TITLE
Tighten chat settings metadata typing

### DIFF
--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -60,6 +60,10 @@ import { useStartNewChat } from "./useStartNewChat";
 
 type ChatSortOption = "newest" | "oldest" | "name-asc" | "name-desc";
 export type ChatSidebarTab = "conversation" | "roleplay" | "game";
+type ChatSidebarRow = {
+  chat: NonNullable<ReturnType<typeof useChatSummaries>["data"]>[number];
+  branchCount: number;
+};
 
 function getChatTags(chat: { metadata?: { tags?: unknown } | null }): string[] {
   return Array.isArray(chat.metadata?.tags)
@@ -351,7 +355,7 @@ export function ChatSidebar({
     });
 
     const seenGroups = new Set<string>();
-    const result: { chat: (typeof sorted)[number]; branchCount: number }[] = [];
+    const result: ChatSidebarRow[] = [];
     const activeFilteredChat = activeChat ? sorted.find((chat) => chat.id === activeChat.id) : undefined;
 
     for (const chat of sorted) {
@@ -625,7 +629,7 @@ export function ChatSidebar({
   );
 
   // ── Chat row renderer (shared between unfiled + folder sections) ──
-  const renderChatRow = ({ chat, branchCount }: (typeof displayChats)[number]) => {
+  const renderChatRow = ({ chat, branchCount }: ChatSidebarRow) => {
     const cfg = MODE_CONFIG[chat.mode] ?? MODE_CONFIG.conversation;
     const isActive = activeChatId === chat.id || (chat.groupId != null && chat.groupId === activeGroupId);
     const isSelected = selectedChatIds.has(chat.id);
@@ -1369,8 +1373,8 @@ function FolderRow({
   onDelete,
 }: {
   folder: ChatFolder;
-  entries: { chat: any; branchCount: number }[];
-  renderChatRow: (entry: any) => React.ReactNode;
+  entries: ChatSidebarRow[];
+  renderChatRow: (entry: ChatSidebarRow) => React.ReactNode;
   onToggleCollapse: (folder: ChatFolder) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;

--- a/src/engine/modes/game/prompts/gm-prompts.ts
+++ b/src/engine/modes/game/prompts/gm-prompts.ts
@@ -379,7 +379,7 @@ function buildCompactInventoryLine(items: Array<{ name: string; quantity: number
 
 function buildWidgetSummaryLines(widgets: HudWidget[]): string[] {
   return widgets.map((widget) => {
-    const config = (widget.config ?? {}) as Record<string, any>;
+    const config = widget.config ?? {};
     if (widget.type === "stat_block" && Array.isArray(config.stats) && config.stats.length > 0) {
       const stats = config.stats.map((stat) => `${stat.name}=${stat.value}`).join(", ");
       return `- ${widget.id} (${widget.type}): ${stats}`;

--- a/src/features/catalog/characters/components/CharacterListRow.tsx
+++ b/src/features/catalog/characters/components/CharacterListRow.tsx
@@ -20,6 +20,10 @@ export type CharacterListRowAssigningGroup = {
   memberIds: string[];
 };
 
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
 export function CharacterListRow({
   character,
   hasActiveChat,
@@ -56,7 +60,8 @@ export function CharacterListRow({
   const charName = getText(character.parsed.name) || "Unnamed";
   const charTitle = getCharacterTitle({ name: charName, comment: character.comment });
   const charTags = getCharacterTags(character);
-  const charNameColor = (character.parsed.extensions?.nameColor as string) || undefined;
+  const extensions = readRecord(character.parsed.extensions);
+  const charNameColor = typeof extensions.nameColor === "string" ? extensions.nameColor : undefined;
   const avatarUrl = characterAvatarUrl(character);
   const isInTargetGroup = assigningGroup?.memberIds.includes(character.id) ?? false;
   const previewMetadata = getCharacterPreviewMetadata(character);
@@ -136,7 +141,7 @@ export function CharacterListRow({
               avatarFilePath={character.avatarFilePath}
               avatarFilename={character.avatarFilename}
               alt={charName}
-              crop={character.parsed.extensions?.avatarCrop}
+              crop={extensions.avatarCrop}
             />
           </div>
         ) : (

--- a/src/features/catalog/characters/hooks/use-characters-panel-data.ts
+++ b/src/features/catalog/characters/hooks/use-characters-panel-data.ts
@@ -11,6 +11,10 @@ import {
 } from "../lib/characters-panel-model";
 import type { CharacterScopedSearchTerm } from "../lib/character-search";
 
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
 export function useCharactersPanelData({
   assigningToGroup,
   excludedTags,
@@ -38,11 +42,12 @@ export function useCharactersPanelData({
       { name: string; comment?: string | null; avatarPath: string | null; avatarCrop?: unknown }
     >();
     for (const character of parsedCharacters) {
+      const extensions = readRecord(character.parsed.extensions);
       map.set(character.id, {
-        name: character.parsed.name ?? "Unknown",
+        name: typeof character.parsed.name === "string" ? character.parsed.name : "Unknown",
         comment: character.comment,
         avatarPath: characterAvatarUrl(character),
-        avatarCrop: character.parsed.extensions?.avatarCrop,
+        avatarCrop: extensions.avatarCrop,
       });
     }
     return map;

--- a/src/features/catalog/characters/lib/characters-panel-model.ts
+++ b/src/features/catalog/characters/lib/characters-panel-model.ts
@@ -10,7 +10,7 @@ import {
 
 export type CharacterRow = {
   id: string;
-  data: CharacterSearchData & Record<string, any>;
+  data: CharacterSearchData & Record<string, unknown>;
   comment?: string | null;
   avatarPath?: string | null;
   avatarFilePath?: string | null;
@@ -27,7 +27,7 @@ type GroupRow = {
   avatarPath?: string | null;
 };
 
-export type ParsedCharacterRow = CharacterRow & { parsed: Record<string, any> };
+export type ParsedCharacterRow = CharacterRow & { parsed: Record<string, unknown> };
 
 export type ParsedGroupRow = Omit<GroupRow, "characterIds"> & {
   characterIds: string[];
@@ -39,6 +39,18 @@ export type SortOption = "name-asc" | "name-desc" | "newest" | "oldest" | "favor
 export type FavoriteFilter = "all" | "favorites" | "non-favorites";
 
 const UNGROUPED_CHARACTER_GROUP_ID = "__ungrouped-characters__";
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function characterExtensions(char: ParsedCharacterRow): Record<string, unknown> {
+  return readRecord(char.parsed.extensions);
+}
 
 export function parseCharacterRows(characters: unknown): ParsedCharacterRow[] {
   if (!characters) return [];
@@ -56,10 +68,8 @@ export function getCharacterPreviewMetadata(char: ParsedCharacterRow): string | 
   const parts: string[] = [];
   const creator = typeof char.parsed.creator === "string" ? char.parsed.creator.trim() : "";
   const version = typeof char.parsed.character_version === "string" ? char.parsed.character_version.trim() : "";
-  const importMetadata =
-    char.parsed.extensions?.importMetadata && typeof char.parsed.extensions.importMetadata === "object"
-      ? (char.parsed.extensions.importMetadata as Record<string, unknown>)
-      : {};
+  const extensions = characterExtensions(char);
+  const importMetadata = readRecord(extensions.importMetadata);
   const cardMetadata =
     importMetadata.card && typeof importMetadata.card === "object"
       ? (importMetadata.card as Record<string, unknown>)
@@ -94,9 +104,9 @@ export function filterCharacterRows({
 }): ParsedCharacterRow[] {
   let list = characters;
   if (favoriteFilter === "favorites") {
-    list = list.filter((c) => c.parsed.extensions?.fav);
+    list = list.filter((c) => characterExtensions(c).fav);
   } else if (favoriteFilter === "non-favorites") {
-    list = list.filter((c) => !c.parsed.extensions?.fav);
+    list = list.filter((c) => !characterExtensions(c).fav);
   }
   if (includedTags.size > 0) {
     list = list.filter((c) => countIncludedTagMatches(c.parsed, includedTags) > 0);
@@ -139,11 +149,11 @@ export function sortCharacterRows(
   switch (sort) {
     case "name-asc":
       return list.sort(
-        (a, b) => compareIncludedTagMatches(a, b) || (a.parsed.name ?? "").localeCompare(b.parsed.name ?? ""),
+        (a, b) => compareIncludedTagMatches(a, b) || readString(a.parsed.name).localeCompare(readString(b.parsed.name)),
       );
     case "name-desc":
       return list.sort(
-        (a, b) => compareIncludedTagMatches(a, b) || (b.parsed.name ?? "").localeCompare(a.parsed.name ?? ""),
+        (a, b) => compareIncludedTagMatches(a, b) || readString(b.parsed.name).localeCompare(readString(a.parsed.name)),
       );
     case "newest":
       return list.sort(
@@ -155,12 +165,12 @@ export function sortCharacterRows(
       );
     case "favorites":
       return list.sort((a, b) => {
-        const aFav = a.parsed.extensions?.fav ? 1 : 0;
-        const bFav = b.parsed.extensions?.fav ? 1 : 0;
+        const aFav = characterExtensions(a).fav ? 1 : 0;
+        const bFav = characterExtensions(b).fav ? 1 : 0;
         if (bFav !== aFav) return bFav - aFav;
         const tagMatchDiff = compareIncludedTagMatches(a, b);
         if (tagMatchDiff !== 0) return tagMatchDiff;
-        return (a.parsed.name ?? "").localeCompare(b.parsed.name ?? "");
+        return readString(a.parsed.name).localeCompare(readString(b.parsed.name));
       });
     default:
       return list;
@@ -181,7 +191,7 @@ export function parseCharacterGroups(groups: unknown, parsedCharacters: ParsedCh
   });
   const ungroupedMemberIds = parsedCharacters
     .filter((char) => !assignedIds.has(char.id))
-    .sort((a, b) => (a.parsed.name ?? "").localeCompare(b.parsed.name ?? ""))
+    .sort((a, b) => readString(a.parsed.name).localeCompare(readString(b.parsed.name)))
     .map((char) => char.id);
   if (ungroupedMemberIds.length === 0) return realGroups;
   return [

--- a/src/features/modes/conversation/components/ChatConversationSurface.tsx
+++ b/src/features/modes/conversation/components/ChatConversationSurface.tsx
@@ -37,7 +37,7 @@ type ConversationSurfaceProps = {
   characterMap: CharacterMap;
   characterNames: string[];
   personaInfo?: PersonaInfo;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   chatCharIds: string[];
   enabledAgentTypes?: Set<string>;
   connectedChatName?: string;

--- a/src/features/modes/conversation/components/ConversationAutonomousEffects.tsx
+++ b/src/features/modes/conversation/components/ConversationAutonomousEffects.tsx
@@ -12,7 +12,7 @@ type ConversationAutonomousEffectsProps = {
   chatId: string;
   messages: Message[] | undefined;
   characterMap: CharacterMap;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
 };
 
 export function ConversationAutonomousEffects({

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -26,7 +26,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useGenerate } from "../../../runtime/generation/index";
-import { useApplyRegex } from "../../../catalog/agents/regex-application";
+import { useApplyRegex, type ScopedRegexMode } from "../../../catalog/agents/regex-application";
 import {
   useCreateMessage,
   useDeleteMessage,
@@ -87,6 +87,10 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yaml",
   "yml",
 ]);
+
+function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
+  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
+}
 
 const SAVED_STATUS_LIMIT = 12;
 const SAVED_STATUS_MAX_LENGTH = 120;
@@ -568,7 +572,10 @@ export function ConversationInput({
       const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
       const streamMeta = parseChatMetadata(activeChatData?.metadata);
       // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-      let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros, scopedMode: streamMeta.scopedRegexMode });
+      let message = applyToUserInput(raw, {
+        resolveMacros: resolveInputMacros,
+        scopedMode: readScopedRegexMode(streamMeta.scopedRegexMode),
+      });
       // Input translation for streaming path too
       if (streamMeta.translateInput && message.trim()) {
         try {
@@ -673,7 +680,10 @@ export function ConversationInput({
     const resolveInputMacros = createInputMacroResolverForChat(activeChat, cachedCharacters, cachedPersonas, raw);
     const chatMeta = parseChatMetadata(activeChat?.metadata);
     // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-    let message = applyToUserInput(raw, { resolveMacros: resolveInputMacros, scopedMode: chatMeta.scopedRegexMode });
+    let message = applyToUserInput(raw, {
+      resolveMacros: resolveInputMacros,
+      scopedMode: readScopedRegexMode(chatMeta.scopedRegexMode),
+    });
 
     // Input translation: translate user's message before sending
     if (chatMeta.translateInput && message.trim()) {
@@ -872,7 +882,7 @@ export function ConversationInput({
     const postOnlyMeta = parseChatMetadata(activeChatData?.metadata);
     let message = applyToUserInput(raw, {
       resolveMacros: resolveInputMacros,
-      scopedMode: postOnlyMeta.scopedRegexMode,
+      scopedMode: readScopedRegexMode(postOnlyMeta.scopedRegexMode),
     });
 
     if (postOnlyMeta.translateInput && message.trim()) {

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -258,20 +258,10 @@ function groupConsecutiveSegments(segments: SpeakerSegment[]): GroupedSegment[] 
   return groups;
 }
 
-interface MessageData {
-  id: string;
-  chatId: string;
-  role: "user" | "assistant" | "system" | "narrator";
-  characterId: string | null;
-  content: string;
-  activeSwipeIndex: number;
-  swipeCount?: number;
-  extra: ConversationMessageExtra | string;
-  createdAt: string;
-}
+type ConversationMessageData = Omit<Message, "extra"> & { extra: ConversationMessageExtra | string };
 
 interface ConversationMessageProps {
-  message: MessageData;
+  message: ConversationMessageData;
   isStreaming?: boolean;
   isGrouped?: boolean;
   hideActions?: boolean;

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -90,16 +90,18 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
 
   const connectedChatId = (data.chat as unknown as { connectedChatId?: string | null } | null | undefined)
     ?.connectedChatId;
-  const activeSceneChat = data.chatMeta.activeSceneChatId
-    ? data.chatList.find((item) => item.id === data.chatMeta.activeSceneChatId)
+  const activeSceneChatId =
+    typeof data.chatMeta.activeSceneChatId === "string" ? data.chatMeta.activeSceneChatId : null;
+  const activeSceneChat = activeSceneChatId
+    ? data.chatList.find((item) => item.id === activeSceneChatId)
     : undefined;
   const activeSceneMeta = parseChatMetadata(activeSceneChat?.metadata);
   const hasActiveLinkedScene = activeSceneChat && activeSceneMeta.sceneStatus === "active";
   const sceneInfo =
-    data.chatMeta.activeSceneChatId && hasActiveLinkedScene
+    activeSceneChatId && hasActiveLinkedScene
       ? {
           variant: "origin" as const,
-          sceneChatId: data.chatMeta.activeSceneChatId,
+          sceneChatId: activeSceneChatId,
           sceneChatName: getChatDisplayName(activeSceneChat),
         }
       : undefined;

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -58,7 +58,7 @@ interface ConversationViewProps {
   characterMap: CharacterMap;
   characterNames: string[];
   personaInfo?: PersonaInfo;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   chatName?: string;
   chatGroupId?: string | null;
   chatCharIds: string[];
@@ -105,6 +105,10 @@ function formatDaySeparator(dateStr: string): string {
 function getDayKey(dateStr: string): string {
   const d = new Date(dateStr);
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function chatMetaString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
 }
 
 /** Check if a message's content uses "Name: text" format with known chat-member character names */
@@ -1035,7 +1039,7 @@ export function ConversationView({
             elements.push(
               <ConversationMessage
                 key={item.key}
-                message={displayMsg as any}
+                message={displayMsg}
                 isStreaming={hasStreamContent}
                 isGrouped={isGrouped}
                 onDelete={onDelete}
@@ -1046,7 +1050,7 @@ export function ConversationView({
                 onToggleHiddenFromAI={onToggleHiddenFromAI}
                 isLastAssistantMessage={msg.id === lastAssistantMessageId}
                 characterMap={characterMap}
-                personaInfo={personaInfo as any}
+                personaInfo={personaInfo}
                 chatCharacterIds={chatCharIds}
                 messageIndex={item.index + 1}
                 messageOrderIndex={item.index}
@@ -1133,7 +1137,7 @@ export function ConversationView({
           activeChatCharIds.length > 1
             ? chatMeta.groupResponseOrder === "manual"
               ? "manual"
-              : (chatMeta.groupResponseOrder ?? "sequential")
+              : chatMetaString(chatMeta.groupResponseOrder, "sequential")
             : undefined
         }
         chatCharacters={
@@ -1222,7 +1226,7 @@ function SplitMessageGroup({
       <div className="group relative">
         <ConversationMessage
           key={firstItem.key}
-          message={{ ...msg, content: "" } as any}
+          message={{ ...msg, content: "" }}
           isStreaming={false}
           isGrouped={firstItem.isGrouped}
           noHoverGroup
@@ -1236,7 +1240,7 @@ function SplitMessageGroup({
           isLastAssistantMessage={false}
           characterMap={characterMap}
           chatCharacterIds={chatCharacterIds}
-          personaInfo={personaInfo as any}
+          personaInfo={personaInfo}
         />
         <div className="space-y-2 pl-14 pr-4 -mt-1">
           <textarea
@@ -1298,7 +1302,7 @@ function SplitMessageGroup({
             return (
               <ConversationMessage
                 key={firstItem.key}
-                message={{ ...firstItem.msg, content: "", extra: regenExtra } as any}
+                message={{ ...firstItem.msg, content: "", extra: regenExtra }}
                 isStreaming={false}
                 isGrouped={firstItem.isGrouped}
                 hideActions
@@ -1312,7 +1316,7 @@ function SplitMessageGroup({
                 isLastAssistantMessage={false}
                 characterMap={characterMap}
                 chatCharacterIds={chatCharacterIds}
-                personaInfo={personaInfo as any}
+                personaInfo={personaInfo}
               />
             );
           }
@@ -1324,7 +1328,7 @@ function SplitMessageGroup({
           return (
             <ConversationMessage
               key={firstItem.key}
-              message={dMsg as any}
+              message={dMsg}
               isStreaming
               isGrouped={firstItem.isGrouped}
               hideActions={false}
@@ -1340,7 +1344,7 @@ function SplitMessageGroup({
               isLastAssistantMessage={firstItem.msg.id === lastAssistantMessageId}
               characterMap={characterMap}
               chatCharacterIds={chatCharacterIds}
-              personaInfo={personaInfo as any}
+              personaInfo={personaInfo}
               messageIndex={firstItem.index + 1}
             />
           );
@@ -1352,7 +1356,7 @@ function SplitMessageGroup({
           return (
             <ConversationMessage
               key={gi.key}
-              message={msg as any}
+              message={msg}
               isStreaming={false}
               isGrouped={grp}
               hideActions={isChild}
@@ -1368,7 +1372,7 @@ function SplitMessageGroup({
               isLastAssistantMessage={msg.id === lastAssistantMessageId}
               characterMap={characterMap}
               chatCharacterIds={chatCharacterIds}
-              personaInfo={personaInfo as any}
+              personaInfo={personaInfo}
               messageIndex={gi.index + 1}
             />
           );

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -247,6 +247,29 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+function sheetAttributes(value: unknown): ReadonlyArray<{ name: string; value: number }> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const attrs = value
+    .map((item) => {
+      const record = asRecord(item);
+      const name = typeof record.name === "string" ? record.name : "";
+      const parsedValue = Number(record.value);
+      return name && Number.isFinite(parsedValue) ? { name, value: parsedValue } : null;
+    })
+    .filter((item): item is { name: string; value: number } => item !== null);
+  return attrs.length ? attrs : undefined;
+}
+
+const WEATHER_SEASONS = new Set<Season>(["spring", "summer", "autumn", "winter"]);
+
+function isWeatherSeason(value: unknown): value is Season {
+  return typeof value === "string" && WEATHER_SEASONS.has(value as Season);
+}
+
+function weatherSeason(value: unknown): Season {
+  return isWeatherSeason(value) ? value : "summer";
+}
+
 function chatMeta(chat: Chat | null | undefined): Record<string, unknown> {
   return asRecord(chat?.metadata);
 }
@@ -1045,15 +1068,7 @@ function playerAttributes(meta: Record<string, unknown>): Partial<RPGAttributes>
   const cards = Array.isArray(meta.gameCharacterCards) ? meta.gameCharacterCards : [];
   const first = asRecord(cards[0]);
   const rpgStats = asRecord(first.rpgStats);
-  return mapSheetAttributesToRPG(
-    Array.isArray(rpgStats.attributes)
-      ? (rpgStats.attributes as ReadonlyArray<{ name: string; value: number }>)
-      : undefined,
-  );
-}
-
-function isWeatherSeason(value: unknown): value is Season {
-  return value === "spring" || value === "summer" || value === "autumn" || value === "winter";
+  return mapSheetAttributesToRPG(sheetAttributes(rpgStats.attributes));
 }
 
 function replaceFirstUnresolvedSkillCheckTag(content: string, resolvedTag: string): string {
@@ -1969,7 +1984,7 @@ export const gameApi = {
       forced = { type: data.type, temperature: 20, description: "", wind: "calm", visibility: "clear" } as WeatherState;
     } else {
       const biome = inferBiome(data.location ?? "");
-      const season = isWeatherSeason(data.season) ? data.season : "summer";
+      const season = weatherSeason(data.season);
       if (data.season && season === "summer" && data.season !== "summer") {
         console.warn("[game] Invalid weather season; defaulting to summer", {
           season: data.season,

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -489,8 +489,25 @@ function finiteNumber(value: unknown): number | null {
   return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
 }
 
-type LegacyInventoryItem = { name: string; slot?: string | number; quantity?: number };
-type LegacyInventoryConfig = Omit<HudWidget["config"], "items"> & { items?: LegacyInventoryItem[] };
+type LegacyInventoryGridItem = { name: string; slot?: string; quantity?: number };
+
+function legacyInventoryGridItems(value: unknown): LegacyInventoryGridItem[] | null {
+  if (!Array.isArray(value)) return null;
+  const items: LegacyInventoryGridItem[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name : "";
+    if (!name) continue;
+    const slot = typeof record.slot === "string" ? record.slot : undefined;
+    items.push({
+      name,
+      ...(slot ? { slot } : {}),
+      quantity: finiteNumber(record.quantity) ?? 1,
+    });
+  }
+  return items;
+}
 
 function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
   return widgets.map((w) => {
@@ -512,18 +529,13 @@ function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
       }
     }
 
-    const inventoryConfig = w.config as LegacyInventoryConfig;
-    if (w.type === "inventory_grid" && !w.config.contents && Array.isArray(inventoryConfig.items)) {
-      const items = inventoryConfig.items;
+    const legacyItems = legacyInventoryGridItems((w.config as HudWidget["config"] & { items?: unknown }).items);
+    if (w.type === "inventory_grid" && !w.config.contents && legacyItems) {
       return {
         ...w,
         config: {
           ...w.config,
-          contents: items.map((i) => ({
-            name: i.name,
-            slot: typeof i.slot === "string" ? i.slot : undefined,
-            quantity: i.quantity ?? 1,
-          })),
+          contents: legacyItems,
         },
       };
     }
@@ -680,7 +692,7 @@ export function useUpdateReputation() {
     mutationFn: (data: { chatId: string; actions: Array<{ npcId: string; action: string; modifier?: number }> }) =>
       gameApi.updateReputation(data),
     onSuccess: (res, variables) => {
-      store.getState().setNpcs(res.npcs as GameNpc[]);
+      store.getState().setNpcs(res.npcs);
       publishSessionChat(qc, res.sessionChat);
       qc.invalidateQueries({ queryKey: chatKeys.detail(variables.chatId) });
       qc.invalidateQueries({ queryKey: [...gameKeys.all, "journal", variables.chatId] });

--- a/src/features/modes/roleplay/components/ChatRoleplayPanels.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplayPanels.tsx
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { PenLine, X } from "lucide-react";
 import { useUpdateChatMetadata } from "../../../catalog/chats/index";
 
+function readAuthorNotesDepth(value: unknown): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 4;
+}
+
 export function AuthorNotesPanel({
   chatId,
   chatMeta,
@@ -9,31 +14,33 @@ export function AuthorNotesPanel({
   onClose,
 }: {
   chatId: string;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   isMobile: boolean;
   onClose: () => void;
 }) {
-  const [notes, setNotes] = useState((chatMeta.authorNotes as string) ?? "");
-  const [depthStr, setDepthStr] = useState(String((chatMeta.authorNotesDepth as number) ?? 4));
+  const authorNotes = typeof chatMeta.authorNotes === "string" ? chatMeta.authorNotes : "";
+  const authorNotesDepth = readAuthorNotesDepth(chatMeta.authorNotesDepth);
+  const [notes, setNotes] = useState(authorNotes);
+  const [depthStr, setDepthStr] = useState(String(authorNotesDepth));
   const updateMeta = useUpdateChatMetadata();
 
   const latestRef = useRef({ notes, depthStr });
   latestRef.current = { notes, depthStr };
   const baselineRef = useRef({
-    notes: (chatMeta.authorNotes as string) ?? "",
-    depth: (chatMeta.authorNotesDepth as number) ?? 4,
+    notes: authorNotes,
+    depth: authorNotesDepth,
   });
   const mutateRef = useRef(updateMeta.mutate);
   mutateRef.current = updateMeta.mutate;
 
   useEffect(() => {
-    setNotes((chatMeta.authorNotes as string) ?? "");
-    setDepthStr(String((chatMeta.authorNotesDepth as number) ?? 4));
+    setNotes(authorNotes);
+    setDepthStr(String(authorNotesDepth));
     baselineRef.current = {
-      notes: (chatMeta.authorNotes as string) ?? "",
-      depth: (chatMeta.authorNotesDepth as number) ?? 4,
+      notes: authorNotes,
+      depth: authorNotesDepth,
     };
-  }, [chatMeta.authorNotes, chatMeta.authorNotesDepth]);
+  }, [authorNotes, authorNotesDepth]);
 
   // Outside-click closes the popover via mousedown, which unmounts the
   // textarea before its onBlur (the only save trigger) can fire. Flush

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -398,7 +398,17 @@ function SummaryButton({
   );
 }
 
-function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMeta: Record<string, any> }) {
+function metadataString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function metadataStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMeta: Record<string, unknown> }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
@@ -500,7 +510,7 @@ type RoleplaySurfaceProps = {
   activeChatId: string;
   chat: ChatData | null | undefined;
   allChats: Array<{ id: string; name: string; metadata?: string | Record<string, unknown> | null }> | undefined;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   chatMode: string;
   isRoleplay: boolean;
   centerCompact: boolean;
@@ -736,7 +746,7 @@ export function ChatRoleplaySurface({
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
   const inactiveCharacterIdSet = useMemo(
-    () => new Set(Array.isArray(chatMeta.inactiveCharacterIds) ? chatMeta.inactiveCharacterIds : []),
+    () => new Set(metadataStringArray(chatMeta.inactiveCharacterIds)),
     [chatMeta.inactiveCharacterIds],
   );
   const activeChatCharIds = useMemo(
@@ -831,7 +841,7 @@ export function ChatRoleplaySurface({
                   <ToolbarMenu>
                     <SummaryButton
                       chatId={chat?.id ?? null}
-                      summary={chatMeta.summary ?? null}
+                      summary={metadataString(chatMeta.summary) || null}
                       summaryContextSize={summaryContextSize}
                       totalMessageCount={totalMessageCount}
                       onContextSizeChange={onSummaryContextSizeChange}
@@ -901,7 +911,7 @@ export function ChatRoleplaySurface({
                         />
                         <SummaryButton
                           chatId={chat?.id ?? null}
-                          summary={chatMeta.summary ?? null}
+                          summary={metadataString(chatMeta.summary) || null}
                           summaryContextSize={summaryContextSize}
                           totalMessageCount={totalMessageCount}
                           onContextSizeChange={onSummaryContextSizeChange}
@@ -942,7 +952,7 @@ export function ChatRoleplaySurface({
                       />
                       <SummaryButton
                         chatId={chat?.id ?? null}
-                        summary={chatMeta.summary ?? null}
+                        summary={metadataString(chatMeta.summary) || null}
                         summaryContextSize={summaryContextSize}
                         totalMessageCount={totalMessageCount}
                         onContextSizeChange={onSummaryContextSizeChange}
@@ -1115,7 +1125,7 @@ export function ChatRoleplaySurface({
                 {chatMeta.sceneStatus === "active" && (
                   <EndSceneBar
                     sceneChatId={activeChatId}
-                    originChatId={chatMeta.sceneOriginChatId}
+                    originChatId={metadataString(chatMeta.sceneOriginChatId) || undefined}
                     onConclude={onConcludeScene}
                     onAbandon={onAbandonScene}
                     onFork={onForkScene}
@@ -1125,8 +1135,8 @@ export function ChatRoleplaySurface({
                 {isConcludedScene && (
                   <SceneBanner
                     variant="scene"
-                    originChatId={chatMeta.sceneOriginChatId}
-                    description={chatMeta.sceneDescription}
+                    originChatId={metadataString(chatMeta.sceneOriginChatId) || undefined}
+                    description={metadataString(chatMeta.sceneDescription) || undefined}
                   />
                 )}
                 {!isConcludedScene && combatAgentEnabled && (
@@ -1148,7 +1158,7 @@ export function ChatRoleplaySurface({
                     characterNames={activeCharacterNames}
                     groupResponseOrder={
                       activeChatCharIds.length > 1 && groupChatMode === "individual"
-                        ? (chatMeta.groupResponseOrder ?? "sequential")
+                        ? metadataString(chatMeta.groupResponseOrder, "sequential")
                         : undefined
                     }
                     chatCharacters={activeChatCharIds

--- a/src/features/modes/roleplay/components/EncounterModal.tsx
+++ b/src/features/modes/roleplay/components/EncounterModal.tsx
@@ -38,6 +38,14 @@ import type { Lorebook } from "../../../../engine/contracts/types/lorebook";
 // Sub-components
 // ──────────────────────────────────────────────
 
+const NARRATIVE_TENSE_OPTIONS = ["present", "past"] as const satisfies readonly NarrativeStyle["tense"][];
+const NARRATIVE_PERSON_OPTIONS = ["first", "second", "third"] as const satisfies readonly NarrativeStyle["person"][];
+const NARRATIVE_MODE_OPTIONS = ["omniscient", "limited"] as const satisfies readonly NarrativeStyle["narration"][];
+
+function selectNarrativeOption<T extends string>(nextValue: string, options: readonly T[], fallback: T): T {
+  return (options as readonly string[]).includes(nextValue) ? (nextValue as T) : fallback;
+}
+
 function HPBar({ current, max, isParty }: { current: number; max: number; isParty?: boolean }) {
   const pct = Math.max(0, Math.min(100, (current / max) * 100));
   const isDead = current <= 0;
@@ -286,7 +294,12 @@ function NarrativeSelect({
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <select
           value={value.tense}
-          onChange={(e) => onChange({ ...value, tense: e.target.value as any })}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              tense: selectNarrativeOption(e.target.value, NARRATIVE_TENSE_OPTIONS, value.tense),
+            })
+          }
           className="rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 py-1.5 text-xs text-[var(--foreground)]"
         >
           <option value="present">Present Tense</option>
@@ -294,7 +307,12 @@ function NarrativeSelect({
         </select>
         <select
           value={value.person}
-          onChange={(e) => onChange({ ...value, person: e.target.value as any })}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              person: selectNarrativeOption(e.target.value, NARRATIVE_PERSON_OPTIONS, value.person),
+            })
+          }
           className="rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 py-1.5 text-xs text-[var(--foreground)]"
         >
           <option value="first">First Person</option>
@@ -303,7 +321,12 @@ function NarrativeSelect({
         </select>
         <select
           value={value.narration}
-          onChange={(e) => onChange({ ...value, narration: e.target.value as any })}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              narration: selectNarrativeOption(e.target.value, NARRATIVE_MODE_OPTIONS, value.narration),
+            })
+          }
           className="rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 py-1.5 text-xs text-[var(--foreground)]"
         >
           <option value="omniscient">Omniscient</option>

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -62,6 +62,10 @@ function normalizeMessageSpriteExpressions(value: unknown): Record<string, strin
   return expressions;
 }
 
+function metadataString(value: unknown, fallback: string): string {
+  return typeof value === "string" ? value : fallback;
+}
+
 function resolveExpressionAvatarSpriteUrl(sprites: Map<string, string> | undefined, expression: string): string | null {
   const normalizedExpression = expression.trim().toLowerCase();
   if (!normalizedExpression) return null;
@@ -191,7 +195,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
   if (renderMessages?.length) hasAnimatedRef.current = true;
 
   const groupChatMode: string | undefined =
-    data.chatCharIds.length > 1 ? (data.chatMeta.groupChatMode ?? "merged") : undefined;
+    data.chatCharIds.length > 1 ? metadataString(data.chatMeta.groupChatMode, "merged") : undefined;
   const msgPayload = useMemo(() => {
     const messages = renderMessages ?? [];
     const start = Math.max(0, messages.length - SPRITE_OVERLAY_MESSAGE_SCAN_LIMIT);

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -39,16 +39,20 @@ export function RecentChats() {
     if (!recentCharacters) return map;
     for (const char of recentCharacters as Array<{
       id: string;
-      data: Record<string, any>;
+      data: Record<string, unknown>;
       avatarPath?: string | null;
       avatarFilePath?: string | null;
       avatarFilename?: string | null;
     }>) {
       const parsed = char.data ?? {};
+      const extensions =
+        parsed.extensions && typeof parsed.extensions === "object" && !Array.isArray(parsed.extensions)
+          ? (parsed.extensions as Record<string, unknown>)
+          : {};
       map.set(char.id, {
-        name: parsed.name ?? "Unknown",
+        name: typeof parsed.name === "string" ? parsed.name : "Unknown",
         avatarUrl: characterAvatarUrl(char),
-        avatarCrop: parsed.extensions?.avatarCrop ?? null,
+        avatarCrop: (extensions.avatarCrop as AvatarCropValue | undefined) ?? null,
       });
     }
     return map;

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -21,7 +21,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import { useGenerate } from "../../../../runtime/generation/index";
-import { useApplyRegex } from "../../../../catalog/agents/regex-application";
+import { useApplyRegex, type ScopedRegexMode } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
 import { characterKeys } from "../../../../catalog/characters/index";
 import { personaKeys } from "../../../../catalog/personas/index";
@@ -74,6 +74,10 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yaml",
   "yml",
 ]);
+
+function readScopedRegexMode(value: unknown): ScopedRegexMode | undefined {
+  return value === "disabled" || value === "exclusive" || value === "chat" ? value : undefined;
+}
 
 function getFileExtension(fileName: string): string {
   const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
@@ -572,7 +576,10 @@ export const ChatInput = memo(function ChatInput({
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     const chatMeta = parseChatMetadata(chat?.metadata);
-    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros, scopedMode: chatMeta.scopedRegexMode });
+    let message = applyToUserInput(normalized, {
+      resolveMacros: resolveInputMacros,
+      scopedMode: readScopedRegexMode(chatMeta.scopedRegexMode),
+    });
 
     // Input translation: translate user's message before sending
     if (chatMeta.translateInput && message.trim()) {
@@ -750,7 +757,10 @@ export const ChatInput = memo(function ChatInput({
     const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(personaKeys.list);
     const resolveInputMacros = createInputMacroResolverForChat(chat, cachedCharacters, cachedPersonas, normalized);
     const chatMeta2 = parseChatMetadata(chat?.metadata);
-    let message = applyToUserInput(normalized, { resolveMacros: resolveInputMacros, scopedMode: chatMeta2.scopedRegexMode });
+    let message = applyToUserInput(normalized, {
+      resolveMacros: resolveInputMacros,
+      scopedMode: readScopedRegexMode(chatMeta2.scopedRegexMode),
+    });
 
     if (chatMeta2.translateInput && message.trim()) {
       try {

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -449,6 +449,56 @@ function normalizeNonNegativeInteger(value: unknown, fallback: number, max: numb
   return Math.max(0, Math.min(max, Math.trunc(value)));
 }
 
+type ChoiceSelections = Record<string, string | string[]>;
+type TranslationProvider = "ai" | "deeplx" | "deepl" | "google";
+type ScopedRegexModeValue = "disabled" | "exclusive" | "chat";
+type CharacterScheduleMap = Record<
+  string,
+  {
+    weekStart: string;
+    days: Record<string, ScheduleBlock[]>;
+    inactivityThresholdMinutes: number;
+    idleResponseDelayMinutes?: number;
+    dndResponseDelayMinutes?: number;
+    talkativeness: number;
+  }
+>;
+
+function metadataString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function metadataStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function metadataNumber(value: unknown, fallback = 0): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function metadataChoiceSelections(value: unknown): ChoiceSelections {
+  const record = metadataRecord(value);
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      (entry): entry is [string, string | string[]] =>
+        typeof entry[1] === "string" || (Array.isArray(entry[1]) && entry[1].every((item) => typeof item === "string")),
+    ),
+  );
+}
+
+function metadataTranslationProvider(value: unknown): TranslationProvider {
+  return value === "ai" || value === "deeplx" || value === "deepl" || value === "google" ? value : "google";
+}
+
+function metadataScopedRegexMode(value: unknown): ScopedRegexModeValue {
+  return value === "disabled" || value === "exclusive" || value === "chat" ? value : "chat";
+}
+
 function getChatActiveAgentIds(chat: Chat): string[] {
   const metadata =
     chat.metadata && typeof chat.metadata === "object" && !Array.isArray(chat.metadata) ? chat.metadata : {};
@@ -559,20 +609,18 @@ function ChatSettingsDrawerInner({
   const { data: allChats } = useChatSummaries();
   const personas = useMemo(() => (allPersonas ?? []) as DrawerPersona[], [allPersonas]);
 
-  const metadata = useMemo<Record<string, any>>(
+  const metadata = useMemo<Record<string, unknown>>(
     () => (chat.metadata && typeof chat.metadata === "object" && !Array.isArray(chat.metadata) ? chat.metadata : {}),
     [chat.metadata],
   );
+  const characterSchedules = metadataRecord(metadata.characterSchedules) as unknown as CharacterScheduleMap;
   const isSceneChat = metadata.sceneStatus === "active" || typeof metadata.sceneOriginChatId === "string";
-  const hasGeneratedConversationSchedules =
-    !!metadata.characterSchedules &&
-    typeof metadata.characterSchedules === "object" &&
-    Object.keys(metadata.characterSchedules).length > 0;
+  const hasGeneratedConversationSchedules = Object.keys(characterSchedules).length > 0;
   const conversationSchedulesEnabled =
     metadata.conversationSchedulesEnabled === true ||
     (metadata.conversationSchedulesEnabled == null && hasGeneratedConversationSchedules);
   const activeLorebookIds = useMemo<string[]>(
-    () => (Array.isArray(metadata.activeLorebookIds) ? metadata.activeLorebookIds : []),
+    () => metadataStringArray(metadata.activeLorebookIds),
     [metadata.activeLorebookIds],
   );
   const gameLorebookKeeperEnabled = metadata.gameLorebookKeeperEnabled === true;
@@ -604,7 +652,7 @@ function ChatSettingsDrawerInner({
     typeof metadata.lorebookTokenBudget === "number" && Number.isFinite(metadata.lorebookTokenBudget)
       ? Math.max(0, Math.floor(metadata.lorebookTokenBudget))
       : LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET;
-  const activeAgentIds = useMemo<string[]>(() => metadata.activeAgentIds ?? [], [metadata.activeAgentIds]);
+  const activeAgentIds = useMemo<string[]>(() => metadataStringArray(metadata.activeAgentIds), [metadata.activeAgentIds]);
   const inactiveCharacterIds = useMemo<string[]>(
     () =>
       Array.isArray(metadata.inactiveCharacterIds)
@@ -619,7 +667,31 @@ function ChatSettingsDrawerInner({
     () => chatCharIds.filter((id) => !inactiveCharacterIdSet.has(id)).length,
     [chatCharIds, inactiveCharacterIdSet],
   );
-  const activeToolIds: string[] = metadata.activeToolIds ?? [];
+  const activeToolIds = metadataStringArray(metadata.activeToolIds);
+  const agentsEnabled = isEnabledFlag(metadata.enableAgents, false);
+  const toolsEnabled = isEnabledFlag(metadata.enableTools, false);
+  const manualTrackersEnabled = isEnabledFlag(metadata.manualTrackers, false);
+  const hapticFeedbackEnabled = isEnabledFlag(metadata.enableHapticFeedback, false);
+  const spriteGenerationEnabled = isEnabledFlag(metadata.enableSpriteGeneration, false);
+  const autonomousMessagesEnabled = isEnabledFlag(metadata.autonomousMessages, false);
+  const characterExchangesEnabled = isEnabledFlag(metadata.characterExchanges, false);
+  const groupSpeakerColorsEnabled = isEnabledFlag(metadata.groupSpeakerColors, false);
+  const autoTranslateEnabled = isEnabledFlag(metadata.autoTranslate, false);
+  const translateInputEnabled = isEnabledFlag(metadata.translateInput, false);
+  const inputTranslateButtonVisible = isEnabledFlag(metadata.showInputTranslateButton, false);
+  const contextMessageLimit = metadataNumber(metadata.contextMessageLimit, 0);
+  const hasContextMessageLimit = contextMessageLimit > 0;
+  const discordWebhookUrl = metadataString(metadata.discordWebhookUrl);
+  const translationProvider = metadataTranslationProvider(metadata.translationProvider);
+  const translationTargetLang = metadataString(metadata.translationTargetLang, "en");
+  const translationConnectionId = metadataString(metadata.translationConnectionId);
+  const translationDeeplApiKey = metadataString(metadata.translationDeeplApiKey);
+  const translationDeeplxUrl = metadataString(metadata.translationDeeplxUrl);
+  const sceneSystemPrompt = metadataString(metadata.sceneSystemPrompt);
+  const groupScenarioText = metadataString(metadata.groupScenarioText);
+  const gameExtraPrompt = metadataString(metadata.gameExtraPrompt);
+  const gameImagePromptInstructions = metadataString(metadata.gameImagePromptInstructions);
+  const presetChoices = metadataChoiceSelections(metadata.presetChoices);
   const { data: allRegexScripts } = useRegexScripts(chatCharIds);
   const updateRegexScript = useUpdateRegexScript();
   const scopedRegexScripts = useMemo(() => (allRegexScripts ?? []).filter((s) => !!s.characterId), [allRegexScripts]);
@@ -640,7 +712,7 @@ function ChatSettingsDrawerInner({
     typeof metadata.gameSpotifyPlaylistId === "string" ? metadata.gameSpotifyPlaylistId : "";
   const gameSpotifyArtist = typeof metadata.gameSpotifyArtist === "string" ? metadata.gameSpotifyArtist : "";
   const gameAgentFeatureCount =
-    (metadata.enableAgents ? 1 : 0) + (gameLorebookKeeperEnabled ? 1 : 0) + (gameUseSpotifyMusic ? 1 : 0);
+    (agentsEnabled ? 1 : 0) + (gameLorebookKeeperEnabled ? 1 : 0) + (gameUseSpotifyMusic ? 1 : 0);
   const spriteCharacterIds = useMemo<string[]>(
     () => (Array.isArray(metadata.spriteCharacterIds) ? metadata.spriteCharacterIds : []),
     [metadata.spriteCharacterIds],
@@ -668,7 +740,7 @@ function ChatSettingsDrawerInner({
     enabled:
       open &&
       ((isGame && gameUseSpotifyMusic && gameSpotifySourceType === "playlist") ||
-        (isRoleplayMode && metadata.enableAgents && spotifyActive && spotifySourceType === "playlist")),
+        (isRoleplayMode && agentsEnabled && spotifyActive && spotifySourceType === "playlist")),
     staleTime: 60_000,
     retry: false,
   });
@@ -1438,17 +1510,17 @@ function ChatSettingsDrawerInner({
     [chat.id, chatCharIds, qc],
   );
   const [scenePromptExpanded, setScenePromptExpanded] = useState(false);
-  const [scenePromptDraft, setScenePromptDraft] = useState(metadata.sceneSystemPrompt ?? "");
-  const [groupScenarioDraft, setGroupScenarioDraft] = useState((metadata.groupScenarioText as string) ?? "");
+  const [scenePromptDraft, setScenePromptDraft] = useState(sceneSystemPrompt);
+  const [groupScenarioDraft, setGroupScenarioDraft] = useState(groupScenarioText);
   const [groupScenarioExpanded, setGroupScenarioExpanded] = useState(false);
   const gameAgentPool = useMemo(
     () => Array.from(new Set(activeAgentIds.filter((id) => id !== "spotify" && id !== "lorebook-keeper"))),
     [activeAgentIds],
   );
-  const [extraPromptDraft, setExtraPromptDraft] = useState((metadata.gameExtraPrompt as string) ?? "");
+  const [extraPromptDraft, setExtraPromptDraft] = useState(gameExtraPrompt);
   const [extraPromptExpanded, setExtraPromptExpanded] = useState(false);
   const [gameImagePromptInstructionsDraft, setGameImagePromptInstructionsDraft] = useState(
-    (metadata.gameImagePromptInstructions as string) ?? "",
+    gameImagePromptInstructions,
   );
   const [spotifyArtistDraft, setSpotifyArtistDraft] = useState(spotifyArtist);
   const [gameSpotifyArtistDraft, setGameSpotifyArtistDraft] = useState(gameSpotifyArtist);
@@ -1489,8 +1561,8 @@ function ChatSettingsDrawerInner({
   }, [open]);
 
   useEffect(() => {
-    setGameImagePromptInstructionsDraft((metadata.gameImagePromptInstructions as string) ?? "");
-  }, [chat.id, metadata.gameImagePromptInstructions]);
+    setGameImagePromptInstructionsDraft(gameImagePromptInstructions);
+  }, [chat.id, gameImagePromptInstructions]);
 
   useEffect(() => {
     setSpotifyArtistDraft(spotifyArtist);
@@ -2102,7 +2174,7 @@ function ChatSettingsDrawerInner({
           </Section>
 
           {/* Preset — hidden for conversation mode and game mode */}
-          {!isConversation && !isGame && !metadata.sceneSystemPrompt && (
+          {!isConversation && !isGame && !sceneSystemPrompt && (
             <Section
               label="Prompt Preset"
               icon={<Sliders size="0.875rem" />}
@@ -2153,7 +2225,7 @@ function ChatSettingsDrawerInner({
                     value={extraPromptDraft}
                     onChange={(e) => setExtraPromptDraft(e.target.value)}
                     onBlur={() => {
-                      const stored = (metadata.gameExtraPrompt as string) ?? "";
+                      const stored = gameExtraPrompt;
                       if (extraPromptDraft !== stored) {
                         updateMeta.mutate({ id: chat.id, gameExtraPrompt: extraPromptDraft || null });
                       }
@@ -2189,7 +2261,7 @@ function ChatSettingsDrawerInner({
                 open={extraPromptExpanded}
                 onClose={() => {
                   setExtraPromptExpanded(false);
-                  const stored = (metadata.gameExtraPrompt as string) ?? "";
+                  const stored = gameExtraPrompt;
                   if (extraPromptDraft !== stored) {
                     updateMeta.mutate({ id: chat.id, gameExtraPrompt: extraPromptDraft || null });
                   }
@@ -2203,7 +2275,7 @@ function ChatSettingsDrawerInner({
           )}
 
           {/* Scene System Prompt — shown only for scene-created chats */}
-          {metadata.sceneSystemPrompt && (
+          {sceneSystemPrompt && (
             <Section
               label="Scene Instructions"
               icon={<Sparkles size="0.875rem" />}
@@ -2214,7 +2286,7 @@ function ChatSettingsDrawerInner({
                   value={scenePromptDraft}
                   onChange={(e) => setScenePromptDraft(e.target.value)}
                   onBlur={() => {
-                    if (scenePromptDraft !== metadata.sceneSystemPrompt) {
+                    if (scenePromptDraft !== sceneSystemPrompt) {
                       updateMeta.mutate({ id: chat.id, sceneSystemPrompt: scenePromptDraft });
                     }
                   }}
@@ -2234,7 +2306,7 @@ function ChatSettingsDrawerInner({
                 open={scenePromptExpanded}
                 onClose={() => {
                   setScenePromptExpanded(false);
-                  if (scenePromptDraft !== metadata.sceneSystemPrompt) {
+                  if (scenePromptDraft !== sceneSystemPrompt) {
                     updateMeta.mutate({ id: chat.id, sceneSystemPrompt: scenePromptDraft });
                   }
                 }}
@@ -3003,10 +3075,10 @@ function ChatSettingsDrawerInner({
               {!isConversation && (metadata.groupChatMode ?? "merged") === "merged" && (
                 <div className="mt-2">
                   <button
-                    onClick={() => updateMeta.mutate({ id: chat.id, groupSpeakerColors: !metadata.groupSpeakerColors })}
+                    onClick={() => updateMeta.mutate({ id: chat.id, groupSpeakerColors: !groupSpeakerColorsEnabled })}
                     className={cn(
                       "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.groupSpeakerColors
+                      groupSpeakerColorsEnabled
                         ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                         : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                     )}
@@ -3021,13 +3093,13 @@ function ChatSettingsDrawerInner({
                     <div
                       className={cn(
                         "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.groupSpeakerColors ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                        groupSpeakerColorsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                       )}
                     >
                       <div
                         className={cn(
                           "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                          metadata.groupSpeakerColors && "translate-x-3.5",
+                          groupSpeakerColorsEnabled && "translate-x-3.5",
                         )}
                       />
                     </div>
@@ -3133,7 +3205,7 @@ function ChatSettingsDrawerInner({
                       value={groupScenarioDraft}
                       onChange={(e) => setGroupScenarioDraft(e.target.value)}
                       onBlur={() => {
-                        if (groupScenarioDraft !== (metadata.groupScenarioText ?? "")) {
+                        if (groupScenarioDraft !== groupScenarioText) {
                           updateMeta.mutate({ id: chat.id, groupScenarioText: groupScenarioDraft });
                         }
                       }}
@@ -3153,7 +3225,7 @@ function ChatSettingsDrawerInner({
                     open={groupScenarioExpanded}
                     onClose={() => {
                       setGroupScenarioExpanded(false);
-                      if (groupScenarioDraft !== (metadata.groupScenarioText ?? "")) {
+                      if (groupScenarioDraft !== groupScenarioText) {
                         updateMeta.mutate({ id: chat.id, groupScenarioText: groupScenarioDraft });
                       }
                     }}
@@ -3178,11 +3250,11 @@ function ChatSettingsDrawerInner({
                 {/* Enable autonomous messages toggle */}
                 <button
                   onClick={() => {
-                    updateMeta.mutate({ id: chat.id, autonomousMessages: !metadata.autonomousMessages });
+                    updateMeta.mutate({ id: chat.id, autonomousMessages: !autonomousMessagesEnabled });
                   }}
                   className={cn(
                     "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    metadata.autonomousMessages
+                    autonomousMessagesEnabled
                       ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                       : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                   )}
@@ -3196,13 +3268,13 @@ function ChatSettingsDrawerInner({
                   <div
                     className={cn(
                       "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      metadata.autonomousMessages ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                      autonomousMessagesEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                     )}
                   >
                     <div
                       className={cn(
                         "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                        metadata.autonomousMessages && "translate-x-3.5",
+                        autonomousMessagesEnabled && "translate-x-3.5",
                       )}
                     />
                   </div>
@@ -3212,11 +3284,11 @@ function ChatSettingsDrawerInner({
                 {chatCharIds.length > 1 && (
                   <button
                     onClick={() => {
-                      updateMeta.mutate({ id: chat.id, characterExchanges: !metadata.characterExchanges });
+                      updateMeta.mutate({ id: chat.id, characterExchanges: !characterExchangesEnabled });
                     }}
                     className={cn(
                       "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.characterExchanges
+                      characterExchangesEnabled
                         ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                         : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                     )}
@@ -3230,13 +3302,13 @@ function ChatSettingsDrawerInner({
                     <div
                       className={cn(
                         "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.characterExchanges ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                        characterExchangesEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                       )}
                     >
                       <div
                         className={cn(
                           "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                          metadata.characterExchanges && "translate-x-3.5",
+                          characterExchangesEnabled && "translate-x-3.5",
                         )}
                       />
                     </div>
@@ -3325,7 +3397,7 @@ function ChatSettingsDrawerInner({
                 {/* Schedule editor per character */}
                 {conversationSchedulesEnabled && hasGeneratedConversationSchedules && (
                   <ScheduleEditor
-                    characterSchedules={metadata.characterSchedules}
+                    characterSchedules={characterSchedules}
                     chatCharIds={chatCharIds}
                     charNameMap={charNameMap}
                     onSave={(updated) => {
@@ -3911,7 +3983,7 @@ function ChatSettingsDrawerInner({
             help="Character-scoped regex scripts imported from ST cards. Control how they interact with global regex scripts."
           >
             <ScopedRegexModeSelector
-              mode={(metadata.scopedRegexMode as "disabled" | "exclusive" | "chat" | undefined) ?? "chat"}
+              mode={metadataScopedRegexMode(metadata.scopedRegexMode)}
               onChange={(mode) => updateMeta.mutate({ id: chat.id, scopedRegexMode: mode })}
             />
             <ScopedRegexCharacterGroups
@@ -3971,7 +4043,7 @@ function ChatSettingsDrawerInner({
               help="When enabled, AI agents run automatically during generation to enrich the chat with world state tracking, expression detection, and more."
             >
               <div className="space-y-2">
-                {isGame && metadata.enableAgents && (
+                {isGame && agentsEnabled && (
                   <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
                     Toggle agents for this game session. Only the ones below are allowed to ensure the game's format
                     doesn't break.
@@ -3979,11 +4051,11 @@ function ChatSettingsDrawerInner({
                 )}
                 <button
                   onClick={() => {
-                    updateMeta.mutate({ id: chat.id, enableAgents: !metadata.enableAgents });
+                    updateMeta.mutate({ id: chat.id, enableAgents: !agentsEnabled });
                   }}
                   className={cn(
                     "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    metadata.enableAgents
+                    agentsEnabled
                       ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                       : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                   )}
@@ -3996,7 +4068,7 @@ function ChatSettingsDrawerInner({
                         : "Run AI agents during generation (world state, expressions, etc.)"}
                     </p>
                     {isGame &&
-                      metadata.enableAgents &&
+                      agentsEnabled &&
                       (() => {
                         const setupCfg = metadata.gameSetupConfig as Record<string, unknown> | undefined;
                         const sceneConnId =
@@ -4015,18 +4087,18 @@ function ChatSettingsDrawerInner({
                   <div
                     className={cn(
                       "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      metadata.enableAgents ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                      agentsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                     )}
                   >
                     <div
                       className={cn(
                         "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                        metadata.enableAgents && "translate-x-3.5",
+                        agentsEnabled && "translate-x-3.5",
                       )}
                     />
                   </div>
                 </button>
-                {isGame && metadata.enableAgents && (
+                {isGame && agentsEnabled && (
                   <div className="mt-1.5 px-3">
                     <select
                       value={(metadata.gameSceneConnectionId as string) ?? ""}
@@ -4238,7 +4310,7 @@ function ChatSettingsDrawerInner({
                   </div>
                 )}
 
-                {metadata.enableAgents && !isGame && (
+                {agentsEnabled && !isGame && (
                   <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                       <div className="min-w-0">
@@ -4350,7 +4422,7 @@ function ChatSettingsDrawerInner({
                   </div>
                 )}
 
-                {metadata.enableAgents && !isGame && (
+                {agentsEnabled && !isGame && (
                   <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
                     <div className="flex items-start gap-2">
                       <Image size="0.75rem" className="mt-0.5 text-[var(--primary)]" />
@@ -4585,7 +4657,7 @@ function ChatSettingsDrawerInner({
                   </div>
                 )}
 
-                {metadata.enableAgents && isRoleplayMode && spotifyActive && (
+                {agentsEnabled && isRoleplayMode && spotifyActive && (
                   <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
                     <div className="flex items-start gap-2">
                       <Music2 size="0.75rem" className="mt-0.5 text-[var(--primary)]" />
@@ -4710,12 +4782,12 @@ function ChatSettingsDrawerInner({
                 )}
 
                 {/* Manual trackers toggle — not for game mode */}
-                {metadata.enableAgents && !isGame && (
+                {agentsEnabled && !isGame && (
                   <button
-                    onClick={() => updateMeta.mutate({ id: chat.id, manualTrackers: !metadata.manualTrackers })}
+                    onClick={() => updateMeta.mutate({ id: chat.id, manualTrackers: !manualTrackersEnabled })}
                     className={cn(
                       "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.manualTrackers
+                      manualTrackersEnabled
                         ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                         : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                     )}
@@ -4723,7 +4795,7 @@ function ChatSettingsDrawerInner({
                     <div>
                       <span className="text-[0.6875rem] font-medium">Manual Trackers</span>
                       <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                        {metadata.manualTrackers
+                        {manualTrackersEnabled
                           ? "Trackers won't run automatically — use the button in the HUD to trigger them."
                           : "Trackers run automatically after every generation."}
                       </p>
@@ -4731,13 +4803,13 @@ function ChatSettingsDrawerInner({
                     <div
                       className={cn(
                         "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors shrink-0",
-                        metadata.manualTrackers ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                        manualTrackersEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                       )}
                     >
                       <div
                         className={cn(
                           "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                          metadata.manualTrackers && "translate-x-3.5",
+                          manualTrackersEnabled && "translate-x-3.5",
                         )}
                       />
                     </div>
@@ -4745,15 +4817,15 @@ function ChatSettingsDrawerInner({
                 )}
 
                 {/* Love Toys Control — not for game mode */}
-                {metadata.enableAgents && !isGame && hapticAgentActive && (
+                {agentsEnabled && !isGame && hapticAgentActive && (
                   <div className="space-y-1.5">
                     <button
                       onClick={() => {
-                        updateMeta.mutate({ id: chat.id, enableHapticFeedback: !metadata.enableHapticFeedback });
+                        updateMeta.mutate({ id: chat.id, enableHapticFeedback: !hapticFeedbackEnabled });
                       }}
                       className={cn(
                         "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                        metadata.enableHapticFeedback
+                        hapticFeedbackEnabled
                           ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                           : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                       )}
@@ -4769,18 +4841,18 @@ function ChatSettingsDrawerInner({
                       <div
                         className={cn(
                           "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                          metadata.enableHapticFeedback ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                          hapticFeedbackEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                         )}
                       >
                         <div
                           className={cn(
                             "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                            metadata.enableHapticFeedback && "translate-x-3.5",
+                            hapticFeedbackEnabled && "translate-x-3.5",
                           )}
                         />
                       </div>
                     </button>
-                    {metadata.enableHapticFeedback && (
+                    {hapticFeedbackEnabled && (
                       <HapticConnectionPanel
                         intifaceUrl={
                           typeof metadata.hapticIntifaceUrl === "string" ? metadata.hapticIntifaceUrl : undefined
@@ -4798,11 +4870,11 @@ function ChatSettingsDrawerInner({
                   <div>
                     <button
                       onClick={() =>
-                        updateMeta.mutate({ id: chat.id, enableSpriteGeneration: !metadata.enableSpriteGeneration })
+                        updateMeta.mutate({ id: chat.id, enableSpriteGeneration: !spriteGenerationEnabled })
                       }
                       className={cn(
                         "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                        metadata.enableSpriteGeneration
+                        spriteGenerationEnabled
                           ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                           : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                       )}
@@ -4818,18 +4890,18 @@ function ChatSettingsDrawerInner({
                       <div
                         className={cn(
                           "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                          metadata.enableSpriteGeneration ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                          spriteGenerationEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                         )}
                       >
                         <div
                           className={cn(
                             "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                            metadata.enableSpriteGeneration && "translate-x-3.5",
+                            spriteGenerationEnabled && "translate-x-3.5",
                           )}
                         />
                       </div>
                     </button>
-                    {metadata.enableSpriteGeneration && (
+                    {spriteGenerationEnabled && (
                       <div className="mt-1.5 space-y-2 px-3">
                         <select
                           value={(metadata.gameImageConnectionId as string) ?? ""}
@@ -4874,7 +4946,7 @@ function ChatSettingsDrawerInner({
                 )}
 
                 {/* Categorized agent sub-sections */}
-                {metadata.enableAgents && (
+                {agentsEnabled && (
                   <>
                     {isGame ? (
                       <div className="space-y-1">
@@ -5380,16 +5452,16 @@ function ChatSettingsDrawerInner({
               <input
                 type="url"
                 placeholder="https://discord.com/api/webhooks/..."
-                value={(metadata.discordWebhookUrl as string) ?? ""}
+                value={discordWebhookUrl}
                 onChange={(e) => {
                   updateMeta.mutate({ id: chat.id, discordWebhookUrl: e.target.value.trim() || undefined });
                 }}
                 className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-[0.6875rem] text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50 ring-1 ring-transparent focus:ring-[var(--primary)]/40 focus:outline-none transition-all"
               />
-              {metadata.discordWebhookUrl &&
-                !/^https:\/\/discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/.test(
-                  (metadata.discordWebhookUrl as string).trim(),
-                ) && <p className="text-[0.625rem] text-red-400">Invalid webhook URL format</p>}
+              {discordWebhookUrl &&
+                !/^https:\/\/discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/.test(discordWebhookUrl.trim()) && (
+                  <p className="text-[0.625rem] text-red-400">Invalid webhook URL format</p>
+                )}
             </div>
           </Section>
 
@@ -5403,11 +5475,11 @@ function ChatSettingsDrawerInner({
             <div className="space-y-2">
               <button
                 onClick={() => {
-                  updateMeta.mutate({ id: chat.id, enableTools: !metadata.enableTools });
+                  updateMeta.mutate({ id: chat.id, enableTools: !toolsEnabled });
                 }}
                 className={cn(
                   "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                  metadata.enableTools
+                  toolsEnabled
                     ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                     : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                 )}
@@ -5421,25 +5493,25 @@ function ChatSettingsDrawerInner({
                 <div
                   className={cn(
                     "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors",
-                    metadata.enableTools ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                    toolsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                   )}
                 >
                   <div
                     className={cn(
                       "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      metadata.enableTools && "translate-x-3.5",
+                      toolsEnabled && "translate-x-3.5",
                     )}
                   />
                 </div>
               </button>
               <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1">
-                {metadata.enableTools
+                {toolsEnabled
                   ? "If enabled, this chat can use globally enabled tools (or any tools you add below)."
                   : "If disabled, no functions will be available."}
               </p>
 
               {/* Per-chat tool list */}
-              {metadata.enableTools && (
+              {toolsEnabled && (
                 <>
                   {activeToolIds.length === 0 ? (
                     <p className="text-[0.6875rem] text-[var(--muted-foreground)] px-1">
@@ -5585,7 +5657,7 @@ function ChatSettingsDrawerInner({
               <div>
                 <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Provider</label>
                 <select
-                  value={metadata.translationProvider ?? "google"}
+                  value={translationProvider}
                   onChange={(e) => updateMeta.mutate({ id: chat.id, translationProvider: e.target.value })}
                   className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                 >
@@ -5602,7 +5674,7 @@ function ChatSettingsDrawerInner({
                   Target Language
                   <HelpTooltip
                     text={
-                      metadata.translationProvider === "ai"
+                      translationProvider === "ai"
                         ? "Language name (e.g. English, Japanese, Spanish)"
                         : "Language code (e.g. en, ja, es, de, fr, zh, ko)"
                     }
@@ -5611,22 +5683,22 @@ function ChatSettingsDrawerInner({
                 </label>
                 <input
                   type="text"
-                  value={metadata.translationTargetLang ?? "en"}
+                  value={translationTargetLang}
                   onChange={(e) => updateMeta.mutate({ id: chat.id, translationTargetLang: e.target.value })}
-                  placeholder={metadata.translationProvider === "ai" ? "English" : "en"}
+                  placeholder={translationProvider === "ai" ? "English" : "en"}
                   className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                 />
               </div>
 
               {/* AI-specific: connection selector */}
-              {metadata.translationProvider === "ai" && (
+              {translationProvider === "ai" && (
                 <div>
                   <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
                     Connection
                     <HelpTooltip text="Which AI connection to use for translation" size="0.625rem" />
                   </label>
                   <select
-                    value={metadata.translationConnectionId ?? ""}
+                    value={translationConnectionId}
                     onChange={(e) =>
                       updateMeta.mutate({ id: chat.id, translationConnectionId: e.target.value || undefined })
                     }
@@ -5643,12 +5715,12 @@ function ChatSettingsDrawerInner({
               )}
 
               {/* DeepL API key */}
-              {metadata.translationProvider === "deepl" && (
+              {translationProvider === "deepl" && (
                 <div>
                   <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">DeepL API Key</label>
                   <input
                     type="password"
-                    value={metadata.translationDeeplApiKey ?? ""}
+                    value={translationDeeplApiKey}
                     onChange={(e) => updateMeta.mutate({ id: chat.id, translationDeeplApiKey: e.target.value })}
                     placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:fx"
                     className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
@@ -5657,7 +5729,7 @@ function ChatSettingsDrawerInner({
               )}
 
               {/* DeepLX URL */}
-              {metadata.translationProvider === "deeplx" && (
+              {translationProvider === "deeplx" && (
                 <div>
                   <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
                     DeepLX URL
@@ -5668,7 +5740,7 @@ function ChatSettingsDrawerInner({
                   </label>
                   <input
                     type="text"
-                    value={metadata.translationDeeplxUrl ?? ""}
+                    value={translationDeeplxUrl}
                     onChange={(e) => updateMeta.mutate({ id: chat.id, translationDeeplxUrl: e.target.value })}
                     placeholder="http://localhost:1188"
                     className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
@@ -5679,11 +5751,11 @@ function ChatSettingsDrawerInner({
               {/* Auto-translate toggle */}
               <button
                 onClick={() => {
-                  updateMeta.mutate({ id: chat.id, autoTranslate: !metadata.autoTranslate });
+                  updateMeta.mutate({ id: chat.id, autoTranslate: !autoTranslateEnabled });
                 }}
                 className={cn(
                   "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                  metadata.autoTranslate
+                  autoTranslateEnabled
                     ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                     : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                 )}
@@ -5697,13 +5769,13 @@ function ChatSettingsDrawerInner({
                 <div
                   className={cn(
                     "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                    metadata.autoTranslate ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                    autoTranslateEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                   )}
                 >
                   <div
                     className={cn(
                       "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      metadata.autoTranslate && "translate-x-3.5",
+                      autoTranslateEnabled && "translate-x-3.5",
                     )}
                   />
                 </div>
@@ -5712,11 +5784,11 @@ function ChatSettingsDrawerInner({
               {/* Translate input toggle */}
               <button
                 onClick={() => {
-                  updateMeta.mutate({ id: chat.id, translateInput: !metadata.translateInput });
+                  updateMeta.mutate({ id: chat.id, translateInput: !translateInputEnabled });
                 }}
                 className={cn(
                   "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                  metadata.translateInput
+                  translateInputEnabled
                     ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                     : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                 )}
@@ -5730,13 +5802,13 @@ function ChatSettingsDrawerInner({
                 <div
                   className={cn(
                     "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                    metadata.translateInput ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                    translateInputEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                   )}
                 >
                   <div
                     className={cn(
                       "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      metadata.translateInput && "translate-x-3.5",
+                      translateInputEnabled && "translate-x-3.5",
                     )}
                   />
                 </div>
@@ -5745,11 +5817,11 @@ function ChatSettingsDrawerInner({
               {/* Draft translate button toggle */}
               <button
                 onClick={() => {
-                  updateMeta.mutate({ id: chat.id, showInputTranslateButton: !metadata.showInputTranslateButton });
+                  updateMeta.mutate({ id: chat.id, showInputTranslateButton: !inputTranslateButtonVisible });
                 }}
                 className={cn(
                   "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                  metadata.showInputTranslateButton
+                  inputTranslateButtonVisible
                     ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                     : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                 )}
@@ -5763,13 +5835,13 @@ function ChatSettingsDrawerInner({
                 <div
                   className={cn(
                     "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                    metadata.showInputTranslateButton ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                    inputTranslateButtonVisible ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                   )}
                 >
                   <div
                     className={cn(
                       "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      metadata.showInputTranslateButton && "translate-x-3.5",
+                      inputTranslateButtonVisible && "translate-x-3.5",
                     )}
                   />
                 </div>
@@ -5798,7 +5870,7 @@ function ChatSettingsDrawerInner({
             <div className="space-y-2">
               <button
                 onClick={() => {
-                  if (metadata.contextMessageLimit) {
+                  if (hasContextMessageLimit) {
                     updateMeta.mutate({ id: chat.id, contextMessageLimit: null });
                   } else {
                     updateMeta.mutate({ id: chat.id, contextMessageLimit: 50 });
@@ -5806,7 +5878,7 @@ function ChatSettingsDrawerInner({
                 }}
                 className={cn(
                   "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                  metadata.contextMessageLimit
+                  hasContextMessageLimit
                     ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                     : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                 )}
@@ -5820,24 +5892,24 @@ function ChatSettingsDrawerInner({
                 <div
                   className={cn(
                     "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors",
-                    metadata.contextMessageLimit ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                    hasContextMessageLimit ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                   )}
                 >
                   <div
                     className={cn(
                       "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      metadata.contextMessageLimit && "translate-x-3.5",
+                      hasContextMessageLimit && "translate-x-3.5",
                     )}
                   />
                 </div>
               </button>
-              {metadata.contextMessageLimit && (
+              {hasContextMessageLimit && (
                 <div className="flex items-center gap-2 px-1">
                   <input
                     type="number"
                     min={1}
                     max={9999}
-                    value={metadata.contextMessageLimit}
+                    value={contextMessageLimit}
                     onChange={(e) => {
                       const val = parseInt(e.target.value, 10);
                       if (val > 0) {
@@ -5904,7 +5976,7 @@ function ChatSettingsDrawerInner({
         onClose={() => setChoiceModalPresetId(null)}
         presetId={choiceModalPresetId}
         chatId={chat.id}
-        existingChoices={metadata.presetChoices ?? {}}
+        existingChoices={presetChoices}
       />
 
       {/* Automatic summarization editor */}

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-metadata-sync.ts
@@ -7,10 +7,18 @@ import type { MessageWithSwipes } from "../types";
 
 type UseChatMetadataSyncOptions = {
   chat: Chat | null | undefined;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   messages: MessageWithSwipes[] | undefined;
   messagePageCount: number;
 };
+
+function metadataString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function metadataTranslationProvider(value: unknown): "ai" | "deeplx" | "deepl" | "google" {
+  return value === "ai" || value === "deeplx" || value === "deepl" || value === "google" ? value : "google";
+}
 
 export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount }: UseChatMetadataSyncOptions) {
   const chatBackground = useUIStore((state) => state.chatBackground);
@@ -19,11 +27,11 @@ export function useChatMetadataSync({ chat, chatMeta, messages, messagePageCount
   useEffect(() => {
     if (!chat?.id) return;
     useTranslationStore.getState().setConfig({
-      provider: chatMeta.translationProvider ?? "google",
-      targetLanguage: chatMeta.translationTargetLang ?? "en",
-      connectionId: chatMeta.translationConnectionId,
-      deeplApiKey: chatMeta.translationDeeplApiKey,
-      deeplxUrl: chatMeta.translationDeeplxUrl,
+      provider: metadataTranslationProvider(chatMeta.translationProvider),
+      targetLanguage: metadataString(chatMeta.translationTargetLang) ?? "en",
+      connectionId: metadataString(chatMeta.translationConnectionId),
+      deeplApiKey: metadataString(chatMeta.translationDeeplApiKey),
+      deeplxUrl: metadataString(chatMeta.translationDeeplxUrl),
     });
   }, [
     chat?.id,

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -14,7 +14,7 @@ import { useActivePersona, usePersona } from "../../../../catalog/personas/index
 import { ApiError } from "../../../../../shared/api/api-errors";
 import { getConnectedChatDisplayName, parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";
-import { parseAvatarCropJson } from "../../../../../shared/lib/utils";
+import { parseAvatarCropJson, type AvatarCropValue } from "../../../../../shared/lib/utils";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import type { CharacterMap, MessageWithSwipes, PersonaInfo } from "../types";
 
@@ -31,7 +31,7 @@ type UseChatSurfaceDataOptions = {
 
 type CharacterRow = {
   id: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   comment?: string | null;
   avatarPath: string | null;
   avatarFilePath?: string | null;
@@ -69,8 +69,27 @@ function parseChatCharacterIds(chat: Chat | null | undefined): string[] {
   return Array.isArray(raw) ? raw.filter((id): id is string => typeof id === "string") : [];
 }
 
-function parseCharacterData(data: Record<string, any>): Record<string, any> {
+function parseCharacterData(data: Record<string, unknown>): Record<string, unknown> {
   return data && typeof data === "object" ? data : {};
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readAvatarCrop(value: unknown): AvatarCropValue | null {
+  if (!value) return null;
+  if (typeof value === "string") return parseAvatarCropJson(value);
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  try {
+    return parseAvatarCropJson(JSON.stringify(value));
+  } catch {
+    return null;
+  }
 }
 
 function normalizeIds(ids: Array<string | null | undefined>): string[] {
@@ -105,9 +124,11 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
-function collectGameCharacterIds(chatMeta: Record<string, any>): string[] {
+function collectGameCharacterIds(chatMeta: Record<string, unknown>): string[] {
   const setup =
-    chatMeta.gameSetupConfig && typeof chatMeta.gameSetupConfig === "object" ? chatMeta.gameSetupConfig : {};
+    chatMeta.gameSetupConfig && typeof chatMeta.gameSetupConfig === "object" && !Array.isArray(chatMeta.gameSetupConfig)
+      ? (chatMeta.gameSetupConfig as Record<string, unknown>)
+      : {};
   const ids: Array<string | null | undefined> = [
     typeof setup.gmCharacterId === "string" ? setup.gmCharacterId : null,
     ...stringArray(setup.partyCharacterIds),
@@ -249,23 +270,31 @@ export function useChatSurfaceData({
     for (const character of (characterRows ?? []) as CharacterRow[]) {
       try {
         const parsed = parseCharacterData(character.data);
+        const extensions = readRecord(parsed.extensions);
+        const conversationStatus = readString(extensions.conversationStatus);
         map.set(character.id, {
-          name: parsed.name ?? "Unknown",
-          description: parsed.description ?? "",
-          personality: parsed.personality ?? "",
-          backstory: parsed.extensions?.backstory ?? "",
-          appearance: parsed.extensions?.appearance ?? "",
-          scenario: parsed.scenario ?? "",
-          example: parsed.mes_example ?? "",
-          systemPrompt: parsed.system_prompt ?? parsed.systemPrompt ?? "",
-          postHistoryInstructions: parsed.post_history_instructions ?? parsed.postHistoryInstructions ?? "",
+          name: readString(parsed.name, "Unknown"),
+          description: readString(parsed.description),
+          personality: readString(parsed.personality),
+          backstory: readString(extensions.backstory),
+          appearance: readString(extensions.appearance),
+          scenario: readString(parsed.scenario),
+          example: readString(parsed.mes_example),
+          systemPrompt: readString(parsed.system_prompt) || readString(parsed.systemPrompt),
+          postHistoryInstructions:
+            readString(parsed.post_history_instructions) || readString(parsed.postHistoryInstructions),
           avatarUrl: characterAvatarUrl(character),
-          nameColor: parsed.extensions?.nameColor || undefined,
-          dialogueColor: parsed.extensions?.dialogueColor || undefined,
-          boxColor: parsed.extensions?.boxColor || undefined,
-          avatarCrop: parsed.extensions?.avatarCrop || null,
-          conversationStatus: parsed.extensions?.conversationStatus || undefined,
-          conversationActivity: parsed.extensions?.conversationActivity || undefined,
+          nameColor: readString(extensions.nameColor) || undefined,
+          dialogueColor: readString(extensions.dialogueColor) || undefined,
+          boxColor: readString(extensions.boxColor) || undefined,
+          avatarCrop: readAvatarCrop(extensions.avatarCrop),
+          conversationStatus:
+            conversationStatus === "idle" || conversationStatus === "dnd" || conversationStatus === "offline"
+              ? conversationStatus
+              : conversationStatus === "online"
+                ? "online"
+                : undefined,
+          conversationActivity: readString(extensions.conversationActivity) || undefined,
         });
       } catch {
         map.set(character.id, { name: "Unknown", avatarUrl: null });
@@ -303,20 +332,21 @@ export function useChatSurfaceData({
         ? (characterRows as CharacterRow[]).map((character) => {
             try {
               const parsed = parseCharacterData(character.data);
+              const extensions = readRecord(parsed.extensions);
               const display = parseCharacterDisplayData(character);
               return {
                 id: character.id,
                 name: display.name,
                 comment: display.comment,
                 avatarUrl: characterAvatarUrl(character) ?? undefined,
-                avatarCrop: parsed.extensions?.avatarCrop || null,
-                nameColor: parsed.extensions?.nameColor || undefined,
-                dialogueColor: parsed.extensions?.dialogueColor || undefined,
-                description: parsed.description ?? "",
-                personality: parsed.personality ?? "",
-                backstory: parsed.extensions?.backstory ?? "",
-                appearance: parsed.extensions?.appearance ?? "",
-                tags: parsed.tags ?? [],
+                avatarCrop: readAvatarCrop(extensions.avatarCrop),
+                nameColor: readString(extensions.nameColor) || undefined,
+                dialogueColor: readString(extensions.dialogueColor) || undefined,
+                description: readString(parsed.description),
+                personality: readString(parsed.personality),
+                backstory: readString(extensions.backstory),
+                appearance: readString(extensions.appearance),
+                tags: stringArray(parsed.tags),
               };
             } catch {
               return { id: character.id, name: "Unknown" };

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -38,9 +38,9 @@ type UseChatTimelineActionsOptions = {
   refreshWorldStateOnTimelineChange?: boolean;
 };
 
-function readMessageExtra(message: MessageWithSwipes): Record<string, any> {
+function readMessageExtra(message: MessageWithSwipes): Record<string, unknown> {
   return message.extra && typeof message.extra === "object" && !Array.isArray(message.extra)
-    ? (message.extra as Record<string, any>)
+    ? (message.extra as unknown as Record<string, unknown>)
     : {};
 }
 
@@ -625,8 +625,10 @@ export function useChatTimelineActions({
       if (!prev || !curr) return false;
       if (prev.role !== curr.role || prev.characterId !== curr.characterId) return false;
       if (prev.role === "user" && curr.role === "user") {
-        const prevId = readMessageExtra(prev).personaSnapshot?.personaId;
-        const currId = readMessageExtra(curr).personaSnapshot?.personaId;
+        const prevSnapshot = readRecord(readMessageExtra(prev).personaSnapshot);
+        const currSnapshot = readRecord(readMessageExtra(curr).personaSnapshot);
+        const prevId = readString(prevSnapshot.personaId);
+        const currId = readString(currSnapshot.personaId);
         if (prevId && currId && prevId !== currId) return false;
       }
       return true;

--- a/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.ts
@@ -8,7 +8,7 @@ import type { MessageWithSwipes } from "../types";
 
 type UseSpriteMetadataStateOptions = {
   chat: Chat | null | undefined;
-  chatMeta: Record<string, any>;
+  chatMeta: Record<string, unknown>;
   messages?: MessageWithSwipes[] | undefined;
 };
 
@@ -18,10 +18,16 @@ function normalizeSpriteDisplayValue(value: unknown, fallback: number, min: numb
   return Math.max(min, Math.min(max, numeric));
 }
 
-function readMessageExtra(message: MessageWithSwipes): Record<string, any> {
+function readMessageExtra(message: MessageWithSwipes): Record<string, unknown> {
   return message.extra && typeof message.extra === "object" && !Array.isArray(message.extra)
-    ? (message.extra as Record<string, any>)
+    ? (message.extra as unknown as Record<string, unknown>)
     : {};
+}
+
+function stringRecord(value: unknown): Record<string, string> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  return entries.length ? Object.fromEntries(entries) : null;
 }
 
 export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMetadataStateOptions) {
@@ -48,8 +54,9 @@ export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMe
         const message = messages[index]!;
         if (message.role === "assistant") {
           const extra = readMessageExtra(message);
-          if (extra.spriteExpressions && Object.keys(extra.spriteExpressions).length > 0) {
-            return extra.spriteExpressions as Record<string, string>;
+          const spriteExpressions = stringRecord(extra.spriteExpressions);
+          if (spriteExpressions && Object.keys(spriteExpressions).length > 0) {
+            return spriteExpressions;
           }
           break;
         }

--- a/src/shared/lib/chat-display.ts
+++ b/src/shared/lib/chat-display.ts
@@ -7,17 +7,19 @@ export type ChatDisplaySource = {
 
 const PLACEHOLDER_BRANCH_NAME = "New Branch";
 
-export function parseChatMetadata(raw: unknown): Record<string, any> {
+export function parseChatMetadata(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
   if (typeof raw === "string") {
     try {
       const parsed = JSON.parse(raw);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, any>) : {};
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
     } catch {
       return {};
     }
   }
-  return typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, any>) : {};
+  return typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
 }
 
 export function getChatDisplayName(chat: ChatDisplaySource | null | undefined): string {


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Chat settings still had broad metadata reads in the shared settings drawer. Tightening those reads closes the remaining explicit UI metadata typing cleanup while preserving existing bool-ish metadata compatibility.

## What changed

- Replaced the drawer metadata map with `Record<string, unknown>`.
- Added local typed metadata readers for strings, arrays, records, numbers, choice selections, translation provider values, scoped regex mode, and character schedules.
- Normalized settings toggles through the existing bool-ish reader so legacy/imported truthy metadata stays aligned with runtime behavior.
- Replaced direct metadata casts/usages across prompt drafts, schedules, translation settings, tool/agent controls, context limits, and preset choices.

## Refactor impact

Primary owner:

- Shared mode UI: chat settings drawer.

Impact areas reviewed:

- Chat, roleplay, and game settings surfaces that share `ChatSettingsDrawer`.
- Runtime metadata boolean compatibility for agents/tools and related settings toggles.
- Preset choices, translation fields, scoped regex mode, schedule editor input, and context limit reads.

Boundary notes:

- Feature-only UI metadata parsing change.
- No engine, shared API, Rust, Tauri command, or remote runtime boundary changes.

Pressure points touched:

- Shared mode UI: `src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx`.
- No ModeSurface, GameSurface, command registration, or import module changes.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Ran `git diff --cached --check`.
- Ran `pnpm typecheck`.
- Ran `pnpm check:architecture`.
- Ran strict explicit-`any` grep over `src/**/*.ts` and `src/**/*.tsx`; remaining hits are prose/comment strings only.
- Ran `pnpm check` after the final diff; it passed line endings, architecture, frontend typecheck, Rust workspace check, docs, discovery metadata, and unused-code checks.
- Browser/Tauri manual verification not run; this is a metadata typing and compatibility cleanup with no intended visual layout change.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal shared drawer typing cleanup; no new feature or discoverable workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes:

- No docs or release-note changes needed; behavior intent is compatibility-preserving internal cleanup.

## UI evidence

- Not added; no intended visual layout change.
