### PR TITLE
Fix lorebook secondary key gating

### DIFF
--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -490,9 +490,9 @@ export function scanForActivatedEntries(
     const { matched, matchedKeys } = testPrimaryKeys(entry.keys, entryScanText, matchOptions);
     if (!matched) continue;
 
-    // Test secondary keys. Older imports can carry secondary keys without the
-    // selective flag, so the configured logic follows the keys themselves.
-    if (entry.secondaryKeys.length > 0) {
+    // Test secondary keys only for selective entries. Older imports can carry
+    // secondary keys while keeping selective disabled.
+    if (entry.selective && entry.secondaryKeys.length > 0) {
       if (!testSecondaryKeys(entry.secondaryKeys, entryScanText, entry.selectiveLogic, matchOptions)) {
         continue;
       }

--- a/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
@@ -419,7 +419,7 @@ export function LorebookEditor() {
       };
       const { matched } = testPrimaryKeys(entry.keys, text, opts);
       if (!matched) continue;
-      if (entry.secondaryKeys.length > 0) {
+      if (entry.selective && entry.secondaryKeys.length > 0) {
         if (!testSecondaryKeys(entry.secondaryKeys, text, entry.selectiveLogic, opts)) continue;
       }
       result.set(entry.id, "matched");


### PR DESCRIPTION
## Linked issue

Closes #1977

## Why this change

- Refactor lorebook matching required secondary keys whenever `secondaryKeys` was non-empty, even when `selective` was disabled.
- Legacy behavior only used secondary-key logic for selective entries, so imported entries could carry secondary keys while still activating on primary-key matches alone.

## What changed

- Restored the runtime scanner gate so secondary keys are tested only when `entry.selective` is true.
- Matched the lorebook editor keyword preview to the runtime scanner so previewed matches do not drift from generation behavior.

## Refactor impact

Primary owner:

- Engine generation, with catalog lorebook editor preview as the mirrored feature surface.

Impact areas reviewed:

- `src/engine/generation-core/lorebooks/keyword-scanner.ts`
- `src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx`
- Selective=true positive and negative rows for secondary-key matching.

Boundary notes:

- Engine behavior remains in `src/engine`; the feature change only mirrors the same matching condition in the editor preview.
- No storage, import, schema, dependency, or prompt assembly changes.

Pressure points touched:

- Runtime lorebook keyword scanner.
- Lorebook editor keyword-test preview.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Machine proof: `pnpm exec vitest run --config scratch/vitest.issue-1977.config.ts` failed before the fix for a non-selective entry with a primary-key hit and secondary-key miss, then passed after the fix.
- Edge rows covered by the proof: selective=false with stored secondary keys activates on primary-only text; selective=true with secondary hit activates; selective=true with secondary miss stays inactive.
- Machine baseline: `pnpm check` passed after the final diff on the current `upstream/refactor` base.
- Manual verification needed: none for the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; it restores lorebook matching behavior and does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A: no visual layout change. The user-visible editor preview path uses the same restored selective gate as runtime matching and is covered by TypeScript/full-check validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed secondary keyword matching in lorebook entries to only activate when selective mode is explicitly enabled, preventing unintended keyword processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->