### PR TITLE
Fix off-chat generation notifications

### DIFF
--- a/src/features/runtime/generation/hooks/use-generate.test.ts
+++ b/src/features/runtime/generation/hooks/use-generate.test.ts
@@ -32,6 +32,15 @@ vi.mock("../../../../shared/lib/notification-sound", () => ({
   playNotificationPing: vi.fn(),
 }));
 
+vi.mock("../../world-state/index", () => ({
+  useGameStateStore: {
+    getState: () => ({ setGameState: vi.fn() }),
+  },
+  worldStateApi: {
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
 const markAutonomousUnreadMock = vi.mocked(chatCommandApi.markAutonomousUnread);
 const storageGetMock = vi.mocked(storageApi.get);
 const showConversationLocalNotificationMock = vi.mocked(showConversationLocalNotification);
@@ -115,7 +124,8 @@ describe("runGenerationWithUi notifications", () => {
     showConversationLocalNotificationMock.mockResolvedValue(true);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
     queryClient.clear();
     useChatStore.getState().reset();
     vi.clearAllMocks();

--- a/src/features/runtime/generation/hooks/use-generate.test.ts
+++ b/src/features/runtime/generation/hooks/use-generate.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat, Message } from "../../../../engine/contracts/types/chat";
+import { chatCommandApi } from "../../../../shared/api/chat-command-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { showConversationLocalNotification } from "../../../../shared/lib/local-notifications";
+import { playNotificationPing } from "../../../../shared/lib/notification-sound";
+import { useChatStore } from "../../../../shared/stores/chat.store";
+import { useUIStore } from "../../../../shared/stores/ui.store";
+import { chatKeys } from "../../../catalog/chats";
+import { runGenerationWithUi, type GenerateArgs } from "./use-generate";
+
+vi.mock("../../../../shared/api/chat-command-api", () => ({
+  chatCommandApi: {
+    markAutonomousUnread: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/lib/local-notifications", () => ({
+  showConversationLocalNotification: vi.fn(),
+}));
+
+vi.mock("../../../../shared/lib/notification-sound", () => ({
+  playNotificationPing: vi.fn(),
+}));
+
+const markAutonomousUnreadMock = vi.mocked(chatCommandApi.markAutonomousUnread);
+const storageGetMock = vi.mocked(storageApi.get);
+const showConversationLocalNotificationMock = vi.mocked(showConversationLocalNotification);
+const playNotificationPingMock = vi.mocked(playNotificationPing);
+
+function chat(overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: "chat-1",
+    name: "Chat",
+    mode: "conversation",
+    characterIds: ["char-1"],
+    groupId: null,
+    personaId: null,
+    promptPresetId: null,
+    connectionId: null,
+    connectedChatId: null,
+    folderId: null,
+    sortOrder: 0,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    metadata: {} as Chat["metadata"],
+    ...overrides,
+  };
+}
+
+function assistantMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "message-1",
+    chatId: "chat-1",
+    role: "assistant",
+    characterId: "char-1",
+    content: "Fresh reply",
+    activeSwipeIndex: 0,
+    createdAt: "2026-06-01T00:00:01.000Z",
+    extra: {} as Message["extra"],
+    ...overrides,
+  };
+}
+
+async function* stream(events: Array<{ type: string; data?: unknown }>) {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+async function runAssistantMessage(queryClient: QueryClient, args: GenerateArgs, message: Message) {
+  return runGenerationWithUi(queryClient, args, () => stream([{ type: "assistant_message", data: message }]));
+}
+
+describe("runGenerationWithUi notifications", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+    useChatStore.getState().reset();
+    useChatStore.getState().setActiveChatId("other-chat");
+    useUIStore.setState({
+      convoNotificationSound: true,
+      rpNotificationSound: true,
+      conversationBrowserNotifications: true,
+    });
+    markAutonomousUnreadMock.mockResolvedValue(chat());
+    storageGetMock.mockImplementation(async (collection, id) => {
+      if (collection === "characters" && id === "char-1") {
+        return {
+          id: "char-1",
+          avatarPath: "/avatars/mari.png",
+          data: {
+            name: "Mari",
+            extensions: { avatarCrop: { x: 1, y: 2, scale: 3 } },
+          },
+        };
+      }
+      throw new Error(`Unexpected storage get: ${String(collection)} ${String(id)}`);
+    });
+    showConversationLocalNotificationMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    useChatStore.getState().reset();
+    vi.clearAllMocks();
+  });
+
+  it("marks an off-chat Conversation generation unread and shows its avatar bubble", async () => {
+    const currentChat = chat();
+    const message = assistantMessage();
+    queryClient.setQueryData(chatKeys.detail(currentChat.id), currentChat);
+    queryClient.setQueryData(chatKeys.messages(currentChat.id), { pages: [[]], pageParams: [undefined] });
+
+    await runAssistantMessage(queryClient, { chatId: currentChat.id }, message);
+
+    const chatState = useChatStore.getState();
+    expect(markAutonomousUnreadMock).toHaveBeenCalledWith(currentChat.id, { characterId: "char-1" });
+    expect(chatState.unreadCounts.get(currentChat.id)).toBe(1);
+    expect(chatState.chatNotifications.get(currentChat.id)).toMatchObject({
+      chatId: currentChat.id,
+      characterName: "Mari",
+      avatarUrl: "/avatars/mari.png",
+      avatarCrop: { x: 1, y: 2, scale: 3 },
+      count: 1,
+    });
+    expect(playNotificationPingMock).toHaveBeenCalledTimes(1);
+    expect(showConversationLocalNotificationMock).toHaveBeenCalledWith({
+      enabled: true,
+      characterName: "Mari",
+      tag: `marinara-conversation-${currentChat.id}`,
+    });
+  });
+
+  it("uses the Roleplay notification sound toggle for off-chat Roleplay generation", async () => {
+    const currentChat = chat({ mode: "roleplay" });
+    const message = assistantMessage();
+    queryClient.setQueryData(chatKeys.detail(currentChat.id), currentChat);
+    queryClient.setQueryData(chatKeys.messages(currentChat.id), { pages: [[]], pageParams: [undefined] });
+    useUIStore.setState({ convoNotificationSound: false, rpNotificationSound: true });
+
+    await runAssistantMessage(queryClient, { chatId: currentChat.id }, message);
+
+    expect(playNotificationPingMock).toHaveBeenCalledTimes(1);
+    expect(showConversationLocalNotificationMock).not.toHaveBeenCalled();
+    expect(useChatStore.getState().unreadCounts.get(currentChat.id)).toBe(1);
+  });
+
+  it("does not notify when the generated chat is still active", async () => {
+    const currentChat = chat();
+    const message = assistantMessage();
+    queryClient.setQueryData(chatKeys.detail(currentChat.id), currentChat);
+    queryClient.setQueryData(chatKeys.messages(currentChat.id), { pages: [[]], pageParams: [undefined] });
+    useChatStore.getState().setActiveChatId(currentChat.id);
+
+    await runAssistantMessage(queryClient, { chatId: currentChat.id }, message);
+
+    expect(markAutonomousUnreadMock).not.toHaveBeenCalled();
+    expect(playNotificationPingMock).not.toHaveBeenCalled();
+    expect(showConversationLocalNotificationMock).not.toHaveBeenCalled();
+    expect(useChatStore.getState().unreadCounts.has(currentChat.id)).toBe(false);
+    expect(useChatStore.getState().chatNotifications.has(currentChat.id)).toBe(false);
+  });
+
+  it("does not notify if the user returns before notification metadata resolves", async () => {
+    const currentChat = chat();
+    const message = assistantMessage();
+    queryClient.setQueryData(chatKeys.detail(currentChat.id), currentChat);
+    queryClient.setQueryData(chatKeys.messages(currentChat.id), { pages: [[]], pageParams: [undefined] });
+    let resolveCharacter!: (value: unknown) => void;
+    const characterPromise = new Promise((resolve) => {
+      resolveCharacter = resolve;
+    });
+    storageGetMock.mockImplementation(async (collection, id) => {
+      if (collection === "characters" && id === "char-1") return characterPromise;
+      throw new Error(`Unexpected storage get: ${String(collection)} ${String(id)}`);
+    });
+
+    const generationPromise = runAssistantMessage(queryClient, { chatId: currentChat.id }, message);
+    await Promise.resolve();
+    useChatStore.getState().setActiveChatId(currentChat.id);
+    resolveCharacter({
+      id: "char-1",
+      avatarPath: "/avatars/mari.png",
+      data: { name: "Mari" },
+    });
+    await generationPromise;
+
+    expect(markAutonomousUnreadMock).not.toHaveBeenCalled();
+    expect(playNotificationPingMock).not.toHaveBeenCalled();
+    expect(showConversationLocalNotificationMock).not.toHaveBeenCalled();
+    expect(useChatStore.getState().unreadCounts.has(currentChat.id)).toBe(false);
+    expect(useChatStore.getState().chatNotifications.has(currentChat.id)).toBe(false);
+  });
+});

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -19,16 +19,20 @@ import type {
   PresentCharacter,
 } from "../../../../engine/contracts/types/game-state";
 import { chatBackgroundMetadataToUrl } from "../../../../shared/lib/backgrounds";
+import { chatCommandApi } from "../../../../shared/api/chat-command-api";
 import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { integrationGateway } from "../../../../shared/api/integration-gateway";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { visualAssetsApi } from "../../../../shared/api/visual-assets-api";
 import { requestImagePromptReview } from "../../../../shared/components/ui/ImagePromptReviewHost";
+import { showConversationLocalNotification } from "../../../../shared/lib/local-notifications";
+import { playNotificationPing } from "../../../../shared/lib/notification-sound";
 import { useAgentStore, type PendingCardUpdate } from "../../../../shared/stores/agent.store";
 import { formatAgentFailuresToast, toAgentFailure, type AgentFailure } from "../../../../shared/lib/agent-failures";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
+import type { AvatarCropValue } from "../../../../shared/lib/utils";
 import { useGameStateStore } from "../../world-state/index";
 import { worldStateApi, type WorldStateTarget } from "../../world-state/index";
 import {
@@ -341,6 +345,75 @@ function scheduleChatQueryRefresh(queryClient: QueryClient, chatId: string): voi
     ]).catch((error) => console.warn("[generation] chat cache refresh failed", error));
   }, 75);
   scheduledChatRefreshTimers.set(chatId, timer);
+}
+
+async function chatForNotification(queryClient: QueryClient, chatId: string): Promise<Chat | null> {
+  const cached = queryClient.getQueryData<Chat>(chatKeys.detail(chatId));
+  if (cached) return cached;
+  return storageApi.get<Chat>("chats", chatId).catch(() => null);
+}
+
+async function characterNotificationInfo(characterId: string | null): Promise<{
+  characterName: string;
+  avatarUrl: string | null;
+  avatarCrop: AvatarCropValue | null;
+}> {
+  if (!characterId) return { characterName: "Someone", avatarUrl: null, avatarCrop: null };
+
+  try {
+    const row = await storageApi.get<Record<string, unknown>>("characters", characterId);
+    if (!row) return { characterName: "Someone", avatarUrl: null, avatarCrop: null };
+    const data = parseMaybeRecord(row.data);
+    const extensions = parseMaybeRecord(data.extensions);
+    return {
+      characterName: readString(data.name).trim() || readString(row.name).trim() || "Someone",
+      avatarUrl: readString(row.avatarPath).trim() || null,
+      avatarCrop: (extensions.avatarCrop ?? null) as AvatarCropValue | null,
+    };
+  } catch {
+    return { characterName: "Someone", avatarUrl: null, avatarCrop: null };
+  }
+}
+
+async function notifyOffChatAssistantMessage(queryClient: QueryClient, chatId: string, rawMessage: unknown): Promise<void> {
+  const state = useChatStore.getState();
+  if (state.activeChatId === chatId) return;
+
+  const savedMessage = savedMessagePayload(rawMessage, chatId);
+  if (!savedMessage || savedMessage.role !== "assistant") return;
+
+  const chat = await chatForNotification(queryClient, chatId);
+  if (chat?.mode !== "conversation" && chat?.mode !== "roleplay") return;
+
+  const characterId = readString(savedMessage.characterId).trim() || null;
+  const { characterName, avatarUrl, avatarCrop } = await characterNotificationInfo(characterId);
+  if (useChatStore.getState().activeChatId === chatId) return;
+
+  void chatCommandApi
+    .markAutonomousUnread<Chat>(chatId, { characterId })
+    .then((updatedChat) => {
+      queryClient.setQueryData(chatKeys.detail(chatId), updatedChat);
+      void queryClient.invalidateQueries({ queryKey: chatKeys.list() });
+    })
+    .catch(() => {
+      /* persistence is best-effort; keep the local notification */
+    });
+
+  const latestState = useChatStore.getState();
+  latestState.incrementUnread(chatId);
+  latestState.addNotification(chatId, characterName, avatarUrl, avatarCrop);
+
+  const uiState = useUIStore.getState();
+  if (chat.mode === "conversation") {
+    if (uiState.convoNotificationSound) playNotificationPing();
+    void showConversationLocalNotification({
+      enabled: uiState.conversationBrowserNotifications,
+      characterName,
+      tag: `marinara-conversation-${chatId}`,
+    });
+  } else if (uiState.rpNotificationSound) {
+    playNotificationPing();
+  }
 }
 
 function parseMaybeRecord(value: unknown): Record<string, unknown> {
@@ -1305,6 +1378,7 @@ export async function runGenerationWithUi(
             await flushLiveGenerationBuffers();
             upsertCachedMessage(queryClient, chatId, event.data, { replaceMessageId: regenerateMessageId });
             scheduleChatQueryRefresh(queryClient, chatId);
+            await notifyOffChatAssistantMessage(queryClient, chatId, event.data);
             const trackerTarget = trackerTargetFromMessagePayload(event.data);
             runDeferredGenerationWork("game state refresh", () => refreshGameStateFromStorage(chatId, trackerTarget));
             if (groupTurnActive) {

--- a/src/shared/lib/notification-sound.test.ts
+++ b/src/shared/lib/notification-sound.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-function installAudioContext(overrides: Partial<AudioContext> = {}) {
+function installAudioContext(overrides: Partial<AudioContext> | Array<Partial<AudioContext>> = {}) {
   const oscillator = {
     frequency: { value: 0 },
     connect: vi.fn(),
@@ -13,7 +13,12 @@ function installAudioContext(overrides: Partial<AudioContext> = {}) {
     gain: { value: 0 },
     connect: vi.fn(),
   };
+  let instanceIndex = 0;
   const AudioContextMock = vi.fn(function AudioContextMock() {
+    const instanceOverrides = Array.isArray(overrides)
+      ? (overrides[Math.min(instanceIndex, overrides.length - 1)] ?? {})
+      : overrides;
+    instanceIndex += 1;
     return {
       state: "running",
       currentTime: 1,
@@ -21,7 +26,7 @@ function installAudioContext(overrides: Partial<AudioContext> = {}) {
       createOscillator: vi.fn(() => oscillator),
       createGain: vi.fn(() => gain),
       resume: vi.fn().mockResolvedValue(undefined),
-      ...overrides,
+      ...instanceOverrides,
     };
   });
 
@@ -58,5 +63,15 @@ describe("playNotificationPing", () => {
     const { playNotificationPing } = await import("./notification-sound");
 
     expect(() => playNotificationPing()).not.toThrow();
+  });
+
+  it("replaces an interrupted WebKit AudioContext", async () => {
+    const { AudioContextMock } = installAudioContext([{ state: "interrupted" } as Partial<AudioContext>, {}]);
+    const { playNotificationPing } = await import("./notification-sound");
+
+    playNotificationPing();
+    playNotificationPing();
+
+    expect(AudioContextMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/shared/lib/notification-sound.test.ts
+++ b/src/shared/lib/notification-sound.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function installAudioContext(overrides: Partial<AudioContext> = {}) {
+  const oscillator = {
+    frequency: { value: 0 },
+    connect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  };
+  const gain = {
+    gain: { value: 0 },
+    connect: vi.fn(),
+  };
+  const AudioContextMock = vi.fn(function AudioContextMock() {
+    return {
+      state: "running",
+      currentTime: 1,
+      destination: {},
+      createOscillator: vi.fn(() => oscillator),
+      createGain: vi.fn(() => gain),
+      resume: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  });
+
+  Object.defineProperty(window, "AudioContext", {
+    configurable: true,
+    value: AudioContextMock,
+  });
+
+  return { AudioContextMock };
+}
+
+describe("playNotificationPing", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("reuses a single AudioContext for repeated pings", async () => {
+    const { AudioContextMock } = installAudioContext();
+    const { playNotificationPing } = await import("./notification-sound");
+
+    playNotificationPing();
+    playNotificationPing();
+
+    expect(AudioContextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails quietly when Web Audio throws", async () => {
+    installAudioContext({
+      createOscillator: vi.fn(() => {
+        throw new Error("audio blocked");
+      }),
+    } as Partial<AudioContext>);
+    const { playNotificationPing } = await import("./notification-sound");
+
+    expect(() => playNotificationPing()).not.toThrow();
+  });
+});

--- a/src/shared/lib/notification-sound.ts
+++ b/src/shared/lib/notification-sound.ts
@@ -1,11 +1,19 @@
-let notificationAudioContext: AudioContext | null = null;
+type NotificationAudioContext = AudioContext & { state: AudioContextState | "interrupted" };
 
-function getNotificationAudioContext(): AudioContext | null {
+let notificationAudioContext: NotificationAudioContext | null = null;
+
+function getNotificationAudioContext(): NotificationAudioContext | null {
   if (typeof window === "undefined") return null;
   const audioWindow = window as Window & { webkitAudioContext?: typeof AudioContext };
-  const AudioContextClass = window.AudioContext ?? audioWindow.webkitAudioContext;
+  const AudioContextClass = (window.AudioContext ?? audioWindow.webkitAudioContext) as
+    | (new () => NotificationAudioContext)
+    | undefined;
   if (!AudioContextClass) return null;
-  if (!notificationAudioContext || notificationAudioContext.state === "closed") {
+  if (
+    !notificationAudioContext ||
+    notificationAudioContext.state === "closed" ||
+    notificationAudioContext.state === "interrupted"
+  ) {
     notificationAudioContext = new AudioContextClass();
   }
   return notificationAudioContext;
@@ -16,7 +24,7 @@ export function playNotificationPing() {
     const context = getNotificationAudioContext();
     if (!context) return;
 
-    if (context.state === "suspended") {
+    if (context.state === "suspended" || context.state === "interrupted") {
       void context.resume().catch(() => {});
     }
 

--- a/src/shared/lib/notification-sound.ts
+++ b/src/shared/lib/notification-sound.ts
@@ -1,14 +1,34 @@
-export function playNotificationPing() {
-  const AudioContextClass = window.AudioContext;
-  if (!AudioContextClass) return;
+let notificationAudioContext: AudioContext | null = null;
 
-  const context = new AudioContextClass();
-  const oscillator = context.createOscillator();
-  const gain = context.createGain();
-  oscillator.frequency.value = 880;
-  gain.gain.value = 0.03;
-  oscillator.connect(gain);
-  gain.connect(context.destination);
-  oscillator.start();
-  oscillator.stop(context.currentTime + 0.08);
+function getNotificationAudioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const audioWindow = window as Window & { webkitAudioContext?: typeof AudioContext };
+  const AudioContextClass = window.AudioContext ?? audioWindow.webkitAudioContext;
+  if (!AudioContextClass) return null;
+  if (!notificationAudioContext || notificationAudioContext.state === "closed") {
+    notificationAudioContext = new AudioContextClass();
+  }
+  return notificationAudioContext;
+}
+
+export function playNotificationPing() {
+  try {
+    const context = getNotificationAudioContext();
+    if (!context) return;
+
+    if (context.state === "suspended") {
+      void context.resume().catch(() => {});
+    }
+
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    oscillator.frequency.value = 880;
+    gain.gain.value = 0.03;
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start();
+    oscillator.stop(context.currentTime + 0.08);
+  } catch {
+    /* notification audio is best-effort */
+  }
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1808

## Why this change

- Refactor generation saved off-chat Conversation and Roleplay replies without restoring legacy unread state, floating avatar bubbles, or Roleplay notification pings.
- Notification audio also created a fresh `AudioContext` on every ping and did not fail quietly if Web Audio was unavailable or blocked.

## What changed

- Added off-chat assistant-message notification handling in the shared generation runtime for Conversation and Roleplay chats.
- Persisted autonomous unread metadata best-effort, updated local unread counts, and added the existing floating avatar notification bubble.
- Wired Conversation replies to the existing Conversation sound/native notification settings and Roleplay replies to `rpNotificationSound`.
- Reused a single notification `AudioContext` and wrapped Web Audio setup/playback in a quiet best-effort guard.
- Added focused regression coverage for off-chat notification behavior, active-chat negative controls, an async return-before-metadata guard, and audio helper safety.

## Refactor impact

Primary owner:

- Runtime generation

Impact areas reviewed:

- App shell notification bubbles
- Chat/Roleplay notification settings
- Chat unread state and autonomous unread persistence
- Shared notification audio helper

Boundary notes:

- Kept notification wiring in `src/features/runtime/generation`; no engine imports of React, stores, Tauri, or feature internals were added.
- Persistence uses the existing `src/shared/api/chat-command-api.ts` wrapper instead of a raw Tauri call.
- Native local notifications remain Conversation-only, matching the current settings copy.

Pressure points touched:

- `src/features/runtime/generation/hooks/use-generate.ts`
- `src/shared/lib/notification-sound.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm exec vitest run src/features/runtime/generation/hooks/use-generate.test.ts src/shared/lib/notification-sound.test.ts`; 6 tests passed.
- Codex ran `pnpm typecheck`; passed.
- Codex ran `pnpm check`; passed line endings, architecture, frontend typecheck, Rust check, docs, discovery, and unused-code checks.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`; passed.
- Live screenshot proof was not captured because a provider-backed end-to-end generation setup with seeded chats is needed. The focused tests prove the runtime notification contract directly.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing notification settings and shell notification behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshots attached. The visible UI result depends on a live generation finishing after navigation, and this draft keeps that limitation explicit while the runtime contract is covered by focused automated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications for messages arriving in conversations you're not actively viewing: unread indicators, metadata (name/avatar), local notification tags, and optional notification sounds.

* **Improvements**
  * Notification sound system now reuses audio context, is more resilient across browsers, and fails silently on unsupported environments.

* **Tests**
  * Added end-to-end tests covering off-chat notification behavior and audio playback resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->