### PR TITLE
Fix bot browser import parity

### DIFF
--- a/src-tauri/src/commands/storage/imports/normalization.rs
+++ b/src-tauri/src/commands/storage/imports/normalization.rs
@@ -7,7 +7,6 @@ pub(super) fn string_field(value: &Value, key: &str) -> String {
         .unwrap_or("")
         .to_string()
 }
-
 pub(super) fn string_array(value: Option<&Value>) -> Vec<String> {
     match value {
         Some(Value::Array(items)) => items
@@ -21,7 +20,6 @@ pub(super) fn string_array(value: Option<&Value>) -> Vec<String> {
         _ => Vec::new(),
     }
 }
-
 pub(super) fn first_string(values: Vec<Option<&Value>>) -> String {
     values
         .into_iter()
@@ -32,7 +30,6 @@ pub(super) fn first_string(values: Vec<Option<&Value>>) -> String {
         .unwrap_or("")
         .to_string()
 }
-
 pub(super) fn source_character_data(payload: &Value) -> Value {
     if matches!(
         payload.get("spec").and_then(Value::as_str),
@@ -53,7 +50,6 @@ pub(super) fn source_character_data(payload: &Value) -> Value {
     }
     payload.clone()
 }
-
 pub(super) fn embedded_lorebook(payload: &Value) -> Option<Value> {
     let wrapped = source_character_data(payload);
     let mut candidates = Vec::new();
@@ -111,7 +107,10 @@ pub(super) fn character_import_extensions(
     extensions
         .entry("altDescriptions".to_string())
         .or_insert_with(|| alt_descriptions(data));
-
+    let bot_browser_source = string_field(payload, "_botBrowserSource");
+    if !bot_browser_source.trim().is_empty() {
+        extensions.insert("botBrowserSource".to_string(), json!(bot_browser_source));
+    }
     let import_metadata = extensions
         .entry("importMetadata".to_string())
         .or_insert_with(|| json!({}));

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -317,3 +317,40 @@ fn import_st_character_uses_trusted_avatar_source_path() {
     let _ = fs::remove_dir_all(app_root);
     let _ = fs::remove_dir_all(source_root);
 }
+
+#[test]
+fn import_st_character_preserves_bot_browser_source_marker() {
+    let app_root = temp_path("bot-browser-source");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+
+    let result = import_st_character(
+        &state,
+        json!({
+            "spec": "chara_card_v2",
+            "data": {
+                "name": "Browser Import",
+                "extensions": {
+                    "chub": { "id": "creator/browser-import" }
+                }
+            },
+            "_botBrowserSource": "chub:creator/browser-import"
+        }),
+    )
+    .expect("bot browser source marker should import");
+
+    let extensions = result
+        .pointer("/character/data/extensions")
+        .and_then(Value::as_object)
+        .expect("imported character extensions should be an object");
+    assert_eq!(
+        extensions.get("botBrowserSource").and_then(Value::as_str),
+        Some("chub:creator/browser-import")
+    );
+    assert!(
+        extensions.get("chub").is_some(),
+        "existing provider extension metadata should be preserved"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+}

--- a/src/features/shell/bot-browser/api/bot-browser-api.test.ts
+++ b/src/features/shell/bot-browser/api/bot-browser-api.test.ts
@@ -1,0 +1,53 @@
+import { ApiError } from "../../../../shared/api/api-errors";
+import { botBrowserCommandApi } from "../../../../shared/api/bot-browser-command-api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { jannySearchWithBrowserFallback } from "./bot-browser-api";
+
+vi.mock("../../../../shared/api/bot-browser-command-api", () => ({
+  botBrowserCommandApi: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const commandApi = vi.mocked(botBrowserCommandApi);
+
+describe("jannySearchWithBrowserFallback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    commandApi.get.mockReset();
+    commandApi.post.mockReset();
+  });
+
+  it("falls back to browser-side search when the backend reports Cloudflare mitigation", async () => {
+    const payload = { queries: [{ indexUid: "janny-characters", q: "marinara" }] };
+    commandApi.post.mockRejectedValue(
+      new ApiError("JannyAI is blocking this request with Cloudflare bot mitigation", 500, {
+        code: "upstream_blocked",
+      }),
+    );
+    commandApi.get.mockResolvedValue({ token: "browser-token" });
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ results: [{ hits: [{ id: "hit-1" }] }] }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(jannySearchWithBrowserFallback(payload)).resolves.toEqual({
+      results: [{ hits: [{ id: "hit-1" }] }],
+    });
+
+    expect(commandApi.post).toHaveBeenCalledWith("/bot-browser/janny/search", { payload });
+    expect(commandApi.get).toHaveBeenCalledWith("/bot-browser/janny/token?force=true");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://search.jannyai.com/multi-search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(payload),
+        headers: expect.objectContaining({
+          Authorization: "Bearer browser-token",
+        }),
+      }),
+    );
+  });
+});

--- a/src/features/shell/bot-browser/api/bot-browser-api.ts
+++ b/src/features/shell/bot-browser/api/bot-browser-api.ts
@@ -3,6 +3,7 @@ import { importApi } from "../../../../shared/api/import-api";
 import { loadUrlBlob } from "../../../../shared/lib/url-blob";
 
 const TAURI_ASSET_PREFIX = "tauri-api:";
+const JANNY_SEARCH_URL = "https://search.jannyai.com/multi-search";
 
 export interface ImportCharacterResult {
   success?: boolean;
@@ -70,6 +71,48 @@ export async function botBrowserGet<T = unknown>(path: string, init?: RequestIni
 export async function botBrowserPost<T = unknown>(path: string, body?: unknown, init?: RequestInit): Promise<T> {
   if (init?.signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
   return botBrowserCommandApi.post<T>(normalizeBotBrowserPath(path), body);
+}
+
+function errorCode(error: unknown): string {
+  const details = error && typeof error === "object" ? (error as { details?: unknown }).details : null;
+  if (details && typeof details === "object" && typeof (details as { code?: unknown }).code === "string") {
+    return (details as { code: string }).code;
+  }
+  return "";
+}
+
+function isJannyCloudflareBlock(error: unknown): boolean {
+  return errorCode(error) === "upstream_blocked" || String(error).toLowerCase().includes("cloudflare");
+}
+
+async function jannyBrowserSearch<T>(payload: unknown, forceToken: boolean): Promise<T> {
+  const tokenResponse = await botBrowserGet<{ token?: string }>(`janny/token${forceToken ? "?force=true" : ""}`);
+  const token = tokenResponse.token?.trim();
+  if (!token) throw new Error("JannyAI search token is unavailable");
+
+  const response = await fetch(JANNY_SEARCH_URL, {
+    method: "POST",
+    headers: {
+      Accept: "*/*",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "x-meilisearch-client": "Meilisearch instant-meilisearch (v0.19.0) ; Meilisearch JavaScript (v0.41.0)",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`JannyAI browser fallback returned ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function jannySearchWithBrowserFallback<T = unknown>(payload: unknown): Promise<T> {
+  try {
+    return await botBrowserPost<T>("janny/search", { payload });
+  } catch (error) {
+    if (!isJannyCloudflareBlock(error)) throw error;
+    return jannyBrowserSearch<T>(payload, true);
+  }
 }
 
 export async function botBrowserBlob(path: string, fallbackMimeType = "image/png", init?: RequestInit): Promise<Blob> {

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -50,8 +50,10 @@ import {
   botBrowserPost,
   fetchBotBrowserAssetBlob,
   importStCharacter,
+  jannySearchWithBrowserFallback,
   resolveBotBrowserAssetUrl,
 } from "../api/bot-browser-api";
+import { mergeCharacterDetailIntoCharacterJson } from "../lib/character-detail-merge";
 import type {
   ChartavernDetailResponse,
   ChartavernSearchResponse,
@@ -164,6 +166,10 @@ interface CardDetail {
   exampleDialogs?: string;
   alternateGreetings?: string[];
   creatorNotes?: string;
+  systemPrompt?: string;
+  postHistoryInstructions?: string;
+  characterVersion?: string;
+  providerExtensions?: Record<string, unknown>;
   hasLorebook?: boolean;
   embeddedLorebook?: unknown;
   extra?: { title: string; content: string }[];
@@ -187,28 +193,6 @@ const STAT_ICONS = {
   message: MessageSquare,
   hash: Hash,
 };
-
-function attachEmbeddedLorebookToCharacterJson(raw: Record<string, unknown>, embeddedLorebook: unknown) {
-  if (!hasLorebookEntries(embeddedLorebook)) return raw;
-
-  const cloned: Record<string, unknown> = { ...raw };
-  const target =
-    (cloned.spec === "chara_card_v2" || cloned.spec === "chara_card_v3") &&
-    cloned.data &&
-    typeof cloned.data === "object"
-      ? { ...(cloned.data as Record<string, unknown>) }
-      : cloned;
-
-  if (!target.character_book) {
-    target.character_book = embeddedLorebook;
-  }
-
-  if (target !== cloned) {
-    cloned.data = target;
-  }
-
-  return cloned;
-}
 
 function isDatacatTagRecord(tag: DatacatCharacterTag): tag is DatacatTagRecord {
   return typeof tag === "object" && tag !== null;
@@ -465,6 +449,10 @@ const chubProvider: ProviderConfig = {
       exampleDialogs: def.example_dialogs || undefined,
       alternateGreetings: def.alternate_greetings || [],
       creatorNotes: def.description || undefined,
+      systemPrompt: def.system_prompt || undefined,
+      postHistoryInstructions: def.post_history_instructions || undefined,
+      characterVersion: def.character_version || undefined,
+      providerExtensions: def.extensions,
       hasLorebook: !!def.embedded_lorebook,
       embeddedLorebook: def.embedded_lorebook,
     };
@@ -551,7 +539,7 @@ const jannyProvider: ProviderConfig = {
         ],
       };
 
-      const raw = await botBrowserPost<JannySearchResponse>("janny/search", { payload: body });
+      const raw = await jannySearchWithBrowserFallback<JannySearchResponse>(body);
       return raw?.results?.[0];
     };
 
@@ -1455,10 +1443,7 @@ export function BotBrowserView() {
         // abort the import (the detail-view path surfaces failures; this one degrades).
         const cardDetail =
           sourceId === "chub" ? (detail ?? (await provider.fetchDetail(card).catch(() => null))) : detail;
-        const importJson = attachEmbeddedLorebookToCharacterJson(
-          json as Record<string, unknown>,
-          cardDetail?.embeddedLorebook,
-        );
+        const importJson = mergeCharacterDetailIntoCharacterJson(json as Record<string, unknown>, cardDetail);
         const importEmbeddedLorebook = confirmEmbeddedLorebookImport(
           card.name,
           cardDetail?.embeddedLorebook ?? readEmbeddedLorebookFromCharacterPayload(importJson),
@@ -1501,10 +1486,13 @@ export function BotBrowserView() {
           first_mes: cardDetail?.firstMessage || "",
           mes_example: cardDetail?.exampleDialogs || "",
           creator_notes: cardDetail?.creatorNotes || "",
+          system_prompt: cardDetail?.systemPrompt || "",
+          post_history_instructions: cardDetail?.postHistoryInstructions || "",
           tags: card.tags,
           creator: card.creator,
+          character_version: cardDetail?.characterVersion || "",
           alternate_greetings: cardDetail?.alternateGreetings || [],
-          extensions: { [`${sourceId}`]: { id: card.id } },
+          extensions: { ...cardDetail?.providerExtensions, [`${sourceId}`]: { id: card.id } },
           _botBrowserSource: `${sourceId}:${card.id}`,
           tagImportMode,
           importEmbeddedLorebook,
@@ -2688,10 +2676,13 @@ function DetailView({
         first_mes: d?.firstMessage || "",
         mes_example: d?.exampleDialogs || "",
         creator_notes: d?.creatorNotes || "",
+        system_prompt: d?.systemPrompt || "",
+        post_history_instructions: d?.postHistoryInstructions || "",
         tags: card.tags || [],
         creator: card.creator || "",
+        character_version: d?.characterVersion || "",
         alternate_greetings: d?.alternateGreetings || [],
-        extensions: { [`${provider.id}`]: { id: card.id } },
+        extensions: { ...d?.providerExtensions, [`${provider.id}`]: { id: card.id } },
       };
       if (hasLorebookEntries(d?.embeddedLorebook)) {
         charData.character_book = d?.embeddedLorebook;
@@ -2959,11 +2950,11 @@ async function buildCharacterCardPng(avatarUrl: string, charData: Record<string,
       first_mes: charData.first_mes || "",
       mes_example: charData.mes_example || "",
       creator_notes: charData.creator_notes || "",
-      system_prompt: "",
-      post_history_instructions: "",
+      system_prompt: charData.system_prompt || "",
+      post_history_instructions: charData.post_history_instructions || "",
       tags: charData.tags || [],
       creator: charData.creator || "",
-      character_version: "",
+      character_version: charData.character_version || "",
       alternate_greetings: charData.alternate_greetings || [],
       extensions: charData.extensions || {},
     },

--- a/src/features/shell/bot-browser/lib/character-detail-merge.test.ts
+++ b/src/features/shell/bot-browser/lib/character-detail-merge.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { mergeCharacterDetailIntoCharacterJson } from "./character-detail-merge";
+
+describe("mergeCharacterDetailIntoCharacterJson", () => {
+  it("adds Chub detail fields and provider extensions to wrapped card JSON without dropping existing metadata", () => {
+    const merged = mergeCharacterDetailIntoCharacterJson(
+      {
+        spec: "chara_card_v2",
+        spec_version: "2.0",
+        data: {
+          name: "Detail Bot",
+          extensions: {
+            existing: true,
+          },
+        },
+      },
+      {
+        systemPrompt: "System detail",
+        postHistoryInstructions: "Post detail",
+        characterVersion: "2.1",
+        providerExtensions: {
+          chub: { id: "creator/detail-bot" },
+          existing: false,
+        },
+      },
+    );
+
+    expect(merged).toMatchObject({
+      data: {
+        system_prompt: "System detail",
+        post_history_instructions: "Post detail",
+        character_version: "2.1",
+        extensions: {
+          chub: { id: "creator/detail-bot" },
+          existing: true,
+        },
+      },
+    });
+  });
+});

--- a/src/features/shell/bot-browser/lib/character-detail-merge.ts
+++ b/src/features/shell/bot-browser/lib/character-detail-merge.ts
@@ -1,0 +1,55 @@
+import { hasLorebookEntries } from "../../../../shared/lib/character-import";
+
+export interface CharacterDetailImportData {
+  embeddedLorebook?: unknown;
+  systemPrompt?: string;
+  postHistoryInstructions?: string;
+  characterVersion?: string;
+  providerExtensions?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function mergeCharacterDetailIntoCharacterJson(
+  raw: Record<string, unknown>,
+  detail: CharacterDetailImportData | null | undefined,
+) {
+  if (!detail) return raw;
+
+  const cloned: Record<string, unknown> = { ...raw };
+  const target =
+    (cloned.spec === "chara_card_v2" || cloned.spec === "chara_card_v3") && isRecord(cloned.data)
+      ? { ...cloned.data }
+      : cloned;
+
+  if (hasLorebookEntries(detail.embeddedLorebook) && !target.character_book) {
+    target.character_book = detail.embeddedLorebook;
+  }
+
+  const fieldMap: Array<[string, unknown]> = [
+    ["system_prompt", detail.systemPrompt],
+    ["post_history_instructions", detail.postHistoryInstructions],
+    ["character_version", detail.characterVersion],
+  ];
+  for (const [key, value] of fieldMap) {
+    const text = nonEmptyString(value);
+    if (text) target[key] = text;
+  }
+
+  if (isRecord(detail.providerExtensions)) {
+    const existingExtensions = isRecord(target.extensions) ? target.extensions : {};
+    target.extensions = { ...detail.providerExtensions, ...existingExtensions };
+  }
+
+  if (target !== cloned) {
+    cloned.data = target;
+  }
+
+  return cloned;
+}

--- a/src/features/shell/bot-browser/types/provider-responses.ts
+++ b/src/features/shell/bot-browser/types/provider-responses.ts
@@ -26,6 +26,10 @@ interface ChubDefinition {
   example_dialogs?: string;
   alternate_greetings?: string[];
   description?: string;
+  system_prompt?: string;
+  post_history_instructions?: string;
+  character_version?: string;
+  extensions?: Record<string, unknown>;
   embedded_lorebook?: unknown;
 }
 


### PR DESCRIPTION
## Linked issue

Closes #1805.

## Why this change

Bot Browser imports were passing `_botBrowserSource`, but the ST character import normalization did not persist it into `data.extensions.botBrowserSource`, so imported browser cards could disappear from the Browser panel's imported list. The refactor path also dropped Chub detail enrichment fields when importing downloaded PNG cards, and JannyAI search could stop at the backend Cloudflare mitigation error without trying the legacy browser-side route.

## What changed

- Persist `_botBrowserSource` into imported character extensions while preserving existing provider extension metadata.
- Merge Chub detail fields into imported/downloaded card JSON, including `system_prompt`, `post_history_instructions`, `character_version`, embedded lorebook data, and provider extensions.
- Add a JannyAI browser-side search fallback when the Tauri backend reports Cloudflare mitigation.
- Add focused Rust and Vitest coverage for source-marker persistence, Chub detail merging, and the Janny fallback path.

## Validation

- Passed: `pnpm exec vitest run src/features/shell/bot-browser/api/bot-browser-api.test.ts src/features/shell/bot-browser/lib/character-detail-merge.test.ts src/features/shell/bot-browser/components/BotBrowserView.test.tsx`
- Passed: `cargo test --manifest-path src-tauri\Cargo.toml import_st_character_preserves_bot_browser_source_marker`
- Passed: `pnpm check`
- Passed: risky-work proof health ledger. Live-provider manual rows are recorded as non-blocking because upstream provider network behavior can vary.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores existing Bot Browser import/provider parity; no new discoverable surface, setting, mode, or workflow is introduced.

## Docs and release impact

No docs or release notes changed. This restores refactor parity for existing Bot Browser import/provider behavior.

## UI evidence (if applicable)

Not applicable: this is import/provider data-path behavior covered by targeted unit tests and the PR gate.
