### PR TITLE
Fix latest user lorebook budget priority

### DIFF
--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -36,6 +36,8 @@ export interface ActivatedEntry {
   rawContent?: string;
   /** Which key(s) matched */
   matchedKeys: string[];
+  /** True when a primary key matched the latest user message in the chat. */
+  matchedLatestUserMessage?: boolean;
   /** Priority order for injection */
   injectionOrder: number;
   /** True when sticky state kept this entry active without a fresh keyword match */
@@ -329,6 +331,14 @@ function getAdditionalMatchingText(entry: LorebookEntry, sourceText: Partial<Rec
     .join("\n");
 }
 
+function latestUserMessageContent(messages: ScanMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === "user") return message.content;
+  }
+  return "";
+}
+
 /**
  * Group-based selection: within a group, only activate entries up to weight limits.
  */
@@ -426,6 +436,7 @@ export function scanForActivatedEntries(
   // Build the text to scan from recent messages
   const messagesToScan = scanDepth > 0 ? messages.slice(-scanDepth) : messages;
   const combinedText = messagesToScan.map((m) => m.content).join("\n");
+  const latestUserText = latestUserMessageContent(messages);
 
   const activated: ActivatedEntry[] = [];
   const activatedIds = new Set<string>();
@@ -489,6 +500,8 @@ export function scanForActivatedEntries(
     // Test primary keys
     const { matched, matchedKeys } = testPrimaryKeys(entry.keys, entryScanText, matchOptions);
     if (!matched) continue;
+    const matchedLatestUserMessage =
+      latestUserText.length > 0 && testPrimaryKeys(entry.keys, latestUserText, matchOptions).matched;
 
     // Test secondary keys. Older imports can carry secondary keys without the
     // selective flag, so the configured logic follows the keys themselves.
@@ -503,6 +516,7 @@ export function scanForActivatedEntries(
     activated.push({
       entry,
       matchedKeys,
+      matchedLatestUserMessage,
       injectionOrder: entry.order,
     });
     activatedIds.add(entry.id);

--- a/src/engine/generation-core/lorebooks/prompt-injector.test.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { LorebookEntry } from "../../contracts/types/lorebook";
+import { scanForActivatedEntries } from "./keyword-scanner";
+import { applyTokenBudgetWithSkipped } from "./prompt-injector";
+
+function entry(overrides: Partial<LorebookEntry> & Pick<LorebookEntry, "id" | "name" | "keys" | "content" | "order">): LorebookEntry {
+  const { id, name, keys, content, order, ...rest } = overrides;
+  return {
+    id,
+    lorebookId: "book",
+    name,
+    content,
+    description: "",
+    keys,
+    secondaryKeys: [],
+    enabled: true,
+    constant: false,
+    selective: false,
+    selectiveLogic: "and",
+    probability: null,
+    scanDepth: null,
+    matchWholeWords: true,
+    caseSensitive: false,
+    useRegex: false,
+    characterFilterMode: "any",
+    characterFilterIds: [],
+    characterTagFilterMode: "any",
+    characterTagFilters: [],
+    generationTriggerFilterMode: "any",
+    generationTriggerFilters: [],
+    additionalMatchingSources: [],
+    position: 0,
+    depth: 0,
+    order,
+    role: "system",
+    sticky: null,
+    cooldown: null,
+    delay: null,
+    ephemeral: null,
+    group: "",
+    groupWeight: null,
+    folderId: null,
+    locked: false,
+    preventRecursion: false,
+    tag: "",
+    relationships: {},
+    dynamicState: {},
+    activationConditions: [],
+    schedule: null,
+    excludeFromVectorization: false,
+    embedding: null,
+    createdAt: "2026-06-02T00:00:00.000Z",
+    updatedAt: "2026-06-02T00:00:00.000Z",
+    ...rest,
+  };
+}
+
+describe("applyTokenBudgetWithSkipped", () => {
+  it("keeps latest user-message primary-key matches ahead of older context matches", () => {
+    const activated = scanForActivatedEntries(
+      [
+        { role: "user", content: "Earlier chat mentioned old-key." },
+        { role: "assistant", content: "Acknowledged." },
+        { role: "user", content: "Now the current turn mentions new-key." },
+      ],
+      [
+        entry({
+          id: "older-context",
+          name: "Older context",
+          keys: ["old-key"],
+          content: "older context lore",
+          order: 10,
+        }),
+        entry({
+          id: "latest-user",
+          name: "Latest user",
+          keys: ["new-key"],
+          content: "latest user lore",
+          order: 20,
+        }),
+      ],
+    );
+
+    const budgeted = applyTokenBudgetWithSkipped(activated, 5);
+
+    expect(budgeted.includedEntries.map((activatedEntry) => activatedEntry.entry.id)).toEqual(["latest-user"]);
+    expect(budgeted.skippedEntries.map((skipped) => skipped.activatedEntry.entry.id)).toEqual(["older-context"]);
+  });
+});

--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -159,10 +159,12 @@ export function applyTokenBudgetWithSkipped(
   const includedEntries: ActivatedEntry[] = [];
   const skippedEntries: BudgetSkippedActivatedEntry[] = [];
 
-  // Sort: constant entries first, then by order
+  // Sort: constant entries first, then fresh user-turn matches, then by order
   const sorted = [...activatedEntries].sort((a, b) => {
     if (a.entry.constant && !b.entry.constant) return -1;
     if (!a.entry.constant && b.entry.constant) return 1;
+    if (a.matchedLatestUserMessage && !b.matchedLatestUserMessage) return -1;
+    if (!a.matchedLatestUserMessage && b.matchedLatestUserMessage) return 1;
     return a.entry.order - b.entry.order;
   });
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1978

## Why this change

- Target 7 lorebooks parityscan found that the refactor dropped legacy latest-user-message match metadata during lorebook activation. Under a tight lorebook token budget, an older-context match could consume budget before an entry that matched the newest user turn.

## What changed

- Added `matchedLatestUserMessage` metadata to activated lorebook entries when a primary key matches the latest user message.
- Updated lorebook token-budget ordering to keep constants first, then latest-user-message primary-key matches, then existing entry order.
- Added a focused regression test for two activated non-constant entries where budget only fits the latest-user match.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Lorebook keyword scanner metadata.
- Lorebook token-budget ordering and skipped-entry diagnostics.
- Prompt assembly callers that consume `ActivatedEntry` metadata.

Boundary notes:

- Change stays in `src/engine`; no React, shared API, Tauri, storage, import/export, provider, or UI boundaries changed.

Pressure points touched:

- Lorebook prompt injection budget ordering only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex scratch repro before fix: `pnpm exec vitest run --config scratch\vitest.issue-1978.config.mts` failed because budget selection included `older-context` instead of `latest-user`.
- Codex scratch repro after fix: `pnpm exec vitest run --config scratch\vitest.issue-1978.config.mts` passed.
- Codex committed regression: `pnpm exec vitest run src\engine\generation-core\lorebooks\prompt-injector.test.ts` passed.
- Codex lane check: `pnpm typecheck` passed.
- Codex pre-PR baseline after rebase: `pnpm check` passed.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review: passed before draft prep; branch is one focused commit ahead of `upstream/refactor`, diff scope is three lorebook engine files, and `git diff --check upstream/refactor...HEAD` is clean.
- Manual live generation UI smoke not run; the core claim is covered by lorebook scanner/budgeter tests and this PR does not change visible UI.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no visible UI change.
