### PR TITLE
Add Bunny review command bootstrap

### DIFF
--- a/.github/workflows/bunny-review-command.yml
+++ b/.github/workflows/bunny-review-command.yml
@@ -1,0 +1,96 @@
+name: Bunny Review Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  dispatch:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/bunny-review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch trusted Bunny reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          TARGET_REF: refactor
+        run: |
+          # Keep this bootstrap deliberately inert: it only authorizes the slash command
+          # and dispatches the trusted reviewer workflow on the stable target ref.
+          REVIEW_MODE=auto
+          if [[ "$COMMENT_BODY" =~ ^/bunny-review[[:space:]]+full([[:space:]]|$) ]]; then
+            REVIEW_MODE=full
+          fi
+
+          status_body() {
+            local title="$1"
+            local detail="$2"
+            printf '%s\n' \
+              '<!-- bunny-review:command-status -->' \
+              "## Bunny Review $title" \
+              '' \
+              "Command: \`$COMMENT_BODY\`" \
+              "Mode: \`$REVIEW_MODE\`" \
+              "Requested by: \`$COMMENT_AUTHOR\`" \
+              "Target ref: \`$TARGET_REF\`" \
+              "Status: $detail"
+          }
+
+          upsert_status() {
+            local title="$1"
+            local detail="$2"
+            local body
+            body="$(status_body "$title" "$detail")"
+            local comment_id
+            comment_id="$(gh api "repos/${{ github.repository }}/issues/$PR_NUM/comments?per_page=100" \
+              --paginate \
+              --jq '.[] | select(.body | contains("<!-- bunny-review:command-status -->")) | .id' \
+              | tail -n 1)"
+            if [ -n "$comment_id" ]; then
+              gh api \
+                --method PATCH \
+                "repos/${{ github.repository }}/issues/comments/$comment_id" \
+                -f body="$body" >/dev/null
+            else
+              gh api \
+                --method POST \
+                "repos/${{ github.repository }}/issues/$PR_NUM/comments" \
+                -f body="$body" >/dev/null
+            fi
+          }
+
+          upsert_status "Queued" "Command accepted; dispatching the trusted reviewer workflow." \
+            || echo "::warning::Unable to write Bunny command status before dispatch."
+
+          set +e
+          DISPATCH_OUTPUT="$(gh workflow run bunny-review.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$TARGET_REF" \
+            -f pr_number="$PR_NUM" \
+            -f comment_body="$COMMENT_BODY" \
+            -f review_mode="$REVIEW_MODE" \
+            -f requested_by="$COMMENT_AUTHOR" 2>&1)"
+          DISPATCH_RC=$?
+          set -e
+
+          if [ "$DISPATCH_RC" -ne 0 ]; then
+            upsert_status "Failed To Dispatch" "GitHub rejected the reviewer dispatch. Inspect the Bunny Review Command run log." \
+              || echo "::warning::Unable to write Bunny command dispatch failure status."
+            echo "$DISPATCH_OUTPUT"
+            exit "$DISPATCH_RC"
+          fi
+
+          upsert_status "Dispatched" "Reviewer workflow dispatched; waiting for Bunny Review to post results." \
+            || echo "::warning::Unable to write Bunny command dispatched status."


### PR DESCRIPTION
<!-- Target branch: `main`. Main is intentional here because GitHub issue_comment slash-command workflows must exist on the default branch before commands can fire. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #

## Why this change

- Adds the minimal default-branch `/bunny-review` bootstrap so GitHub can receive issue comment commands and dispatch the trusted reviewer workflow on `refactor`.

## What changed

- Added `.github/workflows/bunny-review-command.yml` on `main`.
- The workflow authorizes collaborator/member/owner comments, parses `/bunny-review` mode, writes a command-status comment, and dispatches `bunny-review.yml` on the trusted `refactor` target ref.

## Refactor impact

Primary owner:

- GitHub workflow automation.

Impact areas reviewed:

- GitHub Actions `issue_comment` bootstrap and workflow dispatch wiring.

Boundary notes:

- No app source, engine, React feature, shared API, Tauri, storage, provider, or remote-runtime boundary is touched. This is a default-branch GitHub Actions bootstrap only.

Pressure points touched:

- GitHub Actions issue-comment event handling and dispatch to the trusted Bunny Review workflow on `refactor`.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent ran `git diff --cached --check` before commit.
- Agent inspected the staged workflow diff and confirmed only `.github/workflows/bunny-review-command.yml` is included.
- Runtime proof requires merge to the default branch because `issue_comment` workflows only activate from the default branch.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- GitHub workflow bootstrap only; no in-app user-discoverable behavior is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. No app UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comment-based command system for triggering pull request reviews. Owners, members, and collaborators can now invoke automated code reviews by posting a command in pull request comments. The system provides real-time feedback on command execution status, including success or failure notifications, through automatic comment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->