### PR TITLE
Add managed avatar thumbnails

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1066,6 +1066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colored"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +2885,8 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
  "image-webp",
  "moxcms",
  "num-traits",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ base64 = "0.22"
 buttplug = "10.0.2"
 buttplug_core = "10.0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "gif"] }
 libc = "0.2"
 log = "0.4"
 pdf-extract = "0.10"

--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -2,6 +2,10 @@ use super::media_uploads::{
     managed_record_file_path, persist_image_upload, remove_managed_record_file, safe_filename,
 };
 use super::*;
+use image::ImageFormat;
+use std::path::{Path, PathBuf};
+
+const AVATAR_THUMBNAIL_SIZES: &[u32] = &[64, 96, 128, 256];
 
 pub(crate) fn update_character_avatar(
     state: &AppState,
@@ -159,6 +163,7 @@ fn avatar_mime_type(filename: Option<&str>) -> &'static str {
 }
 
 pub(crate) fn remove_avatar_file(state: &AppState, collection: &str, record: &Value) {
+    remove_avatar_thumbnail_files(state, collection, record);
     remove_managed_record_file(
         state,
         &format!("avatars/{}", safe_filename(collection)),
@@ -166,6 +171,211 @@ pub(crate) fn remove_avatar_file(state: &AppState, collection: &str, record: &Va
         "avatarFilePath",
         "avatarFilename",
     )
+}
+
+fn remove_avatar_thumbnail_files(state: &AppState, collection: &str, record: &Value) {
+    let Ok(Some(path)) = managed_record_file_path(
+        state,
+        &format!("avatars/{}", safe_filename(collection)),
+        record,
+        "avatarFilePath",
+        "avatarFilename",
+    ) else {
+        return;
+    };
+    let Ok(source) = fs::canonicalize(path) else {
+        return;
+    };
+    let Ok(avatars_root) = canonical_avatar_root(state) else {
+        return;
+    };
+    let Ok(relative) = source.strip_prefix(avatars_root) else {
+        return;
+    };
+    for size in AVATAR_THUMBNAIL_SIZES {
+        for target in avatar_thumbnail_removal_targets(state, *size, relative) {
+            if target.is_file() {
+                let _ = fs::remove_file(target);
+            }
+        }
+    }
+}
+
+pub(crate) fn avatar_thumbnail_file_path(
+    state: &AppState,
+    filename: Option<&str>,
+    absolute_path: Option<&str>,
+    size: Option<u32>,
+) -> AppResult<Value> {
+    let source = avatar_source_path(state, filename, absolute_path)?;
+    let thumbnail = avatar_thumbnail_path_for_source(state, &source, size.unwrap_or(128))?;
+    Ok(json!({ "path": thumbnail.to_string_lossy() }))
+}
+
+pub(crate) fn avatar_thumbnail_path_for_source(
+    state: &AppState,
+    source: &Path,
+    size: u32,
+) -> AppResult<PathBuf> {
+    if !AVATAR_THUMBNAIL_SIZES.contains(&size) {
+        return Err(AppError::invalid_input("Unsupported avatar thumbnail size"));
+    }
+    let source = fs::canonicalize(source).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => AppError::not_found("Avatar asset was not found"),
+        _ => AppError::from(error),
+    })?;
+    let avatars_root = canonical_avatar_root(state)?;
+    if !source.starts_with(&avatars_root) {
+        return Err(AppError::invalid_input(
+            "Avatar thumbnail source is outside managed avatars",
+        ));
+    }
+    if !is_resizable_avatar_file(&source) {
+        return Ok(source);
+    }
+
+    let relative = source.strip_prefix(&avatars_root).map_err(|_| {
+        AppError::invalid_input("Avatar thumbnail source is outside managed avatars")
+    })?;
+    let target = avatar_thumbnail_target_path(state, size, relative);
+
+    if avatar_thumbnail_is_fresh(&source, &target)? {
+        return Ok(target);
+    }
+
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    write_avatar_thumbnail(&source, &target, size)?;
+    Ok(target)
+}
+
+fn avatar_thumbnail_target_path(state: &AppState, size: u32, relative: &Path) -> PathBuf {
+    let mut target = state
+        .data_dir
+        .join(".avatar-thumbnails")
+        .join(size.to_string())
+        .join(relative);
+    let filename = target
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "avatar".to_string());
+    target.set_file_name(format!("{filename}.thumb.png"));
+    target
+}
+
+fn legacy_avatar_thumbnail_target_path(state: &AppState, size: u32, relative: &Path) -> PathBuf {
+    let mut target = state
+        .data_dir
+        .join(".avatar-thumbnails")
+        .join(size.to_string())
+        .join(relative);
+    target.set_extension("png");
+    target
+}
+
+fn avatar_thumbnail_removal_targets(state: &AppState, size: u32, relative: &Path) -> [PathBuf; 2] {
+    [
+        avatar_thumbnail_target_path(state, size, relative),
+        legacy_avatar_thumbnail_target_path(state, size, relative),
+    ]
+}
+
+fn write_avatar_thumbnail(source: &Path, target: &Path, size: u32) -> AppResult<()> {
+    let image = image::open(source).map_err(|error| {
+        AppError::invalid_input(format!("Avatar thumbnail could not be decoded: {error}"))
+    })?;
+    let temp = avatar_thumbnail_temp_path(target);
+    image
+        .thumbnail(size, size)
+        .save_with_format(&temp, ImageFormat::Png)
+        .map_err(|error| {
+            let _ = fs::remove_file(&temp);
+            AppError::new("avatar_thumbnail_error", error.to_string())
+        })?;
+    replace_avatar_thumbnail_file(&temp, target).map_err(|error| {
+        let _ = fs::remove_file(&temp);
+        AppError::from(error)
+    })
+}
+
+fn avatar_thumbnail_temp_path(target: &Path) -> PathBuf {
+    let filename = target
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "avatar.thumb.png".to_string());
+    target.with_file_name(format!(".{filename}.{}.tmp", new_id()))
+}
+
+fn replace_avatar_thumbnail_file(temp: &Path, target: &Path) -> std::io::Result<()> {
+    match fs::rename(temp, target) {
+        Ok(()) => Ok(()),
+        Err(_) if target.exists() => {
+            let _ = fs::remove_file(target);
+            fs::rename(temp, target)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn avatar_source_path(
+    state: &AppState,
+    filename: Option<&str>,
+    absolute_path: Option<&str>,
+) -> AppResult<PathBuf> {
+    if let Some(path) = absolute_path.filter(|value| !value.trim().is_empty()) {
+        return avatar_source_candidate(state, PathBuf::from(path));
+    }
+    let filename = filename
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::invalid_input("Avatar filename or path is required"))?;
+    avatar_source_candidate(
+        state,
+        state
+            .data_dir
+            .join("avatars")
+            .join("characters")
+            .join(safe_filename(filename)),
+    )
+}
+
+fn avatar_source_candidate(state: &AppState, candidate: PathBuf) -> AppResult<PathBuf> {
+    let source = fs::canonicalize(candidate).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => AppError::not_found("Avatar asset was not found"),
+        _ => AppError::from(error),
+    })?;
+    let avatars_root = canonical_avatar_root(state)?;
+    if !source.starts_with(avatars_root) {
+        return Err(AppError::invalid_input(
+            "Avatar asset path is outside managed avatars",
+        ));
+    }
+    Ok(source)
+}
+
+fn canonical_avatar_root(state: &AppState) -> AppResult<PathBuf> {
+    let root = state.data_dir.join("avatars");
+    fs::create_dir_all(&root)?;
+    fs::canonicalize(root).map_err(AppError::from)
+}
+
+fn is_resizable_avatar_file(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "png" | "jpg" | "jpeg" | "webp" | "gif"
+    )
+}
+
+fn avatar_thumbnail_is_fresh(source: &Path, target: &Path) -> AppResult<bool> {
+    let source_modified = fs::metadata(source)?.modified()?;
+    let Ok(target_modified) = fs::metadata(target).and_then(|metadata| metadata.modified()) else {
+        return Ok(false);
+    };
+    Ok(target_modified >= source_modified)
 }
 
 pub(crate) fn update_npc_avatar(state: &AppState, chat_id: &str, body: Value) -> AppResult<Value> {
@@ -265,5 +475,139 @@ mod tests {
         assert_eq!(restored["avatarPath"], "data:image/png;base64,b2xk");
         assert_eq!(restored["avatarFilePath"], Value::Null);
         assert_eq!(restored["avatarFilename"], Value::Null);
+    }
+
+    #[test]
+    fn avatar_thumbnail_file_path_creates_managed_cache_without_overwriting_source() {
+        let state = test_state("thumbnail");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join("large.png");
+        let image = image::RgbaImage::from_pixel(320, 240, image::Rgba([255, 0, 0, 255]));
+        image
+            .save(&avatar_path)
+            .expect("avatar fixture should write");
+
+        let response = avatar_thumbnail_file_path(
+            &state,
+            Some("large.png"),
+            Some(&avatar_path.to_string_lossy()),
+            Some(128),
+        )
+        .expect("thumbnail should be generated");
+        let thumbnail = PathBuf::from(response["path"].as_str().expect("path should be returned"));
+
+        assert!(thumbnail.starts_with(state.data_dir.join(".avatar-thumbnails/128/characters")));
+        assert!(thumbnail.is_file());
+        assert_eq!(
+            image::image_dimensions(&thumbnail).expect("thumbnail should decode"),
+            (128, 96)
+        );
+        assert_eq!(
+            image::image_dimensions(&avatar_path).expect("source should decode"),
+            (320, 240)
+        );
+    }
+
+    #[test]
+    fn avatar_thumbnail_file_path_keeps_source_extension_in_cache_key() {
+        let state = test_state("thumbnail-extension-key");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let png_path = avatar_dir.join("same-name.png");
+        let jpg_path = avatar_dir.join("same-name.jpg");
+        image::RgbImage::from_pixel(320, 240, image::Rgb([255, 0, 0]))
+            .save(&png_path)
+            .expect("png fixture should write");
+        image::RgbImage::from_pixel(240, 320, image::Rgb([0, 0, 255]))
+            .save(&jpg_path)
+            .expect("jpg fixture should write");
+
+        let png_response = avatar_thumbnail_file_path(
+            &state,
+            Some("same-name.png"),
+            Some(&png_path.to_string_lossy()),
+            Some(128),
+        )
+        .expect("png thumbnail should be generated");
+        let jpg_response = avatar_thumbnail_file_path(
+            &state,
+            Some("same-name.jpg"),
+            Some(&jpg_path.to_string_lossy()),
+            Some(128),
+        )
+        .expect("jpg thumbnail should be generated");
+        let png_thumbnail = PathBuf::from(
+            png_response["path"]
+                .as_str()
+                .expect("png path should be returned"),
+        );
+        let jpg_thumbnail = PathBuf::from(
+            jpg_response["path"]
+                .as_str()
+                .expect("jpg path should be returned"),
+        );
+
+        assert_ne!(png_thumbnail, jpg_thumbnail);
+        assert_eq!(
+            png_thumbnail.file_name().and_then(|value| value.to_str()),
+            Some("same-name.png.thumb.png")
+        );
+        assert_eq!(
+            jpg_thumbnail.file_name().and_then(|value| value.to_str()),
+            Some("same-name.jpg.thumb.png")
+        );
+        assert_eq!(
+            image::image_dimensions(&png_thumbnail).expect("png thumbnail should decode"),
+            (128, 96)
+        );
+        assert_eq!(
+            image::image_dimensions(&jpg_thumbnail).expect("jpg thumbnail should decode"),
+            (96, 128)
+        );
+    }
+
+    #[test]
+    fn avatar_thumbnail_file_path_resizes_gif_avatar() {
+        let state = test_state("thumbnail-gif");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join("animated.gif");
+        image::RgbaImage::from_pixel(320, 240, image::Rgba([255, 0, 255, 255]))
+            .save(&avatar_path)
+            .expect("gif fixture should write");
+
+        let response = avatar_thumbnail_file_path(
+            &state,
+            Some("animated.gif"),
+            Some(&avatar_path.to_string_lossy()),
+            Some(128),
+        )
+        .expect("gif thumbnail should be generated");
+        let thumbnail = PathBuf::from(response["path"].as_str().expect("path should be returned"));
+
+        assert_ne!(thumbnail, avatar_path);
+        assert_eq!(
+            thumbnail.file_name().and_then(|value| value.to_str()),
+            Some("animated.gif.thumb.png")
+        );
+        assert_eq!(
+            image::image_dimensions(&thumbnail).expect("gif thumbnail should decode"),
+            (128, 96)
+        );
+    }
+
+    #[test]
+    fn avatar_thumbnail_file_path_rejects_sources_outside_managed_avatars() {
+        let state = test_state("thumbnail-outside");
+        let outside = state.data_dir.join("outside.png");
+        let image = image::RgbaImage::from_pixel(1, 1, image::Rgba([0, 0, 0, 255]));
+        image.save(&outside).expect("outside fixture should write");
+
+        let error =
+            avatar_thumbnail_file_path(&state, None, Some(&outside.to_string_lossy()), Some(128))
+                .expect_err("outside source should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
     }
 }

--- a/src-tauri/src/commands/storage/commands/media.rs
+++ b/src-tauri/src/commands/storage/commands/media.rs
@@ -206,6 +206,16 @@ pub fn character_avatar_remove(state: State<'_, AppState>, id: String) -> Result
 }
 
 #[tauri::command]
+pub fn avatar_thumbnail_file_path(
+    state: State<'_, AppState>,
+    filename: Option<String>,
+    absolute_path: Option<String>,
+    size: Option<u32>,
+) -> Result<Value, AppError> {
+    avatars::avatar_thumbnail_file_path(&state, filename.as_deref(), absolute_path.as_deref(), size)
+}
+
+#[tauri::command]
 pub fn character_restore_version(
     state: State<'_, AppState>,
     character_id: String,

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -691,6 +691,12 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "character_avatar_remove" => {
             avatars::remove_character_avatar(state, required_string(&args, "id")?)
         }
+        "avatar_thumbnail_file_path" => avatars::avatar_thumbnail_file_path(
+            state,
+            optional_string(&args, "filename").as_deref(),
+            optional_string(&args, "absolutePath").as_deref(),
+            optional_u32(&args, "size"),
+        ),
         "character_restore_version" => characters::restore_character_version(
             state,
             required_string(&args, "characterId")?,

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1,6 +1,6 @@
 use crate::http_dispatch::{dispatch, InvokeRequest};
 use crate::state::AppState;
-use crate::storage_commands::{fonts, imports, llm, lorebook_images, prompts};
+use crate::storage_commands::{avatars, fonts, imports, llm, lorebook_images, prompts};
 use axum::body::Body;
 use axum::extract::{ConnectInfo, Path, State};
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
@@ -199,6 +199,7 @@ async fn managed_asset(
 fn managed_asset_path(state: &AppState, kind: &str, path: &str) -> Result<PathBuf, AppError> {
     match kind {
         "avatar" => avatar_asset_path(state, path),
+        "avatar-thumbnail" => avatar_thumbnail_asset_path(state, path),
         "background" => Ok(PathBuf::from(state.backgrounds.absolute_path_string(path)?)),
         "font" => fonts::font_file_path(state, path),
         "game" => Ok(PathBuf::from(state.game_assets.absolute_path_string(path)?)),
@@ -231,6 +232,26 @@ fn avatar_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> 
         }
     }
     Ok(asset_path)
+}
+
+fn avatar_thumbnail_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {
+    let (size, avatar_path) = avatar_thumbnail_request(path)?;
+    let source = avatar_asset_path(state, avatar_path)?;
+    avatars::avatar_thumbnail_path_for_source(state, &source, size)
+}
+
+fn avatar_thumbnail_request(path: &str) -> Result<(u32, &str), AppError> {
+    let (size, avatar_path) = path
+        .trim()
+        .split_once('/')
+        .ok_or_else(|| AppError::not_found("Avatar thumbnail asset was not found"))?;
+    let size = size
+        .parse::<u32>()
+        .map_err(|_| AppError::invalid_input("Unsupported avatar thumbnail size"))?;
+    if avatar_path.trim().is_empty() {
+        return Err(AppError::not_found("Avatar thumbnail asset was not found"));
+    }
+    Ok((size, avatar_path))
 }
 
 fn avatar_asset_filename(path: &str) -> Result<String, AppError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -259,6 +259,7 @@ pub fn run() {
             storage_commands::media_commands::persona_activate,
             storage_commands::media_commands::character_avatar_upload,
             storage_commands::media_commands::character_avatar_remove,
+            storage_commands::media_commands::avatar_thumbnail_file_path,
             storage_commands::media_commands::character_restore_version,
             storage_commands::media_commands::persona_avatar_upload,
             storage_commands::media_commands::npc_avatar_upload,

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -1,5 +1,11 @@
 import type { AvatarCropValue } from "../../../../shared/lib/utils";
-import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../shared/api/local-file-api";
+import {
+  avatarFileUrlFromPath,
+  avatarThumbnailFileUrlFromPath,
+  canGenerateAvatarThumbnail,
+  resolveAvatarFileUrl,
+  resolveAvatarThumbnailFileUrl,
+} from "../../../../shared/api/local-file-api";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
 import { getCharacterAvatarLoadingMode } from "../lib/character-avatar-loading";
 import { useEffect, useState } from "react";
@@ -31,6 +37,7 @@ export function CharacterAvatarImage({
   alt,
   crop,
   className,
+  thumbnailSize,
 }: {
   src?: string | null;
   avatarFilePath?: string | null;
@@ -38,21 +45,29 @@ export function CharacterAvatarImage({
   alt: string;
   crop?: unknown;
   className?: string;
+  thumbnailSize?: 64 | 96 | 128 | 256;
 }) {
-  const managedInitialSrc = avatarFileUrlFromPath(avatarFilename, avatarFilePath);
+  const effectiveThumbnailSize =
+    thumbnailSize && canGenerateAvatarThumbnail(avatarFilename, avatarFilePath) ? thumbnailSize : undefined;
+  const managedInitialSrc = effectiveThumbnailSize
+    ? avatarThumbnailFileUrlFromPath(avatarFilename, avatarFilePath, effectiveThumbnailSize)
+    : avatarFileUrlFromPath(avatarFilename, avatarFilePath);
   const hasManagedAvatarInput = Boolean(avatarFilename || avatarFilePath);
-  const initialSrc = managedInitialSrc ?? src ?? null;
+  const initialSrc = managedInitialSrc ?? (effectiveThumbnailSize && hasManagedAvatarInput ? null : src) ?? null;
   const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
 
   useEffect(() => {
     let cancelled = false;
     setAsyncSrc(initialSrc);
-    if (!hasManagedAvatarInput || (managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
+    if (!hasManagedAvatarInput || (!effectiveThumbnailSize && managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
       return () => {
         cancelled = true;
       };
     }
-    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
+    const resolveUrl = effectiveThumbnailSize
+      ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize)
+      : resolveAvatarFileUrl(avatarFilename, avatarFilePath);
+    resolveUrl
       .then((url) => {
         if (!cancelled) setAsyncSrc(url ?? src ?? null);
       })
@@ -62,7 +77,7 @@ export function CharacterAvatarImage({
     return () => {
       cancelled = true;
     };
-  }, [avatarFilename, avatarFilePath, hasManagedAvatarInput, initialSrc, managedInitialSrc, src]);
+  }, [avatarFilename, avatarFilePath, effectiveThumbnailSize, hasManagedAvatarInput, initialSrc, managedInitialSrc, src]);
 
   const resolvedSrc = asyncSrc ?? initialSrc;
   if (!resolvedSrc) return null;
@@ -72,6 +87,8 @@ export function CharacterAvatarImage({
       src={resolvedSrc}
       alt={alt}
       loading={getCharacterAvatarLoadingMode(resolvedSrc)}
+      decoding="async"
+      fetchPriority={effectiveThumbnailSize ? "low" : undefined}
       draggable={false}
       className={cn("h-full w-full object-cover", className)}
       style={getAvatarCropStyle(resolveAvatarCrop(crop))}

--- a/src/features/catalog/characters/components/CharacterGroupsSection.tsx
+++ b/src/features/catalog/characters/components/CharacterGroupsSection.tsx
@@ -23,6 +23,8 @@ export type CharacterGroupMemberPreview = {
   name: string;
   comment?: string | null;
   avatarPath: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   avatarCrop?: unknown;
 };
 
@@ -271,8 +273,11 @@ export function CharacterGroupsSection({
                               {member.avatarPath ? (
                                 <CharacterAvatarImage
                                   src={member.avatarPath}
+                                  avatarFilePath={member.avatarFilePath}
+                                  avatarFilename={member.avatarFilename}
                                   alt={member.name}
                                   crop={member.avatarCrop}
+                                  thumbnailSize={128}
                                 />
                               ) : (
                                 <User size="0.75rem" />

--- a/src/features/catalog/characters/components/CharacterLibraryCard.tsx
+++ b/src/features/catalog/characters/components/CharacterLibraryCard.tsx
@@ -47,6 +47,7 @@ export function CharacterLibraryCard({ character, active, onSelect }: CharacterL
             alt={characterName}
             crop={character.parsed.extensions?.avatarCrop}
             className="transition-transform duration-300 group-hover:scale-[1.03]"
+            thumbnailSize={256}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center text-white/85">

--- a/src/features/catalog/characters/components/CharacterListRow.tsx
+++ b/src/features/catalog/characters/components/CharacterListRow.tsx
@@ -142,6 +142,7 @@ export function CharacterListRow({
               avatarFilename={character.avatarFilename}
               alt={charName}
               crop={extensions.avatarCrop}
+              thumbnailSize={128}
             />
           </div>
         ) : (

--- a/src/features/catalog/characters/hooks/use-characters-panel-data.ts
+++ b/src/features/catalog/characters/hooks/use-characters-panel-data.ts
@@ -39,7 +39,14 @@ export function useCharactersPanelData({
   const charMap = useMemo(() => {
     const map = new Map<
       string,
-      { name: string; comment?: string | null; avatarPath: string | null; avatarCrop?: unknown }
+      {
+        name: string;
+        comment?: string | null;
+        avatarPath: string | null;
+        avatarFilePath?: string | null;
+        avatarFilename?: string | null;
+        avatarCrop?: unknown;
+      }
     >();
     for (const character of parsedCharacters) {
       const extensions = readRecord(character.parsed.extensions);
@@ -47,6 +54,8 @@ export function useCharactersPanelData({
         name: typeof character.parsed.name === "string" ? character.parsed.name : "Unknown",
         comment: character.comment,
         avatarPath: characterAvatarUrl(character),
+        avatarFilePath: character.avatarFilePath,
+        avatarFilename: character.avatarFilename,
         avatarCrop: extensions.avatarCrop,
       });
     }

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -66,7 +66,7 @@ function filePathToAssetUrl(path: string | null | undefined): string {
   }
 }
 
-type RemoteManagedAssetKind = "avatar" | "background" | "font" | "game" | "lorebook";
+type RemoteManagedAssetKind = "avatar" | "avatar-thumbnail" | "background" | "font" | "game" | "lorebook";
 
 function remoteManagedAsset(kind: RemoteManagedAssetKind, path: string | null | undefined): RemoteManagedAsset | null {
   const target = remoteRuntimeTarget();
@@ -215,6 +215,20 @@ function avatarRemoteManagedPath(
   return managedAvatarPathFromAbsolutePath(absolutePath) ?? filename?.trim() ?? filenameFromPath(absolutePath);
 }
 
+function pathExtension(value: string | null | undefined): string | null {
+  const filename = filenameFromPath(value);
+  const extension = filename?.split(".").pop()?.trim().toLowerCase();
+  return extension && extension !== filename?.toLowerCase() ? extension : null;
+}
+
+export function canGenerateAvatarThumbnail(
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+): boolean {
+  const extension = pathExtension(filename) ?? pathExtension(absolutePath);
+  return extension === "png" || extension === "jpg" || extension === "jpeg" || extension === "webp" || extension === "gif";
+}
+
 export function gameAssetFileUrlFromPath(path: string, absolutePath?: string | null): string {
   const remoteUrl = remoteManagedAssetUrl("game", path);
   if (remoteUrl) return remoteUrl;
@@ -234,6 +248,16 @@ export function avatarFileUrlFromPath(
   const remoteUrl = remoteManagedAssetUrl("avatar", avatarRemoteManagedPath(filename, absolutePath));
   if (remoteUrl) return remoteUrl;
   return absolutePath ? filePathToAssetUrl(absolutePath) : null;
+}
+
+export function avatarThumbnailFileUrlFromPath(
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+  size = 128,
+): string | null {
+  const path = avatarRemoteManagedPath(filename, absolutePath);
+  const remoteUrl = remoteManagedAssetUrl("avatar-thumbnail", path ? `${size}/${path}` : null);
+  return remoteUrl;
 }
 
 export async function resolveGameAssetFileUrl(path: string): Promise<string> {
@@ -263,6 +287,22 @@ export async function resolveAvatarFileUrl(
   const remoteUrl = await remoteManagedAssetResolvableUrl("avatar", avatarRemoteManagedPath(filename, absolutePath));
   if (remoteUrl) return remoteUrl;
   return absolutePath ? filePathToAssetUrl(absolutePath) : null;
+}
+
+export async function resolveAvatarThumbnailFileUrl(
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+  size = 128,
+): Promise<string | null> {
+  const remotePath = avatarRemoteManagedPath(filename, absolutePath);
+  const remoteUrl = await remoteManagedAssetResolvableUrl(
+    "avatar-thumbnail",
+    remotePath ? `${size}/${remotePath}` : null,
+  );
+  if (remoteUrl) return remoteUrl;
+  if (!filename && !absolutePath) return null;
+  const response = await invokeTauri<PathResponse>("avatar_thumbnail_file_path", { filename, absolutePath, size });
+  return filePathToAssetUrl(response.path ?? "");
 }
 
 async function resolveLorebookImageFileUrl(filename: string): Promise<string> {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -165,6 +165,7 @@ const REMOTE_COMMANDS = new Set([
   "persona_activate",
   "character_avatar_upload",
   "character_avatar_remove",
+  "avatar_thumbnail_file_path",
   "character_restore_version",
   "persona_avatar_upload",
   "npc_avatar_upload",


### PR DESCRIPTION
## Linked issue

Closes #1938

## Why this change

- Character catalog grids and grouped previews currently load full managed avatar files, which can make dense character views slower and heavier than needed.

## What changed

- Added managed avatar thumbnail generation for 64, 96, 128, and 256 pixel sizes in Rust storage.
- Added hostable `/api/assets/avatar-thumbnail/...` handling and remote runtime command routing for thumbnail path resolution.
- Updated catalog character avatar surfaces to request thumbnails where smaller images are enough.
- Added thumbnail cleanup when managed avatar files are removed.

## Refactor impact

Primary owner:

Rust storage, shared API, remote runtime, catalog characters.

Impact areas reviewed:

- Managed avatar persistence and removal paths.
- Tauri command registration and hostable HTTP dispatch.
- Shared local/remote asset URL resolution.
- Catalog character library cards, rows, and group previews.

Boundary notes:

- Thumbnail generation stays in Rust storage.
- React catalog UI calls typed shared API helpers only.
- Remote-capable behavior uses the explicit shared API -> remote allowlist -> HTTP dispatch/Rust command path.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration.
- `src-tauri/src/http_dispatch.rs` command dispatch.
- `src-tauri/src/http_server.rs` managed asset route.
- `src/shared/api/local-file-api.ts` and `src/shared/api/remote-runtime.ts`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml avatar_thumbnail`
- `pnpm typecheck`
- `pnpm check:architecture`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm build`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is an internal performance/storage behavior change for existing avatar displays.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured. The change affects existing avatar image loading paths; local command validation covered the storage/API/build contracts.
