### PR TITLE
Fix agent run legacy cadence parity

### DIFF
--- a/src-tauri/src/commands/storage/agents.rs
+++ b/src-tauri/src/commands/storage/agents.rs
@@ -1,6 +1,9 @@
 use super::chats::messages_for_chat;
 use super::shared::*;
 use super::*;
+use std::collections::HashSet;
+
+const MAX_ASSISTANT_RUN_INTERVAL: i64 = 100;
 
 fn parse_settings(value: Option<&Value>) -> Map<String, Value> {
     match value {
@@ -10,6 +13,40 @@ fn parse_settings(value: Option<&Value>) -> Map<String, Value> {
             .and_then(|value| value.as_object().cloned())
             .unwrap_or_default(),
         _ => Map::new(),
+    }
+}
+
+fn default_run_interval(agent_type: &str) -> i64 {
+    match agent_type {
+        "director" | "illustrator" => 5,
+        "lorebook-keeper" | "card-evolution-auditor" => 8,
+        "chat-summary" => 5,
+        _ => 1,
+    }
+}
+
+fn positive_run_interval(value: Option<&Value>, fallback: i64, max: i64) -> i64 {
+    let parsed = match value {
+        Some(Value::Number(number)) => number.as_i64(),
+        Some(Value::String(raw)) => raw.trim().parse::<i64>().ok(),
+        _ => None,
+    };
+    parsed
+        .filter(|value| *value >= 1)
+        .unwrap_or(fallback)
+        .clamp(1, max)
+}
+
+fn boolish(value: Option<&Value>, fallback: bool) -> bool {
+    match value {
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(number)) => number.as_i64().map(|value| value != 0).unwrap_or(fallback),
+        Some(Value::String(raw)) => match raw.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "on" => true,
+            "false" | "0" | "no" | "off" => false,
+            _ => fallback,
+        },
+        _ => fallback,
     }
 }
 
@@ -46,12 +83,87 @@ fn agent_config_id(state: &AppState, agent_type: &str, create: bool) -> AppResul
 
 fn run_agent_type(run: &Value) -> Option<&str> {
     run.get("agentType")
+        .or_else(|| run.get("agent_type"))
         .or_else(|| run.get("type"))
         .and_then(Value::as_str)
 }
 
+fn run_agent_config_id(run: &Value) -> Option<&str> {
+    run.get("agentConfigId")
+        .or_else(|| run.get("agent_config_id"))
+        .and_then(Value::as_str)
+}
+
+fn run_result_type(run: &Value) -> Option<&str> {
+    run.get("resultType")
+        .or_else(|| run.get("result_type"))
+        .and_then(Value::as_str)
+}
+
+fn list_agent_runs_for_chat(state: &AppState, chat_id: &str) -> AppResult<Vec<Value>> {
+    let mut rows = state.storage.list_where("agent-runs", &{
+        let mut filters = Map::new();
+        filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
+        filters
+    })?;
+    let mut seen_ids = rows
+        .iter()
+        .filter_map(|row| row.get("id").and_then(Value::as_str).map(ToOwned::to_owned))
+        .collect::<HashSet<_>>();
+    let legacy_rows = state.storage.list_where("agent-runs", &{
+        let mut filters = Map::new();
+        filters.insert("chat_id".to_string(), Value::String(chat_id.to_string()));
+        filters
+    })?;
+    for row in legacy_rows {
+        let id = row.get("id").and_then(Value::as_str);
+        if id.is_some_and(|id| !seen_ids.insert(id.to_string())) {
+            continue;
+        }
+        rows.push(row);
+    }
+    Ok(rows)
+}
+
+fn agent_config_ids_for_type(state: &AppState, agent_type: &str) -> AppResult<HashSet<String>> {
+    let mut ids = HashSet::new();
+    ids.insert(format!("builtin:{agent_type}"));
+    for row in state.storage.list("agents")? {
+        let row_type = row
+            .get("type")
+            .or_else(|| row.get("agentType"))
+            .and_then(Value::as_str);
+        if row_type != Some(agent_type) {
+            continue;
+        }
+        if let Some(id) = row.get("id").and_then(Value::as_str) {
+            ids.insert(id.to_string());
+        }
+    }
+    Ok(ids)
+}
+
+fn run_matches_agent(run: &Value, agent_type: &str, agent_config_ids: &HashSet<String>) -> bool {
+    if let Some(run_type) = run_agent_type(run) {
+        return run_type == agent_type;
+    }
+    run_agent_config_id(run).is_some_and(|id| agent_config_ids.contains(id))
+}
+
+fn run_successful(run: &Value) -> bool {
+    boolish(run.get("success"), false)
+}
+
 fn run_message_id(run: &Value) -> Option<&str> {
-    run.get("messageId").and_then(Value::as_str)
+    run.get("messageId")
+        .or_else(|| run.get("message_id"))
+        .and_then(Value::as_str)
+}
+
+fn run_created_at(run: &Value) -> Option<&str> {
+    run.get("created_at")
+        .or_else(|| run.get("createdAt"))
+        .and_then(Value::as_str)
 }
 
 pub(crate) fn toggle_agent_type(state: &AppState, agent_type: &str) -> AppResult<Value> {
@@ -99,34 +211,24 @@ pub(crate) fn agent_cadence_status(
 ) -> AppResult<Value> {
     let config = find_agent_config(state, agent_type)?;
     let settings = parse_settings(config.as_ref().and_then(|agent| agent.get("settings")));
-    let run_interval = settings
-        .get("runInterval")
-        .and_then(Value::as_i64)
-        .or_else(|| {
-            settings
-                .get("runInterval")
-                .and_then(Value::as_str)
-                .and_then(|value| value.parse().ok())
-        })
-        .unwrap_or(1)
-        .clamp(1, 100);
+    let fallback_interval = default_run_interval(agent_type);
+    let run_interval = positive_run_interval(
+        settings.get("runInterval"),
+        fallback_interval,
+        MAX_ASSISTANT_RUN_INTERVAL,
+    );
     let messages = messages_for_chat(state, chat_id)?;
-    let runs = state
-        .storage
-        .list_where("agent-runs", &{
-            let mut filters = Map::new();
-            filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
-            filters
-        })?
+    let agent_config_ids = agent_config_ids_for_type(state, agent_type)?;
+    let runs = list_agent_runs_for_chat(state, chat_id)?
         .into_iter()
-        .filter(|run| run_agent_type(run) == Some(agent_type))
+        .filter(|run| run_matches_agent(run, agent_type, &agent_config_ids))
         .collect::<Vec<_>>();
     let last_run = runs
         .iter()
-        .filter(|run| !run.get("error").and_then(Value::as_bool).unwrap_or(false))
+        .filter(|run| run_successful(run))
         .max_by(|a, b| {
-            let a_time = a.get("createdAt").and_then(Value::as_str).unwrap_or("");
-            let b_time = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
+            let a_time = run_created_at(a).unwrap_or("");
+            let b_time = run_created_at(b).unwrap_or("");
             a_time.cmp(b_time)
         });
     let mut assistant_messages_since_last_run = None;
@@ -160,8 +262,8 @@ pub(crate) fn agent_cadence_status(
         "agentType": agent_type,
         "runInterval": run_interval,
         "lastSuccessfulRun": last_run.map(|run| json!({
-            "messageId": run.get("messageId").cloned().unwrap_or(Value::Null),
-            "createdAt": run.get("createdAt").cloned().unwrap_or(Value::Null)
+            "messageId": run_message_id(run).map(|value| Value::String(value.to_string())).unwrap_or(Value::Null),
+            "createdAt": run_created_at(run).map(|value| Value::String(value.to_string())).unwrap_or(Value::Null)
         })),
         "assistantMessagesSinceLastRun": assistant_messages_since_last_run,
         "remainingAssistantMessages": remaining,
@@ -243,7 +345,7 @@ pub(crate) fn clear_agent_runs_and_memory_for_chat(
     filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
 
     let mut deleted_runs = 0;
-    for row in state.storage.list_where("agent-runs", &filters)? {
+    for row in list_agent_runs_for_chat(state, chat_id)? {
         if let Some(id) = row.get("id").and_then(Value::as_str) {
             if state.storage.delete("agent-runs", id)? {
                 deleted_runs += 1;
@@ -359,20 +461,18 @@ fn clear_agent_memory(state: &AppState, agent_config_id: &str, chat_id: &str) ->
 }
 
 pub(crate) fn echo_messages(state: &AppState, method: &str, chat_id: &str) -> AppResult<Value> {
-    let mut filters = Map::new();
-    filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
-    let rows = state.storage.list_where("agent-runs", &filters)?;
+    let rows = list_agent_runs_for_chat(state, chat_id)?;
     match method {
         "GET" => Ok(Value::Array(
             rows.into_iter()
-                .filter(|run| run.get("resultType").and_then(Value::as_str) == Some("echo_message"))
+                .filter(|run| run_result_type(run) == Some("echo_message"))
                 .collect(),
         )),
         "DELETE" => {
             let mut deleted = 0;
             for row in rows
                 .into_iter()
-                .filter(|run| run.get("resultType").and_then(Value::as_str) == Some("echo_message"))
+                .filter(|run| run_result_type(run) == Some("echo_message"))
             {
                 if let Some(id) = row.get("id").and_then(Value::as_str) {
                     if state.storage.delete("agent-runs", id)? {
@@ -386,5 +486,161 @@ pub(crate) fn echo_messages(state: &AppState, method: &str, chat_id: &str) -> Ap
             "method_not_allowed",
             "Unsupported echo messages method",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-agent-storage-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp agent dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn seed_message(state: &AppState, id: &str, role: &str, created_at: &str) {
+        state
+            .storage
+            .upsert_with_id(
+                "messages",
+                id,
+                json!({
+                    "id": id,
+                    "chatId": "chat-1",
+                    "role": role,
+                    "content": "",
+                    "createdAt": created_at
+                }),
+            )
+            .expect("message should write");
+    }
+
+    #[test]
+    fn cadence_status_uses_default_interval_and_successful_runs() {
+        let state = test_state("cadence-success");
+        state
+            .storage
+            .upsert_with_id(
+                "agents",
+                "agent-director",
+                json!({
+                    "id": "agent-director",
+                    "type": "director",
+                    "name": "Narrative Director",
+                    "settings": {}
+                }),
+            )
+            .expect("agent config should write");
+        seed_message(&state, "m1", "assistant", "2026-05-20T00:00:00Z");
+        seed_message(&state, "m2", "assistant", "2026-05-20T00:01:00Z");
+        seed_message(&state, "m3", "assistant", "2026-05-20T00:02:00Z");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-runs",
+                "run-success",
+                json!({
+                    "id": "run-success",
+                    "agentConfigId": "agent-director",
+                    "chatId": "chat-1",
+                    "messageId": "m1",
+                    "success": true,
+                    "createdAt": "2026-05-20T00:00:30Z"
+                }),
+            )
+            .expect("successful run should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-runs",
+                "run-failed-newer",
+                json!({
+                    "id": "run-failed-newer",
+                    "agentConfigId": "agent-director",
+                    "agentType": "director",
+                    "chatId": "chat-1",
+                    "messageId": "m3",
+                    "success": false,
+                    "createdAt": "2026-05-20T00:02:30Z"
+                }),
+            )
+            .expect("failed run should write");
+
+        let status = agent_cadence_status(&state, "director", "chat-1")
+            .expect("cadence status should be calculated");
+
+        assert_eq!(status["runInterval"], 5);
+        assert_eq!(status["lastSuccessfulRun"]["messageId"], "m1");
+        assert_eq!(status["assistantMessagesSinceLastRun"], 2);
+        assert_eq!(status["remainingAssistantMessages"], 2);
+        assert_eq!(status["runsNextAssistantMessage"], false);
+        assert_eq!(status["lastRunMessageFound"], true);
+    }
+
+    #[test]
+    fn cadence_status_matches_imported_runs_by_agent_config_id() {
+        let state = test_state("cadence-imported-config-id");
+        state
+            .storage
+            .upsert_with_id(
+                "agents",
+                "custom-agent-1",
+                json!({
+                    "id": "custom-agent-1",
+                    "type": "custom-prophet",
+                    "name": "Custom Prophet",
+                    "settings": { "runInterval": 3 }
+                }),
+            )
+            .expect("agent config should write");
+        seed_message(&state, "m1", "user", "2026-05-20T00:00:00Z");
+        seed_message(&state, "m2", "assistant", "2026-05-20T00:01:00Z");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-runs",
+                "run-imported-newer",
+                json!({
+                    "id": "run-imported-newer",
+                    "agent_config_id": "custom-agent-1",
+                    "chat_id": "chat-1",
+                    "message_id": "m1",
+                    "success": "true",
+                    "created_at": "2026-05-20T00:00:30Z"
+                }),
+            )
+            .expect("newer import-style run should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-runs",
+                "run-imported-older",
+                json!({
+                    "id": "run-imported-older",
+                    "agent_config_id": "custom-agent-1",
+                    "chat_id": "chat-1",
+                    "message_id": "m2",
+                    "success": "true",
+                    "created_at": "2026-05-19T23:59:30Z"
+                }),
+            )
+            .expect("older import-style run should write");
+
+        let status = agent_cadence_status(&state, "custom-prophet", "chat-1")
+            .expect("cadence status should match by config id");
+
+        assert_eq!(status["runInterval"], 3);
+        assert_eq!(status["lastSuccessfulRun"]["messageId"], "m1");
+        assert_eq!(status["assistantMessagesSinceLastRun"], 1);
+        assert_eq!(status["remainingAssistantMessages"], 1);
     }
 }

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -1,9 +1,9 @@
 use super::super::{
     game_state_snapshots, new_id, now_iso,
     shared::{
-        materialize_message_swipe_fields, non_negative_i64_value,
-        normalize_legacy_text_array_fields, normalize_legacy_text_bool_fields,
-        normalize_typed_json_fields, string_array_from_value,
+        agent_run_config_info_from_rows, materialize_message_swipe_fields, non_negative_i64_value,
+        normalize_agent_run_row_fields, normalize_legacy_text_array_fields,
+        normalize_legacy_text_bool_fields, normalize_typed_json_fields, string_array_from_value,
     },
 };
 use super::assets::{
@@ -126,6 +126,7 @@ where
             "prompt-overrides" => {
                 unsupported_prompt_overrides = normalize_profile_prompt_overrides(&mut rows)
             }
+            "agent-runs" => normalize_legacy_agent_runs(&mut rows, tables),
             "lorebooks" => add_legacy_lorebook_links(&mut rows, tables),
             "lorebook-entries" => normalize_legacy_lorebook_entries(&mut rows),
             "chats" => {
@@ -252,6 +253,13 @@ fn gallery_image_url_from_legacy_row(
         }
     }
     None
+}
+
+fn normalize_legacy_agent_runs(rows: &mut [Value], tables: &Map<String, Value>) {
+    let configs = agent_run_config_info_from_rows(table_rows(tables, "agent_configs"));
+    for row in rows {
+        normalize_agent_run_row_fields(row, &configs);
+    }
 }
 
 fn gallery_filename_from_legacy_row(object: &Map<String, Value>) -> Option<String> {
@@ -847,6 +855,66 @@ mod tests {
             .get("app-settings", "ui")
             .expect("ui settings lookup should not fail")
             .is_none());
+    }
+
+    #[test]
+    fn legacy_agent_runs_import_with_config_metadata() {
+        let state = test_state("agent-run-metadata");
+        let mut tables = Map::new();
+        tables.insert(
+            "agent_configs".to_string(),
+            json!([
+                {
+                    "id": "custom-agent-1",
+                    "type": "custom-prophet",
+                    "name": "Custom Prophet",
+                    "description": "Imported custom agent",
+                    "phase": "pre_generation",
+                    "enabled": "true",
+                    "settings": "{}",
+                    "createdAt": "2026-05-20T00:00:00Z",
+                    "updatedAt": "2026-05-20T00:00:00Z"
+                }
+            ]),
+        );
+        tables.insert(
+            "agent_runs".to_string(),
+            json!([
+                {
+                    "id": "agent-run-1",
+                    "agent_config_id": "custom-agent-1",
+                    "chat_id": "chat-1",
+                    "message_id": "message-1",
+                    "result_type": "context_injection",
+                    "result_data": "{\"text\":\"Imported guidance\"}",
+                    "tokens_used": "42",
+                    "duration_ms": "1200",
+                    "success": "true",
+                    "created_at": "2026-05-20T00:01:00Z"
+                }
+            ]),
+        );
+
+        import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
+            .expect("legacy agent run import should succeed");
+
+        let run = state
+            .storage
+            .get("agent-runs", "agent-run-1")
+            .expect("agent run lookup should not fail")
+            .expect("imported agent run should be addressable by id");
+        assert_eq!(run["agentConfigId"], "custom-agent-1");
+        assert_eq!(run["agentType"], "custom-prophet");
+        assert_eq!(run["agentName"], "Custom Prophet");
+        assert_eq!(run["chatId"], "chat-1");
+        assert_eq!(run["messageId"], "message-1");
+        assert_eq!(run["resultType"], "context_injection");
+        assert_eq!(run["resultData"]["text"], "Imported guidance");
+        assert_eq!(run["tokensUsed"], 42);
+        assert_eq!(run["durationMs"], 1200);
+        assert_eq!(run["success"], true);
+        assert_eq!(run["createdAt"], "2026-05-20T00:01:00Z");
+        assert!(!run.as_object().unwrap().contains_key("agent_config_id"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -883,6 +883,8 @@ mod tests {
                 {
                     "id": "agent-run-1",
                     "agent_config_id": "custom-agent-1",
+                    "agentType": "stale-agent-type",
+                    "agent_name": "Stale Agent Name",
                     "chat_id": "chat-1",
                     "message_id": "message-1",
                     "result_type": "context_injection",
@@ -890,7 +892,7 @@ mod tests {
                     "tokens_used": "42",
                     "duration_ms": "1200",
                     "success": "true",
-                    "created_at": "2026-05-20T00:01:00Z"
+                    "created_at": "2026-05-20T00:01:00-04:00"
                 }
             ]),
         );
@@ -913,7 +915,7 @@ mod tests {
         assert_eq!(run["tokensUsed"], 42);
         assert_eq!(run["durationMs"], 1200);
         assert_eq!(run["success"], true);
-        assert_eq!(run["createdAt"], "2026-05-20T00:01:00Z");
+        assert_eq!(run["createdAt"], "2026-05-20T04:01:00+00:00");
         assert!(!run.as_object().unwrap().contains_key("agent_config_id"));
     }
 

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1990,6 +1990,8 @@ pub(crate) struct AgentRunConfigInfo {
 
 const AGENT_RUN_FIELD_ALIASES: &[(&str, &str)] = &[
     ("agentConfigId", "agent_config_id"),
+    ("agentType", "agent_type"),
+    ("agentName", "agent_name"),
     ("chatId", "chat_id"),
     ("messageId", "message_id"),
     ("resultType", "result_type"),
@@ -2047,31 +2049,54 @@ pub(crate) fn normalize_agent_run_row_fields(
 
     let agent_config_id = trimmed_record_string(object.get("agentConfigId"));
     let config = agent_config_id.as_ref().and_then(|id| configs.get(id));
-    let agent_type = trimmed_record_string(object.get("agentType"))
-        .or_else(|| config.map(|config| config.agent_type.clone()))
-        .or_else(|| {
-            agent_config_id
-                .as_deref()
-                .and_then(builtin_agent_type_from_config_id)
-        });
+    if let Some(config) = config {
+        object.insert(
+            "agentType".to_string(),
+            Value::String(config.agent_type.clone()),
+        );
+        object.insert(
+            "agentName".to_string(),
+            Value::String(config.agent_name.clone()),
+        );
+        return;
+    }
+
+    let agent_type = trimmed_record_string(object.get("agentType")).or_else(|| {
+        agent_config_id
+            .as_deref()
+            .and_then(builtin_agent_type_from_config_id)
+    });
     if let Some(agent_type) = agent_type {
         object.insert("agentType".to_string(), Value::String(agent_type.clone()));
         if trimmed_record_string(object.get("agentName")).is_none() {
-            let name = config
-                .map(|config| config.agent_name.clone())
-                .unwrap_or(agent_type);
-            object.insert("agentName".to_string(), Value::String(name));
+            object.insert("agentName".to_string(), Value::String(agent_type));
         }
     }
 }
 
 fn move_record_alias(object: &mut Map<String, Value>, target: &str, legacy: &str) {
     let legacy_value = object.remove(legacy);
-    if let Some(value) = legacy_value {
-        if target == "createdAt" || !object.contains_key(target) {
+    if target == "createdAt" {
+        if let Some(created_at) = normalized_record_timestamp(legacy_value.as_ref()) {
+            object.insert(target.to_string(), Value::String(created_at));
+        }
+        return;
+    }
+    if !object.contains_key(target) {
+        if let Some(value) = legacy_value {
             object.insert(target.to_string(), value);
         }
     }
+}
+
+fn normalized_record_timestamp(value: Option<&Value>) -> Option<String> {
+    let raw = value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|time| time.with_timezone(&chrono::Utc).to_rfc3339())
 }
 
 fn trimmed_record_string(value: Option<&Value>) -> Option<String> {

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1983,6 +1983,129 @@ pub(crate) fn string_array_from_value(value: Option<&Value>) -> Vec<String> {
     }
 }
 
+pub(crate) struct AgentRunConfigInfo {
+    pub(crate) agent_type: String,
+    pub(crate) agent_name: String,
+}
+
+const AGENT_RUN_FIELD_ALIASES: &[(&str, &str)] = &[
+    ("agentConfigId", "agent_config_id"),
+    ("chatId", "chat_id"),
+    ("messageId", "message_id"),
+    ("resultType", "result_type"),
+    ("resultData", "result_data"),
+    ("tokensUsed", "tokens_used"),
+    ("durationMs", "duration_ms"),
+    ("createdAt", "created_at"),
+];
+
+pub(crate) fn agent_run_config_info_from_rows(
+    rows: Vec<Value>,
+) -> HashMap<String, AgentRunConfigInfo> {
+    let mut by_id = HashMap::new();
+    for row in rows {
+        let Some(object) = row.as_object() else {
+            continue;
+        };
+        let Some(id) = trimmed_record_string(object.get("id")) else {
+            continue;
+        };
+        let Some(agent_type) = trimmed_record_string(object.get("type"))
+            .or_else(|| trimmed_record_string(object.get("agentType")))
+        else {
+            continue;
+        };
+        let agent_name =
+            trimmed_record_string(object.get("name")).unwrap_or_else(|| agent_type.clone());
+        by_id.insert(
+            id,
+            AgentRunConfigInfo {
+                agent_type,
+                agent_name,
+            },
+        );
+    }
+    by_id
+}
+
+pub(crate) fn normalize_agent_run_row_fields(
+    row: &mut Value,
+    configs: &HashMap<String, AgentRunConfigInfo>,
+) {
+    for (target, legacy) in AGENT_RUN_FIELD_ALIASES {
+        if let Some(object) = row.as_object_mut() {
+            move_record_alias(object, target, legacy);
+        }
+    }
+    normalize_legacy_text_bool_fields(row, &["success"]);
+    let Some(object) = row.as_object_mut() else {
+        return;
+    };
+    parse_json_string_field(object, "resultData");
+    normalize_non_negative_number_field(object, "tokensUsed");
+    normalize_non_negative_number_field(object, "durationMs");
+
+    let agent_config_id = trimmed_record_string(object.get("agentConfigId"));
+    let config = agent_config_id.as_ref().and_then(|id| configs.get(id));
+    let agent_type = trimmed_record_string(object.get("agentType"))
+        .or_else(|| config.map(|config| config.agent_type.clone()))
+        .or_else(|| {
+            agent_config_id
+                .as_deref()
+                .and_then(builtin_agent_type_from_config_id)
+        });
+    if let Some(agent_type) = agent_type {
+        object.insert("agentType".to_string(), Value::String(agent_type.clone()));
+        if trimmed_record_string(object.get("agentName")).is_none() {
+            let name = config
+                .map(|config| config.agent_name.clone())
+                .unwrap_or(agent_type);
+            object.insert("agentName".to_string(), Value::String(name));
+        }
+    }
+}
+
+fn move_record_alias(object: &mut Map<String, Value>, target: &str, legacy: &str) {
+    let legacy_value = object.remove(legacy);
+    if let Some(value) = legacy_value {
+        if target == "createdAt" || !object.contains_key(target) {
+            object.insert(target.to_string(), value);
+        }
+    }
+}
+
+fn trimmed_record_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn builtin_agent_type_from_config_id(agent_config_id: &str) -> Option<String> {
+    agent_config_id
+        .strip_prefix("builtin:")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn parse_json_string_field(object: &mut Map<String, Value>, field: &str) {
+    let parsed = object
+        .get(field)
+        .and_then(Value::as_str)
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok());
+    if let Some(parsed) = parsed {
+        object.insert(field.to_string(), parsed);
+    }
+}
+
+fn normalize_non_negative_number_field(object: &mut Map<String, Value>, field: &str) {
+    if let Some(value) = non_negative_i64_value(object.get(field)) {
+        object.insert(field.to_string(), json!(value));
+    }
+}
+
 /// Replace any text-encoded boolean field on a record object with a real
 /// JSON boolean. The pre-refactor server stored bool columns as TEXT
 /// (`"true"` / `"false"` strings); the refactor frontend reads these

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -14,7 +14,10 @@ use crate::seed_defaults::seed_bundled_defaults;
 use crate::storage_commands::{
     images::percent_encode_component,
     media_uploads::{file_path_asset_url, safe_filename, unique_file_path},
-    shared::normalize_typed_json_fields,
+    shared::{
+        agent_run_config_info_from_rows, normalize_agent_run_row_fields,
+        normalize_typed_json_fields,
+    },
 };
 
 #[derive(Clone)]
@@ -65,6 +68,7 @@ impl AppState {
         let backgrounds = AssetService::new(data_dir.join("backgrounds"))?;
         Self::seed_defaults(&storage, &game_assets, &backgrounds, default_data_roots)?;
         migrate_storage_json_fields(&storage)?;
+        migrate_agent_run_rows(&storage)?;
         migrate_legacy_chat_group_roots(&storage)?;
         migrate_local_media_references(&storage, &data_dir)?;
 
@@ -232,6 +236,23 @@ fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> Ap
     }
     if changed {
         storage.replace_all(collection, normalized_rows)?;
+    }
+    Ok(())
+}
+
+fn migrate_agent_run_rows(storage: &FileStorage) -> AppResult<()> {
+    let configs = agent_run_config_info_from_rows(storage.list("agents")?);
+    let rows = storage.list("agent-runs")?;
+    let mut changed = false;
+    let mut normalized_rows = Vec::with_capacity(rows.len());
+    for mut row in rows {
+        let before = row.clone();
+        normalize_agent_run_row_fields(&mut row, &configs);
+        changed = changed || row != before;
+        normalized_rows.push(row);
+    }
+    if changed {
+        storage.replace_all("agent-runs", normalized_rows)?;
     }
     Ok(())
 }
@@ -819,6 +840,70 @@ mod tests {
         for row in rows {
             assert!(row["personaStats"].is_null());
         }
+    }
+
+    #[test]
+    fn app_state_startup_normalizes_legacy_agent_run_rows() {
+        let root = temp_root("agent-run-normalization");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        storage
+            .replace_all(
+                "agents",
+                vec![json!({
+                    "id": "custom-agent-1",
+                    "type": "custom-prophet",
+                    "name": "Custom Prophet",
+                    "settings": "{}"
+                })],
+            )
+            .expect("agent config should be seeded");
+        storage
+            .replace_all(
+                "agent-runs",
+                vec![json!({
+                    "id": "agent-run-1",
+                    "agent_config_id": "custom-agent-1",
+                    "chat_id": "chat-1",
+                    "message_id": "message-1",
+                    "result_type": "context_injection",
+                    "result_data": "{\"text\":\"Imported guidance\"}",
+                    "tokens_used": "42",
+                    "duration_ms": "1200",
+                    "success": "true",
+                    "createdAt": "storage-row-created-at",
+                    "created_at": "2026-05-20T00:01:00Z"
+                })],
+            )
+            .expect("legacy agent run should be seeded");
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let run = state
+            .storage
+            .get("agent-runs", "agent-run-1")
+            .expect("agent run lookup should not fail")
+            .expect("agent run should still exist");
+        assert_eq!(run["agentConfigId"], "custom-agent-1");
+        assert_eq!(run["agentType"], "custom-prophet");
+        assert_eq!(run["agentName"], "Custom Prophet");
+        assert_eq!(run["chatId"], "chat-1");
+        assert_eq!(run["messageId"], "message-1");
+        assert_eq!(run["resultType"], "context_injection");
+        assert_eq!(run["resultData"]["text"], "Imported guidance");
+        assert_eq!(run["tokensUsed"], 42);
+        assert_eq!(run["durationMs"], 1200);
+        assert_eq!(run["success"], true);
+        assert_eq!(run["createdAt"], "2026-05-20T00:01:00Z");
+
+        let mut filters = Map::new();
+        filters.insert("chatId".to_string(), Value::String("chat-1".to_string()));
+        assert_eq!(
+            state
+                .storage
+                .list_where("agent-runs", &filters)
+                .expect("normalized agent run should be queryable by chatId")
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -860,19 +860,36 @@ mod tests {
         storage
             .replace_all(
                 "agent-runs",
-                vec![json!({
-                    "id": "agent-run-1",
-                    "agent_config_id": "custom-agent-1",
-                    "chat_id": "chat-1",
-                    "message_id": "message-1",
-                    "result_type": "context_injection",
-                    "result_data": "{\"text\":\"Imported guidance\"}",
-                    "tokens_used": "42",
-                    "duration_ms": "1200",
-                    "success": "true",
-                    "createdAt": "storage-row-created-at",
-                    "created_at": "2026-05-20T00:01:00Z"
-                })],
+                vec![
+                    json!({
+                        "id": "agent-run-1",
+                        "agent_config_id": "custom-agent-1",
+                        "agentType": "stale-agent-type",
+                        "agentName": "Stale Agent Name",
+                        "chat_id": "chat-1",
+                        "message_id": "message-1",
+                        "result_type": "context_injection",
+                        "result_data": "{\"text\":\"Imported guidance\"}",
+                        "tokens_used": "42",
+                        "duration_ms": "1200",
+                        "success": "true",
+                        "createdAt": "storage-row-created-at",
+                        "created_at": "2026-05-20T00:01:00Z"
+                    }),
+                    json!({
+                        "id": "agent-run-invalid-created-at",
+                        "agent_config_id": "custom-agent-1",
+                        "chat_id": "chat-1",
+                        "message_id": "message-2",
+                        "result_type": "context_injection",
+                        "result_data": "{}",
+                        "tokens_used": "0",
+                        "duration_ms": "0",
+                        "success": "true",
+                        "createdAt": "2026-05-20T00:02:00Z",
+                        "created_at": "not-a-date"
+                    }),
+                ],
             )
             .expect("legacy agent run should be seeded");
 
@@ -892,7 +909,14 @@ mod tests {
         assert_eq!(run["tokensUsed"], 42);
         assert_eq!(run["durationMs"], 1200);
         assert_eq!(run["success"], true);
-        assert_eq!(run["createdAt"], "2026-05-20T00:01:00Z");
+        assert_eq!(run["createdAt"], "2026-05-20T00:01:00+00:00");
+
+        let invalid_created_at_run = state
+            .storage
+            .get("agent-runs", "agent-run-invalid-created-at")
+            .expect("agent run lookup should not fail")
+            .expect("agent run should still exist");
+        assert_eq!(invalid_created_at_run["createdAt"], "2026-05-20T00:02:00Z");
 
         let mut filters = Map::new();
         filters.insert("chatId".to_string(), Value::String("chat-1".to_string()));
@@ -902,7 +926,7 @@ mod tests {
                 .list_where("agent-runs", &filters)
                 .expect("normalized agent run should be queryable by chatId")
                 .len(),
-            1
+            2
         );
     }
 

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -113,10 +113,12 @@ interface ResolvedAgentsResult {
 }
 
 const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+const DIRECTOR_AGENT_TYPE = "director";
 const ILLUSTRATOR_AGENT_TYPE = "illustrator";
 const KNOWLEDGE_RETRIEVAL_AGENT_TYPE = "knowledge-retrieval";
 const KNOWLEDGE_ROUTER_AGENT_TYPE = "knowledge-router";
 const KNOWLEDGE_AGENT_TYPES = new Set([KNOWLEDGE_RETRIEVAL_AGENT_TYPE, KNOWLEDGE_ROUTER_AGENT_TYPE]);
+const ASSISTANT_INTERVAL_AGENT_TYPES = new Set([DIRECTOR_AGENT_TYPE, ILLUSTRATOR_AGENT_TYPE]);
 const MAX_ASSISTANT_RUN_INTERVAL = 100;
 const MAX_CUSTOM_AGENT_USER_RUN_INTERVAL = 200;
 const PROMPT_INJECTABLE_RESULT_TYPES = new Set(["context_injection", "director_event"]);
@@ -628,7 +630,7 @@ function automaticIntervalGate(
   builtInAgent: boolean,
 ): AutomaticIntervalGate | null {
   if (input.agentTypes && input.agentTypes.size > 0) return null;
-  if (type === ILLUSTRATOR_AGENT_TYPE) {
+  if (builtInAgent && ASSISTANT_INTERVAL_AGENT_TYPES.has(type)) {
     const fallback = positiveInteger(BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[type], 5, MAX_ASSISTANT_RUN_INTERVAL);
     const runInterval = positiveInteger(settings.runInterval, fallback, MAX_ASSISTANT_RUN_INTERVAL);
     return runInterval > 1
@@ -657,11 +659,23 @@ function automaticIntervalGate(
 }
 
 function runAgentType(run: JsonRecord): string {
-  return readString(run.agentType || run.type).trim();
+  return readString(run.agentType || run.agent_type || run.type).trim();
 }
 
 function runAgentId(run: JsonRecord): string {
-  return readString(run.agentId || run.agentConfigId).trim();
+  return readString(run.agentId || run.agentConfigId || run.agent_config_id).trim();
+}
+
+function runChatId(run: JsonRecord): string {
+  return readString(run.chatId || run.chat_id).trim();
+}
+
+function runMessageId(run: JsonRecord): string {
+  return readString(run.messageId || run.message_id).trim();
+}
+
+function runCreatedAt(run: JsonRecord): string {
+  return readString(run.created_at || run.createdAt).trim();
 }
 
 function runMatchesAgent(run: JsonRecord, agentType: string, agentId: string): boolean {
@@ -672,9 +686,9 @@ function runMatchesAgent(run: JsonRecord, agentType: string, agentId: string): b
 }
 
 function illustratorRunCountsTowardInterval(run: JsonRecord): boolean {
-  const resultType = readString(run.resultType).trim();
+  const resultType = readString(run.resultType || run.result_type).trim();
   if (resultType && resultType !== "image_prompt") return false;
-  const data = parseRecord(run.resultData);
+  const data = parseRecord(run.resultData ?? run.result_data);
   if (boolish(data.parseError, false)) return false;
   if (data.shouldGenerate !== true) return false;
   return readString(data.prompt).trim().length > 0;
@@ -700,15 +714,15 @@ function intervalAnchorRun(
   const indexes = messageIndexById(input);
   return (
     runs
-      .filter((run) => readString(run.chatId).trim() === chatId)
+      .filter((run) => runChatId(run) === chatId)
       .filter((run) => runMatchesAgent(run, agentType, agentId))
       .filter((run) => boolish(run.success, false))
       .filter((run) => agentType !== ILLUSTRATOR_AGENT_TYPE || illustratorRunCountsTowardInterval(run))
-      .map((run) => ({ run, messageIndex: indexes.get(readString(run.messageId).trim()) ?? -1 }))
+      .map((run) => ({ run, messageIndex: indexes.get(runMessageId(run)) ?? -1 }))
       .filter((entry) => entry.messageIndex >= 0)
       .sort(
         (a, b) =>
-          b.messageIndex - a.messageIndex || readString(b.run.createdAt).localeCompare(readString(a.run.createdAt)),
+          b.messageIndex - a.messageIndex || runCreatedAt(b.run).localeCompare(runCreatedAt(a.run)),
       )[0]?.run ?? null
   );
 }
@@ -742,7 +756,7 @@ async function automaticIntervalAllowsRun(
     gate.agentId,
   );
   if (!lastRun) return true;
-  const messageId = readString(lastRun.messageId).trim();
+  const messageId = runMessageId(lastRun);
   if (!messageId) return true;
   const messagesSince = visibleMessagesSinceRun(input, messageId, gate.messageRole);
   if (messagesSince === null) return true;

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1917,10 +1917,14 @@ async function successfulLorebookKeeperMessageIds(storage: StorageGateway, chatI
   const runs = await storage.list<JsonRecord>("agent-runs").catch(() => []);
   return new Set(
     runs
-      .filter((run) => readString(run.chatId).trim() === chatId)
-      .filter((run) => readString(run.agentType).trim() === LOREBOOK_KEEPER_AGENT_TYPE)
+      .filter((run) => readString(run.chatId || run.chat_id).trim() === chatId)
+      .filter((run) => {
+        const type = readString(run.agentType || run.agent_type || run.type).trim();
+        const configId = readString(run.agentConfigId || run.agent_config_id).trim();
+        return type === LOREBOOK_KEEPER_AGENT_TYPE || configId === `builtin:${LOREBOOK_KEEPER_AGENT_TYPE}`;
+      })
       .filter((run) => boolish(run.success, false))
-      .map((run) => readString(run.messageId).trim())
+      .map((run) => readString(run.messageId || run.message_id).trim())
       .filter(Boolean),
   );
 }

--- a/src/features/catalog/agents/hooks/use-agents.ts
+++ b/src/features/catalog/agents/hooks/use-agents.ts
@@ -45,6 +45,73 @@ export interface AgentRunRow {
 
 const builtInAgentTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readNumber(value: unknown, fallback = 0): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : fallback;
+}
+
+function readBoolean(value: unknown, fallback = false): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+function parseStoredResultData(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function builtinAgentTypeFromConfigId(agentConfigId: string): string {
+  return agentConfigId.startsWith("builtin:") ? agentConfigId.slice("builtin:".length).trim() : "";
+}
+
+function normalizeAgentRunRow(
+  raw: Record<string, unknown>,
+  configsById: Map<string, AgentConfigRow>,
+): AgentRunRow | null {
+  const id = readString(raw.id);
+  const agentConfigId = readString(raw.agentConfigId) || readString(raw.agent_config_id);
+  const config = agentConfigId ? configsById.get(agentConfigId) : undefined;
+  const agentType =
+    readString(raw.agentType) ||
+    readString(raw.agent_type) ||
+    readString(raw.type) ||
+    config?.type ||
+    builtinAgentTypeFromConfigId(agentConfigId);
+  const chatId = readString(raw.chatId) || readString(raw.chat_id);
+  const messageId = readString(raw.messageId) || readString(raw.message_id);
+  if (!id || !agentType || !chatId) return null;
+
+  return {
+    id,
+    agentConfigId,
+    agentType,
+    agentName: readString(raw.agentName) || config?.name || agentType,
+    chatId,
+    messageId,
+    resultType: readString(raw.resultType) || readString(raw.result_type) || agentType,
+    resultData: parseStoredResultData(raw.resultData ?? raw.result_data),
+    tokensUsed: readNumber(raw.tokensUsed ?? raw.tokens_used),
+    durationMs: readNumber(raw.durationMs ?? raw.duration_ms),
+    success: readBoolean(raw.success),
+    error: readString(raw.error) || null,
+    createdAt: readString(raw.created_at) || readString(raw.createdAt),
+  };
+}
+
 export function agentCreditLabel(value: unknown): string {
   return typeof value === "string" && value.trim() ? value.trim() : DEFAULT_AGENT_CREDIT;
 }
@@ -82,10 +149,22 @@ export function useAgentConfigs(enabled = true) {
 export function useCustomAgentRuns(chatId: string | null, enabled = true) {
   return useQuery({
     queryKey: agentKeys.customRuns(chatId ?? ""),
-    queryFn: async () =>
-      (await storageApi.list<AgentRunRow>("agent-runs", { filters: { chatId } })).filter(
-        (run) => !!run.agentType && !builtInAgentTypes.has(run.agentType),
-      ),
+    queryFn: async () => {
+      const [currentRuns, legacyRuns, configs] = await Promise.all([
+        storageApi.list<Record<string, unknown>>("agent-runs", { filters: { chatId } }),
+        storageApi.list<Record<string, unknown>>("agent-runs", { filters: { chat_id: chatId } }),
+        storageApi.list<AgentConfigRow>("agents"),
+      ]);
+      const runsById = new Map<string, Record<string, unknown>>();
+      for (const run of [...currentRuns, ...legacyRuns]) {
+        const id = readString(run.id);
+        runsById.set(id || JSON.stringify(run), run);
+      }
+      const configsById = new Map(configs.map((config) => [config.id, config]));
+      return [...runsById.values()]
+        .map((run) => normalizeAgentRunRow(run, configsById))
+        .filter((run): run is AgentRunRow => !!run && !builtInAgentTypes.has(run.agentType));
+    },
     enabled: !!chatId && enabled,
     staleTime: 15_000,
   });

--- a/src/features/catalog/agents/hooks/use-agents.ts
+++ b/src/features/catalog/agents/hooks/use-agents.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { createAgentConfigSchema, updateAgentConfigSchema } from "../../../../engine/contracts/schemas/agent.schema";
-import { BUILT_IN_AGENTS, DEFAULT_AGENT_CREDIT } from "../../../../engine/contracts/types/agent";
+import { BUILT_IN_AGENTS, DEFAULT_AGENT_CREDIT, type AgentResultType } from "../../../../engine/contracts/types/agent";
 import { agentApi } from "../../../../shared/api/agent-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 
@@ -44,6 +44,34 @@ export interface AgentRunRow {
 }
 
 const builtInAgentTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+const agentResultTypeValues = [
+  "game_state_update",
+  "text_rewrite",
+  "sprite_change",
+  "echo_message",
+  "quest_update",
+  "image_prompt",
+  "context_injection",
+  "continuity_check",
+  "director_event",
+  "lorebook_update",
+  "character_card_update",
+  "prompt_review",
+  "background_change",
+  "character_tracker_update",
+  "persona_stats_update",
+  "custom_tracker_update",
+  "chat_summary",
+  "spotify_control",
+  "haptic_command",
+  "cyoa_choices",
+  "secret_plot",
+  "game_master_narration",
+  "party_action",
+  "game_map_update",
+  "game_state_transition",
+] satisfies AgentResultType[];
+const agentResultTypes = new Set<string>(agentResultTypeValues);
 
 function readString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -78,6 +106,10 @@ function builtinAgentTypeFromConfigId(agentConfigId: string): string {
   return agentConfigId.startsWith("builtin:") ? agentConfigId.slice("builtin:".length).trim() : "";
 }
 
+function rawTypeLooksLikeAgentType(rawType: string, resultType: string): boolean {
+  return !!rawType && rawType !== resultType && !agentResultTypes.has(rawType);
+}
+
 function normalizeAgentRunRow(
   raw: Record<string, unknown>,
   configsById: Map<string, AgentConfigRow>,
@@ -85,12 +117,14 @@ function normalizeAgentRunRow(
   const id = readString(raw.id);
   const agentConfigId = readString(raw.agentConfigId) || readString(raw.agent_config_id);
   const config = agentConfigId ? configsById.get(agentConfigId) : undefined;
+  const resultType = readString(raw.resultType) || readString(raw.result_type);
+  const rawType = readString(raw.type);
   const agentType =
     readString(raw.agentType) ||
     readString(raw.agent_type) ||
-    readString(raw.type) ||
-    config?.type ||
-    builtinAgentTypeFromConfigId(agentConfigId);
+    readString(config?.type) ||
+    builtinAgentTypeFromConfigId(agentConfigId) ||
+    (rawTypeLooksLikeAgentType(rawType, resultType) ? rawType : "");
   const chatId = readString(raw.chatId) || readString(raw.chat_id);
   const messageId = readString(raw.messageId) || readString(raw.message_id);
   if (!id || !agentType || !chatId) return null;
@@ -99,16 +133,16 @@ function normalizeAgentRunRow(
     id,
     agentConfigId,
     agentType,
-    agentName: readString(raw.agentName) || config?.name || agentType,
+    agentName: readString(raw.agentName) || readString(config?.name) || agentType,
     chatId,
     messageId,
-    resultType: readString(raw.resultType) || readString(raw.result_type) || agentType,
+    resultType: resultType || agentType,
     resultData: parseStoredResultData(raw.resultData ?? raw.result_data),
     tokensUsed: readNumber(raw.tokensUsed ?? raw.tokens_used),
     durationMs: readNumber(raw.durationMs ?? raw.duration_ms),
     success: readBoolean(raw.success),
     error: readString(raw.error) || null,
-    createdAt: readString(raw.created_at) || readString(raw.createdAt),
+    createdAt: readString(raw.createdAt) || readString(raw.created_at),
   };
 }
 
@@ -156,9 +190,13 @@ export function useCustomAgentRuns(chatId: string | null, enabled = true) {
         storageApi.list<AgentConfigRow>("agents"),
       ]);
       const runsById = new Map<string, Record<string, unknown>>();
+      let missingIdCount = 0;
       for (const run of [...currentRuns, ...legacyRuns]) {
         const id = readString(run.id);
-        runsById.set(id || JSON.stringify(run), run);
+        runsById.set(id || `__missing_agent_run_id__:${missingIdCount++}`, run);
+      }
+      if (missingIdCount > 0) {
+        console.warn("[agents] Loaded agent run row(s) without ids.", { count: missingIdCount });
       }
       const configsById = new Map(configs.map((config) => [config.id, config]));
       return [...runsById.values()]

--- a/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
+++ b/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
@@ -126,9 +126,13 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       .then(([currentRuns, legacyRuns]) => {
         if (useAgentStore.getState().echoLoadedChatId !== activeChatId) return; // stale
         const runsById = new Map<string, Record<string, unknown>>();
+        let missingIdCount = 0;
         for (const run of [...currentRuns, ...legacyRuns]) {
           const id = readEchoText(run.id);
-          runsById.set(id || JSON.stringify(run), run);
+          runsById.set(id || `__missing_echo_run_id__:${missingIdCount++}`, run);
+        }
+        if (missingIdCount > 0) {
+          console.warn("[echo-chamber] Loaded echo run row(s) without ids.", { count: missingIdCount });
         }
         const rows = [...runsById.values()].filter((run) => {
           const resultType = readEchoText(run.resultType) || readEchoText(run.result_type);

--- a/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
+++ b/src/features/modes/shared/chat-ui/components/EchoChamberPanel.tsx
@@ -119,12 +119,21 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       clearEchoMessages();
     }
 
-    storageApi
-      .list<unknown>("agent-runs", {
-        filters: { chatId: activeChatId, resultType: "echo_message" },
-      })
-      .then((rows) => {
+    Promise.all([
+      storageApi.list<Record<string, unknown>>("agent-runs", { filters: { chatId: activeChatId } }),
+      storageApi.list<Record<string, unknown>>("agent-runs", { filters: { chat_id: activeChatId } }),
+    ])
+      .then(([currentRuns, legacyRuns]) => {
         if (useAgentStore.getState().echoLoadedChatId !== activeChatId) return; // stale
+        const runsById = new Map<string, Record<string, unknown>>();
+        for (const run of [...currentRuns, ...legacyRuns]) {
+          const id = readEchoText(run.id);
+          runsById.set(id || JSON.stringify(run), run);
+        }
+        const rows = [...runsById.values()].filter((run) => {
+          const resultType = readEchoText(run.resultType) || readEchoText(run.result_type);
+          return resultType === "echo_message";
+        });
         const msgs = normalizeEchoMessages(rows);
         if (msgs.length > 0) {
           // If real-time messages already arrived (via addEchoMessage from SSE),

--- a/src/features/modes/shared/chat-ui/lib/echo-chamber-messages.ts
+++ b/src/features/modes/shared/chat-ui/lib/echo-chamber-messages.ts
@@ -37,7 +37,7 @@ export function normalizeEchoMessages(rows: unknown[]): EchoMessage[] {
       continue;
     }
 
-    const resultData = readEchoRecord(record.result_data ?? record.resultData);
+    const resultData = readEchoRecord(record.resultData ?? record.result_data);
     const reactions = Array.isArray(resultData.reactions) ? resultData.reactions : [];
     for (const item of reactions) {
       const reactionRecord = readEchoRecord(item);

--- a/src/features/modes/shared/chat-ui/lib/echo-chamber-messages.ts
+++ b/src/features/modes/shared/chat-ui/lib/echo-chamber-messages.ts
@@ -29,7 +29,7 @@ export function normalizeEchoMessages(rows: unknown[]): EchoMessage[] {
   const messages: EchoMessage[] = [];
   for (const row of rows) {
     const record = readEchoRecord(row);
-    const timestamp = readTimestamp(record.timestamp ?? record.createdAt);
+    const timestamp = readTimestamp(record.timestamp ?? record.created_at ?? record.createdAt);
     const directName = readEchoText(record.characterName);
     const directReaction = readEchoText(record.reaction);
     if (directName && directReaction) {
@@ -37,7 +37,7 @@ export function normalizeEchoMessages(rows: unknown[]): EchoMessage[] {
       continue;
     }
 
-    const resultData = readEchoRecord(record.resultData);
+    const resultData = readEchoRecord(record.result_data ?? record.resultData);
     const reactions = Array.isArray(resultData.reactions) ? resultData.reactions : [];
     for (const item of reactions) {
       const reactionRecord = readEchoRecord(item);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep validation checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1791

## Why this change

- Restores legacy/refactor parity for persisted agent run history so imported or pre-normalized `agent_runs` rows continue to drive cadence, echo messages, custom run review, and lorebook-keeper backfill behavior.

## What changed

- Normalized legacy snake_case agent run fields during profile import and app startup, including config metadata, timestamps, result payloads, numeric counters, and boolean success values.
- Updated Rust agent run commands to read current and legacy row shapes when calculating cadence, clearing runs, and deleting echo messages.
- Updated TypeScript generation/runtime readers so automatic interval gates, lorebook-keeper backfill, custom run UI, and echo UI understand both camelCase and snake_case agent run rows.
- Added focused Rust coverage for legacy agent-run import, startup normalization, cadence defaults, success filtering, and config-id matching.

## Refactor impact

Primary owner:

Rust storage/imports and engine generation.

Impact areas reviewed:

- `agent-runs` storage shape and query filters
- legacy profile import
- app startup storage migration
- built-in/custom agent cadence
- custom agent run UI
- echo chamber persisted-message UI
- lorebook-keeper backfill gating

Boundary notes:

- Engine code stays React-free and only reads through the existing storage gateway.
- Feature code still uses `storageApi`; no new raw Tauri imports.
- Rust behavior stays inside storage command/import/shared helpers; no command registration or remote-runtime allowlist changes.

Pressure points touched:

- Import modules: legacy profile import normalization.
- Shared mode UI: echo chamber persisted run loading only.
- No `ModeSurface`, `GameSurface`, or `src-tauri/src/lib.rs` command registration changes.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Commands run locally:

- `cargo test --manifest-path src-tauri\Cargo.toml cadence_status --lib`
- `cargo test --manifest-path src-tauri\Cargo.toml legacy_agent_runs_import_with_config_metadata --lib`
- `cargo test --manifest-path src-tauri\Cargo.toml app_state_startup_normalizes_legacy_agent_run_rows --lib`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `pnpm check:architecture`
- `git diff --check`
- `pnpm check`

Manual Tauri app QA was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix for existing agent run behavior; no new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed; this restores existing behavior and compatibility.

## UI evidence

No screenshots. UI impact is data compatibility for existing agent-run panels rather than a visible layout change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced data migration and normalization of legacy agent configurations and run records during app startup
  * Improved backward compatibility with agent data from previous application versions
  * Better handling of field name variations in stored agent records to ensure consistent data access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->