### PR TITLE
Centralize refactor storage contracts

### DIFF
--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -24,6 +24,8 @@ pub(crate) mod characters;
 pub(crate) mod chats;
 #[path = "storage/connection_secrets.rs"]
 pub(crate) mod connection_secrets;
+#[path = "storage/contracts.rs"]
+pub(crate) mod contracts;
 #[path = "storage/custom_tools.rs"]
 pub(crate) mod custom_tools;
 #[path = "storage/exports.rs"]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -261,7 +261,11 @@ pub async fn storage_create(
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_create_inner(state: &AppState, entity: String, value: Value) -> Result<Value, AppError> {
+pub(crate) fn storage_create_inner(
+    state: &AppState,
+    entity: String,
+    value: Value,
+) -> Result<Value, AppError> {
     validate_connection_folder_for_create(state, &entity, &value)?;
     let created = state
         .storage
@@ -291,7 +295,7 @@ pub async fn storage_update(
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_update_inner(
+pub(crate) fn storage_update_inner(
     state: &AppState,
     entity: String,
     id: String,

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -1,0 +1,580 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TypedJsonKind {
+    JsonArray,
+    NullableJsonArray,
+    JsonObject,
+    NullableJsonObject,
+    Boolish,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct TypedJsonField {
+    pub(crate) name: &'static str,
+    pub(crate) kind: TypedJsonKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DeleteCleanup {
+    ActivateDefaultChatPreset,
+    ClearConnectionFolder,
+    ClearLorebookReferences,
+    DeleteCharacterGallery,
+    DeleteLorebookChildren,
+    DeleteMessageTrackerSnapshots,
+    DeletePromptChildren,
+    RemoveOwnedMedia,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct StorageCollectionContract {
+    pub(crate) name: &'static str,
+    pub(crate) profile: bool,
+    pub(crate) startup_json_repair: bool,
+    pub(crate) create_default_fields: &'static [&'static str],
+    pub(crate) typed_json_fields: &'static [TypedJsonField],
+    pub(crate) delete_cleanup: &'static [DeleteCleanup],
+}
+
+const EMPTY_FIELDS: &[TypedJsonField] = &[];
+const EMPTY_DEFAULTS: &[&str] = &[];
+const EMPTY_CLEANUP: &[DeleteCleanup] = &[];
+
+const CHAT_FIELDS: &[TypedJsonField] = &[
+    array("characterIds"),
+    array("activeLorebookIds"),
+    array("activeAgentIds"),
+    array("activeToolIds"),
+    array("memories"),
+    array("notes"),
+    nullable_object("metadata"),
+    nullable_object("gameState"),
+];
+const MESSAGE_FIELDS: &[TypedJsonField] = &[
+    array("swipes"),
+    array("images"),
+    array("attachments"),
+    nullable_object("extra"),
+];
+const CHARACTER_GROUP_FIELDS: &[TypedJsonField] = &[array("characterIds")];
+const PERSONA_GROUP_FIELDS: &[TypedJsonField] = &[array("personaIds")];
+const LOREBOOK_FIELDS: &[TypedJsonField] =
+    &[array("tags"), array("characterIds"), array("personaIds")];
+const LOREBOOK_ENTRY_FIELDS: &[TypedJsonField] = &[
+    array("keys"),
+    array("secondaryKeys"),
+    array("characterFilterIds"),
+    array("characterTagFilters"),
+    array("generationTriggerFilters"),
+    array("additionalMatchingSources"),
+    array("activationConditions"),
+    boolish("enabled"),
+    boolish("constant"),
+    boolish("selective"),
+    boolish("matchWholeWords"),
+    boolish("caseSensitive"),
+    boolish("useRegex"),
+    boolish("preventRecursion"),
+    boolish("locked"),
+    boolish("excludeFromVectorization"),
+    nullable_object("relationships"),
+    nullable_object("dynamicState"),
+    nullable_object("schedule"),
+];
+const CONNECTION_FIELDS: &[TypedJsonField] = &[
+    nullable_object("defaultParameters"),
+    nullable_object("capabilities"),
+    nullable_object("providerMetadata"),
+    boolish("isDefault"),
+    boolish("default"),
+    boolish("useForRandom"),
+    boolish("defaultForAgents"),
+];
+const CUSTOM_TOOL_FIELDS: &[TypedJsonField] = &[object("parametersSchema")];
+const GAME_STATE_SNAPSHOT_FIELDS: &[TypedJsonField] = &[
+    array("presentCharacters"),
+    array("recentEvents"),
+    nullable_object("playerStats"),
+    nullable_object("metadata"),
+    nullable_array("personaStats"),
+];
+const GAME_CHECKPOINT_FIELDS: &[TypedJsonField] =
+    &[nullable_object("snapshot"), nullable_object("metadata")];
+const CHAT_PRESET_FIELDS: &[TypedJsonField] = &[
+    object("parameters"),
+    object("settings"),
+    boolish("isDefault"),
+    boolish("default"),
+    boolish("isActive"),
+    boolish("active"),
+];
+const PROMPT_FIELDS: &[TypedJsonField] = &[
+    array("sectionOrder"),
+    array("groupOrder"),
+    array("variableOrder"),
+    object("variableValues"),
+    object("parameters"),
+    object("defaultChoices"),
+    array("variableGroups"),
+];
+const PROMPT_SECTION_FIELDS: &[TypedJsonField] = &[nullable_object("markerConfig")];
+const PROMPT_VARIABLE_FIELDS: &[TypedJsonField] = &[array("options")];
+const PERSONA_FIELDS: &[TypedJsonField] = &[
+    array("tags"),
+    array("altDescriptions"),
+    array("savedStatusOptions"),
+    nullable_object("avatarCrop"),
+    nullable_object("personaStats"),
+];
+const AGENT_FIELDS: &[TypedJsonField] = &[object("settings")];
+const REGEX_SCRIPT_FIELDS: &[TypedJsonField] = &[array("placement"), array("trimStrings")];
+
+const CHAT_DEFAULTS: &[&str] = &["metadata", "gameState", "characterIds"];
+const CONNECTION_DEFAULTS: &[&str] = &["enabled"];
+const CONNECTION_FOLDER_DEFAULTS: &[&str] = &["color", "collapsed", "sortOrder", "order"];
+const CHARACTER_DEFAULTS: &[&str] = &["data", "comment", "avatarPath"];
+const LOREBOOK_DEFAULTS: &[&str] = &[
+    "description",
+    "category",
+    "imagePath",
+    "scanDepth",
+    "tokenBudget",
+    "recursiveScanning",
+    "maxRecursionDepth",
+    "characterId",
+    "characterIds",
+    "personaId",
+    "personaIds",
+    "chatId",
+    "isGlobal",
+    "enabled",
+    "excludeFromVectorization",
+    "tags",
+    "generatedBy",
+    "sourceAgentId",
+];
+const PERSONA_DEFAULTS: &[&str] = &[
+    "description",
+    "comment",
+    "personality",
+    "scenario",
+    "backstory",
+    "appearance",
+    "avatarPath",
+    "isActive",
+    "tags",
+    "altDescriptions",
+    "avatarCrop",
+];
+const PROMPT_DEFAULTS: &[&str] = &[
+    "description",
+    "sectionOrder",
+    "groupOrder",
+    "variableGroups",
+    "variableValues",
+    "parameters",
+    "defaultChoices",
+    "isDefault",
+];
+const CHAT_PRESET_DEFAULTS: &[&str] = &["settings", "isDefault", "default", "isActive", "active"];
+const AGENT_DEFAULTS: &[&str] = &["enabled", "credit"];
+
+const LOREBOOK_CLEANUP: &[DeleteCleanup] = &[
+    DeleteCleanup::DeleteLorebookChildren,
+    DeleteCleanup::ClearLorebookReferences,
+    DeleteCleanup::RemoveOwnedMedia,
+];
+const PROMPT_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::DeletePromptChildren];
+const CHAT_PRESET_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ActivateDefaultChatPreset];
+const CONNECTION_FOLDER_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ClearConnectionFolder];
+const CHARACTER_CLEANUP: &[DeleteCleanup] = &[
+    DeleteCleanup::RemoveOwnedMedia,
+    DeleteCleanup::DeleteCharacterGallery,
+];
+const MEDIA_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::RemoveOwnedMedia];
+const MESSAGE_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::DeleteMessageTrackerSnapshots];
+
+pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
+    contract(
+        "characters",
+        true,
+        true,
+        CHARACTER_DEFAULTS,
+        EMPTY_FIELDS,
+        CHARACTER_CLEANUP,
+    ),
+    contract(
+        "character-groups",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        CHARACTER_GROUP_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "character-versions",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "personas",
+        true,
+        true,
+        PERSONA_DEFAULTS,
+        PERSONA_FIELDS,
+        MEDIA_CLEANUP,
+    ),
+    contract(
+        "persona-groups",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        PERSONA_GROUP_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "lorebooks",
+        true,
+        true,
+        LOREBOOK_DEFAULTS,
+        LOREBOOK_FIELDS,
+        LOREBOOK_CLEANUP,
+    ),
+    contract(
+        "lorebook-entries",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        LOREBOOK_ENTRY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "lorebook-folders",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "prompts",
+        true,
+        true,
+        PROMPT_DEFAULTS,
+        PROMPT_FIELDS,
+        PROMPT_CLEANUP,
+    ),
+    contract(
+        "prompt-groups",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "prompt-sections",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        PROMPT_SECTION_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "prompt-variables",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        PROMPT_VARIABLE_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "prompt-overrides",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "chat-presets",
+        true,
+        true,
+        CHAT_PRESET_DEFAULTS,
+        CHAT_PRESET_FIELDS,
+        CHAT_PRESET_CLEANUP,
+    ),
+    contract(
+        "agents",
+        true,
+        true,
+        AGENT_DEFAULTS,
+        AGENT_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "agent-runs",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "agent-memory",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "themes",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "extensions",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "connections",
+        true,
+        true,
+        CONNECTION_DEFAULTS,
+        CONNECTION_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "connection-folders",
+        true,
+        false,
+        CONNECTION_FOLDER_DEFAULTS,
+        EMPTY_FIELDS,
+        CONNECTION_FOLDER_CLEANUP,
+    ),
+    contract(
+        "chats",
+        true,
+        true,
+        CHAT_DEFAULTS,
+        CHAT_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "chat-folders",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "messages",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        MESSAGE_FIELDS,
+        MESSAGE_CLEANUP,
+    ),
+    contract(
+        "custom-tools",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        CUSTOM_TOOL_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "regex-scripts",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        REGEX_SCRIPT_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "app-settings",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "gallery",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        MEDIA_CLEANUP,
+    ),
+    contract(
+        "character-gallery",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        MEDIA_CLEANUP,
+    ),
+    contract(
+        "background-metadata",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "sprites",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "knowledge-sources",
+        true,
+        false,
+        EMPTY_DEFAULTS,
+        EMPTY_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "game-state-snapshots",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        GAME_STATE_SNAPSHOT_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+    contract(
+        "game-checkpoints",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        GAME_CHECKPOINT_FIELDS,
+        EMPTY_CLEANUP,
+    ),
+];
+
+pub(crate) fn collection_contract(collection: &str) -> Option<&'static StorageCollectionContract> {
+    COLLECTIONS
+        .iter()
+        .find(|contract| contract.name == collection)
+}
+
+pub(crate) fn profile_collections() -> impl Iterator<Item = &'static str> {
+    COLLECTIONS
+        .iter()
+        .filter(|contract| contract.profile)
+        .map(|contract| contract.name)
+}
+
+pub(crate) fn startup_json_repair_collections() -> impl Iterator<Item = &'static str> {
+    COLLECTIONS
+        .iter()
+        .filter(|contract| contract.startup_json_repair)
+        .map(|contract| contract.name)
+}
+
+const fn contract(
+    name: &'static str,
+    profile: bool,
+    startup_json_repair: bool,
+    create_default_fields: &'static [&'static str],
+    typed_json_fields: &'static [TypedJsonField],
+    delete_cleanup: &'static [DeleteCleanup],
+) -> StorageCollectionContract {
+    StorageCollectionContract {
+        name,
+        profile,
+        startup_json_repair,
+        create_default_fields,
+        typed_json_fields,
+        delete_cleanup,
+    }
+}
+
+const fn array(name: &'static str) -> TypedJsonField {
+    TypedJsonField {
+        name,
+        kind: TypedJsonKind::JsonArray,
+    }
+}
+
+const fn nullable_array(name: &'static str) -> TypedJsonField {
+    TypedJsonField {
+        name,
+        kind: TypedJsonKind::NullableJsonArray,
+    }
+}
+
+const fn object(name: &'static str) -> TypedJsonField {
+    TypedJsonField {
+        name,
+        kind: TypedJsonKind::JsonObject,
+    }
+}
+
+const fn nullable_object(name: &'static str) -> TypedJsonField {
+    TypedJsonField {
+        name,
+        kind: TypedJsonKind::NullableJsonObject,
+    }
+}
+
+const fn boolish(name: &'static str) -> TypedJsonField {
+    TypedJsonField {
+        name,
+        kind: TypedJsonKind::Boolish,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn registry_has_unique_collection_names() {
+        let mut names = HashSet::new();
+        for contract in COLLECTIONS {
+            assert!(
+                names.insert(contract.name),
+                "duplicate storage contract for {}",
+                contract.name
+            );
+        }
+    }
+
+    #[test]
+    fn registry_answers_core_contract_questions() {
+        let connections = collection_contract("connections").expect("connections contract");
+        assert!(connections.profile);
+        assert!(connections.startup_json_repair);
+        assert!(connections.create_default_fields.contains(&"enabled"));
+        assert!(connections
+            .typed_json_fields
+            .iter()
+            .any(|field| field.name == "defaultForAgents" && field.kind == TypedJsonKind::Boolish));
+
+        let lorebooks = collection_contract("lorebooks").expect("lorebooks contract");
+        assert!(lorebooks
+            .delete_cleanup
+            .contains(&DeleteCleanup::DeleteLorebookChildren));
+        assert!(lorebooks
+            .delete_cleanup
+            .contains(&DeleteCleanup::ClearLorebookReferences));
+    }
+}

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -10,6 +10,7 @@ use self::assets::{
 };
 use self::legacy::import_legacy_profile_tables;
 use self::zip_import::import_profile_zip;
+use super::contracts;
 use super::shared::*;
 use super::*;
 use base64::engine::general_purpose;
@@ -19,43 +20,6 @@ use std::path::{Path, PathBuf};
 
 const PROFILE_EXPORT_JSON_LIMIT_BYTES: usize = 256 * 1024 * 1024;
 const PROFILE_EXPORT_JSON_TOO_LARGE_CODE: &str = "PROFILE_EXPORT_JSON_TOO_LARGE";
-
-const PROFILE_COLLECTIONS: &[&str] = &[
-    "characters",
-    "character-groups",
-    "character-versions",
-    "personas",
-    "persona-groups",
-    "lorebooks",
-    "lorebook-entries",
-    "lorebook-folders",
-    "prompts",
-    "prompt-groups",
-    "prompt-sections",
-    "prompt-variables",
-    "prompt-overrides",
-    "chat-presets",
-    "agents",
-    "agent-runs",
-    "agent-memory",
-    "themes",
-    "extensions",
-    "connections",
-    "connection-folders",
-    "chats",
-    "chat-folders",
-    "messages",
-    "custom-tools",
-    "regex-scripts",
-    "app-settings",
-    "gallery",
-    "character-gallery",
-    "background-metadata",
-    "sprites",
-    "knowledge-sources",
-    "game-state-snapshots",
-    "game-checkpoints",
-];
 
 pub(crate) fn profile_snapshot(state: &AppState) -> AppResult<Value> {
     Ok(json!({
@@ -234,8 +198,8 @@ pub(super) fn validate_native_profile_import(
             ));
         }
     }
-    for collection in PROFILE_COLLECTIONS {
-        match collections.get(*collection) {
+    for collection in contracts::profile_collections() {
+        match collections.get(collection) {
             Some(Value::Array(_)) => {}
             Some(_) => {
                 return Err(AppError::invalid_input(format!(
@@ -264,14 +228,14 @@ where
     let mut imported = Map::new();
     let mut replacements = Vec::new();
     let mut unsupported_prompt_overrides = 0usize;
-    for collection in PROFILE_COLLECTIONS {
+    for collection in contracts::profile_collections() {
         // A partial modern profile (a hand-built export, or a file missing a
         // collection) must not wipe collections it does not carry. Skipping the
         // replacement leaves the user's existing collection untouched; a
         // collection that is present but empty is still an explicit clear and
         // falls through to a normal empty replacement. Mirrors the legacy table
         // path guard added in #1518.
-        let Some(collection_value) = collections.get(*collection) else {
+        let Some(collection_value) = collections.get(collection) else {
             continue;
         };
         // A present-but-non-array collection is malformed (e.g. `"characters": {}`).
@@ -284,18 +248,18 @@ where
             )));
         }
         let mut rows = collection_value.as_array().cloned().unwrap_or_default();
-        if *collection == "prompt-overrides" {
+        if collection == "prompt-overrides" {
             unsupported_prompt_overrides = normalize_profile_prompt_overrides(&mut rows);
         }
         normalize_profile_json_fields(collection, &mut rows)?;
-        if *collection == "connections" {
+        if collection == "connections" {
             rows = rows
                 .into_iter()
                 .map(|row| connection_secrets::prepare_connection_for_create(state, row))
                 .collect::<AppResult<Vec<_>>>()?;
         }
-        imported.insert((*collection).to_string(), json!(rows.len()));
-        replacements.push((*collection, rows));
+        imported.insert(collection.to_string(), json!(rows.len()));
+        replacements.push((collection, rows));
     }
     state
         .storage
@@ -419,13 +383,13 @@ fn insert_profile_import_aliases(imported: &mut Map<String, Value>) {
 
 fn profile_collections(state: &AppState) -> AppResult<Map<String, Value>> {
     let mut collections = Map::new();
-    for collection in PROFILE_COLLECTIONS {
-        let rows = if *collection == "connections" {
+    for collection in contracts::profile_collections() {
+        let rows = if collection == "connections" {
             connection_secrets::connections_for_export(state)?
         } else {
             state.storage.list(collection)?
         };
-        collections.insert((*collection).to_string(), Value::Array(rows));
+        collections.insert(collection.to_string(), Value::Array(rows));
     }
     Ok(collections)
 }
@@ -567,9 +531,8 @@ mod tests {
     }
 
     fn complete_empty_profile_collections() -> Map<String, Value> {
-        PROFILE_COLLECTIONS
-            .iter()
-            .map(|collection| ((*collection).to_string(), json!([])))
+        contracts::profile_collections()
+            .map(|collection| (collection.to_string(), json!([])))
             .collect()
     }
 

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::storage_commands::contracts::{self, TypedJsonKind};
 
 pub(crate) struct ParsedPath {
     pub(crate) parts: Vec<String>,
@@ -474,138 +475,31 @@ pub(crate) fn normalize_typed_json_fields(
     collection: &str,
     object: &mut Map<String, Value>,
 ) -> AppResult<()> {
-    match collection {
-        "characters" => {
-            if let Some(data) = object.get("data") {
-                object.insert(
-                    "data".to_string(),
-                    normalize_character_data_for_storage(data)?,
-                );
+    if collection == "characters" {
+        if let Some(data) = object.get("data") {
+            object.insert(
+                "data".to_string(),
+                normalize_character_data_for_storage(data)?,
+            );
+        }
+    }
+    if let Some(contract) = contracts::collection_contract(collection) {
+        for field in contract.typed_json_fields {
+            match field.kind {
+                TypedJsonKind::JsonArray => normalize_json_array_fields(object, &[field.name])?,
+                TypedJsonKind::NullableJsonArray => {
+                    normalize_nullable_json_array_fields(object, &[field.name])?
+                }
+                TypedJsonKind::JsonObject => normalize_json_object_fields(object, &[field.name])?,
+                TypedJsonKind::NullableJsonObject => {
+                    normalize_nullable_json_object_fields(object, &[field.name])?
+                }
+                TypedJsonKind::Boolish => normalize_boolish_fields(object, &[field.name]),
             }
         }
-        "chats" => {
-            normalize_json_array_fields(
-                object,
-                &[
-                    "characterIds",
-                    "activeLorebookIds",
-                    "activeAgentIds",
-                    "activeToolIds",
-                    "memories",
-                    "notes",
-                ],
-            )?;
-            normalize_nullable_json_object_fields(object, &["metadata", "gameState"])?;
-        }
-        "messages" => {
-            normalize_json_array_fields(object, &["swipes", "images", "attachments"])?;
-            normalize_nullable_json_object_fields(object, &["extra"])?;
-            normalize_message_text_fields(object);
-        }
-        "character-groups" => {
-            normalize_json_array_fields(object, &["characterIds"])?;
-        }
-        "persona-groups" => {
-            normalize_json_array_fields(object, &["personaIds"])?;
-        }
-        "lorebooks" => {
-            normalize_json_array_fields(object, &["tags", "characterIds", "personaIds"])?;
-        }
-        "lorebook-entries" => {
-            // The generic storage boundary is the single contract every
-            // lorebook-entry write crosses (editor, bulk create, copy/move,
-            // tool-generated entries, remote runtime). Coerce every legacy-style
-            // shape - string booleans, JSON-string arrays, and JSON-string
-            // objects - to the native shape, or reject what cannot be coerced,
-            // so downstream UI/generation never has to guess the intended type.
-            normalize_json_array_fields(
-                object,
-                &[
-                    "keys",
-                    "secondaryKeys",
-                    "characterFilterIds",
-                    "characterTagFilters",
-                    "generationTriggerFilters",
-                    "additionalMatchingSources",
-                    "activationConditions",
-                ],
-            )?;
-            normalize_boolish_fields(
-                object,
-                &[
-                    "enabled",
-                    "constant",
-                    "selective",
-                    "matchWholeWords",
-                    "caseSensitive",
-                    "useRegex",
-                    "preventRecursion",
-                    "locked",
-                    "excludeFromVectorization",
-                ],
-            );
-            // Use the nullable object normalizer so a stored entry that already
-            // carries `null` (e.g. round-tripped through a copy/duplicate) is
-            // left untouched rather than rejected, while a JSON-string object is
-            // still parsed and a malformed value still rejected.
-            normalize_nullable_json_object_fields(
-                object,
-                &["relationships", "dynamicState", "schedule"],
-            )?;
-        }
-        "connections" => {
-            normalize_nullable_json_object_fields(
-                object,
-                &["defaultParameters", "capabilities", "providerMetadata"],
-            )?;
-            normalize_boolish_fields(
-                object,
-                &["isDefault", "default", "useForRandom", "defaultForAgents"],
-            );
-        }
-        "custom-tools" => {
-            normalize_json_object_fields(object, &["parametersSchema"])?;
-        }
-        "game-state-snapshots" => {
-            normalize_json_array_fields(object, &["presentCharacters", "recentEvents"])?;
-            normalize_nullable_json_object_fields(object, &["playerStats", "metadata"])?;
-            normalize_nullable_json_array_fields(object, &["personaStats"])?;
-        }
-        "game-checkpoints" => {
-            normalize_nullable_json_object_fields(object, &["snapshot", "metadata"])?;
-        }
-        "chat-presets" => {
-            normalize_json_object_fields(object, &["parameters", "settings"])?;
-            normalize_boolish_fields(object, &["isDefault", "default", "isActive", "active"]);
-        }
-        "prompts" => {
-            normalize_json_array_fields(object, &["sectionOrder", "groupOrder", "variableOrder"])?;
-            normalize_json_object_fields(
-                object,
-                &["variableValues", "parameters", "defaultChoices"],
-            )?;
-            normalize_json_array_fields(object, &["variableGroups"])?;
-        }
-        "prompt-sections" => {
-            normalize_nullable_json_object_fields(object, &["markerConfig"])?;
-        }
-        "prompt-variables" => {
-            normalize_json_array_fields(object, &["options"])?;
-        }
-        "personas" => {
-            normalize_json_array_fields(
-                object,
-                &["tags", "altDescriptions", "savedStatusOptions"],
-            )?;
-            normalize_nullable_json_object_fields(object, &["avatarCrop", "personaStats"])?;
-        }
-        "agents" => {
-            normalize_json_object_fields(object, &["settings"])?;
-        }
-        "regex-scripts" => {
-            normalize_json_array_fields(object, &["placement", "trimStrings"])?;
-        }
-        _ => {}
+    }
+    if collection == "messages" {
+        normalize_message_text_fields(object);
     }
     Ok(())
 }

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -890,40 +890,20 @@ fn storage_get(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> 
 }
 
 fn storage_create(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let entity = required_string(args, "entity")?;
-    let value = optional_value(args, "value");
-    entity_commands::validate_connection_folder_for_create(state, entity, &value)?;
-    let value = entity_commands::prepare_entity_for_create(state, entity, value)?;
-    let created = state.storage.create(entity, value)?;
-    if entity == "messages" {
-        return Ok(shared::project_timeline_message(created));
-    }
-    if entity == "connections" {
-        let mut masked = created;
-        connection_secrets::mask_connection_for_read(&mut masked);
-        return Ok(masked);
-    }
-    Ok(created)
+    entity_commands::storage_create_inner(
+        state,
+        required_string(args, "entity")?.to_string(),
+        optional_value(args, "value"),
+    )
 }
 
 fn storage_update(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let entity = required_string(args, "entity")?;
-    let id = required_string(args, "id")?;
-    if entity == "messages" {
-        return Ok(shared::project_timeline_message(
-            shared::patch_message_update(state, id, optional_value(args, "patch"))?,
-        ));
-    }
-    if entity == "characters" {
-        return characters::update_character(state, id, optional_value(args, "patch"));
-    }
-    let raw_patch = optional_value(args, "patch");
-    entity_commands::validate_connection_folder_for_patch(state, entity, &raw_patch)?;
-    let patch = shared::normalize_update_patch(entity, raw_patch)?;
-    if entity == "connections" {
-        return connection_secrets::patch_connection(state, id, patch);
-    }
-    state.storage.patch(entity, id, patch)
+    entity_commands::storage_update_inner(
+        state,
+        required_string(args, "entity")?.to_string(),
+        required_string(args, "id")?.to_string(),
+        optional_value(args, "patch"),
+    )
 }
 
 fn storage_delete(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
@@ -1588,6 +1568,87 @@ mod tests {
             .get("game-state-snapshots", "snapshot-message-1")
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_create_connection_clears_previous_agent_default() {
+        let state = test_state("remote-connection-default-create");
+        for (id, provider) in [("language-a", "anthropic"), ("language-b", "openai")] {
+            dispatch(
+                &state,
+                InvokeRequest {
+                    command: "storage_create".to_string(),
+                    args: Some(json!({
+                        "entity": "connections",
+                        "value": {
+                            "id": id,
+                            "name": id,
+                            "provider": provider,
+                            "defaultForAgents": true
+                        }
+                    })),
+                },
+            )
+            .await
+            .expect("remote connection create should dispatch");
+        }
+
+        let language_a = state
+            .storage
+            .get("connections", "language-a")
+            .unwrap()
+            .unwrap();
+        let language_b = state
+            .storage
+            .get("connections", "language-b")
+            .unwrap()
+            .unwrap();
+        assert_eq!(language_a["defaultForAgents"], false);
+        assert_eq!(language_b["defaultForAgents"], true);
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_update_rejects_default_chat_preset_mutation() {
+        let state = test_state("remote-default-preset-guard");
+        state
+            .storage
+            .create(
+                "chat-presets",
+                json!({
+                    "id": "default-chat",
+                    "name": "Default Chat",
+                    "mode": "chat",
+                    "isDefault": true,
+                    "default": true,
+                    "isActive": true,
+                    "active": true,
+                    "parameters": {},
+                    "settings": {}
+                }),
+            )
+            .expect("default chat preset should be seeded");
+
+        let error = dispatch(
+            &state,
+            InvokeRequest {
+                command: "storage_update".to_string(),
+                args: Some(json!({
+                    "entity": "chat-presets",
+                    "id": "default-chat",
+                    "patch": { "name": "Mutated" }
+                })),
+            },
+        )
+        .await
+        .expect_err("remote default preset mutation should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        let preset = state
+            .storage
+            .get("chat-presets", "default-chat")
+            .unwrap()
+            .unwrap();
+        assert_eq!(preset["name"], "Default Chat");
     }
 
     #[tokio::test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -12,6 +12,7 @@ use tokio::sync::watch;
 
 use crate::seed_defaults::seed_bundled_defaults;
 use crate::storage_commands::{
+    contracts,
     images::percent_encode_component,
     media_uploads::{file_path_asset_url, safe_filename, unique_file_path},
     shared::{
@@ -178,26 +179,7 @@ fn prune_expired_llm_stream_cancellations_with_now(
 }
 
 fn migrate_storage_json_fields(storage: &FileStorage) -> AppResult<()> {
-    for collection in [
-        "characters",
-        "character-groups",
-        "personas",
-        "persona-groups",
-        "lorebooks",
-        "lorebook-entries",
-        "prompts",
-        "prompt-sections",
-        "prompt-variables",
-        "chat-presets",
-        "agents",
-        "connections",
-        "chats",
-        "messages",
-        "custom-tools",
-        "regex-scripts",
-        "game-state-snapshots",
-        "game-checkpoints",
-    ] {
+    for collection in contracts::startup_json_repair_collections() {
         migrate_collection_json_fields(storage, collection)?;
     }
     Ok(())


### PR DESCRIPTION
## Linked issue

Closes #1893

## Why this change

- Refactor storage contracts were split across startup repair, shared storage normalization, profile export/import coverage, entity command create/update behavior, and remote `/api/invoke` write handling.
- Remote storage create/update duplicated embedded command logic, so connection `defaultForAgents` exclusivity and default chat preset mutation guards could diverge between embedded and hostable runtime writes.

## What changed

- Added a Rust storage contract registry for supported collections, profile inclusion, startup JSON repair, typed JSON fields, create-default fields, and delete cleanup metadata.
- Moved profile export/import coverage and startup JSON repair collection coverage onto the registry.
- Replaced the typed JSON normalization collection switch with registry-backed field metadata.
- Routed remote `storage_create` and `storage_update` through the same entity command helpers used by embedded Tauri commands.
- Added remote dispatch coverage for connection agent-default exclusivity and default chat preset mutation rejection.

## Refactor impact

Primary owner:

Rust storage and remote runtime dispatch.

Impact areas reviewed:

- Tauri storage entity commands
- Hostable `/api/invoke` storage write dispatch
- Profile export/import collection coverage
- Startup storage JSON repair
- Typed JSON normalization

Boundary notes:

- Product-specific entity write behavior remains in storage entity command helpers.
- The HTTP dispatch path now delegates to those helpers instead of duplicating command behavior.
- No React, engine, or shared API imports were added.

Pressure points touched:

- Remote runtime `/api/invoke` dispatch for `storage_create` and `storage_update`.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml dispatch_storage_`
- `cargo test --manifest-path src-tauri/Cargo.toml registry_`
- `pnpm check:architecture`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal Rust storage contract and remote write parity refactor; no new user-discoverable surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes.
