### PR TITLE
Fix persona quote formatting on save

### DIFF
--- a/src/features/catalog/personas/components/editor/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/editor/PersonaEditor.tsx
@@ -34,7 +34,12 @@ import { ExpandedTextarea } from "../../../../../shared/components/ui/ExpandedTe
 import { exportApi } from "../../../../../shared/api/export-api";
 import { AvatarGenerationModal } from "../../../../../shared/components/ui/AvatarGenerationModal";
 import { ExportFormatDialog, type ExportFormatChoice } from "../../../../../shared/components/ui/ExportFormatDialog";
-import { buildPersonaFormData, type PersonaFormData, type PersonaRow } from "../../lib/persona-editor-model";
+import {
+  buildPersonaFormData,
+  buildPersonaSavePayload,
+  type PersonaFormData,
+  type PersonaRow,
+} from "../../lib/persona-editor-model";
 import { PersonaColorsTab } from "./PersonaColorsTab";
 import { PersonaDescriptionTab } from "./PersonaDescriptionTab";
 import { PersonaSpritesTab } from "../sprites/PersonaSpritesTab";
@@ -57,6 +62,7 @@ type TabId = (typeof TABS)[number]["id"];
 export function PersonaEditor() {
   const personaId = useUIStore((s) => s.personaDetailId);
   const closeDetail = useUIStore((s) => s.closePersonaDetail);
+  const quoteFormat = useUIStore((s) => s.quoteFormat);
   const { data: rawPersona, isLoading } = usePersona(personaId);
   const updatePersona = useUpdatePersona();
   const uploadAvatar = useUploadPersonaAvatar();
@@ -115,13 +121,9 @@ export function PersonaEditor() {
     if (!personaId || !formData) return;
     setSaving(true);
     try {
-      const { altDescriptions, tags, avatarCrop, ...rest } = formData;
       await updatePersona.mutateAsync({
         id: personaId,
-        ...rest,
-        altDescriptions,
-        tags,
-        avatarCrop: avatarCrop ?? null,
+        ...buildPersonaSavePayload(formData, quoteFormat),
       });
       setDirty(false);
     } finally {

--- a/src/features/catalog/personas/lib/persona-editor-model.test.ts
+++ b/src/features/catalog/personas/lib/persona-editor-model.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPersonaSavePayload, type PersonaFormData } from "./persona-editor-model";
+
+const baseFormData: PersonaFormData = {
+  name: `Player "Alias"`,
+  comment: `Comment "stays raw"`,
+  description: `She says "hello".`,
+  personality: `Keeps saying "focus".`,
+  scenario: `"Ready?" she asks.`,
+  backstory: `Raised around "old maps".`,
+  appearance: `Wears a jacket called "Lucky".`,
+  nameColor: "#ffffff",
+  dialogueColor: "#111111",
+  boxColor: "#222222",
+  personaStats: null,
+  altDescriptions: [
+    { id: "combat", label: `Label "raw"`, content: `Draws the "silver blade".`, active: true },
+    { id: "empty", label: "Empty", content: "", active: false },
+  ],
+  tags: [`tag "raw"`],
+  avatarCrop: null,
+};
+
+describe("buildPersonaSavePayload", () => {
+  it("applies typographic quote formatting to persona long-text fields and extension content", () => {
+    const payload = buildPersonaSavePayload(baseFormData, "typographic");
+
+    expect(payload.description).toBe("She says \u201chello\u201d.");
+    expect(payload.personality).toBe("Keeps saying \u201cfocus\u201d.");
+    expect(payload.scenario).toBe("\u201cReady?\u201d she asks.");
+    expect(payload.backstory).toBe("Raised around \u201cold maps\u201d.");
+    expect(payload.appearance).toBe("Wears a jacket called \u201cLucky\u201d.");
+    expect(payload.altDescriptions[0]?.content).toBe("Draws the \u201csilver blade\u201d.");
+  });
+
+  it("leaves non-formatted metadata fields unchanged", () => {
+    const payload = buildPersonaSavePayload(baseFormData, "typographic");
+
+    expect(payload.name).toBe(baseFormData.name);
+    expect(payload.comment).toBe(baseFormData.comment);
+    expect(payload.tags).toEqual(baseFormData.tags);
+    expect(payload.altDescriptions[0]?.label).toBe(baseFormData.altDescriptions[0]?.label);
+  });
+
+  it("can normalize typographic quotes back to straight quotes", () => {
+    const payload = buildPersonaSavePayload(
+      {
+        ...baseFormData,
+        description: "She says \u201chello\u201d.",
+        altDescriptions: [{ id: "note", label: "Note", content: "Keeps \u201cfocus\u201d.", active: true }],
+      },
+      "straight",
+    );
+
+    expect(payload.description).toBe(`She says "hello".`);
+    expect(payload.altDescriptions[0]?.content).toBe(`Keeps "focus".`);
+  });
+});

--- a/src/features/catalog/personas/lib/persona-editor-model.ts
+++ b/src/features/catalog/personas/lib/persona-editor-model.ts
@@ -1,4 +1,5 @@
 import { parseAvatarCropJson, type AvatarCrop, type LegacyAvatarCrop } from "../../../../shared/lib/utils";
+import { formatTextQuotes, type QuoteFormat } from "../../../../shared/lib/dialogue-quotes";
 
 export interface AltDescriptionEntry {
   id: string;
@@ -48,6 +49,10 @@ export interface PersonaFormData {
   avatarCrop: AvatarCrop | LegacyAvatarCrop | null;
 }
 
+export type PersonaSavePayload = Omit<PersonaFormData, "avatarCrop"> & {
+  avatarCrop: AvatarCrop | LegacyAvatarCrop | null;
+};
+
 export interface PersonaRow {
   id: string;
   name: string;
@@ -91,6 +96,20 @@ export const DEFAULT_PERSONA_STATS: PersonaStatsData = {
   ],
   rpgStats: DEFAULT_RPG_STATS,
 };
+
+function formatPersonaSavePayloadText(value: string, quoteFormat: QuoteFormat): string {
+  return formatTextQuotes(value, quoteFormat);
+}
+
+function formatAltDescriptionsForSave(
+  altDescriptions: AltDescriptionEntry[],
+  quoteFormat: QuoteFormat,
+): AltDescriptionEntry[] {
+  return altDescriptions.map((entry) => ({
+    ...entry,
+    content: formatPersonaSavePayloadText(entry.content, quoteFormat),
+  }));
+}
 
 function parseAvatarCropValue(value: PersonaRow["avatarCrop"]): AvatarCrop | LegacyAvatarCrop | null {
   if (!value) return null;
@@ -169,5 +188,18 @@ export function buildPersonaFormData(persona: PersonaRow): PersonaFormData {
     altDescriptions: Array.isArray(persona.altDescriptions) ? persona.altDescriptions : [],
     tags: Array.isArray(persona.tags) ? persona.tags : [],
     avatarCrop: parseAvatarCropValue(persona.avatarCrop),
+  };
+}
+
+export function buildPersonaSavePayload(formData: PersonaFormData, quoteFormat: QuoteFormat): PersonaSavePayload {
+  return {
+    ...formData,
+    description: formatPersonaSavePayloadText(formData.description, quoteFormat),
+    personality: formatPersonaSavePayloadText(formData.personality, quoteFormat),
+    scenario: formatPersonaSavePayloadText(formData.scenario, quoteFormat),
+    backstory: formatPersonaSavePayloadText(formData.backstory, quoteFormat),
+    appearance: formatPersonaSavePayloadText(formData.appearance, quoteFormat),
+    altDescriptions: formatAltDescriptionsForSave(formData.altDescriptions, quoteFormat),
+    avatarCrop: formData.avatarCrop ?? null,
   };
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1963

## Why this change

- The refactor persona editor saved persona long-text fields exactly as typed, so the global quote-format setting was not applied before persistence.
- Legacy persona editing normalized description, personality, scenario, backstory, appearance, and description-extension content through the configured quote formatter.

## What changed

- Added a persona save-payload builder that applies `formatTextQuotes` to description, personality, scenario, backstory, appearance, and `altDescriptions[].content`.
- Updated `PersonaEditor` to read the global `quoteFormat` setting and send the formatted payload to `useUpdatePersona`.
- Added focused model coverage for typographic formatting, straight-quote normalization, and unchanged metadata fields.

## Refactor impact

Primary owner:

- Catalog personas

Impact areas reviewed:

- Persona editor save payload
- Persona description extensions
- Global UI quote-format setting

Boundary notes:

- Feature/UI code still calls the existing focused persona update hook.
- No engine, shared API, Tauri/Rust storage, schema, dependency, auth, import/export, prompt assembly, or release metadata changes.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the raw save path with `node scratch\issue-1963-static-repro.mjs before`.
- Codex verified the patched save path with `node scratch\issue-1963-static-repro.mjs after`.
- Codex ran `pnpm exec vitest run src/features/catalog/personas/lib/persona-editor-model.test.ts`: 1 file passed, 3 tests passed.
- Codex ran `pnpm check` after rebasing onto current `upstream/refactor`: passed line endings, architecture, frontend, Rust, docs, discovery, and unused checks.
- Bunny review gate passed before opening this draft.
- No human-only verification is currently known; the core claim is covered by static save-path proof plus focused model tests.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this fixes existing persona editor save behavior for an existing setting.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This is save-payload normalization, not a visible layout/rendering change. The behavior is covered by `scratch/bugfix-verification.json`, the static save-path proof, focused Vitest coverage, and `pnpm check`.
