### PR TITLE
Register Bunny auto review dispatcher on main

### DIFF
--- a/.github/workflows/bunny-review-auto.yml
+++ b/.github/workflows/bunny-review-auto.yml
@@ -1,0 +1,38 @@
+name: Bunny Review Auto Dispatch
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: bunny-review-auto-dispatch-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    if: >
+      github.event.pull_request.base.ref == 'refactor' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch trusted Bunny reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          REQUESTED_BY: ${{ github.event.sender.login }}
+          TARGET_REF: refactor
+        run: |
+          # This pull_request_target workflow is intentionally a dispatcher only.
+          # It must not checkout, install, or execute code from the pull request.
+          gh workflow run bunny-review.yml \
+            --repo "${{ github.repository }}" \
+            --ref "$TARGET_REF" \
+            -f pr_number="$PR_NUM" \
+            -f comment_body="auto pull_request_target dispatch" \
+            -f review_mode="auto" \
+            -f requested_by="$REQUESTED_BY"


### PR DESCRIPTION
<!-- Target branch: `main`. Main is intentional because GitHub registers pull_request_target workflows from the default branch. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #

## Why this change

- Registers the safe Bunny auto-review dispatcher on the default branch so GitHub actually starts the `pull_request_target` workflow for PR events.
- Keeps the dispatcher minimal: it only dispatches the trusted `bunny-review.yml` workflow on `refactor`.

## What changed

- Added `.github/workflows/bunny-review-auto.yml` on `main`.
- The workflow only runs for non-draft PRs targeting `refactor`.
- It does not checkout code, install dependencies, execute PR scripts, or inspect PR files.

## Refactor impact

Primary owner:

- GitHub workflow automation.

Impact areas reviewed:

- Default-branch workflow registration for Bunny auto review.
- Trusted dispatch to `bunny-review.yml` on `refactor`.

Boundary notes:

- No app source, engine, React feature, shared API, Tauri, storage, provider, or remote-runtime boundary is touched. This is default-branch GitHub Actions dispatch wiring only.

Pressure points touched:

- GitHub Actions `pull_request_target` event registration and workflow dispatch.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent ran `git diff --check`.
- Agent inspected the workflow and confirmed it has no checkout/install/script execution of PR-controlled code.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- GitHub workflow bootstrap only; no in-app user-discoverable behavior is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. No app UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal GitHub Actions workflow automation for pull request processing. This infrastructure improvement streamlines development workflows and has no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->