### PR TITLE
Add Branch from here action to Convo messages

### DIFF
--- a/src/features/modes/conversation/components/ChatConversationSurface.tsx
+++ b/src/features/modes/conversation/components/ChatConversationSurface.tsx
@@ -60,6 +60,7 @@ type ConversationSurfaceProps = {
   onSetActiveSwipe: (messageId: string, index: number) => void;
   onPeekPrompt: (options?: PeekPromptOptions) => void;
   onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
+  onBranch: (messageId: string) => void;
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSwitchChat?: () => void;
   onConcludeScene?: () => void;
@@ -125,6 +126,7 @@ export function ChatConversationSurface({
   onSetActiveSwipe,
   onPeekPrompt,
   onToggleHiddenFromAI,
+  onBranch,
   onToggleSelectMessage,
   onSwitchChat,
   onConcludeScene,
@@ -178,6 +180,7 @@ export function ChatConversationSurface({
           onSetActiveSwipe={onSetActiveSwipe}
           onPeekPrompt={onPeekPrompt}
           onToggleHiddenFromAI={onToggleHiddenFromAI}
+          onBranch={onBranch}
           lastAssistantMessageId={lastAssistantMessageId}
           onOpenSettings={onOpenSettings}
           onOpenFiles={onOpenFiles}

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -16,6 +16,7 @@ import {
   X,
   User,
   Languages,
+  GitBranch,
 } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message, MessageExtra } from "../../../../engine/contracts/types/chat";
@@ -273,6 +274,7 @@ interface ConversationMessageProps {
   onSetActiveSwipe?: (messageId: string, index: number) => void;
   onPeekPrompt?: (options?: PeekPromptOptions) => void;
   onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
+  onBranch?: (messageId: string) => void;
   isLastAssistantMessage?: boolean;
   characterMap?: CharacterMap;
   personaInfo?: PersonaInfo;
@@ -301,6 +303,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   onSetActiveSwipe,
   onPeekPrompt,
   onToggleHiddenFromAI,
+  onBranch,
   characterMap,
   personaInfo,
   onEditClick,
@@ -967,6 +970,13 @@ export const ConversationMessage = memo(function ConversationMessage({
           {thinking && (
             <MsgAction icon={<Brain size="0.75rem" />} onClick={() => setShowThinking(true)} title="View thoughts" />
           )}
+          {onBranch && (
+            <MsgAction
+              icon={<GitBranch size="0.75rem" />}
+              onClick={() => onBranch(message.id)}
+              title="Branch from here"
+            />
+          )}
           <MsgAction
             icon={<Trash2 size="0.75rem" />}
             onClick={() => onDelete?.(message.id)}
@@ -1288,6 +1298,13 @@ export const ConversationMessage = memo(function ConversationMessage({
           )}
           {thinking && !isUser && (
             <MsgAction icon={<Brain size="0.75rem" />} onClick={() => setShowThinking(true)} title="View thoughts" />
+          )}
+          {onBranch && (
+            <MsgAction
+              icon={<GitBranch size="0.75rem" />}
+              onClick={() => onBranch(message.id)}
+              title="Branch from here"
+            />
           )}
           <MsgAction
             icon={<Trash2 size="0.75rem" />}

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -168,6 +168,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
         onSetActiveSwipe={timeline.handleSetActiveSwipe}
         onPeekPrompt={timeline.handlePeekPrompt}
         onToggleHiddenFromAI={timeline.handleToggleHiddenFromAI}
+        onBranch={timeline.handleBranch}
         onToggleSelectMessage={timeline.handleToggleSelectMessage}
         onSwitchChat={connectedChatId ? () => setActiveChatId(connectedChatId) : undefined}
         onOpenSettings={overlays.openSettings}

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -75,6 +75,7 @@ interface ConversationViewProps {
   onSetActiveSwipe: (messageId: string, index: number) => void;
   onPeekPrompt: (options?: PeekPromptOptions) => void;
   onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
+  onBranch: (messageId: string) => void;
   lastAssistantMessageId: string | null;
   onOpenSettings: () => void;
   onOpenFiles: () => void;
@@ -339,6 +340,7 @@ export function ConversationView({
   onSetActiveSwipe,
   onPeekPrompt,
   onToggleHiddenFromAI,
+  onBranch,
   lastAssistantMessageId,
   onOpenSettings,
   onOpenFiles,
@@ -1050,6 +1052,7 @@ export function ConversationView({
                   onSetActiveSwipe={onSetActiveSwipe}
                   onPeekPrompt={onPeekPrompt}
                   onToggleHiddenFromAI={onToggleHiddenFromAI}
+                  onBranch={onBranch}
                 />,
               );
               i = j;
@@ -1087,6 +1090,7 @@ export function ConversationView({
                 onSetActiveSwipe={onSetActiveSwipe}
                 onPeekPrompt={onPeekPrompt}
                 onToggleHiddenFromAI={onToggleHiddenFromAI}
+                onBranch={onBranch}
                 isLastAssistantMessage={msg.id === lastAssistantMessageId}
                 characterMap={characterMap}
                 personaInfo={personaInfo}
@@ -1219,6 +1223,7 @@ function SplitMessageGroup({
   onSetActiveSwipe,
   onPeekPrompt,
   onToggleHiddenFromAI,
+  onBranch,
 }: {
   items: Array<{ key: string; msg: Message; isGrouped: boolean; index: number }>;
   isStreaming: boolean;
@@ -1235,6 +1240,7 @@ function SplitMessageGroup({
   onSetActiveSwipe: (id: string, index: number) => void;
   onPeekPrompt: (options?: PeekPromptOptions) => void;
   onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
+  onBranch: (messageId: string) => void;
 }) {
   const [showActions, setShowActions] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -1276,6 +1282,7 @@ function SplitMessageGroup({
           onSetActiveSwipe={onSetActiveSwipe}
           onPeekPrompt={onPeekPrompt}
           onToggleHiddenFromAI={onToggleHiddenFromAI}
+          onBranch={onBranch}
           isLastAssistantMessage={false}
           characterMap={characterMap}
           chatCharacterIds={chatCharacterIds}
@@ -1352,6 +1359,7 @@ function SplitMessageGroup({
                 onSetActiveSwipe={onSetActiveSwipe}
                 onPeekPrompt={onPeekPrompt}
                 onToggleHiddenFromAI={onToggleHiddenFromAI}
+                onBranch={onBranch}
                 isLastAssistantMessage={false}
                 characterMap={characterMap}
                 chatCharacterIds={chatCharacterIds}
@@ -1379,6 +1387,7 @@ function SplitMessageGroup({
               onSetActiveSwipe={onSetActiveSwipe}
               onPeekPrompt={onPeekPrompt}
               onToggleHiddenFromAI={onToggleHiddenFromAI}
+              onBranch={onBranch}
               onEditClick={handleStartEdit}
               isLastAssistantMessage={firstItem.msg.id === lastAssistantMessageId}
               characterMap={characterMap}
@@ -1407,6 +1416,7 @@ function SplitMessageGroup({
               onSetActiveSwipe={onSetActiveSwipe}
               onPeekPrompt={onPeekPrompt}
               onToggleHiddenFromAI={isChild ? undefined : onToggleHiddenFromAI}
+              onBranch={isChild ? undefined : onBranch}
               onEditClick={handleStartEdit}
               isLastAssistantMessage={msg.id === lastAssistantMessageId}
               characterMap={characterMap}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1853

## Why this change

Convo mode did not expose the existing per-message branch workflow, so users had to export, edit, and re-import chat files to branch from an earlier point.

## What changed

- Threaded the existing shared chat branch handler into Convo mode's message surface.
- Added a `Branch from here` action to Convo message toolbars.
- Kept branch creation/storage behavior on the existing `chat_branch` pipeline.

## Refactor impact

Primary owner:

Chat mode / shared mode UI

Impact areas reviewed:

- Convo route/surface prop flow
- Convo regular message toolbar
- Convo split-message group toolbar
- Existing shared branch mutation and storage behavior

Boundary notes:

- Feature UI calls the existing timeline branch handler.
- No new shared API, engine, or Rust storage routing was added in this PR.
- Existing storage regression coverage already verifies future summary metadata is pruned from message-scoped branches.

Pressure points touched:

- Convo mode message rendering
- Shared timeline branch action wiring

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Codex ran:

- `pnpm typecheck`
- `cargo test --manifest-path src-tauri\Cargo.toml branch_chat_prunes_future_summary_metadata_from_new_branch`
- `pnpm check`

Manual/browser click-through was not captured before opening the draft PR.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A for this PR: this exposes the existing branch workflow in Convo's existing per-message toolbar, matching the roleplay/shared message action pattern rather than adding a new top-level feature surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots captured. The visible change is a new `Branch from here` icon action in the existing Convo message hover/tap toolbar.