### PR TITLE
Add Bunny auto review dispatcher

### DIFF
--- a/.github/workflows/bunny-review-auto.yml
+++ b/.github/workflows/bunny-review-auto.yml
@@ -1,0 +1,38 @@
+name: Bunny Review Auto Dispatch
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: bunny-review-auto-dispatch-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    if: >
+      github.event.pull_request.base.ref == 'refactor' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch trusted Bunny reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REQUESTED_BY: ${{ github.event.sender.login }}
+          TARGET_REF: refactor
+        run: |
+          # This pull_request_target workflow is intentionally a dispatcher only.
+          # It must not checkout, install, or execute code from the pull request.
+          gh workflow run bunny-review.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$TARGET_REF" \
+            -f pr_number="$PR_NUM" \
+            -f comment_body="auto pull_request_target dispatch" \
+            -f review_mode="auto" \
+            -f requested_by="$REQUESTED_BY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ For code changes, final responses must include behavior changed, primary files/m
 - `src/shared/api`: Embedded Tauri and hostable runtime wrappers. Feature code should call these wrappers instead of raw Tauri or raw remote-runtime fetch.
 - `src-tauri`: Rust command facades, hostable runtime dispatch, storage, LLM/provider transport, assets, imports, integrations, and other privileged capabilities.
 - `public/sprites/mari`: Professor Mari visual assets used by onboarding, FAQ, title controls, and the Mari shell surface.
-- `.github/workflows/bunny-review.yml`, `.github/bunny-review`: Bunny Review PR comment automation, review packet builder, CI dependencies, path rules, and model reviewer prompt.
+- `.github/workflows/bunny-review.yml`, `.github/workflows/bunny-review-auto.yml`, `.github/workflows/bunny-review-command.yml`, `.github/bunny-review`: Bunny Review PR comment automation, trusted auto and slash-command dispatchers, review packet builder, CI dependencies, path rules, and model reviewer prompt.
 - `skills/frontend-design`: Repo-local frontend concept, layout, visual direction, and first-pass UI implementation workflow that pairs with Impeccable.
 - `skills/impeccable`: Repo-local frontend design, critique, polish, accessibility, responsive, and live-iteration workflow for UI craft passes.
 - `skills/bunny-style-review`: Repo-local branch and PR review workflow for failure-path review and actionable nitpicks.


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #

## Why this change

- Restores automatic Bunny Review for PRs without giving the heavyweight reviewer workflow a privileged `pull_request_target` execution path.
- Avoids the fork-PR write-token failure from direct `pull_request` review posting by using a tiny trusted dispatcher that triggers the existing `workflow_dispatch` worker on `refactor`.

## What changed

- Added `.github/workflows/bunny-review-auto.yml`, a `pull_request_target` dispatcher for PR open/reopen/synchronize/ready events targeting `refactor`.
- The dispatcher does not checkout code, install dependencies, run scripts, or inspect PR files. It only dispatches `bunny-review.yml` on the trusted `refactor` ref with PR metadata.
- Updated `AGENTS.md` so the Bunny Review auto and slash-command dispatcher locations are in the repo map.

## Refactor impact

Primary owner:

- GitHub workflow automation.

Impact areas reviewed:

- Bunny Review auto dispatch path.
- Trusted `workflow_dispatch` reviewer path on `refactor`.
- Professor Mari / agent repo map entry for Bunny Review.

Boundary notes:

- No app source, engine, React feature, shared API, Tauri, storage, provider, or remote-runtime product boundary is touched.
- The privileged `pull_request_target` workflow is intentionally dispatcher-only and must not execute PR-controlled code.

Pressure points touched:

- GitHub Actions `pull_request_target` event handling and dispatch to `bunny-review.yml`.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent ran `git diff --check`.
- Agent ran `pnpm check:docs`.
- Agent inspected the new workflow and confirmed it has no checkout/install/script execution of PR-controlled code.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- GitHub workflow automation only; no in-app user-discoverable behavior is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. No app UI changes.
