### PR TITLE
Auto-vectorize Lorebook Keeper updates

### DIFF
--- a/src-tauri/src/commands/storage/prompts.rs
+++ b/src-tauri/src/commands/storage/prompts.rs
@@ -1,7 +1,7 @@
 use super::shared::*;
 use super::*;
 use marinara_security::is_allowed_outbound_url;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const LEGACY_LOCAL_SIDECAR_CONNECTION_ID: &str = "__local_sidecar__";
 
@@ -177,9 +177,12 @@ pub(crate) async fn vectorize_lorebook(
     lorebook_id: &str,
     body: Value,
 ) -> AppResult<Value> {
-    let connection_id = required_string(&body, "connectionId")?;
     let (embedding_connection_id, mut connection) =
-        resolve_embedding_connection_for_id(state, connection_id)?;
+        if let Some(connection_id) = optional_body_string(&body, "connectionId") {
+            resolve_embedding_connection_for_id(state, connection_id)?
+        } else {
+            resolve_default_configured_embedding_connection(state)?
+        };
     let model = embedding_model(&connection, body.get("model").and_then(Value::as_str))?;
     if let Some(object) = connection.as_object_mut() {
         object.insert("model".to_string(), Value::String(model.clone()));
@@ -193,6 +196,14 @@ pub(crate) async fn vectorize_lorebook(
             Value::Array(rows) => rows,
             _ => Vec::new(),
         };
+    if let Some(entry_ids) = optional_body_string_set(&body, "entryIds") {
+        entries.retain(|entry| {
+            entry
+                .get("id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| entry_ids.contains(id))
+        });
+    }
     for entry in &mut entries {
         normalize_legacy_text_bool_fields(entry, &["excludeFromVectorization"]);
     }
@@ -263,6 +274,67 @@ pub(crate) async fn vectorize_lorebook(
         "vectorized": vectorized,
         "skipped": skipped
     }))
+}
+
+fn optional_body_string<'a>(body: &'a Value, key: &str) -> Option<&'a str> {
+    body.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional_body_string_set(body: &Value, key: &str) -> Option<HashSet<String>> {
+    let ids = body
+        .get(key)
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<HashSet<_>>();
+    (!ids.is_empty()).then_some(ids)
+}
+
+fn resolve_default_configured_embedding_connection(state: &AppState) -> AppResult<(String, Value)> {
+    let connections = connection_secrets::connections_for_runtime(state)?;
+    let embedding_candidates = connections
+        .iter()
+        .filter(|connection| !is_legacy_local_sidecar_connection(connection))
+        .collect::<Vec<_>>();
+    let mut ranked = embedding_candidates
+        .iter()
+        .copied()
+        .filter(|connection| {
+            connection
+                .get("isDefault")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .chain(embedding_candidates.iter().copied().filter(|connection| {
+            !connection
+                .get("isDefault")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        }));
+
+    for candidate in ranked.by_ref() {
+        let Some(connection_id) = candidate.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let Ok((embedding_connection_id, embedding_connection)) =
+            resolve_embedding_connection_for_id(state, connection_id)
+        else {
+            continue;
+        };
+        if has_embedding_model(&embedding_connection) {
+            return Ok((embedding_connection_id, embedding_connection));
+        }
+    }
+
+    Err(AppError::invalid_input(
+        "No embedding connection with an embedding model is configured",
+    ))
 }
 
 pub(crate) fn resolve_embedding_connection_for_id(
@@ -1199,5 +1271,88 @@ mod tests {
         assert_eq!(result["total"], json!(1));
         assert_eq!(result["vectorized"], json!(0));
         assert_eq!(result["skipped"], json!(2));
+    }
+
+    #[tokio::test]
+    async fn vectorize_lorebook_can_target_entry_ids_with_default_connection() {
+        let state = test_state("targeted-default-connection");
+        create_connection(&state);
+        let lorebook_id = create_lorebook(&state, json!(false));
+        state
+            .storage
+            .create(
+                "lorebook-entries",
+                json!({
+                    "id": "target-entry",
+                    "lorebookId": lorebook_id,
+                    "name": "Already vectorized target",
+                    "keys": ["target"],
+                    "content": "This should be counted and skipped.",
+                    "embedding": [0.1, 0.2]
+                }),
+            )
+            .expect("target entry should be stored");
+        state
+            .storage
+            .create(
+                "lorebook-entries",
+                json!({
+                    "id": "untouched-entry",
+                    "lorebookId": lorebook_id,
+                    "name": "Missing embedding outside target set",
+                    "keys": ["outside"],
+                    "content": "This would call the provider if not filtered.",
+                    "embedding": null
+                }),
+            )
+            .expect("untouched entry should be stored");
+
+        let result = vectorize_lorebook(
+            &state,
+            &lorebook_id,
+            json!({
+                "onlyMissing": true,
+                "entryIds": ["target-entry"]
+            }),
+        )
+        .await
+        .expect("targeted vectorization should use the configured default connection");
+
+        assert_eq!(result["total"], json!(1));
+        assert_eq!(result["vectorized"], json!(0));
+        assert_eq!(result["skipped"], json!(1));
+    }
+
+    #[tokio::test]
+    async fn vectorize_lorebook_default_connection_requires_embedding_model() {
+        let state = test_state("default-connection-without-embedding-model");
+        state
+            .storage
+            .create(
+                "connections",
+                json!({
+                    "id": "chat-connection",
+                    "name": "Chat",
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "isDefault": true
+                }),
+            )
+            .expect("chat connection should be stored");
+        let lorebook_id = create_lorebook(&state, json!(false));
+        create_entry(&state, &lorebook_id, json!(false), Value::Null);
+
+        let error = vectorize_lorebook(
+            &state,
+            &lorebook_id,
+            json!({
+                "onlyMissing": true
+            }),
+        )
+        .await
+        .expect_err("auto/default vectorization should require an embedding model");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("embedding model is configured"));
     }
 }

--- a/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.test.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyLorebookKeeperUpdate } from "./lorebook-keeper-updates";
+import { lorebookCommandApi } from "../../../../shared/api/lorebook-command-api";
+import { storageApi } from "../../../../shared/api/storage-api";
+import type { PendingLorebookUpdate } from "../../../../shared/stores/agent.store";
+
+vi.mock("../../../../shared/api/lorebook-command-api", () => ({
+  lorebookCommandApi: {
+    vectorize: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    create: vi.fn(),
+    delete: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+function keeperUpdate(overrides: Partial<PendingLorebookUpdate> = {}): PendingLorebookUpdate {
+  return {
+    id: "pending-1",
+    chatId: "chat-1",
+    lorebookId: "lorebook-1",
+    lorebookName: "Session Lore",
+    action: "update",
+    entryId: "entry-1",
+    entryName: "Old Dock",
+    content: "The old dock is haunted.",
+    newFacts: [],
+    keys: ["dock"],
+    tag: "",
+    reason: "",
+    agentName: "Lorebook Keeper",
+    timestamp: 1,
+    ...overrides,
+  };
+}
+
+describe("applyLorebookKeeperUpdate", () => {
+  beforeEach(() => {
+    vi.mocked(storageApi.create).mockReset();
+    vi.mocked(storageApi.delete).mockReset();
+    vi.mocked(storageApi.get).mockReset();
+    vi.mocked(storageApi.list).mockReset();
+    vi.mocked(storageApi.update).mockReset();
+    vi.mocked(lorebookCommandApi.vectorize).mockReset();
+    vi.mocked(lorebookCommandApi.vectorize).mockResolvedValue({ vectorized: 1, skipped: 0 });
+  });
+
+  it("auto-vectorizes the entry created by Lorebook Keeper", async () => {
+    vi.mocked(storageApi.create).mockResolvedValue({ id: "created-entry", lorebookId: "lorebook-1" });
+
+    const result = await applyLorebookKeeperUpdate(keeperUpdate({ action: "create", entryId: null }));
+
+    expect(result).toMatchObject({
+      applied: true,
+      entryId: "created-entry",
+      vectorization: { status: "vectorized", vectorized: 1, skipped: 0 },
+    });
+    expect(lorebookCommandApi.vectorize).toHaveBeenCalledWith("lorebook-1", {
+      onlyMissing: true,
+      entryIds: ["created-entry"],
+    });
+  });
+
+  it("clears stale embeddings and re-vectorizes changed existing entries", async () => {
+    vi.mocked(storageApi.get).mockResolvedValue({
+      id: "entry-1",
+      lorebookId: "lorebook-1",
+      name: "Old Dock",
+      content: "The old dock exists.",
+      keys: ["dock"],
+      locked: false,
+      tag: "",
+    });
+    vi.mocked(storageApi.update).mockResolvedValue({ id: "entry-1", lorebookId: "lorebook-1" });
+
+    const result = await applyLorebookKeeperUpdate(keeperUpdate({ newFacts: ["A ghost sings there."] }));
+
+    expect(storageApi.update).toHaveBeenCalledWith(
+      "lorebook-entries",
+      "entry-1",
+      expect.objectContaining({ embedding: null }),
+    );
+    expect(result.vectorization).toMatchObject({ status: "vectorized", vectorized: 1 });
+    expect(lorebookCommandApi.vectorize).toHaveBeenCalledWith("lorebook-1", {
+      onlyMissing: true,
+      entryIds: ["entry-1"],
+    });
+  });
+
+  it("does not block the Keeper apply when auto-vectorization fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.mocked(storageApi.create).mockResolvedValue({ id: "created-entry", lorebookId: "lorebook-1" });
+    vi.mocked(lorebookCommandApi.vectorize).mockRejectedValue(new Error("No embedding connection is configured"));
+
+    const result = await applyLorebookKeeperUpdate(keeperUpdate({ action: "create", entryId: null }));
+
+    expect(result).toMatchObject({
+      applied: true,
+      entryId: "created-entry",
+      vectorization: { status: "failed", error: "No embedding connection is configured" },
+    });
+    warn.mockRestore();
+  });
+
+  it("does not vectorize deletes or unchanged updates", async () => {
+    vi.mocked(storageApi.get).mockResolvedValue({
+      id: "entry-1",
+      lorebookId: "lorebook-1",
+      name: "Old Dock",
+      content: "The old dock is haunted.",
+      keys: ["dock"],
+      locked: false,
+      tag: "",
+    });
+
+    const unchanged = await applyLorebookKeeperUpdate(keeperUpdate());
+    const deleted = await applyLorebookKeeperUpdate(keeperUpdate({ action: "delete" }));
+
+    expect(unchanged.applied).toBe(false);
+    expect(deleted.applied).toBe(true);
+    expect(lorebookCommandApi.vectorize).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts
@@ -6,11 +6,24 @@ import {
 import type { Chat } from "../../../../engine/contracts/types/chat";
 import type { Lorebook, LorebookEntry } from "../../../../engine/contracts/types/lorebook";
 import { resolveLorebookKeeperTarget } from "../../../../engine/generation-core/lorebooks/lorebook-keeper-target";
+import { lorebookCommandApi } from "../../../../shared/api/lorebook-command-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { parseChatMetadata } from "../../../../shared/lib/chat-display";
 import type { PendingLorebookUpdate } from "../../../../shared/stores/agent.store";
 import { chatKeys } from "../../chats/query-keys";
 import { lorebookKeys } from "../query-keys";
+
+type LorebookKeeperVectorizationResult =
+  | { status: "not-applicable" }
+  | { status: "vectorized"; vectorized: number; skipped: number }
+  | { status: "failed"; error: string };
+
+interface LorebookKeeperApplyResult {
+  applied: boolean;
+  lorebookId: string;
+  entryId: string | null;
+  vectorization: LorebookKeeperVectorizationResult;
+}
 
 function asRecord(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
@@ -201,23 +214,63 @@ function appendLoreFacts(existingContent: string, update: PendingLorebookUpdate)
   return [existingContent.trim(), additionText].filter(Boolean).join("\n\n");
 }
 
-export async function applyLorebookKeeperUpdate(update: PendingLorebookUpdate): Promise<void> {
+function vectorizationErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Lorebook Keeper auto-vectorization failed.";
+}
+
+async function autoVectorizeKeeperEntry(
+  lorebookId: string,
+  entryId: string | null,
+): Promise<LorebookKeeperVectorizationResult> {
+  if (!entryId) return { status: "not-applicable" };
+  try {
+    const result = await lorebookCommandApi.vectorize<{ vectorized?: number; skipped?: number }>(lorebookId, {
+      onlyMissing: true,
+      entryIds: [entryId],
+    });
+    return {
+      status: "vectorized",
+      vectorized: typeof result.vectorized === "number" ? result.vectorized : 0,
+      skipped: typeof result.skipped === "number" ? result.skipped : 0,
+    };
+  } catch (error) {
+    const message = vectorizationErrorMessage(error);
+    console.warn("[lorebook-keeper] Auto-vectorization failed", { lorebookId, entryId, error });
+    return { status: "failed", error: message };
+  }
+}
+
+function applyResult(
+  update: PendingLorebookUpdate,
+  applied: boolean,
+  entryId: string | null,
+  vectorization: LorebookKeeperVectorizationResult = { status: "not-applicable" },
+): LorebookKeeperApplyResult {
+  return {
+    applied,
+    lorebookId: update.lorebookId,
+    entryId,
+    vectorization,
+  };
+}
+
+export async function applyLorebookKeeperUpdate(update: PendingLorebookUpdate): Promise<LorebookKeeperApplyResult> {
   if (update.action === "create") {
-    await storageApi.create<LorebookEntry>(
+    const created = await storageApi.create<LorebookEntry>(
       "lorebook-entries",
       createLorebookEntrySchema.parse(entryDefaults(update.lorebookId, update)),
     );
-    return;
+    return applyResult(update, true, created.id, await autoVectorizeKeeperEntry(update.lorebookId, created.id));
   }
 
   const existing = await findExistingEntry(update);
   if (!existing) {
-    if (update.action === "delete") return;
-    await storageApi.create<LorebookEntry>(
+    if (update.action === "delete") return applyResult(update, false, null);
+    const created = await storageApi.create<LorebookEntry>(
       "lorebook-entries",
       createLorebookEntrySchema.parse(entryDefaults(update.lorebookId, update)),
     );
-    return;
+    return applyResult(update, true, created.id, await autoVectorizeKeeperEntry(update.lorebookId, created.id));
   }
 
   if (existing.locked) {
@@ -226,7 +279,7 @@ export async function applyLorebookKeeperUpdate(update: PendingLorebookUpdate): 
 
   if (update.action === "delete") {
     await storageApi.delete("lorebook-entries", existing.id);
-    return;
+    return applyResult(update, true, existing.id);
   }
 
   const nextContent = appendLoreFacts(existing.content ?? "", update);
@@ -238,5 +291,7 @@ export async function applyLorebookKeeperUpdate(update: PendingLorebookUpdate): 
   if (Object.keys(patch).length > 0) {
     patch.embedding = null;
     await storageApi.update<LorebookEntry>("lorebook-entries", existing.id, updateLorebookEntrySchema.parse(patch));
+    return applyResult(update, true, existing.id, await autoVectorizeKeeperEntry(update.lorebookId, existing.id));
   }
+  return applyResult(update, false, existing.id);
 }

--- a/src/shared/api/lorebook-command-api.ts
+++ b/src/shared/api/lorebook-command-api.ts
@@ -1,8 +1,15 @@
 import { invokeTauri } from "./tauri-client";
 
+export interface LorebookVectorizeInput {
+  connectionId?: string;
+  model?: string;
+  onlyMissing: boolean;
+  entryIds?: string[];
+}
+
 export const lorebookCommandApi = {
   uploadImage: <T = unknown>(id: string, image: string, filename?: string) =>
     invokeTauri<T>("lorebook_image_upload", { id, body: { image, filename } }),
-  vectorize: <T = unknown>(id: string, body: { connectionId: string; model: string; onlyMissing: boolean }) =>
+  vectorize: <T = unknown>(id: string, body: LorebookVectorizeInput) =>
     invokeTauri<T>("lorebook_vectorize", { id, body }),
 };


### PR DESCRIPTION
## Linked issue

Closes #1854

## Why this change

- Lorebook Keeper clears stale embeddings when it creates or changes entries, but users had to remember to manually re-vectorize afterward for semantic matching.

## What changed

- Added best-effort auto-vectorization after Lorebook Keeper creates or modifies an entry.
- Limited the vectorization command to the Keeper-touched entry IDs instead of re-vectorizing the whole lorebook.
- Allowed the vectorize command to use the configured default embedding connection when no explicit connection is supplied.
- Added regression coverage for create/update/failure/delete paths and targeted vectorization.

## Refactor impact

Primary owner:

- Catalog lorebooks, with shared API and Rust storage command support.

Impact areas reviewed:

- Lorebook Keeper apply flow
- Manual lorebook vectorization command behavior
- Remote-capable `lorebook_vectorize` command surface

Boundary notes:

- Feature code calls the focused shared API wrapper.
- Rust storage owns provider/vector persistence.
- Engine code stays React-free and unchanged.

Pressure points touched:

- `src-tauri/src/commands/storage/prompts.rs`
- `src/features/catalog/lorebooks/lib/lorebook-keeper-updates.ts`
- `src/shared/api/lorebook-command-api.ts`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm test src/features/catalog/lorebooks/lib/lorebook-keeper-updates.test.ts`.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml vectorize_lorebook --workspace`.
- Codex ran `pnpm check`.
- Live embedding-provider verification was not performed in this environment.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- No new UI or discoverable surface; this extends existing Lorebook Keeper and semantic vectorization behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - no visible UI changes.
