### PR TITLE
Fix conversation prompt context parity

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -154,17 +154,35 @@ describe("assembleGenerationPrompt conversation parity", () => {
       characterIds: ["alice"],
       metadata: { crossChatAwareness: true },
     };
+    const emptyNewerSibling = {
+      id: "chat-empty",
+      name: "Empty newer chat",
+      mode: "conversation",
+      characterIds: ["alice"],
+      updatedAt: "2026-06-01T15:00:00Z",
+      metadata: {},
+    };
+    const staleSibling = {
+      id: "chat-stale",
+      name: "Stale chat",
+      mode: "conversation",
+      characterIds: ["alice"],
+      updatedAt: "2026-05-01T15:00:00Z",
+      metadata: {},
+    };
     const sibling = {
       id: "chat-2",
       name: "Sibling chat",
       mode: "conversation",
       characterIds: ["alice", "bob"],
+      updatedAt: "2026-06-01T14:00:00Z",
       metadata: {},
     };
     const storage = createStorage({
-      chats: [chat, sibling],
+      chats: [chat, staleSibling, emptyNewerSibling, sibling],
       characters: [alice, bob],
       messages: {
+        "chat-stale": [{ id: "old", chatId: "chat-stale", role: "user", content: "Old continuity." }],
         "chat-2": [
           { id: "s1", chatId: "chat-2", role: "user", content: "We talked about the comet." },
           { id: "s2", chatId: "chat-2", role: "assistant", characterId: "alice", content: "I will remember it." },
@@ -178,6 +196,8 @@ describe("assembleGenerationPrompt conversation parity", () => {
     expect(enabled).toContain("<cross_chat_awareness>");
     expect(enabled).toContain("Sibling chat");
     expect(enabled).toContain("We talked about the comet.");
+    expect(enabled.indexOf("We talked about the comet.")).toBeLessThan(enabled.indexOf("Old continuity."));
+    expect(enabled).not.toContain("Empty newer chat");
     expect(disabled).not.toContain("<cross_chat_awareness>");
     expect(disabled).not.toContain("We talked about the comet.");
   });
@@ -253,6 +273,36 @@ describe("assembleGenerationPrompt conversation parity", () => {
     expect(enabled).toContain("[scene:");
     expect(enabled).toContain("<note>");
     expect(disabled).not.toContain("<conversation_commands>");
+  });
+
+  it("honors explicit conversation command capability false flags", async () => {
+    const chat = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      metadata: {
+        characterCommands: true,
+        commandCapabilities: {
+          canCrossPost: false,
+          canSelfie: false,
+          canStartScenes: false,
+          canSaveMemory: false,
+          canScheduleUpdate: false,
+        },
+        conversationSchedulesEnabled: true,
+        characterSchedules: { alice: { days: { Monday: [{ time: "10:00", activity: "available" }] } } },
+      },
+    };
+    const storage = createStorage({ chats: [chat], characters: [alice] });
+
+    const text = await promptText(storage, chat);
+
+    expect(text).not.toContain("<conversation_commands>");
+    expect(text).not.toContain("[schedule_update:");
+    expect(text).not.toContain("[cross_post:");
+    expect(text).not.toContain("[selfie");
+    expect(text).not.toContain("[memory:");
+    expect(text).not.toContain("[scene:");
   });
 
   it("does not inject conversation-only context into roleplay prompts", async () => {

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -238,6 +238,43 @@ describe("assembleGenerationPrompt conversation parity", () => {
     expect(text).not.toContain("[scene:");
   });
 
+  it("bounds cross-chat sibling message reads to recent candidates", async () => {
+    const chat = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      metadata: { crossChatAwareness: true },
+    };
+    const emptyRecentSiblings = Array.from({ length: 24 }, (_, index) => ({
+      id: `chat-empty-${index}`,
+      name: `Empty recent ${index}`,
+      mode: "conversation",
+      characterIds: ["alice"],
+      updatedAt: `2026-06-01T14:${String(index).padStart(2, "0")}:00Z`,
+      metadata: {},
+    }));
+    const oldSibling = {
+      id: "chat-old",
+      name: "Old sibling",
+      mode: "conversation",
+      characterIds: ["alice"],
+      updatedAt: "2026-05-01T14:00:00Z",
+      metadata: {},
+    };
+    const storage = createStorage({
+      chats: [chat, oldSibling, ...emptyRecentSiblings],
+      characters: [alice],
+      messages: {
+        "chat-old": [{ id: "old", chatId: "chat-old", role: "user", content: "Old but non-empty continuity." }],
+      },
+    });
+
+    const text = await promptText(storage, chat);
+
+    expect(text).not.toContain("<cross_chat_awareness>");
+    expect(text).not.toContain("Old but non-empty continuity.");
+  });
+
   it("injects linked roleplay and game context into conversation prompts", async () => {
     const conversation = {
       id: "chat-1",

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import type { StorageGateway } from "../capabilities/storage";
+import { assembleGenerationPrompt } from "./prompt-assembly";
+import type { JsonRecord } from "./runtime-records";
+
+function createStorage(args: {
+  chats?: JsonRecord[];
+  characters?: JsonRecord[];
+  personas?: JsonRecord[];
+  messages?: Record<string, JsonRecord[]>;
+}): StorageGateway {
+  const chats = args.chats ?? [];
+  const characters = args.characters ?? [];
+  const personas = args.personas ?? [];
+  const messages = args.messages ?? {};
+
+  const byEntity: Record<string, JsonRecord[]> = {
+    chats,
+    characters,
+    personas,
+    "regex-scripts": [],
+    lorebooks: [],
+    agents: [],
+  };
+
+  return {
+    async list<T = unknown>(entity: string): Promise<T[]> {
+      return ((byEntity[entity] ?? []) as T[]).slice();
+    },
+    async get<T = unknown>(entity: string, id: string): Promise<T | null> {
+      return ((byEntity[entity] ?? []).find((row) => row.id === id) as T | undefined) ?? null;
+    },
+    async create<T = unknown>(_entity: string, value: Record<string, unknown>): Promise<T> {
+      return value as T;
+    },
+    async update<T = unknown>(_entity: string, _id: string, patch: Record<string, unknown>): Promise<T> {
+      return patch as T;
+    },
+    async delete() {
+      return { deleted: true };
+    },
+    async listChatMessages<T = unknown>(chatId: string): Promise<T[]> {
+      return ((messages[chatId] ?? []) as T[]).slice();
+    },
+    async createChatMessage<T = unknown>(_chatId: string, value: Record<string, unknown>): Promise<T> {
+      return value as T;
+    },
+    async updateChatMessage<T = unknown>(_messageId: string, patch: Record<string, unknown>): Promise<T> {
+      return patch as T;
+    },
+    async deleteChatMessage() {
+      return { deleted: true };
+    },
+    async patchChatMessageExtra<T = unknown>(_messageId: string, patch: Record<string, unknown>): Promise<T> {
+      return patch as T;
+    },
+    async addChatMessageSwipe<T = unknown>(_chatId: string, _messageId: string, content: string): Promise<T> {
+      return { content } as T;
+    },
+    async patchChatMetadata<T = unknown>(_chatId: string, patch: Record<string, unknown>): Promise<T> {
+      return patch as T;
+    },
+    async patchChatSummaries<T = unknown>(_chatId: string, patch: Record<string, unknown>): Promise<T> {
+      return patch as T;
+    },
+    async listChatMemories<T = unknown>(): Promise<T[]> {
+      return [];
+    },
+    async getWorldState<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+    async saveTrackerSnapshot<T = unknown>(_chatId: string, snapshot: Record<string, unknown>): Promise<T> {
+      return snapshot as T;
+    },
+    async listLorebookEntries<T = unknown>(): Promise<T[]> {
+      return [];
+    },
+    async createLorebookEntries<T = unknown>(_lorebookId: string, entries: Array<Record<string, unknown>>): Promise<T[]> {
+      return entries as T[];
+    },
+    async promptFull<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+  };
+}
+
+const alice = {
+  id: "alice",
+  data: { name: "Alice", description: "A careful friend." },
+};
+
+const bob = {
+  id: "bob",
+  data: { name: "Bob", description: "A curious friend." },
+};
+
+const persona = {
+  id: "persona-1",
+  isActive: true,
+  data: { name: "Celia", description: "The user." },
+};
+
+const connection = {
+  id: "conn-1",
+  provider: "test",
+  model: "test-model",
+};
+
+async function promptText(storage: StorageGateway, chat: JsonRecord, request: JsonRecord = {}) {
+  const result = await assembleGenerationPrompt(storage, {
+    chat,
+    storedMessages: [{ id: "m1", chatId: chat.id, role: "user", content: "How is tonight looking?" }],
+    connection,
+    request,
+    latestUserInput: "How is tonight looking?",
+  });
+  return result.previewMessages.map((message) => message.content).join("\n\n");
+}
+
+describe("assembleGenerationPrompt conversation parity", () => {
+  it("includes live user status, activity, and character schedules for conversation prompts", async () => {
+    const chat = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      personaId: "persona-1",
+      metadata: {
+        conversationSchedulesEnabled: true,
+        characterSchedules: {
+          alice: {
+            days: {
+              Monday: [{ time: "19:00-21:00", status: "online", activity: "reading texts" }],
+            },
+          },
+        },
+      },
+    };
+    const storage = createStorage({ chats: [chat], characters: [alice], personas: [persona] });
+
+    const text = await promptText(storage, chat, { userStatus: "idle", userActivity: "making tea" });
+
+    expect(text).toContain("<conversation_presence>");
+    expect(text).toContain("User status: idle");
+    expect(text).toContain("User activity: making tea");
+    expect(text).toContain("<character_schedules>");
+    expect(text).toContain("Alice");
+    expect(text).toContain("19:00-21:00 online - reading texts");
+  });
+
+  it("injects recent sibling conversation messages only when cross-chat awareness is enabled", async () => {
+    const chat = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      metadata: { crossChatAwareness: true },
+    };
+    const sibling = {
+      id: "chat-2",
+      name: "Sibling chat",
+      mode: "conversation",
+      characterIds: ["alice", "bob"],
+      metadata: {},
+    };
+    const storage = createStorage({
+      chats: [chat, sibling],
+      characters: [alice, bob],
+      messages: {
+        "chat-2": [
+          { id: "s1", chatId: "chat-2", role: "user", content: "We talked about the comet." },
+          { id: "s2", chatId: "chat-2", role: "assistant", characterId: "alice", content: "I will remember it." },
+        ],
+      },
+    });
+
+    const enabled = await promptText(storage, chat);
+    const disabled = await promptText(storage, { ...chat, metadata: { crossChatAwareness: false } });
+
+    expect(enabled).toContain("<cross_chat_awareness>");
+    expect(enabled).toContain("Sibling chat");
+    expect(enabled).toContain("We talked about the comet.");
+    expect(disabled).not.toContain("<cross_chat_awareness>");
+    expect(disabled).not.toContain("We talked about the comet.");
+  });
+
+  it("injects linked roleplay and game context into conversation prompts", async () => {
+    const conversation = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      connectedChatId: "roleplay-1",
+      metadata: {},
+    };
+    const roleplay = {
+      id: "roleplay-1",
+      name: "Moonlit scene",
+      mode: "roleplay",
+      characterIds: ["alice"],
+      metadata: { sceneDescription: "Alice is investigating moonlit ruins." },
+    };
+    const gameConversation = { ...conversation, id: "chat-game", connectedChatId: "game-1" };
+    const game = {
+      id: "game-1",
+      name: "Dungeon run",
+      mode: "game",
+      characterIds: ["alice"],
+      metadata: { gameState: { location: "Crystal Gate", objective: "Find the key" } },
+    };
+    const storage = createStorage({
+      chats: [conversation, roleplay, gameConversation, game],
+      characters: [alice],
+      messages: {
+        "roleplay-1": [{ id: "r1", chatId: "roleplay-1", role: "assistant", content: "The ruins hum softly." }],
+        "game-1": [{ id: "g1", chatId: "game-1", role: "assistant", content: "The party reaches the gate." }],
+      },
+    });
+
+    const roleplayText = await promptText(storage, conversation);
+    const gameText = await promptText(storage, gameConversation);
+
+    expect(roleplayText).toContain("<connected_roleplay>");
+    expect(roleplayText).toContain("Moonlit scene");
+    expect(roleplayText).toContain("Alice is investigating moonlit ruins.");
+    expect(roleplayText).toContain("The ruins hum softly.");
+    expect(gameText).toContain("<connected_game>");
+    expect(gameText).toContain("Dungeon run");
+    expect(gameText).toContain("Crystal Gate");
+    expect(gameText).toContain("The party reaches the gate.");
+  });
+
+  it("adds gated conversation command instructions when commands are enabled", async () => {
+    const chat = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      connectedChatId: "roleplay-1",
+      metadata: {
+        characterCommands: true,
+        conversationSchedulesEnabled: true,
+        characterSchedules: { alice: { days: { Monday: [] } } },
+      },
+    };
+    const roleplay = { id: "roleplay-1", mode: "roleplay", characterIds: ["alice"], metadata: {} };
+    const storage = createStorage({ chats: [chat, roleplay], characters: [alice] });
+
+    const enabled = await promptText(storage, chat);
+    const disabled = await promptText(storage, { ...chat, metadata: { ...chat.metadata, characterCommands: false } });
+
+    expect(enabled).toContain("<conversation_commands>");
+    expect(enabled).toContain("[schedule_update:");
+    expect(enabled).toContain("[cross_post:");
+    expect(enabled).toContain("[selfie");
+    expect(enabled).toContain("[memory:");
+    expect(enabled).toContain("[scene:");
+    expect(enabled).toContain("<note>");
+    expect(disabled).not.toContain("<conversation_commands>");
+  });
+
+  it("does not inject conversation-only context into roleplay prompts", async () => {
+    const roleplay = {
+      id: "roleplay-1",
+      mode: "roleplay",
+      characterIds: ["alice"],
+      metadata: {
+        characterCommands: true,
+        crossChatAwareness: true,
+        conversationSchedulesEnabled: true,
+        characterSchedules: { alice: { days: { Monday: [{ time: "09:00-10:00", activity: "texts" }] } } },
+      },
+    };
+    const storage = createStorage({ chats: [roleplay], characters: [alice] });
+
+    const text = await promptText(storage, roleplay, { userStatus: "idle", userActivity: "reading" });
+
+    expect(text).not.toContain("<conversation_presence>");
+    expect(text).not.toContain("<character_schedules>");
+    expect(text).not.toContain("<cross_chat_awareness>");
+    expect(text).not.toContain("<conversation_commands>");
+  });
+});

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -24,10 +24,10 @@ function createStorage(args: {
   };
 
   return {
-    async list<T = unknown>(entity: string): Promise<T[]> {
+    async list<T = unknown>(entity: string, _options?: unknown): Promise<T[]> {
       return ((byEntity[entity] ?? []) as T[]).slice();
     },
-    async get<T = unknown>(entity: string, id: string): Promise<T | null> {
+    async get<T = unknown>(entity: string, id: string, _options?: unknown): Promise<T | null> {
       return ((byEntity[entity] ?? []).find((row) => row.id === id) as T | undefined) ?? null;
     },
     async create<T = unknown>(_entity: string, value: Record<string, unknown>): Promise<T> {
@@ -36,10 +36,10 @@ function createStorage(args: {
     async update<T = unknown>(_entity: string, _id: string, patch: Record<string, unknown>): Promise<T> {
       return patch as T;
     },
-    async delete() {
+    async delete(_entity?: unknown, _id?: unknown) {
       return { deleted: true };
     },
-    async listChatMessages<T = unknown>(chatId: string): Promise<T[]> {
+    async listChatMessages<T = unknown>(chatId: string, _options?: unknown): Promise<T[]> {
       return ((messages[chatId] ?? []) as T[]).slice();
     },
     async createChatMessage<T = unknown>(_chatId: string, value: Record<string, unknown>): Promise<T> {
@@ -200,6 +200,42 @@ describe("assembleGenerationPrompt conversation parity", () => {
     expect(enabled).not.toContain("Empty newer chat");
     expect(disabled).not.toContain("<cross_chat_awareness>");
     expect(disabled).not.toContain("We talked about the comet.");
+  });
+
+  it("keeps cross-chat and command instructions quiet when conversation metadata is absent", async () => {
+    const chat = {
+      id: "chat-1",
+      mode: "conversation",
+      characterIds: ["alice"],
+      connectedChatId: "roleplay-1",
+      metadata: {},
+    };
+    const sibling = {
+      id: "chat-2",
+      name: "Sibling chat",
+      mode: "conversation",
+      characterIds: ["alice"],
+      updatedAt: "2026-06-01T14:00:00Z",
+      metadata: {},
+    };
+    const roleplay = { id: "roleplay-1", mode: "roleplay", characterIds: ["alice"], metadata: {} };
+    const storage = createStorage({
+      chats: [chat, sibling, roleplay],
+      characters: [alice],
+      messages: {
+        "chat-2": [{ id: "s1", chatId: "chat-2", role: "user", content: "Private sibling continuity." }],
+      },
+    });
+
+    const text = await promptText(storage, chat);
+
+    expect(text).not.toContain("<cross_chat_awareness>");
+    expect(text).not.toContain("Private sibling continuity.");
+    expect(text).not.toContain("<conversation_commands>");
+    expect(text).not.toContain("[cross_post:");
+    expect(text).not.toContain("[selfie");
+    expect(text).not.toContain("[memory:");
+    expect(text).not.toContain("[scene:");
   });
 
   it("injects linked roleplay and game context into conversation prompts", async () => {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1597,6 +1597,16 @@ function sharesConversationCharacter(source: JsonRecord, candidate: JsonRecord):
   return activeCharacterIds(candidate).some((id) => sourceIds.has(id));
 }
 
+function chatRecencyMs(chat: JsonRecord): number {
+  const raw =
+    readString(chat.lastActivityAt).trim() ||
+    readString(chat.updatedAt).trim() ||
+    readString(chat.lastMessageAt).trim() ||
+    readString(chat.createdAt).trim();
+  const time = raw ? Date.parse(raw) : Number.NaN;
+  return Number.isFinite(time) ? time : 0;
+}
+
 async function buildCrossChatAwarenessBlock(
   storage: StorageGateway,
   chat: JsonRecord,
@@ -1614,9 +1624,10 @@ async function buildCrossChatAwarenessBlock(
     .filter((candidate) => readString(candidate.id).trim() !== chatId)
     .filter((candidate) => modeOf(candidate) === "conversation")
     .filter((candidate) => sharesConversationCharacter(chat, candidate))
-    .slice(0, 6);
+    .sort((left, right) => chatRecencyMs(right) - chatRecencyMs(left));
   const sections: string[] = [];
   for (const sibling of siblingChats) {
+    if (sections.length >= 6) break;
     const siblingId = readString(sibling.id).trim();
     if (!siblingId) continue;
     const lines = recentVisibleMessageLines(
@@ -1706,6 +1717,22 @@ async function buildConversationLinkedChatBlock(
   };
 }
 
+function conversationCommandCapabilities(chat: JsonRecord, meta: JsonRecord): JsonRecord {
+  return {
+    ...parseRecord(meta.commandCapabilities),
+    ...parseRecord(meta.capabilities),
+    ...parseRecord(chat.capabilities),
+  };
+}
+
+function commandCapabilityEnabled(capabilities: JsonRecord, keys: string[], fallback = true): boolean {
+  for (const key of keys) {
+    if (capabilities[key] === false) return false;
+    if (capabilities[key] === true) return true;
+  }
+  return fallback;
+}
+
 function buildConversationCommandBlock(
   chat: JsonRecord,
   characters: GenerationCharacterContext[],
@@ -1715,21 +1742,34 @@ function buildConversationCommandBlock(
   if (modeOf(chat) !== "conversation") return null;
   const meta = parseRecord(chat.metadata);
   if (meta.characterCommands === false) return null;
+  const capabilities = conversationCommandCapabilities(chat, meta);
   const schedules = parseRecord(meta.characterSchedules);
-  const hasSchedules = boolish(meta.conversationSchedulesEnabled, Object.keys(schedules).length > 0);
+  const hasSchedules =
+    boolish(meta.conversationSchedulesEnabled, Object.keys(schedules).length > 0) &&
+    commandCapabilityEnabled(capabilities, ["scheduleUpdate", "canScheduleUpdate", "canUpdateSchedule"]);
   const hasCharacters = characters.length > 0;
   const hasConnectedRoleplayOrGame = connectedMode === "roleplay" || connectedMode === "game";
+  const canCrossPost = commandCapabilityEnabled(capabilities, ["crossPost", "canCrossPost"]);
+  const canSelfie = commandCapabilityEnabled(capabilities, ["selfie", "canSelfie", "imageGeneration", "canGenerateImages"]);
+  const canMemory = commandCapabilityEnabled(capabilities, ["memory", "canSaveMemory"]);
+  const canStartScene = commandCapabilityEnabled(capabilities, ["scene", "canStartScene", "canStartScenes"]);
   const instructions = [
     "When useful, append one hidden command tag after the visible reply. Hidden tags are parsed by Marinara and stripped before the user sees the message. Never describe the tag in visible prose.",
     hasSchedules
       ? '- Update availability with [schedule_update: status="online|idle|dnd|offline", activity="short activity"] when the character is correcting their current status or plans.'
       : "",
-    '- Cross-post a message with [cross_post: target="group or chat name"] when the character naturally wants to move or share a message across conversations.',
-    '- Request an image with [selfie] or [selfie: context="brief visual context"] when a casual conversation selfie is appropriate and image generation is configured.',
-    hasCharacters
+    canCrossPost
+      ? '- Cross-post a message with [cross_post: target="group or chat name"] when the character naturally wants to move or share a message across conversations.'
+      : "",
+    canSelfie
+      ? '- Request an image with [selfie] or [selfie: context="brief visual context"] when a casual conversation selfie is appropriate and image generation is configured.'
+      : "",
+    hasCharacters && canMemory
       ? '- Save a durable character memory with [memory: target="Character Name", summary="brief memory"] when the character learns something they should remember later.'
       : "",
-    '- Start a linked roleplay scene with [scene: scenario="what happens", background="optional setting", plan="optional short plan"] when the conversation clearly calls for a scene.',
+    canStartScene
+      ? '- Start a linked roleplay scene with [scene: scenario="what happens", background="optional setting", plan="optional short plan"] when the conversation clearly calls for a scene.'
+      : "",
     hasConnectedRoleplayOrGame
       ? "- Send linked-chat context with <influence>one-shot OOC steering note</influence> or <note>durable fact for the linked prompt</note> when this conversation should affect the linked roleplay/game."
       : "",

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -11,7 +11,7 @@ import { stripConversationPromptTimestamps } from "../modes/chat/core/summaries/
 import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine";
 import { collapseExcessBlankLines } from "../shared/text/newlines";
 import { cleanPromptText, stripPromptComments } from "../shared/text/prompt-comments";
-import { normalizeUserTimeZone } from "../shared/time/timezone";
+import { formatZonedDate, formatZonedTime, getZonedWeekdayName, normalizeUserTimeZone } from "../shared/time/timezone";
 import type {
   GameActiveState,
   GameCampaignPlan,
@@ -1486,6 +1486,279 @@ function buildConnectedConversationBlocks(chat: JsonRecord): ChatMLMessage[] {
   return blocks;
 }
 
+function characterNameLookup(characters: GenerationCharacterContext[]): Map<string, string> {
+  return new Map(characters.map((character) => [character.id, character.name]));
+}
+
+function promptSnippet(value: unknown, limit = 900): string {
+  const text = collapseExcessBlankLines(readString(value)).replace(/\s+/g, " ").trim();
+  return text.length > limit ? `${text.slice(0, limit - 3).trimEnd()}...` : text;
+}
+
+function modeOf(chat: JsonRecord | null | undefined): string {
+  return readString(chat?.mode || chat?.chatMode, "conversation");
+}
+
+function historyLine(message: JsonRecord, characterNames: Map<string, string>): string {
+  const role = readString(message.role, "message");
+  const characterId = readString(message.characterId).trim();
+  const name =
+    readString(message.name || message.displayName || message.characterName).trim() ||
+    (characterId ? characterNames.get(characterId) : "") ||
+    role;
+  return `${name}: ${promptSnippet(message.content, 700)}`;
+}
+
+function recentVisibleMessageLines(messages: JsonRecord[], characterNames: Map<string, string>, limit = 6): string[] {
+  return messages
+    .filter((message) => !hiddenFromAi(message) && readString(message.content).trim())
+    .slice(-limit)
+    .map((message) => historyLine(message, characterNames));
+}
+
+function buildConversationPresenceBlock(input: PromptAssemblyInput, wrapFormat: WrapFormat): ChatMLMessage | null {
+  const chatMode = modeOf(input.chat);
+  if (chatMode !== "conversation") return null;
+  const status = readString(input.request.userStatus).trim();
+  const activity = readString(input.request.userActivity).trim();
+  const timeZone = resolvePromptTimeZone(input.chat, input.request);
+  const now = new Date();
+  const parts = [
+    status ? `User status: ${status}` : "",
+    activity ? `User activity: ${activity}` : "",
+    `Current date: ${formatZonedDate(now, timeZone)}`,
+    `Current time: ${formatZonedTime(now, timeZone)}`,
+    `Current weekday: ${getZonedWeekdayName(now, timeZone)}`,
+    timeZone ? `Time zone: ${timeZone}` : "",
+  ].filter(Boolean);
+  if (parts.length === 0) return null;
+  return {
+    role: "system",
+    contextKind: "prompt",
+    content: wrapContent(
+      [
+        "Use this live conversation presence context to judge availability, timing, and whether proactive or casual replies make sense.",
+        ...parts,
+      ].join("\n"),
+      "conversation_presence",
+      wrapFormat,
+    ),
+  };
+}
+
+function scheduleLine(block: JsonRecord): string {
+  const time = readString(block.time).trim();
+  const status = readString(block.status).trim();
+  const activity = readString(block.activity).trim();
+  const prefix = [time, status].filter(Boolean).join(" ");
+  if (!prefix) return activity;
+  return activity ? `${prefix} - ${activity}` : prefix;
+}
+
+function buildConversationScheduleBlock(
+  chat: JsonRecord,
+  characters: GenerationCharacterContext[],
+  wrapFormat: WrapFormat,
+): ChatMLMessage | null {
+  if (modeOf(chat) !== "conversation") return null;
+  const meta = parseRecord(chat.metadata);
+  const schedules = parseRecord(meta.characterSchedules);
+  if (!boolish(meta.conversationSchedulesEnabled, Object.keys(schedules).length > 0)) return null;
+  const names = characterNameLookup(characters);
+  const sections: string[] = [];
+  for (const characterId of activeCharacterIds(chat)) {
+    const schedule = parseRecord(schedules[characterId]);
+    const days = parseRecord(schedule.days);
+    const lines = Object.entries(days).flatMap(([day, rawBlocks]) => {
+      const blocks = parseArray(rawBlocks).filter(isRecord).map(scheduleLine).filter((line) => line.trim());
+      return blocks.length > 0 ? [`${day}:`, ...blocks.map((line) => `- ${line}`)] : [];
+    });
+    if (lines.length === 0) continue;
+    sections.push([names.get(characterId) ?? characterId, ...lines.slice(0, 28)].join("\n"));
+  }
+  if (sections.length === 0) return null;
+  return {
+    role: "system",
+    contextKind: "prompt",
+    content: wrapContent(
+      [
+        "Generated weekly availability for conversation characters. Use it as soft context for whether a character is available, busy, or likely to reply.",
+        sections.join("\n\n"),
+      ].join("\n\n"),
+      "character_schedules",
+      wrapFormat,
+    ),
+  };
+}
+
+function sharesConversationCharacter(source: JsonRecord, candidate: JsonRecord): boolean {
+  const sourceIds = new Set(activeCharacterIds(source));
+  if (sourceIds.size === 0) return false;
+  return activeCharacterIds(candidate).some((id) => sourceIds.has(id));
+}
+
+async function buildCrossChatAwarenessBlock(
+  storage: StorageGateway,
+  chat: JsonRecord,
+  characters: GenerationCharacterContext[],
+  wrapFormat: WrapFormat,
+): Promise<ChatMLMessage | null> {
+  if (modeOf(chat) !== "conversation") return null;
+  const meta = parseRecord(chat.metadata);
+  if (meta.crossChatAwareness === false) return null;
+  const chatId = readString(chat.id).trim();
+  if (!chatId) return null;
+  const characterNames = characterNameLookup(characters);
+  const chats = await storage.list<JsonRecord>("chats").catch(() => []);
+  const siblingChats = chats
+    .filter((candidate) => readString(candidate.id).trim() !== chatId)
+    .filter((candidate) => modeOf(candidate) === "conversation")
+    .filter((candidate) => sharesConversationCharacter(chat, candidate))
+    .slice(0, 6);
+  const sections: string[] = [];
+  for (const sibling of siblingChats) {
+    const siblingId = readString(sibling.id).trim();
+    if (!siblingId) continue;
+    const lines = recentVisibleMessageLines(
+      await storage.listChatMessages<JsonRecord>(siblingId, { limit: 8 }).catch(() => []),
+      characterNames,
+      4,
+    );
+    if (lines.length === 0) continue;
+    const title = readString(sibling.name).trim() || siblingId;
+    sections.push([`Chat: ${title}`, ...lines.map((line) => `- ${line}`)].join("\n"));
+  }
+  if (sections.length === 0) return null;
+  return {
+    role: "system",
+    contextKind: "prompt",
+    content: wrapContent(
+      [
+        "Recent sibling conversation context for shared characters. Use it for continuity only; do not quote it as a system artifact.",
+        sections.join("\n\n"),
+      ].join("\n\n"),
+      "cross_chat_awareness",
+      wrapFormat,
+    ),
+  };
+}
+
+function connectedSummaryLines(chat: JsonRecord): string[] {
+  const meta = parseRecord(chat.metadata);
+  const mode = modeOf(chat);
+  const summaryValues = [
+    meta.conversationSummary,
+    meta.summary,
+    meta.lastRoleplaySceneSummary,
+    meta.sceneDescription,
+    meta.sceneScenario,
+  ]
+    .map((value) => promptSnippet(value, 900))
+    .filter(Boolean);
+  const gameState = mode === "game" ? parseRecord(chat.gameState ?? meta.gameState) : {};
+  return [
+    ...summaryValues.map((summary) => `Summary: ${summary}`),
+    Object.keys(gameState).length > 0 ? `Game state: ${JSON.stringify(gameState).slice(0, 1800)}` : "",
+  ].filter(Boolean);
+}
+
+async function buildConversationLinkedChatBlock(
+  storage: StorageGateway,
+  chat: JsonRecord,
+  characters: GenerationCharacterContext[],
+  wrapFormat: WrapFormat,
+): Promise<{ block: ChatMLMessage | null; connectedMode: string | null }> {
+  if (modeOf(chat) !== "conversation") return { block: null, connectedMode: null };
+  const connectedChatId = readString(chat.connectedChatId).trim();
+  if (!connectedChatId) return { block: null, connectedMode: null };
+  const connected = await storage.get<JsonRecord>("chats", connectedChatId).catch(() => null);
+  const connectedMode = modeOf(connected);
+  if (!connected || (connectedMode !== "roleplay" && connectedMode !== "game")) {
+    return { block: null, connectedMode: null };
+  }
+  const characterNames = characterNameLookup(characters);
+  const recentLines = recentVisibleMessageLines(
+    await storage.listChatMessages<JsonRecord>(connectedChatId, { limit: 10 }).catch(() => []),
+    characterNames,
+    6,
+  );
+  const title = readString(connected.name).trim() || connectedChatId;
+  const lines = [
+    `Linked ${connectedMode}: ${title}`,
+    ...connectedSummaryLines(connected),
+    ...(recentLines.length > 0 ? ["Recent linked messages:", ...recentLines.map((line) => `- ${line}`)] : []),
+  ].filter(Boolean);
+  if (lines.length <= 1) return { block: null, connectedMode };
+  return {
+    connectedMode,
+    block: {
+      role: "system",
+      contextKind: "prompt",
+      content: wrapContent(
+        [
+          `This conversation is linked to a ${connectedMode} chat. Use the linked context when the user or character refers to that shared situation, without turning the conversation reply into a full ${connectedMode} turn unless asked.`,
+          lines.join("\n"),
+        ].join("\n\n"),
+        connectedMode === "game" ? "connected_game" : "connected_roleplay",
+        wrapFormat,
+      ),
+    },
+  };
+}
+
+function buildConversationCommandBlock(
+  chat: JsonRecord,
+  characters: GenerationCharacterContext[],
+  connectedMode: string | null,
+  wrapFormat: WrapFormat,
+): ChatMLMessage | null {
+  if (modeOf(chat) !== "conversation") return null;
+  const meta = parseRecord(chat.metadata);
+  if (meta.characterCommands === false) return null;
+  const schedules = parseRecord(meta.characterSchedules);
+  const hasSchedules = boolish(meta.conversationSchedulesEnabled, Object.keys(schedules).length > 0);
+  const hasCharacters = characters.length > 0;
+  const hasConnectedRoleplayOrGame = connectedMode === "roleplay" || connectedMode === "game";
+  const instructions = [
+    "When useful, append one hidden command tag after the visible reply. Hidden tags are parsed by Marinara and stripped before the user sees the message. Never describe the tag in visible prose.",
+    hasSchedules
+      ? '- Update availability with [schedule_update: status="online|idle|dnd|offline", activity="short activity"] when the character is correcting their current status or plans.'
+      : "",
+    '- Cross-post a message with [cross_post: target="group or chat name"] when the character naturally wants to move or share a message across conversations.',
+    '- Request an image with [selfie] or [selfie: context="brief visual context"] when a casual conversation selfie is appropriate and image generation is configured.',
+    hasCharacters
+      ? '- Save a durable character memory with [memory: target="Character Name", summary="brief memory"] when the character learns something they should remember later.'
+      : "",
+    '- Start a linked roleplay scene with [scene: scenario="what happens", background="optional setting", plan="optional short plan"] when the conversation clearly calls for a scene.',
+    hasConnectedRoleplayOrGame
+      ? "- Send linked-chat context with <influence>one-shot OOC steering note</influence> or <note>durable fact for the linked prompt</note> when this conversation should affect the linked roleplay/game."
+      : "",
+  ].filter(Boolean);
+  if (instructions.length <= 1) return null;
+  return {
+    role: "system",
+    contextKind: "prompt",
+    content: wrapContent(instructions.join("\n"), "conversation_commands", wrapFormat),
+  };
+}
+
+async function buildConversationContextBlocks(
+  storage: StorageGateway,
+  input: PromptAssemblyInput,
+  characters: GenerationCharacterContext[],
+  wrapFormat: WrapFormat,
+): Promise<ChatMLMessage[]> {
+  if (modeOf(input.chat) !== "conversation") return [];
+  const linked = await buildConversationLinkedChatBlock(storage, input.chat, characters, wrapFormat);
+  return [
+    buildConversationPresenceBlock(input, wrapFormat),
+    buildConversationScheduleBlock(input.chat, characters, wrapFormat),
+    await buildCrossChatAwarenessBlock(storage, input.chat, characters, wrapFormat),
+    linked.block,
+    buildConversationCommandBlock(input.chat, characters, linked.connectedMode, wrapFormat),
+  ].filter((block): block is ChatMLMessage => block !== null);
+}
+
 function buildRoleplayDirectMessageCommandReminder(chat: JsonRecord): ChatMLMessage[] {
   const mode = readString(chat.mode || chat.chatMode, "conversation");
   const meta = parseRecord(chat.metadata);
@@ -2021,6 +2294,7 @@ export async function assembleGenerationPrompt(
   }
 
   insertBeforeLastUser(messages, [
+    ...(await buildConversationContextBlocks(storage, input, characters, wrapFormat)),
     ...buildConnectedConversationBlocks(input.chat),
     ...buildRoleplayDirectMessageCommandReminder(input.chat),
   ]);

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1597,6 +1597,8 @@ function sharesConversationCharacter(source: JsonRecord, candidate: JsonRecord):
   return activeCharacterIds(candidate).some((id) => sourceIds.has(id));
 }
 
+const CROSS_CHAT_SIBLING_SCAN_LIMIT = 24;
+
 function chatRecencyMs(chat: JsonRecord): number {
   const raw =
     readString(chat.lastActivityAt).trim() ||
@@ -1624,7 +1626,8 @@ async function buildCrossChatAwarenessBlock(
     .filter((candidate) => readString(candidate.id).trim() !== chatId)
     .filter((candidate) => modeOf(candidate) === "conversation")
     .filter((candidate) => sharesConversationCharacter(chat, candidate))
-    .sort((left, right) => chatRecencyMs(right) - chatRecencyMs(left));
+    .sort((left, right) => chatRecencyMs(right) - chatRecencyMs(left))
+    .slice(0, CROSS_CHAT_SIBLING_SCAN_LIMIT);
   const sections: string[] = [];
   for (const sibling of siblingChats) {
     if (sections.length >= 6) break;

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1615,7 +1615,7 @@ async function buildCrossChatAwarenessBlock(
 ): Promise<ChatMLMessage | null> {
   if (modeOf(chat) !== "conversation") return null;
   const meta = parseRecord(chat.metadata);
-  if (meta.crossChatAwareness === false) return null;
+  if (!boolish(meta.crossChatAwareness, false)) return null;
   const chatId = readString(chat.id).trim();
   if (!chatId) return null;
   const characterNames = characterNameLookup(characters);
@@ -1741,7 +1741,7 @@ function buildConversationCommandBlock(
 ): ChatMLMessage | null {
   if (modeOf(chat) !== "conversation") return null;
   const meta = parseRecord(chat.metadata);
-  if (meta.characterCommands === false) return null;
+  if (!boolish(meta.characterCommands, false)) return null;
   const capabilities = conversationCommandCapabilities(chat, meta);
   const schedules = parseRecord(meta.characterSchedules);
   const hasSchedules =

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1416,6 +1416,8 @@ export function useGenerate() {
             { storage: storageApi, llm: llmApi, integrations: reviewedIntegrationGateway, visuals: visualAssetsApi },
             {
               ...streamArgs,
+              userStatus: useUIStore.getState().userStatus,
+              userActivity: useUIStore.getState().userActivity,
               userTimeZone: resolveUserTimeZone(),
               imagePromptSettings: {
                 includeAppearances: useUIStore.getState().imagePromptIncludeAppearances,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1789

## Why this change

- Conversation mode still exposed live presence, schedules, cross-chat awareness, connected chat, and command settings, but the refactor prompt assembly did not include the matching conversation context blocks.

## What changed

- Added conversation prompt context blocks for live user status/activity/time, generated character schedules, sibling conversation awareness, linked roleplay/game context, and gated hidden command instructions.
- Plumbed foreground generation `userStatus` and `userActivity` into `startGeneration` so the engine can render live presence context.
- Added focused prompt-assembly regression coverage for the restored context blocks and their disabled/non-conversation gates.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- conversation mode prompt assembly
- runtime generation request plumbing
- roleplay/game linked-chat prompt boundaries
- architecture/import boundaries via `pnpm check`

Boundary notes:

- Prompt behavior remains engine-owned in `src/engine/generation/prompt-assembly.ts`.
- Feature code only passes existing UI presence state through the generation request; it does not assemble prompt text.
- Roleplay/game-owned prompt blocks are unchanged; conversation context blocks are gated to `mode === "conversation"`.

Pressure points touched:

- `src/engine/generation/prompt-assembly.ts`
- `src/features/runtime/generation/hooks/use-generate.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

Codex machine verification:

- `pnpm exec vitest run src\engine\generation\prompt-assembly.test.ts` passed. The regression suite covers live presence/schedules, cross-chat awareness enabled/disabled, linked roleplay and game context, command instructions enabled/disabled, and roleplay non-injection.
- `pnpm typecheck` passed.
- `pnpm check` passed after the final staged diff: line endings, architecture, frontend typecheck, Rust check, docs, discovery, and unused-code.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed locally.
- Bunny review pass completed locally before PR creation with no blocking findings.

### Manual verification notes

- No manual verification required for the core claim; the prompt assembly behavior is covered by focused automated tests and full local validation.
- Local non-UI proof artifacts were captured under `scratch/issue-1789-vitest-after.txt` and `scratch/issue-1789-proof.png`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix restoring behavior promised by existing conversation settings; no new discoverable surface was added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is prompt assembly/request plumbing, not a visible UI-state change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced AI context with live character presence and weekly schedule information
  * Cross-chat awareness enabling AI to reference related character conversations
  * Support for linked conversation contexts from connected roleplay and game chats
  * Expanded conversation command suite including schedule management, cross-posting, and memory features
  * Improved integration of user status and activity into AI interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->