### PR TITLE
Report Bunny provider failures

### DIFF
--- a/.github/bunny-review/bunny_review.py
+++ b/.github/bunny-review/bunny_review.py
@@ -1125,23 +1125,29 @@ def merge_review_objects(reviews):
     return merged
 
 
-def write_skipped_review(title, body):
+def write_skipped_review(title, body, *, status="unknown", metadata=None):
+    review_obj = {
+        "change_summary": [body],
+        "findings": [],
+        "pre_merge_checks": [{"name": title, "status": status, "detail": body}],
+        "open_questions": [],
+        "what_i_checked": ["No model pass ran; the specimen remained unexamined."],
+    }
+    if metadata:
+        review_obj.update(metadata)
     pathlib.Path("review.json").write_text(
-        json.dumps(
-            {
-                "change_summary": [body],
-                "findings": [],
-                "pre_merge_checks": [
-                    {"name": title, "status": "unknown", "detail": body}
-                ],
-                "open_questions": [],
-                "what_i_checked": ["No model pass ran; the specimen remained unexamined."],
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
+        json.dumps(review_obj, indent=2, sort_keys=True) + "\n",
         "utf-8",
+    )
+
+
+def model_failure_detail(exc):
+    message = " ".join(str(exc).split())
+    if len(message) > 500:
+        message = message[:497] + "..."
+    return (
+        f"Bunny Review could not complete because the model provider rejected the "
+        f"review request: {type(exc).__name__}: {message}"
     )
 
 
@@ -1254,7 +1260,25 @@ def produce_review(args):
                 + "."
             )
             triage_content = triage_for_packet(review_packet, focus_note)
-            chunk_reviews.append(three_pass_review(client, skill, triage_content, stats))
+            try:
+                chunk_reviews.append(
+                    three_pass_review(client, skill, triage_content, stats)
+                )
+            except Exception as exc:
+                write_skipped_review(
+                    "Review Failed",
+                    model_failure_detail(exc),
+                    status="fail",
+                    metadata={
+                        "head_sha": head_sha,
+                        "head_commit_message": commit_subject(head_sha),
+                        "review_base": base,
+                        "base_ref": base_ref,
+                        "mode": effective_mode,
+                    },
+                )
+                print_telemetry(stats)
+                return
         review_obj = merge_review_objects(chunk_reviews)
         review_obj.setdefault("what_i_checked", []).append(
             f"Examined the PR in {len(chunks)} file chunk(s) so the large diff did not contaminate context retention."
@@ -1263,7 +1287,23 @@ def produce_review(args):
         review_packet = build_review_packet(base, ci_status, effective_mode)
         stats = build_stats(review_packet)
         triage_content = triage_for_packet(review_packet, "Review the full current diff.")
-        review_obj = three_pass_review(client, skill, triage_content, stats)
+        try:
+            review_obj = three_pass_review(client, skill, triage_content, stats)
+        except Exception as exc:
+            write_skipped_review(
+                "Review Failed",
+                model_failure_detail(exc),
+                status="fail",
+                metadata={
+                    "head_sha": head_sha,
+                    "head_commit_message": commit_subject(head_sha),
+                    "review_base": base,
+                    "base_ref": base_ref,
+                    "mode": effective_mode,
+                },
+            )
+            print_telemetry(stats)
+            return
     review_obj.setdefault("head_sha", head_sha)
     review_obj.setdefault("head_commit_message", commit_subject(head_sha))
     review_obj.setdefault("review_base", base)


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #

## Why this change

- Prevents Bunny Review from appearing stuck on “running” when the model provider rejects the request, such as an invalid API token.
- Lets the normal render/post path publish a failed review status instead of aborting before posting anything.

## What changed

- Added provider/model exception handling around the model review passes.
- On failure, Bunny now writes a `review.json` with a failing pre-merge check and PR metadata, then exits produce cleanly so render/post can publish the failure.
- Preserves the existing missing-API-key skipped-review behavior.

## Refactor impact

Primary owner:

- GitHub workflow automation / Bunny Review runner.

Impact areas reviewed:

- Bunny Review model call failure path.
- Review JSON rendering and posting path after provider failure.

Boundary notes:

- No app source, engine, React feature, shared API, Tauri, storage, provider, or remote-runtime product boundary is touched.

Pressure points touched:

- Bunny Review provider failure handling and generated review status payloads.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] `pnpm check` passes locally before PR push/handoff, including the unused-code check
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm check:architecture` passes locally
- [ ] `pnpm check:docs` passes locally
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passes locally
- [ ] Rust clippy/tests were run for Rust behavior changes
- [ ] Browser or Tauri app manual verification completed
- [ ] Browser screenshot/recording evidence added when UI/browser state is the claim
- [ ] Remote runtime smoke checked when relevant

### Manual verification notes

- Agent ran `python3 -m py_compile .github/bunny-review/bunny_review.py`.
- Agent ran `pnpm check:docs`.
- Agent smoke-tested the provider failure payload path locally with an `openai` import stub.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- GitHub workflow failure handling only; no in-app user-discoverable behavior is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. No app UI changes.
