### PR TITLE
Fix sprite list managed URLs

### DIFF
--- a/src-tauri/src/commands/storage/sprites.rs
+++ b/src-tauri/src/commands/storage/sprites.rs
@@ -4,6 +4,7 @@ use super::images::{
 };
 use super::shared::*;
 use super::*;
+use crate::storage_commands::media_uploads::file_path_asset_url;
 
 use image::{DynamicImage, GenericImageView, ImageFormat, Rgba, RgbaImage};
 use std::collections::VecDeque;
@@ -11,6 +12,7 @@ use std::env;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::UNIX_EPOCH;
 
 const SPRITE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "avif", "svg"];
 const CLEANUP_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp"];
@@ -62,6 +64,13 @@ impl SpriteOwnerKind {
         match self {
             Self::Character => "character ID",
             Self::Persona => "persona ID",
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Character => "character",
+            Self::Persona => "persona",
         }
     }
 }
@@ -329,7 +338,7 @@ pub(crate) fn list_sprites(
     let owner_kind = SpriteOwnerKind::from_request(owner_type)?;
     let dir = sprites_dir(state, owner_kind, character_id)?;
     fs::create_dir_all(&dir)?;
-    list_sprites_for_dir(&dir)
+    list_sprites_for_dir(&dir, owner_kind, character_id)
 }
 
 pub(crate) fn upload_sprite(
@@ -354,7 +363,7 @@ pub(crate) fn upload_sprite(
     fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{expression}.{ext}"));
     fs::write(&path, bytes)?;
-    sprite_info_from_path(&path)
+    sprite_info_from_path(&path, owner_kind, character_id)
 }
 
 pub(crate) fn upload_sprites(
@@ -415,7 +424,7 @@ pub(crate) fn upload_sprites(
     Ok(json!({
         "imported": imported,
         "failed": failed,
-        "sprites": list_sprites_for_dir(&dir)?
+        "sprites": list_sprites_for_dir(&dir, owner_kind, character_id)?
     }))
 }
 
@@ -509,7 +518,7 @@ pub(crate) fn clean_saved_sprites(
         "externalCleanupProcessed": background_remover_processed,
         "backgroundRemoverProcessed": background_remover_processed,
         "builtinProcessed": builtin_processed,
-        "sprites": list_sprites_for_dir(&dir)?
+        "sprites": list_sprites_for_dir(&dir, owner_kind, character_id)?
     }))
 }
 
@@ -582,7 +591,9 @@ pub(crate) fn restore_sprite_cleanup_point(
     if restored > 0 && failed.is_empty() {
         let _ = fs::remove_dir_all(&restore_point_dir);
     }
-    Ok(json!({ "restored": restored, "failed": failed, "sprites": list_sprites_for_dir(&dir)? }))
+    Ok(
+        json!({ "restored": restored, "failed": failed, "sprites": list_sprites_for_dir(&dir, owner_kind, character_id)? }),
+    )
 }
 
 pub(crate) fn delete_sprite(
@@ -1617,19 +1628,44 @@ fn extract_base64_image_data(value: &str) -> &str {
         .trim()
 }
 
-fn sprite_info_from_path(path: &Path) -> AppResult<Value> {
+fn sprite_info_from_path(
+    path: &Path,
+    owner_kind: SpriteOwnerKind,
+    owner_id: &str,
+) -> AppResult<Value> {
     let filename = file_name(path)?;
     let expression = expression_from_path(path);
-    let bytes = fs::read(path)?;
-    let mime = mime_for_path(path);
+    let metadata = fs::metadata(path)?;
+    let cache_key = sprite_cache_key(&metadata);
+    let mut url = file_path_asset_url(path);
+    url.push_str("?v=");
+    url.push_str(&cache_key);
     Ok(json!({
         "expression": expression,
         "filename": filename,
-        "url": format!("data:{mime};base64,{}", general_purpose::STANDARD.encode(bytes))
+        "absolutePath": path.to_string_lossy(),
+        "ownerId": owner_id,
+        "ownerType": owner_kind.as_str(),
+        "size": metadata.len(),
+        "cacheKey": cache_key,
+        "url": url
     }))
 }
 
-fn list_sprites_for_dir(dir: &Path) -> AppResult<Value> {
+fn sprite_cache_key(metadata: &fs::Metadata) -> String {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis().to_string())
+        .unwrap_or_else(|| metadata.len().to_string())
+}
+
+fn list_sprites_for_dir(
+    dir: &Path,
+    owner_kind: SpriteOwnerKind,
+    owner_id: &str,
+) -> AppResult<Value> {
     let mut items = Vec::new();
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
@@ -1637,7 +1673,7 @@ fn list_sprites_for_dir(dir: &Path) -> AppResult<Value> {
         if !path.is_file() || !is_sprite_file(&path) {
             continue;
         }
-        items.push(sprite_info_from_path(&path)?);
+        items.push(sprite_info_from_path(&path, owner_kind, owner_id)?);
     }
     items.sort_by(|a, b| {
         a.get("expression")
@@ -1781,17 +1817,6 @@ fn extension(path: &Path) -> Option<String> {
     path.extension()
         .and_then(|value| value.to_str())
         .map(|value| value.to_ascii_lowercase())
-}
-
-fn mime_for_path(path: &Path) -> &'static str {
-    match extension(path).as_deref() {
-        Some("jpg" | "jpeg") => "image/jpeg",
-        Some("webp") => "image/webp",
-        Some("gif") => "image/gif",
-        Some("avif") => "image/avif",
-        Some("svg") => "image/svg+xml",
-        _ => "image/png",
-    }
 }
 
 fn normalize_sprite_expression(raw: &str) -> String {
@@ -2494,6 +2519,14 @@ mod sprite_upload_tests {
         assert_eq!(
             sprites[0].get("filename").and_then(Value::as_str),
             Some("happy_face.png")
+        );
+        let url = sprites[0]
+            .get("url")
+            .and_then(Value::as_str)
+            .expect("sprite list item should include a url");
+        assert!(
+            !url.starts_with("data:image/"),
+            "sprite list items should not eagerly embed image bytes"
         );
 
         let _ = fs::remove_dir_all(root);

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -212,8 +212,62 @@ fn managed_asset_path(state: &AppState, kind: &str, path: &str) -> Result<PathBu
                 .map(PathBuf::from)
                 .ok_or_else(|| AppError::not_found("Lorebook image was not found"))
         }
+        "sprite" => sprite_asset_path(state, path),
         _ => Err(AppError::not_found("Managed asset type was not found")),
     }
+}
+
+fn sprite_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {
+    let mut segments = path.split('/');
+    let owner_type = managed_asset_path_segment(
+        segments
+            .next()
+            .ok_or_else(|| AppError::not_found("Sprite asset was not found"))?,
+        "Sprite asset was not found",
+    )?;
+    let owner_id = managed_asset_path_segment(
+        segments
+            .next()
+            .ok_or_else(|| AppError::not_found("Sprite asset was not found"))?,
+        "Sprite asset was not found",
+    )?;
+    let filename = managed_asset_filename(
+        segments
+            .next()
+            .ok_or_else(|| AppError::not_found("Sprite asset was not found"))?,
+        "Sprite asset was not found",
+    )?;
+    if segments.next().is_some() {
+        return Err(AppError::not_found("Sprite asset was not found"));
+    }
+
+    match owner_type.as_str() {
+        "character" => Ok(state.data_dir.join("sprites").join(owner_id).join(filename)),
+        "persona" => Ok(state
+            .data_dir
+            .join("sprites")
+            .join("personas")
+            .join(owner_id)
+            .join(filename)),
+        _ => Err(AppError::not_found("Sprite asset was not found")),
+    }
+}
+
+fn managed_asset_path_segment(
+    value: &str,
+    not_found_message: &'static str,
+) -> Result<String, AppError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value == "."
+        || value == ".."
+        || value.contains("..")
+        || value.contains('\\')
+        || value.contains(':')
+    {
+        return Err(AppError::not_found(not_found_message));
+    }
+    Ok(value.to_string())
 }
 
 fn gallery_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {
@@ -1364,6 +1418,42 @@ mod tests {
         assert!(gallery_asset_path(&state, "gallery/scene.png").is_err());
         assert!(gallery_asset_path(&state, "gallery\\scene.png").is_err());
         assert!(gallery_asset_path(&state, "C:scene.png").is_err());
+    }
+
+    #[test]
+    fn sprite_asset_path_routes_character_and_persona_sprites() {
+        let state = test_state("sprite-assets");
+
+        assert_eq!(
+            sprite_asset_path(&state, "character/character-1/happy.png")
+                .expect("character sprite filename should resolve"),
+            state
+                .data_dir
+                .join("sprites")
+                .join("character-1")
+                .join("happy.png")
+        );
+        assert_eq!(
+            sprite_asset_path(&state, "persona/persona-1/happy.png")
+                .expect("persona sprite filename should resolve"),
+            state
+                .data_dir
+                .join("sprites")
+                .join("personas")
+                .join("persona-1")
+                .join("happy.png")
+        );
+    }
+
+    #[test]
+    fn sprite_asset_path_rejects_path_tokens() {
+        let state = test_state("sprite-asset-sanitize");
+
+        assert!(sprite_asset_path(&state, "character/../happy.png").is_err());
+        assert!(sprite_asset_path(&state, "character/character-1/../happy.png").is_err());
+        assert!(sprite_asset_path(&state, "character/character-1/nested/happy.png").is_err());
+        assert!(sprite_asset_path(&state, "unknown/character-1/happy.png").is_err());
+        assert!(sprite_asset_path(&state, "persona/persona:1/happy.png").is_err());
     }
 
     #[test]

--- a/src/shared/api/image-generation-api.ts
+++ b/src/shared/api/image-generation-api.ts
@@ -1,5 +1,6 @@
 import { invokeTauri } from "./tauri-client";
 import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
+import { resolveSpriteFileUrl } from "./local-file-api";
 
 export type SpriteOwnerType = "character" | "persona";
 
@@ -14,6 +15,69 @@ function spriteOwnerArgs(characterId: string, options?: SpriteOwnerOptions) {
   };
 }
 
+type SpriteRecord = {
+  absolutePath?: unknown;
+  cacheKey?: unknown;
+  expression?: unknown;
+  filename?: unknown;
+  ownerId?: unknown;
+  ownerType?: unknown;
+  url?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readCacheKey(value: unknown): string | number | null {
+  return typeof value === "string" || typeof value === "number" ? value : null;
+}
+
+function isSpriteRecord(value: unknown): value is SpriteRecord {
+  return isRecord(value) && typeof value.filename === "string" && typeof value.expression === "string";
+}
+
+async function resolveSpriteRecordUrl(
+  sprite: SpriteRecord,
+  ownerId: string,
+  ownerType: SpriteOwnerType,
+): Promise<SpriteRecord> {
+  const filename = readString(sprite.filename);
+  if (!filename) return sprite;
+  const resolvedUrl = await resolveSpriteFileUrl(
+    readString(sprite.ownerType) ?? ownerType,
+    readString(sprite.ownerId) ?? ownerId,
+    filename,
+    readString(sprite.absolutePath),
+    readCacheKey(sprite.cacheKey),
+  );
+  return resolvedUrl ? { ...sprite, url: resolvedUrl } : sprite;
+}
+
+async function resolveSpriteResponse<T>(value: T, ownerId: string, ownerType: SpriteOwnerType): Promise<T> {
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((item) => (isSpriteRecord(item) ? resolveSpriteRecordUrl(item, ownerId, ownerType) : item)),
+    ) as T;
+  }
+  if (isRecord(value) && Array.isArray(value.sprites)) {
+    return {
+      ...value,
+      sprites: await Promise.all(
+        value.sprites.map((item) => (isSpriteRecord(item) ? resolveSpriteRecordUrl(item, ownerId, ownerType) : item)),
+      ),
+    } as T;
+  }
+  if (isSpriteRecord(value)) {
+    return (await resolveSpriteRecordUrl(value, ownerId, ownerType)) as T;
+  }
+  return value;
+}
+
 export const spriteApi = {
   capabilities: <T = unknown>() => invokeTauri<T>("sprite_capabilities_command"),
   cleanupStatus: <T = unknown>() => invokeTauri<T>("sprite_cleanup_status_command"),
@@ -21,18 +85,52 @@ export const spriteApi = {
     invokeTauri<T>("sprite_generate_sheet_preview", { body }),
   generateSheet: <T = unknown>(body: Record<string, unknown>) => invokeTauri<T>("sprite_generate_sheet", { body }),
   cleanup: <T = unknown>(body: Record<string, unknown>) => invokeTauri<T>("sprite_cleanup", { body }),
-  list: <T = unknown>(characterId: string, options?: SpriteOwnerOptions) =>
-    invokeTauri<T>("sprite_list", spriteOwnerArgs(characterId, options)),
-  upload: <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) =>
-    invokeTauri<T>("sprite_upload", { ...spriteOwnerArgs(characterId, options), body }),
-  bulkUpload: <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) =>
-    invokeTauri<T>("sprite_upload_bulk", { ...spriteOwnerArgs(characterId, options), body }),
+  list: async <T = unknown>(characterId: string, options?: SpriteOwnerOptions) => {
+    const owner = spriteOwnerArgs(characterId, options);
+    return resolveSpriteResponse(await invokeTauri<T>("sprite_list", owner), owner.characterId, owner.ownerType);
+  },
+  upload: async <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) => {
+    const owner = spriteOwnerArgs(characterId, options);
+    return resolveSpriteResponse(
+      await invokeTauri<T>("sprite_upload", { ...owner, body }),
+      owner.characterId,
+      owner.ownerType,
+    );
+  },
+  bulkUpload: async <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) => {
+    const owner = spriteOwnerArgs(characterId, options);
+    return resolveSpriteResponse(
+      await invokeTauri<T>("sprite_upload_bulk", { ...owner, body }),
+      owner.characterId,
+      owner.ownerType,
+    );
+  },
   delete: <T = unknown>(characterId: string, expression: string, options?: SpriteOwnerOptions) =>
     invokeTauri<T>("sprite_delete", { ...spriteOwnerArgs(characterId, options), expression }),
-  cleanupSaved: <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) =>
-    invokeTauri<T>("sprite_cleanup_saved", { ...spriteOwnerArgs(characterId, options), body }),
-  cleanupRestore: <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) =>
-    invokeTauri<T>("sprite_cleanup_restore", { ...spriteOwnerArgs(characterId, options), body }),
+  cleanupSaved: async <T = unknown>(
+    characterId: string,
+    body: Record<string, unknown>,
+    options?: SpriteOwnerOptions,
+  ) => {
+    const owner = spriteOwnerArgs(characterId, options);
+    return resolveSpriteResponse(
+      await invokeTauri<T>("sprite_cleanup_saved", { ...owner, body }),
+      owner.characterId,
+      owner.ownerType,
+    );
+  },
+  cleanupRestore: async <T = unknown>(
+    characterId: string,
+    body: Record<string, unknown>,
+    options?: SpriteOwnerOptions,
+  ) => {
+    const owner = spriteOwnerArgs(characterId, options);
+    return resolveSpriteResponse(
+      await invokeTauri<T>("sprite_cleanup_restore", { ...owner, body }),
+      owner.characterId,
+      owner.ownerType,
+    );
+  },
 };
 
 export const imageGenerationApi = {

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -66,9 +66,21 @@ function filePathToAssetUrl(path: string | null | undefined): string {
   }
 }
 
-type RemoteManagedAssetKind = "avatar" | "avatar-thumbnail" | "background" | "font" | "gallery" | "game" | "lorebook";
+type RemoteManagedAssetKind =
+  | "avatar"
+  | "avatar-thumbnail"
+  | "background"
+  | "font"
+  | "gallery"
+  | "game"
+  | "lorebook"
+  | "sprite";
 
-function remoteManagedAsset(kind: RemoteManagedAssetKind, path: string | null | undefined): RemoteManagedAsset | null {
+function remoteManagedAsset(
+  kind: RemoteManagedAssetKind,
+  path: string | null | undefined,
+  query?: string,
+): RemoteManagedAsset | null {
   const target = remoteRuntimeTarget();
   if (!target || !path?.trim()) return null;
   const encodedPath = path
@@ -78,11 +90,16 @@ function remoteManagedAsset(kind: RemoteManagedAssetKind, path: string | null | 
     .filter((segment) => segment && segment !== "." && segment !== "..")
     .map(encodeURIComponent)
     .join("/");
-  return encodedPath ? { url: `${target.baseUrl}/api/assets/${kind}/${encodedPath}`, target } : null;
+  const querySuffix = query ? `?${query}` : "";
+  return encodedPath ? { url: `${target.baseUrl}/api/assets/${kind}/${encodedPath}${querySuffix}`, target } : null;
 }
 
-function remoteManagedAssetUrl(kind: RemoteManagedAssetKind, path: string | null | undefined): string | null {
-  const asset = remoteManagedAsset(kind, path);
+function remoteManagedAssetUrl(
+  kind: RemoteManagedAssetKind,
+  path: string | null | undefined,
+  query?: string,
+): string | null {
+  const asset = remoteManagedAsset(kind, path, query);
   if (!asset || asset.target.authorization) return null;
   return asset.url;
 }
@@ -90,8 +107,9 @@ function remoteManagedAssetUrl(kind: RemoteManagedAssetKind, path: string | null
 async function remoteManagedAssetResolvableUrl(
   kind: RemoteManagedAssetKind,
   path: string | null | undefined,
+  query?: string,
 ): Promise<string | null> {
-  const asset = remoteManagedAsset(kind, path);
+  const asset = remoteManagedAsset(kind, path, query);
   if (!asset) return null;
   if (!asset.target.authorization) return asset.url;
   return fetchRemoteManagedAssetBlobUrl(asset);
@@ -221,12 +239,11 @@ function pathExtension(value: string | null | undefined): string | null {
   return extension && extension !== filename?.toLowerCase() ? extension : null;
 }
 
-export function canGenerateAvatarThumbnail(
-  filename: string | null | undefined,
-  absolutePath?: string | null,
-): boolean {
+export function canGenerateAvatarThumbnail(filename: string | null | undefined, absolutePath?: string | null): boolean {
   const extension = pathExtension(filename) ?? pathExtension(absolutePath);
-  return extension === "png" || extension === "jpg" || extension === "jpeg" || extension === "webp" || extension === "gif";
+  return (
+    extension === "png" || extension === "jpg" || extension === "jpeg" || extension === "webp" || extension === "gif"
+  );
 }
 
 export function gameAssetFileUrlFromPath(path: string, absolutePath?: string | null): string {
@@ -303,6 +320,47 @@ export async function resolveGalleryFileUrl(
   const remoteUrl = await remoteManagedAssetResolvableUrl("gallery", galleryRemoteManagedPath(filename, absolutePath));
   if (remoteUrl) return remoteUrl;
   return absolutePath && isAbsoluteFilesystemPath(absolutePath) ? filePathToAssetUrl(absolutePath) : null;
+}
+
+function spriteRemoteManagedPath(
+  ownerType: string | null | undefined,
+  ownerId: string | null | undefined,
+  filename: string | null | undefined,
+): string | null {
+  const normalizedOwnerType = ownerType === "persona" ? "persona" : "character";
+  const normalizedOwnerId = ownerId?.trim();
+  const normalizedFilename = filename?.trim();
+  if (!normalizedOwnerId || !normalizedFilename) return null;
+  return `${normalizedOwnerType}/${normalizedOwnerId}/${normalizedFilename}`;
+}
+
+function cacheBustQuery(cacheKey: string | number | null | undefined): string | undefined {
+  const value = String(cacheKey ?? "").trim();
+  return value ? `v=${encodeURIComponent(value)}` : undefined;
+}
+
+function appendCacheBust(url: string, cacheKey: string | number | null | undefined): string {
+  const query = cacheBustQuery(cacheKey);
+  if (!query || url.startsWith("blob:")) return url;
+  return `${url}${url.includes("?") ? "&" : "?"}${query}`;
+}
+
+export async function resolveSpriteFileUrl(
+  ownerType: string | null | undefined,
+  ownerId: string | null | undefined,
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+  cacheKey?: string | number | null,
+): Promise<string | null> {
+  const remoteUrl = await remoteManagedAssetResolvableUrl(
+    "sprite",
+    spriteRemoteManagedPath(ownerType, ownerId, filename),
+    cacheBustQuery(cacheKey),
+  );
+  if (remoteUrl) return remoteUrl;
+  return absolutePath && isAbsoluteFilesystemPath(absolutePath)
+    ? appendCacheBust(filePathToAssetUrl(absolutePath), cacheKey)
+    : null;
 }
 
 export async function resolveAvatarThumbnailFileUrl(


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1930

## Why this change

- Sprite library listing on `refactor` returned every sprite image as a base64 `data:` URL, so opening a large sprite grid forced the list command to read and serialize every image byte before the UI could render.

## What changed

- Changed sprite list/upload/cleanup result entries to return metadata, cache keys, absolute paths, and managed asset URLs instead of eager base64 payloads.
- Added a hostable `/api/assets/sprite/<ownerType>/<ownerId>/<filename>` asset route with path-token negative controls for remote runtime rendering.
- Updated the shared sprite API wrapper to resolve listed sprite metadata into renderable desktop or remote runtime URLs for existing catalog, roleplay, game, and tracker consumers.

## Refactor impact

Primary owner:

- Rust storage and remote runtime, with a shared API wrapper adjustment.

Impact areas reviewed:

- Catalog sprite grids, roleplay/game sprite consumers, shared sprite API calls, Tauri storage command responses, and hostable managed asset routing.

Boundary notes:

- Engine code was not touched. Feature consumers continue to receive `SpriteInfo.url`; the shared API wrapper owns desktop/remote URL resolution.

Pressure points touched:

- `src-tauri/src/commands/storage/sprites.rs`
- `src-tauri/src/http_server.rs`
- `src/shared/api/image-generation-api.ts`
- `src/shared/api/local-file-api.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the bug before the fix with `cargo test --manifest-path src-tauri\Cargo.toml sprite_upload_tests::bulk_upload_reports_partial_failures_and_returns_refreshed_list`; the new assertion failed because the sprite list item URL was a `data:image/...` payload.
- After the fix, `cargo test --manifest-path src-tauri\Cargo.toml sprite_upload_tests::bulk_upload_reports_partial_failures_and_returns_refreshed_list` passed.
- `cargo test --manifest-path src-tauri\Cargo.toml sprite_asset_path` passed, covering character/persona sprite asset routing and path-token negative controls.
- `pnpm typecheck` passed.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.
- `pnpm check` passed.
- Marinara proof gate passed for `scratch/bugfix-verification.json`.
- Bunny review passed before PR creation. Non-blocking limitation: authorized remote runtimes still require blob URLs when images are actually rendered, but the sprite list command payload no longer embeds image bytes.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing sprite listing/media loading path; no new user-discoverable feature or setting.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a non-visual storage/API payload fix; proof is command-based.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sprite assets now load via external URLs with automatic cache-busting to ensure users receive fresh content when sprite files are updated.
  * Improved sprite organization and tracking with explicit character and persona ownership designation.

* **Bug Fixes**
  * Enhanced asset path validation and security hardening to prevent invalid or malicious asset paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->