### PR TITLE
Fix greeting macro variable persistence

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { StorageGateway } from "../capabilities/storage";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 import type { JsonRecord } from "./runtime-records";
@@ -7,17 +7,29 @@ function createStorage(args: {
   chats?: JsonRecord[];
   characters?: JsonRecord[];
   personas?: JsonRecord[];
+  prompts?: JsonRecord[];
+  promptSections?: JsonRecord[];
+  promptGroups?: JsonRecord[];
+  promptVariables?: JsonRecord[];
   messages?: Record<string, JsonRecord[]>;
 }): StorageGateway {
   const chats = args.chats ?? [];
   const characters = args.characters ?? [];
   const personas = args.personas ?? [];
+  const prompts = args.prompts ?? [];
+  const promptSections = args.promptSections ?? [];
+  const promptGroups = args.promptGroups ?? [];
+  const promptVariables = args.promptVariables ?? [];
   const messages = args.messages ?? {};
 
   const byEntity: Record<string, JsonRecord[]> = {
     chats,
     characters,
     personas,
+    prompts,
+    "prompt-sections": promptSections,
+    "prompt-groups": promptGroups,
+    "prompt-variables": promptVariables,
     "regex-scripts": [],
     lorebooks: [],
     agents: [],
@@ -33,7 +45,10 @@ function createStorage(args: {
     async create<T = unknown>(_entity: string, value: Record<string, unknown>): Promise<T> {
       return value as T;
     },
-    async update<T = unknown>(_entity: string, _id: string, patch: Record<string, unknown>): Promise<T> {
+    async update<T = unknown>(entity: string, id: string, patch: Record<string, unknown>): Promise<T> {
+      const rows = byEntity[entity];
+      const existing = rows?.find((row) => row.id === id);
+      if (existing) Object.assign(existing, patch);
       return patch as T;
     },
     async delete(_entity?: unknown, _id?: unknown) {
@@ -92,6 +107,15 @@ const alice = {
 const bob = {
   id: "bob",
   data: { name: "Bob", description: "A curious friend." },
+};
+
+const coatCharacter = {
+  id: "coat-character",
+  data: {
+    name: "Coat Guy",
+    description: "A character with a stable outfit.",
+    appearance: "He is wearing {{getvar::coat}}.",
+  },
 };
 
 const persona = {
@@ -398,5 +422,164 @@ describe("assembleGenerationPrompt conversation parity", () => {
     expect(text).not.toContain("<character_schedules>");
     expect(text).not.toContain("<cross_chat_awareness>");
     expect(text).not.toContain("<conversation_commands>");
+  });
+});
+
+describe("assembleGenerationPrompt greeting macro variables", () => {
+  const roleplayPreset = {
+    id: "roleplay-preset",
+    wrapFormat: "none",
+    variableValues: {},
+  };
+  const roleplaySections = [
+    {
+      id: "characters",
+      presetId: "roleplay-preset",
+      enabled: true,
+      sortOrder: 0,
+      role: "system",
+      name: "Characters",
+      markerConfig: { type: "character" },
+    },
+    {
+      id: "history",
+      presetId: "roleplay-preset",
+      enabled: true,
+      sortOrder: 1,
+      role: "user",
+      name: "Chat History",
+      markerConfig: { type: "chat_history" },
+    },
+  ];
+
+  it("seeds character field macros from leading greeting setvar side effects", async () => {
+    const chat = {
+      id: "chat-greeting-vars",
+      mode: "roleplay",
+      characterIds: ["coat-character"],
+      promptPresetId: "roleplay-preset",
+      metadata: {},
+    };
+    const storage = createStorage({
+      chats: [chat],
+      characters: [coatCharacter],
+      prompts: [roleplayPreset],
+      promptSections: roleplaySections,
+    });
+
+    const result = await assembleGenerationPrompt(storage, {
+      chat,
+      storedMessages: [
+        {
+          id: "greeting",
+          chatId: chat.id,
+          role: "assistant",
+          characterId: coatCharacter.id,
+          content: "{{setvar::coat::blue coat}}Hello there.",
+        },
+        { id: "user-1", chatId: chat.id, role: "user", content: "What now?" },
+      ],
+      connection,
+      request: {},
+      latestUserInput: "What now?",
+      persistPromptVariables: true,
+    });
+    const text = result.previewMessages.map((message) => message.content).join("\n\n");
+    const updatedChat = await storage.get<JsonRecord>("chats", chat.id);
+
+    expect(text).toContain("Appearance: He is wearing blue coat.");
+    expect(updatedChat?.promptVariables).toEqual({ coat: "blue coat" });
+    expect(updatedChat?.variableValues).toEqual({ coat: "blue coat" });
+  });
+
+  it("keeps persisted greeting variables stable on later prompt assemblies", async () => {
+    const chat = {
+      id: "chat-stable-greeting-vars",
+      mode: "roleplay",
+      characterIds: ["coat-character"],
+      promptPresetId: "roleplay-preset",
+      promptVariables: { coat: "red coat" },
+      variableValues: { coat: "red coat" },
+      metadata: {},
+    };
+    const storage = createStorage({
+      chats: [chat],
+      characters: [coatCharacter],
+      prompts: [roleplayPreset],
+      promptSections: roleplaySections,
+    });
+
+    const result = await assembleGenerationPrompt(storage, {
+      chat,
+      storedMessages: [
+        {
+          id: "greeting",
+          chatId: chat.id,
+          role: "assistant",
+          characterId: coatCharacter.id,
+          content: "{{setvar::coat::blue coat}}Hello there.",
+        },
+        { id: "user-1", chatId: chat.id, role: "user", content: "What now?" },
+      ],
+      connection,
+      request: {},
+      latestUserInput: "What now?",
+      persistPromptVariables: true,
+    });
+    const text = result.previewMessages.map((message) => message.content).join("\n\n");
+    const updatedChat = await storage.get<JsonRecord>("chats", chat.id);
+
+    expect(text).toContain("Appearance: He is wearing red coat.");
+    expect(updatedChat?.promptVariables).toEqual({ coat: "red coat" });
+    expect(updatedChat?.variableValues).toEqual({ coat: "red coat" });
+  });
+
+  it("reuses newly persisted greeting variables across repeated assemblies for the same chat object", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.99);
+    try {
+      const chat = {
+        id: "chat-repeated-greeting-vars",
+        mode: "roleplay",
+        characterIds: ["coat-character"],
+        promptPresetId: "roleplay-preset",
+        metadata: {},
+      };
+      const storage = createStorage({
+        chats: [chat],
+        characters: [coatCharacter],
+        prompts: [roleplayPreset],
+        promptSections: roleplaySections,
+      });
+      const input = {
+        chat,
+        storedMessages: [
+          {
+            id: "greeting",
+            chatId: chat.id,
+            role: "assistant",
+            characterId: coatCharacter.id,
+            content: "{{setvar::coat::{{random::red coat::blue coat}}}}Hello there.",
+          },
+          { id: "user-1", chatId: chat.id, role: "user", content: "What now?" },
+        ],
+        connection,
+        request: {},
+        latestUserInput: "What now?",
+        persistPromptVariables: true,
+      };
+
+      const first = await assembleGenerationPrompt(storage, input);
+      const second = await assembleGenerationPrompt(storage, input);
+      const firstText = first.previewMessages.map((message) => message.content).join("\n\n");
+      const secondText = second.previewMessages.map((message) => message.content).join("\n\n");
+      const updatedChat = await storage.get<JsonRecord>("chats", chat.id);
+
+      expect(firstText).toContain("Appearance: He is wearing red coat.");
+      expect(secondText).toContain("Appearance: He is wearing red coat.");
+      expect(updatedChat?.promptVariables).toEqual({ coat: "red coat" });
+      expect(updatedChat?.variableValues).toEqual({ coat: "red coat" });
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 });

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -122,6 +122,7 @@ export interface PromptAssemblyInput {
   latestUserInput: string;
   agentData?: Record<string, string>;
   embeddingSource?: { embed(texts: string[]): Promise<number[][] | null> } | null;
+  persistPromptVariables?: boolean;
 }
 
 type PromptSectionRecord = JsonRecord & {
@@ -223,6 +224,13 @@ function promptChoiceVariables(
     if (normalized !== null) variables[name] = normalized;
   }
   return variables;
+}
+
+function chatPromptVariables(chat: JsonRecord): Record<string, string> {
+  return {
+    ...stringRecord(chat.variableValues),
+    ...stringRecord(chat.promptVariables),
+  };
 }
 
 function loadCharacterContext(record: JsonRecord): GenerationCharacterContext {
@@ -802,7 +810,7 @@ async function loadSelectedPromptPreset(
         .filter(([name]) => name.length > 0),
     );
     const metadata = parseRecord(input.chat.metadata);
-    const explicitVariables = stringRecord(input.chat.promptVariables ?? input.chat.variableValues);
+    const explicitVariables = chatPromptVariables(input.chat);
     const chatPresetId = readString(input.chat.promptPresetId).trim();
     const chatChoices = chatPresetId === presetId ? (metadata.presetChoices ?? input.chat.presetChoices) : null;
     const mode = readString(input.chat.mode || input.chat.chatMode, "conversation");
@@ -962,7 +970,7 @@ function macroContext(input: {
       systemPrompt: character.systemPrompt,
       postHistoryInstructions: character.postHistoryInstructions,
     })),
-    variables: input.variables ?? stringRecord(input.chat.promptVariables ?? input.chat.variableValues),
+    variables: input.variables ?? chatPromptVariables(input.chat),
     lastInput: input.latestUserInput,
     chatId: readString(input.chat.id),
     model: readString(input.connection.model),
@@ -1930,6 +1938,67 @@ function historyMessages(storedMessages: JsonRecord[], limit: number, includePas
     .filter((message) => message.content.length > 0);
 }
 
+function leadingGreetingContents(storedMessages: JsonRecord[]): string[] {
+  const contents: string[] = [];
+  for (const message of storedMessages) {
+    const role = normalizeRole(message.role);
+    if (role === "user") break;
+    if (role !== "assistant" || hiddenFromAi(message)) continue;
+    const content = historyMessageContent(message, false).trim();
+    if (content) contents.push(content);
+  }
+  return contents;
+}
+
+async function seedPromptVariablesFromGreeting(
+  storage: StorageGateway,
+  input: PromptAssemblyInput,
+  macros: MacroContext,
+): Promise<Record<string, string>> {
+  const greetingContents = leadingGreetingContents(input.storedMessages);
+  if (greetingContents.length === 0) return {};
+
+  const persistedVariables = chatPromptVariables(input.chat);
+  const before = { ...macros.variables };
+  for (const content of greetingContents) {
+    resolveMacros(content, macros, { trimResult: false });
+  }
+
+  for (const [name, value] of Object.entries(persistedVariables)) {
+    macros.variables[name] = value;
+  }
+
+  const discovered: Record<string, string> = {};
+  for (const [name, value] of Object.entries(macros.variables)) {
+    if (persistedVariables[name] !== undefined) continue;
+    if (before[name] === value) continue;
+    discovered[name] = value;
+  }
+
+  if (!input.persistPromptVariables || Object.keys(discovered).length === 0) return discovered;
+
+  const chatId = readString(input.chat.id).trim();
+  if (!chatId) return discovered;
+
+  const promptVariables = {
+    ...stringRecord(input.chat.promptVariables),
+    ...discovered,
+  };
+  const variableValues = {
+    ...stringRecord(input.chat.variableValues),
+    ...discovered,
+  };
+
+  await storage.update("chats", chatId, {
+    promptVariables,
+    variableValues,
+  });
+  input.chat.promptVariables = promptVariables;
+  input.chat.variableValues = variableValues;
+
+  return discovered;
+}
+
 function shouldMergeSameRolePromptMessage(
   previous: ChatMLMessage | undefined,
   _message: ChatMLMessage,
@@ -2271,6 +2340,7 @@ export async function assembleGenerationPrompt(
     variables: selectedPreset?.variables,
     request: input.request,
   });
+  await seedPromptVariablesFromGreeting(storage, input, macros);
   const loreScan = await scanActiveLorebooks({
     storage,
     chat: input.chat,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2274,6 +2274,7 @@ async function runGenerationAgentsForTarget(args: {
     request: input,
     latestUserInput: "",
     embeddingSource: generationEmbeddingSource(deps.llm, connection),
+    persistPromptVariables: true,
   });
   const results: AgentResult[] = [];
   const runtime = await createGenerationAgentRuntime(
@@ -2547,6 +2548,7 @@ export async function* startGeneration(
     request: input,
     latestUserInput,
     embeddingSource: generationEmbeddingSource(deps.llm, connection),
+    persistPromptVariables: true,
   });
   throwIfAborted(signal);
   mirrorSavedUserMessageToDiscord({ deps, chat, input, prepared: preparedUserInput, persona: assembly.persona });
@@ -2606,6 +2608,7 @@ export async function* startGeneration(
       latestUserInput,
       agentData: runtime?.agentData,
       embeddingSource: generationEmbeddingSource(deps.llm, connection),
+      persistPromptVariables: true,
     });
     throwIfAborted(signal);
     await consumePendingConnectedInfluences(deps.storage, chatForGeneration);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1857

## Why this change

- Character greetings can set chat-scoped macro variables, but prompt assembly did not seed those greeting side effects before later character fields rendered.
- A roleplay character whose greeting sets `{{setvar::coat::{{random::...}}}}` could send `{{getvar::coat}}` in appearance/personality as empty, or could re-roll instead of staying stable.

## What changed

- Prompt assembly now scans leading assistant greeting messages before the first user turn for macro variable side effects.
- Real generation assemblies persist newly discovered greeting variables to top-level `chat.promptVariables` and `chat.variableValues`, while prompt preview remains non-persistent.
- Existing persisted chat variables win over raw greeting macros, so already-started chats keep a stable selected value instead of re-rolling.
- Added prompt-assembly regressions for first-use seeding, existing persisted variables, and repeated assemblies on the same chat object.

## Refactor impact

Primary owner:

Engine generation / prompt assembly

Impact areas reviewed:

- Roleplay prompt section rendering
- Start generation prompt assembly calls
- Prompt preview non-persistence boundary
- Chat prompt variable compatibility between `promptVariables` and `variableValues`

Boundary notes:

- Engine-only prompt assembly change plus generation call-site opt-in.
- No React feature UI, shared API wrapper, Rust storage command, remote runtime route, schema, dependency, or version-file changes.

Pressure points touched:

- `startGeneration` prompt assembly calls now opt into variable persistence for real generation.
- `assembleGenerationPrompt` keeps prompt preview callers non-persistent by default.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Before proof: applied the new regression test to untouched `upstream/refactor` in `C:\tmp\Marinara-Engine-issue-1857-before`; `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` failed because the prompt contained `Appearance: He is wearing .` and left the raw greeting `{{setvar}}` in history.
- After proof: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` passed with 11 tests.
- Baseline: `pnpm check` passed after the final diff.
- Proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed locally.
- Bunny review: passed before opening this draft; it caught and the diff now covers the repeated-assembly random-stability case.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing roleplay prompt macro behavior; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is engine prompt assembly behavior with before/after command proof, not a visible UI layout or interaction change.
