### PR TITLE
Preserve projected message list ordering

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -552,6 +552,11 @@ impl FileStorage {
         if !path.exists() || fs::metadata(&path)?.len() == 0 {
             return Ok(None);
         }
+        match read_pretty_record_by_id_from_file(&path, id) {
+            Ok(Some(row)) => return Ok(Some(row)),
+            Ok(None) => {}
+            Err(_) => {}
+        }
         let file = fs::File::open(path)?;
         let reader = BufReader::new(file);
         let mut deserializer = serde_json::Deserializer::from_reader(reader);
@@ -1898,6 +1903,81 @@ fn strip_trailing_json_comma(bytes: &mut Vec<u8>) {
     }
 }
 
+fn read_pretty_record_by_id_from_file(path: &Path, id: &str) -> AppResult<Option<Value>> {
+    let file = fs::File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut record_lines: Vec<String> = Vec::new();
+    let mut in_record = false;
+    let mut saw_array_start = false;
+    let mut saw_record = false;
+    let expected_id_line = format!("\"id\": {}", serde_json::to_string(id)?);
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        let line = line.trim_end_matches('\n').to_string();
+        let trimmed = line.trim_start();
+
+        if !in_record {
+            if trimmed.starts_with('[') {
+                saw_array_start = true;
+                continue;
+            }
+            if trimmed.starts_with(']') {
+                break;
+            }
+            if trimmed.trim().is_empty() {
+                continue;
+            }
+            if trimmed.starts_with('{') {
+                in_record = true;
+                saw_record = true;
+                record_lines.clear();
+                record_lines.push(line);
+                continue;
+            }
+            return Ok(None);
+        }
+
+        let is_id_line = trimmed
+            .strip_suffix(',')
+            .unwrap_or(trimmed)
+            .trim_end()
+            == expected_id_line;
+        record_lines.push(line);
+        if is_id_line {
+            loop {
+                let mut next_line = String::new();
+                let bytes = reader.read_line(&mut next_line)?;
+                if bytes == 0 {
+                    return Ok(None);
+                }
+                let next_line = next_line.trim_end_matches('\n').to_string();
+                let is_end = is_pretty_top_level_record_end(&next_line);
+                record_lines.push(next_line);
+                if is_end {
+                    let mut raw = record_lines.join("\n").into_bytes();
+                    strip_trailing_json_comma(&mut raw);
+                    return serde_json::from_slice(&raw).map(Some).map_err(Into::into);
+                }
+            }
+        }
+
+        if is_pretty_top_level_record_end(record_lines.last().map(String::as_str).unwrap_or_default()) {
+            in_record = false;
+            record_lines.clear();
+        }
+    }
+
+    if !saw_array_start || in_record || !saw_record {
+        return Ok(None);
+    }
+    Ok(None)
+}
+
 fn parse_storage_message_cursor(cursor: &str) -> (String, Option<String>) {
     let mut parts = cursor.splitn(2, '|');
     let created_at = parts.next().unwrap_or_default().to_string();
@@ -2363,6 +2443,59 @@ mod tests {
         assert_eq!(storage.count_messages_for_chat("chat-a").unwrap(), 2);
         assert_eq!(storage.count_messages_for_chat("chat-b").unwrap(), 1);
         assert_eq!(storage.count_messages_for_chat("missing").unwrap(), 0);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn get_reads_pretty_record_by_id_when_data_precedes_id() {
+        let root = temp_storage_root("get-pretty-record-by-id");
+        let storage = FileStorage::new(&root).unwrap();
+        let collection = root.join("collections").join("characters.json");
+        fs::write(
+            &collection,
+            r#"[
+  {
+    "data": {
+      "description": "large skipped payload",
+      "name": "Skip"
+    },
+    "id": "skip-me"
+  },
+  {
+    "data": {
+      "description": "target payload",
+      "name": "Target"
+    },
+    "id": "target"
+  }
+]"#,
+        )
+        .unwrap();
+
+        let row = storage.get("characters", "target").unwrap().unwrap();
+
+        assert_eq!(row["id"], "target");
+        assert_eq!(row["data"]["name"], "Target");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn get_falls_back_for_compact_collection_json() {
+        let root = temp_storage_root("get-compact-record-by-id");
+        let storage = FileStorage::new(&root).unwrap();
+        let collection = root.join("collections").join("characters.json");
+        fs::write(
+            &collection,
+            r#"[{"data":{"name":"Skip"},"id":"skip-me"},{"data":{"name":"Target"},"id":"target"}]"#,
+        )
+        .unwrap();
+
+        let row = storage.get("characters", "target").unwrap().unwrap();
+
+        assert_eq!(row["id"], "target");
+        assert_eq!(row["data"]["name"], "Target");
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -70,6 +70,18 @@ impl FileStorage {
         )
     }
 
+    pub fn list_messages_for_chat_projected(
+        &self,
+        chat_id: &str,
+        fields: &[String],
+        field_selections: &Map<String, Value>,
+    ) -> AppResult<Vec<Value>> {
+        self.read_locked_or_recover(
+            || self.read_messages_for_chat_projected_no_recovery(chat_id, fields, field_selections),
+            || self.read_messages_for_chat_projected(chat_id, fields, field_selections),
+        )
+    }
+
     pub fn list_message_ids_for_chat(&self, chat_id: &str) -> AppResult<Vec<Value>> {
         self.read_locked_or_recover(
             || self.read_message_ids_for_chat_no_recovery(chat_id),
@@ -581,6 +593,64 @@ impl FileStorage {
 
     fn read_messages_for_chat_no_recovery(&self, chat_id: &str) -> AppResult<Vec<Value>> {
         self.read_messages_for_chat_inner(chat_id, false)
+    }
+
+    fn read_messages_for_chat_projected(
+        &self,
+        chat_id: &str,
+        fields: &[String],
+        field_selections: &Map<String, Value>,
+    ) -> AppResult<Vec<Value>> {
+        self.read_messages_for_chat_projected_inner(chat_id, fields, field_selections, true)
+    }
+
+    fn read_messages_for_chat_projected_no_recovery(
+        &self,
+        chat_id: &str,
+        fields: &[String],
+        field_selections: &Map<String, Value>,
+    ) -> AppResult<Vec<Value>> {
+        self.read_messages_for_chat_projected_inner(chat_id, fields, field_selections, false)
+    }
+
+    fn read_messages_for_chat_projected_inner(
+        &self,
+        chat_id: &str,
+        fields: &[String],
+        field_selections: &Map<String, Value>,
+        recover_on_fallback: bool,
+    ) -> AppResult<Vec<Value>> {
+        let path = self.collection_path("messages")?;
+        if fields.is_empty() {
+            return Ok(Vec::new());
+        }
+        if !path.exists() || fs::metadata(&path)?.len() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let field_set: HashSet<String> = fields.iter().cloned().collect();
+        let nested_field_sets = selected_nested_fields(field_selections);
+        let file = fs::File::open(path)?;
+        let reader = BufReader::new(file);
+        let mut deserializer = serde_json::Deserializer::from_reader(reader);
+        match deserializer.deserialize_seq(ProjectedMessageRowsForChatVisitor {
+            chat_id,
+            fields: &field_set,
+            field_selections: &nested_field_sets,
+        }) {
+            Ok(rows) => Ok(rows),
+            Err(_) => {
+                let rows = if recover_on_fallback {
+                    self.read_messages_for_chat(chat_id)?
+                } else {
+                    self.read_messages_for_chat_no_recovery(chat_id)?
+                };
+                Ok(rows
+                    .into_iter()
+                    .map(|row| project_row(row, &field_set, &nested_field_sets))
+                    .collect())
+            }
+        }
     }
 
     fn read_messages_for_chat_inner(
@@ -1552,6 +1622,113 @@ impl<'de, 'a> Visitor<'de> for MessageRowForChatVisitor<'a> {
     }
 }
 
+struct ProjectedMessageRowsForChatVisitor<'a> {
+    chat_id: &'a str,
+    fields: &'a HashSet<String>,
+    field_selections: &'a HashMap<String, HashSet<String>>,
+}
+
+impl<'de, 'a> Visitor<'de> for ProjectedMessageRowsForChatVisitor<'a> {
+    type Value = Vec<Value>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a messages JSON array")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut rows = Vec::new();
+        while let Some(row) = seq.next_element_seed(ProjectedMessageRowForChatSeed {
+            chat_id: self.chat_id,
+            fields: self.fields,
+            field_selections: self.field_selections,
+        })? {
+            if let Some(row) = row {
+                rows.push(row);
+            }
+        }
+        Ok(rows)
+    }
+}
+
+struct ProjectedMessageRowForChatSeed<'a> {
+    chat_id: &'a str,
+    fields: &'a HashSet<String>,
+    field_selections: &'a HashMap<String, HashSet<String>>,
+}
+
+impl<'de, 'a> DeserializeSeed<'de> for ProjectedMessageRowForChatSeed<'a> {
+    type Value = Option<Value>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ProjectedMessageRowForChatVisitor {
+            chat_id: self.chat_id,
+            fields: self.fields,
+            field_selections: self.field_selections,
+        })
+    }
+}
+
+struct ProjectedMessageRowForChatVisitor<'a> {
+    chat_id: &'a str,
+    fields: &'a HashSet<String>,
+    field_selections: &'a HashMap<String, HashSet<String>>,
+}
+
+impl<'de, 'a> Visitor<'de> for ProjectedMessageRowForChatVisitor<'a> {
+    type Value = Option<Value>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a message object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut object = Map::new();
+        let mut matches_chat = None;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "chatId" {
+                let value = map.next_value::<Value>()?;
+                matches_chat = Some(value.as_str() == Some(self.chat_id));
+                if matches_chat == Some(true) && self.fields.contains(&key) {
+                    object.insert(key, value);
+                }
+                continue;
+            }
+
+            if matches_chat == Some(false) {
+                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                continue;
+            }
+
+            if !self.fields.contains(&key) {
+                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                continue;
+            }
+
+            let value = if let Some(nested_fields) = self.field_selections.get(&key) {
+                map.next_value_seed(ProjectedNestedSeed {
+                    fields: nested_fields,
+                })?
+            } else {
+                map.next_value::<Value>()?
+            };
+            object.insert(key, value);
+        }
+
+        Ok(matches_chat
+            .unwrap_or(false)
+            .then_some(Value::Object(object)))
+    }
+}
+
 struct MessageIdRowsForChatVisitor<'a> {
     chat_id: &'a str,
 }
@@ -2420,6 +2597,54 @@ mod tests {
         let rows = storage.list_message_ids_for_chat("chat-a").unwrap();
 
         assert_eq!(rows, vec![json!({ "id": "a-1" }), json!({ "id": "a-2" })]);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn list_messages_for_chat_projected_skips_unrequested_fields() {
+        let root = temp_storage_root("list-messages-for-chat-projected");
+        let storage = FileStorage::new(&root).unwrap();
+        storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({
+                        "id": "skip-me",
+                        "chatId": "chat-b",
+                        "content": "skip",
+                        "extra": { "large": "ignored" },
+                        "swipes": [{ "content": "skip swipe", "extra": { "thinking": "skip thought" } }]
+                    }),
+                    json!({
+                        "id": "target",
+                        "chatId": "chat-a",
+                        "content": "stored content",
+                        "extra": { "large": "ignored", "hiddenFromAI": true },
+                        "swipes": [{ "content": "active swipe", "extra": { "thinking": "visible thought", "large": "ignored" } }]
+                    }),
+                ],
+            )
+            .unwrap();
+        let fields = vec![
+            "id".to_string(),
+            "chatId".to_string(),
+            "content".to_string(),
+            "extra".to_string(),
+        ];
+        let mut selections = Map::new();
+        selections.insert("extra".to_string(), json!(["thinking", "hiddenFromAI"]));
+
+        let rows = storage
+            .list_messages_for_chat_projected("chat-a", &fields, &selections)
+            .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["id"], "target");
+        assert_eq!(rows[0]["chatId"], "chat-a");
+        assert_eq!(rows[0]["content"], "stored content");
+        assert_eq!(rows[0]["extra"], json!({ "hiddenFromAI": true }));
+        assert!(rows[0].get("swipes").is_none());
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -2138,7 +2138,13 @@ fn read_pretty_record_by_id_from_file(path: &Path, id: &str) -> AppResult<Option
                 if is_end {
                     let mut raw = record_lines.join("\n").into_bytes();
                     strip_trailing_json_comma(&mut raw);
-                    return serde_json::from_slice(&raw).map(Some).map_err(Into::into);
+                    let row: Value = serde_json::from_slice(&raw)?;
+                    if row.get("id").and_then(Value::as_str) == Some(id) {
+                        return Ok(Some(row));
+                    }
+                    in_record = false;
+                    record_lines.clear();
+                    break;
                 }
             }
         }
@@ -2693,6 +2699,41 @@ mod tests {
       "name": "Target"
     },
     "id": "target"
+  }
+]"#,
+        )
+        .unwrap();
+
+        let row = storage.get("characters", "target").unwrap().unwrap();
+
+        assert_eq!(row["id"], "target");
+        assert_eq!(row["data"]["name"], "Target");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn get_pretty_record_by_id_ignores_nested_id_matches() {
+        let root = temp_storage_root("get-pretty-record-ignore-nested-id");
+        let storage = FileStorage::new(&root).unwrap();
+        let collection = root.join("collections").join("characters.json");
+        fs::write(
+            &collection,
+            r#"[
+  {
+    "id": "owner",
+    "data": {
+      "book": {
+        "id": "target"
+      },
+      "name": "Wrong"
+    }
+  },
+  {
+    "id": "target",
+    "data": {
+      "name": "Target"
+    }
   }
 ]"#,
         )

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -48,6 +48,12 @@ fn storage_list_inner(
                         .list_messages_for_chat_page(chat_id, limit, before.as_deref())?
                 } else if message_id_projection_only(options.as_ref()) {
                     state.storage.list_message_ids_for_chat(chat_id)?
+                } else if let Some(fields) = projection_fields.as_ref().filter(|fields| !fields.is_empty()) {
+                    state.storage.list_messages_for_chat_projected(
+                        chat_id,
+                        &message_projection_fields_for_materialization(fields),
+                        shared::projection_field_selections(options.as_ref()),
+                    )?
                 } else {
                     state.storage.list_messages_for_chat(chat_id)?
                 }
@@ -165,6 +171,20 @@ fn message_id_projection_only(options: Option<&Value>) -> bool {
         return false;
     };
     fields.len() == 1 && fields.first().and_then(Value::as_str) == Some("id")
+}
+
+fn message_projection_fields_for_materialization(fields: &[String]) -> Vec<String> {
+    let mut projection = fields.to_vec();
+    let needs_swipes = fields.iter().any(|field| {
+        matches!(
+            field.as_str(),
+            "content" | "extra" | "activeSwipeIndex" | "swipeCount" | "swipePreviews"
+        )
+    });
+    if needs_swipes && !projection.iter().any(|field| field == "swipes") {
+        projection.push("swipes".to_string());
+    }
+    projection
 }
 
 fn message_page_options(options: Option<&Value>) -> Option<(usize, Option<String>)> {

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -54,7 +54,7 @@ pub(crate) fn storage_list_inner(
                 {
                     state.storage.list_messages_for_chat_projected(
                         chat_id,
-                        &message_projection_fields_for_materialization(fields),
+                        &message_projection_fields_for_materialization(fields, options.as_ref()),
                         shared::projection_field_selections(options.as_ref()),
                     )?
                 } else {
@@ -176,8 +176,26 @@ fn message_id_projection_only(options: Option<&Value>) -> bool {
     fields.len() == 1 && fields.first().and_then(Value::as_str) == Some("id")
 }
 
-fn message_projection_fields_for_materialization(fields: &[String]) -> Vec<String> {
+fn message_projection_fields_for_materialization(
+    fields: &[String],
+    options: Option<&Value>,
+) -> Vec<String> {
     let mut projection = fields.to_vec();
+    for field in ["id", "sortOrder", "order", "createdAt"] {
+        if !projection.iter().any(|existing| existing == field) {
+            projection.push(field.to_string());
+        }
+    }
+    if let Some(order_by) = options
+        .and_then(|value| value.get("orderBy"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !projection.iter().any(|existing| existing == order_by) {
+            projection.push(order_by.to_string());
+        }
+    }
     let needs_swipes = fields.iter().any(|field| {
         matches!(
             field.as_str(),
@@ -1365,6 +1383,93 @@ mod tests {
             .expect("storage_list returns an array");
         assert_eq!(full_data_rows.len(), 1);
         assert_eq!(full_data_rows[0]["data"]["favorite_color"], "violet");
+    }
+
+    #[test]
+    fn storage_list_projected_messages_keeps_default_created_at_order() {
+        let state = test_state("message-projection-default-sort");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({ "id": "new", "chatId": "chat-1", "createdAt": "2026-01-03T00:00:00Z", "content": "new" }),
+                    json!({ "id": "old", "chatId": "chat-1", "createdAt": "2026-01-01T00:00:00Z", "content": "old" }),
+                    json!({ "id": "other", "chatId": "chat-2", "createdAt": "2026-01-02T00:00:00Z", "content": "other" }),
+                ],
+            )
+            .expect("messages should be seeded");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "filters": { "chatId": "chat-1" },
+                "fields": ["id", "content"]
+            })),
+        )
+        .expect("projected message list should succeed");
+
+        assert_eq!(
+            result,
+            json!([
+                { "id": "old", "content": "old" },
+                { "id": "new", "content": "new" }
+            ])
+        );
+    }
+
+    #[test]
+    fn storage_list_projected_messages_keeps_before_cursor_filter() {
+        let state = test_state("message-projection-before-cursor");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({ "id": "older", "chatId": "chat-1", "createdAt": "2026-01-01T00:00:00Z", "content": "older" }),
+                    json!({ "id": "cursor", "chatId": "chat-1", "createdAt": "2026-01-02T00:00:00Z", "content": "cursor" }),
+                    json!({ "id": "newer", "chatId": "chat-1", "createdAt": "2026-01-03T00:00:00Z", "content": "newer" }),
+                ],
+            )
+            .expect("messages should be seeded");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "filters": { "chatId": "chat-1" },
+                "fields": ["id", "content"],
+                "before": "2026-01-02T00:00:00Z|cursor"
+            })),
+        )
+        .expect("projected message list should succeed");
+
+        assert_eq!(result, json!([{ "id": "older", "content": "older" }]));
+    }
+
+    #[test]
+    fn message_projection_materialization_includes_internal_sort_fields() {
+        let fields = vec!["content".to_string()];
+        let projection = message_projection_fields_for_materialization(
+            &fields,
+            Some(&json!({ "orderBy": "score" })),
+        );
+
+        for field in [
+            "content",
+            "id",
+            "sortOrder",
+            "order",
+            "createdAt",
+            "score",
+            "swipes",
+        ] {
+            assert!(
+                projection.iter().any(|existing| existing == field),
+                "projection should include {field}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -21,7 +21,7 @@ pub async fn storage_list(
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_list_inner(
+pub(crate) fn storage_list_inner(
     state: &AppState,
     entity: String,
     options: Option<Value>,
@@ -48,7 +48,10 @@ fn storage_list_inner(
                         .list_messages_for_chat_page(chat_id, limit, before.as_deref())?
                 } else if message_id_projection_only(options.as_ref()) {
                     state.storage.list_message_ids_for_chat(chat_id)?
-                } else if let Some(fields) = projection_fields.as_ref().filter(|fields| !fields.is_empty()) {
+                } else if let Some(fields) = projection_fields
+                    .as_ref()
+                    .filter(|fields| !fields.is_empty())
+                {
                     state.storage.list_messages_for_chat_projected(
                         chat_id,
                         &message_projection_fields_for_materialization(fields),

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -867,129 +867,13 @@ fn chat_disconnect(state: &AppState, args: &Map<String, Value>) -> AppResult<Val
 }
 
 fn storage_list(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let entity = required_string(args, "entity")?;
-    let options = args.get("options").filter(|value| !value.is_null());
-    let filters = options
-        .and_then(|value| value.get("filters"))
-        .and_then(Value::as_object);
-    let projection_fields = shared::projection_fields(options);
-    let empty_filters = filters.is_none_or(|filters| filters.is_empty());
-    let has_search = shared::has_storage_search(options);
-    let mut rows = match (entity, filters) {
-        ("messages", Some(filters))
-            if filters.len() == 1 && filters.get("chatId").and_then(Value::as_str).is_some() =>
-        {
-            let chat_id = filters
-                .get("chatId")
-                .and_then(Value::as_str)
-                .unwrap_or_default();
-            if !has_search {
-                if let Some((limit, before)) = message_page_options(options) {
-                    state
-                        .storage
-                        .list_messages_for_chat_page(chat_id, limit, before.as_deref())?
-                } else {
-                    state.storage.list_messages_for_chat(chat_id)?
-                }
-            } else {
-                state.storage.list_messages_for_chat(chat_id)?
-            }
-        }
-        (_, _)
-            if empty_filters
-                && has_search
-                && projection_fields
-                    .as_ref()
-                    .is_some_and(|fields| !fields.is_empty()) =>
-        {
-            let search_projection_fields = shared::search_projection_fields(options);
-            let search_projection_field_selections =
-                shared::search_projection_field_selections(options);
-            state.storage.list_projected(
-                entity,
-                &search_projection_fields,
-                &search_projection_field_selections,
-            )?
-        }
-        (_, _)
-            if empty_filters
-                && !has_search
-                && projection_fields
-                    .as_ref()
-                    .is_some_and(|fields| !fields.is_empty()) =>
-        {
-            state.storage.list_projected(
-                entity,
-                projection_fields.as_deref().unwrap_or(&[]),
-                shared::projection_field_selections(options),
-            )?
-        }
-        (_, Some(filters)) if !filters.is_empty() => state.storage.list_where(entity, filters)?,
-        _ => state.storage.list(entity)?,
-    };
-    shared::apply_storage_search(&mut rows, options);
-
-    let order_by = options
-        .and_then(|value| value.get("orderBy"))
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty());
-    let descending = options
-        .and_then(|value| value.get("descending"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-
-    rows.sort_by(|a, b| {
-        let ordering = match order_by {
-            Some(field) => compare_json_values(a.get(field), b.get(field)),
-            None => compare_json_values(
-                a.get("sortOrder")
-                    .or_else(|| a.get("order"))
-                    .or_else(|| a.get("createdAt")),
-                b.get("sortOrder")
-                    .or_else(|| b.get("order"))
-                    .or_else(|| b.get("createdAt")),
-            ),
-        };
-        if descending {
-            ordering.reverse()
-        } else {
-            ordering
-        }
-    });
-
-    if entity == "messages" {
-        apply_message_pagination(&mut rows, options);
-        for row in &mut rows {
-            shared::materialize_message_swipe_fields(row);
-        }
-        return Ok(Value::Array(shared::project_list_rows(rows, options)));
-    }
-
-    if entity == "connections" {
-        connection_secrets::mask_connection_rows_for_read(&mut rows);
-    }
-
-    if let Some(limit) = options
-        .and_then(|value| value.get("limit"))
-        .and_then(Value::as_u64)
-        .map(|value| value as usize)
-    {
-        rows.truncate(limit);
-    }
-
-    Ok(Value::Array(shared::project_list_rows(rows, options)))
-}
-
-fn message_page_options(options: Option<&Value>) -> Option<(usize, Option<String>)> {
-    let options = options?;
-    let limit = options.get("limit").and_then(Value::as_u64)? as usize;
-    let before = options
-        .get("before")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
-    Some((limit, before))
+    entity_commands::storage_list_inner(
+        state,
+        required_string(args, "entity")?.to_string(),
+        args.get("options")
+            .filter(|value| !value.is_null())
+            .cloned(),
+    )
 }
 
 fn storage_get(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
@@ -1120,10 +1004,7 @@ fn chat_message_delete_swipe(state: &AppState, args: &Map<String, Value>) -> App
 }
 
 fn chat_evict_prompt_snapshots(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let keep_last = args
-        .get("keepLast")
-        .and_then(Value::as_u64)
-        .unwrap_or(2) as usize;
+    let keep_last = args.get("keepLast").and_then(Value::as_u64).unwrap_or(2) as usize;
     chats::evict_prompt_snapshots(state, required_string(args, "chatId")?, keep_last)
 }
 
@@ -1230,74 +1111,6 @@ async fn sprite_generate_sheet_preview(
 
 fn llm_stream_cancel(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
     llm::llm_stream_cancel(state, required_string(args, "streamId")?)
-}
-
-fn compare_json_values(left: Option<&Value>, right: Option<&Value>) -> std::cmp::Ordering {
-    match (left, right) {
-        (Some(Value::Number(a)), Some(Value::Number(b))) => a
-            .as_f64()
-            .partial_cmp(&b.as_f64())
-            .unwrap_or(std::cmp::Ordering::Equal),
-        (Some(Value::String(a)), Some(Value::String(b))) => a.cmp(b),
-        (Some(Value::Bool(a)), Some(Value::Bool(b))) => a.cmp(b),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        _ => std::cmp::Ordering::Equal,
-    }
-}
-
-fn apply_message_pagination(rows: &mut Vec<Value>, options: Option<&Value>) {
-    rows.sort_by(|a, b| {
-        let (a_created_at, a_id) = message_cursor(a);
-        let (b_created_at, b_id) = message_cursor(b);
-        a_created_at.cmp(b_created_at).then_with(|| a_id.cmp(b_id))
-    });
-
-    let before = options
-        .and_then(|value| value.get("before"))
-        .and_then(Value::as_str)
-        .filter(|value| !value.trim().is_empty())
-        .map(parse_message_cursor);
-
-    if let Some((before_created_at, before_id)) = before {
-        rows.retain(|row| {
-            let (created_at, id) = message_cursor(row);
-            created_at < before_created_at.as_str()
-                || (created_at == before_created_at.as_str()
-                    && before_id.as_deref().is_some_and(|cursor_id| id < cursor_id))
-        });
-    }
-
-    let Some(limit) = options
-        .and_then(|value| value.get("limit"))
-        .and_then(Value::as_u64)
-        .map(|value| value as usize)
-    else {
-        return;
-    };
-
-    if rows.len() > limit {
-        let keep_from = rows.len() - limit;
-        rows.drain(0..keep_from);
-    }
-}
-
-fn parse_message_cursor(cursor: &str) -> (String, Option<String>) {
-    let mut parts = cursor.splitn(2, '|');
-    let created_at = parts.next().unwrap_or_default().to_string();
-    let id = parts
-        .next()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
-    (created_at, id)
-}
-
-fn message_cursor(row: &Value) -> (&str, &str) {
-    (
-        row.get("createdAt").and_then(Value::as_str).unwrap_or(""),
-        row.get("id").and_then(Value::as_str).unwrap_or(""),
-    )
 }
 
 #[cfg(test)]
@@ -1459,6 +1272,60 @@ mod tests {
         assert_eq!(
             result.get("mimeType"),
             Some(&Value::String("image/png".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_list_uses_projected_message_reads() {
+        let state = test_state("storage-list-projected-messages");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({
+                        "id": "skip-me",
+                        "chatId": "chat-b",
+                        "content": "skip",
+                        "extra": { "large": "ignored" },
+                        "swipes": [{ "content": "skip swipe", "extra": { "thinking": "skip thought" } }]
+                    }),
+                    json!({
+                        "id": "message-1",
+                        "chatId": "chat-a",
+                        "content": "stored content",
+                        "extra": { "thinking": "visible thought", "large": "ignored" },
+                        "swipes": [{ "content": "active swipe", "extra": { "thinking": "swipe thought", "large": "ignored" } }]
+                    }),
+                ],
+            )
+            .expect("messages should be installed");
+
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "storage_list".to_string(),
+                args: Some(json!({
+                    "entity": "messages",
+                    "options": {
+                        "filters": { "chatId": "chat-a" },
+                        "fields": ["id", "chatId", "content", "extra"],
+                        "fieldSelections": { "extra": ["thinking"] }
+                    }
+                })),
+            },
+        )
+        .await
+        .expect("remote storage_list should dispatch");
+
+        assert_eq!(
+            result,
+            json!([{
+                "id": "message-1",
+                "chatId": "chat-a",
+                "content": "active swipe",
+                "extra": { "thinking": "swipe thought" }
+            }])
         );
     }
 

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -15,6 +15,15 @@ function resolveAvatarCrop(crop: unknown): AvatarCropValue | null {
   }
 }
 
+function isLikelyFilesystemPath(value: string): boolean {
+  const normalized = value.replace(/\\/g, "/");
+  return (
+    /^[a-z]:\//i.test(normalized) ||
+    normalized.startsWith("//") ||
+    /^\/(Users|home|var|data|tmp|opt|private)\//i.test(normalized)
+  );
+}
+
 export function CharacterAvatarImage({
   src,
   avatarFilePath,
@@ -36,6 +45,11 @@ export function CharacterAvatarImage({
   useEffect(() => {
     let cancelled = false;
     setAsyncSrc(initialSrc);
+    if (initialSrc && !isLikelyFilesystemPath(initialSrc)) {
+      return () => {
+        cancelled = true;
+      };
+    }
     resolveAvatarFileUrl(avatarFilename, avatarFilePath)
       .then((url) => {
         if (!cancelled) setAsyncSrc(url ?? src ?? null);

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -39,13 +39,15 @@ export function CharacterAvatarImage({
   crop?: unknown;
   className?: string;
 }) {
-  const initialSrc = avatarFileUrlFromPath(avatarFilename, avatarFilePath) ?? src ?? null;
+  const managedInitialSrc = avatarFileUrlFromPath(avatarFilename, avatarFilePath);
+  const hasManagedAvatarInput = Boolean(avatarFilename || avatarFilePath);
+  const initialSrc = managedInitialSrc ?? src ?? null;
   const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
 
   useEffect(() => {
     let cancelled = false;
     setAsyncSrc(initialSrc);
-    if (initialSrc && !isLikelyFilesystemPath(initialSrc)) {
+    if (!hasManagedAvatarInput || (managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
       return () => {
         cancelled = true;
       };
@@ -60,7 +62,7 @@ export function CharacterAvatarImage({
     return () => {
       cancelled = true;
     };
-  }, [avatarFilename, avatarFilePath, initialSrc, src]);
+  }, [avatarFilename, avatarFilePath, hasManagedAvatarInput, initialSrc, managedInitialSrc, src]);
 
   const resolvedSrc = asyncSrc ?? initialSrc;
   if (!resolvedSrc) return null;

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -179,6 +179,19 @@ function characterSearchValues(character: { id?: string; data: unknown; comment?
   ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
 }
 
+function characterGreetingData(character: { data?: unknown } | null | undefined): {
+  firstMes: string;
+  altGreetings: string[];
+} {
+  const data = character?.data && typeof character.data === "object" ? (character.data as Record<string, unknown>) : {};
+  return {
+    firstMes: typeof data.first_mes === "string" ? data.first_mes : "",
+    altGreetings: Array.isArray(data.alternate_greetings)
+      ? data.alternate_greetings.filter((greeting): greeting is string => typeof greeting === "string")
+      : [],
+  };
+}
+
 function characterMatchesSearch(
   character: { id?: string; data: unknown; comment?: string | null },
   search: string,
@@ -1193,41 +1206,29 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
         if (!userEditedName) updateData.name = buildAutoName(current);
         updateChat.mutate(updateData, {
           onSuccess: () => {
-            void storageApi
-              .get<{ data?: unknown }>("characters", charId)
-              .then((char) => {
-                const parsed =
-                  char?.data && typeof char.data === "object" ? (char.data as Record<string, unknown>) : {};
-                const firstMes = typeof parsed.first_mes === "string" ? parsed.first_mes : "";
-                const altGreetings = Array.isArray(parsed.alternate_greetings)
-                  ? parsed.alternate_greetings.filter((greeting): greeting is string => typeof greeting === "string")
-                  : [];
-                if (firstMes) {
-                  createMessage
-                    .mutateAsync({ role: "assistant", content: firstMes, characterId: charId })
-                    .then(async (msg) => {
-                      if (msg?.id && altGreetings.length > 0) {
-                        for (const greeting of altGreetings) {
-                          if (greeting.trim()) {
-                            await storageApi.addChatMessageSwipe(chat.id, msg.id, greeting, { activate: false });
-                          }
-                        }
-                        queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
-                      }
-                    })
-                    .catch((error) => {
-                      toast.error(error instanceof Error ? error.message : "Failed to add character greeting.");
-                    });
+            const selectedCharacter = characters.find((character) => character.id === charId);
+            const { firstMes, altGreetings } = characterGreetingData(selectedCharacter);
+            if (!firstMes) return;
+            createMessage
+              .mutateAsync({ role: "assistant", content: firstMes, characterId: charId })
+              .then(async (msg) => {
+                if (msg?.id && altGreetings.length > 0) {
+                  for (const greeting of altGreetings) {
+                    if (greeting.trim()) {
+                      await storageApi.addChatMessageSwipe(chat.id, msg.id, greeting, { activate: false });
+                    }
+                  }
+                  queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
                 }
               })
               .catch((error) => {
-                toast.error(error instanceof Error ? error.message : "Failed to load character greeting.");
+                toast.error(error instanceof Error ? error.message : "Failed to add character greeting.");
               });
           },
         });
       }
     },
-    [chat.id, chatCharIds, createMessage, updateChat, queryClient, userEditedName, buildAutoName],
+    [chat.id, chatCharIds, characters, createMessage, updateChat, queryClient, userEditedName, buildAutoName],
   );
 
   const toggleLorebook = useCallback(

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -1206,29 +1206,27 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
         if (!userEditedName) updateData.name = buildAutoName(current);
         updateChat.mutate(updateData, {
           onSuccess: () => {
-            const selectedCharacter = characters.find((character) => character.id === charId);
-            const { firstMes, altGreetings } = characterGreetingData(selectedCharacter);
-            if (!firstMes) return;
-            createMessage
-              .mutateAsync({ role: "assistant", content: firstMes, characterId: charId })
-              .then(async (msg) => {
-                if (msg?.id && altGreetings.length > 0) {
-                  for (const greeting of altGreetings) {
-                    if (greeting.trim()) {
-                      await storageApi.addChatMessageSwipe(chat.id, msg.id, greeting, { activate: false });
-                    }
+            void (async () => {
+              const selectedCharacter = await storageApi.get<{ data?: unknown }>("characters", charId);
+              const { firstMes, altGreetings } = characterGreetingData(selectedCharacter);
+              if (!firstMes) return;
+              const msg = await createMessage.mutateAsync({ role: "assistant", content: firstMes, characterId: charId });
+              if (msg?.id && altGreetings.length > 0) {
+                for (const greeting of altGreetings) {
+                  if (greeting.trim()) {
+                    await storageApi.addChatMessageSwipe(chat.id, msg.id, greeting, { activate: false });
                   }
-                  queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
                 }
-              })
-              .catch((error) => {
-                toast.error(error instanceof Error ? error.message : "Failed to add character greeting.");
-              });
+                queryClient.invalidateQueries({ queryKey: chatKeys.messages(chat.id) });
+              }
+            })().catch((error) => {
+              toast.error(error instanceof Error ? error.message : "Failed to add character greeting.");
+            });
           },
         });
       }
     },
-    [chat.id, chatCharIds, characters, createMessage, updateChat, queryClient, userEditedName, buildAutoName],
+    [chat.id, chatCharIds, createMessage, updateChat, queryClient, userEditedName, buildAutoName],
   );
 
   const toggleLorebook = useCallback(


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1885 #1886 #1887 #1888 

## Why this change

- Storage list projection optimizations should not change message ordering, cursor filtering, or hostable/embedded storage parity.
- Projected message reads were loading only caller-visible fields plus swipe data, which could omit internal fields needed by the shared list command before final projection.

## What changed

- Keeps internal message list fields available during projected message materialization: `id`, `sortOrder`, `order`, `createdAt`, and explicit `orderBy` fields.
- Preserves final caller-facing projection after sorting, cursor filtering, swipe materialization, and legacy prompt snapshot synthesis.
- Adds Rust regression coverage for projected message ordering, cursor filtering, and internal projection fields.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Embedded `storage_list` command path.
- Hostable HTTP `storage_list` parity via the shared storage command implementation.
- Message timeline projection and pagination behavior.

Boundary notes:

- No TypeScript engine, React feature, shared API, or command-registration changes.
- The fix stays inside the Rust storage command owner and continues using the existing storage capability APIs.

Pressure points touched:

- `src-tauri/src/commands/storage/commands/entities.rs`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml storage_list_projected_messages -- --nocapture`: passed, 2 tests.
- `cargo test --manifest-path src-tauri/Cargo.toml message_projection_materialization_includes_internal_sort_fields -- --nocapture`: passed, 1 test.
- `cargo test --manifest-path src-tauri/Cargo.toml dispatch_storage_list_uses_projected_message_reads -- --nocapture`: passed, 1 test.
- `cargo test --manifest-path src-tauri/crates/storage/Cargo.toml projected -- --nocapture`: passed, 1 test.
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed.
- `git diff --check`: clean.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for internal storage list behavior; no new user-discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. Storage command behavior only; no visible UI changes.
