### PR TITLE
Open chats at latest message

### DIFF
--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -500,6 +500,7 @@ export function ConversationView({
   const userScrolledAwayRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const userScrolledAtRef = useRef(0);
+  const openedAtBottomChatIdRef = useRef<string | null>(null);
 
   // ── Scroll tracking ──
   useEffect(() => {
@@ -544,6 +545,17 @@ export function ConversationView({
   // Auto-scroll on new messages / streaming / staggered reveals
   const newestMsgId = messages?.[messages.length - 1]?.id;
   const isOptimistic = newestMsgId?.startsWith("__optimistic_");
+  useLayoutEffect(() => {
+    if (openedAtBottomChatIdRef.current === chatId || !messages?.length || isLoadingMoreRef.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    lastScrollTopRef.current = el.scrollTop;
+    isNearBottomRef.current = true;
+    userScrolledAwayRef.current = false;
+    openedAtBottomChatIdRef.current = chatId;
+  }, [chatId, messages?.length, newestMsgId]);
+
   useEffect(() => {
     if (isLoadingMoreRef.current) return;
     // Always scroll when the user just sent a message (optimistic msg)

--- a/src/features/modes/roleplay/hooks/use-roleplay-transcript-scroll.ts
+++ b/src/features/modes/roleplay/hooks/use-roleplay-transcript-scroll.ts
@@ -36,6 +36,7 @@ export function useRoleplayTranscriptScroll({
   const userScrolledAwayRef = useRef(false);
   const lastScrollTopRef = useRef(0);
   const userScrolledAtRef = useRef(0);
+  const openedAtBottomChatIdRef = useRef<string | null>(null);
   const streamBuffer = useChatStore((state) => state.streamBuffers.get(activeChatId) ?? state.streamBuffer);
   const thinkingBuffer = useChatStore((state) => state.thinkingBuffers.get(activeChatId) ?? state.thinkingBuffer);
 
@@ -83,6 +84,17 @@ export function useRoleplayTranscriptScroll({
   const newestMsgRole = messages?.[messages.length - 1]?.role;
   const isOptimistic = newestMsgId?.startsWith("__optimistic_");
   const forceScrollToNewest = isOptimistic || (isStreaming && newestMsgRole === "user");
+  useLayoutEffect(() => {
+    if (openedAtBottomChatIdRef.current === activeChatId || !messages?.length || isLoadingMoreRef.current) return;
+    const element = scrollRef.current;
+    if (!element) return;
+    element.scrollTop = element.scrollHeight;
+    lastScrollTopRef.current = element.scrollTop;
+    isNearBottomRef.current = true;
+    userScrolledAwayRef.current = false;
+    openedAtBottomChatIdRef.current = activeChatId;
+  }, [activeChatId, messages?.length, newestMsgId]);
+
   useEffect(() => {
     if (isLoadingMoreRef.current) return;
     if (forceScrollToNewest || (isNearBottomRef.current && !userScrolledAwayRef.current)) {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1931

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Opening an existing chat could visibly render above the latest message and then smooth-scroll down, instead of opening directly at the most recent message.

## What changed

<!-- List the key changes in this PR. -->

- Added first-open layout positioning for conversation transcripts so the scroll container lands at the latest loaded message before paint.
- Added the same first-open layout positioning for roleplay transcripts.
- Left existing smooth auto-scroll behavior in place for later live updates and kept load-more scroll preservation separate.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

chat mode, roleplay mode

Impact areas reviewed:

- Conversation transcript scroll behavior.
- Roleplay transcript scroll behavior.
- Existing load-more scroll preservation path.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature UI only; no engine, shared API, Rust, storage, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Shared mode transcript scroll behavior in conversation and roleplay surfaces.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- `pnpm typecheck` passed locally.
- No browser/manual UI pass performed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this is a bugfix to existing chat opening behavior, not a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

- Not captured.
