### PR TITLE
Fix configurable TTS request timeout

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -6,6 +6,9 @@ use marinara_security::redact_sensitive_text;
 const TTS_SETTINGS_KEY: &str = "tts";
 const TTS_API_KEY_MASK: &str = "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}";
 const MAX_TTS_AUDIO_BYTES: usize = 20 * 1024 * 1024;
+const DEFAULT_TTS_REQUEST_TIMEOUT_MS: u64 = 60_000;
+const MIN_TTS_REQUEST_TIMEOUT_MS: u64 = 1_000;
+const MAX_TTS_REQUEST_TIMEOUT_MS: u64 = 30 * 60_000;
 
 const OPENAI_FALLBACK_VOICES: &[&str] = &[
     "alloy", "ash", "coral", "echo", "fable", "nova", "onyx", "sage", "shimmer",
@@ -119,6 +122,7 @@ fn default_config() -> Value {
         "voice": "alloy",
         "model": "tts-1",
         "audioFormat": "mp3",
+        "requestTimeoutMs": DEFAULT_TTS_REQUEST_TIMEOUT_MS,
         "speed": 1.0,
         "elevenLabsStability": 0.5,
         "elevenLabsLanguageCode": "",
@@ -182,6 +186,14 @@ fn put_config(state: &AppState, body: Value) -> AppResult<Value> {
         .storage
         .upsert_with_id("app-settings", TTS_SETTINGS_KEY, json!({ "value": config }))?;
     Ok(Value::Null)
+}
+
+fn tts_request_timeout_ms(config: &Value) -> u64 {
+    config
+        .get("requestTimeoutMs")
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_TTS_REQUEST_TIMEOUT_MS)
+        .clamp(MIN_TTS_REQUEST_TIMEOUT_MS, MAX_TTS_REQUEST_TIMEOUT_MS)
 }
 
 async fn voices(state: &AppState) -> AppResult<Value> {
@@ -341,7 +353,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
     };
 
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(60))
+        .timeout(Duration::from_millis(tts_request_timeout_ms(&config)))
         .build()
         .map_err(|error| AppError::new("tts_client_error", error.to_string()))?;
     let provider_text = if source == "elevenlabs" {
@@ -1098,6 +1110,32 @@ mod tests {
         assert!(result["audioBase64"]
             .as_str()
             .is_some_and(|audio| !audio.is_empty()));
+    }
+
+    #[test]
+    fn tts_request_timeout_defaults_to_sixty_seconds() {
+        assert_eq!(tts_request_timeout_ms(&json!({})), 60_000);
+        assert_eq!(config_with_defaults(json!({}))["requestTimeoutMs"], 60_000);
+    }
+
+    #[test]
+    fn tts_request_timeout_uses_configured_value() {
+        assert_eq!(
+            tts_request_timeout_ms(&json!({ "requestTimeoutMs": 180_000 })),
+            180_000
+        );
+    }
+
+    #[test]
+    fn tts_request_timeout_clamps_extreme_values() {
+        assert_eq!(
+            tts_request_timeout_ms(&json!({ "requestTimeoutMs": 0 })),
+            MIN_TTS_REQUEST_TIMEOUT_MS
+        );
+        assert_eq!(
+            tts_request_timeout_ms(&json!({ "requestTimeoutMs": 60 * 60_000 })),
+            MAX_TTS_REQUEST_TIMEOUT_MS
+        );
     }
 
     #[test]

--- a/src/engine/contracts/types/tts.ts
+++ b/src/engine/contracts/types/tts.ts
@@ -112,6 +112,8 @@ export const ttsConfigSchema = z.object({
   narratorVoice: z.string().default(""),
   model: z.string().default("tts-1"),
   audioFormat: ttsAudioFormatSchema.default("mp3"),
+  /** Provider request timeout per generated TTS chunk, in milliseconds. */
+  requestTimeoutMs: z.number().int().min(1000).max(30 * 60_000).default(60_000),
   /** 0.25 – 4.0 */
   speed: z.number().min(0.25).max(4.0).default(1.0),
   /** ElevenLabs only: 0.0 = more expressive/creative, 1.0 = more stable/robust */

--- a/src/features/shell/discovery/discovery-entries.json
+++ b/src/features/shell/discovery/discovery-entries.json
@@ -180,7 +180,7 @@
     "title": "Text-to-Speech",
     "category": "Media",
     "summary": "Configure voice providers and let chats, narration, or characters speak with assigned voices.",
-    "keywords": ["voice", "tts", "speech", "audio", "narrator", "character voices", "elevenlabs", "openai"],
+    "keywords": ["voice", "tts", "speech", "audio", "narrator", "character voices", "elevenlabs", "openai", "timeout", "self-hosted tts"],
     "audience": "Users who want voiced messages, narration, or more immersive scenes.",
     "where": "Settings and connection/provider configuration, with chat-specific voice options where available.",
     "actions": [{ "type": "open-panel", "panel": "settings", "label": "Open Settings" }],

--- a/src/features/shell/settings/components/settings/TTSConfigCard.tsx
+++ b/src/features/shell/settings/components/settings/TTSConfigCard.tsx
@@ -53,6 +53,10 @@ function FieldRow({ label, help, children }: { label: string; help?: string; chi
 const INPUT_CLS =
   "w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]";
 
+const DEFAULT_TTS_REQUEST_TIMEOUT_MS = 60_000;
+const MIN_TTS_REQUEST_TIMEOUT_MS = 1_000;
+const MAX_TTS_REQUEST_TIMEOUT_MS = 30 * 60_000;
+
 const TTS_SOURCE_DEFAULTS: Record<
   TTSSource,
   { label: string; baseUrl: string; model: string; voice: string; idleText: string }
@@ -228,6 +232,11 @@ function sameStringSet(left: string[], right: string[]): boolean {
   return left.every((value) => rightSet.has(value));
 }
 
+function normalizeRequestTimeoutMs(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_TTS_REQUEST_TIMEOUT_MS;
+  return Math.min(MAX_TTS_REQUEST_TIMEOUT_MS, Math.max(MIN_TTS_REQUEST_TIMEOUT_MS, Math.round(value)));
+}
+
 function ToggleRow({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
   return (
     <label className="flex cursor-pointer items-center justify-between rounded-lg p-1.5 transition-colors hover:bg-[var(--secondary)]/50">
@@ -311,6 +320,7 @@ export function TTSConfigCard() {
   const [npcDefaultVoicesEnabled, setNpcDefaultVoicesEnabled] = useState(false);
   const [npcDefaultMaleVoices, setNpcDefaultMaleVoices] = useState<string[]>([]);
   const [npcDefaultFemaleVoices, setNpcDefaultFemaleVoices] = useState<string[]>([]);
+  const [requestTimeoutMs, setRequestTimeoutMs] = useState(DEFAULT_TTS_REQUEST_TIMEOUT_MS);
   const [speed, setSpeed] = useState(1.0);
   const [elevenLabsStability, setElevenLabsStability] = useState(0.5);
   const [elevenLabsLanguageCode, setElevenLabsLanguageCode] = useState("");
@@ -358,6 +368,7 @@ export function TTSConfigCard() {
     setNpcDefaultVoicesEnabled(savedConfig.npcDefaultVoicesEnabled ?? false);
     setNpcDefaultMaleVoices(savedConfig.npcDefaultMaleVoices ?? []);
     setNpcDefaultFemaleVoices(savedConfig.npcDefaultFemaleVoices ?? []);
+    setRequestTimeoutMs(savedConfig.requestTimeoutMs ?? DEFAULT_TTS_REQUEST_TIMEOUT_MS);
     setSpeed(savedConfig.speed);
     setElevenLabsStability(savedConfig.elevenLabsStability ?? 0.5);
     setElevenLabsLanguageCode(savedConfig.elevenLabsLanguageCode ?? "");
@@ -405,6 +416,7 @@ export function TTSConfigCard() {
     npcDefaultVoicesEnabled,
     npcDefaultMaleVoices,
     npcDefaultFemaleVoices,
+    requestTimeoutMs,
     speed,
     elevenLabsStability,
     elevenLabsLanguageCode,
@@ -869,6 +881,28 @@ export function TTSConfigCard() {
               </select>
             </FieldRow>
           )}
+
+          <FieldRow
+            label="Request Timeout"
+            help="Provider request timeout per generated TTS chunk. Raise this for slower self-hosted voice models."
+          >
+            <input
+              type="number"
+              min={MIN_TTS_REQUEST_TIMEOUT_MS}
+              max={MAX_TTS_REQUEST_TIMEOUT_MS}
+              step={1000}
+              value={requestTimeoutMs}
+              onChange={(e) => {
+                const nextTimeout = normalizeRequestTimeoutMs(Number(e.target.value));
+                setRequestTimeoutMs(nextTimeout);
+                mark({ requestTimeoutMs: nextTimeout });
+              }}
+              className={INPUT_CLS}
+            />
+            <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+              Default is 60000 ms. Maximum is 1800000 ms.
+            </p>
+          </FieldRow>
 
           {/* Voice assignment mode */}
           <FieldRow


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #1987

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Self-hosted OpenAI-compatible TTS providers can need more than 60 seconds to synthesize one chunk. Refactor still hard-coded the TTS speak provider timeout at 60 seconds, so slow local voice models could time out even though chunking was working.

## What changed

<!-- List the key changes in this PR. -->

- Added `requestTimeoutMs` to the persisted TTS config with a legacy-compatible 60000 ms default and 1000-1800000 ms bounds.
- Changed the Rust TTS `speak` provider client to use the configured timeout instead of `Duration::from_secs(60)`.
- Added Rust regression coverage for default, configured, and clamped timeout values.
- Added an autosaved Request Timeout control to the existing TTS settings card.
- Updated the existing Text-to-Speech discovery entry with timeout/self-hosted search terms.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Rust storage

Impact areas reviewed:

- TTS Rust integration command path
- TTS config TypeScript schema
- TTS settings card autosave path
- Shell discovery metadata

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature UI continues to use the existing shared TTS API/config hooks.
- Engine contract only adds the config field; no React imports or runtime adapter imports were added to engine code.
- Rust storage remains the privileged owner for provider request execution.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src-tauri/src/commands/storage/integrations/tts.rs`
- `src/features/shell/settings/components/settings/TTSConfigCard.tsx`
- No command registration, mode surface, import, or prompt pipeline changes.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof recorded locally in `scratch/bugfix-verification.json`.
- Before proof: `powershell -NoProfile -ExecutionPolicy Bypass -File scratch\issue-1987-tts-timeout-repro.ps1` reported the hard-coded 60s timeout and missing config field.
- After proof: the same repro reported the TTS speak timeout is configurable through the app-owned config/schema path.
- `cargo test --manifest-path src-tauri\Cargo.toml tts_request_timeout -- --nocapture` passed: 3 passed, 0 failed.
- `pnpm typecheck` passed.
- `cargo check --manifest-path src-tauri\Cargo.toml` passed.
- `pnpm check:discovery` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Final `pnpm check` passed.
- Manual/browser note: no browser screenshot was captured; core claim is covered by command proof, and the new settings control should still be visually smoke-tested by a human if desired.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Updated the existing Text-to-Speech discovery entry with timeout and self-hosted TTS search terms.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

Backend/settings-contract fix; no screenshot captured. The visible UI addition is one numeric Request Timeout control in the existing TTS settings card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text-to-Speech request timeout is now configurable. Adjust the timeout duration in TTS settings (default: 60 seconds, range: 1–1,800 seconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->