### PR TITLE
Fix remote chat avatar resolution

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -84,6 +84,7 @@ import {
   messageAttachmentsFromExtra,
 } from "../lib/message-attachments";
 import { resolvePromptSnapshotFromExtra } from "../lib/prompt-snapshot";
+import { ResolvedAvatarImage } from "./ResolvedAvatarImage";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
@@ -385,6 +386,14 @@ interface ChatMessageProps {
   isSelected?: boolean;
   onToggleSelect?: (toggle: MessageSelectionToggle) => void;
 }
+
+type MergedAvatar = {
+  key: string;
+  url: string;
+  crop: AvatarCropValue | null | undefined;
+  avatarFilePath: string | null;
+  avatarFilename: string | null;
+};
 
 /** Regex to match a plain image URL as the entire content. */
 const IMAGE_URL_RE = /^https?:\/\/\S+\.(?:gif|png|jpe?g|webp)(?:\?[^\s]*)?$/i;
@@ -1399,6 +1408,16 @@ export const ChatMessage = memo(function ChatMessage({
   const expressionAvatarUrl =
     !isUser && message.characterId ? (expressionAvatarResolver?.(message, message.characterId) ?? null) : null;
   const avatarUrl = expressionAvatarUrl ?? baseAvatarUrl;
+  const avatarFilePath = !isUser && !expressionAvatarUrl ? (charInfo?.avatarFilePath ?? null) : null;
+  const avatarFilename = !isUser && !expressionAvatarUrl ? (charInfo?.avatarFilename ?? null) : null;
+  const [resolvedAvatarUrl, setResolvedAvatarUrl] = useState<string | null>(null);
+  useEffect(() => {
+    setResolvedAvatarUrl(null);
+  }, [avatarFilePath, avatarFilename, avatarUrl]);
+  const avatarLightboxUrl = resolvedAvatarUrl ?? avatarUrl;
+  const handleResolvedAvatarSrc = useCallback((src: string | null) => {
+    setResolvedAvatarUrl(src);
+  }, []);
   const personaAvatarCrop = isUser
     ? (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
     : null;
@@ -1441,7 +1460,7 @@ export const ChatMessage = memo(function ChatMessage({
 
   // Merged group chat: cycling avatars + cycling name color
   const isMergedGroup = groupChatMode === "merged" && !isUser && chatCharacterIds && chatCharacterIds.length > 1;
-  const mergedAvatars = useMemo(() => {
+  const mergedAvatars = useMemo<MergedAvatar[]>(() => {
     if (!isMergedGroup || !characterMap || !chatCharacterIds) return [];
     return chatCharacterIds
       .map((id) => {
@@ -1449,9 +1468,15 @@ export const ChatMessage = memo(function ChatMessage({
         const expressionUrl = expressionAvatarResolver?.(message, id) ?? null;
         const url = expressionUrl ?? info?.avatarUrl;
         if (!url) return null;
-        return { url, crop: expressionUrl ? null : info?.avatarCrop };
+        return {
+          key: id,
+          url,
+          crop: expressionUrl ? null : info?.avatarCrop,
+          avatarFilePath: expressionUrl ? null : (info?.avatarFilePath ?? null),
+          avatarFilename: expressionUrl ? null : (info?.avatarFilename ?? null),
+        };
       })
-      .filter(Boolean) as { url: string; crop?: AvatarCropValue | null }[];
+      .filter((avatar): avatar is MergedAvatar => avatar !== null);
   }, [isMergedGroup, characterMap, chatCharacterIds, expressionAvatarResolver, message]);
   const mergedNameColors = useMemo(() => {
     if (!isMergedGroup || !characterMap || !chatCharacterIds) return [];
@@ -1467,6 +1492,24 @@ export const ChatMessage = memo(function ChatMessage({
   const mergedNameRef = useRef<HTMLSpanElement>(null);
   const mergedAvatarRefs = useRef<(HTMLImageElement | null)[]>([]);
   const mergedAvatarTailRefs = useRef<(HTMLImageElement | null)[]>([]);
+  const resolvedMergedAvatarUrlsRef = useRef(new Map<string, string>());
+  useEffect(() => {
+    resolvedMergedAvatarUrlsRef.current.clear();
+  }, [mergedAvatars]);
+  const rememberMergedAvatarSrc = useCallback((key: string, src: string | null) => {
+    if (src) {
+      resolvedMergedAvatarUrlsRef.current.set(key, src);
+    } else {
+      resolvedMergedAvatarUrlsRef.current.delete(key);
+    }
+  }, []);
+  const openMergedAvatarLightbox = useCallback(
+    (avatar?: { key: string; url: string }) => {
+      if (!avatar) return;
+      openImageLightbox(resolvedMergedAvatarUrlsRef.current.get(avatar.key) ?? avatar.url);
+    },
+    [openImageLightbox],
+  );
 
   useEffect(() => {
     if (!isMergedGroup) return;
@@ -1607,31 +1650,37 @@ export const ChatMessage = memo(function ChatMessage({
     isMergedGroup && mergedAvatars.length > 0 ? (
       <div className="rpg-avatar-panel-tail absolute inset-0 pointer-events-none overflow-hidden">
         {mergedAvatars.map((avatar, i) => (
-          <img
-            key={`tail-${avatar.url}`}
+          <ResolvedAvatarImage
+            key={`tail-${avatar.key}`}
             ref={(el) => {
               mergedAvatarTailRefs.current[i] = el;
             }}
             src={avatar.url}
+            avatarFilePath={avatar.avatarFilePath}
+            avatarFilename={avatar.avatarFilename}
             alt=""
             aria-hidden="true"
             loading="lazy"
             decoding="async"
             className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
             style={{ opacity: i === 0 ? 1 : 0, ...panelMergedAvatarCropStyle(avatar) }}
+            onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
           />
         ))}
       </div>
     ) : avatarUrl ? (
       <div className="rpg-avatar-panel-tail absolute inset-0 pointer-events-none overflow-hidden">
-        <img
+        <ResolvedAvatarImage
           src={avatarUrl}
+          avatarFilePath={avatarFilePath}
+          avatarFilename={avatarFilename}
           alt=""
           aria-hidden="true"
           loading="lazy"
           decoding="async"
           className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top"
           style={panelAvatarCropStyle}
+          onResolvedSrc={handleResolvedAvatarSrc}
         />
       </div>
     ) : null
@@ -1839,24 +1888,24 @@ export const ChatMessage = memo(function ChatMessage({
                     "rpg-avatar-glow relative cursor-pointer overflow-hidden ring-2 ring-white/10",
                     compactAvatarFrameClass,
                   )}
-                  onClick={() => {
-                    const visible = mergedAvatars[cycleIndexRef.current];
-                    if (visible) openImageLightbox(visible.url);
-                  }}
+                  onClick={() => openMergedAvatarLightbox(mergedAvatars[cycleIndexRef.current])}
                   aria-label={`Open ${displayName} avatar`}
                 >
                   {mergedAvatars.map((avatar, i) => (
-                    <img
-                      key={avatar.url}
+                    <ResolvedAvatarImage
+                      key={avatar.key}
                       ref={(el) => {
                         mergedAvatarRefs.current[i] = el;
                       }}
                       src={avatar.url}
+                      avatarFilePath={avatar.avatarFilePath}
+                      avatarFilename={avatar.avatarFilename}
                       alt="Group"
                       loading="lazy"
                       decoding="async"
                       className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
                       style={{ opacity: i === 0 ? 1 : 0, ...compactMergedAvatarCropStyle(avatar) }}
+                      onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
                     />
                   ))}
                 </button>
@@ -1868,16 +1917,19 @@ export const ChatMessage = memo(function ChatMessage({
                       "relative cursor-pointer overflow-hidden ring-2 ring-white/10",
                       compactAvatarFrameClass,
                     )}
-                    onClick={() => openImageLightbox(avatarUrl)}
+                    onClick={() => avatarLightboxUrl && openImageLightbox(avatarLightboxUrl)}
                     aria-label={`Open ${displayName} avatar`}
                   >
-                    <img
+                    <ResolvedAvatarImage
                       src={avatarUrl}
+                      avatarFilePath={avatarFilePath}
+                      avatarFilename={avatarFilename}
                       alt={displayName}
                       loading="lazy"
                       decoding="async"
                       className="h-full w-full object-cover"
                       style={compactAvatarCropStyle}
+                      onResolvedSrc={handleResolvedAvatarSrc}
                     />
                   </button>
                 </div>
@@ -1984,24 +2036,24 @@ export const ChatMessage = memo(function ChatMessage({
                         <button
                           type="button"
                           className="rpg-avatar-panel-media rpg-avatar-panel absolute inset-0 block h-full w-full cursor-zoom-in overflow-hidden"
-                          onClick={() => {
-                            const visible = mergedAvatars[cycleIndexRef.current];
-                            if (visible) openImageLightbox(visible.url);
-                          }}
+                          onClick={() => openMergedAvatarLightbox(mergedAvatars[cycleIndexRef.current])}
                           aria-label={`Open ${displayName} avatar`}
                         >
                           {mergedAvatars.map((avatar, i) => (
-                            <img
-                              key={avatar.url}
+                            <ResolvedAvatarImage
+                              key={avatar.key}
                               ref={(el) => {
                                 mergedAvatarRefs.current[i] = el;
                               }}
                               src={avatar.url}
+                              avatarFilePath={avatar.avatarFilePath}
+                              avatarFilename={avatar.avatarFilename}
                               alt="Group"
                               loading="lazy"
                               decoding="async"
                               className="absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
                               style={{ opacity: i === 0 ? 1 : 0, ...panelMergedAvatarCropStyle(avatar) }}
+                              onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
                             />
                           ))}
                         </button>
@@ -2012,16 +2064,19 @@ export const ChatMessage = memo(function ChatMessage({
                             "rpg-avatar-panel-media absolute inset-0 block h-full w-full cursor-zoom-in overflow-hidden",
                             !isUser && "rpg-avatar-panel",
                           )}
-                          onClick={() => openImageLightbox(avatarUrl)}
+                          onClick={() => avatarLightboxUrl && openImageLightbox(avatarLightboxUrl)}
                           aria-label={`Open ${displayName} avatar`}
                         >
-                          <img
+                          <ResolvedAvatarImage
                             src={avatarUrl}
+                            avatarFilePath={avatarFilePath}
+                            avatarFilename={avatarFilename}
                             alt={displayName}
                             loading="lazy"
                             decoding="async"
                             className="h-full w-full object-cover object-top"
                             style={panelAvatarCropStyle}
+                            onResolvedSrc={handleResolvedAvatarSrc}
                           />
                         </button>
                       ) : (
@@ -2367,24 +2422,24 @@ export const ChatMessage = memo(function ChatMessage({
               <button
                 type="button"
                 className="relative h-8 w-8 cursor-pointer overflow-hidden rounded-full"
-                onClick={() => {
-                  const visible = mergedAvatars[cycleIndexRef.current];
-                  if (visible) openImageLightbox(visible.url);
-                }}
+                onClick={() => openMergedAvatarLightbox(mergedAvatars[cycleIndexRef.current])}
                 aria-label={`Open ${displayName} avatar`}
               >
                 {mergedAvatars.map((avatar, i) => (
-                  <img
-                    key={avatar.url}
+                  <ResolvedAvatarImage
+                    key={avatar.key}
                     ref={(el) => {
                       mergedAvatarRefs.current[i] = el;
                     }}
                     src={avatar.url}
+                    avatarFilePath={avatar.avatarFilePath}
+                    avatarFilename={avatar.avatarFilename}
                     alt="Group"
                     loading="lazy"
                     decoding="async"
                     className="absolute inset-0 h-8 w-8 object-cover transition-opacity duration-700"
                     style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
+                    onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
                   />
                 ))}
               </button>
@@ -2392,16 +2447,19 @@ export const ChatMessage = memo(function ChatMessage({
               <button
                 type="button"
                 className="relative h-8 w-8 cursor-pointer overflow-hidden rounded-full"
-                onClick={() => openImageLightbox(avatarUrl)}
+                onClick={() => avatarLightboxUrl && openImageLightbox(avatarLightboxUrl)}
                 aria-label={`Open ${displayName} avatar`}
               >
-                <img
+                <ResolvedAvatarImage
                   src={avatarUrl}
+                  avatarFilePath={avatarFilePath}
+                  avatarFilename={avatarFilename}
                   alt={displayName}
                   loading="lazy"
                   decoding="async"
                   className="h-full w-full object-cover"
                   style={avatarCropStyle}
+                  onResolvedSrc={handleResolvedAvatarSrc}
                 />
               </button>
             ) : (

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
+import { ResolvedAvatarImage } from "./ResolvedAvatarImage";
+
+vi.mock("../../../../../shared/api/local-file-api", () => ({
+  avatarFileUrlFromPath: vi.fn(),
+  resolveAvatarFileUrl: vi.fn(),
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const avatarFileUrlFromPathMock = vi.mocked(avatarFileUrlFromPath);
+const resolveAvatarFileUrlMock = vi.mocked(resolveAvatarFileUrl);
+
+describe("ResolvedAvatarImage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    avatarFileUrlFromPathMock.mockReset();
+    resolveAvatarFileUrlMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("resolves managed avatar files without rendering stale filesystem paths", async () => {
+    avatarFileUrlFromPathMock.mockReturnValue("/Users/philipp/Library/Application Support/marinara/avatar.png");
+    resolveAvatarFileUrlMock.mockResolvedValue("blob:http://localhost/avatar");
+    const onResolvedSrc = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <ResolvedAvatarImage
+          src="/Users/philipp/Library/Application Support/marinara/avatar.png"
+          avatarFilePath="/Users/philipp/Library/Application Support/marinara/avatar.png"
+          avatarFilename="avatar.png"
+          alt="Ada"
+          onResolvedSrc={onResolvedSrc}
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("blob:http://localhost/avatar");
+    expect(container.innerHTML).not.toContain("/Users/philipp");
+    expect(resolveAvatarFileUrlMock).toHaveBeenCalledWith(
+      "avatar.png",
+      "/Users/philipp/Library/Application Support/marinara/avatar.png",
+    );
+    expect(onResolvedSrc).toHaveBeenLastCalledWith("blob:http://localhost/avatar");
+  });
+
+  it("does not fall back to a stale filesystem path when managed resolution fails", async () => {
+    avatarFileUrlFromPathMock.mockReturnValue("/Users/philipp/Library/Application Support/marinara/avatar.png");
+    resolveAvatarFileUrlMock.mockRejectedValue(new Error("401"));
+
+    await act(async () => {
+      root.render(
+        <ResolvedAvatarImage
+          src="/Users/philipp/Library/Application Support/marinara/avatar.png"
+          avatarFilePath="/Users/philipp/Library/Application Support/marinara/avatar.png"
+          avatarFilename="avatar.png"
+          alt="Ada"
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.innerHTML).not.toContain("/Users/philipp");
+  });
+
+  it("renders expression or inline avatar sources directly", async () => {
+    await act(async () => {
+      root.render(<ResolvedAvatarImage src="data:image/png;base64,AAAA" alt="Expression" />);
+    });
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("data:image/png;base64,AAAA");
+    expect(resolveAvatarFileUrlMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.test.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.test.tsx
@@ -16,6 +16,16 @@ vi.mock("../../../../../shared/api/local-file-api", () => ({
 const avatarFileUrlFromPathMock = vi.mocked(avatarFileUrlFromPath);
 const resolveAvatarFileUrlMock = vi.mocked(resolveAvatarFileUrl);
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("ResolvedAvatarImage", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -78,6 +88,49 @@ describe("ResolvedAvatarImage", () => {
 
     expect(container.querySelector("img")).toBeNull();
     expect(container.innerHTML).not.toContain("/Users/philipp");
+  });
+
+  it("does not render the previous resolved avatar after managed avatar props change", async () => {
+    avatarFileUrlFromPathMock.mockReturnValue("/Users/philipp/Library/Application Support/marinara/avatar.png");
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    resolveAvatarFileUrlMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    await act(async () => {
+      root.render(
+        <ResolvedAvatarImage
+          src="/Users/philipp/Library/Application Support/marinara/avatar.png"
+          avatarFilePath="/Users/philipp/Library/Application Support/marinara/avatar.png"
+          avatarFilename="avatar.png"
+          alt="Ada"
+        />,
+      );
+    });
+    await act(async () => {
+      first.resolve("blob:http://localhost/old-avatar");
+      await first.promise;
+    });
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("blob:http://localhost/old-avatar");
+
+    await act(async () => {
+      root.render(
+        <ResolvedAvatarImage
+          src="/Users/philipp/Library/Application Support/marinara/next-avatar.png"
+          avatarFilePath="/Users/philipp/Library/Application Support/marinara/next-avatar.png"
+          avatarFilename="next-avatar.png"
+          alt="Ada"
+        />,
+      );
+    });
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.innerHTML).not.toContain("old-avatar");
+
+    await act(async () => {
+      second.resolve("blob:http://localhost/next-avatar");
+      await second.promise;
+    });
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("blob:http://localhost/next-avatar");
   });
 
   it("renders expression or inline avatar sources directly", async () => {

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
@@ -1,0 +1,107 @@
+import { forwardRef, useEffect, useMemo, useState, type CSSProperties } from "react";
+import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
+
+function hasText(value: string | null | undefined): boolean {
+  return !!value?.trim();
+}
+
+function isLikelyFilesystemPath(value: string): boolean {
+  const normalized = value.replace(/\\/g, "/");
+  return (
+    /^[a-z]:\//i.test(normalized) ||
+    normalized.startsWith("//") ||
+    /^\/(Users|home|var|data|tmp|opt|private)\//i.test(normalized)
+  );
+}
+
+export const ResolvedAvatarImage = forwardRef<
+  HTMLImageElement,
+  {
+    src?: string | null;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
+    alt: string;
+    loading?: "eager" | "lazy";
+    decoding?: "sync" | "async" | "auto";
+    draggable?: boolean;
+    "aria-hidden"?: boolean | "true" | "false";
+    className?: string;
+    style?: CSSProperties;
+    onResolvedSrc?: (src: string | null) => void;
+  }
+>(function ResolvedAvatarImage(
+  {
+    src,
+    avatarFilePath,
+    avatarFilename,
+    alt,
+    loading = "lazy",
+    decoding = "async",
+    draggable,
+    "aria-hidden": ariaHidden,
+    className,
+    style,
+    onResolvedSrc,
+  },
+  ref,
+) {
+  const hasManagedAvatar = hasText(avatarFilename) || hasText(avatarFilePath);
+  const fallbackSrc = useMemo(() => {
+    if (!src) return null;
+    return hasManagedAvatar && isLikelyFilesystemPath(src) ? null : src;
+  }, [hasManagedAvatar, src]);
+  const immediateSrc = useMemo(() => {
+    if (!hasManagedAvatar) return fallbackSrc;
+    const syncUrl = avatarFileUrlFromPath(avatarFilename, avatarFilePath);
+    if (!syncUrl || isLikelyFilesystemPath(syncUrl)) return fallbackSrc;
+    return syncUrl;
+  }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar]);
+  const [resolvedSrc, setResolvedSrc] = useState<string | null>(immediateSrc);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasManagedAvatar) {
+      setResolvedSrc(fallbackSrc);
+      onResolvedSrc?.(fallbackSrc);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setResolvedSrc(immediateSrc);
+    if (immediateSrc) onResolvedSrc?.(immediateSrc);
+    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
+      .then((url) => {
+        if (cancelled) return;
+        const next = url ?? fallbackSrc;
+        setResolvedSrc(next);
+        onResolvedSrc?.(next);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setResolvedSrc(fallbackSrc);
+        onResolvedSrc?.(fallbackSrc);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar, immediateSrc, onResolvedSrc]);
+
+  const imageSrc = resolvedSrc ?? immediateSrc;
+  if (!imageSrc) return null;
+
+  return (
+    <img
+      ref={ref}
+      src={imageSrc}
+      alt={alt}
+      loading={loading}
+      decoding={decoding}
+      draggable={draggable}
+      aria-hidden={ariaHidden}
+      className={className}
+      style={style}
+    />
+  );
+});

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
@@ -56,39 +56,43 @@ export const ResolvedAvatarImage = forwardRef<
     if (!syncUrl || isLikelyFilesystemPath(syncUrl)) return fallbackSrc;
     return syncUrl;
   }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar]);
-  const [resolvedSrc, setResolvedSrc] = useState<string | null>(immediateSrc);
+  const resolutionKey = JSON.stringify([src ?? "", avatarFilename ?? "", avatarFilePath ?? ""]);
+  const [resolvedState, setResolvedState] = useState<{ key: string; src: string | null }>({
+    key: resolutionKey,
+    src: immediateSrc,
+  });
 
   useEffect(() => {
     let cancelled = false;
     if (!hasManagedAvatar) {
-      setResolvedSrc(fallbackSrc);
+      setResolvedState({ key: resolutionKey, src: fallbackSrc });
       onResolvedSrc?.(fallbackSrc);
       return () => {
         cancelled = true;
       };
     }
 
-    setResolvedSrc(immediateSrc);
+    setResolvedState({ key: resolutionKey, src: immediateSrc });
     if (immediateSrc) onResolvedSrc?.(immediateSrc);
     resolveAvatarFileUrl(avatarFilename, avatarFilePath)
       .then((url) => {
         if (cancelled) return;
         const next = url ?? fallbackSrc;
-        setResolvedSrc(next);
+        setResolvedState({ key: resolutionKey, src: next });
         onResolvedSrc?.(next);
       })
       .catch(() => {
         if (cancelled) return;
-        setResolvedSrc(fallbackSrc);
+        setResolvedState({ key: resolutionKey, src: fallbackSrc });
         onResolvedSrc?.(fallbackSrc);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar, immediateSrc, onResolvedSrc]);
+  }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar, immediateSrc, onResolvedSrc, resolutionKey]);
 
-  const imageSrc = resolvedSrc ?? immediateSrc;
+  const imageSrc = resolvedState.key === resolutionKey ? (resolvedState.src ?? immediateSrc) : immediateSrc;
   if (!imageSrc) return null;
 
   return (

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -6,10 +6,7 @@ import {
   type Chat,
   type ChatMode,
 } from "../../../../catalog/chats/index";
-import {
-  characterAvatarUrl,
-  useCharactersByIds,
-} from "../../../../catalog/characters/index";
+import { characterAvatarUrl, useCharactersByIds } from "../../../../catalog/characters/index";
 import { useActivePersona, usePersona } from "../../../../catalog/personas/index";
 import { ApiError } from "../../../../../shared/api/api-errors";
 import { getConnectedChatDisplayName, parseChatMetadata } from "../../../../../shared/lib/chat-display";
@@ -284,6 +281,8 @@ export function useChatSurfaceData({
           postHistoryInstructions:
             readString(parsed.post_history_instructions) || readString(parsed.postHistoryInstructions),
           avatarUrl: characterAvatarUrl(character),
+          avatarFilePath: character.avatarFilePath ?? null,
+          avatarFilename: character.avatarFilename ?? null,
           nameColor: readString(extensions.nameColor) || undefined,
           dialogueColor: readString(extensions.dialogueColor) || undefined,
           boxColor: readString(extensions.boxColor) || undefined,

--- a/src/features/runtime/visuals/types.ts
+++ b/src/features/runtime/visuals/types.ts
@@ -13,6 +13,8 @@ export type CharacterMap = Map<
     systemPrompt?: string;
     postHistoryInstructions?: string;
     avatarUrl: string | null;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
     nameColor?: string;
     dialogueColor?: string;
     boxColor?: string;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1842

## Why this change

- Chat transcript character avatars were still using a synchronous `avatarUrl` string. On authenticated remote runtimes that string could fall back to a stale absolute `avatarFilePath` from the upload machine, producing broken image requests like `/Users/...`.
- Other avatar surfaces resolve managed avatar files asynchronously so Basic Auth headers can be included; the chat transcript now follows the same managed-file contract.

## What changed

- Added `ResolvedAvatarImage` for chat avatars so managed avatar files resolve through `resolveAvatarFileUrl()` before rendering.
- Threaded `avatarFilePath` and `avatarFilename` through `useChatSurfaceData()` and `CharacterMap`.
- Swapped transcript character avatar render paths, including merged group avatars and roleplay panel/tail avatars, to use the resolver component.
- Added focused jsdom coverage for stale filesystem paths, resolver failure fallback, and inline expression avatars.

## Refactor impact

Primary owner:

- shared chat UI

Impact areas reviewed:

- Chat transcript avatar rendering.
- Merged group avatar cycling/lightbox behavior.
- Expression avatar rendering.
- Character map data consumed by chat UI.

Boundary notes:

- Feature/UI code now consumes the existing `src/shared/api/local-file-api.ts` resolver. No engine, Rust, storage schema, dependency, or remote runtime API changes.

Pressure points touched:

- Shared mode UI `ChatMessage.tsx`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm exec vitest run src\features\modes\shared\chat-ui\components\ResolvedAvatarImage.test.tsx`: 4 tests passed.
- Codex ran `pnpm check`: line endings, architecture, frontend typecheck, Rust cargo check, docs, discovery metadata, and knip all passed.
- Manual remote-server visual verification is still pending: test a remote Marinara server with Basic Auth and a character whose stored `avatarFilePath` points at a different machine, then confirm chat transcript avatars render and no `/Users/...` request appears in Network.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshot attached yet. Exact visual proof requires a remote Marinara server with Basic Auth plus stale absolute avatar paths from another machine; this draft should remain draft until that environment is checked.
