### PR TITLE
Fix lorebook depth history anchoring

### DIFF
--- a/src/engine/generation-core/lorebooks/prompt-injector.test.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { injectAtDepth, type PromptMessage } from "./prompt-injector";
+
+describe("injectAtDepth", () => {
+  it("anchors depth entries to provided chat history bounds", () => {
+    const messages: PromptMessage[] = [
+      { role: "system", content: "system prompt", contextKind: "prompt" },
+      { role: "user", content: "history 1", contextKind: "history" },
+      { role: "system", content: "context before latest user", contextKind: "prompt" },
+      { role: "user", content: "history 2", contextKind: "history" },
+      { role: "system", content: "post-history reminder", contextKind: "prompt" },
+    ];
+
+    const result = injectAtDepth(
+      messages,
+      [
+        { role: "system", content: "depth 0", depth: 0 },
+        { role: "system", content: "depth 1", depth: 1 },
+        { role: "system", content: "too deep", depth: 99 },
+      ],
+      { minIndex: 1, anchorIndex: 4 },
+    );
+
+    expect(result.map((message) => message.content)).toEqual([
+      "system prompt",
+      "too deep",
+      "history 1",
+      "context before latest user",
+      "depth 1",
+      "history 2",
+      "depth 0",
+      "post-history reminder",
+    ]);
+  });
+
+  it("falls back to the full prompt length when no bounds are provided", () => {
+    const messages: PromptMessage[] = [
+      { role: "system", content: "system prompt", contextKind: "prompt" },
+      { role: "user", content: "history 1", contextKind: "history" },
+      { role: "system", content: "post-history reminder", contextKind: "prompt" },
+    ];
+
+    const result = injectAtDepth(messages, [{ role: "system", content: "depth 0", depth: 0 }]);
+
+    expect(result.map((message) => message.content)).toEqual([
+      "system prompt",
+      "history 1",
+      "post-history reminder",
+      "depth 0",
+    ]);
+  });
+});

--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -10,6 +10,13 @@ export interface PromptMessage {
   name?: string;
 }
 
+export interface InjectAtDepthOptions {
+  /** Lowest prompt index a depth entry may be inserted at. */
+  minIndex?: number;
+  /** Prompt index depth entries count back from. Defaults to the full prompt length. */
+  anchorIndex?: number;
+}
+
 /**
  * Build the World Info content blocks from activated entries.
  * Position 0 = WORLD_INFO_BEFORE (before character defs)
@@ -73,12 +80,16 @@ function getDepthInjectedEntries(activatedEntries: ActivatedEntry[]): Array<{
 export function injectAtDepth(
   messages: PromptMessage[],
   depthEntries: Array<{ content: string; role: LorebookRole; depth: number }>,
+  options: InjectAtDepthOptions = {},
 ): PromptMessage[] {
   if (depthEntries.length === 0) return messages;
 
+  const anchorIndex = Math.max(0, Math.min(messages.length, Math.floor(options.anchorIndex ?? messages.length)));
+  const minIndex = Math.max(0, Math.min(anchorIndex, Math.floor(options.minIndex ?? 0)));
   const byInsertionIndex = new Map<number, Array<{ content: string; role: LorebookRole }>>();
   for (const entry of depthEntries) {
-    const insertionIndex = Math.max(0, messages.length - entry.depth);
+    const depth = Math.max(0, Math.floor(entry.depth));
+    const insertionIndex = Math.max(minIndex, anchorIndex - depth);
     const list = byInsertionIndex.get(insertionIndex) ?? [];
     list.push({ content: entry.content, role: entry.role });
     byInsertionIndex.set(insertionIndex, list);

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { StorageGateway } from "../capabilities/storage";
+import { assembleGenerationPrompt } from "./prompt-assembly";
+
+type RowMap = Record<string, unknown[]>;
+
+function storageWithRows(rows: RowMap): StorageGateway {
+  return {
+    list: async <T = unknown>(entity: string) => (rows[entity] ?? []) as T[],
+    get: async <T = unknown>(entity: string, id: string) =>
+      ((rows[entity]?.find((row) => (row as { id?: string }).id === id) ?? null) as T | null),
+    create: async <T = unknown>() => ({} as T),
+    update: async <T = unknown>() => ({} as T),
+    delete: async () => ({ deleted: true }),
+    listChatMessages: async <T = unknown>() => [] as T[],
+    createChatMessage: async <T = unknown>() => ({} as T),
+    updateChatMessage: async <T = unknown>() => ({} as T),
+    deleteChatMessage: async () => ({ deleted: true }),
+    patchChatMessageExtra: async <T = unknown>() => ({} as T),
+    addChatMessageSwipe: async <T = unknown>() => ({} as T),
+    patchChatMetadata: async <T = unknown>() => ({} as T),
+    patchChatSummaries: async <T = unknown>() => ({} as T),
+    listChatMemories: async <T = unknown>() => [] as T[],
+    getWorldState: async <T = unknown>() => null as T | null,
+    saveTrackerSnapshot: async <T = unknown>() => ({} as T),
+    listLorebookEntries: async <T = unknown>(lorebookId: string) =>
+      (rows["lorebook-entries"] ?? []).filter((row) => (row as { lorebookId?: string }).lorebookId === lorebookId) as T[],
+    createLorebookEntries: async <T = unknown>() => [] as T[],
+    promptFull: async <T = unknown>() => null as T | null,
+  };
+}
+
+function depthInjectionRows(): RowMap {
+  return {
+    prompts: [
+      {
+        id: "preset-1",
+        isDefault: true,
+        wrapFormat: "none",
+        parameters: { strictRoleFormatting: false },
+      },
+    ],
+    "prompt-sections": [
+      {
+        id: "system",
+        presetId: "preset-1",
+        role: "system",
+        content: "system prompt",
+        enabled: true,
+      },
+      {
+        id: "history",
+        presetId: "preset-1",
+        identifier: "chat_history",
+        enabled: true,
+      },
+      {
+        id: "post-history",
+        presetId: "preset-1",
+        role: "system",
+        content: "post-history prompt",
+        enabled: true,
+      },
+    ],
+    "prompt-groups": [],
+    "prompt-choice-blocks": [],
+    characters: [],
+    personas: [],
+    lorebooks: [{ id: "lorebook-1", name: "Depth lore", enabled: true, isGlobal: true }],
+    "lorebook-folders": [],
+    "lorebook-entries": [
+      {
+        id: "entry-1",
+        lorebookId: "lorebook-1",
+        name: "Depth entry",
+        content: "depth lore entry",
+        constant: true,
+        position: 2,
+        depth: 0,
+        role: "system",
+        enabled: true,
+      },
+    ],
+    "regex-scripts": [],
+  };
+}
+
+describe("assembleGenerationPrompt depth injection", () => {
+  it("anchors lorebook depth entries to chat history bounds", async () => {
+    const storage = storageWithRows(depthInjectionRows());
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", promptPresetId: "preset-1", metadata: {} },
+      storedMessages: [{ id: "message-1", role: "user", content: "latest user message" }],
+      connection: {},
+      request: {},
+      latestUserInput: "latest user message",
+    });
+
+    expect(assembly.previewMessages.map((message) => message.content)).toEqual([
+      "system prompt",
+      "latest user message",
+      "depth lore entry",
+      "post-history prompt",
+    ]);
+  });
+
+  it("falls back to full prompt bounds when no chat history exists", async () => {
+    const storage = storageWithRows(depthInjectionRows());
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", promptPresetId: "preset-1", metadata: {} },
+      storedMessages: [],
+      connection: {},
+      request: {},
+      latestUserInput: "",
+    });
+
+    expect(assembly.previewMessages.map((message) => message.content)).toEqual([
+      "system prompt",
+      "post-history prompt",
+      "depth lore entry",
+    ]);
+  });
+});

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2344,6 +2344,20 @@ function insertBeforeFirstHistory(messages: ChatMLMessage[], message: ChatMLMess
   messages.splice(insertAt >= 0 ? insertAt : messages.length, 0, message);
 }
 
+function chatHistoryDepthInjectionBounds(
+  messages: ChatMLMessage[],
+): { minIndex: number; anchorIndex: number } | undefined {
+  const minIndex = messages.findIndex((message) => message.contextKind === "history");
+  if (minIndex < 0) return undefined;
+
+  let lastHistoryIndex = minIndex;
+  for (let index = minIndex + 1; index < messages.length; index += 1) {
+    if (messages[index]?.contextKind === "history") lastHistoryIndex = index;
+  }
+
+  return { minIndex, anchorIndex: lastHistoryIndex + 1 };
+}
+
 export async function assembleGenerationPrompt(
   storage: StorageGateway,
   rawInput: PromptAssemblyInput,
@@ -2561,6 +2575,7 @@ export async function assembleGenerationPrompt(
     authorNotesEntry
       ? [...processedLore.depthEntries, ...characterDepthEntries, authorNotesEntry]
       : [...processedLore.depthEntries, ...characterDepthEntries],
+    chatHistoryDepthInjectionBounds(messages),
   );
   const regexScripts = await storage.list<JsonRecord>("regex-scripts");
   applyRegexScriptsToPromptMessages(messages, regexScripts, {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1979

## Why this change

- Refactor prompt assembly was anchoring `at depth` lorebook entries against the full assembled prompt, so prompt sections that sit after chat history could shift depth-injected lore out of the legacy/ST-style history window.

## What changed

- Restored bounded depth-injection options on the engine lorebook prompt injector.
- Derived depth-injection bounds from assembled chat-history messages before injecting lorebook, character depth prompt, and author-note depth entries.
- Added focused regression coverage for bounded injector behavior, prompt assembly with a post-history prompt section, and no-history fallback behavior.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Lorebook depth injection
- Prompt assembly ordering
- Character depth prompts and author notes that share the same depth injector

Boundary notes:

- Kept the change inside `src/engine`; no React, shared API, Rust, storage schema, dependency, or remote-runtime boundary changes.

Pressure points touched:

- Runtime prompt assembly immediately before regex application and final message merging.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the pre-fix ordering failure with a focused Vitest harness: old behavior placed the depth lore entry after the post-history prompt block.
- Codex verified the fixed behavior with `pnpm exec vitest run src/engine/generation-core/lorebooks/prompt-injector.test.ts src/engine/generation/prompt-assembly.test.ts`; 2 files passed, 4 tests passed.
- Codex ran final `pnpm check`; line endings, architecture, frontend typecheck, Rust check, docs, discovery metadata, and unused-code checks passed.
- No human-only manual verification is required for the core prompt-ordering claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no user-discoverable feature or setting is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; this is an engine prompt-ordering fix with command/harness proof rather than a visible UI change.
