### PR TITLE
Fix onboarding tutorial copy

### DIFF
--- a/src/features/shell/onboarding/components/OnboardingTutorial.tsx
+++ b/src/features/shell/onboarding/components/OnboardingTutorial.tsx
@@ -45,7 +45,7 @@ const STEPS: TourStep[] = [
   {
     target: "panel-buttons",
     title: "Tab Buttons",
-    body: "These buttons (from left to right) open panels for:\n- **Browser:** browse for downloadable cards and more,\n- **Characters:** view and manage all your character cards,\n- **Lorebooks:** lorebooks with all the information you want,\n- **Presets:** section for prompts,\n- **Connections:** Set up your API connection here,\n- **Agents:** Think of them as extensions to your chats, each agent does something atop your main conversation, e.g., tracks details, creates images, etc.,\n- **Persona:** personas you play as,\n- **Settings:** settings for the entire application.\n\nCheck them all out!",
+    body: "These buttons (from left to right) open panels for:\n- **Browser:** browse for downloadable cards and more,\n- **Characters:** view and manage all your character cards,\n- **Lorebooks:** lorebooks with all the information you want,\n- **Presets:** manage prompts and prompt sections,\n- **Connections:** set up your model connections here,\n- **Agents:** manage chat helpers that can track details, create images, and more,\n- **Personas:** personas you play as,\n- **Settings:** settings for the entire application.\n\nCheck them all out!",
     side: "bottom",
     sprite: { src: "/sprites/mari/Mari_point_up_left.png", flip: true },
   },
@@ -65,7 +65,7 @@ const STEPS: TourStep[] = [
   {
     target: null,
     title: "Meet Professor Mari!",
-    body: "That's Professor Mari. She lives in her own screen now, separate from chats and modes. Use the Mari button in the title bar whenever you want to open that assistant space.",
+    body: "That's Professor Mari. She lives in her own screen now, separate from chats and modes. She can inspect your creative library, search and read app source, make narrow exact-match source edits, and create extension or custom agent records when you ask. Use the Mari button in the title bar whenever you want that assistant space, and review any write-capable changes before keeping them.",
     sprite: { src: "/sprites/mari/Mari_greet.png" },
   },
   {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1809

## Why this change

- The first-run onboarding tutorial drifted from the current refactor shell and Professor Mari capability surface.
- The panel-button step still used stale wording, including singular `Persona`, while the live `RIGHT_PANEL_BUTTONS` registry exposes `Personas`.
- The Professor Mari step did not set expectations that Mari can inspect library/code context and perform write-capable actions when asked.

## What changed

- Updated the onboarding panel-button copy to match the current `RIGHT_PANEL_BUTTONS` labels and clarify the Presets, Connections, Agents, and Personas descriptions.
- Expanded the Professor Mari onboarding copy to disclose creative library inspection, source search/read, narrow exact-match source edits, extension record creation, and custom agent record creation.
- Kept the change copy-only in the onboarding component.

## Refactor impact

Primary owner:

- App shell onboarding

Impact areas reviewed:

- `src/features/shell/onboarding/components/OnboardingTutorial.tsx`
- `src/app/shell/PanelNavButtons.tsx`
- `src/features/shell/mari/components/ProfessorMariSurface.tsx`
- `src-tauri/src/commands/storage/mari.rs`

Boundary notes:

- Feature/UI copy only. No engine, shared API, remote runtime, storage schema, dependency, or command-routing changes.
- The issue text mentions Discover as a panel button, but current `upstream/refactor` `PanelNavButtons` does not expose Discover in `RIGHT_PANEL_BUTTONS`; this PR follows the live registry.

Pressure points touched:

- First-run onboarding tutorial copy only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex proof: `node scratch\issue-1809-onboarding-copy-check.mjs` passed. It checks onboarding panel copy against live `RIGHT_PANEL_BUTTONS` labels and checks the Professor Mari copy against the current Mari tool definitions.
- Codex proof: `node scratch\issue-1809-onboarding-ui-proof.mjs` passed against the running Vite app after rebasing onto current `upstream/refactor`.
- Codex proof: `pnpm check` passed after rebasing onto current `upstream/refactor`.
- Local screenshots captured: `scratch/issue-1809-panel-after.png` and `scratch/issue-1809-mari-after.png`.
- Draft blocker: GitHub-renderable UI evidence is not attached yet. `gh gist create` rejected PNG upload as `binary file not supported`, so this should stay draft until screenshots are attached/uploaded or a maintainer accepts the local-proof limitation.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Copy-only onboarding bugfix; no new discoverable behavior is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Local screenshots captured under `scratch/`, but not GitHub-renderable in this draft yet:
  - `scratch/issue-1809-panel-after.png`
  - `scratch/issue-1809-mari-after.png`
