### PR TITLE
Fix sprite expression fallback state

### DIFF
--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -27,6 +27,10 @@ import {
   getSpriteOwnerId,
   getSpriteOwnerKind,
 } from "../../../runtime/visuals/sprite-owner-keys";
+import {
+  getSpriteExpressionForCharacter,
+  normalizeSpriteExpressionMap,
+} from "../../../runtime/visuals/sprite-expression-lookup";
 import { AgentInjectionReviewModal } from "./AgentInjectionReviewModal";
 import { ChatRoleplaySurface } from "./ChatRoleplaySurface";
 import { CreatorNotesCssInjector } from "../../shared/chat-ui/index";
@@ -49,17 +53,6 @@ function parseMessageExtraRecord(value: unknown): Record<string, unknown> {
     }
   }
   return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
-}
-
-function normalizeMessageSpriteExpressions(value: unknown): Record<string, string> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const expressions: Record<string, string> = {};
-  for (const [key, expression] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof expression !== "string") continue;
-    const trimmed = expression.trim();
-    if (key && trimmed) expressions[key] = trimmed;
-  }
-  return expressions;
 }
 
 function metadataString(value: unknown, fallback: string): string {
@@ -268,13 +261,15 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
     if (!expressionAvatarsEnabled) return undefined;
     return (message: MessageWithSwipes, characterId: string) => {
       const extra = parseMessageExtraRecord(message.extra);
-      const expressions = normalizeMessageSpriteExpressions(extra.spriteExpressions);
+      const expressions = normalizeSpriteExpressionMap(extra.spriteExpressions);
       const characterName = data.characterMap.get(characterId)?.name;
-      const expression = expressions[characterId] ?? (characterName ? expressions[characterName] : undefined);
+      const expression =
+        getSpriteExpressionForCharacter(expressions, characterId, characterName) ??
+        getSpriteExpressionForCharacter(spriteState.spriteExpressions, characterId, characterName);
       if (!expression) return null;
       return resolveExpressionAvatarSpriteUrl(expressionAvatarSpriteMap.get(characterId), expression);
     };
-  }, [data.characterMap, expressionAvatarSpriteMap, expressionAvatarsEnabled]);
+  }, [data.characterMap, expressionAvatarSpriteMap, expressionAvatarsEnabled, spriteState.spriteExpressions]);
 
   const handleCloneSceneFromHere = useCallback(
     (messageId: string) => {

--- a/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.test.tsx
@@ -1,0 +1,134 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageWithSwipes } from "../types";
+import { useSpriteMetadataState } from "./use-sprite-metadata-state";
+
+const updateMetaMutate = vi.fn();
+const updateMessageExtraMutate = vi.fn();
+
+vi.mock("../../../../catalog/chats/index", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useUpdateChatMetadata: () => ({ mutate: updateMetaMutate }),
+  useUpdateMessageExtra: () => ({ mutate: updateMessageExtraMutate }),
+}));
+
+vi.mock("../../../../../shared/stores/ui.store", () => ({
+  useUIStore: <T,>(selector: (state: { roleplaySpriteScale: number }) => T) =>
+    selector({ roleplaySpriteScale: 1 }),
+}));
+
+function message(overrides: Partial<MessageWithSwipes>): MessageWithSwipes {
+  return {
+    id: "message-1",
+    chatId: "chat-1",
+    role: "assistant",
+    content: "",
+    orderIndex: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as MessageWithSwipes;
+}
+
+function extra(value: Record<string, unknown>): MessageWithSwipes["extra"] {
+  return value as unknown as MessageWithSwipes["extra"];
+}
+
+type SpriteState = ReturnType<typeof useSpriteMetadataState>;
+
+function renderSpriteState(props: Parameters<typeof useSpriteMetadataState>[0]) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root: Root = createRoot(host);
+  const result: { current: SpriteState | null } = { current: null };
+
+  function Probe() {
+    result.current = useSpriteMetadataState(props);
+    return null;
+  }
+
+  act(() => {
+    root.render(<Probe />);
+  });
+
+  if (!result.current) throw new Error("Sprite state did not render");
+  return {
+    state: result.current,
+    cleanup: () => {
+      act(() => root.unmount());
+      host.remove();
+    },
+  };
+}
+
+describe("useSpriteMetadataState", () => {
+  beforeEach(() => {
+    updateMetaMutate.mockClear();
+    updateMessageExtraMutate.mockClear();
+  });
+
+  it("falls back to chat-level sprite expressions when the latest assistant message has none", () => {
+    const { state, cleanup } = renderSpriteState({
+      chat: { id: "chat-1" } as Parameters<typeof useSpriteMetadataState>[0]["chat"],
+      chatMeta: { spriteExpressions: { "character:alice": "happy" } },
+      messages: [
+        message({
+          id: "older",
+          extra: extra({ spriteExpressions: { "character:alice": "sad" } }),
+        }),
+        message({
+          id: "latest",
+          extra: extra({}),
+        }),
+      ],
+    });
+
+    expect(state.spriteExpressions).toEqual({ "character:alice": "happy" });
+    cleanup();
+  });
+
+  it("persists manual expression changes to metadata even before an assistant message exists", () => {
+    const { state, cleanup } = renderSpriteState({
+      chat: { id: "chat-1" } as Parameters<typeof useSpriteMetadataState>[0]["chat"],
+      chatMeta: {},
+      messages: [message({ id: "user-message", role: "user" })],
+    });
+
+    act(() => {
+      state.handleExpressionChange("character:alice", "smirk", { immediate: true });
+    });
+
+    expect(updateMetaMutate).toHaveBeenCalledWith({
+      id: "chat-1",
+      spriteExpressions: { "character:alice": "smirk" },
+    });
+    expect(updateMessageExtraMutate).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("persists expression changes to both chat metadata and the latest assistant message", () => {
+    const { state, cleanup } = renderSpriteState({
+      chat: { id: "chat-1" } as Parameters<typeof useSpriteMetadataState>[0]["chat"],
+      chatMeta: {},
+      messages: [
+        message({ id: "assistant-older" }),
+        message({ id: "assistant-latest" }),
+      ],
+    });
+
+    act(() => {
+      state.handleExpressionChange("character:alice", "thinking", { immediate: true });
+    });
+
+    expect(updateMetaMutate).toHaveBeenCalledWith({
+      id: "chat-1",
+      spriteExpressions: { "character:alice": "thinking" },
+    });
+    expect(updateMessageExtraMutate).toHaveBeenCalledWith({
+      messageId: "assistant-latest",
+      extra: { spriteExpressions: { "character:alice": "thinking" } },
+    });
+    cleanup();
+  });
+});

--- a/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.ts
@@ -4,6 +4,7 @@ import type { SpritePlacement, SpriteSide } from "../../../../../engine/contract
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import { mirrorSpritePlacements, normalizeSpritePlacements } from "../../../../runtime/visuals/sprite-placement";
 import { normalizeSpriteDisplayModes, type SpriteDisplayMode } from "../../../../runtime/visuals/sprite-display-modes";
+import { normalizeSpriteExpressionMap } from "../../../../runtime/visuals/sprite-expression-lookup";
 import type { MessageWithSwipes } from "../types";
 
 type UseSpriteMetadataStateOptions = {
@@ -24,10 +25,25 @@ function readMessageExtra(message: MessageWithSwipes): Record<string, unknown> {
     : {};
 }
 
-function stringRecord(value: unknown): Record<string, string> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string");
-  return entries.length ? Object.fromEntries(entries) : null;
+function getLatestAssistantSpriteExpressions(messages?: MessageWithSwipes[]): Record<string, string> | null {
+  if (!messages?.length) return null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!;
+    if (message.role !== "assistant") continue;
+    const extra = readMessageExtra(message);
+    const spriteExpressions = normalizeSpriteExpressionMap(extra.spriteExpressions);
+    return Object.keys(spriteExpressions).length > 0 ? spriteExpressions : null;
+  }
+  return null;
+}
+
+function getLatestAssistantMessageId(messages?: MessageWithSwipes[]): string | null {
+  if (!messages?.length) return null;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!;
+    if (message.role === "assistant") return message.id;
+  }
+  return null;
 }
 
 export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMetadataStateOptions) {
@@ -48,22 +64,14 @@ export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMe
   );
   const hasCustomSpritePlacements = Object.keys(spritePlacements).length > 0;
 
-  const spriteExpressions: Record<string, string> = useMemo(() => {
-    if (messages?.length) {
-      for (let index = messages.length - 1; index >= 0; index -= 1) {
-        const message = messages[index]!;
-        if (message.role === "assistant") {
-          const extra = readMessageExtra(message);
-          const spriteExpressions = stringRecord(extra.spriteExpressions);
-          if (spriteExpressions && Object.keys(spriteExpressions).length > 0) {
-            return spriteExpressions;
-          }
-          break;
-        }
-      }
-    }
-    return {};
-  }, [messages]);
+  const chatSpriteExpressions = useMemo(
+    () => normalizeSpriteExpressionMap(chatMeta.spriteExpressions),
+    [chatMeta.spriteExpressions],
+  );
+  const spriteExpressions: Record<string, string> = useMemo(
+    () => getLatestAssistantSpriteExpressions(messages) ?? chatSpriteExpressions,
+    [chatSpriteExpressions, messages],
+  );
 
   const pendingExpressions = useRef<Record<string, string>>(spriteExpressions);
   const pendingSpritePlacements = useRef<Record<string, SpritePlacement>>(spritePlacements);
@@ -86,20 +94,16 @@ export function useSpriteMetadataState({ chat, chatMeta, messages }: UseSpriteMe
   const persistSpriteExpressions = useCallback(
     (expressions: Record<string, string>) => {
       if (!chat?.id) return;
-      if (messages?.length) {
-        for (let index = messages.length - 1; index >= 0; index -= 1) {
-          const message = messages[index]!;
-          if (message.role === "assistant") {
-            updateMessageExtra.mutate({
-              messageId: message.id,
-              extra: { spriteExpressions: expressions },
-            });
-            break;
-          }
-        }
+      updateMeta.mutate({ id: chat.id, spriteExpressions: expressions });
+      const assistantMessageId = getLatestAssistantMessageId(messages);
+      if (assistantMessageId) {
+        updateMessageExtra.mutate({
+          messageId: assistantMessageId,
+          extra: { spriteExpressions: expressions },
+        });
       }
     },
-    [chat?.id, messages, updateMessageExtra],
+    [chat?.id, messages, updateMessageExtra, updateMeta],
   );
 
   const handleExpressionChange = useCallback(

--- a/src/features/runtime/tracker/components/TrackerSectionList.tsx
+++ b/src/features/runtime/tracker/components/TrackerSectionList.tsx
@@ -15,6 +15,7 @@ import { PersonaInventoryPanel } from "./PersonaTrackerPanel";
 import { CharacterTrackerPanel } from "./CharacterTrackerPanel";
 import { QuestTrackerPanel } from "./QuestTrackerPanel";
 import { CustomTrackerPanel } from "./CustomTrackerPanel";
+import { getSpriteExpressionForPersona } from "../../visuals/sprite-expression-lookup";
 
 export function TrackerSectionList({
   addMode,
@@ -159,7 +160,7 @@ export function TrackerSectionList({
             status={playerStats?.status ?? ""}
             spriteExpression={
               expressionSpritesEnabled && activePersona
-                ? (spriteExpressions[activePersona.id] ?? spriteExpressions[activePersona.name] ?? "neutral")
+                ? (getSpriteExpressionForPersona(spriteExpressions, activePersona.id, activePersona.name) ?? "neutral")
                 : undefined
             }
             trackerPanelSide={trackerPanelSide}

--- a/src/features/runtime/tracker/components/tracker-sprite.helpers.ts
+++ b/src/features/runtime/tracker/components/tracker-sprite.helpers.ts
@@ -1,5 +1,6 @@
 import type { PresentCharacter } from "../../../../engine/contracts/types/game-state";
 import type { SpriteInfo } from "../../../catalog/sprites/index";
+import { getSpriteExpressionForCharacter as getExpressionForCharacterId } from "../../visuals/sprite-expression-lookup";
 
 export function isSpriteLookupCharacterId(characterId: string | null | undefined) {
   const id = characterId?.trim();
@@ -11,10 +12,10 @@ export function getSpriteExpressionForCharacter(
   character: PresentCharacter,
   spriteCharacterId: string | null,
 ) {
-  if (spriteCharacterId && expressions[spriteCharacterId]) return expressions[spriteCharacterId];
-  if (character.characterId && expressions[character.characterId]) return expressions[character.characterId];
-  if (character.name && expressions[character.name]) return expressions[character.name];
-  return undefined;
+  return (
+    getExpressionForCharacterId(expressions, spriteCharacterId, character.name) ??
+    getExpressionForCharacterId(expressions, character.characterId, character.name)
+  );
 }
 
 export function getCharacterExpressionHint(character: PresentCharacter, spriteExpression?: string | null) {

--- a/src/features/runtime/visuals/components/SpriteOverlay.tsx
+++ b/src/features/runtime/visuals/components/SpriteOverlay.tsx
@@ -14,6 +14,7 @@ import {
 } from "../sprite-display-modes";
 import { getCharacterIdFromSpriteOwnerKey, getSpriteOwnerId, getSpriteOwnerKind } from "../sprite-owner-keys";
 import { clampSpritePlacement, getDefaultSpritePlacement, type SpritePlacementMap } from "../sprite-placement";
+import { getSpriteExpressionForOwnerKey } from "../sprite-expression-lookup";
 
 interface SpriteOverlayProps {
   /** Character IDs or sprite owner keys enabled in this chat */
@@ -111,8 +112,7 @@ export function SpriteOverlay({
     const next: Record<string, string> = {};
     if (!spriteExpressions) return next;
     for (const ownerKey of characterIds) {
-      const characterId = getCharacterIdFromSpriteOwnerKey(ownerKey);
-      const expression = spriteExpressions[ownerKey] ?? (characterId ? spriteExpressions[characterId] : undefined);
+      const expression = getSpriteExpressionForOwnerKey(spriteExpressions, ownerKey);
       if (expression) next[ownerKey] = expression;
     }
     return next;

--- a/src/features/runtime/visuals/sprite-expression-lookup.test.tsx
+++ b/src/features/runtime/visuals/sprite-expression-lookup.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSpriteExpressionForCharacter,
+  getSpriteExpressionForOwnerKey,
+  getSpriteExpressionForPersona,
+  normalizeSpriteExpressionMap,
+} from "./sprite-expression-lookup";
+
+describe("sprite expression lookup", () => {
+  it("normalizes only non-empty string expressions", () => {
+    expect(
+      normalizeSpriteExpressionMap({
+        " character:alice ": " happy ",
+        bob: "",
+        clara: 42,
+      }),
+    ).toEqual({ "character:alice": "happy" });
+  });
+
+  it("resolves character owner keys before raw ids and names", () => {
+    const expressions = {
+      "character:alice": "smirk",
+      alice: "sad",
+      Alice: "happy",
+    };
+
+    expect(getSpriteExpressionForCharacter(expressions, "alice", "Alice")).toBe("smirk");
+    expect(getSpriteExpressionForOwnerKey(expressions, "character:alice", "Alice")).toBe("smirk");
+  });
+
+  it("falls back through raw ids and names for legacy expression maps", () => {
+    expect(getSpriteExpressionForCharacter({ Alice: "thinking" }, "alice", "Alice")).toBe("thinking");
+    expect(getSpriteExpressionForCharacter({ alice: "worried" }, "alice", "Alice")).toBe("worried");
+  });
+
+  it("resolves persona owner keys before legacy persona ids and names", () => {
+    const expressions = {
+      "persona:hero": "determined",
+      hero: "sad",
+      Hero: "happy",
+    };
+
+    expect(getSpriteExpressionForPersona(expressions, "hero", "Hero")).toBe("determined");
+  });
+});

--- a/src/features/runtime/visuals/sprite-expression-lookup.ts
+++ b/src/features/runtime/visuals/sprite-expression-lookup.ts
@@ -1,0 +1,60 @@
+import { getSpriteOwnerId, getSpriteOwnerKind, makeSpriteOwnerKey, type SpriteOwnerKind } from "./sprite-owner-keys";
+
+export function normalizeSpriteExpressionMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const expressions: Record<string, string> = {};
+  for (const [key, expression] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof expression !== "string") continue;
+    const trimmedKey = key.trim();
+    const trimmedExpression = expression.trim();
+    if (trimmedKey && trimmedExpression) expressions[trimmedKey] = trimmedExpression;
+  }
+  return expressions;
+}
+
+function getSpriteExpressionForOwner(
+  expressions: Record<string, string>,
+  ownerKind: SpriteOwnerKind,
+  ownerId: string | null | undefined,
+  displayName?: string | null,
+): string | undefined {
+  const id = ownerId?.trim();
+  const candidates = [
+    id ? makeSpriteOwnerKey(ownerKind, id) : null,
+    id,
+    displayName?.trim() || null,
+  ].filter((candidate): candidate is string => !!candidate);
+  for (const candidate of candidates) {
+    const expression = expressions[candidate];
+    if (expression) return expression;
+  }
+  return undefined;
+}
+
+export function getSpriteExpressionForOwnerKey(
+  expressions: Record<string, string>,
+  ownerKey: string,
+  displayName?: string | null,
+): string | undefined {
+  const ownerKind = getSpriteOwnerKind(ownerKey);
+  const ownerId = getSpriteOwnerId(ownerKey);
+  const keyedExpression = expressions[ownerKey];
+  if (keyedExpression) return keyedExpression;
+  return getSpriteExpressionForOwner(expressions, ownerKind, ownerId, displayName);
+}
+
+export function getSpriteExpressionForCharacter(
+  expressions: Record<string, string>,
+  characterId: string | null | undefined,
+  displayName?: string | null,
+): string | undefined {
+  return getSpriteExpressionForOwner(expressions, "character", characterId, displayName);
+}
+
+export function getSpriteExpressionForPersona(
+  expressions: Record<string, string>,
+  personaId: string | null | undefined,
+  displayName?: string | null,
+): string | undefined {
+  return getSpriteExpressionForOwner(expressions, "persona", personaId, displayName);
+}


### PR DESCRIPTION
## Linked issue

Closes #1802

## Why this change

Roleplay runtime visuals could lose sprite expression state after the refactor:

- Legacy chat-level `spriteExpressions` were ignored when the latest assistant message had no expression extra.
- Manual expression changes before the first assistant reply had no message target, so persistence could silently do nothing.
- Owner-keyed expression maps like `character:<id>` and `persona:<id>` were handled by the overlay path but not consistently by expression avatars and tracker consumers.

## What changed

- Restored chat metadata fallback when the latest assistant message lacks `extra.spriteExpressions`.
- Persisted manual expression changes to chat metadata, while still patching the latest assistant message when one exists.
- Added a shared sprite expression lookup helper that normalizes maps and resolves owner keys before legacy raw IDs/names.
- Updated roleplay expression avatars, sprite overlay saved state, character tracker sprites, and persona tracker sprites to use the same owner-key-aware lookup.
- Added focused regression coverage for metadata fallback, no-assistant persistence, dual metadata/message persistence, and owner-key lookup.

## Refactor impact

Primary owner:

- Roleplay mode / shared runtime visuals

Impact areas reviewed:

- Roleplay expression avatars
- Shared chat sprite metadata state
- Runtime sprite overlay
- Runtime tracker expression sprite consumers

Boundary notes:

- Feature/runtime UI-only change; no engine, shared API, Rust, storage command, provider, or remote-runtime boundary changes.
- The change preserves message-level expression state precedence while restoring legacy chat metadata fallback.

Pressure points touched:

- Shared mode UI sprite metadata hook
- Roleplay route expression avatar resolver
- Runtime visuals/tracker consumers

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex targeted proof: `pnpm test -- src/features/modes/shared/chat-ui/hooks/use-sprite-metadata-state.test.tsx src/features/runtime/visuals/sprite-expression-lookup.test.tsx` passed.
- Codex lane check: `pnpm typecheck` passed.
- Codex full gate: `pnpm check` passed.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Manual/browser visual verification is still useful before ready: no screenshot was captured for a seeded legacy chat plus sprite asset state.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this is a compatibility bugfix for existing runtime visual behavior and does not add a discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No browser screenshots or recordings captured. This PR is intentionally left as draft with the missing visual runtime confirmation disclosed.
