### PR TITLE
Fix Gemini stream truncation handling

### DIFF
--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -2518,10 +2518,11 @@ async fn stream_google(
             break;
         }
     }
-    if !completed && !buffer.trim().is_empty() {
-        if process_google_sse_block(&buffer, emit)? == SseBlockStatus::Complete {
-            completed = true;
-        }
+    if !completed
+        && !buffer.trim().is_empty()
+        && process_google_sse_block(&buffer, emit)? == SseBlockStatus::Complete
+    {
+        completed = true;
     }
     ensure_google_stream_completed(completed)
 }

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -2519,9 +2519,21 @@ async fn stream_google(
         }
     }
     if !completed && !buffer.trim().is_empty() {
-        process_google_sse_block(&buffer, emit)?;
+        if process_google_sse_block(&buffer, emit)? == SseBlockStatus::Complete {
+            completed = true;
+        }
     }
-    Ok(())
+    ensure_google_stream_completed(completed)
+}
+
+fn ensure_google_stream_completed(completed: bool) -> AppResult<()> {
+    if completed {
+        return Ok(());
+    }
+    Err(AppError::new(
+        "llm_stream_incomplete",
+        "Google/Gemini stream ended before Gemini sent a finish reason. The provider response may be incomplete; retry the request.",
+    ))
 }
 
 fn process_google_sse_block(
@@ -2580,16 +2592,28 @@ fn process_google_sse_block(
                 }
             }
         }
-        if candidate
+        if let Some(reason) = candidate
             .get("finishReason")
             .and_then(Value::as_str)
             .filter(|reason| !reason.is_empty())
-            .is_some()
         {
+            ensure_google_finish_reason_allows_complete(reason)?;
             return Ok(SseBlockStatus::Complete);
         }
     }
     Ok(SseBlockStatus::Continue)
+}
+
+fn ensure_google_finish_reason_allows_complete(reason: &str) -> AppResult<()> {
+    if reason.eq_ignore_ascii_case("STOP") {
+        return Ok(());
+    }
+    Err(AppError::new(
+        "llm_stream_incomplete",
+        format!(
+            "Google/Gemini stopped before completing the response (finishReason: {reason}). The provider response may be incomplete; retry the request."
+        ),
+    ))
 }
 
 async fn read_error_response_details(response: reqwest::Response) -> AppResult<Value> {
@@ -3166,6 +3190,37 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
 
         assert_eq!(status, SseBlockStatus::Complete);
         assert_eq!(emitted[0], json!({ "type": "usage", "data": { "totalTokenCount": 3 } }));
+    }
+
+    #[test]
+    fn google_stream_max_tokens_finish_reason_is_incomplete() {
+        let mut emitted = Vec::new();
+        let mut emit = |value: Value| {
+            emitted.push(value);
+            Ok(())
+        };
+
+        let error = process_google_sse_block(
+            r#"data: {"candidates":[{"content":{"parts":[{"text":"Above the Skyport, the great brass heating lens lets out a wet,"}]},"finishReason":"MAX_TOKENS"}]}"#,
+            &mut emit,
+        )
+        .expect_err("Gemini MAX_TOKENS finish reason should not be treated as complete");
+
+        assert_eq!(error.code, "llm_stream_incomplete");
+        assert!(error.message.contains("finishReason: MAX_TOKENS"));
+        assert_eq!(
+            emitted[0],
+            json!({ "type": "token", "text": "Above the Skyport, the great brass heating lens lets out a wet,", "data": "Above the Skyport, the great brass heating lens lets out a wet," })
+        );
+    }
+
+    #[test]
+    fn google_stream_requires_terminal_event() {
+        let error = ensure_google_stream_completed(false)
+            .expect_err("abrupt Gemini stream close should fail");
+
+        assert_eq!(error.code, "llm_stream_incomplete");
+        assert!(error.message.contains("ended before Gemini sent a finish reason"));
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #1871

## Why this change

- Game Mode narration could show a partial LinkAPI/Gemini response as if it were final when the Google/Gemini stream ended without a clean stop, or when Gemini stopped for a truncating finish reason such as `MAX_TOKENS`.

## What changed

- Require Google/Gemini streaming responses to receive an explicit terminal event before the Rust LLM stream reports success.
- Treat non-`STOP` Gemini finish reasons as `llm_stream_incomplete` so generation surfaces a provider issue instead of saving/displaying partial narration as complete.
- Added regression coverage for abrupt stream close and `MAX_TOKENS`, while preserving normal `STOP` and usage/thinking stream handling.

## Refactor impact

Primary owner:

- Rust storage / LLM provider transport

Impact areas reviewed:

- Google/Gemini streaming parser
- LinkAPI Gemini endpoint path, because it uses the Google provider stream path
- Runtime generation consumer behavior, which depends on provider stream success/failure

Boundary notes:

- The change stays in the Rust LLM provider stream producer. No React, engine prompt assembly, storage schema, shared API wrapper, or dependency declarations changed.

Pressure points touched:

- `src-tauri/crates/llm/src/lib.rs` Google/Gemini stream parsing and stream completion contract

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the provider-stream bug with a focused regression test: before the fix, an abrupt Gemini stream close returned `Ok(())`.
- `cargo test --manifest-path src-tauri\crates\llm\Cargo.toml google_stream_` passed after the fix.
- `cargo test --manifest-path src-tauri\crates\llm\Cargo.toml` passed after the fix.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed after the fix.
- `pnpm check` passed on the rebased commit before push.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review passed on the rebased commit.
- No live LinkAPI credentialed request was run in this environment; the provider-stream contract is covered by local Rust tests.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a provider-stream bugfix and does not add a new discoverable product surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: backend/provider-stream contract bug. Proof is the failing-before/passing-after Rust regression and PR gate output above.
