### PR TITLE
Fix ArliAI SD API image requests

### DIFF
--- a/src-tauri/src/commands/storage/images.rs
+++ b/src-tauri/src/commands/storage/images.rs
@@ -5,6 +5,7 @@ use super::*;
 mod providers;
 
 pub(crate) use providers::{
+    automatic1111_sdapi_url as image_sdapi_url,
     connection_base_url as image_connection_base_url, generate_image_with_connection,
     generate_image_with_options, image_model as image_generation_model,
     image_source as image_generation_source, is_openai_gpt_image_model, ImageGenerationOptions,

--- a/src-tauri/src/commands/storage/images/providers.rs
+++ b/src-tauri/src/commands/storage/images/providers.rs
@@ -172,6 +172,9 @@ fn infer_image_source(model_or_source: &str, base_url: &str) -> String {
     if url.contains("runpod.ai") {
         return "runpod_comfyui".to_string();
     }
+    if url.contains("arliai.com") || url.contains("/sdapi/v1") {
+        return "automatic1111".to_string();
+    }
     if url.contains(":7860") && !url.contains("drawthings") {
         return "automatic1111".to_string();
     }
@@ -1850,6 +1853,7 @@ async fn generate_automatic1111(
         payload["override_settings"] = json!({ "CLIP_stop_at_last_layers": clip_skip });
     }
     if let Some(model) = model {
+        payload["sd_model_checkpoint"] = Value::String(model.to_string());
         if payload
             .get("override_settings")
             .and_then(Value::as_object)
@@ -1866,17 +1870,16 @@ async fn generate_automatic1111(
             Value::String(model.to_string()),
         );
     }
-    let response = http_client(180)?
-        .post(format!(
-            "{base}/sdapi/v1/{}",
-            if use_img2img { "img2img" } else { "txt2img" }
-        ))
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|error| {
-            AppError::new("image_network_error", image_transport_error_message(error))
-        })?;
+    let endpoint = if use_img2img { "img2img" } else { "txt2img" };
+    let response = bearer(
+        http_client(180)?
+            .post(automatic1111_sdapi_url(&base, endpoint))
+            .json(&payload),
+        &connection_api_key(connection),
+    )
+    .send()
+    .await
+    .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "automatic1111").await?;
     let image = json
         .get("images")
@@ -1886,6 +1889,35 @@ async fn generate_automatic1111(
         .ok_or_else(|| AppError::new("image_response_error", "AUTOMATIC1111 returned no image"))?;
     let (base64, mime) = strip_data_url(image);
     Ok((base64.to_string(), mime.to_string()))
+}
+
+pub(crate) fn automatic1111_sdapi_url(base: &str, endpoint: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    let target_endpoint = endpoint.trim_matches('/');
+    if let Ok(mut parsed) = reqwest::Url::parse(trimmed) {
+        let parts = parsed
+            .path()
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+        let sdapi_index = parts.windows(2).position(|parts| parts == ["sdapi", "v1"]);
+        let prefix = sdapi_index
+            .map(|index| parts[..index].to_vec())
+            .unwrap_or(parts);
+        let path = prefix
+            .into_iter()
+            .chain(["sdapi", "v1", target_endpoint])
+            .collect::<Vec<_>>()
+            .join("/");
+        parsed.set_path(&format!("/{path}"));
+        parsed.set_query(None);
+        parsed.set_fragment(None);
+        return parsed.to_string().trim_end_matches('/').to_string();
+    }
+    if let Some((prefix, _)) = trimmed.split_once("/sdapi/v1") {
+        return format!("{prefix}/sdapi/v1/{target_endpoint}");
+    }
+    format!("{trimmed}/sdapi/v1/{target_endpoint}")
 }
 
 async fn generate_horde(
@@ -2637,6 +2669,72 @@ fn find_comfyui_image<'a>(history: &'a Value, prompt_id: &str) -> Option<&'a Val
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn find_header_end(bytes: &[u8]) -> Option<usize> {
+        bytes.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+
+    fn content_length(headers: &str) -> usize {
+        headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.eq_ignore_ascii_case("content-length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0)
+    }
+
+    async fn serve_single_image_response() -> (String, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test image server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test image server address should be readable");
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test image server should accept one request");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let read = stream
+                    .read(&mut buffer)
+                    .await
+                    .expect("test image server should read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if let Some(header_end) = find_header_end(&request) {
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let expected_len = header_end + 4 + content_length(&headers);
+                    if request.len() >= expected_len {
+                        break;
+                    }
+                }
+            }
+            let body =
+                r#"{"images":["iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="],"info":"{}"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test image server should write response");
+            String::from_utf8_lossy(&request).to_string()
+        });
+        (format!("http://{address}"), handle)
+    }
 
     #[test]
     fn image_provider_error_sanitizer_redacts_secrets() {
@@ -2732,5 +2830,83 @@ mod tests {
 
         assert_eq!(error.code, "image_provider_error");
         assert!(error.message.contains("prompt is too long"));
+    }
+
+    #[tokio::test]
+    async fn automatic1111_sends_arliai_required_auth_and_model_checkpoint() {
+        let (base_url, request_handle) = serve_single_image_response().await;
+        let connection = json!({
+            "provider": "image_generation",
+            "imageGenerationSource": "automatic1111",
+            "baseUrl": format!("{base_url}/sdapi/v1/txt2img"),
+            "apiKey": "arliai-secret",
+            "model": "arliai-image-model",
+            "defaultParameters": {
+                "imageGeneration": {
+                    "service": "automatic1111",
+                    "automatic1111": { "steps": 30, "sampler": "DPM++ 2M Karras" },
+                    "seed": -1
+                }
+            }
+        });
+
+        let result = generate_automatic1111(
+            &connection,
+            "A photo of an astronaut riding a horse on the moon",
+            1024,
+            1024,
+            &ImageGenerationOptions {
+                negative_prompt: Some("ugly, blurry, low quality".to_string()),
+                ..ImageGenerationOptions::default()
+            },
+        )
+        .await
+        .expect("ArliAI-compatible SD API response should parse");
+
+        assert_eq!(result.1, "image/png");
+        let request = request_handle
+            .await
+            .expect("test image server should return captured request");
+        let lower_request = request.to_ascii_lowercase();
+        assert!(request.starts_with("POST /sdapi/v1/txt2img "));
+        assert!(lower_request.contains("authorization: bearer arliai-secret"));
+
+        let body = request
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .expect("request should contain a JSON body");
+        let payload: Value = serde_json::from_str(body).expect("request body should be JSON");
+        assert_eq!(
+            payload["prompt"],
+            json!("A photo of an astronaut riding a horse on the moon")
+        );
+        assert_eq!(payload["sd_model_checkpoint"], json!("arliai-image-model"));
+        assert_eq!(payload["steps"], json!(30));
+        assert_eq!(payload["sampler_name"], json!("DPM++ 2M Karras"));
+    }
+
+    #[test]
+    fn automatic1111_sdapi_url_accepts_roots_and_endpoint_urls() {
+        assert_eq!(
+            automatic1111_sdapi_url("https://api.arliai.com", "txt2img"),
+            "https://api.arliai.com/sdapi/v1/txt2img"
+        );
+        assert_eq!(
+            automatic1111_sdapi_url("https://api.arliai.com/sdapi/v1", "txt2img"),
+            "https://api.arliai.com/sdapi/v1/txt2img"
+        );
+        assert_eq!(
+            automatic1111_sdapi_url("https://api.arliai.com/sdapi/v1/txt2img", "img2img"),
+            "https://api.arliai.com/sdapi/v1/img2img"
+        );
+    }
+
+    #[test]
+    fn arliai_and_sdapi_urls_infer_automatic1111_image_source() {
+        assert_eq!(infer_image_source("", "https://api.arliai.com"), "automatic1111");
+        assert_eq!(
+            infer_image_source("", "https://api.example.test/sdapi/v1/txt2img"),
+            "automatic1111"
+        );
     }
 }

--- a/src-tauri/src/commands/storage/images/providers.rs
+++ b/src-tauri/src/commands/storage/images/providers.rs
@@ -119,6 +119,7 @@ pub(crate) fn image_source(connection: &Value) -> String {
 fn infer_image_source(model_or_source: &str, base_url: &str) -> String {
     let model = model_or_source.trim().to_ascii_lowercase();
     let url = base_url.trim().to_ascii_lowercase();
+    let parsed_url = reqwest::Url::parse(base_url.trim()).ok();
     match model.as_str() {
         "openai" | "stability" | "togetherai" | "novelai" | "pollinations" | "horde"
         | "blockentropy" | "openrouter" | "xai" | "comfyui" | "automatic1111"
@@ -172,7 +173,19 @@ fn infer_image_source(model_or_source: &str, base_url: &str) -> String {
     if url.contains("runpod.ai") {
         return "runpod_comfyui".to_string();
     }
-    if url.contains("arliai.com") || url.contains("/sdapi/v1") {
+    let is_arliai_host = parsed_url
+        .as_ref()
+        .and_then(|url| url.host_str())
+        .map(|host| {
+            let host = host.to_ascii_lowercase();
+            host == "arliai.com" || host.ends_with(".arliai.com")
+        })
+        .unwrap_or(false);
+    let has_sdapi_path = parsed_url
+        .as_ref()
+        .map(|url| url.path().to_ascii_lowercase().contains("/sdapi/v1"))
+        .unwrap_or_else(|| url.contains("/sdapi/v1"));
+    if is_arliai_host || has_sdapi_path {
         return "automatic1111".to_string();
     }
     if url.contains(":7860") && !url.contains("drawthings") {
@@ -2908,5 +2921,7 @@ mod tests {
             infer_image_source("", "https://api.example.test/sdapi/v1/txt2img"),
             "automatic1111"
         );
+        assert_eq!(infer_image_source("", "https://notarliai.com"), "openai");
+        assert_eq!(infer_image_source("", "https://evilarliai.com"), "openai");
     }
 }

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -565,7 +565,7 @@ async fn check_image_generation_connection(connection: &Value) -> AppResult<Stri
             Ok("ComfyUI endpoint is reachable.".to_string())
         }
         "automatic1111" | "drawthings" => {
-            let url = format!("{base}/sdapi/v1/options");
+            let url = super::images::image_sdapi_url(&base, "options");
             check_optional_bearer_get(&url, connection, "Stable Diffusion Web UI").await?;
             Ok("Stable Diffusion Web UI endpoint is reachable.".to_string())
         }
@@ -941,7 +941,7 @@ async fn fetch_image_models(connection: &Value) -> AppResult<Vec<Value>> {
         }
         "automatic1111" | "drawthings" => {
             fetch_json_models(
-                &format!("{base}/sdapi/v1/sd-models"),
+                &super::images::image_sdapi_url(&base, "sd-models"),
                 connection,
                 "image_generation",
                 |json| {


### PR DESCRIPTION
## Linked issue

Closes #1852

## Why this change

- ArliAI's SD API uses the SDNext/AUTOMATIC1111-style `/sdapi/v1/txt2img` response shape, but Marinara's image-generation request path did not send bearer auth and only placed the selected model in `override_settings`.
- Users could also paste the documented `/sdapi/v1/txt2img` endpoint as the base URL, which made related SD API paths append another `/sdapi/v1/...` segment.

## What changed

- Route ArliAI hosts and explicit `/sdapi/v1` image URLs to the AUTOMATIC1111/SDNext image provider instead of the OpenAI-compatible image path.
- Send configured API keys as `Authorization: Bearer ...` for AUTOMATIC1111/SDNext image generation requests.
- Include the selected image model as top-level `sd_model_checkpoint` while preserving the existing `override_settings.sd_model_checkpoint` behavior for local WebUI compatibility.
- Normalize SD API root, `/sdapi/v1`, and endpoint URLs before generation, connection checks, and model-list fetches.
- Added focused Rust regression coverage with a local HTTP harness that captures the outgoing request and returns an `images[]` base64 response.

## Refactor impact

Primary owner:

Rust storage / image provider transport

Impact areas reviewed:

- AUTOMATIC1111 / SDNext image generation request construction
- Image-generation connection checks
- AUTOMATIC1111 / SDNext model-list fetching
- Image provider inference for ArliAI and `/sdapi/v1` URLs

Boundary notes:

- The change stays inside `src-tauri` privileged provider/runtime code.
- No React feature code, engine contracts, storage schema, dependency declarations, or prompt assembly paths changed.

Pressure points touched:

- `src-tauri/src/commands/storage/images/providers.rs`
- `src-tauri/src/commands/storage/images.rs`
- `src-tauri/src/commands/storage/llm.rs`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml automatic1111` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed locally.
- Focused before/after proof: before the fix, the request harness failed because the captured SD API request lacked `Authorization: Bearer arliai-secret`; after the fix, the harness verified `/sdapi/v1/txt2img`, bearer auth, top-level `prompt`, top-level `sd_model_checkpoint`, ArliAI/SD API source inference, and `images[]` base64 parsing.
- Not manually tested against live ArliAI credentials; the core request/response contract was verified with a local harness instead.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing image-generation provider path; no new user-facing feature or discoverable workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; backend/provider transport fix with command proof above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ArliAI endpoints as Automatic1111-compatible providers.
  * Improved recognition of Automatic1111-compatible endpoints.

* **Bug Fixes**
  * Fixed model checkpoint handling in Automatic1111 requests.
  * Enhanced API URL normalization and endpoint detection for Stable Diffusion Web UI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->