### PR TITLE
Fix game Recent Chats badge

### DIFF
--- a/src/features/modes/router/components/RecentChats.test.tsx
+++ b/src/features/modes/router/components/RecentChats.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatListItem } from "../../../catalog/chats/index";
+import { RecentChats } from "./RecentChats";
+
+const recentChats: ChatListItem[] = [];
+
+vi.mock("../../../catalog/chats/index", () => ({
+  useRecentChatSummaries: () => ({ data: recentChats }),
+}));
+
+vi.mock("../../../catalog/characters/index", () => ({
+  useCharacterSummariesByIds: () => ({ data: [] }),
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function chatSummary(overrides: Partial<ChatListItem>): ChatListItem {
+  return {
+    id: "chat-1",
+    name: "Recent game",
+    mode: "game",
+    characterIds: [],
+    groupId: null,
+    personaId: null,
+    promptPresetId: null,
+    connectionId: null,
+    folderId: null,
+    sortOrder: 0,
+    connectedChatId: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("RecentChats", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    recentChats.length = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("labels game chats with a Game mode badge", () => {
+    recentChats.push(chatSummary({ mode: "game" }));
+
+    act(() => {
+      root.render(<RecentChats />);
+    });
+
+    expect(container.querySelector("[title='Game']")).toBeTruthy();
+    expect(container.querySelector("[title='Conversation']")).toBeNull();
+  });
+
+  it("keeps the existing Roleplay badge for roleplay chats", () => {
+    recentChats.push(chatSummary({ mode: "roleplay" }));
+
+    act(() => {
+      root.render(<RecentChats />);
+    });
+
+    expect(container.querySelector("[title='Roleplay']")).toBeTruthy();
+  });
+
+  it("keeps Conversation as the fallback badge for unknown modes", () => {
+    recentChats.push(chatSummary({ mode: "mystery" as ChatListItem["mode"] }));
+
+    act(() => {
+      root.render(<RecentChats />);
+    });
+
+    expect(container.querySelector("[title='Conversation']")).toBeTruthy();
+  });
+});

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -3,7 +3,7 @@
 // interacted chats on the homepage (compact row)
 // ──────────────────────────────────────────────
 import { useEffect, useMemo, useState } from "react";
-import { MessageSquare, BookOpen } from "lucide-react";
+import { MessageSquare, BookOpen, Theater } from "lucide-react";
 import { useRecentChatSummaries, type ChatListItem } from "../../../catalog/chats/index";
 import { characterAvatarUrl, useCharacterSummariesByIds } from "../../../catalog/characters/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
@@ -19,6 +19,11 @@ const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: str
     icon: <BookOpen size="0.375rem" />,
     bg: "linear-gradient(135deg, #eb8951, #d97530)",
     label: "Roleplay",
+  },
+  game: {
+    icon: <Theater size="0.375rem" />,
+    bg: "linear-gradient(135deg, #e15c8c, #c94776)",
+    label: "Game",
   },
 };
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Refs #1797

This fixes the confirmed Recent Chats badge regression from the issue. It intentionally does not close the session-routing product decision described there.

## Why this change

- Game chats on the home Recent Chats row were falling through to the Conversation badge because the router badge map only covered `conversation` and `roleplay`.

## What changed

- Added a `game` entry to the Recent Chats mode badge map using the existing Game sidebar icon/color treatment.
- Added focused jsdom coverage for Game, existing Roleplay behavior, and the unknown-mode Conversation fallback.

## Refactor impact

Primary owner:

- App shell / mode router

Impact areas reviewed:

- Home Recent Chats rendering
- Existing Roleplay badge behavior
- Unknown mode fallback behavior

Boundary notes:

- Kept the fix inside `src/features/modes/router`.
- Did not touch engine contracts, shared API wrappers, Rust storage, remote runtime routing, or game session routing.

Pressure points touched:

- `RecentChats`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the original bug with a focused component run before the fix: `pnpm test src/features/modes/router/components/RecentChats.test.tsx` failed because `[title='Game']` was absent for a `game` recent chat.
- Codex verified the fix with `pnpm test src/features/modes/router/components/RecentChats.test.tsx`: 3 tests passed, covering Game, Roleplay, and unknown-mode fallback rows.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed.
- Codex ran the Marinara proof gate against `scratch/bugfix-verification.json`: passed.
- Live Tauri UI screenshot is not included. The web-shell cannot query `storage_list` without embedded Tauri IPC or a configured remote runtime, so this draft should remain draft until a human/Tauri-profile screenshot is added if reviewer-visible visual evidence is required.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] Feature Discoverability N/A with a short reason: this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a bugfix for an existing Recent Chats badge and does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No live UI screenshot attached. Component behavior is covered by the focused jsdom proof above; visual app proof requires Tauri storage or a configured remote runtime.
