### PR TITLE
Improve managed avatar image delivery

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -1,11 +1,14 @@
 use super::media_uploads::{
-    managed_record_file_path, persist_image_upload, remove_managed_record_file, safe_filename,
+    decode_image_payload, managed_record_file_path, persist_image_upload,
+    remove_managed_record_file, safe_filename,
 };
 use super::*;
 use image::ImageFormat;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 const AVATAR_THUMBNAIL_SIZES: &[u32] = &[64, 96, 128, 256];
+const MAX_INLINE_AVATAR_THUMBNAIL_BYTES: usize = 20 * 1024 * 1024;
 
 pub(crate) fn update_character_avatar(
     state: &AppState,
@@ -205,10 +208,21 @@ pub(crate) fn avatar_thumbnail_file_path(
     state: &AppState,
     filename: Option<&str>,
     absolute_path: Option<&str>,
+    source_url: Option<&str>,
     size: Option<u32>,
 ) -> AppResult<Value> {
-    let source = avatar_source_path(state, filename, absolute_path)?;
-    let thumbnail = avatar_thumbnail_path_for_source(state, &source, size.unwrap_or(128))?;
+    let thumbnail = if filename.is_some_and(|value| !value.trim().is_empty())
+        || absolute_path.is_some_and(|value| !value.trim().is_empty())
+    {
+        let source = avatar_source_path(state, filename, absolute_path)?;
+        avatar_thumbnail_path_for_source(state, &source, size.unwrap_or(128))?
+    } else if let Some(source_url) = source_url.filter(|value| !value.trim().is_empty()) {
+        avatar_thumbnail_path_for_inline_source(state, source_url, size.unwrap_or(128))?
+    } else {
+        return Err(AppError::invalid_input(
+            "Avatar filename or path is required",
+        ));
+    };
     Ok(json!({ "path": thumbnail.to_string_lossy() }))
 }
 
@@ -285,6 +299,14 @@ fn write_avatar_thumbnail(source: &Path, target: &Path, size: u32) -> AppResult<
     let image = image::open(source).map_err(|error| {
         AppError::invalid_input(format!("Avatar thumbnail could not be decoded: {error}"))
     })?;
+    write_avatar_thumbnail_image(image, target, size)
+}
+
+fn write_avatar_thumbnail_image(
+    image: image::DynamicImage,
+    target: &Path,
+    size: u32,
+) -> AppResult<()> {
     let temp = avatar_thumbnail_temp_path(target);
     image
         .thumbnail(size, size)
@@ -316,6 +338,66 @@ fn replace_avatar_thumbnail_file(temp: &Path, target: &Path) -> std::io::Result<
         }
         Err(error) => Err(error),
     }
+}
+
+fn avatar_thumbnail_path_for_inline_source(
+    state: &AppState,
+    source_url: &str,
+    size: u32,
+) -> AppResult<PathBuf> {
+    if !AVATAR_THUMBNAIL_SIZES.contains(&size) {
+        return Err(AppError::invalid_input("Unsupported avatar thumbnail size"));
+    }
+    let source_url = inline_avatar_data_url(source_url).ok_or_else(|| {
+        AppError::invalid_input("Avatar thumbnail source must be inline image data")
+    })?;
+    let (mime, bytes) = decode_image_payload(source_url, "avatarPath")?;
+    if !is_resizable_avatar_mime(&mime) {
+        return Err(AppError::invalid_input(
+            "Avatar thumbnail source uses an unsupported image type",
+        ));
+    }
+    if bytes.len() > MAX_INLINE_AVATAR_THUMBNAIL_BYTES {
+        return Err(AppError::invalid_input(
+            "Avatar thumbnail source is too large",
+        ));
+    }
+
+    let hash = inline_avatar_thumbnail_hash(source_url);
+    let target = state
+        .data_dir
+        .join(".avatar-thumbnails")
+        .join(size.to_string())
+        .join("inline")
+        .join(format!("{hash}.thumb.png"));
+    if target.is_file() {
+        return Ok(target);
+    }
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let image = image::load_from_memory(&bytes).map_err(|error| {
+        AppError::invalid_input(format!("Avatar thumbnail could not be decoded: {error}"))
+    })?;
+    write_avatar_thumbnail_image(image, &target, size)?;
+    Ok(target)
+}
+
+fn inline_avatar_data_url(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.to_ascii_lowercase().starts_with("data:image/") {
+        return Some(trimmed);
+    }
+    let (_, rest) = trimmed.split_once("://")?;
+    if rest.to_ascii_lowercase().starts_with("data:image/") {
+        return Some(rest);
+    }
+    None
+}
+
+fn inline_avatar_thumbnail_hash(source_url: &str) -> String {
+    let digest = Sha256::digest(source_url.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 fn avatar_source_path(
@@ -370,6 +452,13 @@ fn is_resizable_avatar_file(path: &Path) -> bool {
     )
 }
 
+fn is_resizable_avatar_mime(mime: &str) -> bool {
+    matches!(
+        mime.to_ascii_lowercase().as_str(),
+        "image/png" | "image/jpeg" | "image/jpg" | "image/webp" | "image/gif"
+    )
+}
+
 fn avatar_thumbnail_is_fresh(source: &Path, target: &Path) -> AppResult<bool> {
     let source_modified = fs::metadata(source)?.modified()?;
     let Ok(target_modified) = fs::metadata(target).and_then(|metadata| metadata.modified()) else {
@@ -404,6 +493,7 @@ pub(crate) fn update_npc_avatar(state: &AppState, chat_id: &str, body: Value) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn test_state(label: &str) -> AppState {
@@ -492,6 +582,7 @@ mod tests {
             &state,
             Some("large.png"),
             Some(&avatar_path.to_string_lossy()),
+            None,
             Some(128),
         )
         .expect("thumbnail should be generated");
@@ -527,6 +618,7 @@ mod tests {
             &state,
             Some("same-name.png"),
             Some(&png_path.to_string_lossy()),
+            None,
             Some(128),
         )
         .expect("png thumbnail should be generated");
@@ -534,6 +626,7 @@ mod tests {
             &state,
             Some("same-name.jpg"),
             Some(&jpg_path.to_string_lossy()),
+            None,
             Some(128),
         )
         .expect("jpg thumbnail should be generated");
@@ -581,6 +674,7 @@ mod tests {
             &state,
             Some("animated.gif"),
             Some(&avatar_path.to_string_lossy()),
+            None,
             Some(128),
         )
         .expect("gif thumbnail should be generated");
@@ -604,10 +698,72 @@ mod tests {
         let image = image::RgbaImage::from_pixel(1, 1, image::Rgba([0, 0, 0, 255]));
         image.save(&outside).expect("outside fixture should write");
 
-        let error =
-            avatar_thumbnail_file_path(&state, None, Some(&outside.to_string_lossy()), Some(128))
-                .expect_err("outside source should be rejected");
+        let error = avatar_thumbnail_file_path(
+            &state,
+            None,
+            Some(&outside.to_string_lossy()),
+            None,
+            Some(128),
+        )
+        .expect_err("outside source should be rejected");
 
         assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn avatar_thumbnail_file_path_resizes_inline_data_url_avatar() {
+        let state = test_state("thumbnail-inline");
+        let image = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            320,
+            240,
+            image::Rgba([0, 255, 0, 255]),
+        ));
+        let mut buffer = Cursor::new(Vec::new());
+        image
+            .write_to(&mut buffer, ImageFormat::Png)
+            .expect("inline fixture should encode");
+        let data_url = format!(
+            "data:image/png;base64,{}",
+            general_purpose::STANDARD.encode(buffer.into_inner())
+        );
+
+        let response = avatar_thumbnail_file_path(&state, None, None, Some(&data_url), Some(128))
+            .expect("inline thumbnail should be generated");
+        let thumbnail = PathBuf::from(response["path"].as_str().expect("path should be returned"));
+
+        assert!(thumbnail.starts_with(state.data_dir.join(".avatar-thumbnails/128/inline")));
+        assert!(thumbnail.is_file());
+        assert_eq!(
+            image::image_dimensions(&thumbnail).expect("thumbnail should decode"),
+            (128, 96)
+        );
+    }
+
+    #[test]
+    fn avatar_thumbnail_file_path_accepts_scheme_wrapped_inline_data_url_avatar() {
+        let state = test_state("thumbnail-wrapped-inline");
+        let image = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            240,
+            320,
+            image::Rgba([0, 0, 255, 255]),
+        ));
+        let mut buffer = Cursor::new(Vec::new());
+        image
+            .write_to(&mut buffer, ImageFormat::Png)
+            .expect("inline fixture should encode");
+        let data_url = format!(
+            "asset://data:image/png;base64,{}",
+            general_purpose::STANDARD.encode(buffer.into_inner())
+        );
+
+        let response = avatar_thumbnail_file_path(&state, None, None, Some(&data_url), Some(128))
+            .expect("wrapped inline thumbnail should be generated");
+        let thumbnail = PathBuf::from(response["path"].as_str().expect("path should be returned"));
+
+        assert!(thumbnail.starts_with(state.data_dir.join(".avatar-thumbnails/128/inline")));
+        assert_eq!(
+            image::image_dimensions(&thumbnail).expect("thumbnail should decode"),
+            (96, 128)
+        );
     }
 }

--- a/src-tauri/src/commands/storage/commands/media.rs
+++ b/src-tauri/src/commands/storage/commands/media.rs
@@ -210,9 +210,16 @@ pub fn avatar_thumbnail_file_path(
     state: State<'_, AppState>,
     filename: Option<String>,
     absolute_path: Option<String>,
+    source_url: Option<String>,
     size: Option<u32>,
 ) -> Result<Value, AppError> {
-    avatars::avatar_thumbnail_file_path(&state, filename.as_deref(), absolute_path.as_deref(), size)
+    avatars::avatar_thumbnail_file_path(
+        &state,
+        filename.as_deref(),
+        absolute_path.as_deref(),
+        source_url.as_deref(),
+        size,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -695,6 +695,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             state,
             optional_string(&args, "filename").as_deref(),
             optional_string(&args, "absolutePath").as_deref(),
+            optional_string(&args, "sourceUrl").as_deref(),
             optional_u32(&args, "size"),
         ),
         "character_restore_version" => characters::restore_character_version(

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -191,12 +191,13 @@ async fn managed_asset(
         }
     });
     let mut response = Body::from_stream(ReceiverStream::new(rx)).into_response();
-    apply_managed_asset_headers(response.headers_mut(), &path, &metadata);
+    apply_managed_asset_headers(response.headers_mut(), &kind, &path, &metadata);
     Ok(response)
 }
 
 fn apply_managed_asset_headers(
     headers: &mut HeaderMap,
+    kind: &str,
     path: &FsPath,
     metadata: &std::fs::Metadata,
 ) {
@@ -206,10 +207,17 @@ fn apply_managed_asset_headers(
     );
     headers.insert(
         header::CACHE_CONTROL,
-        HeaderValue::from_static("public, max-age=86400"),
+        HeaderValue::from_static(cache_control_for_managed_asset(kind)),
     );
-    if let Some(etag) = asset_etag(&metadata) {
+    if let Some(etag) = asset_etag(metadata) {
         headers.insert(header::ETAG, etag);
+    }
+}
+
+fn cache_control_for_managed_asset(kind: &str) -> &'static str {
+    match kind {
+        "avatar" | "avatar-thumbnail" => "no-cache",
+        _ => "public, max-age=86400",
     }
 }
 
@@ -1388,7 +1396,7 @@ mod tests {
         let metadata = std::fs::metadata(&asset_path).expect("asset metadata should load");
 
         let mut headers = HeaderMap::new();
-        apply_managed_asset_headers(&mut headers, &asset_path, &metadata);
+        apply_managed_asset_headers(&mut headers, "avatar", &asset_path, &metadata);
 
         assert_eq!(
             headers
@@ -1400,11 +1408,20 @@ mod tests {
             headers
                 .get(header::CACHE_CONTROL)
                 .and_then(|value| value.to_str().ok()),
-            Some("public, max-age=86400")
+            Some("no-cache")
         );
         assert!(
             headers.get(header::ETAG).is_some(),
             "managed assets should expose validation metadata"
+        );
+
+        let mut gallery_headers = HeaderMap::new();
+        apply_managed_asset_headers(&mut gallery_headers, "gallery", &asset_path, &metadata);
+        assert_eq!(
+            gallery_headers
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("public, max-age=86400")
         );
     }
 

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -171,6 +171,7 @@ async fn managed_asset(
             ErrorKind::NotFound => AppError::not_found("Managed asset was not found"),
             _ => AppError::from(error),
         })?;
+    let metadata = file.metadata().await.map_err(AppError::from)?;
     let (tx, rx) = mpsc::channel::<Result<Vec<u8>, std::io::Error>>(2);
     tokio::spawn(async move {
         let mut buffer = vec![0; 64 * 1024];
@@ -189,11 +190,37 @@ async fn managed_asset(
             }
         }
     });
-    Ok((
-        [(header::CONTENT_TYPE, content_type_for_path(&path))],
-        Body::from_stream(ReceiverStream::new(rx)),
-    )
-        .into_response())
+    let mut response = Body::from_stream(ReceiverStream::new(rx)).into_response();
+    apply_managed_asset_headers(response.headers_mut(), &path, &metadata);
+    Ok(response)
+}
+
+fn apply_managed_asset_headers(
+    headers: &mut HeaderMap,
+    path: &FsPath,
+    metadata: &std::fs::Metadata,
+) {
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(content_type_for_path(path)),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=86400"),
+    );
+    if let Some(etag) = asset_etag(&metadata) {
+        headers.insert(header::ETAG, etag);
+    }
+}
+
+fn asset_etag(metadata: &std::fs::Metadata) -> Option<HeaderValue> {
+    let modified = metadata
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_nanos();
+    HeaderValue::from_str(&format!("\"{:x}-{modified:x}\"", metadata.len())).ok()
 }
 
 fn managed_asset_path(state: &AppState, kind: &str, path: &str) -> Result<PathBuf, AppError> {
@@ -1349,6 +1376,36 @@ mod tests {
                 "{request_path} should be rejected"
             );
         }
+    }
+
+    #[test]
+    fn managed_asset_headers_include_cache_and_validation_metadata() {
+        let state = test_state("managed-asset-headers");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let asset_path = avatar_dir.join("hero.png");
+        std::fs::write(&asset_path, b"avatar").expect("asset should be written");
+        let metadata = std::fs::metadata(&asset_path).expect("asset metadata should load");
+
+        let mut headers = HeaderMap::new();
+        apply_managed_asset_headers(&mut headers, &asset_path, &metadata);
+
+        assert_eq!(
+            headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("image/png")
+        );
+        assert_eq!(
+            headers
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("public, max-age=86400")
+        );
+        assert!(
+            headers.get(header::ETAG).is_some(),
+            "managed assets should expose validation metadata"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -312,8 +312,37 @@ fn avatar_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> 
 
 fn avatar_thumbnail_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {
     let (size, avatar_path) = avatar_thumbnail_request(path)?;
+    if let Some(filename) = avatar_path.strip_prefix("inline/") {
+        return inline_avatar_thumbnail_asset_path(state, size, filename);
+    }
     let source = avatar_asset_path(state, avatar_path)?;
     avatars::avatar_thumbnail_path_for_source(state, &source, size)
+}
+
+fn inline_avatar_thumbnail_asset_path(
+    state: &AppState,
+    size: u32,
+    filename: &str,
+) -> Result<PathBuf, AppError> {
+    if !matches!(size, 64 | 96 | 128 | 256) {
+        return Err(AppError::invalid_input("Unsupported avatar thumbnail size"));
+    }
+    if !is_inline_avatar_thumbnail_filename(filename) {
+        return Err(AppError::not_found("Avatar thumbnail asset was not found"));
+    }
+    Ok(state
+        .data_dir
+        .join(".avatar-thumbnails")
+        .join(size.to_string())
+        .join("inline")
+        .join(filename))
+}
+
+fn is_inline_avatar_thumbnail_filename(filename: &str) -> bool {
+    let Some(hash) = filename.strip_suffix(".thumb.png") else {
+        return false;
+    };
+    hash.len() == 64 && hash.as_bytes().iter().all(u8::is_ascii_hexdigit)
 }
 
 fn avatar_thumbnail_request(path: &str) -> Result<(u32, &str), AppError> {
@@ -1283,6 +1312,42 @@ mod tests {
                 general_purpose::STANDARD.encode(format!("{user}:{pass}"))
             )
             .into_bytes(),
+        }
+    }
+
+    #[test]
+    fn inline_avatar_thumbnail_asset_path_serves_cached_thumbnail() {
+        let state = test_state("inline-thumbnail-asset");
+        let filename = format!("{}.thumb.png", "a".repeat(64));
+
+        let path = avatar_thumbnail_asset_path(&state, &format!("128/inline/{filename}"))
+            .expect("inline thumbnail route should map to cache file");
+
+        assert_eq!(
+            path,
+            state
+                .data_dir
+                .join(".avatar-thumbnails")
+                .join("128")
+                .join("inline")
+                .join(filename)
+        );
+    }
+
+    #[test]
+    fn inline_avatar_thumbnail_asset_path_rejects_non_cache_names() {
+        let state = test_state("inline-thumbnail-asset-invalid");
+
+        for request_path in [
+            "128/inline/../avatar.thumb.png",
+            "128/inline/not-a-hash.thumb.png",
+            "128/inline/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png",
+            "512/inline/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.thumb.png",
+        ] {
+            assert!(
+                avatar_thumbnail_asset_path(&state, request_path).is_err(),
+                "{request_path} should be rejected"
+            );
         }
     }
 

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -48,24 +48,25 @@ export function CharacterAvatarImage({
   thumbnailSize?: 64 | 96 | 128 | 256;
 }) {
   const effectiveThumbnailSize =
-    thumbnailSize && canGenerateAvatarThumbnail(avatarFilename, avatarFilePath) ? thumbnailSize : undefined;
+    thumbnailSize && canGenerateAvatarThumbnail(avatarFilename, avatarFilePath, src) ? thumbnailSize : undefined;
   const managedInitialSrc = effectiveThumbnailSize
-    ? avatarThumbnailFileUrlFromPath(avatarFilename, avatarFilePath, effectiveThumbnailSize)
+    ? avatarThumbnailFileUrlFromPath(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)
     : avatarFileUrlFromPath(avatarFilename, avatarFilePath);
   const hasManagedAvatarInput = Boolean(avatarFilename || avatarFilePath);
+  const hasResolvableAvatarInput = hasManagedAvatarInput || Boolean(effectiveThumbnailSize && src);
   const initialSrc = managedInitialSrc ?? (effectiveThumbnailSize && hasManagedAvatarInput ? null : src) ?? null;
   const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
 
   useEffect(() => {
     let cancelled = false;
     setAsyncSrc(initialSrc);
-    if (!hasManagedAvatarInput || (!effectiveThumbnailSize && managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
+    if (!hasResolvableAvatarInput || (!effectiveThumbnailSize && managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
       return () => {
         cancelled = true;
       };
     }
     const resolveUrl = effectiveThumbnailSize
-      ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize)
+      ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)
       : resolveAvatarFileUrl(avatarFilename, avatarFilePath);
     resolveUrl
       .then((url) => {
@@ -77,7 +78,7 @@ export function CharacterAvatarImage({
     return () => {
       cancelled = true;
     };
-  }, [avatarFilename, avatarFilePath, effectiveThumbnailSize, hasManagedAvatarInput, initialSrc, managedInitialSrc, src]);
+  }, [avatarFilename, avatarFilePath, effectiveThumbnailSize, hasResolvableAvatarInput, initialSrc, managedInitialSrc, src]);
 
   const resolvedSrc = asyncSrc ?? initialSrc;
   if (!resolvedSrc) return null;

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../../../shared/api/local-file-api";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
 import { getCharacterAvatarLoadingMode } from "../lib/character-avatar-loading";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function resolveAvatarCrop(crop: unknown): AvatarCropValue | null {
   if (!crop) return null;
@@ -30,6 +30,64 @@ function isLikelyFilesystemPath(value: string): boolean {
   );
 }
 
+function waitForImageResolveSlot(element: HTMLElement, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  const waitForViewport = new Promise<void>((resolve) => {
+    if (typeof IntersectionObserver !== "function") {
+      resolve();
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          observer.disconnect();
+          resolve();
+        }
+      },
+      { rootMargin: "240px" },
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+        resolve();
+      },
+      { once: true },
+    );
+    observer.observe(element);
+  });
+
+  return waitForViewport.then(
+    () =>
+      new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        const idleWindow = window as Window & {
+          requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+          cancelIdleCallback?: (handle: number) => void;
+        };
+        const requestIdle = idleWindow.requestIdleCallback;
+        let handle: number | null = null;
+        const finish = () => {
+          if (handle !== null && typeof idleWindow.cancelIdleCallback === "function") {
+            idleWindow.cancelIdleCallback(handle);
+          } else if (handle !== null) {
+            window.clearTimeout(handle);
+          }
+          resolve();
+        };
+        signal.addEventListener("abort", finish, { once: true });
+        if (typeof requestIdle === "function") {
+          handle = requestIdle(finish, { timeout: 600 });
+          return;
+        }
+        handle = window.setTimeout(finish, 80);
+      }),
+  );
+}
+
 export function CharacterAvatarImage({
   src,
   avatarFilePath,
@@ -47,6 +105,7 @@ export function CharacterAvatarImage({
   className?: string;
   thumbnailSize?: 64 | 96 | 128 | 256;
 }) {
+  const imageRef = useRef<HTMLImageElement | null>(null);
   const effectiveThumbnailSize =
     thumbnailSize && canGenerateAvatarThumbnail(avatarFilename, avatarFilePath, src) ? thumbnailSize : undefined;
   const managedInitialSrc = effectiveThumbnailSize
@@ -54,21 +113,29 @@ export function CharacterAvatarImage({
     : avatarFileUrlFromPath(avatarFilename, avatarFilePath);
   const hasManagedAvatarInput = Boolean(avatarFilename || avatarFilePath);
   const hasResolvableAvatarInput = hasManagedAvatarInput || Boolean(effectiveThumbnailSize && src);
-  const initialSrc = managedInitialSrc ?? (effectiveThumbnailSize && hasManagedAvatarInput ? null : src) ?? null;
+  const initialSrc = managedInitialSrc ?? src ?? null;
   const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
 
   useEffect(() => {
     let cancelled = false;
+    const abort = new AbortController();
     setAsyncSrc(initialSrc);
     if (!hasResolvableAvatarInput || (!effectiveThumbnailSize && managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
       return () => {
         cancelled = true;
+        abort.abort();
       };
     }
-    const resolveUrl = effectiveThumbnailSize
-      ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)
-      : resolveAvatarFileUrl(avatarFilename, avatarFilePath);
-    resolveUrl
+    const resolveUrl = async () => {
+      if (effectiveThumbnailSize && imageRef.current) {
+        await waitForImageResolveSlot(imageRef.current, abort.signal);
+      }
+      if (cancelled) return null;
+      return effectiveThumbnailSize
+        ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)
+        : resolveAvatarFileUrl(avatarFilename, avatarFilePath);
+    };
+    resolveUrl()
       .then((url) => {
         if (!cancelled) setAsyncSrc(url ?? src ?? null);
       })
@@ -77,6 +144,7 @@ export function CharacterAvatarImage({
       });
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [avatarFilename, avatarFilePath, effectiveThumbnailSize, hasResolvableAvatarInput, initialSrc, managedInitialSrc, src]);
 
@@ -85,6 +153,7 @@ export function CharacterAvatarImage({
 
   return (
     <img
+      ref={imageRef}
       src={resolvedSrc}
       alt={alt}
       loading={getCharacterAvatarLoadingMode(resolvedSrc)}

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -88,6 +88,7 @@ import {
 } from "../lib/message-attachments";
 import { resolvePromptSnapshotFromExtra } from "../lib/prompt-snapshot";
 import { ResolvedAvatarImage } from "./ResolvedAvatarImage";
+import { resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
@@ -1461,7 +1462,17 @@ export const ChatMessage = memo(function ChatMessage({
   const avatarFilename = !isUser && !expressionAvatarUrl ? (charInfo?.avatarFilename ?? null) : null;
   const [resolvedAvatarUrl, setResolvedAvatarUrl] = useState<string | null>(null);
   useEffect(() => {
+    let cancelled = false;
     setResolvedAvatarUrl(null);
+    if (!avatarFilePath && !avatarFilename) return undefined;
+    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
+      .then((url) => {
+        if (!cancelled) setResolvedAvatarUrl(url);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [avatarFilePath, avatarFilename, avatarUrl]);
   const avatarLightboxUrl = resolvedAvatarUrl ?? avatarUrl;
   const handleResolvedAvatarSrc = useCallback((src: string | null) => {
@@ -1543,7 +1554,22 @@ export const ChatMessage = memo(function ChatMessage({
   const mergedAvatarTailRefs = useRef<(HTMLImageElement | null)[]>([]);
   const resolvedMergedAvatarUrlsRef = useRef(new Map<string, string>());
   useEffect(() => {
+    let cancelled = false;
     resolvedMergedAvatarUrlsRef.current.clear();
+    for (const avatar of mergedAvatars) {
+      if (!avatar.avatarFilePath && !avatar.avatarFilename) {
+        resolvedMergedAvatarUrlsRef.current.set(avatar.key, avatar.url);
+        continue;
+      }
+      resolveAvatarFileUrl(avatar.avatarFilename, avatar.avatarFilePath)
+        .then((url) => {
+          if (!cancelled && url) resolvedMergedAvatarUrlsRef.current.set(avatar.key, url);
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
   }, [mergedAvatars]);
   const rememberMergedAvatarSrc = useCallback((key: string, src: string | null) => {
     if (src) {
@@ -1711,6 +1737,7 @@ export const ChatMessage = memo(function ChatMessage({
             aria-hidden="true"
             loading="lazy"
             decoding="async"
+            thumbnailSize={256}
             className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
             style={{ opacity: i === 0 ? 1 : 0, ...panelMergedAvatarCropStyle(avatar) }}
             onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
@@ -1727,6 +1754,7 @@ export const ChatMessage = memo(function ChatMessage({
           aria-hidden="true"
           loading="lazy"
           decoding="async"
+          thumbnailSize={256}
           className="rpg-avatar-panel-tail-image absolute inset-0 h-full w-full object-cover object-top"
           style={panelAvatarCropStyle}
           onResolvedSrc={handleResolvedAvatarSrc}
@@ -1952,6 +1980,7 @@ export const ChatMessage = memo(function ChatMessage({
                       alt="Group"
                       loading="lazy"
                       decoding="async"
+                      thumbnailSize={128}
                       className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
                       style={{ opacity: i === 0 ? 1 : 0, ...compactMergedAvatarCropStyle(avatar) }}
                       onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
@@ -1976,6 +2005,7 @@ export const ChatMessage = memo(function ChatMessage({
                       alt={displayName}
                       loading="lazy"
                       decoding="async"
+                      thumbnailSize={128}
                       className="h-full w-full object-cover"
                       style={compactAvatarCropStyle}
                       onResolvedSrc={handleResolvedAvatarSrc}
@@ -2100,6 +2130,7 @@ export const ChatMessage = memo(function ChatMessage({
                               alt="Group"
                               loading="lazy"
                               decoding="async"
+                              thumbnailSize={256}
                               className="absolute inset-0 h-full w-full object-cover object-top transition-opacity duration-700"
                               style={{ opacity: i === 0 ? 1 : 0, ...panelMergedAvatarCropStyle(avatar) }}
                               onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
@@ -2123,6 +2154,7 @@ export const ChatMessage = memo(function ChatMessage({
                             alt={displayName}
                             loading="lazy"
                             decoding="async"
+                            thumbnailSize={256}
                             className="h-full w-full object-cover object-top"
                             style={panelAvatarCropStyle}
                             onResolvedSrc={handleResolvedAvatarSrc}
@@ -2498,6 +2530,7 @@ export const ChatMessage = memo(function ChatMessage({
                     alt="Group"
                     loading="lazy"
                     decoding="async"
+                    thumbnailSize={64}
                     className="absolute inset-0 h-8 w-8 object-cover transition-opacity duration-700"
                     style={{ opacity: i === 0 ? 1 : 0, ...getAvatarCropStyle(avatar.crop) }}
                     onResolvedSrc={(src) => rememberMergedAvatarSrc(avatar.key, src)}
@@ -2518,6 +2551,7 @@ export const ChatMessage = memo(function ChatMessage({
                   alt={displayName}
                   loading="lazy"
                   decoding="async"
+                  thumbnailSize={64}
                   className="h-full w-full object-cover"
                   style={avatarCropStyle}
                   onResolvedSrc={handleResolvedAvatarSrc}

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
@@ -1,5 +1,11 @@
 import { forwardRef, useEffect, useMemo, useState, type CSSProperties } from "react";
-import { avatarFileUrlFromPath, resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
+import {
+  avatarFileUrlFromPath,
+  avatarThumbnailFileUrlFromPath,
+  canGenerateAvatarThumbnail,
+  resolveAvatarFileUrl,
+  resolveAvatarThumbnailFileUrl,
+} from "../../../../../shared/api/local-file-api";
 
 const RESOLVED_AVATAR_SRC_CACHE_LIMIT = 128;
 const resolvedAvatarSrcCache = new Map<string, string>();
@@ -45,6 +51,7 @@ export const ResolvedAvatarImage = forwardRef<
     "aria-hidden"?: boolean | "true" | "false";
     className?: string;
     style?: CSSProperties;
+    thumbnailSize?: 64 | 96 | 128 | 256;
     onResolvedSrc?: (src: string | null) => void;
   }
 >(function ResolvedAvatarImage(
@@ -59,23 +66,34 @@ export const ResolvedAvatarImage = forwardRef<
     "aria-hidden": ariaHidden,
     className,
     style,
+    thumbnailSize,
     onResolvedSrc,
   },
   ref,
 ) {
   const hasManagedAvatar = hasText(avatarFilename) || hasText(avatarFilePath);
+  const effectiveThumbnailSize =
+    thumbnailSize && canGenerateAvatarThumbnail(avatarFilename, avatarFilePath, src) ? thumbnailSize : undefined;
+  const hasResolvableAvatar = hasManagedAvatar || Boolean(effectiveThumbnailSize);
   const fallbackSrc = useMemo(() => {
     if (!src) return null;
     return hasManagedAvatar && isLikelyFilesystemPath(src) ? null : src;
   }, [hasManagedAvatar, src]);
   const immediateSrc = useMemo(() => {
     if (!hasManagedAvatar) return fallbackSrc;
-    const syncUrl = avatarFileUrlFromPath(avatarFilename, avatarFilePath);
+    const syncUrl = effectiveThumbnailSize
+      ? avatarThumbnailFileUrlFromPath(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)
+      : avatarFileUrlFromPath(avatarFilename, avatarFilePath);
     if (!syncUrl || isLikelyFilesystemPath(syncUrl)) return fallbackSrc;
     return syncUrl;
-  }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar]);
-  const resolutionKey = JSON.stringify([src ?? "", avatarFilename ?? "", avatarFilePath ?? ""]);
-  const cachedResolvedSrc = hasManagedAvatar ? readCachedResolvedAvatarSrc(resolutionKey) : null;
+  }, [avatarFilePath, avatarFilename, effectiveThumbnailSize, fallbackSrc, hasManagedAvatar, src]);
+  const resolutionKey = JSON.stringify([
+    src ?? "",
+    avatarFilename ?? "",
+    avatarFilePath ?? "",
+    effectiveThumbnailSize ?? "",
+  ]);
+  const cachedResolvedSrc = hasResolvableAvatar ? readCachedResolvedAvatarSrc(resolutionKey) : null;
   const [resolvedState, setResolvedState] = useState<{ key: string; src: string | null }>({
     key: resolutionKey,
     src: cachedResolvedSrc ?? immediateSrc,
@@ -83,9 +101,9 @@ export const ResolvedAvatarImage = forwardRef<
 
   useEffect(() => {
     let cancelled = false;
-    if (!hasManagedAvatar) {
+    if (!hasResolvableAvatar) {
       setResolvedState({ key: resolutionKey, src: fallbackSrc });
-      onResolvedSrc?.(fallbackSrc);
+      if (!effectiveThumbnailSize) onResolvedSrc?.(fallbackSrc);
       return () => {
         cancelled = true;
       };
@@ -94,26 +112,39 @@ export const ResolvedAvatarImage = forwardRef<
     const cachedSrc = readCachedResolvedAvatarSrc(resolutionKey);
     const nextInitialSrc = cachedSrc ?? immediateSrc;
     setResolvedState({ key: resolutionKey, src: nextInitialSrc });
-    if (nextInitialSrc) onResolvedSrc?.(nextInitialSrc);
-    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
+    if (nextInitialSrc && !effectiveThumbnailSize) onResolvedSrc?.(nextInitialSrc);
+    const resolveSrc = effectiveThumbnailSize
+      ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)
+      : resolveAvatarFileUrl(avatarFilename, avatarFilePath);
+    resolveSrc
       .then((url) => {
         if (cancelled) return;
         const next = url ?? fallbackSrc;
         rememberResolvedAvatarSrc(resolutionKey, next);
         setResolvedState({ key: resolutionKey, src: next });
-        onResolvedSrc?.(next);
+        if (!effectiveThumbnailSize) onResolvedSrc?.(next);
       })
       .catch(() => {
         if (cancelled) return;
         rememberResolvedAvatarSrc(resolutionKey, null);
         setResolvedState({ key: resolutionKey, src: fallbackSrc });
-        onResolvedSrc?.(fallbackSrc);
+        if (!effectiveThumbnailSize) onResolvedSrc?.(fallbackSrc);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [avatarFilePath, avatarFilename, fallbackSrc, hasManagedAvatar, immediateSrc, onResolvedSrc, resolutionKey]);
+  }, [
+    avatarFilePath,
+    avatarFilename,
+    effectiveThumbnailSize,
+    fallbackSrc,
+    hasResolvableAvatar,
+    immediateSrc,
+    onResolvedSrc,
+    resolutionKey,
+    src,
+  ]);
 
   const imageSrc =
     resolvedState.key === resolutionKey

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -479,7 +479,7 @@ export async function resolveAvatarThumbnailFileUrl(
     if (pendingAvatarThumbnailResolutions.get(cacheKey) === promise) {
       pendingAvatarThumbnailResolutions.delete(cacheKey);
     }
-  });
+  }).catch(() => {});
   return promise;
 }
 

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -239,10 +239,37 @@ function pathExtension(value: string | null | undefined): string | null {
   return extension && extension !== filename?.toLowerCase() ? extension : null;
 }
 
-export function canGenerateAvatarThumbnail(filename: string | null | undefined, absolutePath?: string | null): boolean {
+function inlineImageDataUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (/^data:image\/(?:png|jpe?g|webp|gif);base64,/i.test(trimmed)) return trimmed;
+  const wrapped = trimmed.match(/^[a-z][a-z0-9+.-]*:\/\/(data:image\/(?:png|jpe?g|webp|gif);base64,.*)$/i);
+  return wrapped?.[1] ?? null;
+}
+
+function inlineAvatarThumbnailRemotePath(path: string | null | undefined, size: number): string | null {
+  const filename = path
+    ?.replace(/\\/g, "/")
+    .split("/")
+    .filter(Boolean)
+    .pop();
+  if (!filename || !/^[a-f0-9]{64}\.thumb\.png$/i.test(filename)) return null;
+  return `${size}/inline/${filename}`;
+}
+
+export function canGenerateAvatarThumbnail(
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+  sourceUrl?: string | null,
+): boolean {
   const extension = pathExtension(filename) ?? pathExtension(absolutePath);
   return (
-    extension === "png" || extension === "jpg" || extension === "jpeg" || extension === "webp" || extension === "gif"
+    extension === "png" ||
+    extension === "jpg" ||
+    extension === "jpeg" ||
+    extension === "webp" ||
+    extension === "gif" ||
+    !!inlineImageDataUrl(sourceUrl)
   );
 }
 
@@ -278,9 +305,11 @@ export function avatarThumbnailFileUrlFromPath(
   filename: string | null | undefined,
   absolutePath?: string | null,
   size = 128,
+  sourceUrl?: string | null,
 ): string | null {
   const path = avatarRemoteManagedPath(filename, absolutePath);
   const remoteUrl = remoteManagedAssetUrl("avatar-thumbnail", path ? `${size}/${path}` : null);
+  if (!remoteUrl && inlineImageDataUrl(sourceUrl)) return null;
   return remoteUrl;
 }
 
@@ -367,6 +396,7 @@ export async function resolveAvatarThumbnailFileUrl(
   filename: string | null | undefined,
   absolutePath?: string | null,
   size = 128,
+  sourceUrl?: string | null,
 ): Promise<string | null> {
   const remotePath = avatarRemoteManagedPath(filename, absolutePath);
   const remoteUrl = await remoteManagedAssetResolvableUrl(
@@ -374,8 +404,21 @@ export async function resolveAvatarThumbnailFileUrl(
     remotePath ? `${size}/${remotePath}` : null,
   );
   if (remoteUrl) return remoteUrl;
-  if (!filename && !absolutePath) return null;
-  const response = await invokeTauri<PathResponse>("avatar_thumbnail_file_path", { filename, absolutePath, size });
+  const normalizedSourceUrl = inlineImageDataUrl(sourceUrl);
+  if (!filename && !absolutePath && !normalizedSourceUrl) return null;
+  const response = await invokeTauri<PathResponse>("avatar_thumbnail_file_path", {
+    filename,
+    absolutePath,
+    sourceUrl: normalizedSourceUrl,
+    size,
+  });
+  if (normalizedSourceUrl) {
+    const inlineRemoteUrl = await remoteManagedAssetResolvableUrl(
+      "avatar-thumbnail",
+      inlineAvatarThumbnailRemotePath(response.path, size),
+    );
+    if (inlineRemoteUrl) return inlineRemoteUrl;
+  }
   return filePathToAssetUrl(response.path ?? "");
 }
 

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -18,6 +18,10 @@ type RemoteAssetObjectUrlEntry = {
 };
 
 const remoteAssetObjectUrls = new Map<string, RemoteAssetObjectUrlEntry>();
+const pendingAvatarThumbnailResolutions = new Map<string, Promise<string | null>>();
+let activeAvatarThumbnailResolutions = 0;
+const queuedAvatarThumbnailResolutions: Array<() => void> = [];
+const MAX_ACTIVE_AVATAR_THUMBNAIL_RESOLUTIONS = 2;
 
 function hasScheme(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:/i.test(value);
@@ -257,6 +261,51 @@ function inlineAvatarThumbnailRemotePath(path: string | null | undefined, size: 
   return `${size}/inline/${filename}`;
 }
 
+function hashCacheInput(value: string | null | undefined): string {
+  const input = value ?? "";
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${input.length}:${(hash >>> 0).toString(16)}`;
+}
+
+function avatarThumbnailResolutionCacheKey(
+  filename: string | null | undefined,
+  absolutePath: string | null | undefined,
+  size: number,
+  sourceUrl: string | null,
+): string {
+  const target = remoteRuntimeTarget();
+  return [
+    target ? `${target.baseUrl}\0${target.authorization ?? ""}` : "embedded",
+    filename?.trim() ?? "",
+    absolutePath?.trim() ?? "",
+    String(size),
+    hashCacheInput(sourceUrl),
+  ].join("\0");
+}
+
+function scheduleAvatarThumbnailResolution<T>(task: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const run = () => {
+      activeAvatarThumbnailResolutions += 1;
+      task()
+        .then(resolve, reject)
+        .finally(() => {
+          activeAvatarThumbnailResolutions -= 1;
+          queuedAvatarThumbnailResolutions.shift()?.();
+        });
+    };
+    if (activeAvatarThumbnailResolutions < MAX_ACTIVE_AVATAR_THUMBNAIL_RESOLUTIONS) {
+      run();
+      return;
+    }
+    queuedAvatarThumbnailResolutions.push(run);
+  });
+}
+
 export function canGenerateAvatarThumbnail(
   filename: string | null | undefined,
   absolutePath?: string | null,
@@ -398,28 +447,40 @@ export async function resolveAvatarThumbnailFileUrl(
   size = 128,
   sourceUrl?: string | null,
 ): Promise<string | null> {
-  const remotePath = avatarRemoteManagedPath(filename, absolutePath);
-  const remoteUrl = await remoteManagedAssetResolvableUrl(
-    "avatar-thumbnail",
-    remotePath ? `${size}/${remotePath}` : null,
-  );
-  if (remoteUrl) return remoteUrl;
   const normalizedSourceUrl = inlineImageDataUrl(sourceUrl);
-  if (!filename && !absolutePath && !normalizedSourceUrl) return null;
-  const response = await invokeTauri<PathResponse>("avatar_thumbnail_file_path", {
-    filename,
-    absolutePath,
-    sourceUrl: normalizedSourceUrl,
-    size,
-  });
-  if (normalizedSourceUrl) {
-    const inlineRemoteUrl = await remoteManagedAssetResolvableUrl(
+  const cacheKey = avatarThumbnailResolutionCacheKey(filename, absolutePath, size, normalizedSourceUrl);
+  const pending = pendingAvatarThumbnailResolutions.get(cacheKey);
+  if (pending) return pending;
+  const promise = scheduleAvatarThumbnailResolution(async () => {
+    const remotePath = avatarRemoteManagedPath(filename, absolutePath);
+    const remoteUrl = await remoteManagedAssetResolvableUrl(
       "avatar-thumbnail",
-      inlineAvatarThumbnailRemotePath(response.path, size),
+      remotePath ? `${size}/${remotePath}` : null,
     );
-    if (inlineRemoteUrl) return inlineRemoteUrl;
-  }
-  return filePathToAssetUrl(response.path ?? "");
+    if (remoteUrl) return remoteUrl;
+    if (!filename && !absolutePath && !normalizedSourceUrl) return null;
+    const response = await invokeTauri<PathResponse>("avatar_thumbnail_file_path", {
+      filename,
+      absolutePath,
+      sourceUrl: normalizedSourceUrl,
+      size,
+    });
+    if (normalizedSourceUrl) {
+      const inlineRemoteUrl = await remoteManagedAssetResolvableUrl(
+        "avatar-thumbnail",
+        inlineAvatarThumbnailRemotePath(response.path, size),
+      );
+      if (inlineRemoteUrl) return inlineRemoteUrl;
+    }
+    return filePathToAssetUrl(response.path ?? "");
+  });
+  pendingAvatarThumbnailResolutions.set(cacheKey, promise);
+  promise.finally(() => {
+    if (pendingAvatarThumbnailResolutions.get(cacheKey) === promise) {
+      pendingAvatarThumbnailResolutions.delete(cacheKey);
+    }
+  });
+  return promise;
 }
 
 async function resolveLorebookImageFileUrl(filename: string): Promise<string> {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1944 - mostly.

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Fixes slow and oversized avatar/image delivery paths where chat and catalog views could load full managed avatar images for tiny displayed dimensions.
- Restores reliable inline avatar thumbnail serving for remote and embedded runtimes.
- Adds related refactor-branch fixes for gallery managed media, active world info scanning, roleplay narrator style, and game asset background handling.

## What changed

<!-- List the key changes in this PR. -->

- Added managed avatar thumbnail generation and serving, including inline data URL thumbnail support.
- Routed small chat and catalog avatar displays through size-bucketed thumbnail URLs while preserving full-size avatar lightbox behavior.
- Added cache and validation headers for managed HTTP assets.
- Hardened gallery/media managed file handling and remote asset URL resolution paths.
- Included active world info scan, roleplay narrator style, swipe, and game asset background fixes already present on this branch.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

shared API, shared mode UI, Rust storage, remote runtime

Impact areas reviewed:

- Managed avatar storage and thumbnail cache paths.
- Chat message avatar rendering, merged avatars, roleplay avatar panels, and catalog avatar cards.
- Hostable HTTP asset routing and remote runtime asset resolution.
- Gallery managed media and related storage cleanup/restore paths.
- Active world info scan and prompt assembly call sites touched by this branch.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature UI continues to call shared API avatar/file helpers rather than raw Tauri or remote fetch.
- Rust keeps privileged file access, thumbnail generation, and managed asset HTTP serving.
- Engine changes remain React-free and stay within generation/storage capability boundaries.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Shared mode UI: `ChatMessage`, `ResolvedAvatarImage`, chat settings and transcript actions.
- Rust command registration and HTTP dispatch for avatar thumbnail file paths.
- Managed asset HTTP server route.
- Import/storage modules for gallery and background managed media.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- `pnpm typecheck`
- `pnpm check:architecture`
- `cargo test --manifest-path src-tauri/Cargo.toml http_server::tests::managed_asset_headers_include_cache_and_validation_metadata`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is primarily bugfix/internal performance and compatibility work. The branch includes discovery metadata changes from existing commits; no new user-facing feature discovery path is required for the avatar thumbnail/cache fix.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

- Not captured.
