### PR TITLE
Add notification sound editor

### DIFF
--- a/src/features/modes/conversation/components/ConversationAutonomousEffects.tsx
+++ b/src/features/modes/conversation/components/ConversationAutonomousEffects.tsx
@@ -31,8 +31,9 @@ export function ConversationAutonomousEffects({
       const charInfo = characterMap.get(characterId);
       const name = charInfo?.name ?? "Someone";
 
-      if (useUIStore.getState().convoNotificationSound) {
-        playNotificationPing();
+      const uiState = useUIStore.getState();
+      if (uiState.convoNotificationSound) {
+        playNotificationPing(uiState.notificationSound, uiState.customNotificationSound);
       }
 
       if (useChatStore.getState().activeChatId !== chatId) {

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -772,7 +772,7 @@ export function ConversationView({
     if (newAssistantMessage) {
       const uiState = useUIStore.getState();
       if (uiState.convoNotificationSound) {
-        playNotificationPing();
+        playNotificationPing(uiState.notificationSound, uiState.customNotificationSound);
       }
       void showConversationLocalNotification({
         enabled: uiState.conversationBrowserNotifications,
@@ -814,8 +814,9 @@ export function ConversationView({
             return next;
           });
           // Play ping for each revealed line
-          if (useUIStore.getState().convoNotificationSound) {
-            playNotificationPing();
+          const uiState = useUIStore.getState();
+          if (uiState.convoNotificationSound) {
+            playNotificationPing(uiState.notificationSound, uiState.customNotificationSound);
           }
           // Remove completed timer from the ref
           if (idx === newSplitChildren.length - 1) {

--- a/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
+++ b/src/features/modes/conversation/hooks/autonomous/use-background-autonomous.ts
@@ -184,8 +184,9 @@ export function useBackgroundAutonomousPolling() {
                 }
 
                 // Play notification sound
-                if (useUIStore.getState().convoNotificationSound) {
-                  playNotificationPing();
+                const uiState = useUIStore.getState();
+                if (uiState.convoNotificationSound) {
+                  playNotificationPing(uiState.notificationSound, uiState.customNotificationSound);
                 }
 
                 // Increment unread badge

--- a/src/features/runtime/generation/hooks/use-generate.test.ts
+++ b/src/features/runtime/generation/hooks/use-generate.test.ts
@@ -105,6 +105,8 @@ describe("runGenerationWithUi notifications", () => {
     useUIStore.setState({
       convoNotificationSound: true,
       rpNotificationSound: true,
+      notificationSound: "refactor",
+      customNotificationSound: null,
       conversationBrowserNotifications: true,
     });
     markAutonomousUnreadMock.mockResolvedValue(chat());
@@ -149,7 +151,7 @@ describe("runGenerationWithUi notifications", () => {
       avatarCrop: { x: 1, y: 2, scale: 3 },
       count: 1,
     });
-    expect(playNotificationPingMock).toHaveBeenCalledTimes(1);
+    expect(playNotificationPingMock).toHaveBeenCalledWith("refactor", null);
     expect(showConversationLocalNotificationMock).toHaveBeenCalledWith({
       enabled: true,
       characterName: "Mari",
@@ -157,16 +159,27 @@ describe("runGenerationWithUi notifications", () => {
     });
   });
 
-  it("uses the Roleplay notification sound toggle for off-chat Roleplay generation", async () => {
+  it("uses the selected Roleplay notification sound for off-chat Roleplay generation", async () => {
     const currentChat = chat({ mode: "roleplay" });
     const message = assistantMessage();
+    const customNotificationSound = {
+      name: "Chime",
+      type: "audio/wav",
+      size: 128,
+      dataUrl: "data:audio/wav;base64,AAAA",
+    };
     queryClient.setQueryData(chatKeys.detail(currentChat.id), currentChat);
     queryClient.setQueryData(chatKeys.messages(currentChat.id), { pages: [[]], pageParams: [undefined] });
-    useUIStore.setState({ convoNotificationSound: false, rpNotificationSound: true });
+    useUIStore.setState({
+      convoNotificationSound: false,
+      rpNotificationSound: true,
+      notificationSound: "custom",
+      customNotificationSound,
+    });
 
     await runAssistantMessage(queryClient, { chatId: currentChat.id }, message);
 
-    expect(playNotificationPingMock).toHaveBeenCalledTimes(1);
+    expect(playNotificationPingMock).toHaveBeenCalledWith("custom", customNotificationSound);
     expect(showConversationLocalNotificationMock).not.toHaveBeenCalled();
     expect(useChatStore.getState().unreadCounts.get(currentChat.id)).toBe(1);
   });

--- a/src/features/runtime/generation/hooks/use-generate.test.ts
+++ b/src/features/runtime/generation/hooks/use-generate.test.ts
@@ -151,7 +151,8 @@ describe("runGenerationWithUi notifications", () => {
       avatarCrop: { x: 1, y: 2, scale: 3 },
       count: 1,
     });
-    expect(playNotificationPingMock).toHaveBeenCalledWith("refactor", null);
+    expect(playNotificationPingMock).toHaveBeenCalledTimes(1);
+    expect(playNotificationPingMock).toHaveBeenNthCalledWith(1, "refactor", null);
     expect(showConversationLocalNotificationMock).toHaveBeenCalledWith({
       enabled: true,
       characterName: "Mari",
@@ -179,7 +180,8 @@ describe("runGenerationWithUi notifications", () => {
 
     await runAssistantMessage(queryClient, { chatId: currentChat.id }, message);
 
-    expect(playNotificationPingMock).toHaveBeenCalledWith("custom", customNotificationSound);
+    expect(playNotificationPingMock).toHaveBeenCalledTimes(1);
+    expect(playNotificationPingMock).toHaveBeenNthCalledWith(1, "custom", customNotificationSound);
     expect(showConversationLocalNotificationMock).not.toHaveBeenCalled();
     expect(useChatStore.getState().unreadCounts.get(currentChat.id)).toBe(1);
   });

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -405,14 +405,16 @@ async function notifyOffChatAssistantMessage(queryClient: QueryClient, chatId: s
 
   const uiState = useUIStore.getState();
   if (chat.mode === "conversation") {
-    if (uiState.convoNotificationSound) playNotificationPing();
+    if (uiState.convoNotificationSound) {
+      playNotificationPing(uiState.notificationSound, uiState.customNotificationSound);
+    }
     void showConversationLocalNotification({
       enabled: uiState.conversationBrowserNotifications,
       characterName,
       tag: `marinara-conversation-${chatId}`,
     });
   } else if (uiState.rpNotificationSound) {
-    playNotificationPing();
+    playNotificationPing(uiState.notificationSound, uiState.customNotificationSound);
   }
 }
 

--- a/src/features/shell/discovery/discovery-entries.json
+++ b/src/features/shell/discovery/discovery-entries.json
@@ -117,7 +117,7 @@
     "keywords": ["notification", "sound", "ping", "ding", "audio", "legacy", "custom sound", "alert"],
     "audience": "Users who want Conversation and Roleplay alerts to sound different or match older Marinara builds.",
     "where": "Settings > Appearance > Notifications.",
-    "actions": [{ "type": "open-settings", "tab": "appearance", "label": "Open Appearance" }],
+    "actions": [{ "type": "open-settings", "tab": "appearance", "label": "Open Notification Sounds" }],
     "coverage": "advanced"
   },
   {

--- a/src/features/shell/discovery/discovery-entries.json
+++ b/src/features/shell/discovery/discovery-entries.json
@@ -110,6 +110,17 @@
     "coverage": "core"
   },
   {
+    "id": "notification-sounds",
+    "title": "Notification Sounds",
+    "category": "Settings",
+    "summary": "Choose the current notification ping, the legacy 1.6.1 ding, or a small custom audio file for local chat alerts.",
+    "keywords": ["notification", "sound", "ping", "ding", "audio", "legacy", "custom sound", "alert"],
+    "audience": "Users who want Conversation and Roleplay alerts to sound different or match older Marinara builds.",
+    "where": "Settings > Appearance > Notifications.",
+    "actions": [{ "type": "open-settings", "tab": "appearance", "label": "Open Appearance" }],
+    "coverage": "advanced"
+  },
+  {
     "id": "imports",
     "title": "Imports",
     "category": "Getting started",

--- a/src/features/shell/settings/components/settings/SettingControls.tsx
+++ b/src/features/shell/settings/components/settings/SettingControls.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useState } from "react";
-import { Bell } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Bell, Play, Upload, X } from "lucide-react";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
-import { playNotificationPing } from "../../../../../shared/lib/notification-sound";
+import {
+  CUSTOM_NOTIFICATION_SOUND_ACCEPT,
+  NOTIFICATION_SOUND_OPTIONS,
+  coerceNotificationSoundDataUrlMime,
+  getNotificationAudioMimeType,
+  playNotificationPing,
+  validateCustomNotificationSoundFile,
+  type CustomNotificationSound,
+} from "../../../../../shared/lib/notification-sound";
 import { HelpTooltip } from "../../../../../shared/components/ui/HelpTooltip";
 import {
   getLocalNotificationPermission,
@@ -14,10 +22,16 @@ export function ConversationSoundSetting() {
   const setConvoNotificationSound = useUIStore((s) => s.setConvoNotificationSound);
   const rpNotificationSound = useUIStore((s) => s.rpNotificationSound);
   const setRpNotificationSound = useUIStore((s) => s.setRpNotificationSound);
+  const notificationSound = useUIStore((s) => s.notificationSound);
+  const setNotificationSound = useUIStore((s) => s.setNotificationSound);
+  const customNotificationSound = useUIStore((s) => s.customNotificationSound);
+  const setCustomNotificationSound = useUIStore((s) => s.setCustomNotificationSound);
   const conversationBrowserNotifications = useUIStore((s) => s.conversationBrowserNotifications);
   const setConversationBrowserNotifications = useUIStore((s) => s.setConversationBrowserNotifications);
   const [localNotificationPermission, setLocalNotificationPermission] =
     useState<LocalNotificationPermission>("default");
+  const [customSoundError, setCustomSoundError] = useState<string | null>(null);
+  const customSoundInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,6 +59,41 @@ export function ConversationSoundSetting() {
         ? "Notifications are blocked in the browser or operating system. Re-enable them in site or system settings to use this."
         : "Show a generic native notification when a Conversation-mode character replies while Marinara is not focused. Message contents are never shown.";
 
+  const previewNotificationSound = (sound: CustomNotificationSound | null = customNotificationSound) => {
+    playNotificationPing(notificationSound, sound);
+  };
+
+  const handleCustomSoundFile = (file: File | null) => {
+    if (!file) return;
+    const error = validateCustomNotificationSoundFile(file);
+    if (error) {
+      setCustomSoundError(error);
+      if (customSoundInputRef.current) customSoundInputRef.current.value = "";
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        setCustomSoundError("Marinara could not read that audio file.");
+        return;
+      }
+      const type = (getNotificationAudioMimeType(file) ?? file.type) || "audio/*";
+      const nextSound: CustomNotificationSound = {
+        name: file.name,
+        type,
+        size: file.size,
+        dataUrl: coerceNotificationSoundDataUrlMime(reader.result, type),
+      };
+      setCustomNotificationSound(nextSound);
+      setNotificationSound("custom");
+      setCustomSoundError(null);
+      playNotificationPing("custom", nextSound);
+    };
+    reader.onerror = () => setCustomSoundError("Marinara could not read that audio file.");
+    reader.readAsDataURL(file);
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-1.5">
@@ -57,7 +106,7 @@ export function ConversationSoundSetting() {
         checked={convoNotificationSound}
         onChange={(v) => {
           setConvoNotificationSound(v);
-          if (v) playNotificationPing();
+          if (v) previewNotificationSound();
         }}
       />
       <ToggleSetting
@@ -90,9 +139,98 @@ export function ConversationSoundSetting() {
         checked={rpNotificationSound}
         onChange={(v) => {
           setRpNotificationSound(v);
-          if (v) playNotificationPing();
+          if (v) previewNotificationSound();
         }}
       />
+      <div className="mt-1 grid gap-2 rounded-lg bg-[var(--background)]/45 p-2 ring-1 ring-[var(--border)]">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--foreground)]">Notification sound</span>
+          <button
+            type="button"
+            onClick={() => previewNotificationSound()}
+            title="Preview notification sound"
+            aria-label="Preview notification sound"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+          >
+            <Play size="0.75rem" />
+          </button>
+        </div>
+        <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-3">
+          {NOTIFICATION_SOUND_OPTIONS.map((option) => {
+            const disabled = option.id === "custom" && !customNotificationSound;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                disabled={disabled}
+                onClick={() => {
+                  setNotificationSound(option.id);
+                  if (option.id !== "custom" || customNotificationSound) {
+                    playNotificationPing(option.id, customNotificationSound);
+                  }
+                }}
+                className={`flex min-h-16 flex-col items-start gap-1 rounded-md border p-2 text-left transition-colors ${
+                  notificationSound === option.id
+                    ? "border-[var(--primary)] bg-[var(--primary)]/10 text-[var(--foreground)]"
+                    : "border-[var(--border)] bg-[var(--secondary)]/45 text-[var(--muted-foreground)] hover:border-[var(--primary)]/45 hover:text-[var(--foreground)]"
+                } disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-[var(--border)] disabled:hover:text-[var(--muted-foreground)]`}
+              >
+                <span className="text-[0.6875rem] font-medium">{option.label}</span>
+                <span className="text-[0.5625rem] leading-snug">{option.description}</span>
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex flex-col gap-1.5 rounded-md bg-[var(--secondary)]/35 p-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              ref={customSoundInputRef}
+              type="file"
+              accept={CUSTOM_NOTIFICATION_SOUND_ACCEPT}
+              className="hidden"
+              onChange={(event) => handleCustomSoundFile(event.target.files?.[0] ?? null)}
+            />
+            <button
+              type="button"
+              onClick={() => customSoundInputRef.current?.click()}
+              className="inline-flex items-center gap-1.5 rounded-md bg-[var(--primary)] px-2 py-1 text-[0.6875rem] font-medium text-[var(--primary-foreground)] transition-colors hover:brightness-110"
+            >
+              <Upload size="0.75rem" />
+              Choose file
+            </button>
+            {customNotificationSound && (
+              <>
+                <span
+                  className="min-w-0 max-w-full truncate text-[0.625rem] text-[var(--muted-foreground)]"
+                  title={customNotificationSound.name}
+                >
+                  {customNotificationSound.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCustomNotificationSound(null);
+                    if (notificationSound === "custom") setNotificationSound("refactor");
+                    setCustomSoundError(null);
+                    if (customSoundInputRef.current) customSoundInputRef.current.value = "";
+                  }}
+                  title="Remove custom notification sound"
+                  aria-label="Remove custom notification sound"
+                  className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
+                >
+                  <X size="0.75rem" />
+                </button>
+              </>
+            )}
+          </div>
+          <p className="text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">
+            Custom files are stored in local settings and must be 512 KB or smaller.
+          </p>
+          {customSoundError && (
+            <p className="text-[0.5625rem] leading-snug text-[var(--destructive)]">{customSoundError}</p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/shared/lib/notification-sound.test.ts
+++ b/src/shared/lib/notification-sound.test.ts
@@ -1,16 +1,27 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CustomNotificationSound } from "./notification-sound";
+
+const CUSTOM_NOTIFICATION_SOUND_MAX_BYTES = 512 * 1024;
 
 function installAudioContext(overrides: Partial<AudioContext> | Array<Partial<AudioContext>> = {}) {
   const oscillator = {
-    frequency: { value: 0 },
+    frequency: {
+      value: 0,
+      setValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    },
     connect: vi.fn(),
     start: vi.fn(),
     stop: vi.fn(),
   };
   const gain = {
-    gain: { value: 0 },
+    gain: {
+      value: 0,
+      setValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    },
     connect: vi.fn(),
   };
   let instanceIndex = 0;
@@ -73,5 +84,68 @@ describe("playNotificationPing", () => {
     playNotificationPing();
 
     expect(AudioContextMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("notification sound settings", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes unknown sound ids to the current refactor sound", async () => {
+    const { normalizeNotificationSoundId } = await import("./notification-sound");
+
+    expect(normalizeNotificationSoundId("legacy-v1.6.1")).toBe("legacy-v1.6.1");
+    expect(normalizeNotificationSoundId("nope")).toBe("refactor");
+    expect(normalizeNotificationSoundId(null)).toBe("refactor");
+  });
+
+  it("accepts small audio files by MIME type or extension", async () => {
+    const { getNotificationAudioMimeType, validateCustomNotificationSoundFile } = await import("./notification-sound");
+
+    expect(validateCustomNotificationSoundFile({ name: "ping.wav", type: "", size: 1024 })).toBeNull();
+    expect(validateCustomNotificationSoundFile({ name: "ping.bin", type: "audio/mpeg", size: 1024 })).toBeNull();
+    expect(getNotificationAudioMimeType({ name: "ping.wav", type: "" })).toBe("audio/wav");
+  });
+
+  it("rejects unsupported or oversized custom audio files", async () => {
+    const { validateCustomNotificationSoundFile } = await import("./notification-sound");
+
+    expect(validateCustomNotificationSoundFile({ name: "ping.txt", type: "text/plain", size: 1024 })).toContain(
+      "audio file",
+    );
+    expect(
+      validateCustomNotificationSoundFile({
+        name: "ping.wav",
+        type: "audio/wav",
+        size: CUSTOM_NOTIFICATION_SOUND_MAX_BYTES + 1,
+      }),
+    ).toContain("512 KB");
+  });
+
+  it("normalizes persisted custom sounds and rejects non-audio data urls", async () => {
+    const { normalizeCustomNotificationSound } = await import("./notification-sound");
+    const sound: CustomNotificationSound = {
+      name: "  soft ping.wav  ",
+      type: "audio/wav",
+      size: 12,
+      dataUrl: "data:audio/wav;base64,AAAA",
+    };
+
+    expect(normalizeCustomNotificationSound(sound)).toEqual({
+      ...sound,
+      name: "soft ping.wav",
+    });
+    expect(normalizeCustomNotificationSound({ ...sound, dataUrl: "data:text/plain;base64,AAAA" })).toBeNull();
+    expect(normalizeCustomNotificationSound({ ...sound, size: CUSTOM_NOTIFICATION_SOUND_MAX_BYTES + 1 })).toBeNull();
+  });
+
+  it("coerces extension-only file reader data urls to an audio MIME type", async () => {
+    const { coerceNotificationSoundDataUrlMime } = await import("./notification-sound");
+
+    expect(coerceNotificationSoundDataUrlMime("data:application/octet-stream;base64,AAAA", "audio/wav")).toBe(
+      "data:audio/wav;base64,AAAA",
+    );
   });
 });

--- a/src/shared/lib/notification-sound.ts
+++ b/src/shared/lib/notification-sound.ts
@@ -10,7 +10,7 @@ export type CustomNotificationSound = {
   dataUrl: string;
 };
 
-export const DEFAULT_NOTIFICATION_SOUND_ID: NotificationSoundId = "refactor";
+const DEFAULT_NOTIFICATION_SOUND_ID: NotificationSoundId = "refactor";
 const CUSTOM_NOTIFICATION_SOUND_MAX_BYTES = 512 * 1024;
 export const CUSTOM_NOTIFICATION_SOUND_ACCEPT = "audio/*,.mp3,.wav,.ogg,.webm,.m4a,.aac,.flac";
 

--- a/src/shared/lib/notification-sound.ts
+++ b/src/shared/lib/notification-sound.ts
@@ -1,5 +1,51 @@
 type NotificationAudioContext = AudioContext & { state: AudioContextState | "interrupted" };
 
+const NOTIFICATION_SOUND_IDS = ["refactor", "legacy-v1.6.1", "custom"] as const;
+export type NotificationSoundId = (typeof NOTIFICATION_SOUND_IDS)[number];
+
+export type CustomNotificationSound = {
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
+};
+
+export const DEFAULT_NOTIFICATION_SOUND_ID: NotificationSoundId = "refactor";
+const CUSTOM_NOTIFICATION_SOUND_MAX_BYTES = 512 * 1024;
+export const CUSTOM_NOTIFICATION_SOUND_ACCEPT = "audio/*,.mp3,.wav,.ogg,.webm,.m4a,.aac,.flac";
+
+export const NOTIFICATION_SOUND_OPTIONS: Array<{
+  id: NotificationSoundId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "refactor",
+    label: "Refactor",
+    description: "The current short Marinara ping.",
+  },
+  {
+    id: "legacy-v1.6.1",
+    label: "Legacy 1.6.1",
+    description: "The softer two-tone ding from v1.6.1.",
+  },
+  {
+    id: "custom",
+    label: "Custom file",
+    description: "Use a small local audio file.",
+  },
+];
+
+const AUDIO_EXTENSION_MIME_TYPES: Record<string, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  webm: "audio/webm",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  flac: "audio/flac",
+};
+
 let notificationAudioContext: NotificationAudioContext | null = null;
 
 function getNotificationAudioContext(): NotificationAudioContext | null {
@@ -19,23 +65,146 @@ function getNotificationAudioContext(): NotificationAudioContext | null {
   return notificationAudioContext;
 }
 
-export function playNotificationPing() {
+function playRefactorPing() {
+  const context = getNotificationAudioContext();
+  if (!context) return;
+
+  if (context.state === "suspended" || context.state === "interrupted") {
+    void context.resume().catch(() => {});
+  }
+
+  const oscillator = context.createOscillator();
+  const gain = context.createGain();
+  oscillator.frequency.value = 880;
+  gain.gain.value = 0.03;
+  oscillator.connect(gain);
+  gain.connect(context.destination);
+  oscillator.start();
+  oscillator.stop(context.currentTime + 0.08);
+}
+
+function playLegacy161Ping() {
+  const context = getNotificationAudioContext();
+  if (!context) return;
+
+  if (context.state === "suspended" || context.state === "interrupted") {
+    void context.resume().catch(() => {});
+  }
+
+  const now = context.currentTime;
+  const main = context.createOscillator();
+  main.type = "sine";
+  main.frequency.setValueAtTime(880, now);
+  main.frequency.exponentialRampToValueAtTime(660, now + 0.15);
+
+  const shimmer = context.createOscillator();
+  shimmer.type = "sine";
+  shimmer.frequency.setValueAtTime(1320, now);
+  shimmer.frequency.exponentialRampToValueAtTime(990, now + 0.12);
+
+  const mainGain = context.createGain();
+  mainGain.gain.setValueAtTime(0.3, now);
+  mainGain.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+
+  const shimmerGain = context.createGain();
+  shimmerGain.gain.setValueAtTime(0.15, now);
+  shimmerGain.gain.exponentialRampToValueAtTime(0.001, now + 0.2);
+
+  main.connect(mainGain).connect(context.destination);
+  shimmer.connect(shimmerGain).connect(context.destination);
+
+  main.start(now);
+  main.stop(now + 0.25);
+  shimmer.start(now);
+  shimmer.stop(now + 0.2);
+}
+
+function playCustomNotificationSound(sound: CustomNotificationSound | null) {
+  if (!sound?.dataUrl || typeof Audio === "undefined") {
+    playRefactorPing();
+    return;
+  }
+
+  const audio = new Audio(sound.dataUrl);
+  audio.preload = "auto";
+  audio.volume = 0.7;
+  void audio.play().catch(() => {});
+}
+
+export function normalizeNotificationSoundId(value: unknown): NotificationSoundId {
+  return NOTIFICATION_SOUND_IDS.includes(value as NotificationSoundId)
+    ? (value as NotificationSoundId)
+    : DEFAULT_NOTIFICATION_SOUND_ID;
+}
+
+export function normalizeCustomNotificationSound(value: unknown): CustomNotificationSound | null {
+  if (typeof value !== "object" || value === null) return null;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.dataUrl !== "string" || !raw.dataUrl.startsWith("data:audio/")) return null;
+  const size = typeof raw.size === "number" && Number.isFinite(raw.size) ? Math.round(raw.size) : 0;
+  if (size < 0 || size > CUSTOM_NOTIFICATION_SOUND_MAX_BYTES) return null;
+  const name = typeof raw.name === "string" && raw.name.trim() ? raw.name.trim().slice(0, 160) : "Custom sound";
+  const type = typeof raw.type === "string" && raw.type.trim() ? raw.type.trim().slice(0, 80) : "audio/*";
+  return {
+    name,
+    type,
+    size,
+    dataUrl: raw.dataUrl,
+  };
+}
+
+export function getNotificationAudioMimeType(file: Pick<File, "name" | "type">): string | null {
+  if (file.type.startsWith("audio/")) return file.type;
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  return AUDIO_EXTENSION_MIME_TYPES[extension] ?? null;
+}
+
+function isSupportedNotificationAudioFile(file: Pick<File, "name" | "type">): boolean {
+  return getNotificationAudioMimeType(file) !== null;
+}
+
+export function coerceNotificationSoundDataUrlMime(dataUrl: string, type: string): string {
+  if (dataUrl.startsWith("data:audio/")) return dataUrl;
+  if (!type.startsWith("audio/")) return dataUrl;
+  return dataUrl.replace(/^data:[^;,]*(?=[;,])/, `data:${type}`);
+}
+
+export function validateCustomNotificationSoundFile(file: Pick<File, "name" | "type" | "size">): string | null {
+  if (!isSupportedNotificationAudioFile(file)) {
+    return "Choose an audio file: MP3, WAV, OGG, WebM, M4A, AAC, or FLAC.";
+  }
+  if (file.size > CUSTOM_NOTIFICATION_SOUND_MAX_BYTES) {
+    return "Choose an audio file smaller than 512 KB.";
+  }
+  return null;
+}
+
+function getPlayableNotificationSoundId(
+  soundId: NotificationSoundId,
+  customSound: CustomNotificationSound | null,
+): Exclude<NotificationSoundId, "custom"> | "custom" {
+  return soundId === "custom" && customSound?.dataUrl
+    ? "custom"
+    : soundId === "legacy-v1.6.1"
+      ? "legacy-v1.6.1"
+      : "refactor";
+}
+
+export function playNotificationPing(
+  soundId: NotificationSoundId = DEFAULT_NOTIFICATION_SOUND_ID,
+  customSound: CustomNotificationSound | null = null,
+) {
   try {
-    const context = getNotificationAudioContext();
-    if (!context) return;
-
-    if (context.state === "suspended" || context.state === "interrupted") {
-      void context.resume().catch(() => {});
+    const playableSoundId = getPlayableNotificationSoundId(soundId, customSound);
+    if (playableSoundId === "custom") {
+      playCustomNotificationSound(customSound);
+      return;
     }
-
-    const oscillator = context.createOscillator();
-    const gain = context.createGain();
-    oscillator.frequency.value = 880;
-    gain.gain.value = 0.03;
-    oscillator.connect(gain);
-    gain.connect(context.destination);
-    oscillator.start();
-    oscillator.stop(context.currentTime + 0.08);
+    if (playableSoundId === "legacy-v1.6.1") {
+      playLegacy161Ping();
+      return;
+    }
+    playRefactorPing();
   } catch {
     /* notification audio is best-effort */
   }

--- a/src/shared/stores/ui.store.ts
+++ b/src/shared/stores/ui.store.ts
@@ -4,7 +4,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { normalizeQuoteFormat } from "../lib/dialogue-quotes";
-import { DEFAULT_NOTIFICATION_SOUND_ID, normalizeNotificationSoundId } from "../lib/notification-sound";
+import { normalizeNotificationSoundId } from "../lib/notification-sound";
 import {
   DEFAULT_GAME_SETUP_LEARNED_OPTIONS,
   DEFAULT_GAME_SETUP_REMEMBERED_TEXT,
@@ -196,7 +196,7 @@ export const useUIStore = create<UIState>()(
       },
       convoNotificationSound: true,
       rpNotificationSound: true,
-      notificationSound: DEFAULT_NOTIFICATION_SOUND_ID,
+      notificationSound: "refactor",
       customNotificationSound: null,
       conversationBrowserNotifications: false,
       customConversationPrompt: null,

--- a/src/shared/stores/ui.store.ts
+++ b/src/shared/stores/ui.store.ts
@@ -4,6 +4,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { normalizeQuoteFormat } from "../lib/dialogue-quotes";
+import { DEFAULT_NOTIFICATION_SOUND_ID, normalizeNotificationSoundId } from "../lib/notification-sound";
 import {
   DEFAULT_GAME_SETUP_LEARNED_OPTIONS,
   DEFAULT_GAME_SETUP_REMEMBERED_TEXT,
@@ -195,6 +196,8 @@ export const useUIStore = create<UIState>()(
       },
       convoNotificationSound: true,
       rpNotificationSound: true,
+      notificationSound: DEFAULT_NOTIFICATION_SOUND_ID,
+      customNotificationSound: null,
       conversationBrowserNotifications: false,
       customConversationPrompt: null,
       scheduleGenerationPreferences: "",
@@ -468,6 +471,8 @@ export const useUIStore = create<UIState>()(
         })),
       setConvoNotificationSound: (v) => set({ convoNotificationSound: v }),
       setRpNotificationSound: (v) => set({ rpNotificationSound: v }),
+      setNotificationSound: (v) => set({ notificationSound: normalizeNotificationSoundId(v) }),
+      setCustomNotificationSound: (v) => set({ customNotificationSound: v }),
       setConversationBrowserNotifications: (v) => set({ conversationBrowserNotifications: v }),
       setCustomConversationPrompt: (v) => set({ customConversationPrompt: v }),
       setScheduleGenerationPreferences: (v) => set({ scheduleGenerationPreferences: v }),

--- a/src/shared/stores/ui/model.ts
+++ b/src/shared/stores/ui/model.ts
@@ -1,6 +1,7 @@
 // UI store types, constants, and pure helpers.
 import { normalizeTemperatureUnit, type TemperatureUnit } from "../../lib/temperature-units";
 import type { QuoteFormat } from "../../lib/dialogue-quotes";
+import type { CustomNotificationSound, NotificationSoundId } from "../../lib/notification-sound";
 
 export type { QuoteFormat };
 
@@ -433,6 +434,10 @@ export interface UIState {
   // ── Sound ──
   convoNotificationSound: boolean;
   rpNotificationSound: boolean;
+  /** Sound used for local Conversation and Roleplay notification pings. */
+  notificationSound: NotificationSoundId;
+  /** Optional browser-readable audio data URL for custom notification pings. */
+  customNotificationSound: CustomNotificationSound | null;
   /** When true, show native local notifications for new Conversation messages while Marinara is unfocused. */
   conversationBrowserNotifications: boolean;
 
@@ -620,6 +625,8 @@ export interface UIState {
   setConvoGradientField: (scheme: "dark" | "light", field: "from" | "to", value: string) => void;
   setConvoNotificationSound: (v: boolean) => void;
   setRpNotificationSound: (v: boolean) => void;
+  setNotificationSound: (v: NotificationSoundId) => void;
+  setCustomNotificationSound: (v: CustomNotificationSound | null) => void;
   setConversationBrowserNotifications: (v: boolean) => void;
   setCustomConversationPrompt: (v: string | null) => void;
   setScheduleGenerationPreferences: (v: string) => void;

--- a/src/shared/stores/ui/persistence.ts
+++ b/src/shared/stores/ui/persistence.ts
@@ -1,5 +1,6 @@
 import { createJSONStorage } from "zustand/middleware";
 import { normalizeQuoteFormat } from "../../lib/dialogue-quotes";
+import { normalizeCustomNotificationSound, normalizeNotificationSoundId } from "../../lib/notification-sound";
 import {
   RIGHT_PANEL_WIDTH_DEFAULT,
   RIGHT_PANEL_WIDTH_MAX,
@@ -160,6 +161,8 @@ export function partializeUiState(state: UIState) {
     userActivity: state.userActivity,
     convoNotificationSound: state.convoNotificationSound,
     rpNotificationSound: state.rpNotificationSound,
+    notificationSound: state.notificationSound,
+    customNotificationSound: state.customNotificationSound,
     conversationBrowserNotifications: state.conversationBrowserNotifications,
     customConversationPrompt: state.customConversationPrompt,
     scheduleGenerationPreferences: state.scheduleGenerationPreferences,
@@ -208,6 +211,8 @@ export function migrateUiState(persistedState: unknown): Partial<UIState> {
   persisted.imagePromptFormat = persisted.imagePromptFormat === "tags" ? "tags" : "descriptive";
   persisted.userStatusManual = persisted.userStatusManual === "dnd" ? "dnd" : "active";
   persisted.userStatus = persisted.userStatusManual === "dnd" ? "dnd" : "active";
+  persisted.notificationSound = normalizeNotificationSoundId(persisted.notificationSound);
+  persisted.customNotificationSound = normalizeCustomNotificationSound(persisted.customNotificationSound);
   delete persisted.trackerPanelWidth;
 
   return persisted;


### PR DESCRIPTION
## Linked issue

Closes #1869

## Why this change

- Adds a notification sound picker for users who do not want the current default ping, want the legacy v1.6.1 sound, or want to use a small custom audio file.

## What changed

- Added notification sound options for the current refactor ping, the legacy v1.6.1 two-tone ding, and a custom audio file.
- Added local settings persistence and validation for custom notification sounds.
- Updated Conversation notification call sites to play the selected sound.
- Added a Discover entry for notification sounds.

## Refactor impact

Primary owner:

- app shell / shared UI settings

Impact areas reviewed:

- Settings notification controls
- Conversation notification ping call sites
- UI settings persistence
- Discover metadata

Boundary notes:

- Kept the feature client-side and used the existing UI store persistence path.
- No engine, Rust, shared API, dependency, schema, or provider changes.

Pressure points touched:

- Settings panel notification controls
- Conversation active/background notification paths

## Validation

- [ ] Focused proof or matching lane command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm test src/shared/lib/notification-sound.test.ts`: passed, 8 tests.
- Codex ran `pnpm check`: passed.
- Manual browser/audio verification is still recommended for actually hearing Refactor, Legacy 1.6.1, and a custom file in the Settings UI.

## Feature Discoverability

Check exactly one:

- [x] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:
- Added `notification-sounds` discovery metadata for the new settings workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshot captured. The PR should stay draft until a human or browser pass confirms the Settings UI and audio playback behavior.
