### PR TITLE
Fix Datacat fresh browser fallback

### DIFF
--- a/src-tauri/src/commands/storage/bot_browser.rs
+++ b/src-tauri/src/commands/storage/bot_browser.rs
@@ -1504,11 +1504,69 @@ async fn datacat_fresh(state: &AppState, route: &ParsedPath) -> AppResult<Value>
             query_param(route, "limitWeek", "20"),
         ),
     ];
-    datacat_json_get(
+    let fresh = datacat_json_get(
         state,
         &format!("/api/characters/fresh?{}", query_string_owned(&params)),
     )
-    .await
+    .await;
+
+    match fresh {
+        Ok(value) => Ok(value),
+        Err(error) if error.code == "upstream_json_error" => {
+            datacat_fresh_recent_fallback(state, route).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn datacat_fresh_recent_fallback(state: &AppState, route: &ParsedPath) -> AppResult<Value> {
+    let params = vec![
+        ("limit".to_string(), query_param(route, "limit24", "80")),
+        ("offset".to_string(), "0".to_string()),
+        ("summary".to_string(), "1".to_string()),
+        (
+            "minTotalTokens".to_string(),
+            query_param(route, "min_tokens", DATACAT_DEFAULT_MIN_TOTAL_TOKENS),
+        ),
+    ];
+    let recent = datacat_json_get(
+        state,
+        &format!(
+            "/api/characters/recent-public?{}",
+            query_string_owned(&params)
+        ),
+    )
+    .await?;
+    Ok(datacat_recent_as_fresh_response(recent))
+}
+
+fn datacat_recent_as_fresh_response(mut recent: Value) -> Value {
+    let characters = recent
+        .get_mut("characters")
+        .and_then(Value::as_array_mut)
+        .map(|items| Value::Array(std::mem::take(items)))
+        .unwrap_or_else(|| json!([]));
+    let count = characters.as_array().map(Vec::len).unwrap_or_default();
+    json!({
+        "success": recent
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        "sortBy": "recent-public",
+        "fallback": {
+            "source": "recent-public",
+            "reason": "fresh endpoint returned invalid JSON"
+        },
+        "windows": {
+            "last24h": {
+                "count": count,
+                "characters": characters
+            }
+        },
+        "last24h": {
+            "count": count
+        }
+    })
 }
 
 async fn datacat_tags(state: &AppState, route: &ParsedPath) -> AppResult<Value> {
@@ -1623,4 +1681,26 @@ fn datacat_headers(token: &str) -> Vec<Header> {
         header("Referer", format!("{DATACAT_API_BASE}/")),
         header("X-Session-Token", token),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datacat_recent_fallback_matches_fresh_shape() {
+        let fallback = datacat_recent_as_fresh_response(json!({
+            "success": true,
+            "totalCount": 2,
+            "characters": [
+                { "characterId": "alpha", "chatName": "Alpha" },
+                { "characterId": "beta", "chatName": "Beta" }
+            ]
+        }));
+
+        let last24h = &fallback["windows"]["last24h"];
+        assert_eq!(last24h["count"], 2);
+        assert_eq!(last24h["characters"][0]["characterId"], "alpha");
+        assert_eq!(fallback["fallback"]["source"], "recent-public");
+    }
 }

--- a/src-tauri/src/commands/storage/bot_browser.rs
+++ b/src-tauri/src/commands/storage/bot_browser.rs
@@ -1558,29 +1558,34 @@ fn datacat_recent_as_fresh_response(mut recent: Value) -> AppResult<Value> {
             )
         })?;
     let count = characters.as_array().map(Vec::len).unwrap_or_default();
-    let empty_week = json!({
+    let unavailable_week = json!({
         "count": 0,
-        "characters": []
+        "characters": [],
+        "available": false,
+        "unavailable": true,
+        "reason": "fresh endpoint returned invalid JSON; recent-public fallback cannot provide thisWeek"
     });
     Ok(json!({
         "success": true,
         "sortBy": "recent-public",
         "fallback": {
             "source": "recent-public",
-            "reason": "fresh endpoint returned invalid JSON"
+            "reason": "fresh endpoint returned invalid JSON",
+            "partial": true,
+            "unavailableWindows": ["thisWeek"]
         },
         "windows": {
             "last24h": {
                 "count": count,
                 "characters": characters
             },
-            "thisWeek": empty_week.clone()
+            "thisWeek": unavailable_week.clone()
         },
         "last24h": {
             "count": count,
             "characters": characters
         },
-        "thisWeek": empty_week
+        "thisWeek": unavailable_week
     }))
 }
 
@@ -1722,7 +1727,11 @@ mod tests {
         assert!(fallback["windows"]["thisWeek"]["characters"]
             .as_array()
             .is_some_and(Vec::is_empty));
+        assert_eq!(fallback["windows"]["thisWeek"]["available"], false);
+        assert_eq!(fallback["windows"]["thisWeek"]["unavailable"], true);
         assert_eq!(fallback["fallback"]["source"], "recent-public");
+        assert_eq!(fallback["fallback"]["partial"], true);
+        assert_eq!(fallback["fallback"]["unavailableWindows"][0], "thisWeek");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/bot_browser.rs
+++ b/src-tauri/src/commands/storage/bot_browser.rs
@@ -1541,10 +1541,10 @@ async fn datacat_fresh_recent_fallback(state: &AppState, route: &ParsedPath) -> 
 }
 
 fn datacat_recent_as_fresh_response(mut recent: Value) -> AppResult<Value> {
-    if recent.get("success").and_then(Value::as_bool) == Some(false) {
+    if recent.get("success").and_then(Value::as_bool) != Some(true) {
         return Err(AppError::new(
             "upstream_response_error",
-            "DataCat recent fallback was unsuccessful",
+            "DataCat recent fallback did not report success",
         ));
     }
     let characters = recent
@@ -1743,6 +1743,16 @@ mod tests {
             "items": []
         }))
         .expect_err("missing character array should stay an upstream error");
+
+        assert_eq!(error.code, "upstream_response_error");
+    }
+
+    #[test]
+    fn datacat_recent_fallback_rejects_missing_success_flag() {
+        let error = datacat_recent_as_fresh_response(json!({
+            "characters": []
+        }))
+        .expect_err("missing success flag should stay an upstream error");
 
         assert_eq!(error.code, "upstream_response_error");
     }

--- a/src-tauri/src/commands/storage/bot_browser.rs
+++ b/src-tauri/src/commands/storage/bot_browser.rs
@@ -1537,21 +1537,33 @@ async fn datacat_fresh_recent_fallback(state: &AppState, route: &ParsedPath) -> 
         ),
     )
     .await?;
-    Ok(datacat_recent_as_fresh_response(recent))
+    datacat_recent_as_fresh_response(recent)
 }
 
-fn datacat_recent_as_fresh_response(mut recent: Value) -> Value {
+fn datacat_recent_as_fresh_response(mut recent: Value) -> AppResult<Value> {
+    if recent.get("success").and_then(Value::as_bool) == Some(false) {
+        return Err(AppError::new(
+            "upstream_response_error",
+            "DataCat recent fallback was unsuccessful",
+        ));
+    }
     let characters = recent
         .get_mut("characters")
         .and_then(Value::as_array_mut)
         .map(|items| Value::Array(std::mem::take(items)))
-        .unwrap_or_else(|| json!([]));
+        .ok_or_else(|| {
+            AppError::new(
+                "upstream_response_error",
+                "DataCat recent fallback did not include characters",
+            )
+        })?;
     let count = characters.as_array().map(Vec::len).unwrap_or_default();
-    json!({
-        "success": recent
-            .get("success")
-            .and_then(Value::as_bool)
-            .unwrap_or(true),
+    let empty_week = json!({
+        "count": 0,
+        "characters": []
+    });
+    Ok(json!({
+        "success": true,
         "sortBy": "recent-public",
         "fallback": {
             "source": "recent-public",
@@ -1561,12 +1573,15 @@ fn datacat_recent_as_fresh_response(mut recent: Value) -> Value {
             "last24h": {
                 "count": count,
                 "characters": characters
-            }
+            },
+            "thisWeek": empty_week.clone()
         },
         "last24h": {
-            "count": count
-        }
-    })
+            "count": count,
+            "characters": characters
+        },
+        "thisWeek": empty_week
+    }))
 }
 
 async fn datacat_tags(state: &AppState, route: &ParsedPath) -> AppResult<Value> {
@@ -1696,11 +1711,39 @@ mod tests {
                 { "characterId": "alpha", "chatName": "Alpha" },
                 { "characterId": "beta", "chatName": "Beta" }
             ]
-        }));
+        }))
+        .expect("valid recent data should become a fresh fallback");
 
         let last24h = &fallback["windows"]["last24h"];
         assert_eq!(last24h["count"], 2);
         assert_eq!(last24h["characters"][0]["characterId"], "alpha");
+        assert_eq!(fallback["last24h"]["characters"][1]["characterId"], "beta");
+        assert_eq!(fallback["windows"]["thisWeek"]["count"], 0);
+        assert!(fallback["windows"]["thisWeek"]["characters"]
+            .as_array()
+            .is_some_and(Vec::is_empty));
         assert_eq!(fallback["fallback"]["source"], "recent-public");
+    }
+
+    #[test]
+    fn datacat_recent_fallback_rejects_unsuccessful_recent_payload() {
+        let error = datacat_recent_as_fresh_response(json!({
+            "success": false,
+            "characters": []
+        }))
+        .expect_err("unsuccessful recent payload should not become a success");
+
+        assert_eq!(error.code, "upstream_response_error");
+    }
+
+    #[test]
+    fn datacat_recent_fallback_rejects_missing_characters() {
+        let error = datacat_recent_as_fresh_response(json!({
+            "success": true,
+            "items": []
+        }))
+        .expect_err("missing character array should stay an upstream error");
+
+        assert_eq!(error.code, "upstream_response_error");
     }
 }

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -2187,10 +2187,6 @@ export function BotBrowserView() {
                     <RefreshCw size="0.75rem" /> Retry
                   </button>
                 </div>
-              ) : results.length === 0 ? (
-                <div className="flex flex-1 items-center justify-center py-12 text-sm text-[var(--muted-foreground)]">
-                  No characters found
-                </div>
               ) : (
                 <>
                   {resultNotice && (
@@ -2199,11 +2195,17 @@ export function BotBrowserView() {
                       <span>{resultNotice}</span>
                     </div>
                   )}
-                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-                    {results.map((card) => (
-                      <CardTile key={card.id} card={card} onClick={() => openDetail(card)} />
-                    ))}
-                  </div>
+                  {results.length === 0 ? (
+                    <div className="flex flex-1 items-center justify-center py-12 text-sm text-[var(--muted-foreground)]">
+                      No characters found
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+                      {results.map((card) => (
+                        <CardTile key={card.id} card={card} onClick={() => openDetail(card)} />
+                      ))}
+                    </div>
+                  )}
                   {(totalPages > 1 || page > 1) && (
                     <div className="flex items-center justify-center gap-2 pt-2 pb-4">
                       <button

--- a/src/features/shell/bot-browser/components/BotBrowserView.tsx
+++ b/src/features/shell/bot-browser/components/BotBrowserView.tsx
@@ -26,6 +26,7 @@ import {
   LogOut,
   KeyRound,
   Cookie,
+  AlertTriangle,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -137,7 +138,7 @@ interface ProviderConfig {
   nsfwAvailable: boolean;
   /** "login" = show login modal, "wyvern" = show sort hint, true/false = normal */
   nsfwMode: "free" | "login" | "wyvern";
-  search: (params: SearchParams) => Promise<{ cards: BrowseCard[]; totalCount: number }>;
+  search: (params: SearchParams) => Promise<{ cards: BrowseCard[]; totalCount: number; notice?: string }>;
   fetchDetail: (card: BrowseCard) => Promise<CardDetail | null>;
   getAvatarUrl: (card: BrowseCard) => string;
   getExternalUrl: (card: BrowseCard) => string;
@@ -1013,6 +1014,7 @@ const datacatProvider: ProviderConfig = {
 
     let list: DatacatCharacter[] = [];
     let totalCount = 0;
+    let notice: string | undefined;
 
     if (useFresh) {
       const params = new URLSearchParams({
@@ -1024,6 +1026,9 @@ const datacatProvider: ProviderConfig = {
       // Response shape: { success, sortBy, windows: { last24h: { count, characters: [...] }, thisWeek: {...} } }
       const last24h = data?.windows?.last24h || data?.last24h;
       list = Array.isArray(last24h) ? last24h : (last24h?.characters ?? []);
+      if (data?.fallback?.partial === true && data.fallback.unavailableWindows?.includes("thisWeek")) {
+        notice = "DataCat Fresh is using recent-public results while the weekly window is unavailable.";
+      }
       // /fresh ignores `page` — the upstream `count` describes the full window
       // even when the response only carries `limit24` items. Reporting that as
       // `totalCount` would let the paginator advertise pages 2+ that just replay
@@ -1086,6 +1091,7 @@ const datacatProvider: ProviderConfig = {
         };
       }),
       totalCount,
+      notice,
     };
   },
   fetchDetail: async (card) => {
@@ -1186,6 +1192,7 @@ export function BotBrowserView() {
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [resultNotice, setResultNotice] = useState<string | null>(null);
 
   const [selectedCard, setSelectedCard] = useState<BrowseCard | null>(null);
   const [detail, setDetail] = useState<CardDetail | null>(null);
@@ -1357,6 +1364,7 @@ export function BotBrowserView() {
     const requestCriteriaKey = searchCriteriaKey;
     setLoading(true);
     setError(null);
+    setResultNotice(null);
     try {
       const result = await provider.search({
         query,
@@ -1375,9 +1383,11 @@ export function BotBrowserView() {
       if (searchRequestIdRef.current !== requestId || searchCriteriaKeyRef.current !== requestCriteriaKey) return;
       setResults(result.cards);
       setTotalCount(result.totalCount);
+      setResultNotice(result.notice ?? null);
     } catch (err) {
       if (searchRequestIdRef.current !== requestId || searchCriteriaKeyRef.current !== requestCriteriaKey) return;
       setError(err instanceof Error ? err.message : "Search failed");
+      setResultNotice(null);
       setResults([]);
     } finally {
       if (searchRequestIdRef.current === requestId && searchCriteriaKeyRef.current === requestCriteriaKey) {
@@ -2183,6 +2193,12 @@ export function BotBrowserView() {
                 </div>
               ) : (
                 <>
+                  {resultNotice && (
+                    <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                      <AlertTriangle size="0.875rem" aria-hidden="true" />
+                      <span>{resultNotice}</span>
+                    </div>
+                  )}
                   <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
                     {results.map((card) => (
                       <CardTile key={card.id} card={card} onClick={() => openDetail(card)} />

--- a/src/features/shell/bot-browser/types/provider-responses.ts
+++ b/src/features/shell/bot-browser/types/provider-responses.ts
@@ -229,13 +229,24 @@ export interface DatacatCharacter {
 interface DatacatFreshWindow {
   count?: number;
   characters?: DatacatCharacter[];
+  available?: boolean;
+  unavailable?: boolean;
+  reason?: string;
 }
 
 export interface DatacatFreshResponse {
   windows?: {
     last24h?: DatacatFreshWindow | DatacatCharacter[];
+    thisWeek?: DatacatFreshWindow | DatacatCharacter[];
   };
   last24h?: DatacatFreshWindow | DatacatCharacter[];
+  thisWeek?: DatacatFreshWindow | DatacatCharacter[];
+  fallback?: {
+    source?: string;
+    reason?: string;
+    partial?: boolean;
+    unavailableWindows?: string[];
+  };
 }
 
 export interface DatacatRecentResponse {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1874

## Why this change

- DataCat's Fresh endpoint currently returns HTTP 200 with malformed JSON, which bubbles through the bot browser as `error decoding response body`.
- The DataCat browser should still show character tiles instead of failing the whole provider when the Fresh endpoint is malformed.

## What changed

- Added a narrow DataCat Fresh fallback in the Rust bot-browser command: only `upstream_json_error` from the Fresh endpoint falls back to DataCat `recent-public`.
- Validates the recent-public fallback payload before reshaping it so bad fallback input stays an upstream error.
- Adapted the recent-public response into the existing Fresh response shape (`windows.last24h.characters`) and marks the unobservable `thisWeek` bucket unavailable/partial so the degraded response stays honest.
- Carries the partial fallback contract through the DataCat response type and Bot Browser rendering path so users see a provider notice while character tiles still render.
- Added focused Rust unit tests for the fallback response shape and malformed fallback inputs.

## Refactor impact

Primary owner:

Rust storage / bot browser provider commands.

Impact areas reviewed:

- `src-tauri/src/commands/storage/bot_browser.rs`
- `src/features/shell/bot-browser/components/BotBrowserView.tsx`
- `src/features/shell/bot-browser/types/provider-responses.ts`
- Hostable `bot_browser_get` remote-runtime path
- DataCat `fresh`, `recent`, and `tags` command paths

Boundary notes:

- The fix stays in `src-tauri`, where the upstream DataCat transport/response contract is owned.
- React bot-browser code consumes the partial fallback marker as a notice while continuing to render the existing `last24h` character shape.

Pressure points touched:

- DataCat branch of the bot browser storage command.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri\Cargo.toml datacat_recent_fallback` passed.
- Live before proof: DataCat Fresh returned HTTP 200 and failed JSON decoding with `unexpected end of hex escape`.
- Production remote-runtime proof after fix: `bot_browser_get` for `/bot-browser/datacat/fresh?sortBy=score&limit24=80&limitWeek=0` returned `fresh_count=50 top_last24h_count=50 week_count=0 week_unavailable=True partial=True unavailable_windows=thisWeek success=True fallback_source=recent-public sortBy=recent-public`.
- Adjacent checks: `datacat/recent?limit=80&offset=0` returned `recent_count=50 totalCount=212807`; `datacat/tags` returned `tags_count=58445 groups=6`.
- `pnpm typecheck` passed after the Bot Browser fallback-notice wiring.
- `pnpm check` passed after the Rust and UI follow-ups.
- Proof gist: https://gist.github.com/cha1latte/706f5818514066cb6f88141b40cd4f57
- Raw proof output: https://gist.githubusercontent.com/cha1latte/706f5818514066cb6f88141b40cd4f57/raw/e0a69808512a9ac213d0578cadefa958ba8b4738/datacat-proof-output.txt

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Issue screenshot shows the visible failure state: `error decoding response body`.
- This fix was verified through the production `bot_browser_get` remote-runtime command path rather than the desktop shell. Reviewer-visible command proof is linked above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bot browser now gracefully falls back to alternative data sources when fresh data is unavailable, ensuring uninterrupted access to bot listings.
  * Added informational notices that appear when the app retrieves data from fallback sources, keeping users informed about data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->