### PR TITLE
Fix generation runtime parity gaps

### DIFF
--- a/src/engine/generation/generation-events.ts
+++ b/src/engine/generation/generation-events.ts
@@ -4,6 +4,10 @@ export type GenerationEvent =
   | { type: "token"; data: string }
   | { type: "tool_call"; data: { id?: string; name: string; arguments: string } }
   | { type: "tool_result"; data: { toolCallId?: string; name: string; result: string; success: boolean } }
+  | { type: "typing"; characters: string[] }
+  | { type: "delayed"; characters: string[]; status: string; delayMs: number }
+  | { type: "offline"; characters: string[] }
+  | { type: "group_turn"; data: { characterId: string; characterName: string; index: number } }
   | { type: "user_message"; data: unknown }
   | { type: "assistant_message"; data: unknown }
   | { type: "agent_injection_review"; data: unknown }

--- a/src/engine/generation/generation-events.ts
+++ b/src/engine/generation/generation-events.ts
@@ -4,9 +4,9 @@ export type GenerationEvent =
   | { type: "token"; data: string }
   | { type: "tool_call"; data: { id?: string; name: string; arguments: string } }
   | { type: "tool_result"; data: { toolCallId?: string; name: string; result: string; success: boolean } }
-  | { type: "typing"; characters: string[] }
-  | { type: "delayed"; characters: string[]; status: string; delayMs: number }
-  | { type: "offline"; characters: string[] }
+  | { type: "typing"; data: { characters: string[] } }
+  | { type: "delayed"; data: { characters: string[]; status: string; delayMs: number } }
+  | { type: "offline"; data: { characters: string[] } }
   | { type: "group_turn"; data: { characterId: string; characterName: string; index: number } }
   | { type: "user_message"; data: unknown }
   | { type: "assistant_message"; data: unknown }

--- a/src/engine/generation/persona-snapshot.ts
+++ b/src/engine/generation/persona-snapshot.ts
@@ -37,11 +37,11 @@ function personaSnapshotFromRecord(value: unknown): PersonaMessageSnapshot | nul
   return {
     personaId,
     name,
-    description: readString(field(value, data, "description")),
-    personality: readString(field(value, data, "personality")),
-    scenario: readString(field(value, data, "scenario")),
-    backstory: readString(field(value, data, "backstory")),
-    appearance: readString(field(value, data, "appearance")),
+    description: optionalString(field(value, data, "description")),
+    personality: optionalString(field(value, data, "personality")),
+    scenario: optionalString(field(value, data, "scenario")),
+    backstory: optionalString(field(value, data, "backstory")),
+    appearance: optionalString(field(value, data, "appearance")),
     avatarUrl:
       optionalString(field(value, data, "avatarPath")) ??
       optionalString(field(value, data, "avatarUrl")) ??

--- a/src/engine/generation/persona-snapshot.ts
+++ b/src/engine/generation/persona-snapshot.ts
@@ -1,0 +1,89 @@
+import type { StorageGateway } from "../capabilities/storage";
+import type { MessageExtra } from "../contracts/types/chat";
+import { boolish, isRecord, parseRecord, readString, type JsonRecord } from "./runtime-records";
+
+export type PersonaMessageSnapshot = NonNullable<MessageExtra["personaSnapshot"]>;
+
+function recordData(record: JsonRecord): JsonRecord {
+  const data = parseRecord(record.data);
+  return Object.keys(data).length > 0 ? data : record;
+}
+
+function field(record: JsonRecord, data: JsonRecord, key: string): unknown {
+  return data[key] ?? record[key];
+}
+
+function optionalString(value: unknown): string | null {
+  const text = readString(value).trim();
+  return text || null;
+}
+
+function avatarCropSnapshot(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null;
+  if (!isRecord(value)) return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function personaSnapshotFromRecord(value: unknown): PersonaMessageSnapshot | null {
+  if (!isRecord(value)) return null;
+  const data = recordData(value);
+  const personaId = readString(value.id ?? data.id).trim();
+  if (!personaId) return null;
+  const name = readString(field(value, data, "name")).trim() || "You";
+  return {
+    personaId,
+    name,
+    description: readString(field(value, data, "description")),
+    personality: readString(field(value, data, "personality")),
+    scenario: readString(field(value, data, "scenario")),
+    backstory: readString(field(value, data, "backstory")),
+    appearance: readString(field(value, data, "appearance")),
+    avatarUrl:
+      optionalString(field(value, data, "avatarPath")) ??
+      optionalString(field(value, data, "avatarUrl")) ??
+      optionalString(field(value, data, "avatar")),
+    avatarCrop: avatarCropSnapshot(field(value, data, "avatarCrop")),
+    nameColor: optionalString(field(value, data, "nameColor")),
+    dialogueColor: optionalString(field(value, data, "dialogueColor")),
+    boxColor: optionalString(field(value, data, "boxColor")),
+  };
+}
+
+function personaRecordMatchesId(value: unknown, personaId: string): value is JsonRecord {
+  if (!isRecord(value)) return false;
+  return readString(value.id ?? parseRecord(value.data).id).trim() === personaId;
+}
+
+function personaRecordIsActive(value: unknown): value is JsonRecord {
+  if (!isRecord(value)) return false;
+  const data = parseRecord(value.data);
+  return boolish(data.isActive ?? value.isActive ?? data.active ?? value.active, false);
+}
+
+export function findPersonaSnapshotForChat(personas: unknown[], chat: unknown): PersonaMessageSnapshot | null {
+  const chatRecord = parseRecord(chat);
+  const personaId = readString(chatRecord.personaId).trim();
+  const persona =
+    (personaId ? personas.find((candidate) => personaRecordMatchesId(candidate, personaId)) : null) ??
+    personas.find(personaRecordIsActive);
+  return personaSnapshotFromRecord(persona);
+}
+
+export async function loadPersonaSnapshotForChat(
+  storage: StorageGateway,
+  chat: unknown,
+): Promise<PersonaMessageSnapshot | null> {
+  const chatRecord = parseRecord(chat);
+  const personaId = readString(chatRecord.personaId).trim();
+  if (personaId) {
+    const persona = await storage.get<JsonRecord>("personas", personaId).catch(() => null);
+    const snapshot = personaSnapshotFromRecord(persona);
+    if (snapshot) return snapshot;
+  }
+  const personas = await storage.list<JsonRecord>("personas").catch(() => []);
+  return findPersonaSnapshotForChat(personas, chatRecord);
+}

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1272,7 +1272,8 @@ async function resolveIndividualGroupTurnIds(args: {
       selectionMode: "multi",
     });
   }
-  return [...activeIds];
+  const sequential = sequentialGroupTarget(args.storedMessages, activeIds);
+  return sequential ? [sequential] : [];
 }
 
 async function* runIndividualGroupTurnLoop(args: {
@@ -1303,6 +1304,11 @@ async function* runIndividualGroupTurnLoop(args: {
 
     for await (const event of startGeneration(args.deps, childInput, args.signal)) {
       if (event.type === "user_message" || event.type === "done") continue;
+      if (event.type === "agent_injection_review") {
+        yield event;
+        yield { type: "done" };
+        return;
+      }
       yield event;
     }
   }
@@ -2484,16 +2490,18 @@ export async function* startGeneration(
         prepared: preparedUserInput,
         persona: savedUserPersonaContext(savedUserMessage),
       });
-      yield { type: "offline", characters: characterNames };
+      yield { type: "offline", data: { characters: characterNames } };
       yield { type: "done" };
       return;
     }
     if (availability && availability.delayMs > 0 && !regenerateMessageId) {
       yield {
         type: "delayed",
-        characters: characterNames,
-        status: availability.delayStatus,
-        delayMs: availability.delayMs,
+        data: {
+          characters: characterNames,
+          status: availability.delayStatus,
+          delayMs: availability.delayMs,
+        },
       };
       await abortableDelay(availability.delayMs, signal);
       throwIfAborted(signal);
@@ -2501,7 +2509,7 @@ export async function* startGeneration(
       generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
     }
     if (characterNames.length > 0) {
-      yield { type: "typing", characters: characterNames };
+      yield { type: "typing", data: { characters: characterNames } };
     }
   }
   const agentEvents: AgentResult[] = [];

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -10,6 +10,8 @@ import type { GenerationGuideSource } from "../shared/text/generation-guide";
 import { chatSummaryFingerprintMatches, fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
 import { collapseExcessBlankLines } from "../shared/text/newlines";
 import { buildImpersonateInstruction } from "../modes/chat/commands/impersonate-prompt";
+import { getConversationStatus } from "../modes/chat/autonomous/autonomous.service";
+import { getBusyDelay, type WeekSchedule } from "../modes/chat/schedules/schedule.service";
 import {
   activeCharacterIds,
   assertChatHasActiveCharacters,
@@ -46,6 +48,7 @@ import {
   normalizeGenerationReplay,
   type GenerationReplay,
 } from "./generation-replay";
+import { loadPersonaSnapshotForChat } from "./persona-snapshot";
 import { assembleGenerationPrompt, chatSummaryForGeneration } from "./prompt-assembly";
 import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
 import { generationInfoFromVisibleParameters, providerVisibleLlmParameters } from "./provider-visible-parameters";
@@ -153,6 +156,14 @@ const DEFAULT_LOREBOOK_KEEPER_RUN_INTERVAL = BUILT_IN_AGENT_RUN_INTERVAL_DEFAULT
 const CONTINUE_ASSISTANT_RESPONSE_INSTRUCTION =
   "[Generation instruction: continue from the latest assistant message. Do not repeat or summarize the previous response; pick up naturally from where it stopped.]";
 
+type InternalStartGenerationOptions = {
+  groupTurnChild?: boolean;
+  latestUserInput?: string | null;
+  skipUserMessageSave?: boolean;
+};
+
+const internalStartGenerationOptions = new WeakMap<StartGenerationInput, InternalStartGenerationOptions>();
+
 type MainGenerationPromptSnapshot = Pick<
   GenerationPromptSnapshot,
   "messages" | "parameters" | "tools" | "promptPresetId"
@@ -250,19 +261,28 @@ async function prepareUserInput(storage: StorageGateway, input: StartGenerationI
   };
 }
 
-function shouldSaveUserMessage(input: StartGenerationInput, prepared: PreparedUserInput): boolean {
+function shouldSaveUserMessage(
+  input: StartGenerationInput,
+  prepared: PreparedUserInput,
+  internalOptions: InternalStartGenerationOptions = {},
+): boolean {
+  if (internalOptions.skipUserMessageSave === true) return false;
   return !!prepared.content.trim() && input.impersonate !== true && !readString(input.regenerateMessageId).trim();
 }
 
 async function saveUserMessage(
   storage: StorageGateway,
+  chat: JsonRecord,
   input: StartGenerationInput,
   prepared: PreparedUserInput,
+  internalOptions: InternalStartGenerationOptions = {},
 ): Promise<unknown | null> {
-  if (!shouldSaveUserMessage(input, prepared)) return null;
+  if (!shouldSaveUserMessage(input, prepared, internalOptions)) return null;
   const extra: Record<string, unknown> = {};
   if (prepared.attachments.length) extra.attachments = prepared.attachments;
   if (prepared.mentionedCharacterNames.length) extra.mentionedCharacterNames = prepared.mentionedCharacterNames;
+  const personaSnapshot = await loadPersonaSnapshotForChat(storage, chat);
+  if (personaSnapshot) extra.personaSnapshot = personaSnapshot;
   const generationReplay = buildGenerationReplay({
     userMessage: inputUserMessage(input) || null,
     impersonate: false,
@@ -378,6 +398,22 @@ function mirrorSavedUserMessageToDiscord(args: {
     content: args.prepared.content || inputUserMessage(args.input),
     username: limitedDiscordName(args.persona?.name, "User"),
   });
+}
+
+function savedUserPersonaContext(saved: unknown): GenerationPersonaContext | null {
+  if (!isRecord(saved)) return null;
+  const snapshot = parseRecord(parseRecord(saved.extra).personaSnapshot);
+  const name = readString(snapshot.name).trim();
+  if (!name) return null;
+  return {
+    name,
+    description: readString(snapshot.description),
+    personality: readString(snapshot.personality),
+    backstory: readString(snapshot.backstory),
+    appearance: readString(snapshot.appearance),
+    scenario: readString(snapshot.scenario),
+    tags: [],
+  };
 }
 
 function imageExtension(mimeType: string): string {
@@ -1080,20 +1116,47 @@ async function smartRoleplayGroupTarget(args: {
   activeIds: string[];
   signal?: AbortSignal;
 }): Promise<string | null> {
+  return (
+    (
+      await smartRoleplayGroupTargets({
+        ...args,
+        selectionMode: "single",
+      })
+    )[0] ?? null
+  );
+}
+
+async function smartRoleplayGroupTargets(args: {
+  deps: GenerationEngineDeps;
+  input: StartGenerationInput;
+  chat: JsonRecord;
+  connection: JsonRecord;
+  storedMessages: JsonRecord[];
+  latestUserInput: string;
+  mentionedNames: string[];
+  activeIds: string[];
+  selectionMode: "single" | "multi";
+  signal?: AbortSignal;
+}): Promise<string[]> {
   const candidates = await loadSmartResponderCandidates(args.deps.storage, args.activeIds);
   const mentionedIds = mentionedSmartResponderIds({
     candidates,
     latestUserInput: args.latestUserInput,
     mentionedNames: args.mentionedNames,
   });
-  if (mentionedIds.length > 0) return mentionedIds[0] ?? null;
-  if (candidates.length === 0) return sequentialGroupTarget(args.storedMessages, args.activeIds);
+  if (mentionedIds.length > 0) return args.selectionMode === "single" ? mentionedIds.slice(0, 1) : mentionedIds;
+  const sequentialFallback = sequentialGroupTarget(args.storedMessages, args.activeIds);
+  if (candidates.length === 0) return sequentialFallback ? [sequentialFallback] : [];
 
   const personaId = readString(args.chat.personaId).trim();
   const persona = personaId ? await args.deps.storage.get<JsonRecord>("personas", personaId).catch(() => null) : null;
   const personaData = isRecord(persona) ? characterDataRecord(persona) : {};
   const chatMode = readString(args.chat.mode || args.chat.chatMode, "conversation");
   const chatKind = chatMode === "conversation" ? "conversation group chat" : "individual-mode roleplay group chat";
+  const selectionInstruction =
+    args.selectionMode === "multi"
+      ? "Choose the character or characters who should respond in this send. Return one or more IDs when multiple characters should take turns."
+      : "Choose which character should respond next based on the latest message, direct address, conversation momentum, and talkativeness. Usually choose exactly one character.";
   const candidateLines = candidates
     .map((candidate) =>
       JSON.stringify({
@@ -1116,7 +1179,7 @@ async function smartRoleplayGroupTarget(args: {
         messages: [
           {
             role: "system",
-            content: `You are a hidden response orchestrator for a ${chatKind}. Choose which character should respond next based on the latest message, direct address, conversation momentum, and talkativeness. Usually choose exactly one character. Return only JSON: {"characterIds":["character-id"],"reason":"short"}.`,
+            content: `You are a hidden response orchestrator for a ${chatKind}. ${selectionInstruction} Return only JSON: {"characterIds":["character-id"],"reason":"short"}.`,
           },
           {
             role: "user",
@@ -1134,9 +1197,9 @@ async function smartRoleplayGroupTarget(args: {
   } catch (error) {
     if (isRecord(error) && readString(error.name) === "AbortError") throw error;
   }
-  return (
-    parseSmartGroupSelectionIds(raw, args.activeIds)[0] ?? sequentialGroupTarget(args.storedMessages, args.activeIds)
-  );
+  const selected = parseSmartGroupSelectionIds(raw, args.activeIds);
+  if (selected.length > 0) return args.selectionMode === "single" ? selected.slice(0, 1) : selected;
+  return sequentialFallback ? [sequentialFallback] : [];
 }
 
 async function resolveGroupTargetForGeneration(args: {
@@ -1177,6 +1240,142 @@ async function resolveGroupTargetForGeneration(args: {
     return smartRoleplayGroupTarget({ ...args, activeIds });
   }
   return sequentialGroupTarget(args.storedMessages, activeIds);
+}
+
+async function resolveIndividualGroupTurnIds(args: {
+  deps: GenerationEngineDeps;
+  input: StartGenerationInput;
+  chat: JsonRecord;
+  connection: JsonRecord;
+  storedMessages: JsonRecord[];
+  latestUserInput: string;
+  mentionedNames: string[];
+  signal?: AbortSignal;
+}): Promise<string[] | null> {
+  if (args.input.impersonate === true || readString(args.input.regenerateMessageId).trim()) return null;
+  if (Array.isArray(args.input.messages) && args.input.messages.length > 0) return null;
+  if (readString(args.chat.mode || args.chat.chatMode).trim() !== "roleplay") return null;
+  const metadata = parseRecord(args.chat.metadata);
+  if (readString(metadata.groupChatMode, "merged") !== "individual") return null;
+
+  const activeIds = activeCharacterIds(args.chat);
+  if (activeIds.length <= 1) return null;
+  const explicit = explicitGroupTarget(args.input, args.storedMessages, activeIds);
+  if (explicit) return [explicit];
+
+  const order = readString(metadata.groupResponseOrder, "sequential");
+  if (order === "manual") return [];
+  if (order === "smart") {
+    return smartRoleplayGroupTargets({
+      ...args,
+      activeIds,
+      selectionMode: "multi",
+    });
+  }
+  return [...activeIds];
+}
+
+async function* runIndividualGroupTurnLoop(args: {
+  deps: GenerationEngineDeps;
+  input: StartGenerationInput;
+  turnIds: string[];
+  latestUserInput: string;
+  signal?: AbortSignal;
+}): AsyncGenerator<GenerationEvent> {
+  for (let index = 0; index < args.turnIds.length; index += 1) {
+    throwIfAborted(args.signal);
+    const characterId = args.turnIds[index]!;
+    const characterName = (await characterNameById(args.deps.storage, [], characterId)) ?? "Character";
+    yield { type: "group_turn", data: { characterId, characterName, index } };
+
+    const childInput: StartGenerationInput = {
+      ...args.input,
+      userMessage: null,
+      message: "",
+      attachments: [],
+      forCharacterId: characterId,
+    };
+    internalStartGenerationOptions.set(childInput, {
+      groupTurnChild: true,
+      latestUserInput: args.latestUserInput,
+      skipUserMessageSave: true,
+    });
+
+    for await (const event of startGeneration(args.deps, childInput, args.signal)) {
+      if (event.type === "user_message" || event.type === "done") continue;
+      yield event;
+    }
+  }
+  yield { type: "done" };
+}
+
+type ConversationAvailabilityStatus = "online" | "idle" | "dnd" | "offline";
+
+type ConversationAvailabilityCharacter = {
+  id: string;
+  name: string;
+  status: ConversationAvailabilityStatus;
+  schedule?: WeekSchedule | null;
+};
+
+function conversationStatus(value: unknown): ConversationAvailabilityStatus {
+  return value === "idle" || value === "dnd" || value === "offline" ? value : "online";
+}
+
+async function resolveConversationAvailability(args: {
+  storage: StorageGateway;
+  chat: JsonRecord;
+  targetCharacterId?: string | null;
+}): Promise<{
+  characters: ConversationAvailabilityCharacter[];
+  allOffline: boolean;
+  delayMs: number;
+  delayStatus: ConversationAvailabilityStatus;
+} | null> {
+  if (readString(args.chat.mode || args.chat.chatMode).trim() !== "conversation") return null;
+  const activeIds = activeCharacterIds(args.chat);
+  if (activeIds.length === 0) return null;
+  const activeSet = new Set(activeIds);
+  const requested = readString(args.targetCharacterId).trim();
+  const respondingIds = requested && activeSet.has(requested) ? [requested] : activeIds;
+  const statusResult = await getConversationStatus(args.storage, readString(args.chat.id).trim());
+  const characters: ConversationAvailabilityCharacter[] = [];
+  for (const id of respondingIds) {
+    const row = statusResult.statuses[id];
+    characters.push({
+      id,
+      name: (await characterNameById(args.storage, [], id)) ?? "Character",
+      status: conversationStatus(row?.status),
+      schedule: isRecord(row?.schedule) ? (row.schedule as unknown as WeekSchedule) : null,
+    });
+  }
+  const allOffline = characters.length > 0 && characters.every((character) => character.status === "offline");
+  let delayMs = 0;
+  let delayStatus: ConversationAvailabilityStatus = "online";
+  for (const character of characters) {
+    const characterDelay = getBusyDelay(character.status, character.schedule ?? undefined);
+    if (characterDelay > delayMs) {
+      delayMs = characterDelay;
+      delayStatus = character.status;
+    }
+  }
+  return { characters, allOffline, delayMs, delayStatus };
+}
+
+function abortableDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (delayMs <= 0) return Promise.resolve();
+  if (signal?.aborted) return Promise.reject(abortGenerationError());
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortGenerationError());
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function sequentialGroupTargetCharacterId(
@@ -1225,6 +1424,7 @@ function shouldContinueAssistantResponse(
   prepared: PreparedUserInput,
   storedMessages: JsonRecord[],
 ): boolean {
+  if (readString(input.forCharacterId).trim()) return false;
   if (!isPassiveGenerationRequest(input, prepared)) return false;
   return readString(latestVisibleMessage(storedMessages)?.role) === "assistant";
 }
@@ -2186,6 +2386,7 @@ export async function* startGeneration(
   throwIfAborted(signal);
   const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
   throwIfAborted(signal);
+  const internalOptions = internalStartGenerationOptions.get(input) ?? {};
   input = await inputWithStoredGenerationReplay(deps.storage, chat, chatId, input);
   throwIfAborted(signal);
   assertChatCanGenerate(chat, input);
@@ -2193,7 +2394,7 @@ export async function* startGeneration(
   yield { type: "phase", data: "Saving message..." };
   const preparedUserInput = await prepareUserInput(deps.storage, input);
   throwIfAborted(signal);
-  const savesUserMessage = shouldSaveUserMessage(input, preparedUserInput);
+  const savesUserMessage = shouldSaveUserMessage(input, preparedUserInput, internalOptions);
   const messageLoadOptions = generationMessageLoadOptions(chat, input);
   let storedMessages: JsonRecord[] | null = null;
   if (savesUserMessage) {
@@ -2202,7 +2403,7 @@ export async function* startGeneration(
     await commitVisibleTrackerSnapshotSafely(deps.storage, chatId, storedMessages);
     throwIfAborted(signal);
   }
-  const savedUserMessage = await saveUserMessage(deps.storage, input, preparedUserInput);
+  const savedUserMessage = await saveUserMessage(deps.storage, chat, input, preparedUserInput, internalOptions);
   throwIfAborted(signal);
   if (savedUserMessage) yield { type: "user_message", data: savedGenerationEventData(savedUserMessage) };
   const connection = await resolveGenerationConnection(deps.storage, chat, input);
@@ -2215,7 +2416,30 @@ export async function* startGeneration(
   } else {
     storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
   }
-  const generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
+  let generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
+  const latestUserInput =
+    readString(internalOptions.latestUserInput).trim() || preparedUserInput.content || inputUserMessage(input);
+  if (internalOptions.groupTurnChild !== true) {
+    const groupTurnIds = await resolveIndividualGroupTurnIds({
+      deps,
+      input,
+      chat,
+      connection,
+      storedMessages: generationMessages,
+      latestUserInput,
+      mentionedNames: preparedUserInput.mentionedCharacterNames,
+      signal,
+    });
+    throwIfAborted(signal);
+    if (groupTurnIds) {
+      if (groupTurnIds.length === 0) {
+        yield { type: "done" };
+        return;
+      }
+      yield* runIndividualGroupTurnLoop({ deps, input, turnIds: groupTurnIds, latestUserInput, signal });
+      return;
+    }
+  }
   const sequentialGroupTargetId = sequentialGroupTargetCharacterId(chat, input, storedMessages);
   if (sequentialGroupTargetId) {
     input = { ...input, forCharacterId: sequentialGroupTargetId };
@@ -2228,7 +2452,6 @@ export async function* startGeneration(
     storedMessages,
   );
   const chatForGeneration = generationTrackerBaseline ? { ...chat, gameState: generationTrackerBaseline } : chat;
-  const latestUserInput = preparedUserInput.content || inputUserMessage(input);
   const resolvedGroupTarget = await resolveGroupTargetForGeneration({
     deps,
     input,
@@ -2244,6 +2467,43 @@ export async function* startGeneration(
     input = { ...input, forCharacterId: resolvedGroupTarget };
   }
   const directMessages = requestMessages(input);
+  if (!directMessages && input.impersonate !== true) {
+    const availability = await resolveConversationAvailability({
+      storage: deps.storage,
+      chat,
+      targetCharacterId: readString(input.forCharacterId).trim() || resolvedGroupTarget,
+    });
+    throwIfAborted(signal);
+    const characterNames = availability?.characters.map((character) => character.name) ?? [];
+    const regenerateMessageId = readString(input.regenerateMessageId).trim();
+    if (availability?.allOffline && !regenerateMessageId) {
+      mirrorSavedUserMessageToDiscord({
+        deps,
+        chat,
+        input,
+        prepared: preparedUserInput,
+        persona: savedUserPersonaContext(savedUserMessage),
+      });
+      yield { type: "offline", characters: characterNames };
+      yield { type: "done" };
+      return;
+    }
+    if (availability && availability.delayMs > 0 && !regenerateMessageId) {
+      yield {
+        type: "delayed",
+        characters: characterNames,
+        status: availability.delayStatus,
+        delayMs: availability.delayMs,
+      };
+      await abortableDelay(availability.delayMs, signal);
+      throwIfAborted(signal);
+      storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
+      generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
+    }
+    if (characterNames.length > 0) {
+      yield { type: "typing", characters: characterNames };
+    }
+  }
   const agentEvents: AgentResult[] = [];
   const continueAssistantResponse = shouldContinueAssistantResponse(input, preparedUserInput, generationMessages);
   const agentInjectionOverrides = normalizedAgentInjectionOverrides(input);

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -38,6 +38,7 @@ import {
   timelineMessageProjection,
 } from "../../../catalog/chats/index";
 import { characterKeys } from "../../../catalog/characters/index";
+import { personaKeys } from "../../../catalog/personas/index";
 import {
   applyLorebookKeeperUpdate,
   buildPendingLorebookUpdates,
@@ -49,6 +50,7 @@ import {
   type GenerationReplayInput,
   type GenerationReplay,
 } from "../../../../engine/generation/generation-replay";
+import { findPersonaSnapshotForChat } from "../../../../engine/generation/persona-snapshot";
 import { readNonNegativeInteger } from "../../../../engine/generation/runtime-records";
 import {
   applyQuestUpdatesToPlayerStats,
@@ -81,6 +83,18 @@ const AGENT_DEBUG_FLUSH_CONTINUE_DELAY_MS = 16;
 const scheduledChatRefreshTimers = new Map<string, number>();
 const queuedAgentDebugEntries: Array<Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }> = [];
 let agentDebugFlushTimer: number | null = null;
+
+function eventCharacters(event: StreamEvent): string[] {
+  const value = (event as { characters?: unknown }).characters;
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && !!entry.trim())
+    : [];
+}
+
+function characterLabel(names: string[], fallback = "Character"): string {
+  if (names.length === 1) return names[0]!;
+  return names.length > 1 ? names.join(", ") : fallback;
+}
 
 function errorMessage(error: unknown): string {
   if (error instanceof ApiError) return error.message;
@@ -131,11 +145,42 @@ function sortMessagesByCreatedAt(messages: Message[]): Message[] {
   });
 }
 
-function optimisticUserMessage(args: GenerateArgs): Message | null {
+function addPersonaRows(target: unknown[], rows: unknown): void {
+  if (Array.isArray(rows)) {
+    target.push(...rows.filter(isRecord));
+  } else if (isRecord(rows)) {
+    target.push(rows);
+  }
+}
+
+function cachedChatForPersonaSnapshot(queryClient: QueryClient, chatId: string): unknown {
+  const detail = queryClient.getQueryData<Chat>(chatKeys.detail(chatId));
+  if (detail) return detail;
+  const list = queryClient.getQueryData<Chat[]>(chatKeys.list());
+  return Array.isArray(list) ? list.find((chat) => readString(chat.id).trim() === chatId) : null;
+}
+
+function cachedPersonaSnapshot(queryClient: QueryClient, chatId: string) {
+  const chat = cachedChatForPersonaSnapshot(queryClient, chatId);
+  const chatRecord = isRecord(chat) ? chat : {};
+  const personaId = readString(chatRecord.personaId).trim();
+  const personas: unknown[] = [];
+  addPersonaRows(personas, queryClient.getQueryData(personaKeys.list));
+  addPersonaRows(personas, queryClient.getQueryData(personaKeys.summaries));
+  addPersonaRows(personas, queryClient.getQueryData(personaKeys.active));
+  if (personaId) {
+    addPersonaRows(personas, queryClient.getQueryData(personaKeys.detail(personaId)));
+    addPersonaRows(personas, queryClient.getQueryData(personaKeys.summaryDetail(personaId)));
+  }
+  return findPersonaSnapshotForChat(personas, chat);
+}
+
+function optimisticUserMessage(queryClient: QueryClient, args: GenerateArgs): Message | null {
   if (args.impersonate === true || readString(args.regenerateMessageId).trim()) return null;
   const content = readString(args.userMessage).trim() || readString(args.message).trim();
   if (!content) return null;
   const attachments = Array.isArray(args.attachments) ? args.attachments : [];
+  const personaSnapshot = cachedPersonaSnapshot(queryClient, args.chatId);
   const createdAt = new Date().toISOString();
   return {
     id: `__optimistic_${Date.now()}`,
@@ -149,6 +194,7 @@ function optimisticUserMessage(args: GenerateArgs): Message | null {
       isGenerated: false,
       tokenCount: null,
       generationInfo: null,
+      personaSnapshot,
       ...(attachments.length ? { attachments } : {}),
     },
     createdAt,
@@ -169,7 +215,7 @@ async function assertChatCanGenerate(queryClient: QueryClient, chatId: string) {
 }
 
 function insertOptimisticUserMessage(queryClient: QueryClient, args: GenerateArgs) {
-  const optimistic = optimisticUserMessage(args);
+  const optimistic = optimisticUserMessage(queryClient, args);
   if (!optimistic) return;
   queryClient.setQueryData<InfiniteData<Message[]>>(chatKeys.messages(args.chatId), (old) => {
     if (!old?.pages?.length) return old;
@@ -943,6 +989,8 @@ export async function runGenerationWithUi(
   useAgentStore.getState().setProcessing(true);
 
   let received = "";
+  let receivedAnyContent = false;
+  let receivedTurnContent = false;
   let receivedThinking = false;
   let visibleStreamText = "";
   let committedStreamText = "";
@@ -1107,6 +1155,26 @@ export async function runGenerationWithUi(
     await flushVisibleStreamText();
   };
 
+  const resetLiveGenerationBuffers = () => {
+    cancelTypewriterFrame();
+    received = "";
+    receivedTurnContent = false;
+    receivedThinking = false;
+    visibleStreamText = "";
+    committedStreamText = "";
+    lastStreamBufferCommitAt = 0;
+    thinkingText = "";
+    committedThinkingText = "";
+    lastThinkingBufferCommitAt = null;
+    pendingReveal = "";
+    typewriterActive = false;
+    lastTypewriterPaintAt = 0;
+    typewriterRemainder = 0;
+    resolveAllRevealWaiters();
+    useChatStore.getState().setStreamBuffer("", chatId);
+    useChatStore.getState().setThinkingBuffer("", chatId);
+  };
+
   const ownsChatController = () => useChatStore.getState().abortControllers.get(chatId) === controller;
 
   const queueAgentResultEffect = (rawResult: unknown) => {
@@ -1131,6 +1199,7 @@ export async function runGenerationWithUi(
   };
 
   let foregroundGenerationReleased = false;
+  let groupTurnActive = false;
 
   const releaseForegroundGenerationUi = () => {
     if (foregroundGenerationReleased) return;
@@ -1180,6 +1249,9 @@ export async function runGenerationWithUi(
               receivedThinking = true;
               const state = useChatStore.getState();
               state.setTypingCharacterName(null);
+              state.setDelayedCharacterInfo(null);
+              state.setPerChatTyping(chatId, null);
+              state.setPerChatDelayed(chatId, null);
               state.setGenerationPhase("Thinking...");
               state.setMariPhase(chatId, "thinking");
             }
@@ -1189,6 +1261,16 @@ export async function runGenerationWithUi(
         case "token":
         case "delta":
           if (!foregroundGenerationReleased && typeof event.data === "string") {
+            const firstVisibleToken = !receivedTurnContent;
+            receivedTurnContent = true;
+            receivedAnyContent = true;
+            if (firstVisibleToken) {
+              const state = useChatStore.getState();
+              state.setTypingCharacterName(null);
+              state.setDelayedCharacterInfo(null);
+              state.setPerChatTyping(chatId, null);
+              state.setPerChatDelayed(chatId, null);
+            }
             received += event.data;
             enqueueVisibleStreamText(event.data);
           }
@@ -1199,7 +1281,7 @@ export async function runGenerationWithUi(
             if (event.type === "user_message") await flushLiveGenerationBuffers();
             upsertCachedMessage(queryClient, chatId, event.data);
             scheduleChatQueryRefresh(queryClient, chatId);
-            releaseForegroundGenerationUi();
+            if (event.type !== "user_message") releaseForegroundGenerationUi();
             drainAgentResultEffects();
           }
           break;
@@ -1210,10 +1292,57 @@ export async function runGenerationWithUi(
             scheduleChatQueryRefresh(queryClient, chatId);
             const trackerTarget = trackerTargetFromMessagePayload(event.data);
             runDeferredGenerationWork("game state refresh", () => refreshGameStateFromStorage(chatId, trackerTarget));
-            releaseForegroundGenerationUi();
+            if (groupTurnActive) {
+              resetLiveGenerationBuffers();
+            } else {
+              releaseForegroundGenerationUi();
+            }
             drainAgentResultEffects();
           }
           break;
+        case "group_turn": {
+          groupTurnActive = true;
+          await flushLiveGenerationBuffers();
+          resetLiveGenerationBuffers();
+          const data = parseMaybeRecord(event.data);
+          const characterId = readString(data.characterId).trim();
+          const characterName = readString(data.characterName).trim();
+          useChatStore.getState().setStreamingCharacterId(characterId || null);
+          if (characterName) {
+            useChatStore.getState().setPerChatTyping(chatId, characterName);
+            useChatStore.getState().setTypingCharacterName(characterName);
+          }
+          break;
+        }
+        case "typing": {
+          const label = characterLabel(eventCharacters(event));
+          useChatStore.getState().setPerChatTyping(chatId, label);
+          useChatStore.getState().setPerChatDelayed(chatId, null);
+          useChatStore.getState().setDelayedCharacterInfo(null);
+          useChatStore.getState().setTypingCharacterName(label);
+          break;
+        }
+        case "delayed": {
+          const label = characterLabel(eventCharacters(event));
+          const status = readString((event as { status?: unknown }).status, "idle");
+          const info = { name: label, status };
+          useChatStore.getState().setPerChatDelayed(chatId, info);
+          useChatStore.getState().setDelayedCharacterInfo(info);
+          runDeferredGenerationWork("character status refresh", () =>
+            queryClient.invalidateQueries({ queryKey: characterKeys.list() }),
+          );
+          break;
+        }
+        case "offline": {
+          const label = characterLabel(eventCharacters(event), "Characters");
+          const verb = label === "Characters" || label.includes(",") ? "are" : "is";
+          toast(`${label} ${verb} offline. They'll respond when they're back online.`);
+          useChatStore.getState().setPerChatTyping(chatId, null);
+          useChatStore.getState().setPerChatDelayed(chatId, null);
+          useChatStore.getState().setTypingCharacterName(null);
+          useChatStore.getState().setDelayedCharacterInfo(null);
+          break;
+        }
         case "agent_result":
           queueAgentResultEffect(event.data);
           break;
@@ -1314,7 +1443,7 @@ export async function runGenerationWithUi(
     }
     await flushLiveGenerationBuffers();
     scheduleChatQueryRefresh(queryClient, chatId);
-    return received.length > 0;
+    return receivedAnyContent;
   } catch (error) {
     if (!isAbortError(error)) {
       const message = errorMessage(error);

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -85,7 +85,7 @@ const queuedAgentDebugEntries: Array<Omit<AgentDebugEntry, "timestamp"> & { time
 let agentDebugFlushTimer: number | null = null;
 
 function eventCharacters(event: StreamEvent): string[] {
-  const value = (event as { characters?: unknown }).characters;
+  const value = parseMaybeRecord(event.data).characters;
   return Array.isArray(value)
     ? value.filter((entry): entry is string => typeof entry === "string" && !!entry.trim())
     : [];
@@ -1177,6 +1177,16 @@ export async function runGenerationWithUi(
 
   const ownsChatController = () => useChatStore.getState().abortControllers.get(chatId) === controller;
 
+  const clearChatAvailabilityState = () => {
+    const state = useChatStore.getState();
+    state.setPerChatTyping(chatId, null);
+    state.setPerChatDelayed(chatId, null);
+    if (state.activeChatId === chatId) {
+      state.setTypingCharacterName(null);
+      state.setDelayedCharacterInfo(null);
+    }
+  };
+
   const queueAgentResultEffect = (rawResult: unknown) => {
     pendingAgentResultEffects.push(rawResult);
   };
@@ -1208,11 +1218,11 @@ export async function runGenerationWithUi(
     foregroundGenerationReleased = true;
     state.setAbortController(chatId, null);
     state.setMariPhase(chatId, "idle");
+    clearChatAvailabilityState();
     if (state.streamingChatId === chatId) {
       state.setStreaming(false, chatId);
       state.setRegenerateMessageId(null);
       state.setGenerationPhase(null);
-      state.setTypingCharacterName(null);
       state.setStreamingCharacterId(null);
     }
     if (useChatStore.getState().abortControllers.size === 0) {
@@ -1247,12 +1257,9 @@ export async function runGenerationWithUi(
           if (!foregroundGenerationReleased && typeof event.data === "string") {
             if (!receivedThinking) {
               receivedThinking = true;
+              clearChatAvailabilityState();
               const state = useChatStore.getState();
-              state.setTypingCharacterName(null);
-              state.setDelayedCharacterInfo(null);
-              state.setPerChatTyping(chatId, null);
-              state.setPerChatDelayed(chatId, null);
-              state.setGenerationPhase("Thinking...");
+              if (state.activeChatId === chatId) state.setGenerationPhase("Thinking...");
               state.setMariPhase(chatId, "thinking");
             }
             appendThinkingText(event.data);
@@ -1265,11 +1272,7 @@ export async function runGenerationWithUi(
             receivedTurnContent = true;
             receivedAnyContent = true;
             if (firstVisibleToken) {
-              const state = useChatStore.getState();
-              state.setTypingCharacterName(null);
-              state.setDelayedCharacterInfo(null);
-              state.setPerChatTyping(chatId, null);
-              state.setPerChatDelayed(chatId, null);
+              clearChatAvailabilityState();
             }
             received += event.data;
             enqueueVisibleStreamText(event.data);
@@ -1307,27 +1310,34 @@ export async function runGenerationWithUi(
           const data = parseMaybeRecord(event.data);
           const characterId = readString(data.characterId).trim();
           const characterName = readString(data.characterName).trim();
-          useChatStore.getState().setStreamingCharacterId(characterId || null);
+          if (useChatStore.getState().activeChatId === chatId) {
+            useChatStore.getState().setStreamingCharacterId(characterId || null);
+          }
           if (characterName) {
-            useChatStore.getState().setPerChatTyping(chatId, characterName);
-            useChatStore.getState().setTypingCharacterName(characterName);
+            const state = useChatStore.getState();
+            state.setPerChatTyping(chatId, characterName);
+            if (state.activeChatId === chatId) state.setTypingCharacterName(characterName);
           }
           break;
         }
         case "typing": {
           const label = characterLabel(eventCharacters(event));
-          useChatStore.getState().setPerChatTyping(chatId, label);
-          useChatStore.getState().setPerChatDelayed(chatId, null);
-          useChatStore.getState().setDelayedCharacterInfo(null);
-          useChatStore.getState().setTypingCharacterName(label);
+          const state = useChatStore.getState();
+          state.setPerChatTyping(chatId, label);
+          state.setPerChatDelayed(chatId, null);
+          if (state.activeChatId === chatId) {
+            state.setDelayedCharacterInfo(null);
+            state.setTypingCharacterName(label);
+          }
           break;
         }
         case "delayed": {
           const label = characterLabel(eventCharacters(event));
-          const status = readString((event as { status?: unknown }).status, "idle");
+          const status = readString(parseMaybeRecord(event.data).status, "idle");
           const info = { name: label, status };
-          useChatStore.getState().setPerChatDelayed(chatId, info);
-          useChatStore.getState().setDelayedCharacterInfo(info);
+          const state = useChatStore.getState();
+          state.setPerChatDelayed(chatId, info);
+          if (state.activeChatId === chatId) state.setDelayedCharacterInfo(info);
           runDeferredGenerationWork("character status refresh", () =>
             queryClient.invalidateQueries({ queryKey: characterKeys.list() }),
           );
@@ -1337,10 +1347,7 @@ export async function runGenerationWithUi(
           const label = characterLabel(eventCharacters(event), "Characters");
           const verb = label === "Characters" || label.includes(",") ? "are" : "is";
           toast(`${label} ${verb} offline. They'll respond when they're back online.`);
-          useChatStore.getState().setPerChatTyping(chatId, null);
-          useChatStore.getState().setPerChatDelayed(chatId, null);
-          useChatStore.getState().setTypingCharacterName(null);
-          useChatStore.getState().setDelayedCharacterInfo(null);
+          clearChatAvailabilityState();
           break;
         }
         case "agent_result":


### PR DESCRIPTION
## Linked issue

Closes #1799

## Why this change

- Runtime generation had parity gaps in the user-message and multi-character response paths.
- Generated user messages did not keep persona snapshots, so message projection could lose user persona context.
- Conversation availability states were resolved in engine code but not surfaced as delayed, typing, or offline UI events.
- Individual roleplay group turns collapsed to one target instead of iterating the selected characters.

## What changed

- Added a shared persona snapshot resolver and attach snapshots to optimistic and persisted generated user messages.
- Wired conversation availability into generation events for delayed, typing, and offline states.
- Restored individual group-turn orchestration so eligible characters run one turn each while saving the user message once.
- Updated runtime generation UI handling so group turns, availability events, and saved user-message echoes do not prematurely end streaming UI.

## Refactor impact

Primary owner:

runtime generation / engine generation

Impact areas reviewed:

- Chat message projection and optimistic message insertion.
- Conversation availability and busy-delay scheduling.
- Roleplay individual group-turn target selection and event sequencing.
- Runtime generation hook buffering, cache updates, and foreground streaming state.

Boundary notes:

- Engine generation stays React-free and uses existing storage/runtime contracts.
- Feature UI reads persona/chat cache state and calls focused engine helpers; no raw Tauri or remote-runtime calls were added.
- Conversation, roleplay, and group-turn ownership stayed inside existing generation surfaces.

Pressure points touched:

- Runtime generation hook streaming state and cached message upserts.
- `startGeneration` event order for user messages, availability, and group turns.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

Automated local validation run:

- `pnpm check`
- `pnpm vitest run --config scratch/vitest.issue-1799.config.ts`
- `pnpm exec prettier --check src/engine/generation/persona-snapshot.ts src/engine/generation/start-generation.ts src/engine/generation/generation-events.ts src/features/runtime/generation/hooks/use-generate.ts`
- `git diff --cached --check`

No browser or native Tauri manual QA was run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing generation behavior fix; no new discoverable feature or entry point.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or changelog update was made because this fixes existing runtime behavior without adding a new documented workflow.

## UI evidence

N/A. This changes generation event wiring and runtime state handling, not visual layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new event types for generation streaming: typing indicators, delayed message states, offline status, and group turn tracking
  * Enhanced persona awareness in chat messages with automatic character snapshot capture
  * Improved roleplay group chat functionality with individual character turn management and smart character selection
  * Added real-time conversation availability detection with offline, delayed, and typing status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->