### PR TITLE
Fix active world info hidden scan

### DIFF
--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -113,6 +113,7 @@ export interface ActiveLorebookScannerInput {
   storedMessages: JsonRecord[];
   request?: JsonRecord;
   latestUserInput?: string;
+  generationTriggers?: string[];
   embeddingSource?: LorebookEmbeddingSource | null;
   ignoreTiming?: boolean;
   contentResolver?: LorebookContentResolver;
@@ -545,7 +546,8 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
       role: readString(message.role, "user"),
       content: readString(message.content),
     }));
-  const generationTriggers = ["chat", readString(input.chat.mode || input.chat.chatMode)].filter(Boolean);
+  const generationTriggers =
+    input.generationTriggers ?? ["chat", readString(input.chat.mode || input.chat.chatMode)].filter(Boolean);
   const lorebookNamesById = new Map(
     lorebooks.map((book) => {
       const id = readString(book.id);

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -35,12 +35,13 @@ function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord
       break;
     }
   }
-  return lastGeneratedIndex >= 0 ? visibleMessages.slice(0, lastGeneratedIndex) : [];
+  return lastGeneratedIndex >= 0 ? visibleMessages.slice(0, lastGeneratedIndex) : visibleMessages;
 }
 
 function activeInfoGenerationTriggers(chat: JsonRecord): string[] {
-  const mode = readString(chat.mode || chat.chatMode).trim() || "roleplay";
-  return Array.from(new Set(["chat", mode]));
+  const mode = readString(chat.mode || chat.chatMode).trim();
+  const modeTrigger = mode === "game" ? "game" : mode || "roleplay";
+  return Array.from(new Set(["test_scan", modeTrigger, "chat"]));
 }
 
 export async function scanActiveLorebookEntries(

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -7,7 +7,7 @@ import {
 } from "./active-lorebook-scanner";
 import { loadChatMessages, requireRecord } from "./context";
 import { loadCharacters, loadPersona } from "./prompt-assembly";
-import { readString, type JsonRecord } from "./runtime-records";
+import { hiddenFromAi, readString, type JsonRecord } from "./runtime-records";
 
 export interface ActiveLorebookScanResult {
   entries: Array<{
@@ -26,20 +26,21 @@ export interface ActiveLorebookScanResult {
 }
 
 function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord[] {
+  const visibleMessages = messages.filter((message) => !hiddenFromAi(message));
   let lastGeneratedIndex = -1;
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const role = readString(messages[index]?.role);
+  for (let index = visibleMessages.length - 1; index >= 0; index--) {
+    const role = readString(visibleMessages[index]?.role);
     if (role === "assistant" || role === "narrator") {
       lastGeneratedIndex = index;
       break;
     }
   }
-  return lastGeneratedIndex >= 0 ? messages.slice(0, lastGeneratedIndex) : messages;
+  return lastGeneratedIndex >= 0 ? visibleMessages.slice(0, lastGeneratedIndex) : [];
 }
 
 function activeInfoGenerationTriggers(chat: JsonRecord): string[] {
   const mode = readString(chat.mode || chat.chatMode).trim() || "roleplay";
-  return Array.from(new Set(["test_scan", mode, "chat"]));
+  return Array.from(new Set(["chat", mode]));
 }
 
 export async function scanActiveLorebookEntries(

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -41,7 +41,7 @@ function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord
 function activeInfoGenerationTriggers(chat: JsonRecord): string[] {
   const mode = readString(chat.mode || chat.chatMode).trim();
   const modeTrigger = mode === "game" ? "game" : mode || "roleplay";
-  return Array.from(new Set([modeTrigger, "chat"]));
+  return Array.from(new Set(["test_scan", modeTrigger, "chat"]));
 }
 
 export async function scanActiveLorebookEntries(

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -41,7 +41,7 @@ function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord
 function activeInfoGenerationTriggers(chat: JsonRecord): string[] {
   const mode = readString(chat.mode || chat.chatMode).trim();
   const modeTrigger = mode === "game" ? "game" : mode || "roleplay";
-  return Array.from(new Set(["test_scan", modeTrigger, "chat"]));
+  return Array.from(new Set([modeTrigger, "chat"]));
 }
 
 export async function scanActiveLorebookEntries(

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -25,6 +25,10 @@ export interface ActiveLorebookScanResult {
   semanticStatus: LorebookSemanticScanStatus;
 }
 
+interface ActiveLorebookScanOptions {
+  includeTestScanTrigger?: boolean;
+}
+
 function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord[] {
   const visibleMessages = messages.filter((message) => !hiddenFromAi(message));
   let lastGeneratedIndex = -1;
@@ -38,15 +42,17 @@ function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord
   return lastGeneratedIndex >= 0 ? visibleMessages.slice(0, lastGeneratedIndex) : visibleMessages;
 }
 
-function activeInfoGenerationTriggers(chat: JsonRecord): string[] {
+function activeInfoGenerationTriggers(chat: JsonRecord, options: ActiveLorebookScanOptions): string[] {
   const mode = readString(chat.mode || chat.chatMode).trim();
   const modeTrigger = mode === "game" ? "game" : mode || "roleplay";
-  return Array.from(new Set(["test_scan", modeTrigger, "chat"]));
+  const triggers = options.includeTestScanTrigger ? ["test_scan", modeTrigger, "chat"] : [modeTrigger, "chat"];
+  return Array.from(new Set(triggers));
 }
 
 export async function scanActiveLorebookEntries(
   storage: StorageGateway,
   chatId: string,
+  options: ActiveLorebookScanOptions = {},
 ): Promise<ActiveLorebookScanResult> {
   const chat = requireRecord(await storage.get("chats", chatId), "Chat");
   const storedMessages = await loadChatMessages(storage, chatId);
@@ -60,7 +66,7 @@ export async function scanActiveLorebookEntries(
     storedMessages: selectMessagesForLastGenerationScan(storedMessages),
     request: {},
     latestUserInput: "",
-    generationTriggers: activeInfoGenerationTriggers(chat),
+    generationTriggers: activeInfoGenerationTriggers(chat, options),
     embeddingSource: null,
   });
   const entries = scan.processedLore.includedEntries.map((entry) => {

--- a/src/engine/generation/active-lorebooks.ts
+++ b/src/engine/generation/active-lorebooks.ts
@@ -7,6 +7,7 @@ import {
 } from "./active-lorebook-scanner";
 import { loadChatMessages, requireRecord } from "./context";
 import { loadCharacters, loadPersona } from "./prompt-assembly";
+import { readString, type JsonRecord } from "./runtime-records";
 
 export interface ActiveLorebookScanResult {
   entries: Array<{
@@ -24,14 +25,26 @@ export interface ActiveLorebookScanResult {
   semanticStatus: LorebookSemanticScanStatus;
 }
 
-interface ActiveLorebookScanOptions {
-  embeddingSource?: { embed(texts: string[]): Promise<number[][] | null> } | null;
+function selectMessagesForLastGenerationScan(messages: JsonRecord[]): JsonRecord[] {
+  let lastGeneratedIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const role = readString(messages[index]?.role);
+    if (role === "assistant" || role === "narrator") {
+      lastGeneratedIndex = index;
+      break;
+    }
+  }
+  return lastGeneratedIndex >= 0 ? messages.slice(0, lastGeneratedIndex) : messages;
+}
+
+function activeInfoGenerationTriggers(chat: JsonRecord): string[] {
+  const mode = readString(chat.mode || chat.chatMode).trim() || "roleplay";
+  return Array.from(new Set(["test_scan", mode, "chat"]));
 }
 
 export async function scanActiveLorebookEntries(
   storage: StorageGateway,
   chatId: string,
-  options: ActiveLorebookScanOptions = {},
 ): Promise<ActiveLorebookScanResult> {
   const chat = requireRecord(await storage.get("chats", chatId), "Chat");
   const storedMessages = await loadChatMessages(storage, chatId);
@@ -42,10 +55,11 @@ export async function scanActiveLorebookEntries(
     chat,
     characters,
     persona,
-    storedMessages,
+    storedMessages: selectMessagesForLastGenerationScan(storedMessages),
     request: {},
     latestUserInput: "",
-    embeddingSource: options.embeddingSource,
+    generationTriggers: activeInfoGenerationTriggers(chat),
+    embeddingSource: null,
   });
   const entries = scan.processedLore.includedEntries.map((entry) => {
     const event = lorebookActivatedEntryForEvent(entry);

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -5,7 +5,6 @@ import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/rea
 import { lorebookKeys } from "../query-keys";
 import { scanActiveLorebookEntries } from "../../../../engine/generation/active-lorebooks";
 import type { LorebookSemanticScanStatus } from "../../../../engine/generation/active-lorebook-scanner";
-import { resolveGenerationConnection } from "../../../../engine/generation/context";
 import {
   createLorebookEntrySchema,
   createLorebookFolderSchema,
@@ -16,13 +15,11 @@ import {
 } from "../../../../engine/contracts/schemas/lorebook.schema";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { ApiError } from "../../../../shared/api/api-errors";
-import { llmApi } from "../../../../shared/api/llm-api";
 import { lorebookCommandApi } from "../../../../shared/api/lorebook-command-api";
 import type { Lorebook, LorebookEntry, LorebookFolder } from "../../../../engine/contracts/types/lorebook";
 import { characterKeys } from "../../characters/query-keys";
 
 export { lorebookKeys } from "../query-keys";
-export type { LorebookSemanticScanStatus };
 
 async function transferLorebookEntries(
   sourceLorebookId: string,
@@ -470,47 +467,10 @@ interface ActiveLorebookScan {
   semanticStatus: LorebookSemanticScanStatus;
 }
 
-function recordString(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-async function activeLorebookEmbeddingSource(chat: Record<string, unknown>) {
-  if (!llmApi.embed) return null;
-  try {
-    const connection = await resolveGenerationConnection(storageApi, chat, {});
-    const connectionId = recordString(connection.id) || null;
-    const model = recordString(connection.embeddingModel) || null;
-    return {
-      embed: (texts: string[]) =>
-        llmApi.embed!({
-          texts,
-          connectionId,
-          model,
-        }),
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "";
-    if (
-      message === "No LLM connection is configured" ||
-      message === "Connection was not found" ||
-      message === "Chat connection was not found"
-    ) {
-      return null;
-    }
-    throw error;
-  }
-}
-
 export function useActiveLorebookEntries(chatId: string | null, enabled = false) {
   return useQuery({
     queryKey: lorebookKeys.active(chatId),
-    queryFn: async () => {
-      const chat = await storageApi.get<Record<string, unknown>>("chats", chatId!);
-      if (!chat) throw new ApiError("Chat not found", 404);
-      return scanActiveLorebookEntries(storageApi, chatId!, {
-        embeddingSource: await activeLorebookEmbeddingSource(chat),
-      }) as Promise<ActiveLorebookScan>;
-    },
+    queryFn: () => scanActiveLorebookEntries(storageApi, chatId!) as Promise<ActiveLorebookScan>,
     enabled: !!chatId && enabled,
     staleTime: 30_000,
   });

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -467,10 +467,20 @@ interface ActiveLorebookScan {
   semanticStatus: LorebookSemanticScanStatus;
 }
 
-export function useActiveLorebookEntries(chatId: string | null, enabled = false) {
+interface ActiveLorebookEntriesOptions {
+  includeTestScanTrigger?: boolean;
+}
+
+export function useActiveLorebookEntries(
+  chatId: string | null,
+  enabled = false,
+  options: ActiveLorebookEntriesOptions = {},
+) {
+  const includeTestScanTrigger = options.includeTestScanTrigger === true;
   return useQuery({
-    queryKey: lorebookKeys.active(chatId),
-    queryFn: () => scanActiveLorebookEntries(storageApi, chatId!) as Promise<ActiveLorebookScan>,
+    queryKey: [...lorebookKeys.active(chatId), { includeTestScanTrigger }] as const,
+    queryFn: () =>
+      scanActiveLorebookEntries(storageApi, chatId!, { includeTestScanTrigger }) as Promise<ActiveLorebookScan>,
     enabled: !!chatId && enabled,
     staleTime: 30_000,
   });

--- a/src/features/runtime/visuals/components/ActiveWorldInfoButton.tsx
+++ b/src/features/runtime/visuals/components/ActiveWorldInfoButton.tsx
@@ -70,7 +70,7 @@ export function ActiveWorldInfoButton({
   title = "Active World Info",
 }: ActiveWorldInfoButtonProps) {
   const [open, setOpen] = useState(false);
-  const { data, isLoading } = useActiveLorebookEntries(chatId, true);
+  const { data, isLoading } = useActiveLorebookEntries(chatId, true, { includeTestScanTrigger: true });
   const ref = useRef<HTMLDivElement>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const compact = useUIStore((s) => s.centerCompact);

--- a/src/features/runtime/visuals/components/WorldInfoPanel.tsx
+++ b/src/features/runtime/visuals/components/WorldInfoPanel.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronRight, Globe, Loader2, X } from "lucide-react";
-import {
-  type BudgetSkippedLorebookEntry,
-  type LorebookSemanticScanStatus,
-  useActiveLorebookEntries,
-} from "../../../catalog/lorebooks/index";
+import { type BudgetSkippedLorebookEntry, useActiveLorebookEntries } from "../../../catalog/lorebooks/index";
 
 function WorldInfoEntryRow({
   entry,
@@ -123,26 +119,6 @@ function BudgetSkippedEntriesNotice({ entries }: { entries: BudgetSkippedLoreboo
   );
 }
 
-function SemanticScanNotice({ status }: { status?: LorebookSemanticScanStatus | null }) {
-  if (!status || status.vectorizedEntryCount === 0 || status.state === "ready" || status.state === "not_applicable") {
-    return null;
-  }
-  const count = status.vectorizedEntryCount.toLocaleString();
-  const message =
-    status.state === "missing_embedding_source"
-      ? `${count} vectorized ${status.vectorizedEntryCount === 1 ? "entry was" : "entries were"} not semantically scanned. Keyword and constant matches are shown.`
-      : status.state === "empty_query"
-        ? `${count} vectorized ${status.vectorizedEntryCount === 1 ? "entry was" : "entries were"} not semantically scanned because there is no chat text to embed.`
-        : `${count} vectorized ${status.vectorizedEntryCount === 1 ? "entry was" : "entries were"} not semantically scanned because embedding was unavailable.`;
-
-  return (
-    <div className="mb-2 flex gap-2 rounded-lg border border-sky-500/25 bg-sky-500/10 p-2 text-xs text-sky-50/85">
-      <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0 text-sky-200" />
-      <span className="leading-relaxed">{message}</span>
-    </div>
-  );
-}
-
 export function WorldInfoPanel({
   chatId,
   isMobile,
@@ -186,7 +162,6 @@ export function WorldInfoPanel({
         </div>
       ) : entries.length === 0 ? (
         <>
-          <SemanticScanNotice status={data?.semanticStatus} />
           <BudgetSkippedEntriesNotice entries={skippedEntries} />
           <p className="py-3 text-center text-xs text-[var(--muted-foreground)]">No active entries for this chat</p>
         </>
@@ -195,7 +170,6 @@ export function WorldInfoPanel({
           <p className="mb-2 text-[0.625rem] text-[var(--muted-foreground)]">
             {entries.length} active * ~{(data?.totalTokens ?? 0).toLocaleString()} tokens
           </p>
-          <SemanticScanNotice status={data?.semanticStatus} />
           <BudgetSkippedEntriesNotice entries={skippedEntries} />
           <div className="space-y-1.5">
             {entries.map((entry) => (

--- a/src/features/runtime/visuals/components/WorldInfoPanel.tsx
+++ b/src/features/runtime/visuals/components/WorldInfoPanel.tsx
@@ -128,7 +128,9 @@ export function WorldInfoPanel({
   isMobile: boolean;
   onClose: () => void;
 }) {
-  const { data, isLoading, isError, error } = useActiveLorebookEntries(chatId, true);
+  const { data, isLoading, isError, error } = useActiveLorebookEntries(chatId, true, {
+    includeTestScanTrigger: true,
+  });
   const entries = data?.entries ?? [];
   const skippedEntries = data?.budgetSkippedEntries ?? [];
   const errorMessage = error instanceof Error ? error.message : "The active world info scan could not complete.";


### PR DESCRIPTION
## Linked issue

Closes #1926

## Why this change

- Opening or switching into a chat mounted the Active World Info control and could run semantic active-lorebook work while the panel was closed.
- Legacy behavior kept Active World Info as a cheap inspector of the previous generation, while semantic lorebook matching stayed on generation paths.

## What changed

- Restored Active World Info to a keyword-only inspector scan with no embedding source.
- Scans messages before the latest assistant or narrator message so the panel reflects the lorebook entries used by the last generation instead of previewing the next turn.
- Keeps semantic active-lorebook matching on generation paths.
- Removes the semantic scan warning from the Active World Info panel because the inspector intentionally does not run semantic scans.

## Refactor impact

Primary owner:

Runtime visuals and engine generation active-lorebook scan.

Impact areas reviewed:

- Runtime visuals Active World Info button and panel.
- Catalog lorebook React Query hook.
- Engine active lorebook scanner.
- Conversation, roleplay, and game surfaces that mount Active World Info.

Boundary notes:

- Feature hook still calls the engine scan helper through the existing storage API path.
- Engine scanner now accepts optional generation triggers; existing generation callers keep their default trigger behavior.
- No raw Tauri calls, remote-runtime routing changes, Rust command changes, or provider transport changes.

Pressure points touched:

- Shared runtime visuals panel touched.
- GameSurface, ConversationView, and ChatRoleplaySurface reviewed as callers; not edited.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `git diff --check` passed.
- `pnpm check` passed: line endings, architecture, frontend typecheck, Rust check, docs, discovery metadata, and unused export check.
- Native Tauri manual/profile pass not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix to existing Active World Info behavior; no new discoverable feature or workflow added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes made; this restores existing Active World Info inspector semantics and does not change run commands, architecture docs, or contributor workflow.

## UI evidence

No screenshots added. This changes when the inspector scan runs provider work and which messages it scans; layout is unchanged.

