### PR TITLE
Fix semantic active lorebook scan

### DIFF
--- a/src/engine/generation/active-lorebooks.test.ts
+++ b/src/engine/generation/active-lorebooks.test.ts
@@ -182,3 +182,20 @@ test("active world info keeps keyword matches when semantic search is unavailabl
   });
   expect(activePanelScan.entries.map((entry) => entry.name)).toEqual(["Gordon keyword"]);
 });
+
+test("active world info does not activate unrelated semantic matches", async () => {
+  const unrelatedStorage: StorageGateway = {
+    ...storage,
+    async listChatMessages<T = unknown>(): Promise<T[]> {
+      return [{ id: "message-1", chatId: "chat-1", role: "user", content: "Tell me about Alice" } as T];
+    },
+  };
+
+  const activePanelScan = await scanActiveLorebookEntries(unrelatedStorage, "chat-1", { embeddingSource });
+
+  expect(activePanelScan.semanticStatus).toEqual({
+    state: "ready",
+    vectorizedEntryCount: 1,
+  });
+  expect(activePanelScan.entries).toEqual([]);
+});

--- a/src/engine/generation/active-lorebooks.test.ts
+++ b/src/engine/generation/active-lorebooks.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "vitest";
+import type { StorageGateway, StorageListOptions } from "../capabilities/storage";
+import { scanActiveLorebookEntries } from "./active-lorebooks";
+import { scanActiveLorebooks } from "./active-lorebook-scanner";
+
+type Row = Record<string, unknown>;
+
+const chat = {
+  id: "chat-1",
+  mode: "roleplay",
+  metadata: {},
+  characterIds: ["char-1"],
+  connectionId: "conn-1",
+};
+
+const lorebook = {
+  id: "book-1",
+  name: "Gordon Facts",
+  enabled: true,
+  isGlobal: true,
+  recursiveScanning: false,
+};
+
+const semanticEntry = {
+  id: "entry-semantic-gordon",
+  lorebookId: "book-1",
+  name: "Gordon",
+  content: "Gordon the rabbit is a jerk.",
+  description: "Gordon the rabbit is a jerk.",
+  keys: [],
+  secondaryKeys: [],
+  enabled: true,
+  constant: false,
+  selective: false,
+  selectiveLogic: "and",
+  probability: 100,
+  position: 0,
+  role: "system",
+  depth: 0,
+  order: 0,
+  useRegex: false,
+  matchWholeWords: false,
+  caseSensitive: false,
+  ephemeral: null,
+  group: "",
+  groupWeight: null,
+  folderId: null,
+  locked: false,
+  preventRecursion: false,
+  tag: "",
+  relationships: {},
+  dynamicState: {},
+  scanDepth: null,
+  sticky: null,
+  cooldown: null,
+  delay: null,
+  activationConditions: [],
+  schedule: null,
+  excludeFromVectorization: false,
+  embedding: [1, 0, 0],
+  additionalMatchingSources: [],
+  characterFilterMode: "any",
+  characterFilterIds: [],
+  characterTagFilterMode: "any",
+  characterTagFilters: [],
+  generationTriggerFilterMode: "any",
+  generationTriggerFilters: [],
+  createdAt: "2026-06-01T00:00:00.000Z",
+  updatedAt: "2026-06-01T00:00:00.000Z",
+};
+
+const keywordEntry = {
+  ...semanticEntry,
+  id: "entry-keyword-gordon",
+  name: "Gordon keyword",
+  keys: ["Gordon"],
+  embedding: null,
+};
+
+const rows: Record<string, Row[]> = {
+  chats: [chat],
+  characters: [{ id: "char-1", name: "Narrator", data: { name: "Narrator" }, tags: [] }],
+  personas: [],
+  lorebooks: [lorebook],
+  "lorebook-entries": [semanticEntry, keywordEntry],
+  "lorebook-folders": [],
+};
+
+function matchesFilters(row: Row, filters?: Record<string, unknown>): boolean {
+  if (!filters) return true;
+  return Object.entries(filters).every(([key, value]) => row[key] === value);
+}
+
+const storage: StorageGateway = {
+  async list<T = unknown>(entity: string, options?: StorageListOptions): Promise<T[]> {
+    return ((rows[entity] ?? []).filter((row) => matchesFilters(row, options?.filters)) as T[]) ?? [];
+  },
+  async get<T = unknown>(entity: string, id: string): Promise<T | null> {
+    return ((rows[entity] ?? []).find((row) => row.id === id) as T | undefined) ?? null;
+  },
+  async listChatMessages<T = unknown>(): Promise<T[]> {
+    return [{ id: "message-1", chatId: "chat-1", role: "user", content: "Tell me about Gordon" } as T];
+  },
+  async listLorebookEntries<T = unknown>(lorebookId: string): Promise<T[]> {
+    return rows["lorebook-entries"].filter((row) => row.lorebookId === lorebookId) as T[];
+  },
+  async create<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async update<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async delete(): Promise<{ deleted: boolean }> {
+    throw new Error("not needed");
+  },
+  async createChatMessage<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async updateChatMessage<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async deleteChatMessage(): Promise<{ deleted: boolean }> {
+    throw new Error("not needed");
+  },
+  async patchChatMessageExtra<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async addChatMessageSwipe<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async patchChatMetadata<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async patchChatSummaries<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async listChatMemories<T = unknown>(): Promise<T[]> {
+    return [];
+  },
+  async getWorldState<T = unknown>(): Promise<T | null> {
+    return null;
+  },
+  async saveTrackerSnapshot<T = unknown>(): Promise<T> {
+    throw new Error("not needed");
+  },
+  async createLorebookEntries<T = unknown>(): Promise<T[]> {
+    throw new Error("not needed");
+  },
+  async promptFull<T = unknown>(): Promise<T | null> {
+    return null;
+  },
+};
+
+const embeddingSource = {
+  async embed(texts: string[]) {
+    return texts.map((text) => (text.toLowerCase().includes("gordon") ? [1, 0, 0] : [0, 1, 0]));
+  },
+};
+
+test("active world info can include semantic-only vectorized lorebook entries", async () => {
+  const activePanelScan = await scanActiveLorebookEntries(storage, "chat-1", { embeddingSource });
+  const directSemanticScan = await scanActiveLorebooks({
+    storage,
+    chat,
+    characters: [{ id: "char-1", name: "Narrator", description: "", tags: [] }],
+    persona: null,
+    storedMessages: await storage.listChatMessages("chat-1"),
+    latestUserInput: "Tell me about Gordon",
+    embeddingSource,
+  });
+
+  expect(directSemanticScan.processedLore.includedEntries.map((entry) => entry.entry.name)).toContain("Gordon");
+  expect(activePanelScan.entries.map((entry) => entry.name)).toContain("Gordon");
+});
+
+test("active world info keeps keyword matches when semantic search is unavailable", async () => {
+  const activePanelScan = await scanActiveLorebookEntries(storage, "chat-1");
+
+  expect(activePanelScan.semanticStatus).toEqual({
+    state: "missing_embedding_source",
+    vectorizedEntryCount: 1,
+  });
+  expect(activePanelScan.entries.map((entry) => entry.name)).toEqual(["Gordon keyword"]);
+});

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -24,9 +24,14 @@ export interface ActiveLorebookScanResult {
   semanticStatus: LorebookSemanticScanStatus;
 }
 
+interface ActiveLorebookScanOptions {
+  embeddingSource?: { embed(texts: string[]): Promise<number[][] | null> } | null;
+}
+
 export async function scanActiveLorebookEntries(
   storage: StorageGateway,
   chatId: string,
+  options: ActiveLorebookScanOptions = {},
 ): Promise<ActiveLorebookScanResult> {
   const chat = requireRecord(await storage.get("chats", chatId), "Chat");
   const storedMessages = await loadChatMessages(storage, chatId);
@@ -40,6 +45,7 @@ export async function scanActiveLorebookEntries(
     storedMessages,
     request: {},
     latestUserInput: "",
+    embeddingSource: options.embeddingSource,
   });
   const entries = scan.processedLore.includedEntries.map((entry) => {
     const event = lorebookActivatedEntryForEvent(entry);

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -5,6 +5,7 @@ import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/rea
 import { lorebookKeys } from "../query-keys";
 import { scanActiveLorebookEntries } from "../../../../engine/generation/active-lorebooks";
 import type { LorebookSemanticScanStatus } from "../../../../engine/generation/active-lorebook-scanner";
+import { resolveGenerationConnection } from "../../../../engine/generation/context";
 import {
   createLorebookEntrySchema,
   createLorebookFolderSchema,
@@ -15,6 +16,7 @@ import {
 } from "../../../../engine/contracts/schemas/lorebook.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { ApiError } from "../../../../shared/api/api-errors";
+import { llmApi } from "../../../../shared/api/llm-api";
 import { lorebookCommandApi } from "../../../../shared/api/lorebook-command-api";
 import type { Lorebook, LorebookEntry, LorebookFolder } from "../../../../engine/contracts/types/lorebook";
 import { characterKeys } from "../../characters/query-keys";
@@ -468,10 +470,47 @@ interface ActiveLorebookScan {
   semanticStatus: LorebookSemanticScanStatus;
 }
 
+function recordString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+async function activeLorebookEmbeddingSource(chat: Record<string, unknown>) {
+  if (!llmApi.embed) return null;
+  try {
+    const connection = await resolveGenerationConnection(storageApi, chat, {});
+    const connectionId = recordString(connection.id) || null;
+    const model = recordString(connection.embeddingModel) || null;
+    return {
+      embed: (texts: string[]) =>
+        llmApi.embed!({
+          texts,
+          connectionId,
+          model,
+        }),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (
+      message === "No LLM connection is configured" ||
+      message === "Connection was not found" ||
+      message === "Chat connection was not found"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export function useActiveLorebookEntries(chatId: string | null, enabled = false) {
   return useQuery({
     queryKey: lorebookKeys.active(chatId),
-    queryFn: () => scanActiveLorebookEntries(storageApi, chatId!) as Promise<ActiveLorebookScan>,
+    queryFn: async () => {
+      const chat = await storageApi.get<Record<string, unknown>>("chats", chatId!);
+      if (!chat) throw new ApiError("Chat not found", 404);
+      return scanActiveLorebookEntries(storageApi, chatId!, {
+        embeddingSource: await activeLorebookEmbeddingSource(chat),
+      }) as Promise<ActiveLorebookScan>;
+    },
     enabled: !!chatId && enabled,
     staleTime: 30_000,
   });


### PR DESCRIPTION
## Linked issue

Closes #1858

## Why this change

- Active World Info could only show keyword/constant lorebook matches because its scan wrapper never supplied the semantic embedding source that the core active-lorebook scanner already supports.
- This made vectorized, keywordless lorebook entries appear unavailable in the visible active-info panel even though the semantic scanner can activate them when an embedding source is present.

## What changed

- Let `scanActiveLorebookEntries` accept the same abstract embedding source used by the active lorebook scanner.
- Build an Active World Info embedding source from the chat's generation connection in the lorebook query hook, using `llmApi.embed`.
- Added a regression test for semantic-only vectorized entries plus the keyword-only fallback path when semantic search is unavailable.

## Refactor impact

Primary owner:

- Engine generation / catalog lorebook UI

Impact areas reviewed:

- Active World Info lorebook scan
- Semantic-only vectorized lorebook activation
- Keyword lorebook activation when no embedding source is available
- Generation prompt scanner boundary, to keep engine code depending only on an abstract embedding source

Boundary notes:

- Engine code still does not import React, Tauri APIs, or shared API adapters.
- Feature code owns `llmApi` and passes only an abstract `{ embed }` source into the engine scanner.
- No storage schema, dependency, prompt preset, or Rust command changes.

Pressure points touched:

- Active World Info query path via `useActiveLorebookEntries`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the issue with `pnpm exec vitest run src/engine/generation/active-lorebooks.test.ts --reporter=verbose`: before the fix, Active World Info returned only `Gordon keyword` and reported `missing_embedding_source`, while the direct semantic scanner returned `Gordon`.
- Codex verified the fix with `pnpm exec vitest run src/engine/generation/active-lorebooks.test.ts --reporter=verbose`: 3 tests passed, covering semantic-only activation, keyword-only fallback when semantic search is unavailable, and an unrelated semantic should-not-match row.
- Codex ran `pnpm typecheck`: passed.
- Codex ran full `pnpm check`: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Bunny review pass: passed before opening the draft PR.
- No true manual verification blocker remains for the core claim. A human can still sanity-check the panel with a real embedding provider in the desktop app before merge.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix to an existing Active World Info/lorebook semantic matching path; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No browser screenshot was captured. The proof is a focused harness for the Active World Info scanner path because the core bug is whether the panel's query supplies semantic embeddings; real-provider desktop visual verification remains a useful reviewer sanity check but is not blocking the core claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * World info entries now support semantic/vector-based matching in addition to keyword matching
  * Integration with generation connection embeddings for improved context relevance
  * Graceful fallback to keyword matching when semantic embedding is unavailable

* **Tests**
  * Comprehensive test coverage for semantic world info entry scanning and matching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->