### PR TITLE
Fix continuity checklist selected action

### DIFF
--- a/src/features/catalog/agents/components/ContinuityIssueChecklist.test.tsx
+++ b/src/features/catalog/agents/components/ContinuityIssueChecklist.test.tsx
@@ -73,5 +73,6 @@ describe("ContinuityIssueChecklist", () => {
     expect(view.textContent).toContain("Second continuity issue");
     expect(view.textContent).toContain("1 of 2 selected");
     expect(view.textContent).toContain("Review all");
+    expect(view.textContent).toContain("Showing selected");
   });
 });

--- a/src/features/catalog/agents/components/ContinuityIssueChecklist.test.tsx
+++ b/src/features/catalog/agents/components/ContinuityIssueChecklist.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { ContinuityIssueChecklist } from "./ContinuityIssueChecklist";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderChecklist(content: string) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<ContinuityIssueChecklist content={content} />);
+  });
+  return container;
+}
+
+function buttonWithText(scope: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(scope.querySelectorAll("button")).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  return button;
+}
+
+function click(button: HTMLButtonElement) {
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount();
+    });
+  }
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe("ContinuityIssueChecklist", () => {
+  it("disables the selected-only action when all findings are already visible", () => {
+    const view = renderChecklist("First continuity issue\nSecond continuity issue");
+
+    const hideUnselected = buttonWithText(view, "Hide unselected");
+
+    expect(hideUnselected.disabled).toBe(true);
+    expect(view.textContent).toContain("First continuity issue");
+    expect(view.textContent).toContain("Second continuity issue");
+  });
+
+  it("hides unselected findings after the user narrows the list", () => {
+    const view = renderChecklist("First continuity issue\nSecond continuity issue");
+
+    click(buttonWithText(view, "First continuity issue"));
+    const hideUnselected = buttonWithText(view, "Hide unselected");
+
+    expect(hideUnselected.disabled).toBe(false);
+
+    click(hideUnselected);
+
+    expect(view.textContent).not.toContain("First continuity issue");
+    expect(view.textContent).toContain("Second continuity issue");
+    expect(view.textContent).toContain("1 of 2 selected");
+    expect(view.textContent).toContain("Review all");
+  });
+});

--- a/src/features/catalog/agents/components/ContinuityIssueChecklist.tsx
+++ b/src/features/catalog/agents/components/ContinuityIssueChecklist.tsx
@@ -98,7 +98,7 @@ export function ContinuityIssueChecklist({ content, compact = false }: Continuit
             onClick={() => setSelectedOnly(true)}
             className="rounded-md bg-[var(--primary)] px-2 py-1 text-[0.5625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-45"
           >
-            Hide unselected
+            {selectedOnly ? "Showing selected" : "Hide unselected"}
           </button>
         </div>
       </div>

--- a/src/features/catalog/agents/components/ContinuityIssueChecklist.tsx
+++ b/src/features/catalog/agents/components/ContinuityIssueChecklist.tsx
@@ -17,22 +17,23 @@ function parseContinuityLines(content: string): string[] {
 export function ContinuityIssueChecklist({ content, compact = false }: ContinuityIssueChecklistProps) {
   const issues = useMemo(() => parseContinuityLines(content), [content]);
   const [selected, setSelected] = useState<Set<number>>(() => new Set(issues.map((_, index) => index)));
-  const [acceptedOnly, setAcceptedOnly] = useState(false);
+  const [selectedOnly, setSelectedOnly] = useState(false);
 
   useEffect(() => {
     setSelected(new Set(issues.map((_, index) => index)));
-    setAcceptedOnly(false);
+    setSelectedOnly(false);
   }, [issues]);
 
   if (issues.length === 0) return null;
 
   const visibleIssues = issues
     .map((line, index) => ({ index, line }))
-    .filter(({ index }) => !acceptedOnly || selected.has(index));
+    .filter(({ index }) => !selectedOnly || selected.has(index));
   const selectedCount = issues.reduce((count, _, index) => (selected.has(index) ? count + 1 : count), 0);
+  const canHideUnselected = selectedCount > 0 && selectedCount < issues.length && !selectedOnly;
 
   const toggleIssue = (index: number) => {
-    setAcceptedOnly(false);
+    setSelectedOnly(false);
     setSelected((current) => {
       const next = new Set(current);
       if (next.has(index)) {
@@ -46,7 +47,7 @@ export function ContinuityIssueChecklist({ content, compact = false }: Continuit
 
   const resetReview = () => {
     setSelected(new Set(issues.map((_, index) => index)));
-    setAcceptedOnly(false);
+    setSelectedOnly(false);
   };
 
   return (
@@ -81,7 +82,7 @@ export function ContinuityIssueChecklist({ content, compact = false }: Continuit
           {selectedCount} of {issues.length} selected
         </span>
         <div className="flex items-center gap-1">
-          {acceptedOnly && (
+          {selectedOnly && (
             <button
               type="button"
               onClick={resetReview}
@@ -93,11 +94,11 @@ export function ContinuityIssueChecklist({ content, compact = false }: Continuit
           )}
           <button
             type="button"
-            disabled={selectedCount === 0 || acceptedOnly}
-            onClick={() => setAcceptedOnly(true)}
+            disabled={!canHideUnselected}
+            onClick={() => setSelectedOnly(true)}
             className="rounded-md bg-[var(--primary)] px-2 py-1 text-[0.5625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-45"
           >
-            Accept selected
+            Hide unselected
           </button>
         </div>
       </div>


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1951

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Continuity Checker showed an `Accept selected` button, but the handler only toggled a local selected-only filter. Because every finding starts selected, clicking the default button left the list unchanged and looked like a broken/apply-nothing action.

## What changed

<!-- List the key changes in this PR. -->

- Renamed the misleading action to `Hide unselected`, matching the behavior the checklist actually supports.
- Disabled the action when all findings are already visible or when the selected-only view is already active, preventing the old enabled no-op.
- Added a focused jsdom React regression test for the all-selected no-op path and the narrowed selected-only path.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Catalog agents UI.

Impact areas reviewed:

- `AgentThoughtBubbles` render path for floating agent activity.
- `RoleplayHUDActionsMenu` render path for the roleplay Agents activity tab.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature UI only. No engine, shared API, Rust storage, prompt, provider, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None. The change stays inside the existing Continuity Checker checklist component.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm test src/features/catalog/agents/components/ContinuityIssueChecklist.test.tsx`: 1 file passed, 2 tests passed.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed, including line endings, architecture, frontend, Rust, docs, discovery, and unused-code checks.
- Codex ran a Vite-served browser fixture for the real checklist component and saved local screenshots:
  - `scratch/continuity-checklist-default-disabled.png`
  - `scratch/continuity-checklist-selected-only.png`
- GitHub-renderable image upload is not embedded in this draft because `gh gist create` rejected binary PNG uploads in this environment.
- Full provider-generated Continuity Checker chat replay was not run; the verified claim is the checklist affordance itself.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix to an existing Continuity Checker UI affordance; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

- Local proof screenshots are listed in the validation notes. This draft does not embed GitHub-renderable screenshots because CLI binary upload was unavailable.
