### PR TITLE
Fix Consistency Editor HTML preservation

### DIFF
--- a/src/engine/agents-runtime/executor/agent-executor.test.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentContext } from "../../contracts/types/agent";
+import type {
+  BaseLLMProvider,
+  ChatCompleteOptions,
+  ChatCompleteResult,
+  ChatMessage,
+} from "../../generation-core/llm/base-provider";
+import { executeAgent, type AgentExecConfig } from "./agent-executor";
+
+class CapturingProvider implements BaseLLMProvider {
+  maxTokensOverrideValue = null;
+  messages: ChatMessage[] = [];
+
+  async chatComplete(messages: ChatMessage[], _options: ChatCompleteOptions): Promise<ChatCompleteResult> {
+    this.messages = messages;
+    return {
+      content: JSON.stringify({
+        editedText: "unchanged",
+        changes: [],
+      }),
+    };
+  }
+}
+
+function createAgentContext(mainResponse: string): AgentContext {
+  return {
+    chatId: "chat-1",
+    chatMode: "roleplay",
+    recentMessages: [
+      { role: "user", content: "Keep her blue coat consistent." },
+      { role: "assistant", content: mainResponse, characterId: "char-1" },
+    ],
+    mainResponse,
+    mainResponseCharacterId: "char-1",
+    gameState: null,
+    characters: [{ id: "char-1", name: "Mira", description: "Mira wears a blue coat." }],
+    persona: null,
+    memory: {},
+    activatedLorebookEntries: null,
+    writableLorebookIds: null,
+    chatSummary: null,
+    streaming: false,
+  };
+}
+
+const editorConfig: AgentExecConfig = {
+  id: "editor-1",
+  type: "editor",
+  name: "Consistency Editor",
+  phase: "post_processing",
+  promptTemplate: "",
+  connectionId: null,
+  settings: {},
+};
+
+describe("executeAgent", () => {
+  it("preserves HTML-heavy main responses for the consistency editor prompt", async () => {
+    const provider = new CapturingProvider();
+    const htmlResponse = [
+      `<section class="social-card" data-theme="neon">`,
+      `<style>.social-card { color: #7dd3fc; }</style>`,
+      `<p style="font-weight: 700">She is safe now.</p>`,
+      `</section>`,
+    ].join("");
+
+    await executeAgent(editorConfig, createAgentContext(htmlResponse), provider, "test-model");
+
+    const prompt = provider.messages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain(`<assistant_response>`);
+    expect(prompt).toContain(`<section class="social-card" data-theme="neon">`);
+    expect(prompt).toContain(`<style>.social-card { color: #7dd3fc; }</style>`);
+    expect(prompt).toContain(`<p style="font-weight: 700">She is safe now.</p>`);
+  });
+});

--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -931,6 +931,10 @@ function truncateAgentText(text: string, maxChars: number): string {
   return chars.slice(0, head).join("") + marker + chars.slice(-tail).join("");
 }
 
+function formatMainResponseForAgent(agentType: string, text: string): string {
+  return agentType === "editor" ? text.trim() : stripHtmlTags(text);
+}
+
 function findLatestAssistantMessage(context: AgentContext): { index: number; content: string } | null {
   for (let index = context.recentMessages.length - 1; index >= 0; index--) {
     const message = context.recentMessages[index]!;
@@ -1214,7 +1218,7 @@ function buildAgentMessages(
 
   if (context.mainResponse) {
     finalParts.push(`<assistant_response>`);
-    finalParts.push(stripHtmlTags(context.mainResponse));
+    finalParts.push(formatMainResponseForAgent(agentType, context.mainResponse));
     finalParts.push(`</assistant_response>`);
   }
 

--- a/src/engine/contracts/constants/agent-prompts.ts
+++ b/src/engine/contracts/constants/agent-prompts.ts
@@ -536,9 +536,10 @@ What NOT to do:
 3. Do NOT remove content that isn't contradictory.
 4. Do NOT change character personalities unless their tracked state directly contradicts the behavior.
 5. If the response has no issues, return it unchanged.
-6. Keep all original formatting (markdown, HTML, etc.) intact.
+6. Keep all original formatting (markdown, HTML, etc.) intact. If the response contains HTML, CSS, inline styles, classes, data attributes, scripts, SVG, or other visual markup, treat that markup as structure. Edit only the visible human-readable text nodes unless the contradiction is inside an attribute value. Preserve tag order, nesting, attributes, styles, scripts, and CSS blocks exactly whenever possible.
 7. Do NOT react to or incorporate OOC comments into the narrative.
-8. Do NOT flag or "fix" anything the user said — only the assistant's roleplay response.
+8. Do NOT replace HTML/CSS with plain text. If you make a text edit inside a visual HTML message, return the full original HTML/CSS wrapper with only the necessary readable text changed.
+9. Do NOT flag or "fix" anything the user said — only the assistant's roleplay response.
 Respond ONLY with valid JSON — no markdown, no commentary.
 Schema:
 {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1945

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Consistency Editor received HTML-heavy assistant responses after the executor stripped HTML/XML tags for token compaction, so the editor could either make useful text edits while returning plain text or preserve visuals while declining meaningful edits.

## What changed

<!-- List the key changes in this PR. -->

- Preserves the raw current `mainResponse` only for the Consistency Editor prompt so the editor can see the original HTML/CSS scaffolding inside `<assistant_response>`.
- Tightens the default Consistency Editor prompt to treat HTML/CSS/visual markup as structure and edit only visible readable text where possible.
- Adds a focused regression test with a fake provider that verifies HTML-heavy `mainResponse` markup reaches the editor prompt intact.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Engine generation / agent runtime

Impact areas reviewed:

- Standard post-processing agent prompt assembly.
- Consistency Editor default prompt contract.
- Non-editor agent compaction path remains scoped to `stripHtmlTags`.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only change. No React feature code, shared API wrapper, Tauri command, storage, provider, schema, or dependency changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Agent executor prompt assembly for `context.mainResponse`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex verification:
- `git grep -n "stripHtmlTags(context.mainResponse)" upstream/refactor -- src/engine/agents-runtime/executor/agent-executor.ts` showed the pre-fix prompt flattened the editor's current response.
- `pnpm test src/engine/agents-runtime/executor/agent-executor.test.ts` passed: 1 test file, 1 test.
- `pnpm typecheck` passed.
- `pnpm check` passed: line endings, architecture, frontend typecheck, Rust cargo check, docs, discovery metadata, and unused-code checks.
- Bunny review passed on the focused diff.
- Proof gate passed for `scratch/bugfix-verification.json`.
- Manual limitation: this proves the editor input/prompt contract and scoped compaction behavior; individual provider quality for subjective "useful edits" can still vary by model.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix to existing Consistency Editor behavior; no new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is an engine prompt-contract fix, verified with a focused fake-provider regression and full repo checks rather than a visible UI surface.
