### PR TITLE
Fix World State explicit fact drift

### DIFF
--- a/src/engine/contracts/constants/agent-prompts.test.ts
+++ b/src/engine/contracts/constants/agent-prompts.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_AGENT_PROMPTS } from "./agent-prompts";
 
 describe("DEFAULT_AGENT_PROMPTS", () => {
+  it("tells World State to preserve exact day, time, and temperature facts", () => {
+    const prompt = DEFAULT_AGENT_PROMPTS["world-state"];
+
+    expect(prompt).toMatch(/explicit scene facts/i);
+    expect(prompt).toMatch(/day of week, exact clock time, or exact temperature/i);
+    expect(prompt).toMatch(/carry forward the prior value exactly/i);
+    expect(prompt).not.toMatch(/Infer sensible defaults/i);
+  });
+
   it("instructs Lorebook Keeper to extract focused facts instead of copying whole messages", () => {
     const prompt = DEFAULT_AGENT_PROMPTS["lorebook-keeper"];
 

--- a/src/engine/contracts/constants/agent-prompts.ts
+++ b/src/engine/contracts/constants/agent-prompts.ts
@@ -17,9 +17,10 @@ Schema:
   "temperature": "string|null"
 }
 Instructions:
-1. Always provide date, time, location, weather, and temperature. Infer sensible defaults from genre, setting, and context when the narrative doesn't spell them out (e.g., a medieval tavern at night → "Cool", "Clear skies", "Late evening").
-  1a. Set a field to null ONLY when there is genuinely no way to guess, and not because the text didn't say the exact word.
-2. Preserve continuity. Only change what the narrative changes. If the party entered a tavern two messages ago and hasn't left, they're still in the tavern.`,
+1. Treat explicit scene facts in the latest assistant message as authoritative. If the text states a day of week, exact clock time, or exact temperature, copy that value into date, time, or temperature even if older context differs.
+2. Preserve continuity. Only change what the narrative changes. If a field is not mentioned or changed in the latest assistant message, carry forward the prior value exactly instead of inventing, normalizing, or replacing it with a genre default.
+3. Use null only when there is no prior value and no grounded scene clue. Do not clear day, time, or temperature merely because the latest message did not repeat them.
+4. Still provide date, time, location, weather, and temperature keys in the JSON output.`,
 
   /* ────────────────────────────────────────── */
   "prose-guardian": `Study the last few assistant messages and produce concrete, actionable writing directives for the next generation. You do NOT write story content, only directives.

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1522,11 +1522,12 @@ async function persistTrackerSnapshotSafely(
   targetMessage: unknown,
   results: AgentResult[],
   baseSnapshot?: GameState | null,
+  sourceText?: string | null,
 ): Promise<void> {
   const target = trackerSnapshotTargetFromMessage(targetMessage);
   if (!target) return;
   try {
-    await persistTrackerSnapshotForTurn(storage, chatId, target, results, { baseSnapshot });
+    await persistTrackerSnapshotForTurn(storage, chatId, target, results, { baseSnapshot, sourceText });
   } catch (error) {
     console.warn("[generation] tracker snapshot persist failed", error);
   }
@@ -2345,7 +2346,7 @@ async function runGenerationAgentsForTarget(args: {
     runtime.availableSprites,
   );
   if (target) {
-    await persistTrackerSnapshotSafely(deps.storage, chatId, target, finalResults, retryBaseline);
+    await persistTrackerSnapshotSafely(deps.storage, chatId, target, finalResults, retryBaseline, mainResponse);
   }
   await persistSecretPlotAgentMemorySafely(deps.storage, chatId, finalResults);
   await persistAgentResults(deps.storage, chatId, target ? readString(target.id) || null : null, finalResults);
@@ -2806,7 +2807,14 @@ export async function* startGeneration(
     }
     throwIfAborted(signal);
     if (saved && input.impersonate !== true) {
-      await persistTrackerSnapshotSafely(deps.storage, chatId, latestSaved, allAgentResults, generationTrackerBaseline);
+      await persistTrackerSnapshotSafely(
+        deps.storage,
+        chatId,
+        latestSaved,
+        allAgentResults,
+        generationTrackerBaseline,
+        readString(parseRecord(latestSaved).content),
+      );
     }
     throwIfAborted(signal);
     await persistSecretPlotAgentMemorySafely(deps.storage, chatId, allAgentResults);

--- a/src/engine/generation/tracker-snapshots.test.ts
+++ b/src/engine/generation/tracker-snapshots.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { AgentResult } from "../contracts/types/agent";
+import type { GameState } from "../contracts/types/game-state";
+import type { StorageGateway } from "../capabilities/storage";
+import { persistTrackerSnapshotForTurn } from "./tracker-snapshots";
+
+function gameState(overrides: Partial<GameState>): GameState {
+  return {
+    id: "snapshot-1",
+    chatId: "chat-1",
+    messageId: "assistant-1",
+    swipeIndex: 0,
+    date: null,
+    time: null,
+    location: "Apartment",
+    weather: null,
+    temperature: null,
+    presentCharacters: [],
+    recentEvents: [],
+    playerStats: null,
+    personaStats: null,
+    committed: false,
+    createdAt: "2026-06-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function worldStateResult(data: unknown): AgentResult {
+  return {
+    agentId: "world-state",
+    agentType: "world-state",
+    type: "game_state_update",
+    data,
+    tokensUsed: 0,
+    durationMs: 0,
+    success: true,
+    error: null,
+  };
+}
+
+describe("persistTrackerSnapshotForTurn", () => {
+  it("uses the pre-generation baseline to undo optimistic silent drift", async () => {
+    const optimisticSnapshot = gameState({
+      date: "Tuesday",
+      time: "Morning",
+      temperature: "Mild",
+    });
+    const baseline = gameState({
+      id: "baseline-1",
+      messageId: "assistant-0",
+      date: "Monday",
+      time: "7:30 PM",
+      temperature: "68\u00b0F",
+      committed: true,
+    });
+    const savedRows: Array<Record<string, unknown>> = [];
+    const storage = {
+      async list(collection: string) {
+        return collection === "game-state-snapshots" ? [optimisticSnapshot] : [];
+      },
+      async saveTrackerSnapshot(_chatId: string, snapshot: Record<string, unknown>) {
+        savedRows.push(snapshot);
+        return snapshot;
+      },
+      async update() {
+        return {};
+      },
+    } as unknown as StorageGateway;
+
+    const saved = await persistTrackerSnapshotForTurn(
+      storage,
+      "chat-1",
+      { messageId: "assistant-1", swipeIndex: 0 },
+      [
+        worldStateResult({
+          date: "Tuesday",
+          time: "Morning",
+          temperature: "Mild",
+        }),
+      ],
+      {
+        baseSnapshot: baseline,
+        sourceText: "They keep talking in the apartment, neither checking the clock nor mentioning the weather.",
+      },
+    );
+
+    expect(savedRows).toHaveLength(1);
+    expect(saved).toMatchObject({
+      date: "Monday",
+      time: "7:30 PM",
+      temperature: "68\u00b0F",
+    });
+  });
+});

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -403,11 +403,18 @@ export async function commitTrackerSnapshotForTarget(
   return normalizeGameState(saved, chatId, { messageId: existing.messageId, swipeIndex: existing.swipeIndex });
 }
 
-function gameStatePatchFromAgentResult(result: AgentResult, snapshot: GameState): TrackerStatePatch | null {
+function gameStatePatchFromAgentResult(
+  result: AgentResult,
+  snapshot: GameState,
+  previousWorldState: GameState,
+  sourceText?: string | null,
+): TrackerStatePatch | null {
   if (!result.success) return null;
   if (result.agentType === "world-state" || result.type === "game_state_update") {
     const patch = worldStatePatchFromAgentData(result.data, {
       allowFreeform: result.agentType === "world-state",
+      previousWorldState,
+      sourceText,
     }) as TrackerStatePatch | null;
     return patch ? mergeWorldStatePatchWithManualOverrides(snapshot, patch) : null;
   }
@@ -463,7 +470,7 @@ export async function persistTrackerSnapshotForTurn(
   chatId: string,
   target: TrackerSnapshotTurnTarget | null,
   results: AgentResult[],
-  options: { baseSnapshot?: GameState | null } = {},
+  options: { baseSnapshot?: GameState | null; sourceText?: string | null } = {},
 ): Promise<GameState | null> {
   if (!target || !target.messageId || results.length === 0) return null;
   const existing = await getTrackerSnapshotForTarget(storage, chatId, target);
@@ -476,7 +483,8 @@ export async function persistTrackerSnapshotForTurn(
   let changed = false;
 
   for (const result of results) {
-    const patch = gameStatePatchFromAgentResult(result, snapshot);
+    const previousWorldState = options.baseSnapshot ?? snapshot;
+    const patch = gameStatePatchFromAgentResult(result, snapshot, previousWorldState, options.sourceText);
     if (!patch) continue;
     snapshot = normalizeGameState({ ...snapshot, ...patch }, chatId, target);
     changed = true;

--- a/src/engine/generation/world-state-agent-result.test.ts
+++ b/src/engine/generation/world-state-agent-result.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { worldStatePatchFromAgentData } from "./world-state-agent-result";
+
+describe("worldStatePatchFromAgentData", () => {
+  it("uses explicit narration facts over vague or missing agent output", () => {
+    const patch = worldStatePatchFromAgentData(
+      {
+        date: null,
+        time: "Late evening",
+        temperature: "Cool",
+      },
+      {
+        sourceText: "It is Monday at 7:30 PM, and the apartment thermometer reads 68\u00b0F.",
+        previousWorldState: {
+          date: "Sunday",
+          time: "6:00 PM",
+          temperature: "72\u00b0F",
+        },
+      },
+    );
+
+    expect(patch).toEqual({
+      date: "Monday",
+      time: "7:30 PM",
+      temperature: "68\u00b0F",
+    });
+  });
+
+  it("preserves prior day, time, and temperature when the latest narration is silent", () => {
+    const patch = worldStatePatchFromAgentData(
+      {
+        date: "Tuesday",
+        time: "Morning",
+        temperature: "Mild",
+      },
+      {
+        sourceText: "They keep talking in the apartment, neither checking the clock nor mentioning the weather.",
+        previousWorldState: {
+          date: "Monday",
+          time: "7:30 PM",
+          temperature: "68\u00b0F",
+        },
+      },
+    );
+
+    expect(patch).toEqual({
+      date: "Monday",
+      time: "7:30 PM",
+      temperature: "68\u00b0F",
+    });
+  });
+
+  it("allows agent updates when the latest narration mentions the field changing", () => {
+    const patch = worldStatePatchFromAgentData(
+      {
+        date: "Monday",
+        time: "10:30 PM",
+        temperature: "Chilly",
+      },
+      {
+        sourceText: "Hours later, the air turns chilly as they keep watch near the open window.",
+        previousWorldState: {
+          date: "Monday",
+          time: "7:30 PM",
+          temperature: "68\u00b0F",
+        },
+      },
+    );
+
+    expect(patch).toEqual({
+      date: "Monday",
+      time: "10:30 PM",
+      temperature: "Chilly",
+    });
+  });
+});

--- a/src/engine/generation/world-state-agent-result.ts
+++ b/src/engine/generation/world-state-agent-result.ts
@@ -1,10 +1,18 @@
 import { isRecord, parseRecord } from "./runtime-records";
 
 const WORLD_STATE_FIELDS = ["date", "time", "location", "weather", "temperature"] as const;
+const STABLE_EXPLICIT_FIELDS = ["date", "time", "temperature"] as const;
 const TEXT_FALLBACK_KEYS = ["text", "summary", "value", "content", "result"] as const;
 
 type WorldStateAgentField = (typeof WORLD_STATE_FIELDS)[number];
 export type WorldStateAgentPatch = Partial<Record<WorldStateAgentField, string | null>>;
+type StableExplicitField = (typeof STABLE_EXPLICIT_FIELDS)[number];
+
+export interface WorldStateAgentPatchOptions {
+  allowFreeform?: boolean;
+  sourceText?: string | null;
+  previousWorldState?: Partial<Record<StableExplicitField, unknown>> | null;
+}
 
 function readNullableWorldStateString(value: unknown): string | null {
   if (value === null || value === undefined) return null;
@@ -84,13 +92,13 @@ function normalizeFreeformWorldStateText(text: string): string {
 }
 
 function looksLikeDate(text: string): boolean {
-  return /\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|today|tomorrow|yesterday|day\s+\d+|january|february|march|april|may|june|july|august|september|october|november|december|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4})\b/i.test(
+  return /\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday|today|tomorrow|yesterday|next\s+day|following\s+day|day\s+\d+|january|february|march|april|may|june|july|august|september|october|november|december|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4})\b/i.test(
     text,
   );
 }
 
 function looksLikeTime(text: string): boolean {
-  return /\b(?:dawn|daybreak|sunrise|morning|noon|afternoon|sunset|dusk|evening|night|midnight|twilight|hour|late|early|\d{1,2}:\d{2}|\d{1,2}\s*(?:am|pm))\b/i.test(
+  return /\b(?:dawn|daybreak|sunrise|morning|noon|afternoon|sunset|dusk|evening|night|midnight|twilight|hours?\s+later|later\s+that\s+(?:morning|afternoon|evening|night)|hour|late|early|\d{1,2}:\d{2}|\d{1,2}\s*(?:am|pm|a\.m\.|p\.m\.))\b/i.test(
     text,
   );
 }
@@ -105,6 +113,120 @@ function looksLikeTemperature(text: string): boolean {
   return /\b(?:-?\d+(?:\.\d+)?\s*(?:°|degrees?\s*)?(?:c|f|celsius|fahrenheit)|freezing|cold|cool|chilly|frigid|icy|mild|temperate|warm|hot|scorching|sweltering)\b/i.test(
     text,
   );
+}
+
+function readPreviousStableField(
+  previousWorldState: WorldStateAgentPatchOptions["previousWorldState"],
+  field: StableExplicitField,
+): string | null {
+  if (!previousWorldState) return null;
+  return readNullableWorldStateString(previousWorldState[field]);
+}
+
+function normalizeSpaces(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function titleCaseWord(text: string): string {
+  const lower = text.toLowerCase();
+  return `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`;
+}
+
+function normalizeTimeSuffix(text: string): string {
+  return normalizeSpaces(text).replace(/\s*(a\.m\.|p\.m\.|am|pm)\b/i, (match) =>
+    ` ${match.replace(/\./g, "").toUpperCase().trim()}`,
+  );
+}
+
+function normalizeTemperature(text: string): string {
+  return normalizeSpaces(text)
+    .replace(/\s+/g, "")
+    .replace(/\u00b0?([CF])$/i, (_match, unit: string) => `\u00b0${unit.toUpperCase()}`)
+    .replace(/celsius$/i, "\u00b0C")
+    .replace(/fahrenheit$/i, "\u00b0F");
+}
+
+function exactDateFromText(text: string): string | null {
+  const weekday = text.match(/\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i)?.[0];
+  if (weekday) return titleCaseWord(weekday);
+
+  const monthDate = text.match(
+    /\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2}(?:,\s*\d{2,4})?\b/i,
+  )?.[0];
+  if (monthDate) return normalizeSpaces(monthDate);
+
+  const numericDate = text.match(/\b\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?\b/)?.[0];
+  if (numericDate) return numericDate;
+
+  const storyDay = text.match(/\bday\s+\d+\b/i)?.[0];
+  return storyDay ? normalizeSpaces(storyDay) : null;
+}
+
+function exactTimeFromText(text: string): string | null {
+  const clock = text.match(/\b\d{1,2}:\d{2}\s*(?:am|pm|a\.m\.|p\.m\.)?\b/i)?.[0];
+  if (clock) return normalizeTimeSuffix(clock);
+
+  const hour = text.match(/\b\d{1,2}\s*(?:am|pm|a\.m\.|p\.m\.)\b/i)?.[0];
+  if (hour) return normalizeTimeSuffix(hour);
+
+  const named = text.match(/\b(?:noon|midnight|dawn|daybreak|sunrise|morning|afternoon|sunset|dusk|evening|night|twilight)\b/i)?.[0];
+  return named ? normalizeSpaces(named) : null;
+}
+
+function exactTemperatureFromText(text: string): string | null {
+  const unitTemperature = text.match(/\b-?\d+(?:\.\d+)?\s*(?:\u00b0\s*)?(?:c|f|celsius|fahrenheit)\b/i)?.[0];
+  if (unitTemperature) return normalizeTemperature(unitTemperature);
+
+  const degreeTemperature = text.match(
+    /\b(?:temperature|thermometer|air|room|outside|inside|weather)\b[^.?!;\n]{0,60}\b-?\d+(?:\.\d+)?\s*degrees?\b/i,
+  )?.[0];
+  if (!degreeTemperature) return null;
+  const value = degreeTemperature.match(/\b-?\d+(?:\.\d+)?\s*degrees?\b/i)?.[0];
+  return value ? normalizeSpaces(value) : null;
+}
+
+function explicitWorldStateFactsFromText(text: string | null | undefined): WorldStateAgentPatch {
+  const sourceText = (text ?? "").trim();
+  if (!sourceText) return {};
+  const patch: WorldStateAgentPatch = {};
+  const date = exactDateFromText(sourceText);
+  const time = exactTimeFromText(sourceText);
+  const temperature = exactTemperatureFromText(sourceText);
+  if (date) patch.date = date;
+  if (time) patch.time = time;
+  if (temperature) patch.temperature = temperature;
+  return patch;
+}
+
+function sourceMentionsStableField(text: string | null | undefined, field: StableExplicitField): boolean {
+  const sourceText = (text ?? "").trim();
+  if (!sourceText) return false;
+  if (field === "date") return looksLikeDate(sourceText);
+  if (field === "time") return looksLikeTime(sourceText);
+  return looksLikeTemperature(sourceText);
+}
+
+function stabilizeExplicitFields(
+  patch: WorldStateAgentPatch | null,
+  options: WorldStateAgentPatchOptions,
+): WorldStateAgentPatch | null {
+  const explicitFacts = explicitWorldStateFactsFromText(options.sourceText);
+  if (!patch && Object.keys(explicitFacts).length === 0) return null;
+
+  const nextPatch: WorldStateAgentPatch = { ...(patch ?? {}) };
+  for (const field of STABLE_EXPLICIT_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(explicitFacts, field)) {
+      nextPatch[field] = explicitFacts[field] ?? null;
+      continue;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(nextPatch, field)) continue;
+    if (sourceMentionsStableField(options.sourceText, field)) continue;
+    const previous = readPreviousStableField(options.previousWorldState, field);
+    if (previous) nextPatch[field] = previous;
+  }
+
+  return Object.keys(nextPatch).length ? nextPatch : null;
 }
 
 function freeformWorldStatePatch(text: string): WorldStateAgentPatch | null {
@@ -151,13 +273,13 @@ function freeformWorldStatePatch(text: string): WorldStateAgentPatch | null {
 
 export function worldStatePatchFromAgentData(
   data: unknown,
-  options: { allowFreeform?: boolean } = {},
+  options: WorldStateAgentPatchOptions = {},
 ): WorldStateAgentPatch | null {
   const structured = structuredWorldStatePatch(data) ?? nestedStructuredWorldStatePatch(data);
-  if (structured) return structured;
-  if (options.allowFreeform === false) return null;
+  if (structured) return stabilizeExplicitFields(structured, options);
+  if (options.allowFreeform === false) return stabilizeExplicitFields(null, options);
 
   const text = textFallback(data);
-  if (!text) return null;
-  return structuredWorldStatePatchFromText(text) ?? freeformWorldStatePatch(text);
+  if (!text) return stabilizeExplicitFields(null, options);
+  return stabilizeExplicitFields(structuredWorldStatePatchFromText(text) ?? freeformWorldStatePatch(text), options);
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1950

## Why this change

- World State could miss explicit day/time/temperature facts from narration or replace prior exact values on follow-up turns where those facts were not repeated.
- The default World State prompt also encouraged genre/default inference, which made exact fact drift more likely.

## What changed

- Tightened the default World State prompt so explicit day-of-week, exact clock time, and exact temperature are authoritative.
- Added source-text stabilization to `worldStatePatchFromAgentData` so explicit facts in the assistant response override vague/null agent output.
- Threaded the assistant response text and pre-generation tracker baseline through final tracker snapshot persistence.
- Guarded against the live optimistic tracker-result path by using the pre-generation baseline when final persistence corrects silent date/time/temperature drift.
- Added focused Vitest coverage for explicit fact override, silent preservation, adjacent time/temperature updates, and optimistic drift correction.

## Refactor impact

Primary owner:

engine generation / world-state tracker

Impact areas reviewed:

- World State agent result parsing
- Tracker snapshot persistence
- Retry/rerun tracker path
- Default built-in World State prompt

Boundary notes:

- Engine-only change; no React UI, shared API adapter, Tauri command, schema, dependency, or storage format changes.
- Existing location/weather and freeform fallback behavior remains in place; the new stability guard is limited to date, time, and temperature.

Pressure points touched:

- `start-generation.ts` final tracker snapshot persistence
- `tracker-snapshots.ts` World State patch merge
- `world-state-agent-result.ts` agent result parser/fallback

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm exec vitest run src/engine/generation/world-state-agent-result.test.ts src/engine/generation/tracker-snapshots.test.ts src/engine/contracts/constants/agent-prompts.test.ts` and all 7 tests passed after merging latest `upstream/refactor`.
- Codex ran `pnpm typecheck` and it passed.
- Codex ran full `pnpm check` and it passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` and it passed.
- No app UI screenshot is attached because this is backend/engine tracker logic with no visible layout change.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - no visible UI change.
