### PR TITLE
Disable automatic Bunny review trigger

### DIFF
--- a/.github/workflows/bunny-review.yml
+++ b/.github/workflows/bunny-review.yml
@@ -2,8 +2,6 @@
 name: Bunny Review
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #

## Why this change

- Disables automatic Bunny Review runs on `pull_request` events after fork PRs exposed GitHub token write restrictions during comment posting.
- Keeps the trusted manual `/bunny-review` slash-command path available while the safer automatic dispatcher design is worked out.

## What changed

- Removed the `pull_request` trigger from `.github/workflows/bunny-review.yml`.
- Left `workflow_dispatch` intact so the default-branch slash-command bootstrap can continue dispatching Bunny Review manually.

## Refactor impact

Primary owner:

- GitHub workflow automation.

Impact areas reviewed:

- Bunny Review workflow triggers.
- Manual `/bunny-review` dispatch path remains dependent on `workflow_dispatch`.

Boundary notes:

- No app source, engine, React feature, shared API, Tauri, storage, provider, or remote-runtime boundary is touched. This is GitHub Actions trigger wiring only.

Pressure points touched:

- GitHub Actions event trigger behavior for Bunny Review.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent ran `pnpm check:docs`.
- Agent inspected the workflow diff and confirmed only the automatic `pull_request` trigger was removed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- GitHub workflow trigger behavior only; no in-app user-discoverable behavior is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. No app UI changes.
