### PR TITLE
Fix compact Discover home bar

### DIFF
--- a/src/features/shell/discovery/components/DiscoverPanel.test.tsx
+++ b/src/features/shell/discovery/components/DiscoverPanel.test.tsx
@@ -38,8 +38,27 @@ describe("DiscoverPanel", () => {
     });
 
     expect(container.textContent).toContain("Discover Marinara");
-    expect(container.textContent).toContain("Conversation Mode");
     expect(container.textContent).toContain(`${DISCOVERY_ENTRIES.length} tracked`);
+  });
+
+  it("keeps the default feature list compact until expanded", () => {
+    act(() => {
+      root.render(<DiscoverPanel />);
+    });
+
+    expect(container.querySelectorAll("article")).toHaveLength(0);
+    expect(container.textContent).toContain(`${DISCOVERY_ENTRIES.length} features tracked`);
+    expect(container.textContent).toContain(`Browse all ${DISCOVERY_ENTRIES.length}`);
+
+    const showAllButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Browse all"),
+    );
+    act(() => {
+      showAllButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelectorAll("article")).toHaveLength(DISCOVERY_ENTRIES.length);
+    expect(container.textContent).toContain("Show fewer");
   });
 
   it("shows the empty state for unmatched searches", () => {
@@ -59,6 +78,11 @@ describe("DiscoverPanel", () => {
   it("runs panel actions from entry buttons", () => {
     act(() => {
       root.render(<DiscoverPanel />);
+    });
+
+    const input = container.querySelector("input") as HTMLInputElement;
+    act(() => {
+      changeInput(input, "characters");
     });
 
     const buttons = Array.from(container.querySelectorAll("button"));

--- a/src/features/shell/discovery/components/DiscoverPanel.test.tsx
+++ b/src/features/shell/discovery/components/DiscoverPanel.test.tsx
@@ -59,6 +59,17 @@ describe("DiscoverPanel", () => {
 
     expect(container.querySelectorAll("article")).toHaveLength(DISCOVERY_ENTRIES.length);
     expect(container.textContent).toContain("Show fewer");
+
+    const showFewerButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Show fewer"),
+    );
+    act(() => {
+      showFewerButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelectorAll("article")).toHaveLength(0);
+    expect(container.textContent).toContain(`${DISCOVERY_ENTRIES.length} features tracked`);
+    expect(container.textContent).toContain(`Browse all ${DISCOVERY_ENTRIES.length}`);
   });
 
   it("shows the empty state for unmatched searches", () => {

--- a/src/features/shell/discovery/components/DiscoverPanel.tsx
+++ b/src/features/shell/discovery/components/DiscoverPanel.tsx
@@ -1,4 +1,4 @@
-import { Compass, HelpCircle, Search, Sparkles } from "lucide-react";
+import { ChevronDown, ChevronUp, Compass, HelpCircle, Search, Sparkles } from "lucide-react";
 import { useMemo, useState } from "react";
 import { cn } from "../../../../shared/lib/utils";
 import {
@@ -24,6 +24,8 @@ const COVERAGE_CLASS: Record<DiscoveryCoverage, string> = {
   experimental: "border-amber-400/25 bg-amber-500/10 text-amber-700 dark:text-amber-200",
   "needs-polish": "border-zinc-400/25 bg-zinc-500/10 text-zinc-600 dark:text-zinc-300",
 };
+
+const DEFAULT_PREVIEW_COUNT = 0;
 
 function DiscoveryEntryRow({ entry }: { entry: DiscoveryEntry }) {
   return (
@@ -78,11 +80,15 @@ export function DiscoverPanel() {
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<DiscoveryCategory | "All">("All");
   const [coverage, setCoverage] = useState<DiscoveryCoverage | "All">("All");
+  const [showAllEntries, setShowAllEntries] = useState(false);
 
   const entries = useMemo(
     () => filterDiscoveryEntries(DISCOVERY_ENTRIES, query, { category, coverage }),
     [category, coverage, query],
   );
+  const hasActiveFilter = query.trim().length > 0 || category !== "All" || coverage !== "All";
+  const shouldShowPreview = !hasActiveFilter && !showAllEntries;
+  const visibleEntries = shouldShowPreview ? entries.slice(0, DEFAULT_PREVIEW_COUNT) : entries;
 
   return (
     <div className="flex min-h-full flex-col gap-3 p-3">
@@ -155,15 +161,31 @@ export function DiscoverPanel() {
       </div>
 
       <div className="flex items-center justify-between px-0.5 text-[0.68rem] text-[var(--muted-foreground)]">
-        <span>{entries.length} features</span>
+        <span>
+          {shouldShowPreview
+            ? `${entries.length} features tracked`
+            : visibleEntries.length === entries.length
+              ? `${entries.length} features`
+              : `Showing ${visibleEntries.length} of ${entries.length} features`}
+        </span>
         <span>{DISCOVERY_ENTRIES.length} tracked</span>
       </div>
 
       {entries.length > 0 ? (
         <div className="flex flex-col gap-2">
-          {entries.map((entry) => (
+          {visibleEntries.map((entry) => (
             <DiscoveryEntryRow key={entry.id} entry={entry} />
           ))}
+          {!hasActiveFilter && entries.length > DEFAULT_PREVIEW_COUNT && (
+            <button
+              type="button"
+              onClick={() => setShowAllEntries((value) => !value)}
+              className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--secondary)]/65 px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/40 hover:text-[var(--primary)]"
+            >
+              {showAllEntries ? <ChevronUp size="0.85rem" aria-hidden /> : <ChevronDown size="0.85rem" aria-hidden />}
+              {showAllEntries ? "Show fewer" : `Browse all ${entries.length}`}
+            </button>
+          )}
         </div>
       ) : (
         <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--card)]/45 p-5 text-center">


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1868

## Why this change

- The Discover surface on the home screen rendered the full seeded feature list by default, making launch look like an overlong scrolling guide instead of a compact discovery bar.

## What changed

- Keeps the default Discover home surface compact by hiding entry cards until the user searches, filters, or chooses `Browse all 36`.
- Preserves full browsing with a `Show fewer` collapse action after expansion.
- Updates Discover panel tests for compact default rendering, expansion, empty search, and searched entry actions.

## Refactor impact

Primary owner:

- App shell discovery UI.

Impact areas reviewed:

- `src/features/shell/discovery/components/DiscoverPanel.tsx`
- `src/features/shell/discovery/components/DiscoverPanel.test.tsx`

Boundary notes:

- Feature-only React UI change. No engine, shared API, Rust, storage, import/export, prompt, dependency, or schema boundary changes.

Pressure points touched:

- Home Discover surface rendered through `ModeHomeSurface`; no mode surface/router behavior changed.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex local browser proof before fix: launch captured `entryCount=36` for the Discover home surface.
- Codex local browser proof after fix: launch captured `entryCount=0` and `hasBrowseAll=true`.
- Codex interaction proof: `Browse all 36` expands to 36 entries; searching `characters` returns 6 entries and 2 `Open Characters` actions.
- `pnpm exec vitest run src/features/shell/discovery/components/DiscoverPanel.test.tsx src/features/shell/discovery/discovery-registry.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check:discovery` passed.
- `pnpm check` passed.
- Marinara proof gate passed with `scratch/bugfix-verification.json`.
- Bunny pass completed for the current diff.
- No manual verification blocker remains for the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This changes the presentation of the existing Discover surface only; it does not add a new discoverable capability.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Before:

![Before: Discover renders the full list at launch](https://gist.githubusercontent.com/cha1latte/c7f464a59f96479d9a88244b3e600cdb/raw/3412b0cfbb32cc4b4357da3b985aea9098cf80ff/discover-before.svg)

After:

![After: Discover stays compact with Browse all](https://gist.githubusercontent.com/cha1latte/c7f464a59f96479d9a88244b3e600cdb/raw/b5738346b365bc60dac0611e65a6c7b0643268ec/discover-after.svg)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery Panel adds a compact preview mode with a "Browse all" / "Show fewer" toggle and dynamic counts when expanded or collapsed.

* **Tests**
  * Updated tests to validate preview behavior, toggle transitions, correct counts in each state, and filtered entry selection via the search input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->