### PR TITLE
Fix chat summary parity regressions

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -24,8 +24,10 @@ pub(crate) fn messages_for_chat(state: &AppState, chat_id: &str) -> AppResult<Ve
     Ok(rows)
 }
 
-const PROMPT_SNAPSHOT_KEYS: [&str; 2] =
-    ["generationPromptSnapshot", "generationPromptSnapshotsBySwipe"];
+const PROMPT_SNAPSHOT_KEYS: [&str; 2] = [
+    "generationPromptSnapshot",
+    "generationPromptSnapshotsBySwipe",
+];
 
 /// Drop saved prompt snapshots from an `extra` object, returning the rewritten
 /// object only when something was actually removed. Leaves every other field
@@ -96,7 +98,12 @@ pub(crate) fn evict_prompt_snapshots(
     let assistant_ids: Vec<String> = messages
         .iter()
         .filter(|message| message.get("role").and_then(Value::as_str) == Some("assistant"))
-        .filter_map(|message| message.get("id").and_then(Value::as_str).map(str::to_string))
+        .filter_map(|message| {
+            message
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
         .collect();
     let stale_cutoff = assistant_ids.len().saturating_sub(keep_last);
     let stale: HashSet<&str> = assistant_ids[..stale_cutoff]
@@ -283,6 +290,15 @@ fn active_swipe_update_response(message: &Value) -> Value {
         }
     }
     Value::Object(response)
+}
+
+fn prune_branch_summary_metadata(chat: &mut Value) {
+    let Some(metadata) = chat.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for key in ["summary", "summaryEntries", "daySummaries", "weekSummaries"] {
+        metadata.remove(key);
+    }
 }
 
 fn object_extra(value: Option<&Value>) -> Option<Value> {
@@ -854,6 +870,7 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
         Value::String(format!("{base_name} Branch")),
     );
     object.insert("groupId".to_string(), Value::String(group_id.clone()));
+    prune_branch_summary_metadata(&mut chat);
     let source_has_tracker_snapshots =
         game_state_snapshots::latest_tracker_snapshot(state, chat_id)?.is_some();
     let mut new_chat = state.storage.create("chats", chat)?;
@@ -1444,6 +1461,70 @@ mod tests {
     }
 
     #[test]
+    fn branch_chat_prunes_future_summary_metadata_from_new_branch() {
+        let state = test_state("branch-summary-prune");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "root-1",
+                    "name": "Summarized Chat",
+                    "mode": "conversation",
+                    "characterIds": [],
+                    "metadata": {
+                        "summary": "Future rolling summary",
+                        "summaryEntries": [{ "id": "summary-1", "content": "Future entry" }],
+                        "summaryContextSize": 42,
+                        "summaryPromptTemplates": [{ "id": "template-1", "name": "Short", "prompt": "Summarize." }],
+                        "activeSummaryPromptTemplateId": "template-1",
+                        "daySummaries": { "01.06.2026": { "summary": "Future day", "keyDetails": [] } },
+                        "weekSummaries": { "25.05.2026": { "summary": "Future week", "keyDetails": [] } }
+                    }
+                }),
+            )
+            .expect("source chat should be created");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "root-1",
+                    "role": "user",
+                    "content": "hello"
+                }),
+            )
+            .expect("message should be created");
+
+        let branch = branch_chat(&state, "root-1", json!({ "upToMessageId": "message-1" }))
+            .expect("branch should be created");
+        let metadata = branch
+            .get("metadata")
+            .and_then(Value::as_object)
+            .expect("branch metadata should remain an object");
+
+        for key in ["summary", "summaryEntries", "daySummaries", "weekSummaries"] {
+            assert!(
+                !metadata.contains_key(key),
+                "branch should not inherit {key}"
+            );
+        }
+        assert_eq!(metadata.get("summaryContextSize"), Some(&json!(42)));
+        assert_eq!(
+            metadata.get("activeSummaryPromptTemplateId"),
+            Some(&json!("template-1"))
+        );
+
+        let source = state
+            .storage
+            .get("chats", "root-1")
+            .expect("source lookup should not fail")
+            .expect("source chat should still exist");
+        assert_eq!(source["metadata"]["summary"], "Future rolling summary");
+    }
+
+    #[test]
     fn update_message_content_if_unchanged_updates_only_matching_content() {
         let state = test_state("conditional-content");
         state
@@ -1754,8 +1835,7 @@ mod tests {
             )
             .expect("swipe should be added");
 
-        let result =
-            evict_prompt_snapshots(&state, "chat-1", 2).expect("eviction should succeed");
+        let result = evict_prompt_snapshots(&state, "chat-1", 2).expect("eviction should succeed");
         assert_eq!(result["evicted"], json!(1));
 
         let get = |id: &str| {
@@ -1769,7 +1849,9 @@ mod tests {
         // Oldest assistant message: snapshot, by-swipe map, and swipe snapshot cleared.
         let old = get("assistant-old");
         assert!(old["extra"].get("generationPromptSnapshot").is_none());
-        assert!(old["extra"].get("generationPromptSnapshotsBySwipe").is_none());
+        assert!(old["extra"]
+            .get("generationPromptSnapshotsBySwipe")
+            .is_none());
         assert!(old["swipes"][0]["extra"]
             .get("generationPromptSnapshot")
             .is_none());
@@ -1783,7 +1865,10 @@ mod tests {
             .is_some());
 
         // User message and its legacy cached prompt are untouched (negative control).
-        assert_eq!(get("user-1")["extra"]["cachedPrompt"][0]["content"], json!("hi"));
+        assert_eq!(
+            get("user-1")["extra"]["cachedPrompt"][0]["content"],
+            json!("hi")
+        );
     }
 
     #[test]

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -88,6 +88,7 @@ export interface StorageGateway {
   patchChatMetadata<T = unknown>(chatId: string, patch: Record<string, unknown>): Promise<T>;
   patchChatSummaries<T = unknown>(chatId: string, patch: Record<string, unknown>): Promise<T>;
   listChatMemories<T = unknown>(chatId: string): Promise<T[]>;
+  refreshChatMemories?<T = unknown>(chatId: string): Promise<T>;
   getWorldState<T = unknown>(chatId: string): Promise<T | null>;
   saveTrackerSnapshot<T = unknown>(chatId: string, snapshot: Record<string, unknown>): Promise<T>;
   listLorebookEntries<T = unknown>(lorebookId: string): Promise<T[]>;

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -90,8 +90,8 @@ export interface ChatSummaryPromptTemplate {
 /** Rolling summary entry category. Extensible beyond rolling summaries later. */
 export type ChatSummaryEntryKind = "rolling";
 
-/** Whether a rolling summary entry was user-created or agent-created. */
-export type ChatSummaryEntryOrigin = "manual" | "automated";
+/** Whether a rolling summary entry was user-created, agent-created, or preserved from legacy metadata. */
+export type ChatSummaryEntryOrigin = "manual" | "automated" | "legacy";
 
 /** Source selector used to create a rolling summary entry. */
 export type ChatSummaryEntrySource = "last" | "range" | "agent";

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -9,6 +9,7 @@ import { mergeAdjacentMessages, squashLeadingSystemMessages } from "../generatio
 import { applyRegexScriptsToPromptMessages } from "../generation-core/regex/regex-application";
 import { stripConversationPromptTimestamps } from "../modes/chat/core/summaries/transcript-sanitize";
 import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine";
+import { normalizeChatSummaryMetadata } from "../shared/text/chat-summary-entries";
 import { collapseExcessBlankLines } from "../shared/text/newlines";
 import { cleanPromptText, stripPromptComments } from "../shared/text/prompt-comments";
 import { normalizeUserTimeZone } from "../shared/time/timezone";
@@ -1246,11 +1247,12 @@ export function chatSummaryForGeneration(chat: JsonRecord): string | null {
   const meta = parseRecord(chat.metadata);
   const mode = readString(chat.mode || chat.chatMode, "conversation");
   const includeSceneSummary = mode !== "conversation" || meta.crossChatAwareness !== false;
+  const rollingSummary = normalizeChatSummaryMetadata(meta).summary;
   const parts = [
     meta.conversationSummary,
-    meta.summary,
-    meta.daySummaries,
-    meta.weekSummaries,
+    rollingSummary,
+    formatSummaryMap("Day", meta.daySummaries),
+    formatSummaryMap("Week", meta.weekSummaries),
     includeSceneSummary ? meta.lastRoleplaySceneSummary : null,
   ]
     .map((value) =>
@@ -1258,6 +1260,73 @@ export function chatSummaryForGeneration(chat: JsonRecord): string | null {
     )
     .filter((value) => value.trim().length > 0);
   return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+function formatSummaryEntry(label: string, key: string, value: unknown): string {
+  const entry = parseRecord(value);
+  const summary = readString(entry.summary).trim();
+  const keyDetails = stringArray(entry.keyDetails);
+  if (!summary && keyDetails.length === 0) return "";
+  const parts = [`${label} summary ${key}`];
+  if (summary) parts.push(summary);
+  if (keyDetails.length > 0) {
+    parts.push(["Key details:", ...keyDetails.map((detail) => `- ${detail}`)].join("\n"));
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
+function formatSummaryMap(label: "Day" | "Week", value: unknown): string {
+  const entries = Object.entries(parseRecord(value))
+    .map(([key, entry]) => ({ key, text: formatSummaryEntry(label, key, entry) }))
+    .filter((entry) => entry.text.trim().length > 0)
+    .sort((a, b) => compareSummaryKeys(a.key, b.key));
+  return entries.map((entry) => entry.text).join("\n\n");
+}
+
+function summaryKeyTimestamp(key: string): number | null {
+  const dotted = key.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+  if (dotted) {
+    const [, day, month, year] = dotted;
+    return Date.UTC(Number(year), Number(month) - 1, Number(day));
+  }
+  const parsed = Date.parse(key);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function compareSummaryKeys(a: string, b: string): number {
+  const aTime = summaryKeyTimestamp(a);
+  const bTime = summaryKeyTimestamp(b);
+  if (aTime !== null && bTime !== null && aTime !== bTime) return aTime - bTime;
+  return a.localeCompare(b);
+}
+
+function hasConversationSummaryCompaction(meta: JsonRecord): boolean {
+  return !!formatSummaryMap("Day", meta.daySummaries).trim() || !!formatSummaryMap("Week", meta.weekSummaries).trim();
+}
+
+function presetCanInsertChatSummary(preset: SelectedPromptPreset | null, summary: string | null): boolean {
+  if (!preset || !summary?.trim()) return false;
+  return preset.sections.some(
+    (section) => boolish(section.enabled, true) && markerConfig(section)?.type === "chat_summary",
+  );
+}
+
+function shouldCompactHistoryForSummary(
+  chat: JsonRecord,
+  selectedPreset: SelectedPromptPreset | null,
+  summary: string | null,
+): boolean {
+  if (!summary?.trim()) return false;
+  const meta = parseRecord(chat.metadata);
+  if (!hasConversationSummaryCompaction(meta)) return false;
+  if (!selectedPreset) return true;
+  return presetCanInsertChatSummary(selectedPreset, summary) || shouldForceRoleplaySummaryIntoSystem(chat);
+}
+
+function compactedHistoryLimit(meta: JsonRecord, fallbackLimit: number, shouldCompact: boolean): number {
+  if (!shouldCompact) return fallbackLimit;
+  const tail = Math.max(0, Math.min(50, Math.floor(readNumber(meta.summaryTailMessages, 10))));
+  return Math.min(fallbackLimit, tail);
 }
 
 const MEMORY_EMBEDDING_DIMS = 256;
@@ -1530,6 +1599,7 @@ function historyMessageContent(message: JsonRecord, includePastReasoning: boolea
 }
 
 function historyMessages(storedMessages: JsonRecord[], limit: number, includePastReasoning = false): ChatMLMessage[] {
+  if (limit <= 0) return [];
   return storedMessages
     .filter((message) => !hiddenFromAi(message))
     .slice(-limit)
@@ -1896,7 +1966,11 @@ export async function assembleGenerationPrompt(
   const metadataHistoryLimit = readNumber(chatMeta.contextMessageLimit, 0);
   const requestedHistoryLimit = readNumber(input.request.historyLimit, metadataHistoryLimit || 300);
   const historyLimit = Math.max(1, Math.min(300, metadataHistoryLimit || requestedHistoryLimit || 300));
-  const history = historyMessages(input.storedMessages, historyLimit, chatMeta.excludePastReasoning === false);
+  const history = historyMessages(
+    input.storedMessages,
+    compactedHistoryLimit(chatMeta, historyLimit, shouldCompactHistoryForSummary(input.chat, selectedPreset, summary)),
+    chatMeta.excludePastReasoning === false,
+  );
   const macros = macroContext({
     chat: input.chat,
     connection: input.connection,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1328,6 +1328,24 @@ async function evictStalePromptSnapshotsSafely(storage: StorageGateway, chatId: 
   }
 }
 
+function shouldRefreshMemoryRecall(chat: JsonRecord): boolean {
+  const meta = parseRecord(chat.metadata);
+  if (typeof meta.enableMemoryRecall === "boolean") return meta.enableMemoryRecall;
+  const mode = readString(chat.mode || chat.chatMode);
+  return mode === "conversation" || meta.sceneStatus === "active";
+}
+
+async function refreshMemoryRecallSafely(storage: StorageGateway, chat: JsonRecord): Promise<void> {
+  if (!storage.refreshChatMemories || !shouldRefreshMemoryRecall(chat)) return;
+  const chatId = readString(chat.id).trim();
+  if (!chatId) return;
+  try {
+    await storage.refreshChatMemories(chatId);
+  } catch (error) {
+    console.warn("[generation] memory recall refresh failed", error);
+  }
+}
+
 async function persistLorebookTimingStatesSafely(
   storage: StorageGateway,
   chatId: string,
@@ -2497,6 +2515,9 @@ export async function* startGeneration(
         yield { type: "agent_result", data: result };
       }
     }
+    if (saved && input.impersonate !== true) {
+      await refreshMemoryRecallSafely(deps.storage, chat);
+    }
     yield { type: "done", data: { transcript: visibleTranscript(generationMessages) } };
     return;
   }
@@ -2610,6 +2631,9 @@ export async function* startGeneration(
     for (const result of autoLorebookResults) {
       yield { type: "agent_result", data: result };
     }
+  }
+  if (saved && input.impersonate !== true) {
+    await refreshMemoryRecallSafely(deps.storage, chat);
   }
   yield { type: "done" };
 }

--- a/src/engine/shared/text/chat-summary-entries.ts
+++ b/src/engine/shared/text/chat-summary-entries.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../contracts/types/chat.js";
 
 const VALID_KINDS = new Set<ChatSummaryEntryKind>(["rolling"]);
-const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated"]);
+const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated", "legacy"]);
 const VALID_SOURCES = new Set<ChatSummaryEntrySource>(["last", "range", "agent"]);
 
 const COMPILED_CHAT_SUMMARY_MAX_BYTES = 64 * 1024;
@@ -110,6 +110,7 @@ function estimateChatSummaryTokens(content: string): number {
 function generateChatSummaryEntryTitle(
   entry: Pick<ChatSummaryEntry, "origin" | "sourceMode" | "messageCount" | "rangeStartIndex" | "rangeEndIndex">,
 ): string {
+  if (entry.origin === "legacy") return "Legacy summary";
   if (entry.origin === "automated") return "Automated summary";
   if (entry.sourceMode === "range" && entry.rangeStartIndex && entry.rangeEndIndex) {
     return `Summary messages ${entry.rangeStartIndex}-${entry.rangeEndIndex}`;
@@ -191,6 +192,8 @@ function sortChatSummaryEntries(entries: ChatSummaryEntry[]): ChatSummaryEntry[]
   return entries
     .map((entry, index) => ({ entry, index }))
     .sort((a, b) => {
+      if (a.entry.origin === "legacy" && b.entry.origin !== "legacy") return -1;
+      if (a.entry.origin !== "legacy" && b.entry.origin === "legacy") return 1;
       const aRange = a.entry.rangeStartIndex ?? Number.MAX_SAFE_INTEGER;
       const bRange = b.entry.rangeStartIndex ?? Number.MAX_SAFE_INTEGER;
       if (aRange !== bRange) return aRange - bRange;
@@ -222,7 +225,7 @@ function normalizeChatSummaryEntries(
   return sortChatSummaryEntries(entries);
 }
 
-function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string | null {
+export function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string | null {
   const compiled = sortChatSummaryEntries(entries)
     .filter((entry) => entry.enabled)
     .map((entry) => entry.content.trim())
@@ -233,12 +236,47 @@ function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string | null {
   return trimToUtf8Bytes(compiled, COMPILED_CHAT_SUMMARY_MAX_BYTES, true).trim() || null;
 }
 
+function legacySummaryEntry(
+  summary: string,
+  entries: ChatSummaryEntry[],
+  options: ChatSummaryEntryNormalizeOptions = {},
+): ChatSummaryEntry | null {
+  const content = trimString(summary);
+  if (!content) return null;
+  const compiledEntries = compileChatSummaryEntries(entries);
+  if (compiledEntries === content) return null;
+  if (entries.some((entry) => entry.content.trim() === content)) return null;
+  return createChatSummaryEntry(
+    {
+      id: "summary-legacy",
+      content,
+      origin: "legacy",
+      sourceMode: "last",
+      title: "Legacy summary",
+    },
+    options,
+  );
+}
+
+export function normalizeChatSummaryMetadata(
+  metadata: Record<string, unknown>,
+  options: ChatSummaryEntryNormalizeOptions = {},
+): { entries: ChatSummaryEntry[]; summary: string | null } {
+  const entries = normalizeChatSummaryEntries(metadata.summaryEntries, options);
+  const legacy = legacySummaryEntry(trimString(metadata.summary), entries, options);
+  const nextEntries = legacy ? sortChatSummaryEntries([legacy, ...entries]) : entries;
+  return {
+    entries: nextEntries,
+    summary: compileChatSummaryEntries(nextEntries),
+  };
+}
+
 export function appendChatSummaryEntryToMetadata(
   metadata: Record<string, unknown>,
   input: ChatSummaryEntryInput,
   options: ChatSummaryEntryNormalizeOptions = {},
 ): { entry: ChatSummaryEntry; entries: ChatSummaryEntry[]; summary: string | null } {
-  const entries = normalizeChatSummaryEntries(metadata.summaryEntries, options);
+  const entries = normalizeChatSummaryMetadata(metadata, options).entries;
   const entry = createChatSummaryEntry(input, options);
   const nextEntries = sortChatSummaryEntries([...entries, entry]);
   return {

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -16,6 +16,7 @@ import {
   type PromptPreviewResult,
 } from "../../../../engine/generation/prompt-preview";
 import { createMessageSchema, summariesPatchSchema } from "../../../../engine/contracts/schemas/chat.schema";
+import { getDefaultAgentPrompt } from "../../../../engine/contracts/constants/agent-prompts";
 import { boolish } from "../../../../engine/generation/runtime-records";
 import { backfillConversationSummaries } from "../../../../engine/modes/chat/core/summaries/auto-summary.service";
 import { appendChatSummaryEntryToMetadata } from "../../../../engine/shared/text/chat-summary-entries";
@@ -34,17 +35,13 @@ import { downloadTextFile } from "../lib/download";
 import { sanitizeTimelineMessage, timelineMessageProjection } from "../lib/timeline-message";
 import { lorebookKeys } from "../../lorebooks/query-keys";
 import { CHAT_SUMMARY_FIELDS } from "./use-chat-summaries";
-import {
-  applyChatFieldPatch,
-  cancelChatCacheQueries,
-  setChatCacheRecord,
-  type ChatCacheRecord,
-} from "./chat-cache";
+import { applyChatFieldPatch, cancelChatCacheQueries, setChatCacheRecord, type ChatCacheRecord } from "./chat-cache";
 import type {
   Chat,
   ChatMemoryChunk,
   ConversationNote,
   Message,
+  ChatSummaryPromptTemplate,
   DaySummaryEntry,
   WeekSummaryEntry,
 } from "../../../../engine/contracts/types/chat";
@@ -780,6 +777,7 @@ export type GenerateSummaryInput = {
   contextSize?: number;
   rangeStartIndex?: number;
   rangeEndIndex?: number;
+  promptTemplateId?: string | null;
 };
 
 export type GenerateSummaryResult = {
@@ -797,18 +795,29 @@ function compactTranscript(messages: Message[]) {
 }
 
 async function resolveSummaryConnectionId(chat: Chat): Promise<string> {
+  const [agents, connections] = await Promise.all([
+    storageApi.list<Record<string, unknown>>("agents").catch(() => []),
+    storageApi.list<Record<string, unknown>>("connections"),
+  ]);
+  const summaryAgent = agents.find(
+    (agent) => readString(agent.id).trim() === "chat-summary" || readString(agent.type).trim() === "chat-summary",
+  );
+  const summaryConnectionId = readString(summaryAgent?.connectionId).trim();
+  if (summaryConnectionId) return summaryConnectionId;
+  const agentDefault = connections.find((connection) => boolish(connection.defaultForAgents, false));
+  const agentDefaultId = readString(agentDefault?.id).trim();
+  if (agentDefaultId) return agentDefaultId;
   if (typeof chat.connectionId === "string" && chat.connectionId.trim()) return chat.connectionId.trim();
-  const connections = await storageApi.list<Record<string, unknown>>("connections");
   const selected =
     connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
     connections[0];
-  const connectionId = typeof selected?.id === "string" ? selected.id.trim() : "";
+  const connectionId = readString(selected?.id).trim();
   if (!connectionId) throw new Error("No API connection configured for summary generation.");
   return connectionId;
 }
 
 async function generateLlmChatSummary(input: GenerateSummaryInput): Promise<GenerateSummaryResult> {
-  const { chatId, contextSize, rangeStartIndex, rangeEndIndex } = input;
+  const { chatId, contextSize, rangeStartIndex, rangeEndIndex, promptTemplateId } = input;
   const [chat, allMessages] = await Promise.all([
     storageApi.get<Chat>("chats", chatId),
     storageApi.listChatMessages<Message>(chatId),
@@ -837,18 +846,25 @@ async function generateLlmChatSummary(input: GenerateSummaryInput): Promise<Gene
   if (selected.length === 0) throw new Error("No non-hidden messages available for the requested summary.");
 
   const connectionId = await resolveSummaryConnectionId(chat);
+  const metadata = parseRecord(chat.metadata);
+  const promptTemplate = resolveSummaryPromptTemplate(metadata, promptTemplateId);
   const transcript = compactTranscript(selected);
   const rawSummary = await llmApi.complete({
     connectionId,
     messages: [
       {
         role: "system",
-        content:
-          "Summarize the provided chat transcript for future roleplay/conversation context. Preserve durable facts, relationships, goals, decisions, unresolved threads, and emotional state. Do not add new events.",
+        content: promptTemplate.prompt,
       },
       {
         role: "user",
-        content: `Create a concise but useful memory summary from this transcript:\n\n${transcript}`,
+        content: [
+          "Existing summary:",
+          readString(metadata.summary).trim() || "(none)",
+          "",
+          "Transcript to summarize:",
+          transcript,
+        ].join("\n"),
       },
     ],
     parameters: { temperature: 0.2, maxTokens: 700 },
@@ -856,7 +872,6 @@ async function generateLlmChatSummary(input: GenerateSummaryInput): Promise<Gene
   const content = rawSummary.trim();
   if (!content) throw new Error("Summary generation returned an empty response.");
 
-  const metadata = parseRecord(chat.metadata);
   const now = new Date().toISOString();
   const appended = appendChatSummaryEntryToMetadata(
     metadata,
@@ -869,6 +884,7 @@ async function generateLlmChatSummary(input: GenerateSummaryInput): Promise<Gene
       rangeStartIndex: rangeLow ?? undefined,
       rangeEndIndex: rangeHigh ?? undefined,
       messageIds: selected.map((message) => message.id),
+      promptTemplateId: promptTemplate.id,
     },
     {
       now,
@@ -883,6 +899,39 @@ async function generateLlmChatSummary(input: GenerateSummaryInput): Promise<Gene
     summaryContextSize: limit,
   });
   return { summary: appended.summary ?? content, messageIds: selected.map((message) => message.id) };
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function summaryPromptTemplates(value: unknown): ChatSummaryPromptTemplate[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((template): template is ChatSummaryPromptTemplate => {
+      if (!template || typeof template !== "object" || Array.isArray(template)) return false;
+      const record = template as Record<string, unknown>;
+      return !!readString(record.id).trim() && !!readString(record.name).trim() && !!readString(record.prompt).trim();
+    })
+    .map((template) => ({
+      id: template.id.trim(),
+      name: template.name.trim(),
+      prompt: template.prompt.trim(),
+    }));
+}
+
+function resolveSummaryPromptTemplate(
+  metadata: Record<string, unknown>,
+  requestedTemplateId?: string | null,
+): { id: string | null; prompt: string } {
+  const templates = summaryPromptTemplates(metadata.summaryPromptTemplates);
+  const selectedId =
+    readString(requestedTemplateId).trim() || readString(metadata.activeSummaryPromptTemplateId).trim();
+  const selected = templates.find((template) => template.id === selectedId);
+  return {
+    id: selected?.id ?? null,
+    prompt: selected?.prompt ?? getDefaultAgentPrompt("chat-summary"),
+  };
 }
 
 /** Peek at the assembled prompt for a chat */

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -23,6 +23,7 @@ import {
   Image as ImageIcon,
   ArrowRightLeft,
   MoreHorizontal,
+  ScrollText,
 } from "lucide-react";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
@@ -36,6 +37,7 @@ import { playNotificationPing } from "../../../../shared/lib/notification-sound"
 import { getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
 import { usePageActivity } from "../../../../shared/hooks/use-page-activity";
 import { invalidateCharacterCollectionQueries } from "../../../catalog/characters/index";
+import { useUpdateChatMetadata } from "../../../catalog/chats/index";
 import { getConversationStatus } from "../../../../engine/modes/chat/autonomous/autonomous.service";
 import { storageApi } from "../../../../shared/api/storage-api";
 import type { CharacterMap, MessageSelectionToggle, PeekPromptOptions, PersonaInfo } from "../../shared/chat-ui/types";
@@ -44,6 +46,11 @@ import type { Message } from "../../../../engine/contracts/types/chat";
 const ConversationAutonomousEffects = lazy(async () => {
   const module = await import("./ConversationAutonomousEffects");
   return { default: module.ConversationAutonomousEffects };
+});
+
+const SummaryPopover = lazy(async () => {
+  const module = await import("../../shared/chat-ui/index");
+  return { default: module.SummaryPopover };
 });
 
 interface ConversationViewProps {
@@ -411,6 +418,12 @@ export function ConversationView({
   }, [convoGradient, theme]);
   const hasAutonomousMessaging = !!chatMeta.autonomousMessages || !!chatMeta.characterExchanges;
   const [mobileWorldInfoOpen, setMobileWorldInfoOpen] = useState(false);
+  const [summaryOpen, setSummaryOpen] = useState(false);
+  const updateMeta = useUpdateChatMetadata();
+  const summaryContextSize =
+    typeof chatMeta.summaryContextSize === "number" && Number.isFinite(chatMeta.summaryContextSize)
+      ? chatMeta.summaryContextSize
+      : 50;
   const renderToolbarActions = (compact = false) => (
     <>
       <ChatBranchSelector
@@ -422,6 +435,28 @@ export function ConversationView({
           compact ? "bg-transparent text-foreground/80 hover:bg-[var(--accent)] hover:text-foreground" : undefined
         }
       />
+      <div className="relative" onClick={(e) => e.stopPropagation()}>
+        <button
+          onClick={() => setSummaryOpen((open) => !open)}
+          className={compact ? MOBILE_MENU_BTN : HEADER_BTN}
+          title="Chat Summary"
+          aria-label="Chat Summary"
+        >
+          <ScrollText size="0.875rem" />
+        </button>
+        {summaryOpen && compact === (typeof window !== "undefined" && window.innerWidth < 768) && (
+          <Suspense fallback={null}>
+            <SummaryPopover
+              chatId={chatId}
+              summary={chatMetaString(chatMeta.summary, "") || null}
+              contextSize={summaryContextSize}
+              totalMessageCount={totalMessageCount}
+              onContextSizeChange={(size) => updateMeta.mutate({ id: chatId, summaryContextSize: size })}
+              onClose={() => setSummaryOpen(false)}
+            />
+          </Suspense>
+        )}
+      </div>
       {compact ? (
         <button
           onClick={() => setMobileWorldInfoOpen(true)}
@@ -809,7 +844,11 @@ export function ConversationView({
   }, [hiddenCount]);
 
   return (
-    <div className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden" data-chat-mode="conversation" style={{ ...gradientStyle, isolation: "isolate" }}>
+    <div
+      className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
+      data-chat-mode="conversation"
+      style={{ ...gradientStyle, isolation: "isolate" }}
+    >
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}

--- a/src/features/modes/shared/chat-ui/components/SummaryPopover.tsx
+++ b/src/features/modes/shared/chat-ui/components/SummaryPopover.tsx
@@ -6,12 +6,19 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import {
   useBulkSetMessagesHiddenFromAI,
+  useChat,
   useGenerateSummary,
   useUpdateChatMetadata,
 } from "../../../../catalog/chats/index";
 import { Check, Info, Loader2, Save, ScrollText, Settings2, Sparkles, X } from "lucide-react";
 import { cn } from "../../../../../shared/lib/utils";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
+import {
+  appendChatSummaryEntryToMetadata,
+  compileChatSummaryEntries,
+  normalizeChatSummaryMetadata,
+} from "../../../../../engine/shared/text/chat-summary-entries";
+import type { ChatSummaryEntry } from "../../../../../engine/contracts/types/chat";
 import type { SummaryPopoverSourceMode } from "../../../../../shared/stores/ui.store";
 
 interface SummaryPopoverProps {
@@ -44,11 +51,13 @@ export function SummaryPopover({
   onClose,
 }: SummaryPopoverProps) {
   const [editing, setEditing] = useState(false);
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
   const [draft, setDraft] = useState(summary ?? "");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
   const summaryPopoverSettings = useUIStore((s) => s.summaryPopoverSettings);
   const setSummaryPopoverSettings = useUIStore((s) => s.setSummaryPopoverSettings);
+  const chatQuery = useChat(chatId);
   const persistedContextSize = clampSummaryCount(summaryPopoverSettings.contextSize ?? contextSize ?? 50);
   const [localSize, setLocalSize] = useState(String(persistedContextSize));
   const [rangeStart, setRangeStart] = useState(String(summaryPopoverSettings.rangeStart ?? 1));
@@ -147,6 +156,20 @@ export function SummaryPopover({
       : totalMessageCount > 0
         ? `Last ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
         : "No messages yet";
+  const chatMetadata: Record<string, unknown> =
+    chatQuery.data?.metadata && typeof chatQuery.data.metadata === "object" ? chatQuery.data.metadata : {};
+  const promptTemplates = Array.isArray(chatMetadata.summaryPromptTemplates)
+    ? chatMetadata.summaryPromptTemplates.filter(
+        (template: unknown): template is { id: string; name: string; prompt: string } => {
+          if (!template || typeof template !== "object" || Array.isArray(template)) return false;
+          const record = template as Record<string, unknown>;
+          return typeof record.id === "string" && typeof record.name === "string" && typeof record.prompt === "string";
+        },
+      )
+    : [];
+  const activeSummaryPromptTemplateId =
+    typeof chatMetadata.activeSummaryPromptTemplateId === "string" ? chatMetadata.activeSummaryPromptTemplateId : "";
+  const summaryEntries = normalizeChatSummaryMetadata(chatMetadata).entries;
 
   const maybeHideSummarizedMessages = useCallback(
     (messageIds: string[]) => {
@@ -158,6 +181,7 @@ export function SummaryPopover({
 
   const handleGenerate = useCallback(() => {
     setErrorText(null);
+    setEditingEntryId(null);
     if (summaryPopoverSettings.sourceMode === "range") {
       if (totalMessageCount === 0) {
         setErrorText("No messages available for summary generation.");
@@ -169,10 +193,17 @@ export function SummaryPopover({
       }
       setSummaryPopoverSettings({ rangeStart: rangeLow, rangeEnd: rangeHigh });
       generateSummary.mutate(
-        { chatId, contextSize: normalizedLastSize, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh },
+        {
+          chatId,
+          contextSize: normalizedLastSize,
+          rangeStartIndex: rangeLow,
+          rangeEndIndex: rangeHigh,
+          promptTemplateId: activeSummaryPromptTemplateId || null,
+        },
         {
           onSuccess: (data) => {
             setDraft(data.summary);
+            setEditingEntryId(null);
             setEditing(false);
             maybeHideSummarizedMessages(data.messageIds);
           },
@@ -184,10 +215,11 @@ export function SummaryPopover({
 
     persistContextSize(normalizedLastSize);
     generateSummary.mutate(
-      { chatId, contextSize: normalizedLastSize },
+      { chatId, contextSize: normalizedLastSize, promptTemplateId: activeSummaryPromptTemplateId || null },
       {
         onSuccess: (data) => {
           setDraft(data.summary);
+          setEditingEntryId(null);
           setEditing(false);
           maybeHideSummarizedMessages(data.messageIds);
         },
@@ -204,14 +236,67 @@ export function SummaryPopover({
     rangeLow,
     rangeTooLarge,
     setSummaryPopoverSettings,
+    activeSummaryPromptTemplateId,
     summaryPopoverSettings.sourceMode,
     totalMessageCount,
   ]);
 
+  const patchSummaryEntries = useCallback(
+    (entries: ChatSummaryEntry[]) => {
+      updateMeta.mutate({ id: chatId, summary: compileChatSummaryEntries(entries), summaryEntries: entries });
+    },
+    [chatId, updateMeta],
+  );
+
   const handleSave = useCallback(() => {
-    updateMeta.mutate({ id: chatId, summary: draft || null });
+    const content = draft.trim();
+    if (editingEntryId) {
+      const now = new Date().toISOString();
+      const nextEntries = content
+        ? summaryEntries.map((entry) =>
+            entry.id === editingEntryId
+              ? { ...entry, content, tokenEstimate: Math.max(1, Math.ceil(content.length / 4)), updatedAt: now }
+              : entry,
+          )
+        : summaryEntries.filter((entry) => entry.id !== editingEntryId);
+      patchSummaryEntries(nextEntries);
+      setEditingEntryId(null);
+      setEditing(false);
+      return;
+    }
+    if (!content) {
+      updateMeta.mutate({ id: chatId, summary: null, summaryEntries: [] });
+      setEditing(false);
+      return;
+    }
+    const appended = appendChatSummaryEntryToMetadata(chatMetadata, {
+      content,
+      origin: "manual",
+      sourceMode: "last",
+      title: "Manual summary",
+    });
+    updateMeta.mutate({ id: chatId, summary: appended.summary, summaryEntries: appended.entries });
+    setEditingEntryId(null);
     setEditing(false);
-  }, [chatId, draft, updateMeta]);
+  }, [chatId, chatMetadata, draft, editingEntryId, patchSummaryEntries, summaryEntries, updateMeta]);
+
+  const toggleEntry = useCallback(
+    (entryId: string) => {
+      patchSummaryEntries(
+        summaryEntries.map((entry) =>
+          entry.id === entryId ? { ...entry, enabled: !entry.enabled, updatedAt: new Date().toISOString() } : entry,
+        ),
+      );
+    },
+    [patchSummaryEntries, summaryEntries],
+  );
+
+  const deleteEntry = useCallback(
+    (entryId: string) => {
+      patchSummaryEntries(summaryEntries.filter((entry) => entry.id !== entryId));
+    },
+    [patchSummaryEntries, summaryEntries],
+  );
 
   const isGenerating = generateSummary.isPending;
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
@@ -351,6 +436,23 @@ export function SummaryPopover({
             )}
 
             <div className="space-y-2">
+              <label className="block space-y-1">
+                <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Prompt</span>
+                <select
+                  value={activeSummaryPromptTemplateId}
+                  onChange={(e) =>
+                    updateMeta.mutate({ id: chatId, activeSummaryPromptTemplateId: e.target.value || null })
+                  }
+                  className="w-full rounded-md bg-[var(--secondary)] px-2 py-1 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                >
+                  <option value="">Default chat-summary prompt</option>
+                  {promptTemplates.map((template) => (
+                    <option key={template.id} value={template.id}>
+                      {template.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <label className="flex items-center gap-2 text-[0.6875rem] text-[var(--foreground)]/80">
                 <input
                   type="checkbox"
@@ -402,6 +504,7 @@ export function SummaryPopover({
                   type="button"
                   onClick={() => {
                     setDraft(summary ?? "");
+                    setEditingEntryId(null);
                     setEditing(false);
                   }}
                   className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
@@ -421,6 +524,52 @@ export function SummaryPopover({
             </div>
           ) : (
             <div>
+              {summaryEntries.length > 0 && (
+                <div className="mb-2 space-y-1.5">
+                  {summaryEntries.map((entry) => (
+                    <div
+                      key={entry.id}
+                      className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/50 px-2 py-1.5"
+                    >
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => toggleEntry(entry.id)}
+                          className={cn(
+                            "h-3 w-3 rounded-sm border",
+                            entry.enabled
+                              ? "border-amber-400 bg-amber-400"
+                              : "border-[var(--muted-foreground)] bg-transparent",
+                          )}
+                          title={entry.enabled ? "Disable summary entry" : "Enable summary entry"}
+                          aria-label={entry.enabled ? "Disable summary entry" : "Enable summary entry"}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDraft(entry.content);
+                            setEditingEntryId(entry.id);
+                            setEditing(true);
+                          }}
+                          className="min-w-0 flex-1 truncate text-left text-[0.6875rem] font-medium text-[var(--foreground)]/85 hover:underline"
+                          title="Edit summary entry"
+                        >
+                          {entry.title}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => deleteEntry(entry.id)}
+                          className="rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                          title="Delete summary entry"
+                          aria-label="Delete summary entry"
+                        >
+                          <X size="0.6875rem" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
               {draft ? (
                 <div
                   className="cursor-pointer rounded-lg p-2 transition-colors hover:bg-[var(--accent)]"

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -238,6 +238,7 @@ export const storageApi: StorageGateway = {
     const chat = await storageApi.get<Record<string, unknown>>("chats", chatId);
     return asArray(chat?.memories);
   },
+  refreshChatMemories: (chatId) => invokeTauri("chat_memories_refresh", { chatId }),
   getWorldState: async (chatId) => {
     const chat = await storageApi.get<Record<string, unknown>>("chats", chatId);
     return (chat?.gameState as never) ?? null;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1787

## Why this change

- Restores refactor chat parity for summary management, branch metadata cleanup, Memory Recall refresh, and day/week summary prompt compaction.

## What changed

- Preserves legacy `metadata.summary` as a structured `legacy` rolling summary entry when structured summary entries are introduced.
- Restores structured summary entry display/edit/toggle/delete controls, prompt template selection, and the shared summary popover in conversation mode.
- Routes generated summaries through the chat-summary/default-for-agents fallback chain and records the selected summary prompt template.
- Formats day/week summary maps as readable prompt blocks and limits raw history to the configured summary tail when compacted summaries exist.
- Prunes future-facing summary fields from new branches while keeping summary configuration metadata.
- Refreshes Memory Recall after successful non-impersonation generation when the storage gateway supports refresh.

## Refactor impact

Primary owner:

Chat mode / shared mode UI, with engine generation and Rust storage support.

Impact areas reviewed:

- Summary popover shared UI and conversation toolbar mounting.
- Chat summary generation routing and prompt template resolution.
- Prompt assembly for rolling, day, and week summaries.
- Native `chat_branch` storage behavior.
- Generation post-save Memory Recall refresh path.

Boundary notes:

- Engine code stays React-free and only depends on engine helpers.
- Feature UI calls focused catalog/shared API hooks instead of raw Tauri.
- The Memory Recall refresh is exposed as an optional `StorageGateway` capability and implemented by the Tauri storage API wrapper.
- Rust storage owns branch metadata pruning.

Pressure points touched:

- Shared mode UI `SummaryPopover`.
- Conversation mode toolbar.
- Engine prompt assembly and generation start pipeline.
- `src-tauri/src/commands/storage/chats.rs`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Codex proof run:
- `pnpm exec vitest run --config scratch\vitest.issue-1787.config.ts`
- `cargo test --manifest-path src-tauri\Cargo.toml branch_chat_prunes_future_summary_metadata_from_new_branch`
- `cargo check --manifest-path src-tauri\Cargo.toml --workspace`
- `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`
- Bunny review passed before PR open.
- No real Tauri/browser screenshot was captured. The visual UI row is limited to component wiring and typecheck proof; hands-on Tauri visual inspection is still useful before merge.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores existing chat summary parity rather than adding a new discoverable workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not attached. The conversation summary button and popover wiring are code/typecheck covered, but real Tauri visual verification is not included in this draft.
