### PR TITLE
Fix game checkpoints and scene asset safeguards

### DIFF
--- a/src/engine/modes/game/scene/game-scene-analysis.service.test.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.test.ts
@@ -246,6 +246,34 @@ describe("analyzeGameScene", () => {
     expect(result.directions).toEqual([]);
   });
 
+  it("surfaces provider failures so the UI can run inline tag fallback", async () => {
+    const llm = {
+      complete: vi.fn(async () => {
+        throw new Error("scene provider unavailable");
+      }),
+      stream: emptyStream,
+      listModels: vi.fn(async () => []),
+    } satisfies LlmGateway;
+    const storage = {
+      get: vi.fn(async () => ({ id: "chat-1", metadata: { gameSceneConnectionId: "scene-conn" } })),
+      list: vi.fn(async () => []),
+    } as unknown as StorageGateway;
+
+    await expect(
+      analyzeGameScene(
+        { storage, llm },
+        {
+          chatId: "chat-1",
+          narration: "The party enters the cave. [background: cave]",
+          context: {
+            availableBackgrounds: ["backgrounds:cave"],
+            availableSfx: [],
+          },
+        },
+      ),
+    ).rejects.toThrow("scene provider unavailable");
+  });
+
   it("does not fall back to Spotify candidates when Spotify music is disabled", async () => {
     const llm = {
       complete: vi.fn(async () => "{ not valid json"),

--- a/src/engine/modes/game/scene/game-scene-analysis.service.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.ts
@@ -242,24 +242,19 @@ export async function analyzeGameScene(
   capabilities: GameSceneAnalysisCapabilities,
   input: GameSceneAnalysisRequest,
 ): Promise<SceneAnalysis> {
-  let chat: JsonRecord | null = null;
-  try {
-    chat = input.chatId ? await capabilities.storage.get<JsonRecord>("chats", input.chatId) : null;
-    const connectionId = await resolveGameSceneConnectionId(capabilities.storage, chat, input.connectionId ?? null);
-    const sceneContext = normalizeSceneAnalyzerContext(input.context);
+  const chat = input.chatId ? await capabilities.storage.get<JsonRecord>("chats", input.chatId) : null;
+  const connectionId = await resolveGameSceneConnectionId(capabilities.storage, chat, input.connectionId ?? null);
+  const sceneContext = normalizeSceneAnalyzerContext(input.context);
 
-    const raw = await capabilities.llm.complete({
-      connectionId,
-      messages: [
-        { role: "system", content: buildSceneAnalyzerSystemPrompt(sceneContext) },
-        { role: "user", content: buildSceneAnalyzerUserPrompt(input.narration, undefined, sceneContext) },
-      ],
-      parameters: { maxTokens: 1200, temperature: 0.2 },
-    });
-    const parsed = parseObject(raw);
-    const analysis = parsed ? sanitizeGameSceneAnalysis(parsed) : malformedJsonFallback(sceneContext);
-    return postProcessSceneResult(analysis, scenePostProcessContext(sceneContext));
-  } catch (error) {
-    throw error;
-  }
+  const raw = await capabilities.llm.complete({
+    connectionId,
+    messages: [
+      { role: "system", content: buildSceneAnalyzerSystemPrompt(sceneContext) },
+      { role: "user", content: buildSceneAnalyzerUserPrompt(input.narration, undefined, sceneContext) },
+    ],
+    parameters: { maxTokens: 1200, temperature: 0.2 },
+  });
+  const parsed = parseObject(raw);
+  const analysis = parsed ? sanitizeGameSceneAnalysis(parsed) : malformedJsonFallback(sceneContext);
+  return postProcessSceneResult(analysis, scenePostProcessContext(sceneContext));
 }

--- a/src/engine/modes/game/scene/game-scene-analysis.service.ts
+++ b/src/engine/modes/game/scene/game-scene-analysis.service.ts
@@ -259,7 +259,7 @@ export async function analyzeGameScene(
     const parsed = parseObject(raw);
     const analysis = parsed ? sanitizeGameSceneAnalysis(parsed) : malformedJsonFallback(sceneContext);
     return postProcessSceneResult(analysis, scenePostProcessContext(sceneContext));
-  } catch {
-    return defaultGameSceneAnalysis();
+  } catch (error) {
+    throw error;
   }
 }

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -110,17 +110,27 @@ export interface StartGameResponse {
   status: string;
   alreadyStarted?: boolean;
   sessionChat: Chat;
+  checkpointWarning?: GameCheckpointWarning;
 }
 
 export interface StartSessionResponse {
   sessionChat: Chat;
   sessionNumber: number;
   recap: string;
+  checkpointWarning?: GameCheckpointWarning;
 }
 
 export interface SessionSummaryResponse {
   summary: SessionSummary;
   sessionChat: Chat;
+  checkpointWarning?: GameCheckpointWarning;
+}
+
+export interface GameCheckpointWarning {
+  chatId: string;
+  triggerType: string;
+  label: string;
+  message: string;
 }
 
 export interface RegenerateSessionLorebookResponse {
@@ -368,14 +378,28 @@ async function createGameCheckpoint(data: {
   return { id: record.id };
 }
 
-async function createAutomaticGameCheckpoint(data: { chatId: string; label: string; triggerType: string }): Promise<void> {
-  await createGameCheckpoint(data).catch((error) => {
+async function createAutomaticGameCheckpoint(data: {
+  chatId: string;
+  label: string;
+  triggerType: string;
+}): Promise<GameCheckpointWarning | null> {
+  try {
+    await createGameCheckpoint(data);
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Automatic checkpoint failed";
     console.warn("[game] Automatic checkpoint failed", {
       chatId: data.chatId,
       triggerType: data.triggerType,
       error,
     });
-  });
+    return {
+      chatId: data.chatId,
+      triggerType: data.triggerType,
+      label: data.label || "Checkpoint",
+      message,
+    };
+  }
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | null {
@@ -1716,8 +1740,12 @@ export const gameApi = {
       gameSessionStatus: "active",
       gameActiveState: "exploration",
     });
-    await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Session started", triggerType: "session_start" });
-    return { status: "active", alreadyStarted: false, sessionChat };
+    const checkpointWarning = await createAutomaticGameCheckpoint({
+      chatId: data.chatId,
+      label: "Session started",
+      triggerType: "session_start",
+    });
+    return { status: "active", alreadyStarted: false, sessionChat, ...(checkpointWarning ? { checkpointWarning } : {}) };
   },
 
   async startSession(data: { gameId: string; connectionId?: string }): Promise<StartSessionResponse> {
@@ -1784,8 +1812,12 @@ export const gameApi = {
       });
       mirrorGameMessageToDiscord(chatMeta(sessionChat), recap.trim(), "Narrator");
     }
-    await createAutomaticGameCheckpoint({ chatId: sessionChat.id, label: "Session started", triggerType: "session_start" });
-    return { sessionChat, sessionNumber, recap };
+    const checkpointWarning = await createAutomaticGameCheckpoint({
+      chatId: sessionChat.id,
+      label: "Session started",
+      triggerType: "session_start",
+    });
+    return { sessionChat, sessionNumber, recap, ...(checkpointWarning ? { checkpointWarning } : {}) };
   },
 
   async concludeSession(data: {
@@ -1857,8 +1889,12 @@ export const gameApi = {
       gameCampaignProgression: campaignProgression,
       gameCharacterCards: characterCards,
     });
-    await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Session ended", triggerType: "session_end" });
-    return { summary, sessionChat };
+    const checkpointWarning = await createAutomaticGameCheckpoint({
+      chatId: data.chatId,
+      label: "Session ended",
+      triggerType: "session_end",
+    });
+    return { summary, sessionChat, ...(checkpointWarning ? { checkpointWarning } : {}) };
   },
 
   async regenerateSessionLorebook(data: {
@@ -2051,14 +2087,23 @@ export const gameApi = {
     const previousState = (meta.gameActiveState as GameActiveState | undefined) ?? "exploration";
     const newState = validateTransition(previousState, data.newState);
     const sessionChat = await patchChatMetadata(data.chatId, { gameActiveState: newState });
+    let checkpointWarning: GameCheckpointWarning | null = null;
     if (previousState !== newState) {
       if (newState === "combat") {
-        await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Combat started", triggerType: "combat_start" });
+        checkpointWarning = await createAutomaticGameCheckpoint({
+          chatId: data.chatId,
+          label: "Combat started",
+          triggerType: "combat_start",
+        });
       } else if (previousState === "combat") {
-        await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Combat ended", triggerType: "combat_end" });
+        checkpointWarning = await createAutomaticGameCheckpoint({
+          chatId: data.chatId,
+          label: "Combat ended",
+          triggerType: "combat_end",
+        });
       }
     }
-    return { previousState, newState, sessionChat };
+    return { previousState, newState, sessionChat, ...(checkpointWarning ? { checkpointWarning } : {}) };
   },
 
   async generateMap(data: {

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1358,7 +1358,8 @@ function fullBodySpriteReference(sprites: Array<Record<string, unknown>>): strin
 }
 
 async function gameIllustrationTurnNumber(chatId: string): Promise<number> {
-  const messages = await listMessages(chatId);
+  const messages = await listMessages(chatId).catch(() => []);
+  if (!Array.isArray(messages)) return 0;
   return messages.filter((message) => message.role === "assistant" || message.role === "narrator").length;
 }
 
@@ -2656,7 +2657,7 @@ export const gameApi = {
           referenceImageCount: item.referenceImages?.length ?? 0,
           gameAssetTag: tag,
         });
-        generatedIllustration.galleryId = gallery.id ?? null;
+        generatedIllustration.galleryId = gallery?.id ?? null;
         sessionChat = await patchChatMetadata(chatId, {
           gameLastIllustrationTurn: illustrationTurnNumber,
           gameLastIllustrationSessionNumber: Number(meta.gameSessionNumber ?? 1),

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -345,19 +345,37 @@ async function createGameCheckpoint(data: {
     gameState: (chat as { gameState?: unknown }).gameState ?? {},
     metadata: chatMeta(chat),
   });
-  const record = await storageApi.create<{ id: string }>("game-checkpoints", {
-    chatId: data.chatId,
-    snapshotId: snapshot.id,
-    messageId: "",
-    label: data.label || "Checkpoint",
-    triggerType: data.triggerType || "manual",
-    location: null,
-    gameState: null,
-    weather: null,
-    timeOfDay: null,
-    turnNumber: null,
-  });
+  let record: { id: string };
+  try {
+    record = await storageApi.create<{ id: string }>("game-checkpoints", {
+      chatId: data.chatId,
+      snapshotId: snapshot.id,
+      messageId: "",
+      label: data.label || "Checkpoint",
+      triggerType: data.triggerType || "manual",
+      location: null,
+      gameState: null,
+      weather: null,
+      timeOfDay: null,
+      turnNumber: null,
+    });
+  } catch (error) {
+    await storageApi.delete("game-state-snapshots", snapshot.id).catch((cleanupError) => {
+      console.warn("[game] Failed to clean up checkpoint snapshot after checkpoint creation failed", cleanupError);
+    });
+    throw error;
+  }
   return { id: record.id };
+}
+
+async function createAutomaticGameCheckpoint(data: { chatId: string; label: string; triggerType: string }): Promise<void> {
+  await createGameCheckpoint(data).catch((error) => {
+    console.warn("[game] Automatic checkpoint failed", {
+      chatId: data.chatId,
+      triggerType: data.triggerType,
+      error,
+    });
+  });
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | null {
@@ -1698,7 +1716,7 @@ export const gameApi = {
       gameSessionStatus: "active",
       gameActiveState: "exploration",
     });
-    await createGameCheckpoint({ chatId: data.chatId, label: "Session started", triggerType: "session_start" });
+    await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Session started", triggerType: "session_start" });
     return { status: "active", alreadyStarted: false, sessionChat };
   },
 
@@ -1766,7 +1784,7 @@ export const gameApi = {
       });
       mirrorGameMessageToDiscord(chatMeta(sessionChat), recap.trim(), "Narrator");
     }
-    await createGameCheckpoint({ chatId: sessionChat.id, label: "Session started", triggerType: "session_start" });
+    await createAutomaticGameCheckpoint({ chatId: sessionChat.id, label: "Session started", triggerType: "session_start" });
     return { sessionChat, sessionNumber, recap };
   },
 
@@ -1839,7 +1857,7 @@ export const gameApi = {
       gameCampaignProgression: campaignProgression,
       gameCharacterCards: characterCards,
     });
-    await createGameCheckpoint({ chatId: data.chatId, label: "Session ended", triggerType: "session_end" });
+    await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Session ended", triggerType: "session_end" });
     return { summary, sessionChat };
   },
 
@@ -2035,9 +2053,9 @@ export const gameApi = {
     const sessionChat = await patchChatMetadata(data.chatId, { gameActiveState: newState });
     if (previousState !== newState) {
       if (newState === "combat") {
-        await createGameCheckpoint({ chatId: data.chatId, label: "Combat started", triggerType: "combat_start" });
+        await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Combat started", triggerType: "combat_start" });
       } else if (previousState === "combat") {
-        await createGameCheckpoint({ chatId: data.chatId, label: "Combat ended", triggerType: "combat_end" });
+        await createAutomaticGameCheckpoint({ chatId: data.chatId, label: "Combat ended", triggerType: "combat_end" });
       }
     }
     return { previousState, newState, sessionChat };

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -23,7 +23,7 @@ import type {
 import type { RPGAttributes } from "../../../../engine/contracts/types/game-state";
 import { ApiError, type JsonRepairRequest } from "../../../../shared/api/api-errors";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
-import { imageGenerationApi } from "../../../../shared/api/image-generation-api";
+import { imageGenerationApi, spriteApi } from "../../../../shared/api/image-generation-api";
 import { integrationGateway } from "../../../../shared/api/integration-gateway";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { llmApi } from "../../../../shared/api/llm-api";
@@ -169,12 +169,14 @@ export interface GameImagePromptReviewItem {
   prompt: string;
   width: number;
   height: number;
+  referenceImages?: string[];
+  referenceSubjectNames?: string[];
 }
 
 export interface GameAssetGenerationResult {
   generatedBackground: string | null;
   fallbackBackground: string | null;
-  generatedIllustration: { tag: string; segment?: number } | null;
+  generatedIllustration: { tag: string; segment?: number; galleryId?: string | null } | null;
   generatedNpcAvatars: Array<{ name: string; avatarUrl: string }>;
   sessionChat?: Chat;
 }
@@ -205,6 +207,13 @@ type ChatMessage = {
   [key: string]: unknown;
 };
 
+type IllustrationReferenceSubject = {
+  id: string;
+  name: string;
+  avatar: string;
+  spriteOwnerType?: "character" | "persona";
+};
+
 type PromptOverride = {
   id?: string;
   prompt?: string;
@@ -233,6 +242,10 @@ function newId(prefix = ""): string {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function readTrimmed(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -318,6 +331,33 @@ async function createChatRecord(value: Record<string, unknown>): Promise<Chat> {
 
 async function createChatMessage(chatId: string, value: Record<string, unknown>): Promise<ChatMessage> {
   return storageApi.create<ChatMessage>("messages", { ...value, chatId });
+}
+
+async function createGameCheckpoint(data: {
+  chatId: string;
+  label: string;
+  triggerType: string;
+}): Promise<{ id: string }> {
+  const chat = await getChat(data.chatId);
+  const snapshot = await storageApi.create<{ id: string }>("game-state-snapshots", {
+    chatId: data.chatId,
+    messageId: null,
+    gameState: (chat as { gameState?: unknown }).gameState ?? {},
+    metadata: chatMeta(chat),
+  });
+  const record = await storageApi.create<{ id: string }>("game-checkpoints", {
+    chatId: data.chatId,
+    snapshotId: snapshot.id,
+    messageId: "",
+    label: data.label || "Checkpoint",
+    triggerType: data.triggerType || "manual",
+    location: null,
+    gameState: null,
+    weather: null,
+    timeOfDay: null,
+    turnNumber: null,
+  });
+  return { id: record.id };
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | null {
@@ -1262,6 +1302,156 @@ function base64File(base64: string, name: string, type: string): File {
   return new File([bytes], name, { type });
 }
 
+const GAME_SCENE_ILLUSTRATION_COOLDOWN_TURNS = 8;
+
+function usableReferenceImage(value: unknown): string {
+  const text = readTrimmed(value);
+  if (!text) return "";
+  if (text.startsWith("data:image/")) return text;
+  if (/^[A-Za-z0-9+/=\s]+$/.test(text) && text.replace(/\s+/g, "").length > 80) return text;
+  return "";
+}
+
+function recordName(record: Record<string, unknown>): string {
+  const data = asRecord(record.data);
+  return readTrimmed(data.name) || readTrimmed(record.name);
+}
+
+function recordAvatar(record: Record<string, unknown>): string {
+  const data = asRecord(record.data);
+  return usableReferenceImage(
+    record.avatarPath ?? record.avatar ?? record.avatarUrl ?? data.avatarPath ?? data.avatar ?? data.avatarUrl,
+  );
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((entry) => readTrimmed(entry)).filter(Boolean) : [];
+}
+
+function matchesIllustrationSubject(
+  subject: IllustrationReferenceSubject,
+  illustration: Record<string, unknown>,
+): boolean {
+  const name = subject.name.toLowerCase();
+  if (!name) return false;
+  const requestedNames = stringArray(illustration.characters).map((entry) => entry.toLowerCase());
+  if (requestedNames.length > 0) {
+    return requestedNames.some(
+      (requested) => requested === name || requested.includes(name) || name.includes(requested),
+    );
+  }
+  const prompt = readTrimmed(illustration.prompt).toLowerCase();
+  if (prompt.includes(name)) return true;
+  return name
+    .split(/\s+/)
+    .filter((part) => part.length > 2)
+    .some((part) => prompt.includes(part));
+}
+
+function fullBodySpriteReference(sprites: Array<Record<string, unknown>>): string {
+  const fullBody = sprites.filter((sprite) => readTrimmed(sprite.expression).toLowerCase().startsWith("full_"));
+  const preferred =
+    fullBody.find((sprite) =>
+      ["full_idle", "full_neutral", "full_default"].includes(readTrimmed(sprite.expression).toLowerCase()),
+    ) ?? fullBody[0];
+  return usableReferenceImage(preferred?.url ?? preferred?.image ?? preferred?.base64);
+}
+
+async function gameIllustrationTurnNumber(chatId: string): Promise<number> {
+  const messages = await listMessages(chatId);
+  return messages.filter((message) => message.role === "assistant" || message.role === "narrator").length;
+}
+
+function canGenerateSceneIllustration(meta: Record<string, unknown>, turnNumber: number): boolean {
+  const sessionNumber = Number(meta.gameSessionNumber ?? 1);
+  const lastSessionNumber = Number(meta.gameLastIllustrationSessionNumber ?? Number.NaN);
+  const lastTurnNumber = Number(meta.gameLastIllustrationTurn ?? Number.NaN);
+  if (!Number.isFinite(lastSessionNumber) || !Number.isFinite(lastTurnNumber)) return true;
+  if (lastSessionNumber !== sessionNumber) return true;
+  return turnNumber - lastTurnNumber >= GAME_SCENE_ILLUSTRATION_COOLDOWN_TURNS;
+}
+
+async function loadIllustrationReferenceSubjects(
+  chat: Chat,
+  meta: Record<string, unknown>,
+): Promise<IllustrationReferenceSubject[]> {
+  const characterRows = await Promise.all(
+    (Array.isArray(chat.characterIds) ? chat.characterIds : []).map((id) =>
+      storageApi.get<Record<string, unknown>>("characters", id).catch(() => null),
+    ),
+  );
+  const subjects: IllustrationReferenceSubject[] = characterRows
+    .filter((row): row is Record<string, unknown> => !!row)
+    .map((row) => ({
+      id: readTrimmed(row.id),
+      name: recordName(row),
+      avatar: recordAvatar(row),
+      spriteOwnerType: "character",
+    }));
+
+  const personaId = readTrimmed(chat.personaId);
+  const persona = personaId
+    ? await storageApi.get<Record<string, unknown>>("personas", personaId).catch(() => null)
+    : null;
+  if (persona) {
+    subjects.push({
+      id: personaId || readTrimmed(persona.id),
+      name: recordName(persona),
+      avatar: recordAvatar(persona),
+      spriteOwnerType: "persona",
+    });
+  }
+
+  const npcs = Array.isArray(meta.gameNpcs) ? (meta.gameNpcs as Array<Record<string, unknown>>) : [];
+  for (const npc of npcs) {
+    const avatar = usableReferenceImage(npc.avatarUrl ?? npc.avatar ?? npc.image);
+    if (!avatar) continue;
+    subjects.push({
+      id: readTrimmed(npc.id) || readTrimmed(npc.name),
+      name: readTrimmed(npc.name),
+      avatar,
+    });
+  }
+
+  return subjects.filter((subject) => subject.id && subject.name);
+}
+
+async function illustrationReferenceData(args: {
+  chat: Chat;
+  meta: Record<string, unknown>;
+  illustration: Record<string, unknown>;
+}): Promise<{ referenceImages: string[]; referenceSubjectNames: string[] }> {
+  const subjects = await loadIllustrationReferenceSubjects(args.chat, args.meta);
+  const referenceImages: string[] = [];
+  const referenceSubjectNames: string[] = [];
+  for (const subject of subjects.filter((item) => matchesIllustrationSubject(item, args.illustration))) {
+    let spriteReference = "";
+    if (subject.spriteOwnerType) {
+      const sprites = await spriteApi
+        .list<Array<Record<string, unknown>>>(subject.id, { ownerType: subject.spriteOwnerType })
+        .catch(() => []);
+      spriteReference = fullBodySpriteReference(sprites);
+    }
+    const reference = spriteReference || subject.avatar;
+    if (reference && !referenceImages.includes(reference)) referenceImages.push(reference);
+    if (reference && !referenceSubjectNames.includes(subject.name)) referenceSubjectNames.push(subject.name);
+  }
+  return { referenceImages, referenceSubjectNames };
+}
+
+function fallbackSceneBackground(meta: Record<string, unknown>): string | null {
+  const background = readTrimmed(meta.gameSceneBackground);
+  return background && !background.startsWith("backgrounds:illustrations:") ? background : null;
+}
+
+function imageUrlFromGeneration(image: { base64?: string; mimeType?: string; image?: string }): string {
+  const direct = readTrimmed(image.image);
+  if (direct) return direct;
+  const base64 = readTrimmed(image.base64);
+  const mimeType = readTrimmed(image.mimeType) || "image/png";
+  return base64 ? `data:${mimeType};base64,${base64}` : "";
+}
+
 async function uploadGeneratedAsset(
   category: string,
   subcategory: string,
@@ -1353,7 +1543,10 @@ export const gameApi = {
   }): Promise<CreateGameResponse> {
     const gameId = newId("game");
     if (data.chatId) {
-      await patchChat(data.chatId, gameSetupChatPatch(data.setupConfig, data.connectionId ?? null));
+      await patchChat(data.chatId, {
+        ...gameSetupChatPatch(data.setupConfig, data.connectionId ?? null),
+        groupId: gameId,
+      });
       const sessionChat = await patchChatMetadata(data.chatId, {
         gameId,
         gameSessionNumber: 1,
@@ -1367,6 +1560,7 @@ export const gameApi = {
     const sessionChat = await createChatRecord({
       name: data.name || "New Game",
       mode: "game",
+      groupId: gameId,
       characterIds: data.partyCharacterIds ?? chatPatch.characterIds ?? [],
       personaId: data.setupConfig.personaId ?? null,
       folderId: data.folderId ?? null,
@@ -1503,6 +1697,7 @@ export const gameApi = {
       gameSessionStatus: "active",
       gameActiveState: "exploration",
     });
+    await createGameCheckpoint({ chatId: data.chatId, label: "Session started", triggerType: "session_start" });
     return { status: "active", alreadyStarted: false, sessionChat };
   },
 
@@ -1544,6 +1739,7 @@ export const gameApi = {
       id: sessionChatId,
       name: `Game Session ${sessionNumber}`,
       mode: "game",
+      groupId: data.gameId,
       characterIds: Array.isArray(previousChat?.characterIds) ? previousChat.characterIds : [],
       personaId: previousChat?.personaId ?? null,
       folderId: previousChat?.folderId ?? null,
@@ -1569,6 +1765,7 @@ export const gameApi = {
       });
       mirrorGameMessageToDiscord(chatMeta(sessionChat), recap.trim(), "Narrator");
     }
+    await createGameCheckpoint({ chatId: sessionChat.id, label: "Session started", triggerType: "session_start" });
     return { sessionChat, sessionNumber, recap };
   },
 
@@ -1641,6 +1838,7 @@ export const gameApi = {
       gameCampaignProgression: campaignProgression,
       gameCharacterCards: characterCards,
     });
+    await createGameCheckpoint({ chatId: data.chatId, label: "Session ended", triggerType: "session_end" });
     return { summary, sessionChat };
   },
 
@@ -1834,6 +2032,13 @@ export const gameApi = {
     const previousState = (meta.gameActiveState as GameActiveState | undefined) ?? "exploration";
     const newState = validateTransition(previousState, data.newState);
     const sessionChat = await patchChatMetadata(data.chatId, { gameActiveState: newState });
+    if (previousState !== newState) {
+      if (newState === "combat") {
+        await createGameCheckpoint({ chatId: data.chatId, label: "Combat started", triggerType: "combat_start" });
+      } else if (previousState === "combat") {
+        await createGameCheckpoint({ chatId: data.chatId, label: "Combat ended", triggerType: "combat_end" });
+      }
+    }
     return { previousState, newState, sessionChat };
   },
 
@@ -2056,26 +2261,7 @@ export const gameApi = {
   },
 
   async createCheckpoint(data: { chatId: string; label: string; triggerType: string }) {
-    const chat = await getChat(data.chatId);
-    const snapshot = await storageApi.create<{ id: string }>("game-state-snapshots", {
-      chatId: data.chatId,
-      messageId: null,
-      gameState: (chat as { gameState?: unknown }).gameState ?? {},
-      metadata: chatMeta(chat),
-    });
-    const record = await storageApi.create<{ id: string }>("game-checkpoints", {
-      chatId: data.chatId,
-      snapshotId: snapshot.id,
-      messageId: "",
-      label: data.label || "Checkpoint",
-      triggerType: data.triggerType || "manual",
-      location: null,
-      gameState: null,
-      weather: null,
-      timeOfDay: null,
-      turnNumber: null,
-    });
-    return { id: record.id };
+    return createGameCheckpoint(data);
   },
 
   async loadCheckpoint(data: { chatId: string; checkpointId: string }) {
@@ -2271,7 +2457,8 @@ export const gameApi = {
 
   async previewGeneratedAssets(payload: GameAssetGenerationPayload): Promise<{ items: GameImagePromptReviewItem[] }> {
     const record = payload as unknown as Record<string, unknown>;
-    const meta = chatMeta(await getChat(String(record.chatId)));
+    const chat = await getChat(String(record.chatId));
+    const meta = chatMeta(chat);
     const setup = asRecord(meta.gameSetupConfig);
     const artStyle =
       (typeof record.artStylePrompt === "string" && record.artStylePrompt) ||
@@ -2306,7 +2493,10 @@ export const gameApi = {
       });
     }
     const illustration = asRecord(record.illustration);
-    if (Object.keys(illustration).length > 0) {
+    const hasIllustrationRequest = Object.keys(illustration).length > 0;
+    const illustrationAllowed =
+      hasIllustrationRequest && canGenerateSceneIllustration(meta, await gameIllustrationTurnNumber(String(record.chatId)));
+    if (illustrationAllowed) {
       const label =
         (typeof illustration.reason === "string" && illustration.reason) ||
         (typeof illustration.slug === "string" && illustration.slug) ||
@@ -2315,6 +2505,7 @@ export const gameApi = {
       const id = imageReviewId("illustration", label);
       const detail = String(illustration.prompt ?? label);
       const defaultPrompt = sceneAssetPrompt("illustration", label, detail, artStyle, promptSettings);
+      const referenceData = await illustrationReferenceData({ chat, meta, illustration });
       items.push({
         id,
         kind: "illustration",
@@ -2330,6 +2521,8 @@ export const gameApi = {
           })),
         width: imageSize(record, "background", "width", 1280),
         height: imageSize(record, "background", "height", 720),
+        referenceImages: referenceData.referenceImages,
+        referenceSubjectNames: referenceData.referenceSubjectNames,
       });
     }
     const npcs = Array.isArray(record.npcsNeedingAvatars) ? record.npcsNeedingAvatars : [];
@@ -2387,17 +2580,36 @@ export const gameApi = {
 
     const preview = await gameApi.previewGeneratedAssets(payload);
     let generatedBackground: string | null = null;
+    let fallbackBackground: string | null = null;
     let generatedIllustration: GameAssetGenerationResult["generatedIllustration"] = null;
     const generatedNpcAvatars: GameAssetGenerationResult["generatedNpcAvatars"] = [];
 
     for (const item of preview.items) {
       if (signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
-      const image = await imageGenerationApi.generate<{ base64: string; mimeType: string; image?: string }>({
-        connectionId: imageConnectionId,
-        prompt: item.prompt,
-        width: item.width,
-        height: item.height,
-      });
+      let image: { base64: string; mimeType: string; image?: string; provider?: string; model?: string };
+      try {
+        image = await imageGenerationApi.generate<{
+          base64: string;
+          mimeType: string;
+          image?: string;
+          provider?: string;
+          model?: string;
+        }>({
+          connectionId: imageConnectionId,
+          prompt: item.prompt,
+          width: item.width,
+          height: item.height,
+          ...(item.kind === "illustration" && item.referenceImages?.length
+            ? { referenceImages: item.referenceImages }
+            : {}),
+        });
+      } catch (error) {
+        if (item.kind === "background") {
+          fallbackBackground = fallbackSceneBackground(meta);
+          if (fallbackBackground) continue;
+        }
+        throw error;
+      }
       if (item.kind === "background") {
         const key = typeof record.backgroundTag === "string" ? record.backgroundTag : "generated-background";
         const tag = await uploadGeneratedAsset(
@@ -2410,6 +2622,7 @@ export const gameApi = {
         generatedBackground = tag;
         sessionChat = await patchChatMetadata(chatId, { gameSceneBackground: tag });
       } else if (item.kind === "illustration") {
+        const illustrationTurnNumber = await gameIllustrationTurnNumber(chatId);
         const illustration = asRecord(record.illustration);
         const key = (typeof illustration.slug === "string" && illustration.slug) || item.title || "scene-illustration";
         const tag = await uploadGeneratedAsset(
@@ -2423,6 +2636,32 @@ export const gameApi = {
           tag,
           ...(Number.isInteger(illustration.segment) ? { segment: illustration.segment as number } : {}),
         };
+        const mimeType = image.mimeType || "image/png";
+        const imageUrl = imageUrlFromGeneration(image);
+        const filename = `${generatedAssetSlug(key)}.${imageExt(mimeType)}`;
+        const gallery = await storageApi.create<{ id?: string }>("gallery", {
+          chatId,
+          filePath: filename,
+          filename,
+          url: imageUrl,
+          prompt: item.prompt,
+          provider: image.provider ?? "image_generation",
+          model: image.model ?? null,
+          width: item.width,
+          height: item.height,
+          kind: "illustration",
+          characters: item.referenceSubjectNames?.length
+            ? item.referenceSubjectNames
+            : stringArray(illustration.characters),
+          referenceImageCount: item.referenceImages?.length ?? 0,
+          gameAssetTag: tag,
+        });
+        generatedIllustration.galleryId = gallery.id ?? null;
+        sessionChat = await patchChatMetadata(chatId, {
+          gameLastIllustrationTurn: illustrationTurnNumber,
+          gameLastIllustrationSessionNumber: Number(meta.gameSessionNumber ?? 1),
+          gameLastIllustrationTag: tag,
+        });
       } else if (item.kind === "portrait") {
         generatedNpcAvatars.push({
           name: item.title.replace(/^Portrait:\s*/, "") || "NPC",
@@ -2455,7 +2694,7 @@ export const gameApi = {
       sessionChat = await patchChatMetadata(chatId, { gameNpcs: npcs });
     }
 
-    return { generatedBackground, fallbackBackground: null, generatedIllustration, generatedNpcAvatars, sessionChat };
+    return { generatedBackground, fallbackBackground, generatedIllustration, generatedNpcAvatars, sessionChat };
   },
 };
 

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -265,6 +265,22 @@ function isPartyTurnMessage(message: Message): boolean {
   );
 }
 
+function gameSceneTurnNumber(messages: Message[]): number {
+  return messages.filter((message) => message.role === "assistant" || message.role === "narrator").length;
+}
+
+function canRequestGameSceneIllustration(
+  chatMeta: Record<string, unknown>,
+  sessionNumber: number,
+  turnNumber: number,
+): boolean {
+  const lastSessionNumber = Number(chatMeta.gameLastIllustrationSessionNumber ?? Number.NaN);
+  const lastTurnNumber = Number(chatMeta.gameLastIllustrationTurn ?? Number.NaN);
+  if (!Number.isFinite(lastSessionNumber) || !Number.isFinite(lastTurnNumber)) return true;
+  if (lastSessionNumber !== sessionNumber) return true;
+  return turnNumber - lastTurnNumber >= GAME_SCENE_ILLUSTRATION_COOLDOWN_TURNS;
+}
+
 function stripPartyTurnMarker(content: string): string {
   return content.trimStart().replace(PARTY_TURN_MESSAGE_RE, "").trim();
 }
@@ -285,6 +301,7 @@ function getConfiguredGameAssetImageSizes(): NonNullable<GameAssetGenerationPayl
 const GAME_ASSET_GENERATION_TIMEOUT_MS = 240_000;
 const GAME_ASSET_PREVIEW_TIMEOUT_MS = 180_000;
 const GAME_ASSET_PROMPT_REVIEW_TIMEOUT_MS = 180_000;
+const GAME_SCENE_ILLUSTRATION_COOLDOWN_TURNS = 8;
 const IMAGE_PROMPT_REVIEW_TIMED_OUT = Symbol("IMAGE_PROMPT_REVIEW_TIMED_OUT");
 
 class TimeoutError extends Error {
@@ -1756,6 +1773,11 @@ export function GameSurface({
   const quoteFormat = useUIStore((s) => s.quoteFormat);
   const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
   const gameSnapshot = useGameStateStore((s) => (s.current?.chatId === activeChatId ? s.current : null));
+  const sceneTurnNumber = useMemo(() => gameSceneTurnNumber(messages), [messages]);
+  const gameSceneIllustrationAllowed =
+    !!chatMeta.enableSpriteGeneration &&
+    !!chatMeta.gameImageConnectionId &&
+    canRequestGameSceneIllustration(chatMeta as Record<string, unknown>, sessionNumber, sceneTurnNumber);
   const { patchField: patchVisibleGameStateField, flushPatch: flushVisibleGameStatePatch } = useGameStatePatcher(
     activeChatId,
     "game-surface",
@@ -3862,8 +3884,9 @@ export function GameSurface({
       currentAmbient: useGameAssetStore.getState().currentAmbient,
       currentWeather: gameSnapshot?.weather ?? null,
       currentTimeOfDay: gameSnapshot?.time ?? null,
+      turnNumber: sceneTurnNumber,
       canGenerateBackgrounds: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
-      canGenerateIllustrations: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
+      canGenerateIllustrations: gameSceneIllustrationAllowed,
       artStylePrompt:
         ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.artStylePrompt as string | undefined) ??
         null,
@@ -4699,8 +4722,9 @@ export function GameSurface({
       currentAmbient: useGameAssetStore.getState().currentAmbient,
       currentWeather: gameSnapshot?.weather ?? null,
       currentTimeOfDay: gameSnapshot?.time ?? null,
+      turnNumber: sceneTurnNumber,
       canGenerateBackgrounds: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
-      canGenerateIllustrations: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
+      canGenerateIllustrations: gameSceneIllustrationAllowed,
       artStylePrompt:
         ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.artStylePrompt as string | undefined) ??
         null,
@@ -7602,8 +7626,9 @@ export function GameSurface({
       currentAmbient: useGameAssetStore.getState().currentAmbient,
       currentWeather: gameSnapshot?.weather ?? null,
       currentTimeOfDay: gameSnapshot?.time ?? null,
+      turnNumber: sceneTurnNumber,
       canGenerateBackgrounds: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
-      canGenerateIllustrations: !!chatMeta.enableSpriteGeneration && !!chatMeta.gameImageConnectionId,
+      canGenerateIllustrations: gameSceneIllustrationAllowed,
       artStylePrompt: (setupConfig?.artStylePrompt as string | undefined) ?? null,
       imagePromptInstructions:
         typeof chatMeta.gameImagePromptInstructions === "string" ? chatMeta.gameImagePromptInstructions : null,
@@ -7645,6 +7670,8 @@ export function GameSurface({
     sceneAnalysis,
     sceneWrapCharacterNames,
     sceneAnalysisEnabled,
+    sceneTurnNumber,
+    gameSceneIllustrationAllowed,
   ]);
 
   const normalizedWidgets = hudWidgets;

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -4777,6 +4777,7 @@ export function GameSurface({
     chatMeta.gameSetupConfig,
     currentBackground,
     fetchSpotifySceneCandidates,
+    gameSceneIllustrationAllowed,
     gameSnapshot?.time,
     gameSnapshot?.weather,
     gameState,
@@ -4787,6 +4788,7 @@ export function GameSurface({
     playSpotifySceneTrack,
     sceneAnalysis,
     sceneWrapCharacterNames,
+    sceneTurnNumber,
     useSpotifyGameMusic,
   ]);
 


### PR DESCRIPTION
## Linked issue

Closes #1792

## Why this change

- Game mode refactor paths lost legacy side effects around automatic checkpoints, scene-analysis failure fallback, generated scene illustration safeguards, and game session gallery grouping.

## What changed

- Restored automatic checkpoint creation for session start, session end, combat start, and combat end.
- Restored game `groupId` persistence for first and follow-up game session chats so gallery/history can scope across sessions.
- Let scene-analysis provider failures reject so the existing UI `onError` path can apply inline GM tags.
- Added scene illustration safeguards: session-aware cooldown metadata, character/persona/NPC reference image payloads, chat gallery preservation, and fallback to the current reusable background if generated background creation fails.

## Refactor impact

Primary owner:

Game mode

Impact areas reviewed:

- Game mode API and GameSurface scene-analysis context
- React-free game scene-analysis service
- Chat/gallery storage metadata shapes used by game sessions
- Image-generation request payloads and gallery row preservation

Boundary notes:

- Feature code continues to use shared API wrappers (`storageApi`, `imageGenerationApi`, `spriteApi`, `gameAssetsApi`) rather than raw Tauri calls.
- Engine scene-analysis remains React-free and only changes provider-failure error propagation.
- No dependency, schema, auth, release, prompt-pipeline, import/export, or Rust command changes.

Pressure points touched:

- `GameSurface` scene-analysis context and illustration cooldown gating
- Game mode API session/combat transition side effects
- Scene-analysis service failure handling

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Codex machine verification:

- `pnpm exec vitest run src/engine/modes/game/scene/game-scene-analysis.service.test.ts src/features/modes/game/api/game-api.test.ts` passed after first failing before the production fix.
- `pnpm typecheck` passed.
- `pnpm check` passed after rebasing onto current `upstream/refactor`.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review pass completed on the current rebased diff.

Manual/browser verification:

- Not run. This PR changes game API/storage/provider payload logic; the core claim is covered by the targeted command harness and full repo gate.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix restoring existing Game mode parity; no new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes were needed for this bugfix.

## UI evidence

N/A. No visible UI layout/browser state changed; proof is the command harness and full repo validation above.

