### PR TITLE
Fix connection storage invariants

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -6,6 +6,7 @@ use crate::builtins::is_protected_record;
 use crate::state::AppState;
 use marinara_core::{ensure_object, AppError};
 use serde_json::{json, Map, Value};
+use std::collections::HashSet;
 use tauri::State;
 
 #[tauri::command]
@@ -534,6 +535,7 @@ pub(crate) fn connection_folder_reorder_inner(
     state: &AppState,
     ordered_ids: Vec<String>,
 ) -> Result<Value, AppError> {
+    validate_connection_folder_reorder(state, &ordered_ids)?;
     let patches = ordered_ids
         .into_iter()
         .enumerate()
@@ -541,6 +543,40 @@ pub(crate) fn connection_folder_reorder_inner(
         .collect::<Vec<_>>();
     let rows = state.storage.patch_many("connection-folders", patches)?;
     Ok(Value::Array(rows))
+}
+
+fn validate_connection_folder_reorder(
+    state: &AppState,
+    ordered_ids: &[String],
+) -> Result<(), AppError> {
+    let mut seen = HashSet::with_capacity(ordered_ids.len());
+    if ordered_ids
+        .iter()
+        .any(|id| id.trim().is_empty() || !seen.insert(id.as_str()))
+    {
+        return Err(AppError::invalid_input(
+            "Connection folder reorder must include each folder id exactly once",
+        ));
+    }
+
+    let existing_ids = state
+        .storage
+        .list("connection-folders")?
+        .into_iter()
+        .filter_map(|folder| {
+            folder
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect::<HashSet<_>>();
+    let ordered_ids = ordered_ids.iter().cloned().collect::<HashSet<_>>();
+    if existing_ids != ordered_ids {
+        return Err(AppError::invalid_input(
+            "Connection folder reorder must include every existing folder exactly once",
+        ));
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -742,12 +778,33 @@ pub(crate) fn duplicate_entity(
     if entity == "chat-presets" {
         return duplicate_chat_preset(state, id);
     }
-    let duplicated = shared::duplicate_record(state, entity, id)?;
     if entity == "connections" {
-        let mut masked = duplicated;
-        connection_secrets::mask_connection_for_read(&mut masked);
-        return Ok(masked);
+        return duplicate_connection(state, id);
     }
+    let duplicated = shared::duplicate_record(state, entity, id)?;
+    Ok(duplicated)
+}
+
+fn duplicate_connection(state: &AppState, id: &str) -> Result<Value, AppError> {
+    let mut record = shared::get_required(state, "connections", id)?;
+    let object = record
+        .as_object_mut()
+        .ok_or_else(|| AppError::invalid_input("Connection is not an object"))?;
+    object.remove("id");
+    if let Some(name) = object
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    {
+        object.insert("name".to_string(), Value::String(format!("{name} Copy")));
+    }
+    object.insert("isDefault".to_string(), Value::Bool(false));
+    object.insert("default".to_string(), Value::Bool(false));
+    object.insert("defaultForAgents".to_string(), Value::Bool(false));
+
+    let prepared = connection_secrets::prepare_connection_for_create(state, record)?;
+    let mut duplicated = state.storage.create("connections", prepared)?;
+    connection_secrets::mask_connection_for_read(&mut duplicated);
     Ok(duplicated)
 }
 
@@ -1441,6 +1498,44 @@ mod tests {
     }
 
     #[test]
+    fn duplicating_connection_resets_default_flags_and_keeps_secret_masked() {
+        let state = test_state("connection-duplicate-defaults");
+        storage_create_inner(
+            &state,
+            "connections".to_string(),
+            json!({
+                "id": "default-connection",
+                "name": "Default Connection",
+                "provider": "anthropic",
+                "model": "claude-opus-4-8",
+                "isDefault": true,
+                "default": true,
+                "defaultForAgents": true,
+                "apiKey": "sk-secret"
+            }),
+        )
+        .expect("connection should be created");
+
+        let duplicated = duplicate_entity(&state, "connections", "default-connection")
+            .expect("connection duplicate should succeed");
+
+        assert_ne!(duplicated["id"], "default-connection");
+        assert_eq!(duplicated["name"], "Default Connection Copy");
+        assert_eq!(duplicated["isDefault"], false);
+        assert_eq!(duplicated["default"], false);
+        assert_eq!(duplicated["defaultForAgents"], false);
+        assert_eq!(duplicated["apiKey"], connection_secrets::API_KEY_MASK);
+
+        let raw = state
+            .storage
+            .get("connections", duplicated["id"].as_str().unwrap())
+            .expect("duplicate should read")
+            .expect("duplicate should exist");
+        assert!(raw.get("apiKey").is_none());
+        assert!(raw.get("apiKeyEncrypted").is_some());
+    }
+
+    #[test]
     fn deleting_connection_folder_unfiles_child_connections() {
         let state = test_state("connection-folder-delete");
         storage_create_inner(
@@ -1492,5 +1587,40 @@ mod tests {
             connection_move_inner(&state, "connection-a", Some("missing-folder".to_string()))
                 .expect_err("missing folders should be rejected");
         assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn reordering_connection_folders_requires_each_folder_once() {
+        let state = test_state("connection-folder-reorder-validate");
+        storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({ "id": "folder-a", "name": "Folder A" }),
+        )
+        .expect("first folder should be created");
+        storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({ "id": "folder-b", "name": "Folder B" }),
+        )
+        .expect("second folder should be created");
+
+        let duplicate_error = connection_folder_reorder_inner(
+            &state,
+            vec!["folder-a".to_string(), "folder-a".to_string()],
+        )
+        .expect_err("duplicate folder ids should reject the reorder");
+        assert_eq!(duplicate_error.code, "invalid_input");
+
+        let missing_error = connection_folder_reorder_inner(&state, vec!["folder-a".to_string()])
+            .expect_err("omitted folders should reject the reorder");
+        assert_eq!(missing_error.code, "invalid_input");
+
+        let folder_b = state
+            .storage
+            .get("connection-folders", "folder-b")
+            .expect("folder should read")
+            .expect("folder should exist");
+        assert_eq!(folder_b["sortOrder"], 1);
     }
 }

--- a/src-tauri/src/commands/storage/connection_secrets.rs
+++ b/src-tauri/src/commands/storage/connection_secrets.rs
@@ -84,14 +84,8 @@ pub(crate) fn connections_for_export(state: &AppState) -> AppResult<Vec<Value>> 
         .storage
         .list("connections")?
         .into_iter()
-        .map(|row| {
-            let mut connection = materialize_connection_for_runtime(state, row)?;
-            if let Some(object) = connection.as_object_mut() {
-                object.remove("apiKeyEncrypted");
-                object.remove("apiKeyHash");
-                object.remove("apiKeyMasked");
-                object.remove("hasApiKey");
-            }
+        .map(|mut connection| {
+            mask_connection_for_read(&mut connection);
             Ok(connection)
         })
         .collect()

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -704,7 +704,11 @@ mod tests {
         );
         assert_eq!(
             snapshot["data"]["collections"]["connections"][0]["apiKey"],
-            "sk-export-secret"
+            connection_secrets::API_KEY_MASK
+        );
+        assert_eq!(
+            snapshot["data"]["collections"]["connections"][0]["hasApiKey"],
+            true
         );
         assert!(snapshot["data"]["collections"]["connections"][0]
             .get("apiKeyEncrypted")
@@ -729,10 +733,7 @@ mod tests {
         assert_eq!(connection["folderId"], "folder-1");
         assert_eq!(connection["sortOrder"], 7);
         assert!(connection.get("apiKey").is_none());
-        assert!(connection.get("apiKeyEncrypted").is_some());
-        let runtime_connection = connection_secrets::connection_for_runtime(&target, "conn-1")
-            .expect("imported connection secret should decrypt");
-        assert_eq!(runtime_connection["apiKey"], "sk-export-secret");
+        assert!(connection.get("apiKeyEncrypted").is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1807

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Restores connection-specific storage invariants that generic refactor storage still missed: duplicated default connections could remain defaults, folder reorder accepted invalid lists, and profile export could expose raw connection API keys.

## What changed

<!-- List the key changes in this PR. -->

- Masks connection secrets in profile export instead of materializing plaintext API keys.
- Routes connection duplication through a connection-aware path that resets `isDefault`, `default`, and `defaultForAgents` while preserving encrypted secrets.
- Validates connection folder reorder requests so every existing folder id appears exactly once before applying any order patches.
- Adds Rust regression coverage for duplicate defaults, folder reorder validation, and masked profile export/import behavior.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Rust storage

Impact areas reviewed:

- Connection create/update/read secret masking and runtime materialization
- Connection duplicate command behavior
- Connection folder delete/move/reorder behavior
- Profile export/import connection handling

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- The fix stays in `src-tauri` storage/profile command code. Existing frontend hooks continue to call the storage and connection command wrappers.
- Profile exports now preserve the fact that a key existed without exporting the key itself. Re-importing an exported profile requires re-entering provider API keys.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Profile export/import connection collections
- Generic storage duplicate command for `connections`
- `connection_folder_reorder`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex reproduced the original failures with Rust command tests before the fix:
  - `cargo test --manifest-path src-tauri\Cargo.toml duplicating_connection_resets_default_flags_and_keeps_secret_masked -- --nocapture` failed because the duplicate retained `isDefault: true`.
  - `cargo test --manifest-path src-tauri\Cargo.toml reordering_connection_folders_requires_each_folder_once -- --nocapture` failed because duplicate folder ids were accepted and mutated order.
  - `cargo test --manifest-path src-tauri\Cargo.toml profile_export_import_preserves_connection_folders -- --nocapture` failed because profile export returned `sk-export-secret` as plaintext.
- After the fix, `cargo test --manifest-path src-tauri\Cargo.toml connection_ -- --nocapture` passed: 28 passed.
- After rebasing onto current `upstream/refactor`, `pnpm check` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Manual note: because exported profiles no longer carry connection API key plaintext, importing an exported profile requires re-entering provider API keys. Before replacing profile data through import/export workflows, back up the active profile `data/storage/connections.json` and `data/secrets/connection-master.key` to a separate folder outside the active Marinara profile data directory.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this is a storage/security parity bugfix and does not add a discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes made. Release note may want to mention that profile export no longer includes provider API keys in plaintext.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A; this is a backend storage/profile command fix with Rust command proof and full `pnpm check`.
