### PR TITLE
Fix startup storage persistence and import rollback flushes

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -979,6 +979,7 @@ fn import_st_chat_text(
             created_message_ids.push(created_record_id(&message, "message")?);
             imported += 1;
         }
+        flush_import_writes(state)?;
         Ok(
             json!({ "success": true, "chatId": chat_id, "chat": chat_record, "messagesImported": imported }),
         )
@@ -1086,10 +1087,24 @@ fn import_persona_payload(
             );
         }
     }
-    state
-        .storage
-        .create("personas", with_entity_defaults("personas", Value::Object(object))?)
-        .map(|record| json!({ "success": true, "id": record.get("id").cloned().unwrap_or(Value::Null), "name": record.get("name").cloned().unwrap_or(Value::Null), "persona": record }))
+    let mut created_persona_id = None;
+    let result = (|| -> AppResult<Value> {
+        let record = state
+            .storage
+            .create("personas", with_entity_defaults("personas", Value::Object(object))?)?;
+        let persona_id = created_record_id(&record, "persona")?;
+        created_persona_id = Some(persona_id.clone());
+        flush_import_writes(state)?;
+        Ok(json!({ "success": true, "id": persona_id, "name": record.get("name").cloned().unwrap_or(Value::Null), "persona": record }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        if let Some(persona_id) = created_persona_id.as_deref() {
+            rollback_created_records(state, "personas", &[persona_id.to_string()], &mut rollback_errors);
+        }
+        append_rollback_errors(error, "persona import", rollback_errors)
+    })
 }
 
 fn import_persona_file(state: &AppState, path: &Path) -> AppResult<Value> {
@@ -2269,6 +2284,10 @@ mod tests {
         assert!(
             !app_root.join("avatars").join("personas").exists(),
             "failed persona avatar import must remove the managed avatar file"
+        );
+        assert!(
+            state.storage.list("personas").unwrap().is_empty(),
+            "failed persona avatar import must remove the created persona row"
         );
 
         let _ = fs::remove_dir_all(app_root);

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -220,6 +220,7 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
             let sprites_imported = restore_sprites(state, &character_id, data.get("sprites"))?;
             let gallery_imported =
                 restore_character_gallery(state, &character_id, data.get("gallery"))?;
+            flush_import_writes(state)?;
             Ok(json!({
                 "success": true,
                 "type": "marinara_character",
@@ -295,6 +296,7 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
                     .map(ToOwned::to_owned)
             })
             .unwrap_or_else(|| "Imported Character".to_string());
+        flush_import_writes(state)?;
         Ok(json!({
             "success": true,
             "type": "marinara_character",
@@ -345,6 +347,7 @@ fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
         let persona_id = created_record_id(&record, "persona")?;
         created_persona_id = Some(persona_id.clone());
         let sprites_imported = restore_persona_sprites(state, &persona_id, data.get("sprites"))?;
+        flush_import_writes(state)?;
         Ok(json!({
             "success": true,
             "type": "marinara_persona",
@@ -444,6 +447,7 @@ fn import_marinara_lorebook(
             created_entry_ids.push(created_record_id(&entry_record, "lorebook entry")?);
         }
 
+        flush_import_writes(state)?;
         Ok(json!({
             "success": true,
             "type": "marinara_lorebook",
@@ -553,6 +557,7 @@ fn import_marinara_preset(
             variables_imported += 1;
         }
 
+        flush_import_writes(state)?;
         Ok(json!({
             "success": true,
             "type": "marinara_preset",

--- a/src-tauri/src/commands/storage/imports/rollback.rs
+++ b/src-tauri/src/commands/storage/imports/rollback.rs
@@ -9,6 +9,10 @@ pub(super) fn created_record_id(record: &Value, label: &str) -> AppResult<String
         .ok_or_else(|| AppError::new("storage_error", format!("Created {label} is missing an id")))
 }
 
+pub(super) fn flush_import_writes(state: &AppState) -> AppResult<()> {
+    state.storage.flush()
+}
+
 pub(super) fn append_rollback_errors(
     error: AppError,
     context: &str,

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -51,6 +51,7 @@ fn create_lorebook_from_payload(
             )?;
             created_entry_ids.push(created_record_id(&entry, "lorebook entry")?);
         }
+        flush_import_writes(state)?;
         Ok(json!({
             "success": true,
             "lorebookId": lorebook_id,
@@ -211,6 +212,7 @@ fn import_st_character_payload(
             }
         }
 
+        flush_import_writes(state)?;
         Ok(json!({
             "success": true,
             "characterId": character.get("id").cloned().unwrap_or(Value::Null),

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -23,6 +23,12 @@ fn block_collection_writes(state: &AppState, collection: &str) {
     if let Some(parent) = collection_path.parent() {
         fs::create_dir_all(parent).expect("collection parent should be created");
     }
+    if collection_path.is_file() {
+        fs::remove_file(&collection_path).expect("collection file should be removed before block");
+    } else if collection_path.exists() {
+        fs::remove_dir_all(&collection_path)
+            .expect("collection directory should be reset before block");
+    }
     fs::create_dir(collection_path).expect("collection path should block file writes");
 }
 
@@ -37,6 +43,18 @@ fn uploaded_bytes(name: &str, content_type: &str, bytes: Vec<u8>) -> Value {
         "type": content_type,
         "base64": general_purpose::STANDARD.encode(bytes),
     })
+}
+
+fn collection_ids(state: &AppState, collection: &str) -> Vec<String> {
+    let mut ids = state
+        .storage
+        .list(collection)
+        .expect("collection should be readable")
+        .into_iter()
+        .filter_map(|row| row.get("id").and_then(Value::as_str).map(ToOwned::to_owned))
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
 }
 
 #[test]
@@ -220,6 +238,58 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
     assert!(
         !app_root.join("avatars").join("characters").exists(),
         "failed character import must remove the managed avatar file"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+}
+
+#[test]
+fn import_st_preset_rolls_back_prompt_tree_when_section_flush_fails() {
+    let app_root = temp_path("st-preset-rollback");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+    let baseline_prompt_ids = collection_ids(&state, "prompts");
+    let baseline_group_ids = collection_ids(&state, "prompt-groups");
+    let baseline_section_ids = collection_ids(&state, "prompt-sections");
+    block_collection_writes(&state, "prompt-sections");
+
+    let error = import_call(
+        &state,
+        &["st-preset"],
+        json!({
+            "name": "Rollback Preset",
+            "prompts": [
+                { "identifier": "group-start", "name": "┌ Rollback Group", "content": "" },
+                { "identifier": "main", "name": "Main", "content": "hello", "role": "system" },
+                { "identifier": "group-end", "name": "└ Rollback Group", "content": "" }
+            ],
+            "prompt_order": [{
+                "character_id": 100001,
+                "order": [
+                    { "identifier": "group-start", "enabled": true },
+                    { "identifier": "main", "enabled": true },
+                    { "identifier": "group-end", "enabled": true }
+                ]
+            }]
+        }),
+    )
+    .expect_err("section flush failure should reject ST preset import");
+
+    assert_eq!(error.code, "io_error");
+    assert_eq!(
+        collection_ids(&state, "prompts"),
+        baseline_prompt_ids,
+        "failed preset import must remove the created prompt"
+    );
+    assert_eq!(
+        collection_ids(&state, "prompt-groups"),
+        baseline_group_ids,
+        "failed preset import must remove created prompt groups"
+    );
+    assert_eq!(
+        collection_ids(&state, "prompt-sections"),
+        baseline_section_ids,
+        "failed preset import must remove created prompt sections from the cache"
     );
 
     let _ = fs::remove_dir_all(app_root);

--- a/src-tauri/src/commands/storage/imports/st_preset.rs
+++ b/src-tauri/src/commands/storage/imports/st_preset.rs
@@ -176,6 +176,7 @@ fn create_st_prompt_groups(
     state: &AppState,
     preset_id: &str,
     prompts: &[Value],
+    created_group_ids: &mut Vec<String>,
 ) -> AppResult<(HashMap<String, String>, Vec<String>)> {
     let mut identifier_group_map = HashMap::new();
     let mut group_ids = Vec::new();
@@ -204,10 +205,12 @@ fn create_st_prompt_groups(
                 }),
             )?;
             if let Some(group_id) = created.get("id").and_then(Value::as_str) {
-                group_ids.push(group_id.to_string());
+                let group_id = group_id.to_string();
+                created_group_ids.push(group_id.clone());
+                group_ids.push(group_id.clone());
                 for inner in prompts.iter().take(index).skip(start_index + 1) {
                     if let Some(identifier) = inner.get("identifier").and_then(Value::as_str) {
-                        identifier_group_map.insert(identifier.to_string(), group_id.to_string());
+                        identifier_group_map.insert(identifier.to_string(), group_id.clone());
                     }
                 }
             }
@@ -256,150 +259,182 @@ pub(super) fn import_st_preset_payload(
         .round()
         .max(1.0);
 
-    let preset = state.storage.create(
-        "prompts",
-        with_entity_defaults(
+    let mut created_preset_id = None;
+    let mut created_group_ids = Vec::new();
+    let mut created_section_ids = Vec::new();
+
+    let result = (|| -> AppResult<Value> {
+        let preset = state.storage.create(
             "prompts",
-            json!({
-                "name": format!("Imported: {}", st_prompt_name(&raw, file_name)),
-                "description": "Imported from SillyTavern",
-                "variableGroups": st_variable_groups(&prompts),
-                "variableValues": {},
-                "defaultChoices": {},
-                "wrapFormat": "xml",
-                "sectionOrder": [],
-                "groupOrder": [],
-                "parameters": {
-                    "temperature": clamp_number(raw.get("temperature").and_then(Value::as_f64), 1.0, 0.0, 2.0),
-                    "topP": normalize_top_p(raw.get("top_p").and_then(Value::as_f64)),
-                    "topK": top_k,
-                    "minP": clamp_number(raw.get("min_p").and_then(Value::as_f64), 0.0, 0.0, 1.0),
-                    "maxTokens": max_tokens,
-                    "maxContext": max_context,
-                    "frequencyPenalty": clamp_number(raw.get("frequency_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
-                    "presencePenalty": clamp_number(raw.get("presence_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
-                    "reasoningEffort": st_reasoning_effort(raw.get("reasoning_effort")),
-                    "verbosity": Value::Null,
-                    "assistantPrefill": "",
-                    "customParameters": {},
-                    "squashSystemMessages": raw.get("squash_system_messages").and_then(Value::as_bool).unwrap_or(true),
-                    "showThoughts": raw.get("show_thoughts").and_then(Value::as_bool).unwrap_or(true),
-                    "useMaxContext": false,
-                    "stopSequences": [],
-                    "strictRoleFormatting": true,
-                    "singleUserMessage": false
-                }
-            }),
-        )?,
-    )?;
-    let preset_id = preset
-        .get("id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| AppError::new("storage_error", "Created preset is missing an id"))?
-        .to_string();
+            with_entity_defaults(
+                "prompts",
+                json!({
+                    "name": format!("Imported: {}", st_prompt_name(&raw, file_name)),
+                    "description": "Imported from SillyTavern",
+                    "variableGroups": st_variable_groups(&prompts),
+                    "variableValues": {},
+                    "defaultChoices": {},
+                    "wrapFormat": "xml",
+                    "sectionOrder": [],
+                    "groupOrder": [],
+                    "parameters": {
+                        "temperature": clamp_number(raw.get("temperature").and_then(Value::as_f64), 1.0, 0.0, 2.0),
+                        "topP": normalize_top_p(raw.get("top_p").and_then(Value::as_f64)),
+                        "topK": top_k,
+                        "minP": clamp_number(raw.get("min_p").and_then(Value::as_f64), 0.0, 0.0, 1.0),
+                        "maxTokens": max_tokens,
+                        "maxContext": max_context,
+                        "frequencyPenalty": clamp_number(raw.get("frequency_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
+                        "presencePenalty": clamp_number(raw.get("presence_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
+                        "reasoningEffort": st_reasoning_effort(raw.get("reasoning_effort")),
+                        "verbosity": Value::Null,
+                        "assistantPrefill": "",
+                        "customParameters": {},
+                        "squashSystemMessages": raw.get("squash_system_messages").and_then(Value::as_bool).unwrap_or(true),
+                        "showThoughts": raw.get("show_thoughts").and_then(Value::as_bool).unwrap_or(true),
+                        "useMaxContext": false,
+                        "stopSequences": [],
+                        "strictRoleFormatting": true,
+                        "singleUserMessage": false
+                    }
+                }),
+            )?,
+        )?;
+        let preset_id = created_record_id(&preset, "preset")?;
+        created_preset_id = Some(preset_id.clone());
 
-    let (group_id_map, group_ids) = create_st_prompt_groups(state, &preset_id, &sorted_prompts)?;
-    let mut section_ids = Vec::new();
-    let mut emitted_markers: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let (group_id_map, group_ids) =
+            create_st_prompt_groups(state, &preset_id, &sorted_prompts, &mut created_group_ids)?;
+        let mut section_ids = Vec::new();
+        let mut emitted_markers: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
-    for prompt in &sorted_prompts {
-        let identifier = prompt
-            .get("identifier")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string();
-        let name = prompt
-            .get("name")
-            .and_then(Value::as_str)
-            .unwrap_or("Prompt");
-        let content = prompt.get("content").and_then(Value::as_str).unwrap_or("");
-        if starts_with_any(name, &['┌', '└', '┎', '┖', '⌈', '⌊', '⌜', '⌞'])
-            && content.trim().is_empty()
-        {
-            continue;
-        }
-
-        let marker_config = if prompt
-            .get("marker")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
-        {
-            st_marker_config(&identifier)
-        } else {
-            None
-        };
-        if let Some(marker_type) = marker_config
-            .as_ref()
-            .and_then(|marker| marker.get("type"))
-            .and_then(Value::as_str)
-        {
-            if emitted_markers.contains(marker_type) {
+        for prompt in &sorted_prompts {
+            let identifier = prompt
+                .get("identifier")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let name = prompt
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("Prompt");
+            let content = prompt.get("content").and_then(Value::as_str).unwrap_or("");
+            if starts_with_any(name, &['┌', '└', '┎', '┖', '⌈', '⌊', '⌜', '⌞'])
+                && content.trim().is_empty()
+            {
                 continue;
             }
-            emitted_markers.insert(marker_type.to_string());
+
+            let marker_config = if prompt
+                .get("marker")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                st_marker_config(&identifier)
+            } else {
+                None
+            };
+            if let Some(marker_type) = marker_config
+                .as_ref()
+                .and_then(|marker| marker.get("type"))
+                .and_then(Value::as_str)
+            {
+                if emitted_markers.contains(marker_type) {
+                    continue;
+                }
+                emitted_markers.insert(marker_type.to_string());
+            }
+
+            let role = match prompt.get("role").and_then(Value::as_str) {
+                Some("user") => "user",
+                Some("assistant") => "assistant",
+                _ => "system",
+            };
+            let enabled = order_map
+                .get(&identifier)
+                .map(|(_, enabled)| *enabled)
+                .or_else(|| prompt.get("enabled").and_then(Value::as_bool))
+                .unwrap_or(true);
+            let marker_type = marker_config
+                .as_ref()
+                .and_then(|marker| marker.get("type"))
+                .and_then(Value::as_str);
+            let section_name = marker_type
+                .map(|marker_type| st_marker_display_name(marker_type, name))
+                .unwrap_or_else(|| name.to_string());
+            let order = section_ids.len();
+            let created = state.storage.create(
+                "prompt-sections",
+                json!({
+                    "presetId": preset_id,
+                    "identifier": if identifier.is_empty() { format!("imported-section-{order}") } else { identifier.clone() },
+                    "name": section_name,
+                    "content": content,
+                    "role": role,
+                    "enabled": enabled,
+                    "isMarker": marker_config.is_some(),
+                    "injectionPosition": if prompt.get("injection_position").and_then(Value::as_i64) == Some(1) { "depth" } else { "ordered" },
+                    "injectionDepth": prompt.get("injection_depth").and_then(Value::as_i64).unwrap_or(0),
+                    "injectionOrder": prompt.get("injection_order").and_then(Value::as_i64).unwrap_or(100),
+                    "groupId": group_id_map.get(&identifier).map(|id| Value::String(id.clone())).unwrap_or(Value::Null),
+                    "markerConfig": marker_config.unwrap_or(Value::Null),
+                    "forbidOverrides": prompt.get("forbid_overrides").and_then(Value::as_bool).unwrap_or(false),
+                    "order": order,
+                    "sortOrder": order
+                }),
+            )?;
+            if let Some(section_id) = created.get("id").and_then(Value::as_str) {
+                let section_id = section_id.to_string();
+                created_section_ids.push(section_id.clone());
+                section_ids.push(section_id);
+            }
         }
 
-        let role = match prompt.get("role").and_then(Value::as_str) {
-            Some("user") => "user",
-            Some("assistant") => "assistant",
-            _ => "system",
-        };
-        let enabled = order_map
-            .get(&identifier)
-            .map(|(_, enabled)| *enabled)
-            .or_else(|| prompt.get("enabled").and_then(Value::as_bool))
-            .unwrap_or(true);
-        let marker_type = marker_config
-            .as_ref()
-            .and_then(|marker| marker.get("type"))
-            .and_then(Value::as_str);
-        let section_name = marker_type
-            .map(|marker_type| st_marker_display_name(marker_type, name))
-            .unwrap_or_else(|| name.to_string());
-        let order = section_ids.len();
-        let created = state.storage.create(
-            "prompt-sections",
+        state.storage.patch(
+            "prompts",
+            &preset_id,
             json!({
-                "presetId": preset_id,
-                "identifier": if identifier.is_empty() { format!("imported-section-{order}") } else { identifier.clone() },
-                "name": section_name,
-                "content": content,
-                "role": role,
-                "enabled": enabled,
-                "isMarker": marker_config.is_some(),
-                "injectionPosition": if prompt.get("injection_position").and_then(Value::as_i64) == Some(1) { "depth" } else { "ordered" },
-                "injectionDepth": prompt.get("injection_depth").and_then(Value::as_i64).unwrap_or(0),
-                "injectionOrder": prompt.get("injection_order").and_then(Value::as_i64).unwrap_or(100),
-                "groupId": group_id_map.get(&identifier).map(|id| Value::String(id.clone())).unwrap_or(Value::Null),
-                "markerConfig": marker_config.unwrap_or(Value::Null),
-                "forbidOverrides": prompt.get("forbid_overrides").and_then(Value::as_bool).unwrap_or(false),
-                "order": order,
-                "sortOrder": order
+                "sectionOrder": section_ids,
+                "groupOrder": group_ids
             }),
         )?;
-        if let Some(section_id) = created.get("id").and_then(Value::as_str) {
-            section_ids.push(section_id.to_string());
+        flush_import_writes(state)?;
+
+        Ok(json!({
+            "success": true,
+            "type": "st_preset",
+            "presetId": preset_id,
+            "id": preset_id,
+            "sectionsImported": section_ids.len(),
+            "groupsImported": group_ids.len(),
+            "variableGroups": st_variable_groups(&prompts).as_array().map(Vec::len).unwrap_or(0),
+            "preset": preset
+        }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_created_records(
+            state,
+            "prompt-sections",
+            &created_section_ids,
+            &mut rollback_errors,
+        );
+        rollback_created_records(
+            state,
+            "prompt-groups",
+            &created_group_ids,
+            &mut rollback_errors,
+        );
+        if let Some(preset_id) = created_preset_id.as_deref() {
+            rollback_created_records(
+                state,
+                "prompts",
+                &[preset_id.to_string()],
+                &mut rollback_errors,
+            );
         }
-    }
-
-    state.storage.patch(
-        "prompts",
-        &preset_id,
-        json!({
-            "sectionOrder": section_ids,
-            "groupOrder": group_ids
-        }),
-    )?;
-    flush_import_writes(state)?;
-
-    Ok(json!({
-        "success": true,
-        "type": "st_preset",
-        "presetId": preset_id,
-        "id": preset_id,
-        "sectionsImported": section_ids.len(),
-        "groupsImported": group_ids.len(),
-        "variableGroups": st_variable_groups(&prompts).as_array().map(Vec::len).unwrap_or(0),
-        "preset": preset
-    }))
+        append_rollback_errors(error, "ST preset import", rollback_errors)
+    })
 }

--- a/src-tauri/src/commands/storage/imports/st_preset.rs
+++ b/src-tauri/src/commands/storage/imports/st_preset.rs
@@ -390,6 +390,7 @@ pub(super) fn import_st_preset_payload(
             "groupOrder": group_ids
         }),
     )?;
+    flush_import_writes(state)?;
 
     Ok(json!({
         "success": true,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -698,6 +698,10 @@ mod tests {
         TempRoot(std::env::temp_dir().join(format!("marinara-state-{test_name}-{suffix}")))
     }
 
+    fn persist_fixture_storage(storage: &FileStorage) {
+        storage.flush().expect("fixture writes should persist");
+    }
+
     #[test]
     fn llm_stream_pending_cancellations_inside_ttl_are_retained() {
         let now = Instant::now();
@@ -775,6 +779,7 @@ mod tests {
                 }),
             )
             .expect("snapshot should be inserted");
+        persist_fixture_storage(&storage);
 
         let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
         let rows = state
@@ -811,6 +816,7 @@ mod tests {
                 )
                 .expect("snapshot should be inserted");
         }
+        persist_fixture_storage(&storage);
 
         let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
         let rows = state
@@ -933,6 +939,7 @@ mod tests {
                 }),
             )
             .expect("character should be inserted");
+        persist_fixture_storage(&storage);
 
         let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
         let character = state
@@ -979,6 +986,7 @@ mod tests {
                 }),
             )
             .expect("chat should be inserted");
+        persist_fixture_storage(&storage);
 
         let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
         let chat = state
@@ -1040,6 +1048,7 @@ mod tests {
                 .create("chats", chat)
                 .expect("chat row should be inserted");
         }
+        persist_fixture_storage(&storage);
 
         let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
         let root_chat = state


### PR DESCRIPTION
## Linked issue

No linked issue.

## Why this change

Startup storage repair tests and import rollback paths need to observe durable storage writes when correctness depends on persisted data. A debounced storage write could leave startup fixtures invisible to a fresh storage instance, and import flows could return success before a pending write failure was surfaced.

## What changed

- Flush startup test fixture storage before constructing a fresh `AppState`.
- Add an import-layer helper that flushes pending storage writes before import success responses.
- Apply the flush boundary to SillyTavern chat/persona/preset imports and Marinara character/persona/lorebook/preset imports.
- Preserve rollback behavior when flush failures occur, including persona avatar imports removing both managed avatar files and created persona rows.

## Refactor impact

Primary owner:

Rust storage and imports.

Impact areas reviewed:

- Startup state repair and media migration tests
- Import success and rollback paths
- SillyTavern chat/persona/preset imports
- Marinara envelope character/persona/lorebook/preset imports

Boundary notes:

No React, engine, shared API, or remote-runtime boundaries changed. The change stays in `src-tauri` storage/import ownership.

Pressure points touched:

Import modules under `src-tauri/src/commands/storage/imports`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml state::tests -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml import_persona_avatar_file_rolls_back_avatar_when_persona_write_fails -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml rolls_back -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml branch_import_fails -- --nocapture`
- `pnpm check:rust:test`
- `pnpm check:rust`
- `pnpm check:rust:nextest`
- `pnpm check`
- `git diff --check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

This is a Rust storage/import rollback correctness fix and does not add a discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes needed; no public workflow, command, architecture, or discoverability documentation changed.

## UI evidence

No UI changes.
