### PR TITLE
Fix remote storage write guard parity

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -233,7 +233,7 @@ pub async fn storage_get(
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_get_inner(
+pub(crate) fn storage_get_inner(
     state: &AppState,
     entity: String,
     id: String,
@@ -261,7 +261,11 @@ pub async fn storage_create(
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_create_inner(state: &AppState, entity: String, value: Value) -> Result<Value, AppError> {
+pub(crate) fn storage_create_inner(
+    state: &AppState,
+    entity: String,
+    value: Value,
+) -> Result<Value, AppError> {
     validate_connection_folder_for_create(state, &entity, &value)?;
     let created = state
         .storage
@@ -291,7 +295,7 @@ pub async fn storage_update(
         .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
-fn storage_update_inner(
+pub(crate) fn storage_update_inner(
     state: &AppState,
     entity: String,
     id: String,

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1,10 +1,9 @@
 use crate::state::AppState;
 use crate::storage_commands::{
-    admin, agents, avatars, backgrounds, backup, bot_browser, characters, chats,
-    connection_secrets, custom_tools, entity_commands, exports, fonts, game_assets,
-    game_state_snapshots, generation, http, images, imports, integrations, knowledge, llm,
-    lorebook_images, mari, personas, profile, profile_commands, prompts, shared, sprites,
-    translation, updates,
+    admin, agents, avatars, backgrounds, backup, bot_browser, characters, chats, custom_tools,
+    entity_commands, exports, fonts, game_assets, game_state_snapshots, generation, http, images,
+    imports, integrations, knowledge, llm, lorebook_images, mari, personas, profile,
+    profile_commands, prompts, shared, sprites, translation, updates,
 };
 use marinara_core::{AppError, AppResult};
 use serde::Deserialize;
@@ -877,53 +876,31 @@ fn storage_list(state: &AppState, args: &Map<String, Value>) -> AppResult<Value>
 }
 
 fn storage_get(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let entity = required_string(args, "entity")?;
-    let id = required_string(args, "id")?;
-    let mut value = state.storage.get(entity, id)?.unwrap_or(Value::Null);
-    if entity == "messages" {
-        shared::materialize_message_swipe_fields(&mut value);
-    }
-    if entity == "connections" {
-        connection_secrets::mask_connection_for_read(&mut value);
-    }
-    Ok(shared::project_record(value, args.get("options")))
+    entity_commands::storage_get_inner(
+        state,
+        required_string(args, "entity")?.to_string(),
+        required_string(args, "id")?.to_string(),
+        args.get("options")
+            .filter(|value| !value.is_null())
+            .cloned(),
+    )
 }
 
 fn storage_create(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let entity = required_string(args, "entity")?;
-    let value = optional_value(args, "value");
-    entity_commands::validate_connection_folder_for_create(state, entity, &value)?;
-    let value = entity_commands::prepare_entity_for_create(state, entity, value)?;
-    let created = state.storage.create(entity, value)?;
-    if entity == "messages" {
-        return Ok(shared::project_timeline_message(created));
-    }
-    if entity == "connections" {
-        let mut masked = created;
-        connection_secrets::mask_connection_for_read(&mut masked);
-        return Ok(masked);
-    }
-    Ok(created)
+    entity_commands::storage_create_inner(
+        state,
+        required_string(args, "entity")?.to_string(),
+        optional_value(args, "value"),
+    )
 }
 
 fn storage_update(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
-    let entity = required_string(args, "entity")?;
-    let id = required_string(args, "id")?;
-    if entity == "messages" {
-        return Ok(shared::project_timeline_message(
-            shared::patch_message_update(state, id, optional_value(args, "patch"))?,
-        ));
-    }
-    if entity == "characters" {
-        return characters::update_character(state, id, optional_value(args, "patch"));
-    }
-    let raw_patch = optional_value(args, "patch");
-    entity_commands::validate_connection_folder_for_patch(state, entity, &raw_patch)?;
-    let patch = shared::normalize_update_patch(entity, raw_patch)?;
-    if entity == "connections" {
-        return connection_secrets::patch_connection(state, id, patch);
-    }
-    state.storage.patch(entity, id, patch)
+    entity_commands::storage_update_inner(
+        state,
+        required_string(args, "entity")?.to_string(),
+        required_string(args, "id")?.to_string(),
+        optional_value(args, "patch"),
+    )
 }
 
 fn storage_delete(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
@@ -1167,6 +1144,15 @@ mod tests {
         })
     }
 
+    fn default_for_agents(state: &AppState, id: &str) -> bool {
+        state
+            .storage
+            .get("connections", id)
+            .expect("connection should read")
+            .and_then(|row| row.get("defaultForAgents").and_then(Value::as_bool))
+            .unwrap_or(false)
+    }
+
     fn quoted_commands(source: &str) -> BTreeSet<String> {
         source
             .split('"')
@@ -1327,6 +1313,110 @@ mod tests {
                 "extra": { "thinking": "swipe thought" }
             }])
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_create_connection_clears_previous_agent_default() {
+        let state = test_state("storage-create-connection-agent-default");
+        for (id, provider) in [("language-a", "anthropic"), ("language-b", "openai")] {
+            dispatch(
+                &state,
+                InvokeRequest {
+                    command: "storage_create".to_string(),
+                    args: Some(json!({
+                        "entity": "connections",
+                        "value": {
+                            "id": id,
+                            "name": id,
+                            "provider": provider,
+                            "defaultForAgents": true
+                        }
+                    })),
+                },
+            )
+            .await
+            .expect("remote connection create should dispatch");
+        }
+
+        assert!(!default_for_agents(&state, "language-a"));
+        assert!(default_for_agents(&state, "language-b"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_update_connection_clears_previous_agent_default() {
+        let state = test_state("storage-update-connection-agent-default");
+        for (id, default_for_agents) in [("language-a", true), ("language-b", false)] {
+            state
+                .storage
+                .create(
+                    "connections",
+                    json!({
+                        "id": id,
+                        "name": id,
+                        "provider": "openai",
+                        "defaultForAgents": default_for_agents
+                    }),
+                )
+                .expect("connection should be seeded");
+        }
+
+        dispatch(
+            &state,
+            InvokeRequest {
+                command: "storage_update".to_string(),
+                args: Some(json!({
+                    "entity": "connections",
+                    "id": "language-b",
+                    "patch": { "defaultForAgents": true }
+                })),
+            },
+        )
+        .await
+        .expect("remote connection update should dispatch");
+
+        assert!(!default_for_agents(&state, "language-a"));
+        assert!(default_for_agents(&state, "language-b"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_storage_update_protects_default_chat_preset_fields() {
+        let state = test_state("storage-update-default-chat-preset");
+        state
+            .storage
+            .create(
+                "chat-presets",
+                json!({
+                    "id": "default-chat-preset",
+                    "name": "Default Chat",
+                    "mode": "chat",
+                    "isDefault": true,
+                    "isActive": true
+                }),
+            )
+            .expect("default chat preset should be seeded");
+
+        let error = dispatch(
+            &state,
+            InvokeRequest {
+                command: "storage_update".to_string(),
+                args: Some(json!({
+                    "entity": "chat-presets",
+                    "id": "default-chat-preset",
+                    "patch": { "name": "Mutated Default" }
+                })),
+            },
+        )
+        .await
+        .expect_err("default chat preset field mutations should be rejected remotely");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.message, "Default chat presets cannot be updated");
+        let preset = state
+            .storage
+            .get("chat-presets", "default-chat-preset")
+            .expect("chat preset should read")
+            .expect("chat preset should still exist");
+        assert_eq!(preset["name"], "Default Chat");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Linked issue

Closes #1895

## Why this change

- Remote `/api/invoke` storage writes had drifted from the embedded Tauri storage command behavior.
- Remote connection create/update could leave multiple `defaultForAgents` connections in the same language/image scope.
- Remote chat preset updates could bypass the embedded guard that rejects protected default-preset field mutations.

## What changed

- Reused the embedded storage entity helpers for remote `storage_get`, `storage_create`, and `storage_update` dispatch.
- Exposed the existing storage entity inner helpers within the crate so HTTP dispatch does not duplicate storage write behavior.
- Added focused remote dispatcher coverage for connection default cleanup on create/update and default chat preset mutation rejection.

## Refactor impact

Primary owner:

Rust storage and remote runtime.

Impact areas reviewed:

- `src-tauri/src/commands/storage/commands/entities.rs`
- `src-tauri/src/http_dispatch.rs`
- Connection default-agent cleanup
- Chat preset protected/default update guard
- Remote `/api/invoke` storage routing

Boundary notes:

- Remote runtime dispatch now delegates to the Rust storage command owner instead of duplicating create/update/get behavior.
- No React, engine, or shared API wrapper changes were needed.
- No new remote command names or allowlist entries were added.

Pressure points touched:

- Remote runtime `/api/invoke` storage command dispatch in `src-tauri/src/http_dispatch.rs`.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml http_dispatch::tests::dispatch_storage`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal remote runtime/storage bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. Rust storage/runtime behavior only; no visible UI changes.
