### PR TITLE
Fix tracker world-state snapshot parity

### DIFF
--- a/src-tauri/src/commands/storage/game_state_snapshots.rs
+++ b/src-tauri/src/commands/storage/game_state_snapshots.rs
@@ -207,6 +207,7 @@ pub(crate) fn save_tracker_snapshot(
     let mut snapshot = normalize_tracker_snapshot(chat_id, body)?;
     let message_id =
         tracker_message_id(string_value(&snapshot, "messageId").as_deref())?.to_string();
+    ensure_tracker_target_message_belongs_to_chat(state, chat_id, &message_id)?;
     let swipe_index = parse_swipe_index(snapshot.get("swipeIndex"))?;
     let mut existing = tracker_snapshots_for_target(state, chat_id, &message_id, swipe_index)?;
     sort_newest_first(&mut existing);
@@ -292,6 +293,34 @@ fn tracker_snapshots_for_target(
         .filter(is_tracker_snapshot)
         .filter(|row| non_negative_i64_value(row.get("swipeIndex")) == Some(swipe_index))
         .collect())
+}
+
+fn ensure_tracker_target_message_belongs_to_chat(
+    state: &AppState,
+    chat_id: &str,
+    message_id: &str,
+) -> AppResult<()> {
+    let chat_id = required_chat_id(chat_id)?;
+    let message_id = tracker_message_id(Some(message_id))?;
+    if message_id.is_empty() {
+        return Ok(());
+    }
+    let Some(message) = state.storage.get("messages", message_id)? else {
+        return Err(AppError::invalid_input(
+            "Tracker snapshot target message was not found",
+        ));
+    };
+    let message_chat_id = message
+        .get("chatId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    if message_chat_id != chat_id {
+        return Err(AppError::invalid_input(
+            "Tracker snapshot target message does not belong to the target chat",
+        ));
+    }
+    Ok(())
 }
 
 fn visible_tracker_snapshot(state: &AppState, chat_id: &str) -> AppResult<Option<Value>> {
@@ -600,6 +629,37 @@ fn parse_timestamp(value: Option<&Value>) -> Option<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    struct TempRoot(std::path::PathBuf);
+
+    impl TempRoot {
+        fn new(test_name: &str) -> Self {
+            let suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos();
+            Self(
+                std::env::temp_dir()
+                    .join(format!("marinara-tracker-snapshot-{test_name}-{suffix}")),
+            )
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn test_state(test_name: &str) -> (TempRoot, AppState) {
+        let root = TempRoot::new(test_name);
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        (root, state)
+    }
 
     #[test]
     fn normalize_tracker_snapshot_uses_repo_json_shape() {
@@ -686,6 +746,98 @@ mod tests {
             }),
         )
         .expect_err("malformed swipe index should fail");
+
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn save_tracker_snapshot_allows_message_from_same_chat() {
+        let (_root, state) = test_state("same-chat-message");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "turn"
+                }),
+            )
+            .expect("message should be created");
+
+        let snapshot = save_tracker_snapshot(
+            &state,
+            "chat-1",
+            json!({
+                "messageId": "message-1",
+                "location": "Harbor"
+            }),
+        )
+        .expect("same-chat message should save");
+
+        assert_eq!(snapshot["messageId"], "message-1");
+        assert_eq!(snapshot["location"], "Harbor");
+    }
+
+    #[test]
+    fn save_tracker_snapshot_allows_bootstrap_without_message_record() {
+        let (_root, state) = test_state("bootstrap-target");
+
+        let snapshot = save_tracker_snapshot(
+            &state,
+            "chat-1",
+            json!({
+                "messageId": "",
+                "location": "Harbor"
+            }),
+        )
+        .expect("bootstrap target should save without a message");
+
+        assert_eq!(snapshot["messageId"], "");
+        assert_eq!(snapshot["location"], "Harbor");
+    }
+
+    #[test]
+    fn save_tracker_snapshot_rejects_missing_target_message() {
+        let (_root, state) = test_state("missing-message");
+
+        let error = save_tracker_snapshot(
+            &state,
+            "chat-1",
+            json!({
+                "messageId": "missing-message"
+            }),
+        )
+        .expect_err("missing target message should fail");
+
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn save_tracker_snapshot_rejects_message_from_another_chat() {
+        let (_root, state) = test_state("wrong-chat-message");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-2",
+                    "role": "assistant",
+                    "content": "turn"
+                }),
+            )
+            .expect("message should be created");
+
+        let error = save_tracker_snapshot(
+            &state,
+            "chat-1",
+            json!({
+                "messageId": "message-1"
+            }),
+        )
+        .expect_err("cross-chat target message should fail");
 
         assert_eq!(error.code, "invalid_input");
     }

--- a/src/features/runtime/world-state/api/world-state-api.test.tsx
+++ b/src/features/runtime/world-state/api/world-state-api.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { storageApi } from "../../../../shared/api/storage-api";
+import { trackerSnapshotApi } from "../../../../shared/api/tracker-snapshot-api";
+import { worldStateApi, type WorldState } from "./world-state-api";
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    get: vi.fn(),
+    listChatMessages: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/tracker-snapshot-api", () => ({
+  trackerSnapshotApi: {
+    get: vi.fn(),
+    latest: vi.fn(),
+    save: vi.fn(),
+  },
+}));
+
+const storageGetMock = vi.mocked(storageApi.get);
+const listChatMessagesMock = vi.mocked(storageApi.listChatMessages);
+const snapshotGetMock = vi.mocked(trackerSnapshotApi.get);
+const snapshotLatestMock = vi.mocked(trackerSnapshotApi.latest);
+
+function state(overrides: Partial<WorldState> = {}): WorldState {
+  return {
+    id: "state-1",
+    chatId: "chat-1",
+    messageId: "message-1",
+    swipeIndex: 0,
+    date: null,
+    time: null,
+    location: "Harbor",
+    weather: null,
+    temperature: null,
+    presentCharacters: [
+      {
+        characterId: "character-1",
+        name: "Mari",
+        emoji: "",
+        mood: "",
+        appearance: null,
+        outfit: null,
+        customFields: {},
+        stats: [],
+        thoughts: null,
+      },
+    ],
+    recentEvents: [],
+    playerStats: null,
+    personaStats: null,
+    createdAt: "2026-05-26T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("worldStateApi.get", () => {
+  beforeEach(() => {
+    storageGetMock.mockReset();
+    listChatMessagesMock.mockReset();
+    snapshotGetMock.mockReset();
+    snapshotLatestMock.mockReset();
+  });
+
+  it("falls back to synced chat state from an older visible assistant target", async () => {
+    storageGetMock.mockResolvedValue({ gameState: state({ id: "chat-state", messageId: "message-1" }) });
+    listChatMessagesMock.mockResolvedValue([
+      { id: "message-1", role: "assistant", activeSwipeIndex: 0 },
+      { id: "message-2", role: "assistant", activeSwipeIndex: 0 },
+    ]);
+    snapshotGetMock.mockResolvedValue(null);
+    snapshotLatestMock.mockResolvedValue(null);
+
+    const result = await worldStateApi.get("chat-1");
+
+    expect(snapshotGetMock).toHaveBeenCalledWith("chat-1", { messageId: "message-2", swipeIndex: 0 });
+    expect(result).toEqual(expect.objectContaining({ location: "Harbor", messageId: "message-2", swipeIndex: 0 }));
+  });
+
+  it("falls back to the latest tracker snapshot when the visible target has no snapshot", async () => {
+    storageGetMock.mockResolvedValue({ gameState: null });
+    listChatMessagesMock.mockResolvedValue([
+      { id: "message-1", role: "assistant", activeSwipeIndex: 0 },
+      { id: "message-2", role: "assistant", activeSwipeIndex: 1 },
+    ]);
+    snapshotGetMock.mockResolvedValue(null);
+    snapshotLatestMock.mockResolvedValue({
+      ...state({ id: "snapshot-1", messageId: "message-1", location: "Library" }),
+      kind: "tracker",
+    });
+
+    const result = await worldStateApi.get("chat-1");
+
+    expect(snapshotLatestMock).toHaveBeenCalledWith("chat-1");
+    expect(result).toEqual(expect.objectContaining({ location: "Library", messageId: "message-2", swipeIndex: 1 }));
+  });
+
+  it("does not use a visible fallback for explicit target reads", async () => {
+    storageGetMock.mockResolvedValue({ gameState: state({ messageId: "message-1" }) });
+    snapshotGetMock.mockResolvedValue(null);
+
+    const result = await worldStateApi.get("chat-1", { messageId: "message-2", swipeIndex: 0 });
+
+    expect(listChatMessagesMock).not.toHaveBeenCalled();
+    expect(snapshotLatestMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("does not use chat state from a message outside the visible chat history", async () => {
+    storageGetMock.mockResolvedValue({ gameState: state({ messageId: "other-chat-message" }) });
+    listChatMessagesMock.mockResolvedValue([{ id: "message-2", role: "assistant", activeSwipeIndex: 0 }]);
+    snapshotGetMock.mockResolvedValue(null);
+    snapshotLatestMock.mockResolvedValue(null);
+
+    await expect(worldStateApi.get("chat-1")).resolves.toBeNull();
+  });
+});

--- a/src/features/runtime/world-state/api/world-state-api.ts
+++ b/src/features/runtime/world-state/api/world-state-api.ts
@@ -124,6 +124,9 @@ function canUseChatGameStateFallback(
   const exact = stateTarget.messageId === target.messageId && stateTarget.swipeIndex === target.swipeIndex;
   if (options.requestedTarget) return exact;
   if (exact && options.hasVisibleTarget) return true;
+  if (options.hasVisibleTarget && stateTarget.messageId) {
+    return options.activeTargetKeys?.has(targetKey(stateTarget)) ?? false;
+  }
   return exact && (options.activeTargetKeys?.has(targetKey(stateTarget)) ?? false);
 }
 
@@ -180,13 +183,20 @@ async function getWorldState(
     throwIfAborted(init);
     if (snapshot) return snapshot;
   }
-  return canUseChatGameStateFallback(chat?.gameState, target, {
-    activeTargetKeys: visibleContext?.activeTargetKeys,
-    hasVisibleTarget: !!visibleContext?.target,
-    requestedTarget: !!requestedTarget,
-  }) && chat?.gameState
-    ? withTarget(chat.gameState, chatId, target)
-    : null;
+  if (
+    canUseChatGameStateFallback(chat?.gameState, target, {
+      activeTargetKeys: visibleContext?.activeTargetKeys,
+      hasVisibleTarget: !!visibleContext?.target,
+      requestedTarget: !!requestedTarget,
+    }) &&
+    chat?.gameState
+  ) {
+    return withTarget(chat.gameState, chatId, target);
+  }
+  const latestSnapshot = !requestedTarget && target ? await trackerSnapshotApi.latest(chatId).catch(() => null) : null;
+  throwIfAborted(init);
+  if (latestSnapshot) return withTarget(latestSnapshot, chatId, target);
+  return null;
 }
 
 export const worldStateApi: WorldStateApi = {

--- a/src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.test.tsx
+++ b/src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { npcAvatarApi } from "../../../../shared/api/avatar-api";
+import type { PresentCharacter } from "../../../../engine/contracts/types/game-state";
+import { useGameStateStore } from "../stores/world-state.store";
+import { useTrackerCharacterAvatarActions } from "./use-tracker-character-avatar-actions";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../../../../shared/api/avatar-api", () => ({
+  npcAvatarApi: {
+    upload: vi.fn(),
+  },
+}));
+
+vi.mock("../../../catalog/agents/index", () => ({
+  useAgentConfigs: vi.fn(() => ({ data: [] })),
+  useUpdateAgent: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+const uploadMock = vi.mocked(npcAvatarApi.upload);
+
+function character(overrides: Partial<PresentCharacter> = {}): PresentCharacter {
+  return {
+    characterId: "character-1",
+    name: "Mari",
+    emoji: "",
+    mood: "",
+    appearance: null,
+    outfit: null,
+    customFields: {},
+    stats: [],
+    thoughts: null,
+    ...overrides,
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useTrackerCharacterAvatarActions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+  let originalFileReader: typeof FileReader;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    useGameStateStore.getState().reset();
+    uploadMock.mockReset();
+    originalFileReader = globalThis.FileReader;
+    class TestFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: DOMException | null = null;
+      onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+      onerror: ((event: ProgressEvent<FileReader>) => void) | null = null;
+
+      readAsDataURL(file: File) {
+        setTimeout(() => {
+          this.result = `data:${file.type};name=${file.name};base64,test`;
+          this.onload?.(new ProgressEvent("load") as ProgressEvent<FileReader>);
+        }, 0);
+      }
+    }
+    globalThis.FileReader = TestFileReader as unknown as typeof FileReader;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    useGameStateStore.getState().reset();
+    globalThis.FileReader = originalFileReader;
+  });
+
+  async function renderHook<TValue>(useHook: () => TValue): Promise<TValue> {
+    let value: TValue | undefined;
+
+    function Probe() {
+      value = useHook();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        createElement(QueryClientProvider, {
+          client: queryClient,
+          children: createElement(Probe),
+        }),
+      );
+    });
+
+    if (!value) throw new Error("Hook did not render");
+    return value;
+  }
+
+  it("keeps an older upload completion from overwriting a newer avatar for the same character", async () => {
+    const firstUpload = createDeferred<{ avatarPath: string }>();
+    uploadMock
+      .mockReturnValueOnce(firstUpload.promise as never)
+      .mockResolvedValueOnce({ avatarPath: "asset://newer.png" } as never);
+    useGameStateStore.getState().setGameState({
+      id: "state-1",
+      chatId: "chat-1",
+      messageId: "message-1",
+      swipeIndex: 0,
+      date: null,
+      time: null,
+      location: null,
+      weather: null,
+      temperature: null,
+      presentCharacters: [character()],
+      recentEvents: [],
+      playerStats: null,
+      personaStats: null,
+      createdAt: "2026-05-26T10:00:00.000Z",
+    });
+    const updates: unknown[] = [];
+    const actions = await renderHook(() =>
+      useTrackerCharacterAvatarActions({
+        chatId: "chat-1",
+        characters: [character()],
+        onUpdateCharacters: (characters) => {
+          updates.push(characters);
+          useGameStateStore.getState().setGameState({
+            ...useGameStateStore.getState().current!,
+            presentCharacters: characters,
+          });
+        },
+      }),
+    );
+    const older = new File(["older"], "older.png", { type: "image/png" });
+    const newer = new File(["newer"], "newer.png", { type: "image/png" });
+
+    const firstPromise = actions.uploadCharacterAvatar(0, older);
+    await vi.waitFor(() => expect(uploadMock).toHaveBeenCalledTimes(1));
+    const secondPromise = actions.uploadCharacterAvatar(0, newer);
+    await act(async () => {
+      await secondPromise;
+    });
+    firstUpload.resolve({ avatarPath: "asset://older.png" });
+    await act(async () => {
+      await firstPromise;
+    });
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toEqual([
+      expect.objectContaining({ characterId: "character-1", avatarPath: "asset://newer.png" }),
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1804

## Why this change

Runtime tracker/world-state parity had three regressions from the legacy path:

- opening the tracker on a visible assistant turn with no exact snapshot could show no tracker data even when older tracker state existed;
- stale tracker avatar upload completions needed regression coverage so older responses cannot overwrite newer selections;
- targeted tracker snapshot saves accepted a non-bootstrap `messageId` without proving it belongs to the target chat.

## What changed

- `worldStateApi.get` now falls back from a missing exact visible snapshot to synced chat tracker state from another visible assistant target, then to the latest tracker snapshot, stamping the fallback to the currently visible target.
- Added focused Vitest coverage for visible fallback, latest snapshot fallback, explicit-target negative control, and outside-history negative control.
- Added focused Vitest coverage proving the current per-character tracker avatar upload token keeps an older completion from overwriting a newer avatar.
- `save_tracker_snapshot` now validates non-bootstrap target messages before save, rejecting missing or cross-chat targets while preserving bootstrap saves.
- Added Rust unit coverage for same-chat target saves, bootstrap saves, missing target rejection, and cross-chat target rejection.

## Refactor impact

Primary owner:

Runtime world-state and Rust storage.

Impact areas reviewed:

- Tracker sidebar/world-state read path.
- Tracker avatar upload async ordering.
- Tauri and HTTP runtime tracker snapshot save path via shared Rust storage function.

Boundary notes:

- Feature runtime code still calls shared API wrappers; no raw Tauri imports were added.
- Rust storage owns the privileged message-ownership enforcement.
- Engine contracts are consumed only as types; no React imports were added to engine code.
- No dependency, schema, auth, prompt-pipeline, import/export, migration, release, or version files changed.

Pressure points touched:

- TrackerDataSidebar data source through `worldStateApi.get`.
- `tracker_snapshot_save` command implementation through `game_state_snapshots::save_tracker_snapshot`.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Codex-run proof:

- `pnpm test src/features/runtime/world-state/api/world-state-api.test.tsx src/features/runtime/world-state/hooks/use-tracker-character-avatar-actions.test.tsx` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml game_state_snapshots::tests::save_tracker_snapshot -- --nocapture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- Marinara proof gate passed locally on the structured verification artifact.
- Bunny review pass found no blocking issues before PR open.

Manual limitation:

- I did not capture a reviewer-visible before/after app screenshot for the tracker sidebar. The core fallback and save paths are covered by targeted harness tests and full repo validation, but the PR is intentionally left draft for any desired visual confirmation.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a parity bugfix for existing tracker/world-state behavior and does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release metadata changes were needed for this runtime/storage bugfix.

## UI evidence (if applicable)

No screenshot captured. This PR is kept draft; the changed behavior is covered by focused runtime/storage tests and full `pnpm check`.
