### PR TITLE
Fix profile import export parity

### DIFF
--- a/src-tauri/src/commands/storage/backup.rs
+++ b/src-tauri/src/commands/storage/backup.rs
@@ -254,6 +254,24 @@ pub(crate) fn download_backup(state: &AppState, name: Option<&str>) -> AppResult
     }))
 }
 
+pub(crate) fn download_profile_zip(state: &AppState) -> AppResult<Value> {
+    let temp_dir = state
+        .data_dir
+        .join(".profile-export-downloads")
+        .join(format!("marinara-profile-{}-staging", now_millis()));
+    if temp_dir.exists() {
+        fs::remove_dir_all(&temp_dir)?;
+    }
+    write_backup_payload(state, &temp_dir)?;
+    let bytes = zip_backup_folder(&temp_dir, "marinara-profile")?;
+    let _ = fs::remove_dir_all(temp_dir);
+    Ok(json!({
+        "base64": general_purpose::STANDARD.encode(bytes),
+        "filename": "marinara-profile.zip",
+        "contentType": "application/zip",
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/storage/commands/profile.rs
+++ b/src-tauri/src/commands/storage/commands/profile.rs
@@ -199,8 +199,11 @@ fn hex_value(byte: u8) -> Option<u8> {
 }
 
 #[tauri::command]
-pub fn profile_export(state: State<'_, AppState>) -> Result<Value, AppError> {
-    profile::profile_snapshot(&state)
+pub fn profile_export(
+    state: State<'_, AppState>,
+    format: Option<String>,
+) -> Result<Value, AppError> {
+    profile::export_profile(&state, format.as_deref())
 }
 
 #[tauri::command]
@@ -217,6 +220,15 @@ pub fn profile_import(state: State<'_, AppState>, envelope: Value) -> Result<Val
 #[tauri::command]
 pub fn profile_import_file(state: State<'_, AppState>, path: String) -> Result<Value, AppError> {
     profile::import_profile_file_path(&state, &path)
+}
+
+#[tauri::command]
+pub fn profile_import_upload(
+    state: State<'_, AppState>,
+    filename: String,
+    base64: String,
+) -> Result<Value, AppError> {
+    profile::import_profile_upload(&state, &filename, &base64)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -243,6 +243,48 @@ pub(crate) fn export_lorebooks(state: &AppState, body: Value) -> AppResult<Value
     ))
 }
 
+pub(crate) fn export_compatible_profile(state: &AppState) -> AppResult<Value> {
+    let mut zip = ExportZip::new();
+    let characters = state.storage.list("characters")?;
+    let personas = state.storage.list("personas")?;
+    let lorebooks = state.storage.list("lorebooks")?;
+
+    for (index, character) in characters.iter().enumerate() {
+        let fallback = format!("character-{}", index + 1);
+        let name = item_export_name("characters", character).unwrap_or_else(|| fallback.clone());
+        zip.add_json(
+            &format!("characters/{}.json", safe_export_name(&name, &fallback)),
+            &compatible_character_export(character),
+        )?;
+    }
+
+    for (index, persona) in personas.iter().enumerate() {
+        let fallback = format!("persona-{}", index + 1);
+        let name = item_export_name("personas", persona).unwrap_or_else(|| fallback.clone());
+        zip.add_json(
+            &format!("personas/{}.json", safe_export_name(&name, &fallback)),
+            &compatible_persona_export(persona),
+        )?;
+    }
+
+    for (index, lorebook) in lorebooks.iter().enumerate() {
+        let id = record_id(lorebook, "lorebook")?;
+        let entries = list_collection(state, "lorebook-entries", Some(("lorebookId", id)))?;
+        let fallback = format!("lorebook-{}", index + 1);
+        let name = item_export_name("lorebooks", lorebook).unwrap_or_else(|| fallback.clone());
+        zip.add_json(
+            &format!("lorebooks/{}.json", safe_export_name(&name, &fallback)),
+            &compatible_lorebook_export(lorebook, &entries),
+        )?;
+    }
+
+    Ok(binary_download(
+        zip.finish()?,
+        "application/zip",
+        "marinara-compatible-export.zip",
+    ))
+}
+
 fn native_record_export(
     state: &AppState,
     kind: &str,

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -12,9 +12,13 @@ use self::legacy::import_legacy_profile_tables;
 use self::zip_import::import_profile_zip;
 use super::shared::*;
 use super::*;
+use base64::engine::general_purpose;
 use std::collections::HashSet;
-use std::fs::File;
-use std::path::PathBuf;
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+
+const PROFILE_EXPORT_JSON_LIMIT_BYTES: usize = 256 * 1024 * 1024;
+const PROFILE_EXPORT_JSON_TOO_LARGE_CODE: &str = "PROFILE_EXPORT_JSON_TOO_LARGE";
 
 const PROFILE_COLLECTIONS: &[&str] = &[
     "characters",
@@ -101,6 +105,37 @@ pub(crate) fn import_profile_file_path(state: &AppState, value: &str) -> AppResu
     }
 }
 
+pub(crate) fn import_profile_upload(
+    state: &AppState,
+    filename: &str,
+    base64: &str,
+) -> AppResult<Value> {
+    let extension = Path::new(filename)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .ok_or_else(|| AppError::invalid_input("Profile upload must be a .json or .zip file"))?;
+    let bytes =
+        base64::Engine::decode(&general_purpose::STANDARD, base64.trim()).map_err(|error| {
+            AppError::invalid_input(format!("Invalid profile upload data: {error}"))
+        })?;
+    match extension.as_str() {
+        "json" => import_profile(state, serde_json::from_slice(&bytes)?),
+        "zip" => {
+            let upload_dir = state.data_dir.join(".profile-upload-imports");
+            fs::create_dir_all(&upload_dir)?;
+            let path = upload_dir.join(format!("profile-import-{}.zip", now_millis()));
+            fs::write(&path, bytes)?;
+            let result = import_profile_zip(state, &path);
+            let _ = fs::remove_file(path);
+            result
+        }
+        _ => Err(AppError::invalid_input(
+            "Profile upload must be a .json or .zip file",
+        )),
+    }
+}
+
 pub(crate) fn profile_call(
     state: &AppState,
     method: &str,
@@ -118,13 +153,32 @@ pub(crate) fn profile_call(
     }
 }
 
-fn export_profile(state: &AppState, format: Option<&str>) -> AppResult<Value> {
+pub(crate) fn export_profile(state: &AppState, format: Option<&str>) -> AppResult<Value> {
     match format {
-        Some("native") | None => profile_snapshot(state),
+        Some("native") | None => native_profile_export(state),
+        Some("compatible") => super::exports::export_compatible_profile(state),
+        Some("zip") => super::backup::download_profile_zip(state),
         Some(_) => Err(AppError::invalid_input(
-            "Only native Marinara profile JSON export is supported.",
+            "Profile export format must be native, compatible, or zip.",
         )),
     }
+}
+
+fn native_profile_export(state: &AppState) -> AppResult<Value> {
+    let snapshot = profile_snapshot(state)?;
+    let estimated_bytes = serde_json::to_vec(&snapshot)?.len();
+    if estimated_bytes > PROFILE_EXPORT_JSON_LIMIT_BYTES {
+        return Err(AppError::with_details(
+            PROFILE_EXPORT_JSON_TOO_LARGE_CODE,
+            "This profile is too large for the JSON profile exporter. Export it as a profile ZIP instead.",
+            json!({
+                "fallbackFormat": "zip",
+                "estimatedBytes": estimated_bytes,
+                "limitBytes": PROFILE_EXPORT_JSON_LIMIT_BYTES,
+            }),
+        ));
+    }
+    Ok(snapshot)
 }
 
 fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
@@ -332,9 +386,15 @@ fn finish_profile_import_assets(
     restored_assets: RestoredProfileAssets,
     result: AppResult<Value>,
 ) -> AppResult<Value> {
+    let warnings = restored_assets.warnings().to_vec();
     match result {
-        Ok(value) => {
+        Ok(mut value) => {
             restored_assets.commit();
+            if !warnings.is_empty() {
+                if let Some(object) = value.as_object_mut() {
+                    object.insert("warnings".to_string(), Value::Array(warnings));
+                }
+            }
             Ok(value)
         }
         Err(error) => {
@@ -734,6 +794,86 @@ mod tests {
         assert_eq!(connection["sortOrder"], 7);
         assert!(connection.get("apiKey").is_none());
         assert!(connection.get("apiKeyEncrypted").is_none());
+    }
+
+    #[test]
+    fn profile_export_supports_compatible_and_zip_formats() {
+        let state = test_state("profile-export-formats");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "character-1",
+                    "data": {
+                        "name": "Bundle Character"
+                    }
+                }),
+            )
+            .expect("fixture character should write");
+
+        let compatible = profile_call(
+            &state,
+            "GET",
+            &["export"],
+            &ParsedPath::new("/profile/export?format=compatible"),
+            Value::Null,
+        )
+        .expect("compatible profile export should succeed");
+        assert_eq!(compatible["filename"], "marinara-compatible-export.zip");
+        assert_eq!(compatible["contentType"], "application/zip");
+        assert!(compatible["base64"].as_str().unwrap_or_default().len() > 16);
+
+        let zip = profile_call(
+            &state,
+            "GET",
+            &["export"],
+            &ParsedPath::new("/profile/export?format=zip"),
+            Value::Null,
+        )
+        .expect("profile ZIP export should succeed");
+        assert_eq!(zip["filename"], "marinara-profile.zip");
+        assert_eq!(zip["contentType"], "application/zip");
+        assert!(zip["base64"].as_str().unwrap_or_default().len() > 16);
+    }
+
+    #[test]
+    fn profile_upload_import_accepts_json_payloads() {
+        let state = test_state("profile-upload-json");
+        let envelope = json!({
+            "type": "marinara_profile",
+            "version": 1,
+            "data": {
+                "fileStorage": {
+                    "tables": {
+                        "chats": [
+                            {
+                                "id": "chat-1",
+                                "name": "Uploaded Chat",
+                                "mode": "conversation",
+                                "metadata": {},
+                                "characterIds": []
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        let base64 = base64::Engine::encode(
+            &general_purpose::STANDARD,
+            serde_json::to_vec(&envelope).unwrap(),
+        );
+
+        let result = import_profile_upload(&state, "profile.json", &base64)
+            .expect("uploaded profile JSON should import");
+
+        assert_eq!(result["success"], true);
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat lookup should not fail")
+            .expect("uploaded chat should import");
+        assert_eq!(chat["name"], "Uploaded Chat");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -62,6 +62,7 @@ struct ProfileAssetRestore {
 pub(super) struct RestoredProfileAssets {
     restored: usize,
     transaction: Option<ProfileAssetTransaction>,
+    warnings: Vec<Value>,
 }
 
 struct ProfileAssetTransaction {
@@ -76,6 +77,10 @@ struct ProfileAssetTransaction {
 impl RestoredProfileAssets {
     pub(super) fn restored(&self) -> usize {
         self.restored
+    }
+
+    pub(super) fn warnings(&self) -> &[Value] {
+        &self.warnings
     }
 
     /// Path where staged assets live before `install()` moves them into the
@@ -344,6 +349,7 @@ fn restore_profile_json_assets_in_root(
         return Ok(RestoredProfileAssets {
             restored: 0,
             transaction: None,
+            warnings: Vec::new(),
         });
     }
     let assets = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
@@ -355,6 +361,7 @@ fn restore_profile_json_assets_in_root(
     Ok(RestoredProfileAssets {
         restored,
         transaction: Some(transaction),
+        warnings: Vec::new(),
     })
 }
 
@@ -402,9 +409,10 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
         return Ok(RestoredProfileAssets {
             restored: 0,
             transaction: None,
+            warnings: Vec::new(),
         });
     }
-    let assets = decoded_profile_zip_assets(raw_assets, names, profile_prefix)?;
+    let (assets, warnings) = decoded_profile_zip_assets(raw_assets, names, profile_prefix)?;
     let restored = assets.len();
     let transaction = ProfileAssetTransaction::new(&state.data_dir)?;
     for asset in assets {
@@ -431,6 +439,7 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
     Ok(RestoredProfileAssets {
         restored,
         transaction: Some(transaction),
+        warnings,
     })
 }
 
@@ -438,11 +447,12 @@ fn decoded_profile_zip_assets(
     raw_assets: Option<&Value>,
     names: &[String],
     profile_prefix: &str,
-) -> AppResult<Vec<ProfileAssetRestore>> {
+) -> AppResult<(Vec<ProfileAssetRestore>, Vec<Value>)> {
     let Some(assets) = profile_asset_manifest(raw_assets)? else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     };
     let mut decoded = Vec::new();
+    let mut warnings = Vec::new();
     for (index, asset) in assets.iter().enumerate() {
         let path = profile_asset_manifest_path(asset, index)?;
         if is_legacy_cleanup_backup_asset_path(path) {
@@ -458,13 +468,16 @@ fn decoded_profile_zip_assets(
         } else if let Some(entry_name) = zip_asset_entry_name(names, profile_prefix, path) {
             ProfileAssetSource::ZipEntry(entry_name)
         } else {
-            return Err(AppError::invalid_input(format!(
-                "Profile ZIP is missing asset file: {path}"
-            )));
+            warnings.push(json!({
+                "type": "missing_asset",
+                "path": path,
+                "message": format!("Profile ZIP is missing {path}. Imported the rest of the profile without that asset."),
+            }));
+            continue;
         };
         decoded.push(ProfileAssetRestore { relative, source });
     }
-    Ok(decoded)
+    Ok((decoded, warnings))
 }
 
 fn profile_asset_manifest(raw_assets: Option<&Value>) -> AppResult<Option<&Vec<Value>>> {
@@ -1088,9 +1101,10 @@ mod tests {
         ]);
         let names = vec!["sprites/character-1/neutral.png".to_string()];
 
-        let decoded = decoded_profile_zip_assets(Some(&assets), &names, "")
+        let (decoded, warnings) = decoded_profile_zip_assets(Some(&assets), &names, "")
             .expect("legacy cleanup backups should be skipped, not reject the profile zip");
 
+        assert!(warnings.is_empty());
         assert_eq!(decoded.len(), 1);
         assert_eq!(
             decoded[0].relative,
@@ -1122,7 +1136,7 @@ mod tests {
     }
 
     #[test]
-    fn profile_zip_assets_reject_manifest_entries_without_matching_file() {
+    fn profile_zip_assets_warn_manifest_entries_without_matching_file() {
         let assets = json!([
             {
                 "path": "avatars/missing-from-zip.png",
@@ -1130,12 +1144,12 @@ mod tests {
         ]);
         let names = Vec::new();
 
-        let error = match decoded_profile_zip_assets(Some(&assets), &names, "") {
-            Ok(_) => panic!("missing ZIP asset entry should reject the import"),
-            Err(error) => error,
-        };
+        let (decoded, warnings) = decoded_profile_zip_assets(Some(&assets), &names, "")
+            .expect("missing ZIP asset entries should warn without rejecting the import");
 
-        assert_eq!(error.code, "invalid_input");
-        assert!(error.message.contains("missing-from-zip.png"));
+        assert!(decoded.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0]["type"], "missing_asset");
+        assert_eq!(warnings[0]["path"], "avatars/missing-from-zip.png");
     }
 }

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -205,4 +205,54 @@ mod tests {
 
         let _ = std::fs::remove_file(&zip_path);
     }
+
+    #[test]
+    fn import_profile_zip_warns_and_preserves_data_when_asset_file_is_missing() {
+        let state = test_state("missing-asset-warning");
+        let profile_json = json!({
+            "type": "marinara_profile",
+            "data": {
+                "fileStorage": {
+                    "tables": {
+                        "chats": [
+                            {
+                                "id": "chat-1",
+                                "name": "Recovered Chat",
+                                "mode": "conversation",
+                                "metadata": {},
+                                "characterIds": []
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "path": "avatars/missing-from-zip.png",
+                            "size": 12
+                        }
+                    ]
+                }
+            }
+        })
+        .to_string();
+        let zip_path = write_profile_zip("missing-asset-warning", &profile_json);
+
+        let result = import_profile_zip(&state, &zip_path)
+            .expect("zip import should preserve tables and warn about missing assets");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["imported"]["files"], 0);
+        assert_eq!(result["warnings"][0]["type"], "missing_asset");
+        assert_eq!(
+            result["warnings"][0]["path"],
+            "avatars/missing-from-zip.png"
+        );
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat lookup should not fail")
+            .expect("recoverable profile data should import");
+        assert_eq!(chat["name"], "Recovered Chat");
+
+        let _ = std::fs::remove_file(&zip_path);
+    }
 }

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -81,13 +81,20 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
     let args = args_object(request.args)?;
     match command {
         "load_url_binary" => load_url_binary(state, &args).await,
-        "profile_export" => profile::profile_snapshot(state),
+        "profile_export" => {
+            profile::export_profile(state, optional_string(&args, "format").as_deref())
+        }
         "profile_import" => profile::profile_call(
             state,
             "POST",
             &["import"],
             &shared::ParsedPath::new("/profile/import"),
             optional_value(&args, "envelope"),
+        ),
+        "profile_import_upload" => profile::import_profile_upload(
+            state,
+            required_string(&args, "filename")?,
+            required_string(&args, "base64")?,
         ),
         "backup_create" => backup::create_backup(state),
         "backup_list" => backup::list_backups(state),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -88,6 +88,7 @@ pub fn run() {
             storage_commands::profile_commands::profile_export,
             storage_commands::profile_commands::profile_import,
             storage_commands::profile_commands::profile_import_file,
+            storage_commands::profile_commands::profile_import_upload,
             storage_commands::backup_commands::backup_create,
             storage_commands::backup_commands::backup_list,
             storage_commands::backup_commands::backup_delete,

--- a/src/features/shell/settings/components/ProfileImportSection.test.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../../../../shared/api/profile-api", () => ({
   profileApi: {
     importProfile: vi.fn(),
     importProfileFile: vi.fn(),
+    importProfileUpload: vi.fn(),
   },
 }));
 
@@ -35,6 +36,8 @@ const toastError = vi.mocked(await import("sonner")).toast.error;
 const toastSuccess = vi.mocked(await import("sonner")).toast.success;
 const importProfile = (await import("../../../../shared/api/profile-api")).profileApi
   .importProfile as unknown as ReturnType<typeof vi.fn>;
+const importProfileUpload = (await import("../../../../shared/api/profile-api")).profileApi
+  .importProfileUpload as unknown as ReturnType<typeof vi.fn>;
 const showConfirmDialog = vi.mocked(await import("../../../../shared/lib/app-dialogs")).showConfirmDialog;
 
 async function changeProfileFileInput(input: HTMLInputElement, file: File) {
@@ -76,7 +79,7 @@ describe("ProfileImportSection", () => {
     });
 
     const button = container.querySelector("button");
-    expect(button?.textContent).toContain("Import Profile (JSON)");
+    expect(button?.textContent).toContain("Import Profile (JSON/ZIP)");
 
     await act(async () => {
       button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -115,6 +118,36 @@ describe("ProfileImportSection", () => {
     expect(toastSuccess).toHaveBeenCalledWith("Imported: 1 characters");
   });
 
+  it("imports a remote profile ZIP file through the upload API", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://localhost:4111" });
+    showConfirmDialog.mockResolvedValue(true);
+    importProfileUpload.mockResolvedValue({
+      success: true,
+      imported: { characters: 1, files: 0 },
+      warnings: [{ type: "missing_asset", path: "avatars/missing.png", message: "Missing avatar" }],
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={new QueryClient()}>
+          <ProfileImportSection />
+        </QueryClientProvider>,
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input?.accept).toContain(".zip");
+
+    const file = new File(["zip-bytes"], "profile.zip", { type: "application/zip" });
+    await changeProfileFileInput(input!, file);
+
+    await vi.waitFor(() => {
+      expect(importProfileUpload).toHaveBeenCalledWith(file);
+    });
+    expect(importProfile).not.toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalledWith("Imported: 1 characters 1 warning reported.");
+  });
+
   it("reports a SyntaxError toast when a remote profile JSON file cannot be parsed", async () => {
     useUIStore.setState({ remoteRuntimeUrl: "http://localhost:4111" });
     showConfirmDialog.mockResolvedValue(true);
@@ -133,7 +166,7 @@ describe("ProfileImportSection", () => {
     await changeProfileFileInput(input!, new File(["{"], "profile.json", { type: "application/json" }));
 
     await vi.waitFor(() => {
-      expect(toastError).toHaveBeenCalledWith("Import failed. Make sure this is a valid profile JSON file.");
+      expect(toastError).toHaveBeenCalledWith("Import failed. Make sure this is a valid profile JSON or ZIP file.");
     });
     expect(importProfile).not.toHaveBeenCalled();
   });

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -31,7 +31,14 @@ type ProfileImportProgressState = {
   startedAt: number;
   elapsedSeconds: number;
   imported?: ProfileImportStats;
+  warnings?: ProfileImportWarning[];
   error?: string;
+};
+
+type ProfileImportWarning = {
+  type?: string;
+  path?: string;
+  message?: string;
 };
 
 type ProfileImportResult = {
@@ -39,6 +46,7 @@ type ProfileImportResult = {
   error?: string;
   message?: string;
   imported?: ProfileImportStats;
+  warnings?: ProfileImportWarning[];
 };
 
 function formatProfileImportDuration(seconds: number) {
@@ -90,6 +98,16 @@ function formatProfileImportSkippedStats(stats?: ProfileImportStats) {
   return `${count} unsupported prompt override${count === 1 ? "" : "s"} skipped`;
 }
 
+function formatProfileImportWarnings(warnings?: ProfileImportWarning[]) {
+  const count = warnings?.length ?? 0;
+  if (count <= 0) return "";
+  return `${count} warning${count === 1 ? "" : "s"}`;
+}
+
+function isProfileZipFile(file: File) {
+  return file.name.toLowerCase().endsWith(".zip") || file.type.toLowerCase().includes("zip");
+}
+
 export function ProfileImportSection() {
   const qc = useQueryClient();
   const remoteProfileInputRef = useRef<HTMLInputElement>(null);
@@ -117,8 +135,10 @@ export function ProfileImportSection() {
     if (data?.success === false) throw new Error(data.error ?? data.message ?? "Unknown error");
     qc.invalidateQueries();
     const imported = data?.imported;
+    const warnings = Array.isArray(data?.warnings) ? data.warnings : [];
     const summary = formatProfileImportStats(imported);
     const skippedSummary = formatProfileImportSkippedStats(imported);
+    const warningSummary = formatProfileImportWarnings(warnings);
     setProfileImportProgress((current) => {
       const totalItems = Math.max(1, current?.totalItems ?? 1);
       return {
@@ -129,10 +149,15 @@ export function ProfileImportSection() {
         startedAt,
         elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
         imported,
+        warnings,
       };
     });
     toast.success(
-      [summary ? `Imported: ${summary}` : "Profile imported.", skippedSummary ? `Skipped: ${skippedSummary}.` : ""]
+      [
+        summary ? `Imported: ${summary}` : "Profile imported.",
+        skippedSummary ? `Skipped: ${skippedSummary}.` : "",
+        warningSummary ? `${warningSummary} reported.` : "",
+      ]
         .filter(Boolean)
         .join(" "),
     );
@@ -176,7 +201,7 @@ export function ProfileImportSection() {
   };
 
   const showProfileImportError = (err: unknown, startedAt: number) => {
-    const expectedProfileFile = isRemoteRuntime ? "profile JSON file" : "profile JSON or ZIP file";
+    const expectedProfileFile = "profile JSON or ZIP file";
     const message =
       err instanceof SyntaxError
         ? `Import failed. Make sure this is a valid ${expectedProfileFile}.`
@@ -244,6 +269,9 @@ export function ProfileImportSection() {
     });
     try {
       await runConfirmedProfileImport(startedAt, async () => {
+        if (isProfileZipFile(file)) {
+          return profileApi.importProfileUpload<ProfileImportResult>(file);
+        }
         const envelope = JSON.parse(await file.text()) as unknown;
         return profileApi.importProfile<ProfileImportResult>(envelope);
       });
@@ -257,7 +285,7 @@ export function ProfileImportSection() {
       <input
         ref={remoteProfileInputRef}
         type="file"
-        accept=".json,application/json"
+        accept=".json,.zip,application/json,application/zip,application/x-zip-compressed"
         className="hidden"
         onChange={(event) => void handleRemoteProfileFileChange(event)}
       />
@@ -273,9 +301,7 @@ export function ProfileImportSection() {
         {profileImportBusy ? <Loader2 size="1rem" className="animate-spin" /> : <Download size="1rem" />}
         {profileImportBusy
           ? "Importing Profile..."
-          : isRemoteRuntime
-            ? "Import Profile (JSON)"
-            : "Import Profile (JSON/ZIP)"}
+          : "Import Profile (JSON/ZIP)"}
       </button>
 
       {profileImportProgress && (
@@ -336,6 +362,11 @@ export function ProfileImportSection() {
               {formatProfileImportSkippedStats(profileImportProgress.imported) && (
                 <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
                   Skipped: {formatProfileImportSkippedStats(profileImportProgress.imported)}
+                </div>
+              )}
+              {formatProfileImportWarnings(profileImportProgress.warnings) && (
+                <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
+                  Warnings: {formatProfileImportWarnings(profileImportProgress.warnings)}
                 </div>
               )}
             </>

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -26,7 +26,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
 import { openExternalUrl } from "../../../../shared/api/external-link-api";
 import { importApi } from "../../../../shared/api/import-api";
-import { backupApi, profileApi, type ManagedBackup } from "../../../../shared/api/profile-api";
+import { backupApi, profileApi, type ManagedBackup, type ProfileExportFormat } from "../../../../shared/api/profile-api";
+import { ApiError } from "../../../../shared/api/api-errors";
 import { updatesApi, type UpdateCheckResponse } from "../../../../shared/api/updates-api";
 import { backgroundsApi, fontsApi } from "../../../../shared/api/settings-assets-api";
 import { storageApi } from "../../../../shared/api/storage-api";
@@ -97,6 +98,7 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useGameAssetStore } from "../../../modes/game/index";
 import { chatKeys } from "../../../catalog/chats";
 import { HelpTooltip } from "../../../../shared/components/ui/HelpTooltip";
+import { ExportFormatDialog, type ExportFormatChoice } from "../../../../shared/components/ui/ExportFormatDialog";
 import { TrackerPanelIcon } from "../../../../shared/components/ui/TrackerPanelIcon";
 import { TrackerSizeTierIcon } from "../../../../shared/components/ui/TrackerSizeTierIcon";
 import { ImageUploadDropzone } from "../../../../shared/components/ui/ImageUploadDropzone";
@@ -105,6 +107,7 @@ import { PromptOverridesEditor } from "./settings/PromptOverridesEditor";
 import { DraftNumberInput } from "../../../../shared/components/ui/DraftNumberInput";
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../../../shared/lib/character-import";
 import { ProfileImportSection } from "./ProfileImportSection";
+import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 
 type CustomFontFace = {
   filename: string;
@@ -3258,6 +3261,7 @@ function AdvancedSettings() {
   const [selectedScopes, setSelectedScopes] = useState<ExpungeScope[]>(["chats"]);
   const [confirmAction, setConfirmAction] = useState<"selected" | "all" | null>(null);
   const [exportingProfile, setExportingProfile] = useState(false);
+  const [exportProfileDialogOpen, setExportProfileDialogOpen] = useState(false);
   const [downloadingBackupName, setDownloadingBackupName] = useState<string | null>(null);
   const [refreshingSpa, setRefreshingSpa] = useState(false);
   const [checkingUpdates, setCheckingUpdates] = useState(false);
@@ -3369,16 +3373,51 @@ function AdvancedSettings() {
     if (enabled) setQuickRepliesDrawerOpen(true);
   };
 
-  const handleExportProfile = async () => {
+  const profileExportSuccessMessages: Record<ProfileExportFormat, string> = {
+    native: "Profile JSON exported!",
+    compatible: "Compatible profile bundle exported!",
+    zip: "Profile ZIP exported!",
+  };
+
+  const profileExportFallbackFormat = (err: unknown) => {
+    if (!(err instanceof ApiError) || !err.details || typeof err.details !== "object") return null;
+    const payload = err.details as { code?: unknown; details?: unknown };
+    if (payload.code !== "PROFILE_EXPORT_JSON_TOO_LARGE") return null;
+    const details = payload.details && typeof payload.details === "object" ? (payload.details as Record<string, unknown>) : {};
+    return details.fallbackFormat === "zip" ? "zip" : null;
+  };
+
+  const handleExportProfile = async (format: ProfileExportFormat) => {
     setExportingProfile(true);
+    setExportProfileDialogOpen(false);
     try {
-      triggerDownload(await profileApi.exportProfile());
-      toast.success("Profile exported!");
+      triggerDownload(await profileApi.exportProfile(format));
+      toast.success(profileExportSuccessMessages[format]);
     } catch (err) {
+      if (format === "native" && profileExportFallbackFormat(err) === "zip") {
+        const confirmed = await showConfirmDialog({
+          title: "Export profile as ZIP?",
+          message:
+            err instanceof Error
+              ? err.message
+              : "This profile is too large for JSON export. Export it as a profile ZIP instead?",
+          confirmLabel: "Export ZIP",
+          cancelLabel: "Cancel",
+        });
+        if (confirmed) {
+          await handleExportProfile("zip");
+        }
+        return;
+      }
       toast.error(err instanceof Error ? err.message : "Failed to export profile");
     } finally {
       setExportingProfile(false);
     }
+  };
+
+  const handleExportProfileChoice = (format: ExportFormatChoice) => {
+    if (format === "compatible-png") return;
+    void handleExportProfile(format);
   };
 
   const handleDownloadBackup = async (name?: string) => {
@@ -3497,6 +3536,17 @@ function AdvancedSettings() {
 
   return (
     <div className="flex flex-col gap-3">
+      <ExportFormatDialog
+        open={exportProfileDialogOpen}
+        title="Export Profile"
+        description="Native JSON keeps full Marinara import fidelity. Profile ZIP packages the same data with asset files outside the JSON for large profiles and recovery."
+        nativeDescription="Creates a Marinara profile JSON for direct re-import when the profile is small enough."
+        compatibleDescription="Exports character cards, simple persona JSON, and folderless lorebooks for other roleplay tools."
+        zipDescription="Creates an importable profile ZIP with Marinara data plus managed assets for large profiles and recovery."
+        showZipOption
+        onClose={() => setExportProfileDialogOpen(false)}
+        onSelect={handleExportProfileChoice}
+      />
       <div className="text-xs text-[var(--muted-foreground)]">Advanced settings for power users.</div>
 
       <div className="flex flex-col gap-2 rounded-lg bg-[var(--secondary)]/40 p-2.5 ring-1 ring-[var(--border)]">
@@ -3909,10 +3959,10 @@ function AdvancedSettings() {
         <div className="flex items-center gap-1.5">
           <Download size="0.75rem" className="text-[var(--muted-foreground)]" />
           <span className="text-xs font-medium">Profile Export</span>
-          <HelpTooltip text="Exports the current Marinara profile as native JSON for re-import through Import Profile." />
+          <HelpTooltip text="Exports the current profile as native JSON, compatible bundle, or ZIP for large profiles and recovery." />
         </div>
         <button
-          onClick={() => void handleExportProfile()}
+          onClick={() => setExportProfileDialogOpen(true)}
           disabled={exportingProfile}
           className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
         >
@@ -3924,7 +3974,7 @@ function AdvancedSettings() {
           ) : (
             <>
               <Download size="0.8125rem" />
-              Export Profile (JSON)
+              Export Profile
             </>
           )}
         </button>

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -3,9 +3,30 @@ import { ApiError } from "./api-errors";
 import { downloadPayloadFromApiValue, type DownloadPayload } from "./download-payload";
 import { remoteRuntimeTarget } from "./remote-runtime";
 
-async function exportProfile(): Promise<DownloadPayload> {
-  const value = await invokeTauri("profile_export");
-  return downloadPayloadFromApiValue(value, "marinara-profile.json", "application/json");
+export type ProfileExportFormat = "native" | "compatible" | "zip";
+
+const PROFILE_EXPORT_FALLBACKS: Record<ProfileExportFormat, { filename: string; contentType: string }> = {
+  native: { filename: "marinara-profile.json", contentType: "application/json" },
+  compatible: { filename: "marinara-compatible-export.zip", contentType: "application/zip" },
+  zip: { filename: "marinara-profile.zip", contentType: "application/zip" },
+};
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read profile file"));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      resolve(result.split(",", 2)[1] ?? result);
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+async function exportProfile(format: ProfileExportFormat = "native"): Promise<DownloadPayload> {
+  const value = await invokeTauri("profile_export", { format });
+  const fallback = PROFILE_EXPORT_FALLBACKS[format];
+  return downloadPayloadFromApiValue(value, fallback.filename, fallback.contentType);
 }
 
 async function importProfile<T>(envelope: unknown): Promise<T> {
@@ -21,6 +42,13 @@ async function importProfileFile<T>(path: string): Promise<T> {
     );
   }
   return invokeTauri<T>("profile_import_file", { path });
+}
+
+async function importProfileUpload<T>(file: File): Promise<T> {
+  return invokeTauri<T>("profile_import_upload", {
+    filename: file.name,
+    base64: await readFileAsBase64(file),
+  });
 }
 
 export type ManagedBackup = {
@@ -50,6 +78,7 @@ export const profileApi = {
   exportProfile,
   importProfile,
   importProfileFile,
+  importProfileUpload,
 };
 
 export const backupApi = {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -7,6 +7,7 @@ const REMOTE_COMMANDS = new Set([
   "load_url_binary",
   "profile_export",
   "profile_import",
+  "profile_import_upload",
   "backup_create",
   "backup_list",
   "backup_delete",

--- a/src/shared/components/ui/ExportFormatDialog.tsx
+++ b/src/shared/components/ui/ExportFormatDialog.tsx
@@ -1,8 +1,8 @@
-import { FileJson, ImageDown, Layers, X } from "lucide-react";
+import { Archive, FileJson, ImageDown, Layers, X } from "lucide-react";
 import { Modal } from "./Modal";
 import { cn } from "../../lib/utils";
 
-export type ExportFormatChoice = "native" | "compatible" | "compatible-png";
+export type ExportFormatChoice = "native" | "compatible" | "zip" | "compatible-png";
 
 interface ExportFormatDialogProps {
   open: boolean;
@@ -10,7 +10,9 @@ interface ExportFormatDialogProps {
   description?: string;
   nativeDescription?: string;
   compatibleDescription?: string;
+  zipDescription?: string;
   pngDescription?: string;
+  showZipOption?: boolean;
   showPngOption?: boolean;
   onClose: () => void;
   onSelect: (format: ExportFormatChoice) => void;
@@ -23,6 +25,8 @@ export function ExportFormatDialog({
   nativeDescription = "Keeps Marinara-specific fields, folders, metadata, and import fidelity.",
   compatibleDescription = "Uses folderless, platform-friendly JSON where possible for tools like SillyTavern and Chub.",
   pngDescription = "Chara Card V2 PNG with the avatar baked in — works in SillyTavern, Chub, and Risu.",
+  zipDescription = "Packages the native export with external asset files for large profiles and recovery.",
+  showZipOption = false,
   showPngOption = false,
   onClose,
   onSelect,
@@ -35,16 +39,18 @@ export function ExportFormatDialog({
   }> = [
     { id: "native", label: "Marinara Native", icon: Layers, description: nativeDescription },
     { id: "compatible", label: "Compatible JSON", icon: FileJson, description: compatibleDescription },
+    ...(showZipOption ? [{ id: "zip" as const, label: "Profile ZIP", icon: Archive, description: zipDescription }] : []),
     ...(showPngOption
       ? [{ id: "compatible-png" as const, label: "Compatible PNG Card", icon: ImageDown, description: pngDescription }]
       : []),
   ];
+  const gridColumns = options.length >= 3 ? "sm:grid-cols-3" : "sm:grid-cols-2";
 
   return (
     <Modal open={open} onClose={onClose} title={title} width="max-w-lg">
       <div className="space-y-4">
         <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">{description}</p>
-        <div className={cn("grid gap-2", showPngOption ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
+        <div className={cn("grid gap-2", gridColumns)}>
           {options.map((option) => {
             const Icon = option.icon;
             return (


### PR DESCRIPTION
## Linked issue

Closes #1811

## Why this change

- Settings profile import/export regressed to a native-JSON-only path in places, which removed compatible/profile ZIP export choices, blocked remote ZIP imports, and made ZIP imports fail hard when an otherwise recoverable profile referenced a missing asset file.

## What changed

- Restored profile export format selection for native JSON, compatible ZIP bundles, and profile ZIP downloads.
- Added JSON-too-large fallback metadata so native JSON export can offer profile ZIP recovery instead of failing without a next step.
- Added remote/browser profile upload import support for JSON and ZIP files through the shared profile API wrapper.
- Changed profile ZIP asset restoration to warn about missing asset files while importing recoverable profile data.
- Added focused Rust and settings component coverage for the restored export/import paths.

## Refactor impact

Primary owner:

- Rust storage/import-export

Impact areas reviewed:

- Settings Advanced profile export UI
- Settings profile import UI
- Shared profile API wrapper and remote runtime command allowlist
- Tauri command registration and remote invoke dispatch
- Profile ZIP asset recovery

Boundary notes:

- Feature UI continues to call `src/shared/api/profile-api.ts` instead of raw Tauri or remote fetch.
- Rust storage owns the profile export/import behavior and warning payloads.
- Engine code is not touched.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration
- Profile import/export modules
- Remote runtime dispatch for profile commands

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri\Cargo.toml profile_zip_assets_warn_manifest_entries_without_matching_file`
- `cargo test --manifest-path src-tauri\Cargo.toml import_profile_zip_warns_and_preserves_data_when_asset_file_is_missing`
- `cargo test --manifest-path src-tauri\Cargo.toml profile_export_supports_compatible_and_zip_formats`
- `cargo test --manifest-path src-tauri\Cargo.toml profile_upload_import_accepts_json_payloads`
- `pnpm exec vitest run src\features\shell\settings\components\ProfileImportSection.test.tsx`
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix restores existing profile import/export compatibility and recovery options; it does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured. This change is covered by component tests and Rust import/export command tests; no browser proof was required for the non-layout claim.
