### PR TITLE
storage: reject duplicate create ids

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -131,6 +131,11 @@ impl FileStorage {
             .filter(|id| !id.trim().is_empty())
             .map(ToOwned::to_owned)
             .unwrap_or_else(new_id);
+        if had_id && self.read_collection_find_by_id(collection, &id)?.is_some() {
+            return Err(AppError::invalid_input(format!(
+                "{collection}/{id} already exists"
+            )));
+        }
         let now = now_iso();
         object.insert("id".to_string(), Value::String(id.clone()));
         object
@@ -2498,6 +2503,54 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<Value>(&fs::read_to_string(&backup).unwrap()).unwrap(),
             json!([{ "id": "second" }])
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn create_rejects_duplicate_caller_provided_id_without_mutating_existing_row() {
+        let root = temp_storage_root("create-rejects-duplicate-id");
+        let storage = FileStorage::new(&root).unwrap();
+
+        storage
+            .create(
+                "characters",
+                json!({
+                    "id": "duplicate-test",
+                    "name": "Original"
+                }),
+            )
+            .expect("initial create should succeed");
+
+        let error = storage
+            .create(
+                "characters",
+                json!({
+                    "id": "duplicate-test",
+                    "name": "Replacement"
+                }),
+            )
+            .expect_err("duplicate create should fail");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.message, "characters/duplicate-test already exists");
+        let original = storage
+            .get("characters", "duplicate-test")
+            .unwrap()
+            .expect("original row should remain");
+        assert_eq!(original["name"], "Original");
+        assert_eq!(original["id"], "duplicate-test");
+        assert!(original.get("createdAt").is_some());
+        assert!(original.get("updatedAt").is_some());
+        assert_eq!(
+            storage.list("characters").unwrap(),
+            vec![json!({
+                "id": original["id"].clone(),
+                "name": original["name"].clone(),
+                "createdAt": original["createdAt"].clone(),
+                "updatedAt": original["updatedAt"].clone()
+            })]
         );
 
         fs::remove_dir_all(root).unwrap();


### PR DESCRIPTION
## Linked issue

Closes #1891

## Why this change

- `storage_create` could silently replace an existing row when the caller supplied an `id` already present in the target collection.
- Create semantics should reject duplicate caller-provided IDs; intentional replacement should stay on update or upsert paths.

## What changed

- Added a duplicate-ID guard in `FileStorage::create` for non-empty caller-provided IDs.
- Added a focused Rust regression test proving duplicate create fails without mutating the original row.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Embedded Tauri `storage_create` command path
- Remote runtime `/api/invoke` `storage_create` dispatch path
- Shared storage callers across catalog resources, chat, roleplay, and game modes

Boundary notes:

- Fixed at the Rust storage owner where both embedded and remote storage create paths converge.
- No React, engine, shared API, command registration, or HTTP allowlist changes were needed.
- `upsert_with_id` remains the explicit replacement path.

Pressure points touched:

- None beyond `src-tauri/crates/storage/src/lib.rs`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/crates/storage/Cargo.toml create_rejects_duplicate_caller_provided_id_without_mutating_existing_row`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A; storage behavior only.
