### PR TITLE
Fix haptic command safeguards

### DIFF
--- a/src-tauri/src/commands/storage/integrations/haptic.rs
+++ b/src-tauri/src/commands/storage/integrations/haptic.rs
@@ -5,7 +5,8 @@ use buttplug::{
     ButtplugClient, ButtplugClientDevice, ButtplugWebsocketClientTransport,
 };
 use buttplug_core::message::OutputType;
-use std::sync::OnceLock;
+use std::{collections::HashMap, sync::OnceLock};
+use tauri::async_runtime::JoinHandle;
 use tokio::sync::Mutex;
 
 const DEFAULT_INTIFACE_URL: &str = "ws://127.0.0.1:12345";
@@ -21,6 +22,9 @@ struct HapticRuntime {
     preferred_server_url: Option<String>,
     scanning: bool,
     last_command_at: u128,
+    stop_tasks: HashMap<u32, JoinHandle<()>>,
+    stop_task_generations: HashMap<u32, u64>,
+    next_stop_task_generation: u64,
 }
 
 pub(crate) async fn haptic_call(rest: &[&str], body: Value) -> AppResult<Value> {
@@ -100,6 +104,7 @@ async fn disconnect() -> AppResult<Value> {
             let _ = client.disconnect().await;
         }
     }
+    clear_stop_tasks(&mut runtime);
     runtime.server_url = None;
     runtime.scanning = false;
     Ok(status_value(&runtime))
@@ -130,7 +135,8 @@ async fn stop_scan() -> AppResult<Value> {
 }
 
 async fn stop_all() -> AppResult<Value> {
-    let runtime = runtime().lock().await;
+    let mut runtime = runtime().lock().await;
+    clear_stop_tasks(&mut runtime);
     if let Some(client) = runtime.client.as_ref().filter(|client| client.connected()) {
         client
             .stop_all_devices()
@@ -165,20 +171,89 @@ async fn command(body: Value) -> AppResult<Value> {
     let targets = command_targets(client, &body)?;
     let intensity = clamp_unit(body.get("intensity"), 0.5);
     let duration = clamp_duration(body.get("duration"));
+    if targets.is_empty() {
+        return Err(AppError::invalid_input("No connected haptic devices"));
+    }
 
+    let mut successes = Vec::new();
+    let mut failures = Vec::new();
     for device in &targets {
-        run_device_command(device, action, intensity, duration).await?;
+        let index = device.index();
+        if action == "stop" {
+            cancel_stop_task(&mut runtime, index);
+        }
+        match run_device_command(device, action, intensity, duration).await {
+            Ok(()) => {
+                if action != "stop" && (duration <= 0.0 || action == "position") {
+                    cancel_stop_task(&mut runtime, index);
+                }
+                successes.push(index);
+            }
+            Err(error) => failures.push(json!({
+                "deviceIndex": index,
+                "deviceName": device.display_name().as_deref().unwrap_or(device.name()),
+                "error": error.message,
+            })),
+        }
+    }
+    if successes.is_empty() {
+        let error = failures
+            .first()
+            .and_then(|failure| failure.get("error"))
+            .and_then(Value::as_str)
+            .unwrap_or("Haptic command failed");
+        return Err(AppError::new("haptic_command_failed", error));
     }
     if duration > 0.0 && action != "position" && action != "stop" {
-        let stop_targets = targets.clone();
-        tauri::async_runtime::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs_f64(duration)).await;
-            for device in stop_targets {
-                let _ = device.stop().await;
-            }
-        });
+        for device in targets
+            .iter()
+            .filter(|device| successes.contains(&device.index()))
+            .cloned()
+        {
+            schedule_stop_task(&mut runtime, device, duration);
+        }
     }
-    Ok(json!({ "ok": true }))
+    Ok(json!({
+        "ok": failures.is_empty(),
+        "successes": successes,
+        "failures": failures
+    }))
+}
+
+fn clear_stop_tasks(runtime: &mut HapticRuntime) {
+    for (_, task) in runtime.stop_tasks.drain() {
+        task.abort();
+    }
+    runtime.stop_task_generations.clear();
+}
+
+fn cancel_stop_task(runtime: &mut HapticRuntime, device_index: u32) {
+    if let Some(task) = runtime.stop_tasks.remove(&device_index) {
+        task.abort();
+    }
+    runtime.stop_task_generations.remove(&device_index);
+}
+
+fn schedule_stop_task(state: &mut HapticRuntime, device: ButtplugClientDevice, duration: f64) {
+    let device_index = device.index();
+    cancel_stop_task(state, device_index);
+    state.next_stop_task_generation = state.next_stop_task_generation.saturating_add(1);
+    let generation = state.next_stop_task_generation;
+    state.stop_task_generations.insert(device_index, generation);
+    let task = tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs_f64(duration)).await;
+        let _ = device.stop().await;
+        let mut state = runtime().lock().await;
+        if state
+            .stop_task_generations
+            .get(&device_index)
+            .is_some_and(|current| *current == generation)
+        {
+            state.stop_tasks.remove(&device_index);
+            state.stop_task_generations.remove(&device_index);
+        }
+    });
+    state.stop_tasks.insert(device_index, task);
 }
 
 fn enforce_command_rate_limit(

--- a/src/engine/capabilities/integrations.ts
+++ b/src/engine/capabilities/integrations.ts
@@ -9,6 +9,8 @@ export interface SpotifyGateway {
 }
 
 export interface HapticGateway {
+  status<T = unknown>(): Promise<T>;
+  connect<T = unknown>(input?: { url?: string | null }): Promise<T>;
   command<T = unknown>(input: Record<string, unknown>): Promise<T>;
   stopAll<T = unknown>(): Promise<T>;
 }

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -6,6 +6,7 @@ import {
   type AgentContext,
   type AgentResult,
 } from "../contracts/types/agent";
+import type { HapticDevice, HapticStatus } from "../contracts/types/haptic";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway, LlmMessage } from "../capabilities/llm";
 import type { StorageGateway } from "../capabilities/storage";
@@ -115,6 +116,7 @@ interface ResolvedAgentsResult {
 const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const DIRECTOR_AGENT_TYPE = "director";
 const ILLUSTRATOR_AGENT_TYPE = "illustrator";
+const HAPTIC_AGENT_TYPE = "haptic";
 const KNOWLEDGE_RETRIEVAL_AGENT_TYPE = "knowledge-retrieval";
 const KNOWLEDGE_ROUTER_AGENT_TYPE = "knowledge-router";
 const KNOWLEDGE_AGENT_TYPES = new Set([KNOWLEDGE_RETRIEVAL_AGENT_TYPE, KNOWLEDGE_ROUTER_AGENT_TYPE]);
@@ -834,7 +836,9 @@ function skippedLorebookKeeperTargetResult(agent: JsonRecord): AgentResult {
 
 function suppressAgentForTurn(input: GenerationAgentRuntimeInput, type: string): boolean {
   const isRegeneration = !!readString(input.regenerateMessageId).trim();
-  return isRegeneration && type === "echo-chamber";
+  if (isRegeneration && type === "echo-chamber") return true;
+  if (type === HAPTIC_AGENT_TYPE) return !boolish(chatMetadata(input).enableHapticFeedback, false);
+  return false;
 }
 
 async function resolveLorebookKeeperRuntimeTarget(
@@ -1183,6 +1187,51 @@ async function populateAgentVisualContext(
   }
 }
 
+function hapticAgentActive(agents: ResolvedAgent[]): boolean {
+  return agents.some((agent) => agent.type === HAPTIC_AGENT_TYPE);
+}
+
+function normalizedHapticDevices(status: HapticStatus | null): HapticDevice[] {
+  if (!status?.connected || !Array.isArray(status.devices)) return [];
+  return status.devices
+    .filter((device): device is HapticDevice => {
+      return (
+        typeof device.index === "number" &&
+        typeof device.name === "string" &&
+        Array.isArray(device.capabilities)
+      );
+    })
+    .map((device) => ({
+      index: device.index,
+      name: device.name,
+      capabilities: device.capabilities.filter((capability): capability is HapticDevice["capabilities"][number] =>
+        typeof capability === "string",
+      ),
+    }));
+}
+
+async function hapticStatusWithAutoConnect(
+  integrations: IntegrationGateway,
+  chatMeta: JsonRecord,
+): Promise<HapticStatus | null> {
+  const current = await integrations.haptic.status<HapticStatus>().catch(() => null);
+  if (current?.connected && normalizedHapticDevices(current).length > 0) return current;
+  const url = readString(chatMeta.hapticIntifaceUrl).trim();
+  return integrations.haptic.connect<HapticStatus>(url ? { url } : undefined).catch(() => current);
+}
+
+async function populateHapticDeviceContext(
+  integrations: IntegrationGateway,
+  agents: ResolvedAgent[],
+  memory: Record<string, unknown>,
+  chatMeta: JsonRecord,
+): Promise<void> {
+  if (!hapticAgentActive(agents) || !boolish(chatMeta.enableHapticFeedback, false)) return;
+  const status = await hapticStatusWithAutoConnect(integrations, chatMeta);
+  const devices = normalizedHapticDevices(status);
+  if (devices.length > 0) memory._connectedDevices = devices;
+}
+
 async function buildAgentContext(
   deps: AgentDeps,
   input: GenerationAgentRuntimeInput,
@@ -1205,6 +1254,7 @@ async function buildAgentContext(
     const existingLorebookEntries = await loadLorebookKeeperEntries(deps.storage, input);
     if (existingLorebookEntries) memory._existingLorebookEntries = existingLorebookEntries;
   }
+  await populateHapticDeviceContext(deps.integrations, agents, memory, chatMeta);
   const context: AgentContext = {
     chatId,
     chatMode,

--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { persistConnectedCommandTags } from "./connected-commands";
+
+const storage = {} as never;
+
+type HapticGateCase = {
+  name: string;
+  metadata: Record<string, unknown>;
+  shouldExecute: boolean;
+};
+
+const hapticGateCases: HapticGateCase[] = [
+  {
+    name: "character commands disabled, haptic feedback disabled",
+    metadata: { characterCommands: false, enableHapticFeedback: false },
+    shouldExecute: false,
+  },
+  {
+    name: "character commands enabled, haptic feedback disabled",
+    metadata: { characterCommands: true, enableHapticFeedback: false },
+    shouldExecute: false,
+  },
+  {
+    name: "character commands disabled, haptic feedback enabled",
+    metadata: { characterCommands: false, enableHapticFeedback: true },
+    shouldExecute: false,
+  },
+  {
+    name: "character commands enabled, haptic feedback enabled",
+    metadata: { characterCommands: true, enableHapticFeedback: true },
+    shouldExecute: true,
+  },
+];
+
+describe("persistConnectedCommandTags", () => {
+  test.each(hapticGateCases)("gates haptic commands when $name", async (testCase) => {
+    let commandCalls = 0;
+    const result = await persistConnectedCommandTags(
+      storage,
+      { id: "chat-1", mode: "conversation", metadata: testCase.metadata },
+      'ok [haptic: action="vibrate", intensity=0.7, duration=2]',
+      {
+        haptic: {
+          status: async <T = unknown>() => ({ connected: true, devices: [] } as T),
+          connect: async <T = unknown>() => ({ connected: true, devices: [] } as T),
+          command: async <T = unknown>() => {
+            commandCalls += 1;
+            return { ok: true } as T;
+          },
+          stopAll: async <T = unknown>() => ({ ok: true } as T),
+        },
+        spotify: {} as never,
+        customTools: {} as never,
+        image: {} as never,
+      },
+    );
+
+    expect(commandCalls > 0).toBe(testCase.shouldExecute);
+    expect(result.executedCommands.includes("haptic")).toBe(testCase.shouldExecute);
+  });
+});

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -480,6 +480,14 @@ function eventsPushCommandError(events: ConnectedCommandEvent[], command: string
   events.push({ type: "command_error", data: { command, error } });
 }
 
+function characterCommandsEnabled(chat: JsonRecord): boolean {
+  return boolish(parseRecord(chat.metadata).characterCommands, true);
+}
+
+function hapticFeedbackEnabled(chat: JsonRecord): boolean {
+  return boolish(parseRecord(chat.metadata).enableHapticFeedback, false);
+}
+
 async function createSceneFromCommand(args: {
   storage: StorageGateway;
   llm?: LlmGateway;
@@ -700,6 +708,9 @@ async function executeCommand(
       return { name: "memory" };
     }
     case "haptic":
+      if (!characterCommandsEnabled(chat) || !hapticFeedbackEnabled(chat)) {
+        return null;
+      }
       if (integrations) {
         await integrations.haptic.command({
           action: command.action,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1814,7 +1814,7 @@ function buildConversationCommandBlock(
 ): ChatMLMessage | null {
   if (modeOf(chat) !== "conversation") return null;
   const meta = parseRecord(chat.metadata);
-  if (!boolish(meta.characterCommands, true)) return null;
+  if (!boolish(meta.characterCommands, false)) return null;
   const capabilities = conversationCommandCapabilities(chat, meta);
   const schedules = parseRecord(meta.characterSchedules);
   const hasSchedules =

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1814,7 +1814,7 @@ function buildConversationCommandBlock(
 ): ChatMLMessage | null {
   if (modeOf(chat) !== "conversation") return null;
   const meta = parseRecord(chat.metadata);
-  if (!boolish(meta.characterCommands, false)) return null;
+  if (!boolish(meta.characterCommands, true)) return null;
   const capabilities = conversationCommandCapabilities(chat, meta);
   const schedules = parseRecord(meta.characterSchedules);
   const hasSchedules =

--- a/src/engine/modes/chat/commands/character-commands.ts
+++ b/src/engine/modes/chat/commands/character-commands.ts
@@ -90,7 +90,7 @@ export interface DirectMessageCommand {
 interface HapticCommand {
   type: "haptic";
   /** Device action */
-  action: "vibrate" | "oscillate" | "rotate" | "position" | "stop";
+  action: "vibrate" | "oscillate" | "rotate" | "constrict" | "position" | "stop";
   /** Intensity / speed (0.0-1.0) */
   intensity?: number;
   /** Duration in seconds */
@@ -628,7 +628,7 @@ export function parseCharacterCommands(content: string): {
     const actionMatch = params.match(/action="([^"]+)"/);
     if (actionMatch) {
       const a = actionMatch[1]!.toLowerCase();
-      if (["vibrate", "oscillate", "rotate", "position", "stop"].includes(a)) {
+      if (["vibrate", "oscillate", "rotate", "constrict", "position", "stop"].includes(a)) {
         cmd.action = a as HapticCommand["action"];
       }
     }

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -60,6 +60,7 @@ import {
 } from "../../../../engine/shared/game-state/player-stats";
 import type { AgentDebugEntry } from "../../../../engine/contracts/types/agent";
 import type { IntegrationGateway } from "../../../../engine/capabilities/integrations";
+import type { HapticStatus } from "../../../../engine/contracts/types/haptic";
 
 export type GenerateArgs = GenerationReplayInput & {
   chatId: string;
@@ -858,6 +859,8 @@ function delay(ms: number): Promise<void> {
 }
 
 async function applyHapticAgentResult(rawData: unknown) {
+  const status = await integrationGateway.haptic.status<HapticStatus>().catch(() => null);
+  if (!status?.connected || !Array.isArray(status.devices) || status.devices.length === 0) return;
   const data = parseMaybeRecord(rawData);
   const rawCommands = Array.isArray(data.commands) ? data.commands : [];
   for (const rawCommand of rawCommands) {
@@ -879,6 +882,13 @@ async function applyHapticAgentResult(rawData: unknown) {
       console.warn("Failed to send haptic agent command", error);
     }
   }
+}
+
+async function hapticFeedbackEnabledForChat(queryClient: QueryClient, chatId: string): Promise<boolean> {
+  const cachedChat =
+    queryClient.getQueryData<Chat>(chatKeys.detail(chatId)) ??
+    ((await storageApi.get<Chat>("chats", chatId).catch(() => null)) as Chat | null);
+  return parseMaybeRecord(cachedChat?.metadata).enableHapticFeedback === true;
 }
 
 async function applyAgentResultEffects(
@@ -955,7 +965,9 @@ async function applyAgentResultEffects(
     }
   }
 
-  if (result.type === "haptic_command" || result.agentType === "haptic") await applyHapticAgentResult(result.data);
+  if (result.type === "haptic_command" || result.agentType === "haptic") {
+    if (await hapticFeedbackEnabledForChat(queryClient, chatId)) await applyHapticAgentResult(result.data);
+  }
   if (result.type === "background_change" || result.agentType === "background") {
     await applyBackgroundChoice(chatId, data.chosen);
   }

--- a/src/shared/api/haptics-api.ts
+++ b/src/shared/api/haptics-api.ts
@@ -2,8 +2,8 @@ import type { HapticDeviceCommand, HapticStatus } from "../../engine/contracts/t
 import { invokeTauri } from "./tauri-client";
 
 export const hapticsApi = {
-  status: () => invokeTauri<HapticStatus>("haptic_status"),
-  connect: (url?: string) => invokeTauri<HapticStatus>("haptic_connect", { body: url ? { url } : null }),
+  status: <T = HapticStatus>() => invokeTauri<T>("haptic_status"),
+  connect: <T = HapticStatus>(url?: string) => invokeTauri<T>("haptic_connect", { body: url ? { url } : null }),
   disconnect: () => invokeTauri<HapticStatus>("haptic_disconnect"),
   startScan: <T = unknown>() => invokeTauri<T>("haptic_start_scan"),
   stopScan: <T = unknown>() => invokeTauri<T>("haptic_stop_scan"),

--- a/src/shared/api/integration-gateway.ts
+++ b/src/shared/api/integration-gateway.ts
@@ -19,6 +19,8 @@ export const integrationGateway: IntegrationGateway = {
     volume: <T = unknown>(input: Record<string, unknown>) => spotifyApi.volume(input) as Promise<T>,
   },
   haptic: {
+    status: <T = unknown>() => hapticsApi.status<T>(),
+    connect: <T = unknown>(input?: { url?: string | null }) => hapticsApi.connect<T>(input?.url ?? undefined),
     command: <T = unknown>(input: Record<string, unknown>) => hapticsApi.command<T>(input),
     stopAll: <T = unknown>() => hapticsApi.stopAll<T>(),
   },


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1800

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Haptic output could still execute from hidden generated tags or haptic-agent results without re-checking the chat's haptic controls and live device state.
- The Rust haptic runtime also needed to preserve safer legacy-style behavior for mixed-device commands and managed duration stop timers.

## What changed

<!-- List the key changes in this PR. -->

- Gates hidden `[haptic: ...]` commands behind both `metadata.characterCommands` and `metadata.enableHapticFeedback`, with regression coverage for each enabled/disabled combination.
- Preserves the existing conversation command prompt default: command instructions stay quiet unless `characterCommands` is explicitly enabled, while haptic execution still re-checks both chat controls before running.
- Adds haptic status/connect methods to the shared integration gateway so engine haptic agents can auto-connect with the chat Intiface URL and receive connected device names/capabilities.
- Skips haptic-agent execution/replay when haptic feedback is disabled or no connected devices are available.
- Restores `constrict` parsing for hidden haptic tags.
- Updates the Rust haptic command path to return partial-success results, avoid failing all targets on the first incompatible device, and replace/clear per-target duration stop timers.

## Refactor impact

Primary owner:

Engine generation and Rust haptic integration runtime.

Impact areas reviewed:

- `src/engine/generation/connected-commands.ts`
- `src/engine/generation/agent-runner.ts`
- `src/features/runtime/generation/hooks/use-generate.ts`
- `src/shared/api/integration-gateway.ts`
- `src-tauri/src/commands/storage/integrations/haptic.rs`

Boundary notes:

- Engine code depends only on the haptic gateway contract, not React, raw Tauri calls, or feature internals.
- Feature replay remains in the runtime generation hook and calls the focused shared API gateway.
- Privileged device execution, partial success, rate limiting, and timer management remain in Rust.
- Haptics remain Tauri-local; this PR does not add a remote/browser haptics transport.

Pressure points touched:

- Runtime generation haptic agent result handling.
- Engine connected-command execution.
- Tauri haptic integration command handling.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

Codex-run proof:

- Before fix, `pnpm exec vitest run src/engine/generation/connected-commands.test.ts` failed 3 of 4 haptic gate cases because hidden haptic commands executed when one or both gates were disabled.
- After fix, `pnpm exec vitest run src/engine/generation/connected-commands.test.ts` passed.
- `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/generation/connected-commands.test.ts` passed after preserving the prompt default.
- `pnpm test` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml haptic --lib` passed.
- `pnpm check` passed.
- The Marinara proof gate passed locally against the verification artifact.
- Bunny review pass completed before opening this draft.

Manual limitations:

- Physical Intiface/haptic hardware QA was not available in this environment, so real-device vibration/rotation/constriction behavior and mixed real-device partial success were not manually observed.
- `inflate` was not restored. Local Buttplug Rust 10.0.2 sources have `OutputType::Inflate` commented out and no `ClientDeviceOutputCommand::Inflate` variant, so restoring it needs a separate dependency/API decision.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing haptics behavior; no new discoverable workflow was added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence (if applicable)

N/A; this is backend/engine/Rust haptic behavior. Proof is command-output based, with physical hardware QA called out above as unavailable.
