### PR TITLE
Fix eager Game restore history fetch

### DIFF
--- a/src/features/modes/game/components/GameConversationView.test.tsx
+++ b/src/features/modes/game/components/GameConversationView.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GameConversationView } from "./GameConversationView";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchNextPage: vi.fn(),
+  refetchChat: vi.fn(),
+}));
+
+vi.mock("../../../../shared/stores/ui.store", () => ({
+  useUIStore: <T,>(selector: (state: { messagesPerPage: number }) => T) => selector({ messagesPerPage: 20 }),
+}));
+
+vi.mock("../../shared/chat-ui/index", () => ({
+  ChatCommonOverlays: () => null,
+  CreatorNotesCssInjector: () => null,
+  useChatMetadataSync: () => ({ chatBackground: null }),
+  useChatOverlays: () => ({
+    settingsOpen: false,
+    filesOpen: false,
+    galleryOpen: false,
+    wizardOpen: false,
+    spriteArrangeMode: false,
+    openSettings: vi.fn(),
+    closeSettings: vi.fn(),
+    closeFiles: vi.fn(),
+    closeGallery: vi.fn(),
+    toggleSpriteArrange: vi.fn(),
+    finishWizard: vi.fn(),
+  }),
+  useChatSurfaceData: () => ({
+    chat: { id: "game-chat", mode: "game", name: "Restored Game", metadata: "{}" },
+    chatError: null,
+    refetchChat: mocks.refetchChat,
+    chatMeta: { gameId: "game-1" },
+    messages: [{ id: "m1", role: "assistant", content: "Welcome back.", createdAt: "2026-06-02T00:00:00.000Z" }],
+    pageCount: 1,
+    isLoading: false,
+    fetchNextPage: mocks.fetchNextPage,
+    hasNextPage: true,
+    isFetchingNextPage: false,
+    loadedMessageCount: 1,
+    totalMessageCount: 120,
+    messageIdByOrderIndex: new Map([[119, "m1"]]),
+    characterMap: new Map(),
+    chatCharIds: [],
+    gameCharacters: [],
+    personaInfo: undefined,
+    allCharacters: [],
+  }),
+  useChatTimelineActions: () => ({
+    isStreaming: false,
+    peekPromptData: null,
+    deleteDialogMessageId: null,
+    deleteDialogCanDeleteSwipe: false,
+    deleteDialogActiveSwipeIndex: 0,
+    deleteDialogSwipeCount: 0,
+    multiSelectMode: false,
+    selectedMessageIds: new Set(),
+    handleDelete: vi.fn(),
+    handleIllustrate: vi.fn(),
+    handleDeleteConfirm: vi.fn(),
+    handleDeleteSwipe: vi.fn(),
+    handleDeleteMore: vi.fn(),
+    closeDeleteDialog: vi.fn(),
+    handleBulkDelete: vi.fn(),
+    handleCancelMultiSelect: vi.fn(),
+    handleUnselectAllMessages: vi.fn(),
+    handleSelectAllAboveSelection: vi.fn(),
+    handleSelectAllBelowSelection: vi.fn(),
+  }),
+  useSpriteMetadataState: () => ({
+    handleResetSpritePlacements: vi.fn(),
+    handleSetSpritePosition: vi.fn(),
+  }),
+}));
+
+vi.mock("./GameSurface", () => ({
+  GameSurface: () => <div data-testid="game-surface" />,
+}));
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderGameConversationView() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<GameConversationView activeChatId="game-chat" />);
+  });
+  return container;
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount();
+    });
+  }
+  container?.remove();
+  root = null;
+  container = null;
+  vi.clearAllMocks();
+});
+
+describe("GameConversationView", () => {
+  it("does not eagerly fetch every older page when a restored game chat mounts", () => {
+    const view = renderGameConversationView();
+
+    expect(view.querySelector("[data-testid='game-surface']")).not.toBeNull();
+    expect(mocks.fetchNextPage).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/modes/game/components/GameConversationView.tsx
+++ b/src/features/modes/game/components/GameConversationView.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { RefreshCw } from "lucide-react";
 import type { Chat as EngineChat } from "../../../../engine/contracts/types/chat";
 import { useUIStore } from "../../../../shared/stores/ui.store";
@@ -79,15 +78,6 @@ export function GameConversationView({ activeChatId }: GameConversationViewProps
     messageIdByOrderIndex: data.messageIdByOrderIndex,
     refreshWorldStateOnTimelineChange: true,
   });
-  const { fetchNextPage, hasNextPage, isFetchingNextPage, loadedMessageCount, totalMessageCount } = data;
-
-  useEffect(() => {
-    if (loadedMessageCount <= 0) return;
-    if (totalMessageCount <= loadedMessageCount) return;
-    if (!hasNextPage || isFetchingNextPage) return;
-    void fetchNextPage();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, loadedMessageCount, totalMessageCount]);
-
   if (!data.chat) {
     if (data.chatError) {
       return <GameChatHydrationState status="error" onRetry={() => void data.refetchChat()} />;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #1986

## Why this change

- Restoring directly into a Game chat with a long history could immediately start draining older message pages on mount. That extra startup hydration can make Game restore slow and can keep unrelated conversation navigation waiting behind avoidable work.

## What changed

- Removed the Game route's eager `fetchNextPage()` loop so restored Game chats render from the initially loaded page instead of automatically fetching every older page.
- Added regression coverage proving a restored Game chat with `hasNextPage=true` does not call `fetchNextPage` on mount.

## Refactor impact

Primary owner:

- Game mode

Impact areas reviewed:

- Game mode route hydration
- Shared chat surface pagination behavior
- Startup/navigation pressure from restored Game chats

Boundary notes:

- Feature-only React change. No engine, shared API, Rust, storage, import/export, prompt assembly, or dependency changes.

Pressure points touched:

- `GameConversationView`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the root path with `pnpm exec vitest run src\features\modes\game\components\GameConversationView.test.tsx`: before the production patch, the test failed because `fetchNextPage` was called once on mount; after the patch, the test passed.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Bunny review before PR: pass for the focused staged diff.
- Manual/visual limitation: exact Tauri desktop before/after screenshots with Celia's large restored Game profile were not available in this isolated worktree. This draft proves the eager pagination root path at component level.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshots captured. The issue's exact large-profile Tauri restore state was unavailable; this draft includes command-level proof for the eager Game history fetch that caused avoidable startup hydration.
