### PR TITLE
Fix Lorebook Keeper focused fact extraction

### DIFF
--- a/src/engine/contracts/constants/agent-prompts.test.ts
+++ b/src/engine/contracts/constants/agent-prompts.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_AGENT_PROMPTS } from "./agent-prompts";
+
+describe("DEFAULT_AGENT_PROMPTS", () => {
+  it("instructs Lorebook Keeper to extract focused facts instead of copying whole messages", () => {
+    const prompt = DEFAULT_AGENT_PROMPTS["lorebook-keeper"];
+
+    expect(prompt).toContain("<assistant_response>");
+    expect(prompt).toMatch(/never copy[^.]+whole source message/i);
+    expect(prompt).toMatch(/not a transcript/i);
+    expect(prompt).toMatch(/content[^.]+concise neutral lore note/i);
+    expect(prompt).toMatch(/each bullet/i);
+  });
+});

--- a/src/engine/contracts/constants/agent-prompts.ts
+++ b/src/engine/contracts/constants/agent-prompts.ts
@@ -223,22 +223,25 @@ Prompt quality rules:
 
   /* ────────────────────────────────────────── */
   "lorebook-keeper": `Analyze the narrative for new lore, character details, locations, or world-building information worth recording for future reference.
+The latest generated message is provided in <assistant_response>. Treat that block as source material to extract from, not as lorebook content to save.
 1. Only create entries for significant, reusable information. Don't record trivial moment-to-moment actions: a character revealing they grew up in a specific city is worth recording; them ordering a drink is not.
 2. Focus on: character backstories, location descriptions, faction politics, magical systems, important NPCs, recurring items, cultural details, and relationship dynamics.
-3. Keep entries concise but comprehensive, enough that someone reading only the lorebook entry would understand the subject.
-4. Keys should include character names, location names, and contextually related terms that would trigger recall.
-5. If nothing noteworthy was established this turn, return: { "updates": [] }
-6. DEDUPLICATION, CRITICAL: Check the <existing_entries> list of existing lorebook entries before creating anything. If an entry with the same or a very similar name already exists, use "update" instead of "create". NEVER create a second entry for a subject that's already covered. Prefer updating and enriching an existing entry over making a new one.
-7. LOCKED ENTRIES: Entries marked as locked CANNOT be modified. Do not emit updates targeting locked entry names. Respect the user's protection.
-8. When updating an existing entry, do NOT rewrite the full entry. Return only the durable additions in "newFacts"; the app will append them to the existing content without erasing old details. Use "content" for creates, or only for an update when the existing entry is empty or malformed.
-9. CHAT SUMMARY AWARENESS: If a <chat_summary> block is provided, it contains information already captured by the summary system. Do NOT create lorebook entries for facts that are only restated from the summary and not newly established in the latest messages. Only record genuinely new lore not already covered by the summary.
+3. Never copy, quote, summarize, or paraphrase the whole source message as a lorebook entry. A saved entry is not a transcript, scene recap, or roleplay paragraph.
+4. For creates, "content" must be a concise neutral lore note: 1-4 short bullet points or 1 compact paragraph about one durable subject. Each bullet should state one reusable fact. If you cannot extract focused facts, return no update.
+5. Keep entries concise but comprehensive, enough that someone reading only the lorebook entry would understand the subject.
+6. Keys should include character names, location names, and contextually related terms that would trigger recall.
+7. If nothing noteworthy was established this turn, return: { "updates": [] }
+8. DEDUPLICATION, CRITICAL: Check the <existing_entries> list of existing lorebook entries before creating anything. If an entry with the same or a very similar name already exists, use "update" instead of "create". NEVER create a second entry for a subject that's already covered. Prefer updating and enriching an existing entry over making a new one.
+9. LOCKED ENTRIES: Entries marked as locked CANNOT be modified. Do not emit updates targeting locked entry names. Respect the user's protection.
+10. When updating an existing entry, do NOT rewrite the full entry. Return only the durable additions in "newFacts"; the app will append them to the existing content without erasing old details. Use "content" for creates, or only for an update when the existing entry is empty or malformed.
+11. CHAT SUMMARY AWARENESS: If a <chat_summary> block is provided, it contains information already captured by the summary system. Do NOT create lorebook entries for facts that are only restated from the summary and not newly established in the latest messages. Only record genuinely new lore not already covered by the summary.
 Output format:
 {
   "updates": [
     {
       "action": "create|update",
       "entryName": "string — name of the entry (must match existing name exactly when updating)",
-      "content": "string — full lore content for creates; for updates, only use this if replacing an empty or malformed entry is truly necessary",
+      "content": "string — concise neutral extracted lore note for creates, never the whole source message; for updates, only use this if replacing an empty or malformed entry is truly necessary",
       "newFacts": ["string — for updates only: atomic new facts to append to the existing entry without rewriting it"],
       "keys": ["string — activation keywords for this entry"],
       "tag": "string — category tag (character, location, item, faction, event, lore)",


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1946

## Why this change

- Lorebook Keeper's default prompt told the model to create "full lore content" but did not clearly say that the generated `<assistant_response>` is source material, not content to save wholesale. Some models responded by proposing whole-message lorebook bodies instead of focused durable facts.

## What changed

- Tightened the built-in Lorebook Keeper prompt so it explicitly extracts from `<assistant_response>`.
- Added guardrails that forbid whole-message transcript/recap entries and define `content` as concise neutral extracted lore.
- Added a focused prompt-contract regression test for the default Lorebook Keeper prompt.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Built-in agent prompt contract.
- Lorebook Keeper output shape consumed by pending lorebook update handling.

Boundary notes:

- Engine-only prompt/default-contract change. No React UI, shared API, storage, Rust, remote-runtime, schema, dependency, or version files changed.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex repro before fix: `pnpm exec vitest run src/engine/contracts/constants/agent-prompts.test.ts` failed because the default Lorebook Keeper prompt did not mention `<assistant_response>` or whole-message-copy guardrails.
- Codex verification after fix: `pnpm exec vitest run src/engine/contracts/constants/agent-prompts.test.ts` passed.
- Codex validation: `pnpm typecheck` passed.
- Codex validation: `pnpm check` passed after rerun with a longer timeout. The first 120s run timed out before completion.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- No manual UI validation needed; this is a default prompt-contract fix with no visible UI surface.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix to an existing built-in agent prompt; no new discoverable product surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a default prompt-contract fix with command-based verification rather than a visible UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for the lorebook-keeper prompt to ensure proper formatting and extraction behavior.

* **Chores**
  * Enhanced lorebook-keeper prompt with improved content extraction rules and deduplication handling to ensure more accurate and consistent information processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->