### PR TITLE
Improve refactor build performance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Current development targets `refactor`.
 - Base feature, bug fix, and documentation branches on `refactor`.
 - Open pull requests against `refactor`.
 - Do not target `main` unless a maintainer explicitly asks for a mainline or release change.
+- Treat `refactor` docs as the only authoritative docs for current work. Do not use `main` or historical `staging` docs for refactor implementation, integrations, or release guidance unless a maintainer explicitly asks for that branch context.
 - Keep PRs focused. Separate architecture moves, product behavior, UI polish, and docs-only work when they can be reviewed independently.
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Marinara Engine is a local-first AI chat, roleplay, and game engine built as a Tauri desktop app. It combines a React interface, a TypeScript product engine, and Rust capability modules for local storage, managed assets, provider transport, integrations, and an optional hostable runtime.
 
 This repository is an active refactor branch. The app is usable from source, but public release packaging and end-user installation guides are still being rebuilt around the new architecture.
+Use the `refactor` branch copy of this documentation for current development and integration work. `main` and historical `staging` branch docs may describe legacy architecture and should not be treated as authoritative for the refactor build unless a maintainer explicitly asks for that branch context.
 The refactor build keeps an explicit in-app update check in Settings > Advanced. It checks Marinara Engine GitHub releases and opens the matching release page for manual install; signed Tauri auto-install artifacts are not configured on this branch yet. See [Release Update Strategy](docs/release-update-strategy.md) for the stable refactor update policy.
 Token budget displays and prompt budget paths currently use deterministic estimates rather than provider-exact tokenizers. See [Token Budget Estimates](docs/token-budget-estimates.md) for the tokenizer support decision and future requirements.
 

--- a/custom_components/marinara_engine/manifest.json
+++ b/custom_components/marinara_engine/manifest.json
@@ -3,7 +3,7 @@
   "name": "Marinara Engine",
   "version": "1.0.0",
   "config_flow": true,
-  "documentation": "https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/integrations/home-assistant.md",
+  "documentation": "https://github.com/Pasta-Devs/Marinara-Engine/blob/refactor/docs/integrations/home-assistant.md",
   "issue_tracker": "https://github.com/Pasta-Devs/Marinara-Engine/issues",
   "requirements": [],
   "dependencies": ["webhook"],

--- a/src/features/modes/game-assets/components/AssetGrid.tsx
+++ b/src/features/modes/game-assets/components/AssetGrid.tsx
@@ -4,7 +4,7 @@
 import { Check, Folder, FolderOpen, Minus, MoreHorizontal } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { TreeNode } from "../hooks/use-game-assets";
-import type { GameAssetSelectionStatus } from "../../game/index";
+import type { GameAssetSelectionStatus } from "../../game/assets";
 import { formatBytes, formatDate } from "../../../../shared/lib/format";
 import { gameAssetFileUrlFromPath, resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
 import { CATEGORY_ICONS } from "./constants";
@@ -62,15 +62,7 @@ function FolderSelectionMark({ status }: { status: GameAssetSelectionStatus }) {
   return null;
 }
 
-function GameAssetImage({
-  node,
-  alt,
-  className,
-}: {
-  node: TreeNode;
-  alt: string;
-  className: string;
-}) {
+function GameAssetImage({ node, alt, className }: { node: TreeNode; alt: string; className: string }) {
   const [src, setSrc] = useState(() => gameAssetFileUrlFromPath(node.path, node.absolutePath));
 
   useEffect(() => {

--- a/src/features/modes/game-assets/components/FolderTree.tsx
+++ b/src/features/modes/game-assets/components/FolderTree.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { Check, ChevronDown, ChevronRight, Folder, Minus } from "lucide-react";
 import type { TreeNode } from "../hooks/use-game-assets";
-import type { GameAssetSelectionStatus } from "../../game/index";
+import type { GameAssetSelectionStatus } from "../../game/assets";
 import { cn } from "../../../../shared/lib/utils";
 import { CATEGORY_ICONS } from "./constants";
 

--- a/src/features/modes/game-assets/components/GameAssetsBrowserView.test.tsx
+++ b/src/features/modes/game-assets/components/GameAssetsBrowserView.test.tsx
@@ -46,16 +46,6 @@ vi.mock("../../../catalog/chats/index", () => ({
   useUpdateChatMetadata: () => mutationStub(),
 }));
 
-// game/index re-exports heavy GameSurface/GameModeRoute components; the view
-// only needs the pure folder-selection helpers.
-vi.mock("../../game/index", () => ({
-  excludeGameAssetFolder: (_path: string, folders: string[]) => folders,
-  includeGameAssetFolder: (_path: string, folders: string[]) => folders,
-  getGameAssetFolderSelectionStatus: () => "included",
-  parseGameAssetExcludedFolders: () => [],
-  serializeGameAssetSelection: () => undefined,
-}));
-
 // local-file-api imports @tauri-apps/api at module load.
 vi.mock("../../../../shared/api/local-file-api", () => ({
   resolveGameAssetFileUrl: vi.fn(async (path: string) => path),

--- a/src/features/modes/game-assets/components/GameAssetsBrowserView.tsx
+++ b/src/features/modes/game-assets/components/GameAssetsBrowserView.tsx
@@ -61,7 +61,7 @@ import {
   parseGameAssetExcludedFolders,
   serializeGameAssetSelection,
   type GameAssetSelectionStatus,
-} from "../../game/index";
+} from "../../game/assets";
 
 const PROTECTED_PATHS = new Set(["", "music", "sfx", "ambient", "sprites", "backgrounds"]);
 

--- a/src/features/modes/game/assets.ts
+++ b/src/features/modes/game/assets.ts
@@ -1,0 +1,1 @@
+export * from "./lib/game-asset-selection";

--- a/src/features/modes/game/components/GameCharacterSheet.tsx
+++ b/src/features/modes/game/components/GameCharacterSheet.tsx
@@ -817,9 +817,9 @@ export function GameCharacterSheet({
                       </div>
                       <div className="h-2.5 overflow-hidden rounded-full bg-[var(--secondary)] ring-1 ring-[var(--border)]">
                         <div
-                          className="h-full rounded-full transition-all"
+                          className="h-full w-full origin-left rounded-full transition-transform"
                           style={{
-                            width: `${(hpValue / hpMax) * 100}%`,
+                            transform: `scaleX(${hpValue / hpMax})`,
                             background: "#ef4444",
                           }}
                         />
@@ -848,9 +848,9 @@ export function GameCharacterSheet({
                       </div>
                       <div className="h-2 overflow-hidden rounded-full bg-[var(--secondary)] ring-1 ring-[var(--border)]">
                         <div
-                          className="h-full rounded-full transition-all"
+                          className="h-full w-full origin-left rounded-full transition-transform"
                           style={{
-                            width: `${width}%`,
+                            transform: `scaleX(${width / 100})`,
                             background: stat.color || "var(--primary)",
                           }}
                         />

--- a/src/features/modes/game/components/GameCharacterSheet.tsx
+++ b/src/features/modes/game/components/GameCharacterSheet.tsx
@@ -79,6 +79,16 @@ const DEFAULT_ATTRIBUTES = [
   { name: "CHA", value: 10 },
 ];
 
+function finiteNumber(value: unknown, fallback: number): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function clampUnitScale(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
 // Mirrors server's attributeModifier in skill-check.service.ts: floor((score - 10) / 2).
 function formatAttributeModifier(score: number): string {
   const mod = Math.floor((score - 10) / 2);
@@ -805,8 +815,9 @@ export function GameCharacterSheet({
               )}
               {hasRpgHp &&
                 (() => {
-                  const hpMax = Math.max(1, Number(previewGameCard.rpgStats.hp.max) || 1);
-                  const hpValue = Math.max(0, Math.min(hpMax, Number(previewGameCard.rpgStats.hp.value) || 0));
+                  const hpMax = Math.max(1, finiteNumber(previewGameCard.rpgStats.hp.max, 1));
+                  const hpValue = Math.max(0, Math.min(hpMax, finiteNumber(previewGameCard.rpgStats.hp.value, 0)));
+                  const hpScale = clampUnitScale(hpValue / hpMax);
                   return (
                     <div>
                       <div className="mb-0.5 flex items-center justify-between text-xs">
@@ -819,7 +830,7 @@ export function GameCharacterSheet({
                         <div
                           className="h-full w-full origin-left rounded-full transition-transform"
                           style={{
-                            transform: `scaleX(${hpValue / hpMax})`,
+                            transform: `scaleX(${hpScale})`,
                             background: "#ef4444",
                           }}
                         />
@@ -835,9 +846,9 @@ export function GameCharacterSheet({
               <SectionHeader icon={<Shield size={12} />} title="Stats" className="text-[var(--muted-foreground)]" />
               <div className="space-y-2">
                 {card.stats.map((stat) => {
-                  const max = Math.max(1, stat.max ?? 100);
-                  const value = Math.max(0, Math.min(max, stat.value));
-                  const width = (value / max) * 100;
+                  const max = Math.max(1, finiteNumber(stat.max, 100));
+                  const value = Math.max(0, Math.min(max, finiteNumber(stat.value, 0)));
+                  const scale = clampUnitScale(value / max);
                   return (
                     <div key={stat.name}>
                       <div className="mb-0.5 flex items-center justify-between text-xs">
@@ -850,7 +861,7 @@ export function GameCharacterSheet({
                         <div
                           className="h-full w-full origin-left rounded-full transition-transform"
                           style={{
-                            transform: `scaleX(${width / 100})`,
+                            transform: `scaleX(${scale})`,
                             background: stat.color || "var(--primary)",
                           }}
                         />

--- a/src/features/modes/game/components/GameCombatUI.tsx
+++ b/src/features/modes/game/components/GameCombatUI.tsx
@@ -107,6 +107,11 @@ function numberFromUnknown(value: unknown, fallback: number): number {
   return Number.isFinite(numeric) ? numeric : fallback;
 }
 
+function clampUnitScale(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
 function normalizeCombatSkillType(value: unknown): CombatSkillType {
   return value === "heal" || value === "buff" || value === "debuff" ? value : "attack";
 }
@@ -2705,8 +2710,10 @@ function CombatantCard({
   onSelect?: () => void;
   damagePopups: DamagePopup[];
 }) {
-  const hpPercent = combatant.maxHp > 0 ? (combatant.hp / combatant.maxHp) * 100 : 0;
-  const mpPercent = combatant.maxMp && combatant.maxMp > 0 ? ((combatant.mp ?? 0) / combatant.maxMp) * 100 : null;
+  const hpScale = clampUnitScale(combatant.maxHp > 0 ? combatant.hp / combatant.maxHp : 0);
+  const mpScale = combatant.maxMp && combatant.maxMp > 0 ? clampUnitScale((combatant.mp ?? 0) / combatant.maxMp) : null;
+  const hpPercent = hpScale * 100;
+  const mpPercent = mpScale === null ? null : mpScale * 100;
   const isKo = combatant.hp <= 0;
 
   const hpColor = hpPercent > 60 ? "bg-emerald-500" : hpPercent > 25 ? "bg-amber-500" : "bg-red-500";
@@ -2831,7 +2838,7 @@ function CombatantCard({
                 "h-full w-full origin-left rounded-full transition-transform duration-500 ease-out",
                 hpColor,
               )}
-              style={{ transform: `scaleX(${hpPercent / 100})` }}
+              style={{ transform: `scaleX(${hpScale})` }}
             />
           </div>
           <span className="min-w-[2.5rem] text-right text-[0.55rem] tabular-nums text-white/50">
@@ -2846,7 +2853,7 @@ function CombatantCard({
             <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
               <div
                 className="h-full w-full origin-left rounded-full bg-blue-500 transition-transform duration-500"
-                style={{ transform: `scaleX(${mpPercent / 100})` }}
+                style={{ transform: `scaleX(${mpScale})` }}
               />
             </div>
             <span className="min-w-[2.5rem] text-right text-[0.55rem] tabular-nums text-white/40">
@@ -2894,7 +2901,8 @@ function MobileCombatantChip({
   onSelect?: () => void;
   damagePopups: DamagePopup[];
 }) {
-  const hpPercent = combatant.maxHp > 0 ? (combatant.hp / combatant.maxHp) * 100 : 0;
+  const hpScale = clampUnitScale(combatant.maxHp > 0 ? combatant.hp / combatant.maxHp : 0);
+  const hpPercent = hpScale * 100;
   const isKo = combatant.hp <= 0;
   const hpColor = hpPercent > 60 ? "bg-emerald-500" : hpPercent > 25 ? "bg-amber-500" : "bg-red-500";
   const latestPopup = damagePopups[damagePopups.length - 1] ?? null;
@@ -2957,7 +2965,7 @@ function MobileCombatantChip({
                 "h-full w-full origin-left rounded-full transition-transform duration-500 ease-out",
                 hpColor,
               )}
-              style={{ transform: `scaleX(${hpPercent / 100})` }}
+              style={{ transform: `scaleX(${hpScale})` }}
             />
           </div>
           <span className="shrink-0 text-[0.5rem] tabular-nums text-white/55">{combatant.hp}</span>

--- a/src/features/modes/game/components/GameCombatUI.tsx
+++ b/src/features/modes/game/components/GameCombatUI.tsx
@@ -2827,8 +2827,11 @@ function CombatantCard({
           <Heart size={9} className={cn(isKo ? "text-white/20" : "text-red-400")} />
           <div className={cn("h-2 flex-1 overflow-hidden rounded-full bg-white/10", !isKo && `shadow-sm ${hpGlow}`)}>
             <div
-              className={cn("h-full rounded-full transition-all duration-500 ease-out", hpColor)}
-              style={{ width: `${hpPercent}%` }}
+              className={cn(
+                "h-full w-full origin-left rounded-full transition-transform duration-500 ease-out",
+                hpColor,
+              )}
+              style={{ transform: `scaleX(${hpPercent / 100})` }}
             />
           </div>
           <span className="min-w-[2.5rem] text-right text-[0.55rem] tabular-nums text-white/50">
@@ -2842,8 +2845,8 @@ function CombatantCard({
             <Droplets size={9} className="text-blue-400" />
             <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
               <div
-                className="h-full rounded-full bg-blue-500 transition-all duration-500"
-                style={{ width: `${mpPercent}%` }}
+                className="h-full w-full origin-left rounded-full bg-blue-500 transition-transform duration-500"
+                style={{ transform: `scaleX(${mpPercent / 100})` }}
               />
             </div>
             <span className="min-w-[2.5rem] text-right text-[0.55rem] tabular-nums text-white/40">
@@ -2950,8 +2953,11 @@ function MobileCombatantChip({
           <Heart size={8} className={cn(isKo ? "text-white/20" : "text-red-400")} />
           <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
             <div
-              className={cn("h-full rounded-full transition-all duration-500 ease-out", hpColor)}
-              style={{ width: `${hpPercent}%` }}
+              className={cn(
+                "h-full w-full origin-left rounded-full transition-transform duration-500 ease-out",
+                hpColor,
+              )}
+              style={{ transform: `scaleX(${hpPercent / 100})` }}
             />
           </div>
           <span className="shrink-0 text-[0.5rem] tabular-nums text-white/55">{combatant.hp}</span>

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -1051,6 +1051,22 @@ const GameTutorial = lazy(async () => {
   return { default: module.GameTutorial };
 });
 
+function GameOverlayLoadingFallback({ label, zClassName = "z-40" }: { label: string; zClassName?: string }) {
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto absolute inset-0 flex items-center justify-center bg-black/55 px-4 backdrop-blur-sm",
+        zClassName,
+      )}
+    >
+      <div className="flex items-center gap-2 rounded-lg border border-white/15 bg-black/70 px-3 py-2 text-xs font-semibold text-white/80 shadow-xl">
+        <Loader2 size={14} className="animate-spin" />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}
+
 type InventoryNotificationKind = "gain" | "loss" | "use-pending" | "use-kept" | "use-consumed" | "error";
 
 interface InventoryNotification {
@@ -9038,7 +9054,7 @@ export function GameSurface({
                 )}
 
                 {/* Session history panel (full overlay) */}
-                <Suspense fallback={null}>
+                <Suspense fallback={<GameOverlayLoadingFallback label="Loading history..." />}>
                   {historyOpen && (
                     <GameSessionHistory
                       summaries={sessionSummaries}
@@ -9088,7 +9104,7 @@ export function GameSurface({
                   )}
                 </Suspense>
 
-                <Suspense fallback={null}>
+                <Suspense fallback={<GameOverlayLoadingFallback label="Loading checkpoints..." />}>
                   {checkpointsOpen && (
                     <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
                       <div className="h-[82vh] w-full max-w-3xl overflow-hidden rounded-xl border border-white/15 bg-[var(--card)] shadow-2xl">
@@ -9184,7 +9200,7 @@ export function GameSurface({
               </div>
 
               {/* Journal overlay — positioned on the outer column so it covers state indicator + content */}
-              <Suspense fallback={null}>
+              <Suspense fallback={<GameOverlayLoadingFallback label="Loading journal..." />}>
                 {journalOpen && (
                   <GameJournal
                     chatId={activeChatId}
@@ -9218,7 +9234,7 @@ export function GameSurface({
               />
 
               {/* Gallery drawer */}
-              <Suspense fallback={null}>
+              <Suspense fallback={<GameOverlayLoadingFallback label="Loading gallery..." />}>
                 {galleryOpen && (
                   <ChatGalleryDrawer
                     chat={chat}
@@ -9230,7 +9246,7 @@ export function GameSurface({
               </Suspense>
 
               {/* Inventory overlay */}
-              <Suspense fallback={null}>
+              <Suspense fallback={<GameOverlayLoadingFallback label="Loading inventory..." />}>
                 {inventoryOpen && (
                   <GameInventory
                     items={inventoryItems}
@@ -9249,7 +9265,7 @@ export function GameSurface({
               </Suspense>
 
               {/* Readable document display (Notes / Books) */}
-              <Suspense fallback={null}>
+              <Suspense fallback={<GameOverlayLoadingFallback label="Loading document..." />}>
                 {activeReadable && (
                   <GameReadableDisplay
                     type={activeReadable.type}
@@ -9263,7 +9279,7 @@ export function GameSurface({
               </Suspense>
 
               {/* First-game spotlight tutorial (auto-opens once; (?) button re-opens) */}
-              <Suspense fallback={null}>
+              <Suspense fallback={<GameOverlayLoadingFallback label="Loading tutorial..." zClassName="z-[9999]" />}>
                 {tutorialOpen && <GameTutorial open={tutorialOpen} onClose={handleCloseTutorial} />}
               </Suspense>
 

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -4,6 +4,28 @@
 import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { toast } from "sonner";
+import {
+  AlertTriangle,
+  BookOpen,
+  Folder,
+  Globe,
+  HelpCircle,
+  History,
+  Image,
+  ListRestart,
+  Loader2,
+  MoreHorizontal,
+  Play,
+  Plug,
+  RefreshCw,
+  RotateCcw,
+  ScrollText,
+  Settings2,
+  Square,
+  Volume2,
+  VolumeX,
+  X,
+} from "lucide-react";
 import { useGameModeStore } from "../stores/game-mode.store";
 import { useGameAssetStore } from "../stores/game-asset.store";
 import { gameApi } from "../api/game-api";
@@ -63,10 +85,7 @@ import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, type AvatarCropValue } from "../../../../shared/lib/utils";
 import { filterLanguageGenerationConnections } from "../../../../shared/lib/connection-filters";
 import { audioManager } from "../lib/game-audio";
-import {
-  canStartGameWithConnection,
-  GAME_START_CONNECTION_REQUIRED_MESSAGE,
-} from "../lib/game-start-connection";
+import { canStartGameWithConnection, GAME_START_CONNECTION_REQUIRED_MESSAGE } from "../lib/game-start-connection";
 import {
   GAME_AUDIO_SETTINGS_STORAGE_KEY,
   getEffectiveVolume,
@@ -92,12 +111,11 @@ import { normalizeGameSegmentEdit, serializeGameSegmentEdit, type GameSegmentEdi
 import { useGameSceneAnalysis } from "../hooks/use-game-scene-analysis";
 import { usePartyTurn } from "../hooks/use-party-turn";
 import { parsePartyDialogue } from "../lib/party-dialogue-parser";
-import {
-  flushPendingGameMetadataPatches,
-  persistGameMetadataPatch,
-} from "../lib/game-metadata-persistence";
+import { flushPendingGameMetadataPatches, persistGameMetadataPatch } from "../lib/game-metadata-persistence";
 import { dispatchSpotifySceneTrackChange } from "../../../../shared/lib/spotify-playback-events";
 import { ActiveWorldInfoButton, ActiveWorldInfoModal } from "../../../runtime/visuals/index";
+import { Modal } from "../../../../shared/components/ui/Modal";
+import type { Chat, Message } from "../../../../engine/contracts/types/chat";
 import type {
   CombatInitState,
   CombatPartyMember,
@@ -115,6 +133,9 @@ import type {
   DiceRollResult,
   HudWidget,
   SkillCheckResult,
+  SessionSummary,
+  Combatant,
+  GameCombatStateSnapshot,
 } from "../../../../engine/contracts/types/game";
 import type { GameState, InventoryItem } from "../../../../engine/contracts/types/game-state";
 import type {
@@ -142,24 +163,19 @@ import { GameDiceResult } from "./GameDiceResult";
 import { GameSkillCheckResult } from "./GameSkillCheckResult";
 import { GameElementReaction } from "./GameElementReaction";
 import { GameTravelView } from "./GameTravelView";
-import { GameSessionHistory, type CurrentSessionSecrets } from "./GameSessionHistory";
+import type { CurrentSessionSecrets } from "./GameSessionHistory";
 import { GameTransitionManager } from "./GameTransitionManager";
 import { GameChoiceCards } from "./GameChoiceCards";
 import { GameQteOverlay } from "./GameQteOverlay";
-import { GameJournal } from "./GameJournal";
-import { GameCheckpoints } from "./GameCheckpoints";
 import { GameJsonRepairModal } from "./GameJsonRepairModal";
 import {
   ImagePromptReviewModal as GameImagePromptReviewModal,
   type ImagePromptOverride as GameImagePromptOverride,
   type ImagePromptReviewItem as GameImagePromptReviewItem,
 } from "../../../../shared/components/ui/ImagePromptReviewModal";
-import { GameTutorial } from "./GameTutorial";
 import { DirectionEngine } from "./DirectionEngine";
 import { GameWidgetPanel, GameWidgetSessionPrepModal, MobileWidgetPanel } from "./GameWidgetPanel";
 import { WeatherEffects } from "../../../runtime/visuals/index";
-import { GameInventory } from "./GameInventory";
-import { GameReadableDisplay } from "./GameReadableDisplay";
 import {
   buildMissingSceneAssetGenerationPayload,
   normalizeSceneAssetNameForGeneration,
@@ -167,6 +183,7 @@ import {
 import { ChatGalleryDrawer } from "../../shared/chat-ui/index";
 import type { ReadableTag } from "../lib/game-tag-parser";
 import type { DirectionCommand, GameNpc } from "../../../../engine/contracts/types/game";
+import type { CharacterMap, PersonaInfo } from "../../shared/chat-ui/types";
 
 type JournalReadable = ReadableTag & {
   sourceMessageId?: string | null;
@@ -1004,10 +1021,35 @@ const GameCombatUI = lazy(async () => {
   return { default: module.GameCombatUI };
 });
 
-import { Modal } from "../../../../shared/components/ui/Modal";
-import type { Chat, Message } from "../../../../engine/contracts/types/chat";
-import type { SessionSummary, Combatant, GameCombatStateSnapshot } from "../../../../engine/contracts/types/game";
-import type { CharacterMap, PersonaInfo } from "../../shared/chat-ui/types";
+const GameSessionHistory = lazy(async () => {
+  const module = await import("./GameSessionHistory");
+  return { default: module.GameSessionHistory };
+});
+
+const GameJournal = lazy(async () => {
+  const module = await import("./GameJournal");
+  return { default: module.GameJournal };
+});
+
+const GameCheckpoints = lazy(async () => {
+  const module = await import("./GameCheckpoints");
+  return { default: module.GameCheckpoints };
+});
+
+const GameInventory = lazy(async () => {
+  const module = await import("./GameInventory");
+  return { default: module.GameInventory };
+});
+
+const GameReadableDisplay = lazy(async () => {
+  const module = await import("./GameReadableDisplay");
+  return { default: module.GameReadableDisplay };
+});
+
+const GameTutorial = lazy(async () => {
+  const module = await import("./GameTutorial");
+  return { default: module.GameTutorial };
+});
 
 type InventoryNotificationKind = "gain" | "loss" | "use-pending" | "use-kept" | "use-consumed" | "error";
 
@@ -1547,29 +1589,6 @@ function renameInventoryItem<T extends { name: string; quantity: number }>(
     resolvedName: normalizeInventoryName(mergeTarget.name) || cleanedNextName,
   };
 }
-
-import {
-  AlertTriangle,
-  BookOpen,
-  Folder,
-  Globe,
-  HelpCircle,
-  History,
-  Image,
-  ListRestart,
-  Loader2,
-  MoreHorizontal,
-  Play,
-  Plug,
-  RefreshCw,
-  RotateCcw,
-  ScrollText,
-  Settings2,
-  Square,
-  Volume2,
-  VolumeX,
-  X,
-} from "lucide-react";
 
 /** Randomly sample up to `max` items from an array (Fisher-Yates shuffle). */
 function sampleTags(tags: string[], max: number): string[] {
@@ -5370,7 +5389,14 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, showInventoryNotifications, updateChatMetadata],
+    [
+      activeChatId,
+      inventoryItems,
+      patchVisibleGameState,
+      publishSessionChat,
+      showInventoryNotifications,
+      updateChatMetadata,
+    ],
   );
 
   const handleClearInventoryItem = useCallback(
@@ -5439,7 +5465,14 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, showInventoryNotifications, updateChatMetadata],
+    [
+      activeChatId,
+      inventoryItems,
+      patchVisibleGameState,
+      publishSessionChat,
+      showInventoryNotifications,
+      updateChatMetadata,
+    ],
   );
 
   const handleUseCombatInventoryItem = useCallback(
@@ -5507,7 +5540,14 @@ export function GameSurface({
         toast.error(message);
       }
     },
-    [activeChatId, inventoryItems, patchVisibleGameState, publishSessionChat, showInventoryNotifications, updateChatMetadata],
+    [
+      activeChatId,
+      inventoryItems,
+      patchVisibleGameState,
+      publishSessionChat,
+      showInventoryNotifications,
+      updateChatMetadata,
+    ],
   );
 
   const handleRenameInventoryItem = useCallback(
@@ -8141,7 +8181,11 @@ export function GameSurface({
   }
 
   return (
-    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" data-chat-mode="game" style={{ isolation: "isolate" }}>
+    <div
+      className="relative flex h-full overflow-hidden bg-black mari-card-css"
+      data-chat-mode="game"
+      style={{ isolation: "isolate" }}
+    >
       <GameTransitionManager gameState={gameState} location={gameSnapshot?.location ?? null}>
         <DirectionEngine
           directions={activeDirections}
@@ -8994,65 +9038,69 @@ export function GameSurface({
                 )}
 
                 {/* Session history panel (full overlay) */}
-                {historyOpen && (
-                  <GameSessionHistory
-                    summaries={sessionSummaries}
-                    currentSessionNumber={displaySessionNumber}
-                    currentSessionDate={
-                      (chatMeta.gameCurrentSessionStartedAt as string | undefined) || chat.createdAt || chat.updatedAt
-                    }
-                    currentSecrets={currentSessionSecrets}
-                    savingSessionNumber={savingSessionSummary}
-                    savingCurrentSecrets={savingCurrentSessionSecrets}
-                    regeneratingSessionNumber={
-                      regenerateSessionConclusion.isPending
-                        ? (regenerateSessionConclusion.variables?.sessionNumber ?? null)
-                        : null
-                    }
-                    lorebookKeeperEnabled={chatMeta.gameLorebookKeeperEnabled === true}
-                    lorebookKeeperLastRun={
-                      chatMeta.gameLorebookKeeperLastRun &&
-                      typeof chatMeta.gameLorebookKeeperLastRun === "object" &&
-                      !Array.isArray(chatMeta.gameLorebookKeeperLastRun)
-                        ? (chatMeta.gameLorebookKeeperLastRun as {
-                            sessionNumber: number;
-                            status: "running" | "success" | "failed";
-                            updatedAt: string;
-                            entryCount?: number;
-                            error?: string;
-                          })
-                        : null
-                    }
-                    regeneratingLorebookSessionNumber={
-                      regenerateSessionLorebook.isPending
-                        ? (regenerateSessionLorebook.variables?.sessionNumber ?? null)
-                        : null
-                    }
-                    updatingPlotArcsSessionNumber={
-                      updateCampaignProgression.isPending
-                        ? (updateCampaignProgression.variables?.sessionNumber ?? null)
-                        : null
-                    }
-                    onSaveCurrentSecrets={handleSaveCurrentSessionSecrets}
-                    onSaveSession={handleSaveSessionDetails}
-                    onRegenerateSession={handleRegenerateSessionConclusion}
-                    onRegenerateLorebook={handleRegenerateSessionLorebook}
-                    onUpdatePlotArcs={handleUpdateCampaignProgression}
-                    onClose={() => setHistoryOpen(false)}
-                  />
-                )}
+                <Suspense fallback={null}>
+                  {historyOpen && (
+                    <GameSessionHistory
+                      summaries={sessionSummaries}
+                      currentSessionNumber={displaySessionNumber}
+                      currentSessionDate={
+                        (chatMeta.gameCurrentSessionStartedAt as string | undefined) || chat.createdAt || chat.updatedAt
+                      }
+                      currentSecrets={currentSessionSecrets}
+                      savingSessionNumber={savingSessionSummary}
+                      savingCurrentSecrets={savingCurrentSessionSecrets}
+                      regeneratingSessionNumber={
+                        regenerateSessionConclusion.isPending
+                          ? (regenerateSessionConclusion.variables?.sessionNumber ?? null)
+                          : null
+                      }
+                      lorebookKeeperEnabled={chatMeta.gameLorebookKeeperEnabled === true}
+                      lorebookKeeperLastRun={
+                        chatMeta.gameLorebookKeeperLastRun &&
+                        typeof chatMeta.gameLorebookKeeperLastRun === "object" &&
+                        !Array.isArray(chatMeta.gameLorebookKeeperLastRun)
+                          ? (chatMeta.gameLorebookKeeperLastRun as {
+                              sessionNumber: number;
+                              status: "running" | "success" | "failed";
+                              updatedAt: string;
+                              entryCount?: number;
+                              error?: string;
+                            })
+                          : null
+                      }
+                      regeneratingLorebookSessionNumber={
+                        regenerateSessionLorebook.isPending
+                          ? (regenerateSessionLorebook.variables?.sessionNumber ?? null)
+                          : null
+                      }
+                      updatingPlotArcsSessionNumber={
+                        updateCampaignProgression.isPending
+                          ? (updateCampaignProgression.variables?.sessionNumber ?? null)
+                          : null
+                      }
+                      onSaveCurrentSecrets={handleSaveCurrentSessionSecrets}
+                      onSaveSession={handleSaveSessionDetails}
+                      onRegenerateSession={handleRegenerateSessionConclusion}
+                      onRegenerateLorebook={handleRegenerateSessionLorebook}
+                      onUpdatePlotArcs={handleUpdateCampaignProgression}
+                      onClose={() => setHistoryOpen(false)}
+                    />
+                  )}
+                </Suspense>
 
-                {checkpointsOpen && (
-                  <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
-                    <div className="h-[82vh] w-full max-w-3xl overflow-hidden rounded-xl border border-white/15 bg-[var(--card)] shadow-2xl">
-                      <GameCheckpoints
-                        chatId={activeChatId}
-                        onClose={() => setCheckpointsOpen(false)}
-                        onLoaded={handleCheckpointLoaded}
-                      />
+                <Suspense fallback={null}>
+                  {checkpointsOpen && (
+                    <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
+                      <div className="h-[82vh] w-full max-w-3xl overflow-hidden rounded-xl border border-white/15 bg-[var(--card)] shadow-2xl">
+                        <GameCheckpoints
+                          chatId={activeChatId}
+                          onClose={() => setCheckpointsOpen(false)}
+                          onLoaded={handleCheckpointLoaded}
+                        />
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
+                </Suspense>
 
                 {combatLogsOpen && (
                   <div
@@ -9136,20 +9184,22 @@ export function GameSurface({
               </div>
 
               {/* Journal overlay — positioned on the outer column so it covers state indicator + content */}
-              {journalOpen && (
-                <GameJournal
-                  chatId={activeChatId}
-                  npcs={npcs}
-                  onClose={() => setJournalOpen(false)}
-                  onNpcPortraitClick={handleNpcPortraitClick}
-                  onNpcPortraitGenerate={handleNpcPortraitGenerate}
-                  npcPortraitGenerationEnabled={
-                    chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
-                  }
-                  generatingNpcPortraitNames={generatingNpcPortraitNames}
-                  onNpcRemove={handleRemoveNpcFromJournal}
-                />
-              )}
+              <Suspense fallback={null}>
+                {journalOpen && (
+                  <GameJournal
+                    chatId={activeChatId}
+                    npcs={npcs}
+                    onClose={() => setJournalOpen(false)}
+                    onNpcPortraitClick={handleNpcPortraitClick}
+                    onNpcPortraitGenerate={handleNpcPortraitGenerate}
+                    npcPortraitGenerationEnabled={
+                      chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
+                    }
+                    generatingNpcPortraitNames={generatingNpcPortraitNames}
+                    onNpcRemove={handleRemoveNpcFromJournal}
+                  />
+                )}
+              </Suspense>
 
               <input
                 ref={npcPortraitUploadInputRef}
@@ -9180,34 +9230,42 @@ export function GameSurface({
               </Suspense>
 
               {/* Inventory overlay */}
-              <GameInventory
-                items={inventoryItems}
-                open={inventoryOpen}
-                onClose={() => setInventoryOpen(false)}
-                onAddItem={handleAddInventoryItem}
-                onRenameItem={handleRenameInventoryItem}
-                onRemoveItem={handleRemoveInventoryItem}
-                onClearItem={handleClearInventoryItem}
-                onIncrementItem={handleIncrementInventoryItem}
-                onReorderItem={handleReorderInventoryItem}
-                canInteract={sessionInteractive && narrationDone && !isStreaming}
-                onUseItem={handleUseInventoryItem}
-              />
+              <Suspense fallback={null}>
+                {inventoryOpen && (
+                  <GameInventory
+                    items={inventoryItems}
+                    open={inventoryOpen}
+                    onClose={() => setInventoryOpen(false)}
+                    onAddItem={handleAddInventoryItem}
+                    onRenameItem={handleRenameInventoryItem}
+                    onRemoveItem={handleRemoveInventoryItem}
+                    onClearItem={handleClearInventoryItem}
+                    onIncrementItem={handleIncrementInventoryItem}
+                    onReorderItem={handleReorderInventoryItem}
+                    canInteract={sessionInteractive && narrationDone && !isStreaming}
+                    onUseItem={handleUseInventoryItem}
+                  />
+                )}
+              </Suspense>
 
               {/* Readable document display (Notes / Books) */}
-              {activeReadable && (
-                <GameReadableDisplay
-                  type={activeReadable.type}
-                  content={activeReadable.content}
-                  onClose={() => {
-                    const next = readableQueueRef.current.shift();
-                    setActiveReadable(next ?? null);
-                  }}
-                />
-              )}
+              <Suspense fallback={null}>
+                {activeReadable && (
+                  <GameReadableDisplay
+                    type={activeReadable.type}
+                    content={activeReadable.content}
+                    onClose={() => {
+                      const next = readableQueueRef.current.shift();
+                      setActiveReadable(next ?? null);
+                    }}
+                  />
+                )}
+              </Suspense>
 
               {/* First-game spotlight tutorial (auto-opens once; (?) button re-opens) */}
-              <GameTutorial open={tutorialOpen} onClose={handleCloseTutorial} />
+              <Suspense fallback={null}>
+                {tutorialOpen && <GameTutorial open={tutorialOpen} onClose={handleCloseTutorial} />}
+              </Suspense>
 
               {/* Inventory notifications */}
               {inventoryNotifications.length > 0 && (
@@ -9221,7 +9279,8 @@ export function GameSurface({
                         notification.kind === "loss" && "border-red-400/30 bg-red-900/80 text-red-200",
                         notification.kind === "use-pending" && "border-amber-300/35 bg-amber-950/85 text-amber-100",
                         notification.kind === "use-kept" && "border-sky-300/30 bg-sky-950/85 text-sky-100",
-                        notification.kind === "use-consumed" && "border-amber-300/35 bg-emerald-950/85 text-emerald-100",
+                        notification.kind === "use-consumed" &&
+                          "border-amber-300/35 bg-emerald-950/85 text-emerald-100",
                         notification.kind === "error" && "border-red-400/35 bg-red-950/85 text-red-100",
                       )}
                     >

--- a/src/features/modes/game/index.ts
+++ b/src/features/modes/game/index.ts
@@ -1,5 +1,5 @@
 export * from "./components/GameSurface";
 export * from "./components/GameModeRoute";
-export * from "./lib/game-asset-selection";
+export * from "./assets";
 export * from "./stores/game-asset.store";
 export * from "./stores/game-mode.store";

--- a/src/features/modes/game/lib/game-audio.ts
+++ b/src/features/modes/game/lib/game-audio.ts
@@ -229,8 +229,18 @@ class GameAudioManager {
     } catch {
       // Some browsers do not allow seeking before metadata is ready.
     }
-    void audio
-      .play()
+    const playResult = audio.play() as Promise<void> | undefined;
+    if (!playResult || typeof playResult.then !== "function") {
+      audio.pause();
+      try {
+        audio.currentTime = 0;
+      } catch {
+        // Ignore unlock cleanup failures.
+      }
+      return;
+    }
+
+    void playResult
       .then(() => {
         audio.pause();
         try {

--- a/src/features/modes/shared/chat-ui/components/SummaryPopover.tsx
+++ b/src/features/modes/shared/chat-ui/components/SummaryPopover.tsx
@@ -2,7 +2,7 @@
 // Summary Popover — View / edit / generate chat summary
 // Shown via the scroll icon in the chat header bar.
 // ──────────────────────────────────────────────
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
   useBulkSetMessagesHiddenFromAI,
@@ -197,30 +197,36 @@ export function SummaryPopover({
       : totalMessageCount > 0
         ? `Last ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
         : "No messages yet";
-  const chatMetadata: Record<string, unknown> =
-    chatQuery.data?.metadata && typeof chatQuery.data.metadata === "object" ? chatQuery.data.metadata : {};
-  const promptTemplates: ChatSummaryPromptTemplate[] = Array.isArray(chatMetadata.summaryPromptTemplates)
-    ? chatMetadata.summaryPromptTemplates.filter((template: unknown): template is ChatSummaryPromptTemplate => {
-        if (!template || typeof template !== "object" || Array.isArray(template)) return false;
-        const record = template as Record<string, unknown>;
-        return (
-          typeof record.id === "string" &&
-          record.id.trim().length > 0 &&
-          typeof record.name === "string" &&
-          record.name.trim().length > 0 &&
-          typeof record.prompt === "string" &&
-          record.prompt.trim().length > 0
-        );
-      })
-    : [];
+  const chatMetadata = useMemo<Record<string, unknown>>(
+    () => (chatQuery.data?.metadata && typeof chatQuery.data.metadata === "object" ? chatQuery.data.metadata : {}),
+    [chatQuery.data?.metadata],
+  );
+  const promptTemplates = useMemo<ChatSummaryPromptTemplate[]>(
+    () =>
+      Array.isArray(chatMetadata.summaryPromptTemplates)
+        ? chatMetadata.summaryPromptTemplates.filter((template: unknown): template is ChatSummaryPromptTemplate => {
+            if (!template || typeof template !== "object" || Array.isArray(template)) return false;
+            const record = template as Record<string, unknown>;
+            return (
+              typeof record.id === "string" &&
+              record.id.trim().length > 0 &&
+              typeof record.name === "string" &&
+              record.name.trim().length > 0 &&
+              typeof record.prompt === "string" &&
+              record.prompt.trim().length > 0
+            );
+          })
+        : [],
+    [chatMetadata],
+  );
   const activeSummaryPromptTemplateId =
     typeof chatMetadata.activeSummaryPromptTemplateId === "string" ? chatMetadata.activeSummaryPromptTemplateId : "";
-  const summaryEntries = normalizeChatSummaryMetadata(chatMetadata).entries;
-  const enabledTokenEstimate = summaryEntries.reduce(
-    (total, entry) => (entry.enabled ? total + entry.tokenEstimate : total),
-    0,
+  const summaryEntries = useMemo(() => normalizeChatSummaryMetadata(chatMetadata).entries, [chatMetadata]);
+  const enabledTokenEstimate = useMemo(
+    () => summaryEntries.reduce((total, entry) => (entry.enabled ? total + entry.tokenEstimate : total), 0),
+    [summaryEntries],
   );
-  const disabledEntryCount = summaryEntries.filter((entry) => !entry.enabled).length;
+  const disabledEntryCount = useMemo(() => summaryEntries.filter((entry) => !entry.enabled).length, [summaryEntries]);
   const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
   const hasTemplateDraft = templateNameDraft.trim().length > 0 && templatePromptDraft.trim().length > 0;
 

--- a/src/features/runtime/tracker/components/TrackerProfileStats.css
+++ b/src/features/runtime/tracker/components/TrackerProfileStats.css
@@ -161,11 +161,13 @@
 }
 
 .tracker-stat-fill {
+  width: 100%;
   height: 100%;
   border-radius: inherit;
   background: var(--primary);
+  transform-origin: left center;
   transition-duration: 200ms;
-  transition-property: width;
+  transition-property: transform;
 }
 
 .tracker-stat-fill--instrument {

--- a/src/features/runtime/tracker/components/quest-tracker/QuestRow.css
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestRow.css
@@ -187,10 +187,12 @@
 }
 
 .tracker-quest-row__progress-fill {
+  width: 100%;
   height: 100%;
   border-radius: 1px;
   background: color-mix(in srgb, var(--primary) 85%, transparent);
-  transition: width 200ms;
+  transform-origin: left center;
+  transition: transform 200ms;
 }
 
 .tracker-quest-row__progress-fill--complete {

--- a/src/features/runtime/tracker/components/quest-tracker/QuestRow.tsx
+++ b/src/features/runtime/tracker/components/quest-tracker/QuestRow.tsx
@@ -93,9 +93,7 @@ export function QuestRow({
             editHintMode={wrapsText ? "overlay" : "inline"}
             className={cn(
               "tracker-quest-row__title-edit",
-              wrapsText
-                ? "tracker-quest-row__title-edit--wrapped"
-                : "tracker-quest-row__title-edit--single-line",
+              wrapsText ? "tracker-quest-row__title-edit--wrapped" : "tracker-quest-row__title-edit--single-line",
               quest.completed && "tracker-quest-row__title-edit--completed",
             )}
           />
@@ -130,7 +128,7 @@ export function QuestRow({
             "tracker-quest-row__progress-fill",
             quest.completed && "tracker-quest-row__progress-fill--complete",
           )}
-          style={{ width: `${completionPercent}%` }}
+          style={{ transform: `scaleX(${completionPercent / 100})` }}
         />
       </div>
 

--- a/src/features/runtime/tracker/components/tracker-data-sidebar.stats.tsx
+++ b/src/features/runtime/tracker/components/tracker-data-sidebar.stats.tsx
@@ -235,7 +235,7 @@ function StatBar({
       <div className={cn(statTrackClass, isInstrument ? "mt-0.5" : isRoomy ? "mt-0.5" : "mt-0", barClass)}>
         <div
           className={statFillClass}
-          style={{ width: `${percent}%`, backgroundColor: stat.color || "var(--primary)" }}
+          style={{ transform: `scaleX(${percent / 100})`, backgroundColor: stat.color || "var(--primary)" }}
         />
       </div>
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2669,9 +2669,11 @@ summary[class*="cursor-pointer"],
 }
 
 .game-stats-bar-fill {
+  width: 100%;
   height: 100%;
   border-radius: 0.1875rem;
-  transition: width 0.5s ease;
+  transform-origin: left center;
+  transition: transform 0.5s ease;
 }
 
 .game-stats-bar-hp {
@@ -2948,7 +2950,7 @@ summary[class*="cursor-pointer"],
 }
 
 .game-stats-bar-fill {
-  will-change: width;
+  will-change: transform;
 }
 
 .overflow-y-auto {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

None.

## Why this change

Refactor builds were carrying avoidable game-mode bundle weight and layout work in hot UI paths. This change trims initial game-surface payload, avoids layout-bound progress bar animation, and makes branch-specific docs point contributors at the active refactor line.

## What changed

- Lazy-loads heavy game overlays from `GameSurface`, including session history, journal, checkpoints, inventory, readable documents, and the first-game tutorial.
- Adds a game asset helper entrypoint so the game-assets browser can import pure selection helpers without pulling through the game-mode barrel.
- Changes game/combat/tracker progress fills from animated `width` updates to `transform: scaleX(...)` updates.
- Memoizes summary metadata derivations used by the shared summary popover.
- Handles non-promise `audio.play()` returns in the game audio unlock path.
- Marks `refactor` docs as authoritative for current work and updates the Home Assistant integration docs link to the `refactor` branch.

## Refactor impact

Primary owner:

game mode, game assets, shared mode UI, runtime tracker, repo docs

Impact areas reviewed:

- Game mode bundle/chunk output
- Game assets browser imports and tests
- Game character/combat stat bar rendering
- Runtime tracker stat/progress bar rendering
- Shared summary popover derived metadata
- Docs branch guidance and Home Assistant documentation link

Boundary notes:

- No engine, shared API, Rust command, storage, provider transport, or remote-runtime boundary changes.
- Game-assets now imports asset-selection helpers through a small game-owned entrypoint instead of the full game barrel.

Pressure points touched:

- `GameSurface`
- game asset import modules
- shared mode UI summary popover
- runtime tracker bars
- global game stat-bar CSS

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm test` (`62` test files, `240` tests)
- `corepack pnpm lint:eslint`
- `corepack pnpm check:docs`
- `corepack pnpm check:architecture`
- `corepack pnpm check:unused`
- `corepack pnpm check:discovery`
- `corepack pnpm check:line-endings`
- `corepack pnpm perf:size`
- `corepack pnpm exec prettier --check --ignore-unknown` on touched files
- `git diff --check`
- Browser smoke: Vite app booted at `127.0.0.1:5173`, title rendered as `Marinara Engine`, no browser console errors after boot and shallow Game starter click.
- Bundle comparison against `origin/refactor`: `GameSurface` dropped from `652.16 kB` raw / `179.47 kB` gzip to `588.92 kB` raw / `165.59 kB` gzip, removing the Vite >650 kB chunk warning for that chunk.
- `npx --yes pnpm@10.33.2 check` completed line endings, architecture, and frontend, then stopped at `check:rust` because `cargo` is not available on PATH in this environment.
- Follow-up validation after reviewer-observation fixes: `corepack pnpm typecheck`.
- Follow-up validation after reviewer-observation fixes: `corepack pnpm test -- src/features/modes/game-assets/components/GameAssetsBrowserView.test.tsx` (Vitest ran `62` test files, `240` tests).
- Follow-up validation after reviewer-observation fixes: `corepack pnpm exec prettier --check --ignore-unknown` on touched files.
- Follow-up validation after reviewer-observation fixes: `corepack pnpm build`.
- Follow-up browser smoke: Vite app booted at `localhost:1420`, title rendered as `Marinara Engine`, and no browser console warnings or errors were reported.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a performance/refactor/docs guidance change and does not add a discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshot included. The UI-facing changes are progress bar animation internals and lazy-loaded overlays; browser smoke verified app boot and starter Game path without console errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved media playback handling for better browser compatibility.

* **Performance**
  * Optimized progress bar animations for smoother, GPU-accelerated transitions.
  * Implemented lazy loading for game UI panels to reduce initial load time.
  * Enhanced component memoization to minimize unnecessary re-renders.

* **Documentation**
  * Updated documentation links to reference the current refactor branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

