### PR TITLE
Fix schedule update extension persistence

### DIFF
--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -554,9 +554,17 @@ async function applyScheduleUpdate(
   if (characterId) {
     const row = await storage.get<JsonRecord>("characters", characterId);
     if (row?.id) {
+      const data = parseData(row);
+      const extensions = parseRecord(data.extensions);
       await storage.update("characters", characterId, {
-        conversationStatus: update.status,
-        conversationActivity: update.activity,
+        data: {
+          ...data,
+          extensions: {
+            ...extensions,
+            conversationStatus: update.status,
+            conversationActivity: update.activity,
+          },
+        },
       });
     }
   }


### PR DESCRIPTION
## Linked issue

Closes #1958

## Why this change

- The `schedule_update` connected command persisted `conversationStatus` and `conversationActivity` on the character storage row wrapper, while the conversation UI reads those values from the card data's `extensions` object.

## What changed

- Updated the schedule update command path to merge status/activity into `data.extensions`.
- Preserved existing card data and existing extension fields during the update.
- Avoided writing stray root-level conversation status fields.

## Refactor impact

Primary owner:

- Engine generation

Impact areas reviewed:

- Chat mode schedule/status command handling
- Shared chat UI and app sidebar status readers
- Character card storage contract

Boundary notes:

- The fix stays in React-free engine code and continues using the existing storage gateway.
- No feature/UI/Rust/shared API boundary changes.

Pressure points touched:

- `src/engine/generation/connected-commands.ts`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run tests/unit/issue-1958-schedule-update-repro.test.ts --config vitest.config.ts` passed after the fix. Before the fix, the same repro failed because `extensions.conversationStatus` stayed `undefined`.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:rust` passed.
- `pnpm check:docs` passed.
- `pnpm check:discovery` passed.
- `pnpm check:unused` passed.
- `pnpm check` is currently blocked before this change's gates by unrelated CRLF line-ending failures in `.github/workflows/bunny-review-command.yml`, `DESIGN.md`, and `custom_components/marinara_engine/*.py`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; this is a storage contract fix for the connected command path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal data structure reorganization for character conversation tracking. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->