### PR TITLE
Clarify agent brevity guidance

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -2,13 +2,9 @@
 
 This is Marinara Engine's adapted workflow overlay for AI coding agents.
 
-Source inspiration: `cha1latte/chai-agent-workflow-pack`
-<https://github.com/cha1latte/chai-agent-workflow-pack>
-
-The upstream pack was reviewed as an external workflow reference. This file is
-not a verbatim vendor copy; it adapts the workflow for Marinara's existing
-`AGENTS.md`, `CONTRIBUTING.md`, PR template, issue templates, and validation
-commands.
+Source inspiration: `cha1latte/chai-agent-workflow-pack`. This overlay adapts
+that workflow for Marinara's `AGENTS.md`, `CONTRIBUTING.md`, PR/issue templates,
+and validation commands; it is not a vendor copy.
 
 ## Priority
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 ## Credit And Workflow Budget
 
 - Preserve coding quality: use high/adaptive reasoning for code edits, reviews, risky debugging, and architecture. Save credits by avoiding unnecessary agents, browser proof, and PR loops rather than weakening coding reasoning.
+- Default to brief unless precision requires detail. Expand for proof, risk, exact external text, approval gates, repo boundaries, or user-facing tone.
 - Ordinary bugfix language means local fix and verification by default. Commit, push, draft PR creation, CodeRabbit, CI polling, ready marking, and merge require an explicit shipping request such as "ship it", "open a PR", "push this", or "ready for review".
 - Use the tiny local bug path for narrow, low-risk, machine-provable fixes: no full ledger by default, just a short claim/proof/validation/files/risk/vault receipt. Escalate to the full workflow as soon as the bug is nontrivial, PR-affecting, cross-boundary, storage/import/export/prompt/provider/security-sensitive, browser-evidence-dependent, or uncertain.
 - Before local bugfix edits, name only the cheap gate: core claim, likely owner/lane, risk level, and proof target. Broaden the gate only after a hypothesis is falsified or a risk boundary appears.

--- a/skills/marinara-agent-workflow/SKILL.md
+++ b/skills/marinara-agent-workflow/SKILL.md
@@ -7,9 +7,10 @@ description: "Apply Marinara's repo-local version of the Chai agent workflow pac
 
 ## Overview
 
-Use this skill as a workflow overlay, not a replacement for `AGENTS.md` or the more specific Marinara skills. It adapts the cloned Chai Agent Workflow Pack to this repo so agents can keep proof, review, risk, and communication discipline while still obeying Marinara's layered Tauri architecture.
-
-Source context: adapted from `cha1latte/chai-agent-workflow-pack`. Keep only the repo-specific workflow here; update this skill when the repo's agent workflow changes.
+Use this as a repo-specific workflow overlay, not a replacement for `AGENTS.md`
+or more specific Marinara skills. It keeps proof, review, risk, and
+communication discipline aligned with Marinara's layered Tauri architecture.
+Source context: adapted from `cha1latte/chai-agent-workflow-pack`.
 
 ## Priority
 


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Clarifies that Marinara's repo-local workflow already prefers brief reports and targeted proof without adding a global compression/style skill.
- Keeps brevity guidance bounded so agents still expand for proof, risk, exact external text, approval gates, repo boundaries, and user-facing tone.

## What changed

- Added a brief-by-default rule to root agent guidance.
- Tightened the source/context wording in the GitHub workflow overlay.
- Tightened the Marinara agent workflow skill overview without changing proof, safety, or approval gates.

## Refactor impact

Primary owner:

docs/workflow

Impact areas reviewed:

- Root `AGENTS.md`
- `.github/agents/chai-workflow.md`
- `skills/marinara-agent-workflow/SKILL.md`

Boundary notes:

- No product/runtime boundary changes.
- No engine, feature, shared API, Rust, or remote-runtime behavior changed.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof: `pnpm check:docs` passed.
- Codex proof: `git diff --check` passed.
- Codex proof: `pnpm check:workflow-names` ran and skipped metadata because no PR title/source branch args were provided.
- Attempted `pnpm check:agent-workflow`; this refactor base does not define that script, so `pnpm check:docs` is the matching available docs/agent guidance check.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Docs/workflow guidance only; no user-discoverable product behavior changed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; docs/workflow guidance only.
