### PR TITLE
Fix Immersive HTML prompt injection

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -1,11 +1,13 @@
 import {
   BUILT_IN_AGENTS,
+  BUILT_IN_AGENT_IDS,
   BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS,
   DEFAULT_AGENT_TOOLS,
   getDefaultBuiltInAgentSettings,
   type AgentContext,
   type AgentResult,
 } from "../contracts/types/agent";
+import { getDefaultAgentPrompt } from "../contracts/constants/agent-prompts";
 import type { HapticDevice, HapticStatus } from "../contracts/types/haptic";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway, LlmMessage } from "../capabilities/llm";
@@ -112,6 +114,7 @@ interface AgentDeps {
 interface ResolvedAgentsResult {
   agents: ResolvedAgent[];
   skippedResults: AgentResult[];
+  staticInjections: AgentInjection[];
 }
 
 const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
@@ -122,6 +125,7 @@ const KNOWLEDGE_RETRIEVAL_AGENT_TYPE = "knowledge-retrieval";
 const KNOWLEDGE_ROUTER_AGENT_TYPE = "knowledge-router";
 const KNOWLEDGE_AGENT_TYPES = new Set([KNOWLEDGE_RETRIEVAL_AGENT_TYPE, KNOWLEDGE_ROUTER_AGENT_TYPE]);
 const ASSISTANT_INTERVAL_AGENT_TYPES = new Set([DIRECTOR_AGENT_TYPE, ILLUSTRATOR_AGENT_TYPE]);
+const STATIC_CONTEXT_INJECTION_AGENT_TYPES = new Set<string>([BUILT_IN_AGENT_IDS.HTML]);
 const MAX_ASSISTANT_RUN_INTERVAL = 100;
 const MAX_CUSTOM_AGENT_USER_RUN_INTERVAL = 200;
 const MAX_AGENT_PARALLEL_JOBS = 16;
@@ -167,6 +171,26 @@ function agentDataFromInjections(injections: AgentInjection[]): Record<string, s
     if (injection.text.trim()) data[injection.agentType] = injection.text.trim();
   }
   return data;
+}
+
+function mergeAgentInjections(...groups: AgentInjection[][]): AgentInjection[] {
+  const merged: AgentInjection[] = [];
+  const indexByType = new Map<string, number>();
+  for (const group of groups) {
+    for (const injection of group) {
+      const text = injection.text.trim();
+      if (!injection.agentType || !text) continue;
+      const next = { ...injection, text };
+      const index = indexByType.get(injection.agentType);
+      if (index == null) {
+        indexByType.set(injection.agentType, merged.length);
+        merged.push(next);
+      } else {
+        merged[index] = next;
+      }
+    }
+  }
+  return merged;
 }
 
 function uniqueStrings(values: string[]): string[] {
@@ -862,7 +886,7 @@ async function resolveLorebookKeeperRuntimeTarget(
 }
 
 async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput): Promise<ResolvedAgentsResult> {
-  if (!chatAgentsEnabled(input)) return { agents: [], skippedResults: [] };
+  if (!chatAgentsEnabled(input)) return { agents: [], skippedResults: [], staticInjections: [] };
   const scopedAgentIds = chatActiveAgentIds(input);
   const activationMessages = activationScanMessages(input);
   const requestedAgentTypes = input.agentTypes ?? null;
@@ -900,6 +924,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
   let customTools: Map<string, CustomToolRecord> | null = null;
   const resolved: ResolvedAgent[] = [];
   const skippedResults: AgentResult[] = [];
+  const staticInjections: AgentInjection[] = [];
   let defaultAgentConnection: JsonRecord | null | undefined;
   for (const agent of rows) {
     const type = readString(agent.type || agent.agentType) || "agent";
@@ -917,6 +942,17 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     }
     const intervalGate = automaticIntervalGate(input, id, type, settings, builtInAgent);
     if (intervalGate && !(await automaticIntervalAllowsRun(deps.storage, input, intervalGate))) {
+      continue;
+    }
+    if (STATIC_CONTEXT_INJECTION_AGENT_TYPES.has(type) && normalizePhase(agent) === "pre_generation") {
+      const text = readString(agent.promptTemplate).trim() || getDefaultAgentPrompt(type).trim();
+      if (text) {
+        staticInjections.push({
+          agentType: type,
+          agentName: readString(agent.name).trim() || readString(agent.type).trim() || type,
+          text,
+        });
+      }
       continue;
     }
     const requestedConnectionId = readString(agent.connectionId).trim();
@@ -955,7 +991,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
       toolContext: buildAgentToolContext(deps, input, agent, settings, customTools),
     });
   }
-  return { agents: resolved, skippedResults };
+  return { agents: resolved, skippedResults, staticInjections };
 }
 
 type SpotifyDjSourceType = "liked" | "playlist" | "artist" | "any";
@@ -1324,16 +1360,17 @@ export async function createGenerationAgentRuntime(
   input: GenerationAgentRuntimeInput,
   onResult?: (result: AgentResult) => void,
 ): Promise<GenerationAgentRuntime> {
-  const { agents, skippedResults } = await resolveAgents(deps, input);
+  const { agents, skippedResults, staticInjections } = await resolveAgents(deps, input);
   const preResults: AgentResult[] = [...skippedResults];
   const overrideInjections = normalizedAgentInjectionOverrides(input.agentInjectionOverrides);
-  const agentData: Record<string, string> = agentDataFromInjections(overrideInjections);
+  const initialInjections = mergeAgentInjections(staticInjections, overrideInjections);
+  const agentData: Record<string, string> = agentDataFromInjections(initialInjections);
   for (const result of skippedResults) {
     onResult?.(result);
   }
   if (agents.length === 0) {
     return {
-      preInjections: overrideInjections,
+      preInjections: initialInjections,
       preResults,
       agentData,
       availableSprites: [],
@@ -1353,12 +1390,12 @@ export async function createGenerationAgentRuntime(
 
   if (overrideInjections.length > 0) {
     return {
-      preInjections: overrideInjections,
+      preInjections: initialInjections,
       preResults,
       agentData,
       availableSprites,
       runParallel: async () => pipeline.runParallel(),
-      runPost: async (mainResponse) => pipeline.postGenerate(mainResponse, { preGenInjections: overrideInjections }),
+      runPost: async (mainResponse) => pipeline.postGenerate(mainResponse, { preGenInjections: initialInjections }),
     };
   }
 
@@ -1370,7 +1407,7 @@ export async function createGenerationAgentRuntime(
       onResult?.(resultEventData(result));
     }),
   ]);
-  const preInjections = [...pipelinePreInjections, ...knowledgePre.injections];
+  const preInjections = mergeAgentInjections(initialInjections, pipelinePreInjections, knowledgePre.injections);
   for (const result of pipeline.results) {
     if (result.agentType && !preResults.includes(result)) preResults.push(result);
   }

--- a/src/engine/generation/immersive-html-agent.test.ts
+++ b/src/engine/generation/immersive-html-agent.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_AGENT_PROMPTS } from "../contracts/constants/agent-prompts";
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmGateway } from "../capabilities/llm";
+import type { StorageGateway } from "../capabilities/storage";
+import { createGenerationAgentRuntime } from "./agent-runner";
+import { assembleGenerationPrompt } from "./prompt-assembly";
+
+type RowMap = Record<string, unknown[]>;
+
+function storageWithRows(rows: RowMap): StorageGateway {
+  return {
+    list: async <T = unknown>(entity: string) => (rows[entity] ?? []) as T[],
+    get: async <T = unknown>(entity: string, id: string) =>
+      ((rows[entity]?.find((row) => (row as { id?: string }).id === id) ?? null) as T | null),
+    create: async <T = unknown>() => ({} as T),
+    update: async <T = unknown>() => ({} as T),
+    delete: async () => ({ deleted: true }),
+    listChatMessages: async <T = unknown>() => [] as T[],
+    createChatMessage: async <T = unknown>() => ({} as T),
+    updateChatMessage: async <T = unknown>() => ({} as T),
+    deleteChatMessage: async () => ({ deleted: true }),
+    patchChatMessageExtra: async <T = unknown>() => ({} as T),
+    addChatMessageSwipe: async <T = unknown>() => ({} as T),
+    patchChatMetadata: async <T = unknown>() => ({} as T),
+    patchChatSummaries: async <T = unknown>() => ({} as T),
+    listChatMemories: async <T = unknown>() => [] as T[],
+    getWorldState: async <T = unknown>() => null as T | null,
+    saveTrackerSnapshot: async <T = unknown>() => ({} as T),
+    listLorebookEntries: async <T = unknown>() => [] as T[],
+    createLorebookEntries: async <T = unknown>() => [] as T[],
+    promptFull: async <T = unknown>() => null as T | null,
+  };
+}
+
+describe("Immersive HTML agent", () => {
+  it("injects the built-in HTML directive without an agent LLM call", async () => {
+    const storage = storageWithRows({ agents: [] });
+    const llm: LlmGateway = {
+      complete: vi.fn(),
+      listModels: vi.fn(async () => []),
+      stream: vi.fn(async function* () {
+        throw new Error("Immersive HTML should not call the LLM");
+      }),
+    };
+
+    const runtime = await createGenerationAgentRuntime({
+      storage,
+      llm,
+      integrations: {} as IntegrationGateway,
+    }, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        metadata: { enableAgents: true, activeAgentIds: ["html"] },
+      },
+      connection: {},
+      storedMessages: [{ id: "m1", role: "user", content: "Show me the sign." }],
+      characters: [],
+      persona: null,
+      activatedLorebookEntries: [],
+      chatSummary: null,
+    });
+
+    expect(runtime.preInjections).toEqual([
+      {
+        agentType: "html",
+        agentName: "Immersive HTML",
+        text: DEFAULT_AGENT_PROMPTS.html,
+      },
+    ]);
+    expect(runtime.agentData.html).toBe(DEFAULT_AGENT_PROMPTS.html);
+    expect(llm.stream).not.toHaveBeenCalled();
+  });
+
+  it("adds agent instructions to prompts that do not have an agent_data marker", async () => {
+    const storage = storageWithRows({
+      agents: [],
+      prompts: [],
+      "regex-scripts": [],
+      lorebooks: [],
+      personas: [],
+      characters: [
+        {
+          id: "char-1",
+          name: "Ari",
+          data: { name: "Ari", description: "A sign painter." },
+        },
+      ],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1"],
+        metadata: {},
+      },
+      storedMessages: [{ id: "m1", role: "user", content: "Make the shop sign vivid." }],
+      connection: {},
+      request: {},
+      latestUserInput: "Make the shop sign vivid.",
+      agentData: { html: DEFAULT_AGENT_PROMPTS.html },
+    });
+
+    const promptText = assembly.messages.map((message) => message.content).join("\n\n");
+    expect(promptText).toContain("<agent_instructions>");
+    expect(promptText).toContain("html:");
+    expect(promptText).toContain("inline HTML, CSS, and JS");
+  });
+});

--- a/src/engine/generation/immersive-html-agent.test.ts
+++ b/src/engine/generation/immersive-html-agent.test.ts
@@ -40,6 +40,7 @@ describe("Immersive HTML agent", () => {
       complete: vi.fn(),
       listModels: vi.fn(async () => []),
       stream: vi.fn(async function* () {
+        yield* [];
         throw new Error("Immersive HTML should not call the LLM");
       }),
     };

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2324,6 +2324,26 @@ function sectionContent(args: {
   }
 }
 
+function agentDataPromptBlock(
+  agentData: Record<string, string>,
+  wrapFormat: WrapFormat,
+  consumed: { all: boolean; types: Set<string> },
+): string {
+  if (consumed.all) return "";
+  const entries = Object.entries(agentData)
+    .map(([type, text]) => ({ type, text: cleanPromptText(text) }))
+    .filter((entry) => !consumed.types.has(entry.type))
+    .filter((entry) => entry.type.trim() && entry.text.trim());
+  if (entries.length === 0) return "";
+  const content = entries.map((entry) => `${entry.type}:\n${entry.text}`).join("\n\n");
+  return wrapContent(content, "Agent Instructions", wrapFormat);
+}
+
+function insertBeforeFirstHistory(messages: ChatMLMessage[], message: ChatMLMessage): void {
+  const insertAt = messages.findIndex((entry) => entry.contextKind === "history");
+  messages.splice(insertAt >= 0 ? insertAt : messages.length, 0, message);
+}
+
 export async function assembleGenerationPrompt(
   storage: StorageGateway,
   rawInput: PromptAssemblyInput,
@@ -2398,6 +2418,7 @@ export async function assembleGenerationPrompt(
   let messages: ChatMLMessage[] = [];
   let insertedHistory = false;
   let insertedSummary = false;
+  const insertedAgentData = { all: false, types: new Set<string>() };
   let usedFallbackSystemPrompt = false;
 
   if (selectedPreset) {
@@ -2432,6 +2453,14 @@ export async function assembleGenerationPrompt(
       const resolved = cleanPromptText(resolveMacros(rawContent, macros));
       if (!resolved.trim()) continue;
       if (marker?.type === "chat_summary" && summary?.trim()) insertedSummary = true;
+      if (marker?.type === "agent_data") {
+        const agentType = readString(marker.agentType).trim();
+        if (agentType) {
+          insertedAgentData.types.add(agentType);
+        } else {
+          insertedAgentData.all = true;
+        }
+      }
       const name = readString(section.name) || readString(section.identifier) || marker?.type || "Prompt";
       const group = promptGroupForSection(section, groupsById);
       promptEntries.push({
@@ -2464,6 +2493,16 @@ export async function assembleGenerationPrompt(
 
   if (!usedFallbackSystemPrompt && !insertedSummary && shouldForceRoleplaySummaryIntoSystem(input.chat)) {
     appendSummaryToSystemPrompt(messages, summary, wrapFormat);
+  }
+
+  const agentDataBlock = agentDataPromptBlock(agentData, wrapFormat, insertedAgentData);
+  if (agentDataBlock) {
+    insertBeforeFirstHistory(messages, {
+      role: "system",
+      content: agentDataBlock,
+      contextKind: "injection",
+      displayName: "Agent Instructions",
+    });
   }
 
   if (!insertedHistory) {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1947

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Immersive HTML could appear enabled while failing to affect generation when its directive never reached the main prompt.

## What changed

<!-- List the key changes in this PR. -->

- Treat the built-in `html` agent as a static pre-generation context injection, so it does not require or spend an agent LLM call.
- Preserve static/override injections in `preInjections` and `agentData` for prompt assembly and the Injections panel.
- Add a prompt-assembly fallback that inserts agent instructions when the selected preset has no matching `agent_data` marker.
- Add regression coverage for zero-call Immersive HTML injection and prompt fallback insertion.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

engine generation

Impact areas reviewed:

- Agent runtime resolution and pre-generation injection merging.
- Prompt assembly behavior for presets with and without `agent_data` markers.
- Default roleplay prompt path with no explicit agent marker.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only change; no React UI, shared API, Rust command, storage schema, dependency, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src/engine/generation/agent-runner.ts`
- `src/engine/generation/prompt-assembly.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm test src/engine/generation/immersive-html-agent.test.ts` and it passed.
- Codex ran `pnpm typecheck` and it passed.
- Codex ran full `pnpm check` after the final diff and it passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` and it passed.
- Bunny review pass completed locally for the current diff.
- No manual verification needed for the core claim; this is engine prompt wiring with focused command proof.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing agent; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is engine prompt wiring; proof is the focused regression command and full repo validation above.
