### PR TITLE
Fix native character avatar import storage

### DIFF
--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -230,15 +230,8 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
             "format": data.get("spec").and_then(Value::as_str).unwrap_or("chara_card_v2"),
         });
         let avatar_payload = native_character_avatar_payload(&data);
-        let avatar_absolute_path =
-            if let Some(avatar) = imported_avatar_reference(state, &avatar_payload, None, None)? {
-                Some(apply_imported_character_avatar_metadata(
-                    &mut record,
-                    avatar,
-                ))
-            } else {
-                None
-            };
+        let avatar_absolute_path = imported_avatar_reference(state, &avatar_payload, None, None)?
+            .map(|avatar| apply_imported_character_avatar_metadata(&mut record, avatar));
         apply_import_timestamps(&mut record, &data);
         let name = character_data
             .get("name")
@@ -313,15 +306,8 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
     }
     let mut record_value = with_entity_defaults("characters", source)?;
     let avatar_payload = native_character_avatar_payload(&data);
-    let avatar_absolute_path =
-        if let Some(avatar) = imported_avatar_reference(state, &avatar_payload, None, None)? {
-            Some(apply_imported_character_avatar_metadata(
-                &mut record_value,
-                avatar,
-            ))
-        } else {
-            None
-        };
+    let avatar_absolute_path = imported_avatar_reference(state, &avatar_payload, None, None)?
+        .map(|avatar| apply_imported_character_avatar_metadata(&mut record_value, avatar));
     apply_import_timestamps(&mut record_value, &data);
     let mut created_character_id = None;
     let result = (|| -> AppResult<Value> {

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -187,6 +187,34 @@ fn array_from_envelope(data: &Value, envelope: &Map<String, Value>, key: &str) -
         .unwrap_or_default()
 }
 
+fn native_character_avatar_payload(data: &Value) -> Value {
+    let mut payload = data.clone();
+    let Some(avatar) = data_image_string(data.get("avatar")) else {
+        return payload;
+    };
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("_avatarDataUrl".to_string(), Value::String(avatar));
+    }
+    payload
+}
+
+fn apply_imported_character_avatar_metadata(
+    record: &mut Value,
+    avatar: ImportedAvatarReference,
+) -> String {
+    let absolute_path = avatar.absolute_path.clone();
+    let object = record
+        .as_object_mut()
+        .expect("native character import record should be an object");
+    object.insert("avatarPath".to_string(), Value::String(avatar.asset_url));
+    object.insert(
+        "avatarFilePath".to_string(),
+        Value::String(absolute_path.clone()),
+    );
+    object.insert("avatarFilename".to_string(), Value::String(avatar.filename));
+    absolute_path
+}
+
 fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> {
     if data.get("spec").is_some() && data.get("data").is_some_and(Value::is_object) {
         let mut character_data = data.get("data").cloned().unwrap_or_else(|| json!({}));
@@ -198,14 +226,19 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
                 .and_then(|metadata| metadata.get("comment"))
                 .and_then(Value::as_str)
                 .unwrap_or(""),
-            "avatarPath": data_image_string(data.get("avatar")).map(Value::String).unwrap_or(Value::Null),
+            "avatarPath": null,
             "format": data.get("spec").and_then(Value::as_str).unwrap_or("chara_card_v2"),
         });
-        if let Some(avatar) = data_image_string(data.get("avatar")) {
-            if let Some(object) = record.as_object_mut() {
-                object.insert("avatar".to_string(), Value::String(avatar));
-            }
-        }
+        let avatar_payload = native_character_avatar_payload(&data);
+        let avatar_absolute_path =
+            if let Some(avatar) = imported_avatar_reference(state, &avatar_payload, None, None)? {
+                Some(apply_imported_character_avatar_metadata(
+                    &mut record,
+                    avatar,
+                ))
+            } else {
+                None
+            };
         apply_import_timestamps(&mut record, &data);
         let name = character_data
             .get("name")
@@ -250,6 +283,9 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
                     &mut rollback_errors,
                 );
             }
+            if let Some(path) = avatar_absolute_path.as_deref() {
+                rollback_managed_file_path(state, "avatars/characters", path, &mut rollback_errors);
+            }
             append_marinara_rollback_errors(error, "character import", rollback_errors)
         });
     }
@@ -262,7 +298,10 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
     }
 
     let mut source = data.clone();
-    remove_fields(&mut source, &["id", "sprites", "gallery", "metadata"]);
+    remove_fields(
+        &mut source,
+        &["id", "sprites", "gallery", "metadata", "avatar"],
+    );
     if let Some(object) = source.as_object_mut() {
         if let Some(Value::String(raw)) = object.get("data") {
             let parsed = serde_json::from_str::<Value>(raw)
@@ -273,12 +312,16 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
         }
     }
     let mut record_value = with_entity_defaults("characters", source)?;
-    if let Some(avatar) = data.get("avatar").and_then(Value::as_str) {
-        if let Some(record) = record_value.as_object_mut() {
-            record.insert("avatarPath".to_string(), Value::String(avatar.to_string()));
-            record.insert("avatar".to_string(), Value::String(avatar.to_string()));
-        }
-    }
+    let avatar_payload = native_character_avatar_payload(&data);
+    let avatar_absolute_path =
+        if let Some(avatar) = imported_avatar_reference(state, &avatar_payload, None, None)? {
+            Some(apply_imported_character_avatar_metadata(
+                &mut record_value,
+                avatar,
+            ))
+        } else {
+            None
+        };
     apply_import_timestamps(&mut record_value, &data);
     let mut created_character_id = None;
     let result = (|| -> AppResult<Value> {
@@ -325,6 +368,9 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
                 &[character_id.to_string()],
                 &mut rollback_errors,
             );
+        }
+        if let Some(path) = avatar_absolute_path.as_deref() {
+            rollback_managed_file_path(state, "avatars/characters", path, &mut rollback_errors);
         }
         append_marinara_rollback_errors(error, "character import", rollback_errors)
     })

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -308,6 +308,14 @@ fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> 
     let avatar_payload = native_character_avatar_payload(&data);
     let avatar_absolute_path = imported_avatar_reference(state, &avatar_payload, None, None)?
         .map(|avatar| apply_imported_character_avatar_metadata(&mut record_value, avatar));
+    if avatar_absolute_path.is_none() {
+        if let Some(avatar) = data.get("avatar").and_then(Value::as_str) {
+            if let Some(record) = record_value.as_object_mut() {
+                record.insert("avatarPath".to_string(), Value::String(avatar.to_string()));
+                record.insert("avatar".to_string(), Value::String(avatar.to_string()));
+            }
+        }
+    }
     apply_import_timestamps(&mut record_value, &data);
     let mut created_character_id = None;
     let result = (|| -> AppResult<Value> {

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::state::AppState;
+use base64::engine::general_purpose;
 use std::fs;
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn test_state(label: &str) -> AppState {
@@ -44,6 +46,38 @@ fn block_collection_writes(state: &AppState, collection: &str) {
     fs::create_dir(collection_path).expect("collection path should block file writes");
 }
 
+fn embedded_avatar() -> String {
+    format!(
+        "data:image/png;base64,{}",
+        general_purpose::STANDARD.encode(b"native-avatar-bytes")
+    )
+}
+
+fn assert_managed_character_avatar(character: &Value) {
+    let avatar_path = test_string(character, "avatarPath");
+    assert!(
+        !avatar_path.starts_with("data:image/"),
+        "native character imports should store managed avatar asset URLs, not inline data"
+    );
+    let avatar_file_path = test_string(character, "avatarFilePath");
+    assert!(
+        avatar_file_path.contains("avatars") && avatar_file_path.contains("characters"),
+        "managed avatar path should stay under character avatar storage"
+    );
+    assert!(
+        Path::new(avatar_file_path).exists(),
+        "managed avatar file should exist"
+    );
+    assert!(
+        test_string(character, "avatarFilename").ends_with(".png"),
+        "embedded PNG avatar should persist with a PNG filename"
+    );
+    assert!(
+        character.get("avatar").is_none(),
+        "native character import should not duplicate avatar bytes into the avatar field"
+    );
+}
+
 #[test]
 fn created_record_id_rejects_missing_or_blank_ids() {
     let missing = created_record_id(&json!({ "name": "No id" }), "record")
@@ -73,6 +107,87 @@ fn generic_marinara_import_directs_profile_exports_to_profile_import() {
     assert_eq!(error.code, "invalid_input");
     assert!(error.message.contains("Import Profile"));
     assert!(!error.message.contains("Unknown Marinara import type"));
+}
+
+#[test]
+fn native_marinara_character_import_materializes_embedded_avatar() {
+    let state = test_state("native-character-avatar");
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_character",
+            "version": 1,
+            "data": {
+                "spec": "chara_card_v2",
+                "data": {
+                    "name": "Native Avatar Character",
+                    "description": "Has an embedded avatar"
+                },
+                "avatar": embedded_avatar()
+            }
+        }),
+    )
+    .expect("native character import should succeed");
+
+    assert_managed_character_avatar(&imported["character"]);
+}
+
+#[test]
+fn native_marinara_storage_record_import_materializes_embedded_avatar() {
+    let state = test_state("native-storage-avatar");
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_character",
+            "version": 1,
+            "data": {
+                "data": {
+                    "name": "Native Storage Avatar Character",
+                    "description": "Has an embedded avatar"
+                },
+                "format": "chara_card_v2",
+                "avatar": embedded_avatar()
+            }
+        }),
+    )
+    .expect("native storage-record import should succeed");
+
+    assert_managed_character_avatar(&imported["character"]);
+}
+
+#[test]
+fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
+    let state = test_state("native-character-avatar-rollback");
+
+    let error = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_character",
+            "version": 1,
+            "data": {
+                "spec": "chara_card_v2",
+                "data": {
+                    "name": "Rollback Native Avatar Character",
+                    "description": "Should be removed"
+                },
+                "avatar": embedded_avatar(),
+                "sprites": [
+                    { "data": "data:image/png;base64,not-valid-base64!" }
+                ]
+            }
+        }),
+    )
+    .expect_err("sprite decode failure should reject character import");
+
+    assert_eq!(error.code, "invalid_input");
+    assert!(
+        state.storage.list("characters").unwrap().is_empty(),
+        "failed native character import must remove the created character"
+    );
+    assert!(
+        !state.data_dir.join("avatars").join("characters").exists(),
+        "failed native character import must remove the managed avatar file"
+    );
 }
 
 #[test]

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -156,6 +156,36 @@ fn native_marinara_storage_record_import_materializes_embedded_avatar() {
 }
 
 #[test]
+fn native_marinara_storage_record_import_preserves_plain_avatar_string() {
+    let state = test_state("native-storage-plain-avatar");
+    let avatar = "/assets/imported/native-avatar.png";
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_character",
+            "version": 1,
+            "data": {
+                "data": {
+                    "name": "Native Plain Avatar Character",
+                    "description": "Has a legacy avatar reference"
+                },
+                "format": "chara_card_v2",
+                "avatar": avatar
+            }
+        }),
+    )
+    .expect("native storage-record import with plain avatar should succeed");
+
+    let character = &imported["character"];
+    assert_eq!(test_string(character, "avatarPath"), avatar);
+    assert_eq!(test_string(character, "avatar"), avatar);
+    assert!(
+        character.get("avatarFilePath").is_none(),
+        "plain avatar strings should not be materialized as managed files"
+    );
+}
+
+#[test]
 fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
     let state = test_state("native-character-avatar-rollback");
 

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::state::AppState;
-use base64::engine::general_purpose;
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -47,10 +46,7 @@ fn block_collection_writes(state: &AppState, collection: &str) {
 }
 
 fn embedded_avatar() -> String {
-    format!(
-        "data:image/png;base64,{}",
-        general_purpose::STANDARD.encode(b"native-avatar-bytes")
-    )
+    "data:image/png;base64,bmF0aXZlLWF2YXRhci1ieXRlcw==".to_string()
 }
 
 fn assert_managed_character_avatar(character: &Value) {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1960

## Why this change

- Native `.marinara` character imports with embedded avatars were storing the `data:image/...` payload directly in character avatar fields. That diverged from legacy native import behavior and from the current ST/CharX managed avatar import path.

## What changed

- Native Marinara character import now adapts embedded avatar data through the same managed character avatar helper used by ST/CharX import.
- Both ST-shaped native character envelopes and storage-record-shaped native character envelopes now set `avatarPath`, `avatarFilePath`, and `avatarFilename` from managed avatar storage instead of persisting inline avatar bytes.
- Native character import rollback now removes the managed avatar file if a later import step fails after avatar persistence.
- Added Rust regressions for both native character envelope shapes and the rollback path.

## Refactor impact

Primary owner:

Rust storage imports.

Impact areas reviewed:

- Native Marinara character import
- Managed character avatar storage metadata
- Native import rollback for post-avatar failures
- Existing ST/CharX avatar import helper reuse

Boundary notes:

- Change stays inside `src-tauri` storage import code.
- No React, engine, shared API, remote-runtime, schema, dependency, or command registration changes.

Pressure points touched:

- `src-tauri/src/commands/storage/imports/marinara.rs`
- `src-tauri/src/commands/storage/imports/marinara_tests.rs`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml native_marinara_ -- --nocapture`: passed. The tests cover ST-shaped native character avatar materialization, storage-record-shaped native character avatar materialization, and rollback when a later sprite import step fails.
- Codex ran `cargo check --manifest-path src-tauri/Cargo.toml --workspace`: passed.
- Codex ran `rustfmt --check src-tauri/src/commands/storage/imports/marinara.rs src-tauri/src/commands/storage/imports/marinara_tests.rs`: passed.
- Codex ran `git diff --check`: passed.
- Full `cargo fmt --manifest-path src-tauri/Cargo.toml --check` currently reports unrelated pre-existing rustfmt drift outside this PR's files.
- Codex ran `pnpm check`: passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a storage/import bugfix for existing native Marinara character imports; it does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a Rust storage import bugfix with command-level regression coverage; no visible UI surface changed.
