### PR TITLE
Fix lorebook parity gaps

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -495,6 +495,7 @@ pub(crate) fn delete_entity(
     if deleted {
         if entity == "lorebooks" {
             delete_lorebook_children(state, id)?;
+            clear_deleted_lorebook_references(state, id)?;
         }
         if entity == "prompts" {
             prompts::delete_prompt_preset_children(state, id)?;
@@ -603,6 +604,90 @@ fn delete_lorebook_children(state: &AppState, lorebook_id: &str) -> Result<(), A
     );
     state.storage.delete_where("lorebook-entries", &filters)?;
     state.storage.delete_where("lorebook-folders", &filters)?;
+    Ok(())
+}
+
+fn remove_string_from_json_array(value: Option<&Value>, removed_id: &str) -> Option<Value> {
+    let array = value?.as_array()?;
+    let filtered = array
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|id| *id != removed_id)
+        .map(|id| Value::String(id.to_string()))
+        .collect::<Vec<_>>();
+    (filtered.len() != array.len()).then_some(Value::Array(filtered))
+}
+
+fn clear_deleted_lorebook_from_chats(state: &AppState, lorebook_id: &str) -> Result<(), AppError> {
+    for chat in state.storage.list("chats")? {
+        let Some(chat_id) = chat.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let mut patch = Map::new();
+        if let Some(active_ids) =
+            remove_string_from_json_array(chat.get("activeLorebookIds"), lorebook_id)
+        {
+            patch.insert("activeLorebookIds".to_string(), active_ids);
+        }
+
+        let mut metadata = chat
+            .get("metadata")
+            .and_then(|value| shared::json_object_value(Some(value)))
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default();
+        if let Some(active_ids) =
+            remove_string_from_json_array(metadata.get("activeLorebookIds"), lorebook_id)
+        {
+            metadata.insert("activeLorebookIds".to_string(), active_ids);
+            patch.insert("metadata".to_string(), Value::Object(metadata));
+        }
+
+        if !patch.is_empty() {
+            state
+                .storage
+                .patch("chats", chat_id, Value::Object(patch))?;
+        }
+    }
+    Ok(())
+}
+
+fn embedded_lorebook_id(data: &Value) -> Option<&str> {
+    data.pointer("/extensions/importMetadata/embeddedLorebook/lorebookId")
+        .and_then(Value::as_str)
+}
+
+fn clear_deleted_lorebook_from_characters(
+    state: &AppState,
+    lorebook_id: &str,
+) -> Result<(), AppError> {
+    for character in state.storage.list("characters")? {
+        let Some(character_id) = character.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let mut data = character.get("data").cloned().unwrap_or_else(|| json!({}));
+        if embedded_lorebook_id(&data) != Some(lorebook_id) {
+            continue;
+        }
+        let Some(data_object) = data.as_object_mut() else {
+            continue;
+        };
+        data_object.insert("character_book".to_string(), Value::Null);
+        if let Some(import_metadata) = data
+            .pointer_mut("/extensions/importMetadata")
+            .and_then(Value::as_object_mut)
+        {
+            import_metadata.remove("embeddedLorebook");
+        }
+        state
+            .storage
+            .patch("characters", character_id, json!({ "data": data }))?;
+    }
+    Ok(())
+}
+
+fn clear_deleted_lorebook_references(state: &AppState, lorebook_id: &str) -> Result<(), AppError> {
+    clear_deleted_lorebook_from_chats(state, lorebook_id)?;
+    clear_deleted_lorebook_from_characters(state, lorebook_id)?;
     Ok(())
 }
 
@@ -1027,6 +1112,75 @@ mod tests {
             ids_for_lorebook(&state, "lorebook-folders", "book-keep"),
             vec!["folder-keep".to_string()]
         );
+    }
+
+    #[test]
+    fn deleting_lorebook_clears_chat_and_embedded_character_refs() {
+        let state = test_state("lorebook-delete-refs");
+        state
+            .storage
+            .create(
+                "lorebooks",
+                json!({ "id": "book-delete", "name": "Delete me" }),
+            )
+            .expect("lorebook should be created");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "book-keep", "name": "Keep me" }))
+            .expect("other lorebook should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Chat",
+                    "activeLorebookIds": ["book-delete", "book-keep"],
+                    "metadata": { "activeLorebookIds": ["book-delete", "book-keep"] }
+                }),
+            )
+            .expect("chat should be created");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Character",
+                        "character_book": { "entries": [{ "content": "legacy" }] },
+                        "extensions": {
+                            "importMetadata": {
+                                "embeddedLorebook": {
+                                    "hasEmbeddedLorebook": true,
+                                    "lorebookId": "book-delete"
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("character should be created");
+
+        delete_entity(&state, "lorebooks", "book-delete", false).expect("delete should succeed");
+
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat should read")
+            .expect("chat should remain");
+        assert_eq!(chat["activeLorebookIds"], json!(["book-keep"]));
+        assert_eq!(chat["metadata"]["activeLorebookIds"], json!(["book-keep"]));
+
+        let character = state
+            .storage
+            .get("characters", "char-1")
+            .expect("character should read")
+            .expect("character should remain");
+        assert!(character["data"]["character_book"].is_null());
+        assert!(character
+            .pointer("/data/extensions/importMetadata/embeddedLorebook")
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/imports/normalization.rs
+++ b/src-tauri/src/commands/storage/imports/normalization.rs
@@ -222,6 +222,19 @@ pub(super) fn bool_field(value: Option<&Value>, fallback: bool) -> bool {
     value.and_then(Value::as_bool).unwrap_or(fallback)
 }
 
+fn selective_logic_value(value: Option<&Value>) -> &'static str {
+    let raw = match value {
+        Some(Value::String(raw)) => raw.trim().to_ascii_lowercase(),
+        Some(Value::Number(raw)) => raw.as_i64().unwrap_or(0).to_string(),
+        _ => String::new(),
+    };
+    match raw.as_str() {
+        "1" | "or" => "or",
+        "2" | "not" => "not",
+        _ => "and",
+    }
+}
+
 pub(super) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: usize) -> Value {
     let keys = entry.get("key").or_else(|| entry.get("keys"));
     let secondary = entry
@@ -232,18 +245,24 @@ pub(super) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: 
         .and_then(Value::as_bool)
         .map(|disabled| !disabled)
         .unwrap_or_else(|| bool_field(entry.get("enabled"), true));
-    let role = match entry.get("role").and_then(Value::as_str) {
-        Some("user" | "assistant" | "system") => entry
-            .get("role")
-            .and_then(Value::as_str)
-            .unwrap_or("system"),
-        _ => "system",
-    };
+    let role = entry
+        .get("role")
+        .and_then(Value::as_str)
+        .filter(|role| matches!(*role, "user" | "assistant" | "system"))
+        .unwrap_or("system");
     let position = match entry.get("position") {
         Some(Value::String(raw)) if raw == "after_char" => 1,
         Some(Value::String(raw)) if raw == "at_depth" || raw == "depth" => 2,
         Some(Value::Number(raw)) => raw.as_i64().unwrap_or(0),
         _ => 0,
+    };
+    let probability = match entry
+        .get("useProbability")
+        .or_else(|| entry.get("use_probability"))
+        .and_then(Value::as_bool)
+    {
+        Some(false) => Value::Null,
+        _ => optional_number(entry.get("probability")),
     };
     json!({
         "lorebookId": lorebook_id,
@@ -255,8 +274,8 @@ pub(super) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: 
         "enabled": enabled,
         "constant": bool_field(entry.get("constant"), false),
         "selective": bool_field(entry.get("selective"), false),
-        "selectiveLogic": "and",
-        "probability": optional_number(entry.get("probability")),
+        "selectiveLogic": selective_logic_value(entry.get("selectiveLogic").or_else(|| entry.get("selective_logic"))),
+        "probability": probability,
         "scanDepth": optional_number(entry.get("scanDepth").or_else(|| entry.get("scan_depth"))),
         "matchWholeWords": bool_field(entry.get("matchWholeWords").or_else(|| entry.get("match_whole_words")), false),
         "caseSensitive": bool_field(entry.get("caseSensitive").or_else(|| entry.get("case_sensitive")), false),
@@ -357,6 +376,25 @@ pub(super) fn normalize_imported_lorebook_entry(
         object.insert("role".to_string(), Value::String("system".to_string()));
     }
     object.insert(
+        "selectiveLogic".to_string(),
+        Value::String(
+            selective_logic_value(
+                object
+                    .get("selectiveLogic")
+                    .or_else(|| object.get("selective_logic")),
+            )
+            .to_string(),
+        ),
+    );
+    if object
+        .get("useProbability")
+        .or_else(|| object.get("use_probability"))
+        .and_then(Value::as_bool)
+        == Some(false)
+    {
+        object.insert("probability".to_string(), Value::Null);
+    }
+    object.insert(
         "lorebookId".to_string(),
         Value::String(lorebook_id.to_string()),
     );
@@ -365,8 +403,11 @@ pub(super) fn normalize_imported_lorebook_entry(
         "key",
         "keysecondary",
         "secondary_keys",
+        "selective_logic",
         "disable",
         "uid",
+        "useProbability",
+        "use_probability",
     ] {
         object.remove(key);
     }

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -40,6 +40,40 @@ fn uploaded_bytes(name: &str, content_type: &str, bytes: Vec<u8>) -> Value {
 }
 
 #[test]
+fn normalizes_sillytavern_selective_logic_numbers() {
+    let entry = normalize_lorebook_entry(
+        "book-1",
+        &json!({
+            "content": "Lore",
+            "key": ["moon"],
+            "selectiveLogic": 1
+        }),
+        0,
+    );
+
+    assert_eq!(entry["selectiveLogic"], "or");
+}
+
+#[test]
+fn normalizes_imported_lorebook_entry_after_raw_field_merge() {
+    let entry = normalize_imported_lorebook_entry(
+        "book-1",
+        &json!({
+            "content": "Lore",
+            "key": ["moon"],
+            "selectiveLogic": 2,
+            "useProbability": false,
+            "probability": 25
+        }),
+        0,
+    );
+
+    assert_eq!(entry["selectiveLogic"], "not");
+    assert!(entry["probability"].is_null());
+    assert!(entry.get("useProbability").is_none());
+}
+
+#[test]
 fn import_st_character_batch_rejects_wrong_route_lorebook_json() {
     let app_root = temp_path("wrong-route-lorebook");
     let state =

--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -76,31 +76,27 @@ export function injectAtDepth(
 ): PromptMessage[] {
   if (depthEntries.length === 0) return messages;
 
-  const result = [...messages];
-
-  // Group entries by depth
-  const byDepth = new Map<number, Array<{ content: string; role: LorebookRole }>>();
+  const byInsertionIndex = new Map<number, Array<{ content: string; role: LorebookRole }>>();
   for (const entry of depthEntries) {
-    const list = byDepth.get(entry.depth) ?? [];
+    const insertionIndex = Math.max(0, messages.length - entry.depth);
+    const list = byInsertionIndex.get(insertionIndex) ?? [];
     list.push({ content: entry.content, role: entry.role });
-    byDepth.set(entry.depth, list);
+    byInsertionIndex.set(insertionIndex, list);
   }
 
-  // Process depths from highest to lowest (to preserve indices)
-  const depths = [...byDepth.keys()].sort((a, b) => b - a);
+  const result: PromptMessage[] = [];
+  for (let index = 0; index <= messages.length; index += 1) {
+    const entries = byInsertionIndex.get(index) ?? [];
+    result.push(
+      ...entries.map((entry) => ({
+        role: entry.role,
+        content: entry.content,
+        contextKind: "injection" as const,
+      })),
+    );
 
-  for (const depth of depths) {
-    const entries = byDepth.get(depth) ?? [];
-    const insertionIndex = Math.max(0, result.length - depth);
-
-    // Insert all entries for this depth at the same position
-    const toInsert: PromptMessage[] = entries.map((e) => ({
-      role: e.role,
-      content: e.content,
-      contextKind: "injection",
-    }));
-
-    result.splice(insertionIndex, 0, ...toInsert);
+    const message = messages[index];
+    if (message) result.push(message);
   }
 
   return result;
@@ -117,6 +113,23 @@ export interface BudgetSkippedActivatedEntry {
   usedTokensBefore: number;
 }
 
+export interface LorebookContentResolver {
+  resolve(content: string): string;
+}
+
+function withResolvedContent(entry: ActivatedEntry, resolver?: LorebookContentResolver): ActivatedEntry {
+  if (!resolver) return entry;
+  const content = resolver.resolve(entry.entry.content);
+  return {
+    ...entry,
+    rawContent: entry.rawContent ?? entry.entry.content,
+    entry: {
+      ...entry.entry,
+      content,
+    },
+  };
+}
+
 /**
  * Apply token-budget ordering while preserving the
  * entries that were dropped so callers can surface budget diagnostics.
@@ -124,15 +137,17 @@ export interface BudgetSkippedActivatedEntry {
 export function applyTokenBudgetWithSkipped(
   activatedEntries: ActivatedEntry[],
   tokenBudget: number,
+  resolver?: LorebookContentResolver,
 ): {
   includedEntries: ActivatedEntry[];
   skippedEntries: BudgetSkippedActivatedEntry[];
   totalTokensEstimate: number;
 } {
   if (tokenBudget <= 0) {
-    const totalChars = activatedEntries.reduce((sum, entry) => sum + entry.entry.content.length, 0);
+    const includedEntries = activatedEntries.map((entry) => withResolvedContent(entry, resolver));
+    const totalChars = includedEntries.reduce((sum, entry) => sum + entry.entry.content.length, 0);
     return {
-      includedEntries: activatedEntries,
+      includedEntries,
       skippedEntries: [],
       totalTokensEstimate: Math.ceil(totalChars / 4),
     };
@@ -152,14 +167,15 @@ export function applyTokenBudgetWithSkipped(
   });
 
   for (const entry of sorted) {
-    const estimatedTokens = Math.ceil(entry.entry.content.length / CHARS_PER_TOKEN);
+    const resolvedEntry = withResolvedContent(entry, resolver);
+    const estimatedTokens = Math.ceil(resolvedEntry.entry.content.length / CHARS_PER_TOKEN);
     if (budgetExhausted || totalTokens + estimatedTokens > tokenBudget) {
       budgetExhausted = true;
-      skippedEntries.push({ activatedEntry: entry, estimatedTokens, usedTokensBefore: totalTokens });
+      skippedEntries.push({ activatedEntry: resolvedEntry, estimatedTokens, usedTokensBefore: totalTokens });
       continue;
     }
     totalTokens += estimatedTokens;
-    includedEntries.push(entry);
+    includedEntries.push(resolvedEntry);
   }
 
   return {
@@ -175,6 +191,7 @@ export function applyTokenBudgetWithSkipped(
 export function processActivatedEntries(
   activatedEntries: ActivatedEntry[],
   tokenBudget: number = 0,
+  resolver?: LorebookContentResolver,
 ): {
   worldInfoBefore: string;
   worldInfoAfter: string;
@@ -185,7 +202,7 @@ export function processActivatedEntries(
   totalTokensEstimate: number;
 } {
   // Apply budget
-  const budgeted = applyTokenBudgetWithSkipped(activatedEntries, tokenBudget);
+  const budgeted = applyTokenBudgetWithSkipped(activatedEntries, tokenBudget, resolver);
   const includedEntries = budgeted.includedEntries;
 
   // Build blocks

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -5,6 +5,7 @@ import {
   applyTokenBudgetWithSkipped,
   processActivatedEntries,
   type BudgetSkippedActivatedEntry,
+  type LorebookContentResolver,
 } from "../generation-core/lorebooks/prompt-injector";
 import {
   resolveGameLorebookScopeExclusions,
@@ -101,6 +102,7 @@ interface LoadedActivatedLore {
   activeLorebookReasons: ActiveLorebookScopeReason[];
   scopeExclusions: LorebookScopeExclusions;
   semanticStatus: LorebookSemanticScanStatus;
+  previousEntryStateOverrides: Map<string, LorebookEntryStateOverride>;
 }
 
 export interface ActiveLorebookScannerInput {
@@ -113,6 +115,7 @@ export interface ActiveLorebookScannerInput {
   latestUserInput?: string;
   embeddingSource?: LorebookEmbeddingSource | null;
   ignoreTiming?: boolean;
+  contentResolver?: LorebookContentResolver;
 }
 
 export interface ActiveLorebookScannerResult {
@@ -122,12 +125,18 @@ export interface ActiveLorebookScannerResult {
   previousTimingStates: Map<string, EntryTimingState>;
   nextTimingStates: Map<string, EntryTimingState>;
   lorebookTimingStates: Record<string, LorebookEntryTimingState> | null;
+  lorebookEntryStateOverrides: Record<string, { ephemeral?: number | null; enabled?: boolean }> | null;
   budgetSkippedLorebookEntries: BudgetSkippedLorebookEntry[];
   lorebookNamesById: Map<string, string>;
   currentMessageIndex: number;
   activeLorebookReasons: ActiveLorebookScopeReason[];
   scopeExclusions: LorebookScopeExclusions;
   semanticStatus: LorebookSemanticScanStatus;
+}
+
+interface LorebookEntryStateOverride {
+  ephemeral?: number | null;
+  enabled?: boolean;
 }
 
 const MAX_LOREBOOK_RECURSION_DEPTH = 10;
@@ -271,6 +280,93 @@ function normalizeLorebookTimingState(value: unknown): EntryTimingState | null {
   };
 }
 
+function normalizeLorebookEntryStateOverride(value: unknown): LorebookEntryStateOverride | null {
+  if (!isRecord(value)) return null;
+  const state: LorebookEntryStateOverride = {};
+  if (typeof value.enabled === "boolean") state.enabled = value.enabled;
+  if (value.ephemeral === null) {
+    state.ephemeral = null;
+  } else if (value.ephemeral !== undefined) {
+    const ephemeral = readNumber(value.ephemeral, Number.NaN);
+    if (Number.isFinite(ephemeral)) state.ephemeral = Math.max(0, Math.trunc(ephemeral));
+  }
+  return Object.keys(state).length > 0 ? state : null;
+}
+
+function lorebookEntryStateOverrideMap(value: unknown): Map<string, LorebookEntryStateOverride> {
+  const states = new Map<string, LorebookEntryStateOverride>();
+  for (const [entryId, state] of Object.entries(parseRecord(value))) {
+    const normalizedId = entryId.trim();
+    const normalizedState = normalizeLorebookEntryStateOverride(state);
+    if (normalizedId && normalizedState) states.set(normalizedId, normalizedState);
+  }
+  return states;
+}
+
+function entryWithChatState(entry: LorebookEntry, overrides: Map<string, LorebookEntryStateOverride>): LorebookEntry {
+  const override = overrides.get(entry.id);
+  if (!override) return entry;
+  const ephemeral = override.ephemeral === undefined ? entry.ephemeral : override.ephemeral;
+  return {
+    ...entry,
+    enabled: entry.enabled && override.enabled !== false && !(typeof ephemeral === "number" && ephemeral <= 0),
+    ephemeral,
+  };
+}
+
+function serializeLorebookEntryStateOverrides(
+  states: Map<string, LorebookEntryStateOverride>,
+): Record<string, LorebookEntryStateOverride> {
+  return Object.fromEntries(
+    [...states.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([entryId, state]) => [
+        entryId,
+        {
+          ...(state.ephemeral !== undefined ? { ephemeral: state.ephemeral } : {}),
+          ...(state.enabled !== undefined ? { enabled: state.enabled } : {}),
+        },
+      ]),
+  );
+}
+
+function lorebookEntryStateOverridesChanged(
+  previous: Map<string, LorebookEntryStateOverride>,
+  next: Map<string, LorebookEntryStateOverride>,
+): boolean {
+  if (previous.size !== next.size) return true;
+  for (const [entryId, previousState] of previous) {
+    const nextState = next.get(entryId);
+    if (!nextState) return true;
+    if (previousState.ephemeral !== nextState.ephemeral || previousState.enabled !== nextState.enabled) return true;
+  }
+  return false;
+}
+
+function updateEntryStateOverridesForScan(
+  entries: LorebookEntry[],
+  activatedEntries: ActivatedEntry[],
+  previousStates: Map<string, LorebookEntryStateOverride>,
+): Map<string, LorebookEntryStateOverride> {
+  const nextStates = new Map(previousStates);
+  const activatedIds = new Set(activatedEntries.filter((entry) => !entry.sticky).map((entry) => entry.entry.id));
+
+  for (const entry of entries) {
+    if (entry.ephemeral === null) continue;
+    const previous = nextStates.get(entry.id);
+    const remaining = previous?.ephemeral === undefined ? entry.ephemeral : previous.ephemeral;
+    if (typeof remaining !== "number") continue;
+    const nextRemaining = activatedIds.has(entry.id) ? Math.max(0, remaining - 1) : Math.max(0, remaining);
+    nextStates.set(entry.id, {
+      ...previous,
+      ephemeral: nextRemaining,
+      enabled: nextRemaining > 0,
+    });
+  }
+
+  return nextStates;
+}
+
 function lorebookTimingStateMap(value: unknown): Map<string, EntryTimingState> {
   const states = new Map<string, EntryTimingState>();
   for (const [entryId, state] of Object.entries(parseRecord(value))) {
@@ -352,6 +448,7 @@ function scanLorebookEntries(
   entries: LorebookEntry[],
   lorebook: JsonRecord,
   options: ScanOptions,
+  contentResolver?: LorebookContentResolver,
 ): ScannedLorebookEntries {
   const activated = boolish(lorebook.recursiveScanning, false)
     ? recursiveScan(messages, entries, options, resolveLorebookRecursionDepth(lorebook))
@@ -359,7 +456,7 @@ function scanLorebookEntries(
   const lorebookId = readString(lorebook.id);
   const lorebookName = readString(lorebook.name, lorebookId || "Lorebook");
   const lorebookBudget = nonNegativeInteger(lorebook.tokenBudget, 0);
-  const budgeted = applyTokenBudgetWithSkipped(activated, lorebookBudget);
+  const budgeted = applyTokenBudgetWithSkipped(activated, lorebookBudget, contentResolver);
   return {
     activatedEntries: budgeted.includedEntries,
     budgetSkippedEntries: budgeted.skippedEntries.map((skipped) => ({
@@ -441,6 +538,7 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
   const activeCharacterTags = input.characters.flatMap((character) => character.tags);
   const gameState = parseRecord(input.chat.gameState ?? meta.gameState);
   const previousTimingStates = lorebookTimingStateMap(meta.entryTimingStates);
+  const previousEntryStateOverrides = lorebookEntryStateOverrideMap(meta.entryStateOverrides);
   const messages = input.storedMessages
     .filter((message) => !hiddenFromAi(message))
     .map((message) => ({
@@ -455,7 +553,12 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
     }),
   );
   const entriesByBook = await Promise.all(
-    lorebooks.map(async (book) => ({ book, entries: await loadLorebookEntriesForActivation(input.storage, book) })),
+    lorebooks.map(async (book) => ({
+      book,
+      entries: (await loadLorebookEntriesForActivation(input.storage, book)).map((entry) =>
+        entryWithChatState(entry, previousEntryStateOverrides),
+      ),
+    })),
   );
   const vectorizedEntryCount = entriesByBook.reduce(
     (sum, item) => sum + countSemanticCandidateEntries(item.entries),
@@ -478,7 +581,9 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
     chatEmbedding: semantic.chatEmbedding,
     ignoreTiming: input.ignoreTiming,
   };
-  const scanned = entriesByBook.map(({ book, entries }) => scanLorebookEntries(messages, entries, book, options));
+  const scanned = entriesByBook.map(({ book, entries }) =>
+    scanLorebookEntries(messages, entries, book, options, input.contentResolver),
+  );
   return {
     activatedEntries: scanned
       .flatMap((result) => result.activatedEntries)
@@ -486,6 +591,7 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
     budgetSkippedEntries: scanned.flatMap((result) => result.budgetSkippedEntries),
     entriesForTiming: scanned.flatMap((result) => result.entriesForTiming),
     previousTimingStates,
+    previousEntryStateOverrides,
     lorebookNamesById,
     currentMessageIndex: messages.length,
     activeLorebookReasons,
@@ -551,7 +657,11 @@ export function lorebookActivatedEntryForEvent(entry: ActivatedEntry) {
 export async function scanActiveLorebooks(input: ActiveLorebookScannerInput): Promise<ActiveLorebookScannerResult> {
   const loadedLore = await loadActivatedLore(input);
   const lorebookTokenBudget = resolveLorebookTokenBudget(input.chat, input.request ?? {});
-  const processedLore = processActivatedEntries(loadedLore.activatedEntries, lorebookTokenBudget);
+  const processedLore = processActivatedEntries(
+    loadedLore.activatedEntries,
+    lorebookTokenBudget,
+    input.contentResolver,
+  );
   const nextTimingStates = updateTimingStatesForScan(
     loadedLore.entriesForTiming,
     processedLore.includedEntries,
@@ -560,6 +670,17 @@ export async function scanActiveLorebooks(input: ActiveLorebookScannerInput): Pr
   );
   const lorebookTimingStates = lorebookTimingStatesChanged(loadedLore.previousTimingStates, nextTimingStates)
     ? serializeLorebookTimingStates(nextTimingStates)
+    : null;
+  const nextEntryStateOverrides = updateEntryStateOverridesForScan(
+    loadedLore.entriesForTiming,
+    processedLore.includedEntries,
+    loadedLore.previousEntryStateOverrides,
+  );
+  const lorebookEntryStateOverrides = lorebookEntryStateOverridesChanged(
+    loadedLore.previousEntryStateOverrides,
+    nextEntryStateOverrides,
+  )
+    ? serializeLorebookEntryStateOverrides(nextEntryStateOverrides)
     : null;
   const budgetSkippedLorebookEntries = [
     ...loadedLore.budgetSkippedEntries.map((entry) => lorebookBudgetSkippedLoreForEvent(entry, lorebookTokenBudget)),
@@ -574,6 +695,7 @@ export async function scanActiveLorebooks(input: ActiveLorebookScannerInput): Pr
     previousTimingStates: loadedLore.previousTimingStates,
     nextTimingStates,
     lorebookTimingStates,
+    lorebookEntryStateOverrides,
     budgetSkippedLorebookEntries,
     lorebookNamesById: loadedLore.lorebookNamesById,
     currentMessageIndex: loadedLore.currentMessageIndex,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -108,6 +108,7 @@ export interface PromptAssemblyResult {
     constant: boolean;
   }>;
   lorebookTimingStates: Record<string, LorebookEntryTimingState> | null;
+  lorebookEntryStateOverrides: Record<string, { ephemeral?: number | null; enabled?: boolean }> | null;
   budgetSkippedLorebookEntries: BudgetSkippedLorebookEntry[];
   chatSummary: string | null;
   chatSummaryFingerprint: string | null;
@@ -2245,25 +2246,6 @@ export async function assembleGenerationPrompt(
   const characters = await loadCharacters(storage, input.chat);
   const persona = await loadPersona(storage, input.chat);
   const embeddingSource = memoizedEmbeddingSource(input.embeddingSource);
-  const loreScan = await scanActiveLorebooks({
-    storage,
-    chat: input.chat,
-    characters,
-    persona,
-    storedMessages: input.storedMessages,
-    request: input.request,
-    latestUserInput: input.latestUserInput,
-    embeddingSource,
-  });
-  const processedLore = loreScan.processedLore;
-  const summary = chatSummaryForGeneration(input.chat);
-  const memoryRecallBlock = await buildMemoryRecallBlock(
-    storage,
-    input.chat,
-    input.latestUserInput,
-    readNumber(input.connection.maxContext, 0) || undefined,
-    embeddingSource,
-  );
   const selectedPreset = await loadSelectedPromptPreset(storage, {
     chat: input.chat,
     connection: input.connection,
@@ -2279,14 +2261,6 @@ export async function assembleGenerationPrompt(
     normalizeWrapFormat(input.connection.wrapFormat) ??
     "xml";
   const promptCharacters = promptCharactersForGeneration(input, characters);
-  const metadataHistoryLimit = readNumber(chatMeta.contextMessageLimit, 0);
-  const requestedHistoryLimit = readNumber(input.request.historyLimit, metadataHistoryLimit || 300);
-  const historyLimit = Math.max(1, Math.min(300, metadataHistoryLimit || requestedHistoryLimit || 300));
-  const history = historyMessages(
-    input.storedMessages,
-    compactedHistoryLimit(chatMeta, historyLimit, shouldCompactHistoryForSummary(input.chat, selectedPreset, summary)),
-    chatMeta.excludePastReasoning === false,
-  );
   const macros = macroContext({
     chat: input.chat,
     connection: input.connection,
@@ -2297,6 +2271,36 @@ export async function assembleGenerationPrompt(
     variables: selectedPreset?.variables,
     request: input.request,
   });
+  const loreScan = await scanActiveLorebooks({
+    storage,
+    chat: input.chat,
+    characters,
+    persona,
+    storedMessages: input.storedMessages,
+    request: input.request,
+    latestUserInput: input.latestUserInput,
+    embeddingSource,
+    contentResolver: {
+      resolve: (content) => cleanPromptText(resolveMacros(content, macros)),
+    },
+  });
+  const processedLore = loreScan.processedLore;
+  const summary = chatSummaryForGeneration(input.chat);
+  const memoryRecallBlock = await buildMemoryRecallBlock(
+    storage,
+    input.chat,
+    input.latestUserInput,
+    readNumber(input.connection.maxContext, 0) || undefined,
+    embeddingSource,
+  );
+  const metadataHistoryLimit = readNumber(chatMeta.contextMessageLimit, 0);
+  const requestedHistoryLimit = readNumber(input.request.historyLimit, metadataHistoryLimit || 300);
+  const historyLimit = Math.max(1, Math.min(300, metadataHistoryLimit || requestedHistoryLimit || 300));
+  const history = historyMessages(
+    input.storedMessages,
+    compactedHistoryLimit(chatMeta, historyLimit, shouldCompactHistoryForSummary(input.chat, selectedPreset, summary)),
+    chatMeta.excludePastReasoning === false,
+  );
   const agentData = input.agentData ?? {};
   let messages: ChatMLMessage[] = [];
   let insertedHistory = false;
@@ -2469,6 +2473,7 @@ export async function assembleGenerationPrompt(
     persona,
     activatedLorebookEntries: processedLore.includedEntries.map(lorebookActivatedEntryForEvent),
     lorebookTimingStates: loreScan.lorebookTimingStates,
+    lorebookEntryStateOverrides: loreScan.lorebookEntryStateOverrides,
     budgetSkippedLorebookEntries: loreScan.budgetSkippedLorebookEntries,
     chatSummary: summary,
     chatSummaryFingerprint: summaryFingerprint,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1556,12 +1556,16 @@ async function persistLorebookTimingStatesSafely(
   storage: StorageGateway,
   chatId: string,
   timingStates: Record<string, unknown> | null,
+  entryStateOverrides?: Record<string, unknown> | null,
 ): Promise<void> {
-  if (!timingStates) return;
+  const patch: Record<string, unknown> = {};
+  if (timingStates) patch.entryTimingStates = timingStates;
+  if (entryStateOverrides) patch.entryStateOverrides = entryStateOverrides;
+  if (Object.keys(patch).length === 0) return;
   try {
-    await storage.patchChatMetadata(chatId, { entryTimingStates: timingStates });
+    await storage.patchChatMetadata(chatId, patch);
   } catch (error) {
-    console.warn("[generation] lorebook timing state persist failed", error);
+    console.warn("[generation] lorebook runtime state persist failed", error);
   }
 }
 
@@ -2694,7 +2698,12 @@ export async function* startGeneration(
         });
     let latestSaved = saved;
     if (saved) {
-      await persistLorebookTimingStatesSafely(deps.storage, chatId, assembly.lorebookTimingStates);
+      await persistLorebookTimingStatesSafely(
+        deps.storage,
+        chatId,
+        assembly.lorebookTimingStates,
+        assembly.lorebookEntryStateOverrides,
+      );
     }
     throwIfAborted(signal);
     if (saved && input.impersonate !== true) {
@@ -2867,7 +2876,12 @@ export async function* startGeneration(
         promptSnapshot: promptSnapshotDirect,
       });
   if (saved) {
-    await persistLorebookTimingStatesSafely(deps.storage, chatId, assembly.lorebookTimingStates);
+    await persistLorebookTimingStatesSafely(
+      deps.storage,
+      chatId,
+      assembly.lorebookTimingStates,
+      assembly.lorebookEntryStateOverrides,
+    );
   }
   throwIfAborted(signal);
   if (saved && input.impersonate !== true) {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1793

## Why this change

- Restores lorebook parity in the refactor path for deletion cleanup, prompt injection, per-chat finite-use entries, macro-resolved lore content, and SillyTavern import normalization.

## What changed

- Clears deleted lorebook IDs from chat `activeLorebookIds` metadata/top-level fields and clears imported embedded character lorebook pointers when the linked lorebook is deleted.
- Resolves lorebook macros before lore prompt insertion/budgeting and persists per-chat ephemeral entry countdown overrides after generation.
- Anchors depth injection to the original prompt message bounds so inserted entries do not move later depth anchors.
- Normalizes SillyTavern `selectiveLogic` numeric values and keeps probability disabled when `useProbability` / `use_probability` is false, including after raw imported fields are merged.

## Refactor impact

Primary owner:

engine generation, Rust storage, imports

Impact areas reviewed:

- Lorebook prompt injection and active lorebook scanning
- Generation prompt assembly and lorebook runtime state persistence
- Generic storage deletion cascade for lorebooks
- SillyTavern lorebook/embedded character import normalization

Boundary notes:

- Engine changes remain React-free and stay inside `src/engine`.
- Storage and import cleanup stays inside `src-tauri`.
- No shared API/raw Tauri/remote runtime boundary changes.

Pressure points touched:

- Prompt assembly lorebook pipeline
- `src-tauri` storage delete command
- `src-tauri` import normalization modules

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Machine proof: `pnpm exec vitest run --config scratch/vitest.issue-1793.config.ts --pool=forks` passed with 3 focused lorebook parity rows.
- Machine proof: `cargo test --manifest-path src-tauri/Cargo.toml --workspace deleting_lorebook_clears_chat_and_embedded_character_refs` passed.
- Machine proof: `cargo test --manifest-path src-tauri/Cargo.toml --workspace normalizes_sillytavern_selective_logic_numbers` passed.
- Machine proof: `cargo test --manifest-path src-tauri/Cargo.toml --workspace normalizes_imported_lorebook_entry_after_raw_field_merge` passed.
- Baseline: `pnpm check` passed.
- Proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review: passed before opening the PR.
- No manual verification blockers identified for the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix/compatibility parity work only; no new discoverable surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: this is engine/storage/import behavior with command and harness proof rather than a visible UI change.
