### PR TITLE
Fix avatar reload lag on chat switch

### DIFF
--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, useEffect, useMemo, useState, type CSSProperties } from "react";
 import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
 
+const resolvedAvatarSrcCache = new Map<string, string>();
+
 function hasText(value: string | null | undefined): boolean {
   return !!value?.trim();
 }
@@ -57,9 +59,10 @@ export const ResolvedAvatarImage = forwardRef<
     return syncUrl;
   }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar]);
   const resolutionKey = JSON.stringify([src ?? "", avatarFilename ?? "", avatarFilePath ?? ""]);
+  const cachedResolvedSrc = hasManagedAvatar ? (resolvedAvatarSrcCache.get(resolutionKey) ?? null) : null;
   const [resolvedState, setResolvedState] = useState<{ key: string; src: string | null }>({
     key: resolutionKey,
-    src: immediateSrc,
+    src: cachedResolvedSrc ?? immediateSrc,
   });
 
   useEffect(() => {
@@ -72,17 +75,25 @@ export const ResolvedAvatarImage = forwardRef<
       };
     }
 
-    setResolvedState({ key: resolutionKey, src: immediateSrc });
-    if (immediateSrc) onResolvedSrc?.(immediateSrc);
+    const cachedSrc = resolvedAvatarSrcCache.get(resolutionKey) ?? null;
+    const nextInitialSrc = cachedSrc ?? immediateSrc;
+    setResolvedState({ key: resolutionKey, src: nextInitialSrc });
+    if (nextInitialSrc) onResolvedSrc?.(nextInitialSrc);
     resolveAvatarFileUrl(avatarFilename, avatarFilePath)
       .then((url) => {
         if (cancelled) return;
         const next = url ?? fallbackSrc;
+        if (next) {
+          resolvedAvatarSrcCache.set(resolutionKey, next);
+        } else {
+          resolvedAvatarSrcCache.delete(resolutionKey);
+        }
         setResolvedState({ key: resolutionKey, src: next });
         onResolvedSrc?.(next);
       })
       .catch(() => {
         if (cancelled) return;
+        resolvedAvatarSrcCache.delete(resolutionKey);
         setResolvedState({ key: resolutionKey, src: fallbackSrc });
         onResolvedSrc?.(fallbackSrc);
       });
@@ -92,7 +103,10 @@ export const ResolvedAvatarImage = forwardRef<
     };
   }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar, immediateSrc, onResolvedSrc, resolutionKey]);
 
-  const imageSrc = resolvedState.key === resolutionKey ? (resolvedState.src ?? immediateSrc) : immediateSrc;
+  const imageSrc =
+    resolvedState.key === resolutionKey
+      ? (resolvedState.src ?? cachedResolvedSrc ?? immediateSrc)
+      : (cachedResolvedSrc ?? immediateSrc);
   if (!imageSrc) return null;
 
   return (

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
@@ -1,7 +1,23 @@
 import { forwardRef, useEffect, useMemo, useState, type CSSProperties } from "react";
 import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
 
+const RESOLVED_AVATAR_SRC_CACHE_LIMIT = 128;
 const resolvedAvatarSrcCache = new Map<string, string>();
+
+function readCachedResolvedAvatarSrc(key: string): string | null {
+  return resolvedAvatarSrcCache.get(key) ?? null;
+}
+
+function rememberResolvedAvatarSrc(key: string, src: string | null): void {
+  resolvedAvatarSrcCache.delete(key);
+  if (!src) return;
+  resolvedAvatarSrcCache.set(key, src);
+  while (resolvedAvatarSrcCache.size > RESOLVED_AVATAR_SRC_CACHE_LIMIT) {
+    const oldestKey = resolvedAvatarSrcCache.keys().next().value;
+    if (!oldestKey) break;
+    resolvedAvatarSrcCache.delete(oldestKey);
+  }
+}
 
 function hasText(value: string | null | undefined): boolean {
   return !!value?.trim();
@@ -59,7 +75,7 @@ export const ResolvedAvatarImage = forwardRef<
     return syncUrl;
   }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar]);
   const resolutionKey = JSON.stringify([src ?? "", avatarFilename ?? "", avatarFilePath ?? ""]);
-  const cachedResolvedSrc = hasManagedAvatar ? (resolvedAvatarSrcCache.get(resolutionKey) ?? null) : null;
+  const cachedResolvedSrc = hasManagedAvatar ? readCachedResolvedAvatarSrc(resolutionKey) : null;
   const [resolvedState, setResolvedState] = useState<{ key: string; src: string | null }>({
     key: resolutionKey,
     src: cachedResolvedSrc ?? immediateSrc,
@@ -75,7 +91,7 @@ export const ResolvedAvatarImage = forwardRef<
       };
     }
 
-    const cachedSrc = resolvedAvatarSrcCache.get(resolutionKey) ?? null;
+    const cachedSrc = readCachedResolvedAvatarSrc(resolutionKey);
     const nextInitialSrc = cachedSrc ?? immediateSrc;
     setResolvedState({ key: resolutionKey, src: nextInitialSrc });
     if (nextInitialSrc) onResolvedSrc?.(nextInitialSrc);
@@ -83,17 +99,13 @@ export const ResolvedAvatarImage = forwardRef<
       .then((url) => {
         if (cancelled) return;
         const next = url ?? fallbackSrc;
-        if (next) {
-          resolvedAvatarSrcCache.set(resolutionKey, next);
-        } else {
-          resolvedAvatarSrcCache.delete(resolutionKey);
-        }
+        rememberResolvedAvatarSrc(resolutionKey, next);
         setResolvedState({ key: resolutionKey, src: next });
         onResolvedSrc?.(next);
       })
       .catch(() => {
         if (cancelled) return;
-        resolvedAvatarSrcCache.delete(resolutionKey);
+        rememberResolvedAvatarSrc(resolutionKey, null);
         setResolvedState({ key: resolutionKey, src: fallbackSrc });
         onResolvedSrc?.(fallbackSrc);
       });


### PR DESCRIPTION
## Linked issue

Closes #1866

## Why this change

- Managed avatar images can blank or lag during chat switches because the shared avatar renderer waits for the async managed-file resolver again after remount.

## What changed

- Cache resolved managed avatar image URLs by source/filename/file path key inside the shared avatar image component.
- Seed remounted avatar images from the cached resolved URL when available.
- Evict cached avatar URLs when resolution returns no usable URL or fails, so stale/broken images do not persist.

## Refactor impact

Primary owner:

Shared mode UI

Impact areas reviewed:

- Chat message avatar rendering
- Shared roleplay/chat transcript avatar surfaces that use `ResolvedAvatarImage`
- Shared local-file API boundary, which is called but not changed

Boundary notes:

- No engine changes.
- No storage or Rust capability changes.
- No new raw Tauri or remote-runtime calls.
- Change stays in feature-owned shared mode UI and keeps the existing focused shared API wrapper contract.

Pressure points touched:

- Shared mode UI: `src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.test.tsx` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed after rerun with network access for Rust dependency resolution.
- Manual Tauri/browser chat-switch verification not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated src/features/shell/discovery/ metadata
- [x] N/A Reason: Bugfix only; no new discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not captured; no browser/Tauri visual proof run.
