### PR TITLE
Fix active persona fallback data

### DIFF
--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -111,7 +111,10 @@ export function usePersona(id: string | null, enabled = true) {
 export function useActivePersona(enabled = true) {
   return useQuery({
     queryKey: personaKeys.active,
-    queryFn: async () => (await listPersonaSummaries()).find(personaIsActive) ?? null,
+    queryFn: async () => {
+      const activePersona = (await listPersonaSummaries()).find(personaIsActive);
+      return activePersona?.id ? getPersona(activePersona.id) : null;
+    },
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1964

## Why this change

- Chat and shared mode surfaces rely on fallback active persona resolution when a chat does not have an explicit `personaId`.
- The fallback was returning the active persona summary projection, so consumers missed full persona fields such as saved statuses, long persona text, and active description extensions.

## What changed

- Updated `useActivePersona` to use persona summaries only to find the active persona id, then fetch the full persona row for the active-persona cache.
- Preserved the lightweight summary projection for persona lists and switchers.

## Refactor impact

Primary owner:

- Catalog personas

Impact areas reviewed:

- Catalog persona hooks
- Chat mode saved status consumer
- Shared mode UI persona-info consumer
- Runtime generation persona snapshot cache reader

Boundary notes:

- Change stays in `src/features/catalog/personas`.
- No engine, shared API wrapper, Rust storage, schema, import/export, or remote-runtime behavior changed.

Pressure points touched:

- Active persona React Query cache value consumed by chat input, shared mode UI, and generation cache snapshot helpers.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Local scratch proof `node scratch\proof-1964-active-persona.mjs` passed: active fallback still finds the active id through summaries, fetches the full persona row by id, and no longer returns the projected summary row directly.
- `pnpm typecheck` passed.
- `pnpm check` passed after rebasing onto current `origin/refactor`.
- No manual app/browser validation was needed for this data-resolution fix.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This fixes the active persona data row returned by the fallback hook; there is no visible layout change.
