### PR TITLE
Fix Narrative Director reroll cadence

### DIFF
--- a/src/engine/generation/agent-runner.test.ts
+++ b/src/engine/generation/agent-runner.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmGateway } from "../capabilities/llm";
+import type { StorageGateway } from "../capabilities/storage";
+import { createGenerationAgentRuntime } from "./agent-runner";
+
+function storageWithAgentRuns(agentRuns: unknown[]): StorageGateway {
+  const agents = [
+    {
+      id: "director",
+      type: "director",
+      name: "Narrative Director",
+      enabled: true,
+      phase: "pre_generation",
+      settings: { runInterval: 5 },
+    },
+  ];
+  const connections = [{ id: "conn-1", provider: "mock", model: "mock-model" }];
+  return {
+    async list(collection: string) {
+      if (collection === "agents") return agents;
+      if (collection === "connections") return connections;
+      if (collection === "agent-runs") return agentRuns;
+      if (collection === "tools") return [];
+      if (collection === "lorebooks") return [];
+      return [];
+    },
+    async get() {
+      return null;
+    },
+    async listLorebookEntries() {
+      return [];
+    },
+  } as unknown as StorageGateway;
+}
+
+function llmWithDirectorNote(calls: { count: number }): LlmGateway {
+  return {
+    async *stream() {
+      calls.count += 1;
+      yield { type: "token", text: "[Director's note: Take the reroll in a new direction.]" };
+    },
+  } as unknown as LlmGateway;
+}
+
+const integrations = {} as IntegrationGateway;
+const chat = {
+  id: "chat-1",
+  mode: "roleplay",
+  metadata: { enableAgents: true },
+};
+const connection = { id: "conn-1", provider: "mock", model: "mock-model" };
+const storedMessages = [
+  { id: "user-1", role: "user", content: "Start." },
+  { id: "assistant-1", role: "assistant", content: "First guided reply." },
+];
+
+describe("createGenerationAgentRuntime regeneration cadence", () => {
+  it("reruns Narrative Director when its last successful interval run is on the regenerated message", async () => {
+    const calls = { count: 0 };
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgentRuns([
+          {
+            chatId: "chat-1",
+            messageId: "assistant-1",
+            agentType: "director",
+            success: true,
+            createdAt: "2026-06-01T00:00:00.000Z",
+          },
+        ]),
+        llm: llmWithDirectorNote(calls),
+        integrations,
+      },
+      {
+        chat,
+        connection,
+        storedMessages: storedMessages.slice(0, 1),
+        cadenceMessages: storedMessages,
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+        regenerateMessageId: "assistant-1",
+      },
+    );
+
+    expect(calls.count).toBe(1);
+    expect(runtime.preInjections).toEqual([
+      {
+        agentType: "director",
+        agentName: "Narrative Director",
+        text: "[Director's note: Take the reroll in a new direction.]",
+      },
+    ]);
+  });
+
+  it("keeps normal interval suppression for older director runs during regeneration", async () => {
+    const calls = { count: 0 };
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgentRuns([
+          {
+            chatId: "chat-1",
+            messageId: "assistant-0",
+            agentType: "director",
+            success: true,
+            createdAt: "2026-06-01T00:00:00.000Z",
+          },
+        ]),
+        llm: llmWithDirectorNote(calls),
+        integrations,
+      },
+      {
+        chat,
+        connection,
+        storedMessages: storedMessages.slice(0, 1),
+        cadenceMessages: [{ id: "assistant-0", role: "assistant", content: "Earlier." }, ...storedMessages],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+        regenerateMessageId: "assistant-1",
+      },
+    );
+
+    expect(calls.count).toBe(0);
+    expect(runtime.preInjections).toEqual([]);
+  });
+});

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -768,6 +768,8 @@ async function automaticIntervalAllowsRun(
   if (!lastRun) return true;
   const messageId = runMessageId(lastRun);
   if (!messageId) return true;
+  const regenerateMessageId = readString(input.regenerateMessageId).trim();
+  if (regenerateMessageId && regenerateMessageId === messageId) return true;
   const messagesSince = visibleMessagesSinceRun(input, messageId, gate.messageRole);
   if (messagesSince === null) return true;
   return messagesSince + (gate.includePendingMessage ? 1 : 0) >= gate.runInterval;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1948

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Narrative Director guidance could be suppressed during a reroll because the automatic interval gate counted a successful director run attached to the message being regenerated. That left the previous swipe's guidance as the current direction, making regenerated messages repeat the same beat.

## What changed

<!-- List the key changes in this PR. -->

- Let interval-based agents run again when their latest successful run is attached to `regenerateMessageId`.
- Added a focused engine regression test for the reroll target case and the older-run should-not-match cadence case.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

- Engine generation

Impact areas reviewed:

- `createGenerationAgentRuntime` automatic interval gating
- Narrative Director pre-generation injection cadence
- Regeneration/reroll path using `regenerateMessageId`

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only change. No React feature code, shared API wrapper, Rust storage, schema, dependency, or release metadata changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None of the listed UI/Rust pressure points were touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof: temporarily removed the cadence-line fix and ran `pnpm test -- src/engine/generation/agent-runner.test.ts`; the reroll-target row failed with `expected 1, received 0`.
- Codex proof after fix: `pnpm test -- src/engine/generation/agent-runner.test.ts` passed, 1 file / 2 tests.
- Codex baseline: `pnpm typecheck` passed.
- Codex baseline: `pnpm check` passed, including line endings, architecture, frontend typecheck, Rust check, docs, discovery, and unused-code check.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny pass completed locally for the current diff before opening this draft.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a bugfix to existing Narrative Director reroll behavior. No new discoverable feature or setting was added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

- N/A. This is backend/engine cadence logic with no visible UI surface changed; proof is the targeted engine regression and full repo check.
