### PR TITLE
Fix Character Tracker player persona rows

### DIFF
--- a/src/engine/generation/tracker-snapshots.test.ts
+++ b/src/engine/generation/tracker-snapshots.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { StorageGateway } from "../capabilities/storage";
+import type { AgentResult } from "../contracts/types/agent";
+import { persistTrackerSnapshotForTurn } from "./tracker-snapshots";
+
+function storageWithRows(rows: Record<string, Record<string, unknown>[]>): StorageGateway {
+  const snapshots: Record<string, unknown>[] = [];
+  return {
+    list: async <T = unknown>(entity: string) => (entity === "game-state-snapshots" ? snapshots : (rows[entity] ?? [])) as T[],
+    get: async <T = unknown>(entity: string, id: string) =>
+      ((rows[entity]?.find((row) => row.id === id) ?? null) as T | null),
+    create: async <T = unknown>() => ({} as T),
+    update: async <T = unknown>(entity: string, id: string, patch: Record<string, unknown>) => {
+      const row = rows[entity]?.find((candidate) => candidate.id === id);
+      if (row) Object.assign(row, patch);
+      return (row ?? patch) as T;
+    },
+    delete: async () => ({ deleted: true }),
+    listChatMessages: async <T = unknown>() => [] as T[],
+    createChatMessage: async <T = unknown>() => ({} as T),
+    updateChatMessage: async <T = unknown>() => ({} as T),
+    deleteChatMessage: async () => ({ deleted: true }),
+    patchChatMessageExtra: async <T = unknown>() => ({} as T),
+    addChatMessageSwipe: async <T = unknown>() => ({} as T),
+    patchChatMetadata: async <T = unknown>() => ({} as T),
+    patchChatSummaries: async <T = unknown>() => ({} as T),
+    listChatMemories: async <T = unknown>() => [] as T[],
+    getWorldState: async <T = unknown>() => null as T | null,
+    saveTrackerSnapshot: async <T = unknown>(_chatId: string, snapshot: Record<string, unknown>) => {
+      const saved = { ...snapshot, id: "snapshot-1" };
+      snapshots.push(saved);
+      return saved as T;
+    },
+    listLorebookEntries: async <T = unknown>() => [] as T[],
+    createLorebookEntries: async <T = unknown>() => [] as T[],
+    promptFull: async <T = unknown>() => null as T | null,
+  };
+}
+
+function characterTrackerResult(presentCharacters: unknown[]): AgentResult {
+  return {
+    agentId: "agent-characters",
+    agentType: "character-tracker",
+    type: "character_tracker_update",
+    data: { presentCharacters },
+    tokensUsed: 0,
+    durationMs: 0,
+    success: true,
+    error: null,
+  };
+}
+
+describe("tracker snapshots", () => {
+  it("does not persist player persona rows from character tracker output", async () => {
+    const chat = {
+      id: "chat-1",
+      personaId: "persona-1",
+      gameState: {
+        presentCharacters: [{ characterId: "{{user}}", name: "{{user}}" }],
+      },
+    };
+    const storage = storageWithRows({
+      chats: [chat],
+      personas: [{ id: "persona-1", name: "Celia" }],
+    });
+
+    const saved = await persistTrackerSnapshotForTurn(
+      storage,
+      "chat-1",
+      { messageId: "message-1", swipeIndex: 0 },
+      [
+        characterTrackerResult([
+          { characterId: "{{user}}", name: "{{user}}" },
+          { characterId: "persona-1", name: "Celia" },
+          { characterId: "npc-1", name: "Ari", mood: "curious" },
+        ]),
+      ],
+    );
+
+    expect(saved?.presentCharacters).toHaveLength(1);
+    expect(saved?.presentCharacters[0]).toMatchObject({
+      characterId: "npc-1",
+      name: "Ari",
+      mood: "curious",
+    });
+    expect((chat.gameState as { presentCharacters?: unknown[] }).presentCharacters).toEqual(saved?.presentCharacters);
+  });
+});

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -18,6 +18,11 @@ import {
   parseStat,
 } from "../shared/game-state/player-stats";
 import { normalizeGameStateTrackerRows } from "../shared/game-state/tracker-row-ids";
+import {
+  filterPlayerPersonaPresentCharacters,
+  type TrackerPersonaIdentity,
+} from "../shared/game-state/present-character-filter";
+import { loadPersonaSnapshotForChat } from "./persona-snapshot";
 
 export interface TrackerSnapshotTurnTarget {
   messageId: string;
@@ -157,7 +162,12 @@ function parsePresentCharacter(value: unknown): PresentCharacter | null {
   };
 }
 
-function normalizeGameState(value: unknown, chatId: string, target: TrackerSnapshotTurnTarget): GameState {
+function normalizeGameState(
+  value: unknown,
+  chatId: string,
+  target: TrackerSnapshotTurnTarget,
+  persona?: TrackerPersonaIdentity | null,
+): GameState {
   const record = parseRecord(value);
   const manualOverrides = parseManualOverrides(record.manualOverrides);
   return normalizeGameStateTrackerRows({
@@ -171,9 +181,12 @@ function normalizeGameState(value: unknown, chatId: string, target: TrackerSnaps
     weather: manualOverrideValue(manualOverrides, "weather") ?? readNullableString(record.weather),
     temperature: manualOverrideValue(manualOverrides, "temperature") ?? readNullableString(record.temperature),
     presentCharacters: Array.isArray(record.presentCharacters)
-      ? record.presentCharacters
-          .map(parsePresentCharacter)
-          .filter((character): character is PresentCharacter => !!character)
+      ? filterPlayerPersonaPresentCharacters(
+          record.presentCharacters
+            .map(parsePresentCharacter)
+            .filter((character): character is PresentCharacter => !!character),
+          persona,
+        )
       : [],
     recentEvents: Array.isArray(record.recentEvents)
       ? record.recentEvents.map(readNullableString).filter((event): event is string => !!event)
@@ -403,7 +416,11 @@ export async function commitTrackerSnapshotForTarget(
   return normalizeGameState(saved, chatId, { messageId: existing.messageId, swipeIndex: existing.swipeIndex });
 }
 
-function gameStatePatchFromAgentResult(result: AgentResult, snapshot: GameState): TrackerStatePatch | null {
+function gameStatePatchFromAgentResult(
+  result: AgentResult,
+  snapshot: GameState,
+  persona?: TrackerPersonaIdentity | null,
+): TrackerStatePatch | null {
   if (!result.success) return null;
   if (result.agentType === "world-state" || result.type === "game_state_update") {
     const patch = worldStatePatchFromAgentData(result.data, {
@@ -417,9 +434,12 @@ function gameStatePatchFromAgentResult(result: AgentResult, snapshot: GameState)
 
   if (result.agentType === "character-tracker" || result.type === "character_tracker_update") {
     const presentCharacters = Array.isArray(data.presentCharacters)
-      ? data.presentCharacters
-          .map(parsePresentCharacter)
-          .filter((character): character is PresentCharacter => !!character)
+      ? filterPlayerPersonaPresentCharacters(
+          data.presentCharacters
+            .map(parsePresentCharacter)
+            .filter((character): character is PresentCharacter => !!character),
+          persona,
+        )
       : [];
     preserveTrackerCharacterUiFields(
       presentCharacters as unknown as Array<Record<string, unknown>>,
@@ -467,18 +487,25 @@ export async function persistTrackerSnapshotForTurn(
 ): Promise<GameState | null> {
   if (!target || !target.messageId || results.length === 0) return null;
   const existing = await getTrackerSnapshotForTarget(storage, chatId, target);
+  const hasCharacterTrackerResult = results.some(
+    (result) => result.agentType === "character-tracker" || result.type === "character_tracker_update",
+  );
+  const needsChatBaseline = !existing && !options.baseSnapshot;
   const chat =
-    existing || options.baseSnapshot ? null : parseRecord(await storage.get("chats", chatId).catch(() => null));
-  let snapshot = normalizeGameState(existing ?? options.baseSnapshot ?? chat?.gameState, chatId, target);
+    needsChatBaseline || hasCharacterTrackerResult
+      ? parseRecord(await storage.get("chats", chatId).catch(() => null))
+      : null;
+  const persona = hasCharacterTrackerResult ? await loadPersonaSnapshotForChat(storage, chat).catch(() => null) : null;
+  let snapshot = normalizeGameState(existing ?? options.baseSnapshot ?? chat?.gameState, chatId, target, persona);
   if (!existing) {
     snapshot = { ...snapshot, id: "", committed: false, manualOverrides: null, createdAt: nowIso() };
   }
   let changed = false;
 
   for (const result of results) {
-    const patch = gameStatePatchFromAgentResult(result, snapshot);
+    const patch = gameStatePatchFromAgentResult(result, snapshot, persona);
     if (!patch) continue;
-    snapshot = normalizeGameState({ ...snapshot, ...patch }, chatId, target);
+    snapshot = normalizeGameState({ ...snapshot, ...patch }, chatId, target, persona);
     changed = true;
   }
 

--- a/src/engine/shared/game-state/present-character-filter.test.ts
+++ b/src/engine/shared/game-state/present-character-filter.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { filterPlayerPersonaPresentCharacters } from "./present-character-filter";
+
+describe("present character persona filtering", () => {
+  it("filters macro rows even without a resolved persona", () => {
+    expect(
+      filterPlayerPersonaPresentCharacters([
+        { characterId: "{{user}}", name: "{{user}}" },
+        { characterId: "{{ userName }}", name: "User" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("filters exact active persona id and name matches", () => {
+    const persona = { personaId: "persona-1", name: "Celia" };
+    const rows = [
+      { characterId: "persona-1", name: "Celia" },
+      { characterId: "npc-1", name: "Ari" },
+      { characterId: "manual-celia", name: "celia" },
+    ];
+
+    expect(filterPlayerPersonaPresentCharacters(rows, persona)).toEqual([{ characterId: "npc-1", name: "Ari" }]);
+  });
+
+  it("keeps ordinary user-like NPC names when no persona identity is known", () => {
+    const rows = [{ characterId: "npc-user", name: "User" }];
+
+    expect(filterPlayerPersonaPresentCharacters(rows)).toEqual(rows);
+  });
+});

--- a/src/engine/shared/game-state/present-character-filter.ts
+++ b/src/engine/shared/game-state/present-character-filter.ts
@@ -1,0 +1,51 @@
+export interface TrackerPersonaIdentity {
+  personaId?: unknown;
+  id?: unknown;
+  name?: unknown;
+}
+
+export interface PresentCharacterIdentity {
+  characterId?: unknown;
+  name?: unknown;
+}
+
+const PLAYER_PERSONA_MACROS = new Set(["{{user}}", "{{username}}"]);
+
+function readText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeIdentity(value: unknown): string {
+  return readText(value).replace(/\s+/g, " ").toLowerCase();
+}
+
+function normalizeMacroIdentity(value: unknown): string {
+  return normalizeIdentity(value).replace(/\s+/g, "");
+}
+
+function rowIdentities(row: PresentCharacterIdentity): string[] {
+  return [readText(row.characterId), readText(row.name)].filter(Boolean);
+}
+
+function personaIdentities(persona?: TrackerPersonaIdentity | null): string[] {
+  if (!persona) return [];
+  return [readText(persona.personaId ?? persona.id), readText(persona.name)].filter(Boolean);
+}
+
+function isPlayerPersonaPresentCharacter(
+  row: PresentCharacterIdentity,
+  persona?: TrackerPersonaIdentity | null,
+): boolean {
+  const identities = rowIdentities(row);
+  if (identities.some((identity) => PLAYER_PERSONA_MACROS.has(normalizeMacroIdentity(identity)))) return true;
+
+  const personaIdentitySet = new Set(personaIdentities(persona).map(normalizeIdentity).filter(Boolean));
+  return identities.some((identity) => personaIdentitySet.has(normalizeIdentity(identity)));
+}
+
+export function filterPlayerPersonaPresentCharacters<T extends PresentCharacterIdentity>(
+  rows: readonly T[],
+  persona?: TrackerPersonaIdentity | null,
+): T[] {
+  return rows.filter((row) => !isPlayerPersonaPresentCharacter(row, persona));
+}

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -63,6 +63,7 @@ import {
   parseInventoryItem,
   parseStat,
 } from "../../../../engine/shared/game-state/player-stats";
+import { filterPlayerPersonaPresentCharacters } from "../../../../engine/shared/game-state/present-character-filter";
 import type { AgentDebugEntry } from "../../../../engine/contracts/types/agent";
 import type { IntegrationGateway } from "../../../../engine/capabilities/integrations";
 import type { HapticStatus } from "../../../../engine/contracts/types/haptic";
@@ -909,7 +910,11 @@ function parsePresentCharacter(value: unknown): PresentCharacter | null {
   };
 }
 
-function gameStatePatchFromAgentResult(result: AgentResult, chatId: string): Record<string, unknown> | null {
+function gameStatePatchFromAgentResult(
+  result: AgentResult,
+  chatId: string,
+  persona?: ReturnType<typeof cachedPersonaSnapshot>,
+): Record<string, unknown> | null {
   if (result.agentType === "world-state" || result.type === "game_state_update") {
     return worldStatePatchFromAgentData(result.data, {
       allowFreeform: result.agentType === "world-state",
@@ -921,9 +926,12 @@ function gameStatePatchFromAgentResult(result: AgentResult, chatId: string): Rec
 
   if (result.agentType === "character-tracker" || result.type === "character_tracker_update") {
     const presentCharacters = Array.isArray(data.presentCharacters)
-      ? data.presentCharacters
-          .map(parsePresentCharacter)
-          .filter((character): character is PresentCharacter => !!character)
+      ? filterPlayerPersonaPresentCharacters(
+          data.presentCharacters
+            .map(parsePresentCharacter)
+            .filter((character): character is PresentCharacter => !!character),
+          persona,
+        )
       : [];
     return { presentCharacters };
   }
@@ -958,8 +966,8 @@ function gameStatePatchFromAgentResult(result: AgentResult, chatId: string): Rec
   return null;
 }
 
-async function applyTrackerResultToGameState(chatId: string, result: AgentResult) {
-  const patch = gameStatePatchFromAgentResult(result, chatId);
+async function applyTrackerResultToGameState(queryClient: QueryClient, chatId: string, result: AgentResult) {
+  const patch = gameStatePatchFromAgentResult(result, chatId, cachedPersonaSnapshot(queryClient, chatId));
   if (!patch) return;
 
   const store = useGameStateStore.getState();
@@ -1119,7 +1127,7 @@ async function applyAgentResultEffects(
     await applyBackgroundChoice(chatId, data.chosen);
   }
   if (result.agentType === "quest") applyQuestUpdates(result.data);
-  if (!options.skipTrackerSync) await applyTrackerResultToGameState(chatId, result);
+  if (!options.skipTrackerSync) await applyTrackerResultToGameState(queryClient, chatId, result);
 }
 
 export async function runGenerationWithUi(


### PR DESCRIPTION
## Linked issue

Closes #1949

## Why this change

- Character Tracker can accept `{{user}}` or the active player persona as a normal present-character row when the model returns it, which lets the player persona appear in the character tracker and be recreated after deletion.

## What changed

- Added a shared engine helper that filters present-character rows matching `{{user}}`, `{{userName}}`, the active persona id, or the active persona name.
- Applied that filter to persisted tracker snapshots and to the live generation hook so bad rows are blocked in both saved state and immediate UI state.
- Added focused regression coverage for macro rows, active persona rows, NPC negative controls, and persisted snapshot recovery from legacy `{{user}}` state.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Runtime generation live tracker patching
- Tracker snapshot persistence
- Existing persisted `chat.gameState.presentCharacters` and `game-state-snapshots` rows

Boundary notes:

- Engine owns the tracker-row contract. React feature code imports the shared engine filter instead of inventing a UI-only guard.

Pressure points touched:

- Character Tracker agent result handling
- Live runtime generation tracker sync

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex machine proof:
- `pnpm test -- src/engine/shared/game-state/present-character-filter.test.ts src/engine/generation/tracker-snapshots.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed locally.
- No human-only verification is required for the core claim; this is a tracker-state parsing/persistence fix with focused command proof.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. The bug is in tracker-state filtering/persistence, not visible layout; the focused regression tests prove the affected state path.
