### PR TITLE
Route scene UI through public entrypoint

### DIFF
--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -27,7 +27,7 @@ import {
 } from "lucide-react";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
-import { SceneBanner, EndSceneBar } from "../../shared/scene-ui/SceneBanner";
+import { SceneBanner, EndSceneBar } from "../../shared/scene-ui";
 import { ChatBranchSelector } from "../../shared/chat-ui/index";
 import { ActiveWorldInfoButton, ActiveWorldInfoModal } from "../../../runtime/visuals/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -36,7 +36,7 @@ import { ChatMessage } from "../../shared/chat-ui/index";
 import { ChatInput } from "../../shared/chat-ui/index";
 import { CyoaChoices } from "./CyoaChoices";
 import { ChatBranchSelector } from "../../shared/chat-ui/index";
-import { EndSceneBar, SceneBanner } from "../../shared/scene-ui/SceneBanner";
+import { EndSceneBar, SceneBanner } from "../../shared/scene-ui";
 import { ChatCommonOverlays } from "../../shared/chat-ui/index";
 import { ActiveWorldInfoButton } from "../../../runtime/visuals/index";
 import type { SpriteDisplayMode } from "../../../runtime/visuals/sprite-display-modes";

--- a/src/features/modes/shared/scene-ui/SceneBanner.tsx
+++ b/src/features/modes/shared/scene-ui/SceneBanner.tsx
@@ -99,6 +99,15 @@ export function SceneBanner({ variant, sceneChatId, sceneChatName, originChatId,
   );
 }
 
+interface EndSceneBarProps {
+  sceneChatId: string;
+  originChatId?: string;
+  onConclude: (id: string) => void | Promise<void>;
+  onAbandon?: (id: string) => void;
+  onFork?: (id: string, mode: SceneForkMode) => void;
+  isForking?: boolean;
+}
+
 /** End Scene bar — placed above the input area in scene chats */
 export function EndSceneBar({
   sceneChatId,
@@ -107,14 +116,7 @@ export function EndSceneBar({
   onAbandon,
   onFork,
   isForking,
-}: {
-  sceneChatId: string;
-  originChatId?: string;
-  onConclude: (id: string) => void | Promise<void>;
-  onAbandon?: (id: string) => void;
-  onFork?: (id: string, mode: SceneForkMode) => void;
-  isForking?: boolean;
-}) {
+}: EndSceneBarProps) {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const [confirmEnd, setConfirmEnd] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);

--- a/src/features/modes/shared/scene-ui/index.ts
+++ b/src/features/modes/shared/scene-ui/index.ts
@@ -1,0 +1,1 @@
+export { EndSceneBar, SceneBanner } from "./SceneBanner";


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

N/A - local architecture chore only; no public issue.

## Why this change

- Shared scene UI was being consumed through the concrete `SceneBanner` file path instead of a package-level public entrypoint.
- This keeps conversation and roleplay scene UI imports aligned with the repo boundary rule for curated public feature APIs.

## What changed

- Added `src/features/modes/shared/scene-ui/index.ts` as the public scene UI entrypoint.
- Routed conversation and roleplay scene UI imports through `../../shared/scene-ui`.
- Extracted the inline `EndSceneBar` props shape into a local interface while preserving behavior.

## Refactor impact

Primary owner:

shared mode UI (`src/features/modes/shared/scene-ui`)

Impact areas reviewed:

- Conversation scene banner and end-scene bar imports.
- Roleplay scene banner and end-scene bar imports.
- Shared mode UI ownership boundary.

Boundary notes:

- Feature-only import cleanup; no engine, shared API, Rust, storage, provider, or remote-runtime boundary touched.
- No direct concrete-mode imports were added.

Pressure points touched:

- Shared mode UI entrypoint only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm build` passed; Vite reported the existing large `GameSurface` chunk warning.
- `pnpm check` passed after removing unused public type exports caught by Knip.
- `rg "scene-ui/SceneBanner" src` found no remaining private scene UI imports.
- Bunny-style review found no confirmed findings.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal architecture/import cleanup only; no user-discoverable behavior changed.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs, changelog, or release notes needed because this is internal feature import wiring with no user-facing behavior change.

## UI evidence

No screenshots or recordings; UI behavior is intended unchanged and validation is static/build-based.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->