### PR TITLE
Show Bunny review as a PR check

### DIFF
--- a/.github/workflows/bunny-review.yml
+++ b/.github/workflows/bunny-review.yml
@@ -30,6 +30,7 @@ permissions:
   pull-requests: write
   issues: write
   actions: read # needed to read CI status
+  checks: write
 
 concurrency:
   group: bunny-review-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
@@ -79,6 +80,24 @@ jobs:
           git status
           git fetch origin "pull/$PR_NUM/head:pr-$PR_NUM"
           git checkout "pr-$PR_NUM"
+          HEAD_SHA=$(gh pr view "$PR_NUM" --json headRefOid -q .headRefOid)
+          echo "PR_HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+
+      - name: Mark Bunny check in progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/check-runs" \
+            -f name="Bunny Review" \
+            -f head_sha="$PR_HEAD_SHA" \
+            -f status="in_progress" \
+            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f external_id="bunny-review-${PR_NUM}" \
+            -f "output[title]=Bunny Review" \
+            -f "output[summary]=The trusted Bunny reviewer is inspecting this pull request." \
+            --jq .id > bunny-check-run-id.txt
 
       - uses: actions/setup-python@v5
         with:
@@ -162,3 +181,41 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python /tmp/bunny-review-tool/.github/bunny-review/bunny_review.py post
+
+      - name: Complete Bunny check
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHECK_RUN_ID=""
+          if [ -f bunny-check-run-id.txt ]; then
+            CHECK_RUN_ID="$(cat bunny-check-run-id.txt)"
+          fi
+          if [ -z "$CHECK_RUN_ID" ]; then
+            CHECK_RUN_ID="$(gh api "repos/${{ github.repository }}/commits/$PR_HEAD_SHA/check-runs" \
+              --jq '.check_runs[] | select(.name == "Bunny Review") | .id' | tail -n 1)"
+          fi
+          if [ -z "$CHECK_RUN_ID" ]; then
+            echo "::warning::No Bunny check run id found; unable to complete custom check."
+            exit 0
+          fi
+
+          if [ "${{ job.status }}" = "success" ]; then
+            CONCLUSION="success"
+            TITLE="Bunny Review Complete"
+            SUMMARY="Bunny posted or updated its review for this pull request."
+          else
+            CONCLUSION="failure"
+            TITLE="Bunny Review Failed"
+            SUMMARY="Bunny Review did not complete. Inspect the trusted workflow run for details."
+          fi
+
+          gh api \
+            --method PATCH \
+            "repos/${{ github.repository }}/check-runs/$CHECK_RUN_ID" \
+            -f status="completed" \
+            -f conclusion="$CONCLUSION" \
+            -f completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -f details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f "output[title]=$TITLE" \
+            -f "output[summary]=$SUMMARY" >/dev/null


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- The trusted Bunny reviewer now runs through `workflow_dispatch` on `refactor`, so the actual review workflow is attached to the trusted branch SHA rather than the pull request head SHA.
- GitHub therefore shows the safe dispatcher in the PR Checks section, but not the real reviewer status.
- Adding a custom check run on the PR head makes Bunny's actual review state visible in the PR rollup without changing the safe dispatcher architecture.

## What changed

- Grant the trusted Bunny worker `checks: write`.
- Create a `Bunny Review` check run on the PR head SHA once the worker has resolved and checked out the PR head.
- Complete that check with success or failure at the end of the trusted review job, linking back to the trusted workflow run.

## Refactor impact

Primary owner:

- GitHub workflow/review automation

Impact areas reviewed:

- `.github/workflows/bunny-review.yml`
- Existing `pull_request_target` dispatcher and `/bunny-review` command bootstrap remain on `main` unchanged.

Boundary notes:

- No product, engine, React feature, shared API, Rust, or remote-runtime behavior changed.
- The trusted reviewer still runs from `refactor` via `workflow_dispatch`; this only publishes check status for the PR head SHA.

Pressure points touched:

- None

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Ran `pnpm check:docs`; it checked 46 docs and repo guidance files.
- Parsed `.github/workflows/bunny-review.yml` with Python/YAML successfully.
- Verified on origin PR 42 that a dispatched trusted Bunny run created a `Bunny Review` check on the PR head SHA and completed it successfully.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is GitHub workflow status plumbing, not an app feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A
