### PR TITLE
Fix Conversation chat load latency

### DIFF
--- a/src/features/modes/router/components/ModeSurface.test.tsx
+++ b/src/features/modes/router/components/ModeSurface.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatStore } from "../../../../shared/stores/chat.store";
+import { ModeSurface } from "./ModeSurface";
+
+const catalogMocks = vi.hoisted(() => ({
+  chat: undefined as { id: string; mode: "conversation" | "roleplay" | "game" } | undefined,
+  summaries: [] as Array<{ id: string; mode: "conversation" | "roleplay" | "game" }>,
+}));
+
+vi.mock("../../../catalog/chats/index", () => ({
+  useChat: () => ({ data: catalogMocks.chat, error: null, isLoading: true, isFetching: true }),
+  useChatSummaries: () => ({ data: catalogMocks.summaries }),
+}));
+
+vi.mock("../../conversation/index", () => ({
+  ConversationModeRoute: ({ activeChatId }: { activeChatId: string }) => (
+    <div data-testid="conversation-route">{activeChatId}</div>
+  ),
+}));
+
+vi.mock("../../roleplay/index", () => ({
+  RoleplayModeRoute: ({ activeChatId }: { activeChatId: string }) => (
+    <div data-testid="roleplay-route">{activeChatId}</div>
+  ),
+}));
+
+vi.mock("../../game/index", () => ({
+  GameModeRoute: ({ activeChatId }: { activeChatId: string }) => <div data-testid="game-route">{activeChatId}</div>,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ModeSurface", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    catalogMocks.chat = undefined;
+    catalogMocks.summaries = [];
+    useChatStore.setState({ activeChatId: null, activeChat: null });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("uses cached chat summaries to route a selected conversation before detail hydrates", async () => {
+    catalogMocks.summaries = [{ id: "chat-1", mode: "conversation" }];
+    useChatStore.setState({ activeChatId: "chat-1" });
+
+    await act(async () => {
+      root.render(<ModeSurface />);
+    });
+
+    expect(container.querySelector("[data-testid='conversation-route']")?.textContent).toBe("chat-1");
+    expect(container.querySelector("[data-testid='roleplay-route']")).toBeNull();
+    expect(container.querySelector("[data-testid='game-route']")).toBeNull();
+  });
+});

--- a/src/features/modes/router/components/ModeSurface.tsx
+++ b/src/features/modes/router/components/ModeSurface.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useEffect, useRef, type ReactNode } from "react";
-import { useChat, type ChatMode } from "../../../catalog/chats/index";
+import { useChat, useChatSummaries, type ChatMode } from "../../../catalog/chats/index";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { ModeHomeSurface } from "./ModeHomeSurface";
@@ -23,6 +23,8 @@ export function ModeSurface({ homeDiscoverySurface = null }: { homeDiscoverySurf
   const activeChatId = useChatStore((state) => state.activeChatId);
   const setActiveChatId = useChatStore((state) => state.setActiveChatId);
   const { data: chat, error: chatError, isLoading: isChatLoading, isFetching: isChatFetching } = useChat(activeChatId);
+  const { data: chatSummaries } = useChatSummaries();
+  const cachedChat = activeChatId ? chatSummaries?.find((item) => item.id === activeChatId) : undefined;
   const lastChatRef = useRef<{ id: string; mode: ChatMode } | null>(null);
 
   useEffect(() => {
@@ -33,9 +35,10 @@ export function ModeSurface({ homeDiscoverySurface = null }: { homeDiscoverySurf
   if (!activeChatId) return <ModeHomeSurface discoverySurface={homeDiscoverySurface} />;
 
   const fallback = <div className="flex flex-1 overflow-hidden" />;
-  if (chat?.mode) lastChatRef.current = { id: activeChatId, mode: chat.mode };
+  const resolvedChatMode = chat?.mode ?? cachedChat?.mode;
+  if (resolvedChatMode) lastChatRef.current = { id: activeChatId, mode: resolvedChatMode };
 
-  const chatMode = chat?.mode ?? (lastChatRef.current?.id === activeChatId ? lastChatRef.current.mode : null);
+  const chatMode = resolvedChatMode ?? (lastChatRef.current?.id === activeChatId ? lastChatRef.current.mode : null);
   if (!chatMode && (isChatLoading || isChatFetching)) return fallback;
   if (!chatMode) return <ModeHomeSurface discoverySurface={homeDiscoverySurface} />;
 

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatSurfaceData } from "./use-chat-surface-data";
+
+const catalogMocks = vi.hoisted(() => ({
+  useChatMessages: vi.fn(),
+}));
+
+vi.mock("../../../../catalog/chats/index", () => ({
+  useChat: () => ({ data: undefined, error: null }),
+  useChatMessageCount: () => ({ data: undefined }),
+  useChatMessages: catalogMocks.useChatMessages,
+}));
+
+vi.mock("../../../../catalog/characters/index", () => ({
+  characterAvatarUrl: () => null,
+  useCharactersByIds: () => ({ data: [] }),
+}));
+
+vi.mock("../../../../catalog/personas/index", () => ({
+  useActivePersona: () => ({ data: undefined }),
+  usePersona: () => ({ data: undefined }),
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Harness() {
+  useChatSurfaceData({
+    activeChatId: "chat-1",
+    messagePageSize: 20,
+    fallbackChatMode: "conversation",
+    personaFallback: "active-persona",
+  });
+  return null;
+}
+
+describe("useChatSurfaceData", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    catalogMocks.useChatMessages.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    catalogMocks.useChatMessages.mockReset();
+  });
+
+  it("starts loading messages as soon as an active chat id exists", () => {
+    act(() => {
+      root.render(<Harness />);
+    });
+
+    expect(catalogMocks.useChatMessages).toHaveBeenCalledWith("chat-1", 20, true);
+  });
+});

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -193,7 +193,7 @@ export function useChatSurfaceData({
     hasNextPage,
     isFetchingNextPage,
     refetch: refetchMessages,
-  } = useChatMessages(activeChatId, resolvedMessagePageSize, !!chat);
+  } = useChatMessages(activeChatId, resolvedMessagePageSize, !!activeChatId);
 
   useEffect(() => {
     if (!(chatError instanceof ApiError) || chatError.status !== 404) return;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

No linked issue yet; filed from Celia's local bug report that Conversation mode takes too long to load a chat even when that chat only has one message.

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Conversation chat selection could serialize route selection and message loading behind the full chat-detail query. That made tiny existing Conversation chats feel stalled even when there was almost no transcript work to do.

## What changed

<!-- List the key changes in this PR. -->

- Let `ModeSurface` use cached chat summaries to choose the active mode while chat detail is still hydrating.
- Let `useChatSurfaceData` start loading messages as soon as an `activeChatId` exists instead of waiting for chat detail.
- Added focused regression tests for cached-summary routing and immediate message-query enablement.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Shared mode UI.

Impact areas reviewed:

- Conversation mode chat switching/loading.
- Shared chat surface data used by Conversation, Roleplay, and the game conversation pane.
- Mode routing from cached chat summaries versus full chat detail.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Frontend-only change. No engine, shared API wrapper, Rust, storage, remote-runtime, schema, dependency, or version changes.
- Invalid chat ids still rely on the existing chat-detail 404 path to clear active chat state.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `ModeSurface`
- Shared chat UI `useChatSurfaceData`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm test src/features/modes/router/components/ModeSurface.test.tsx src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx` in the clean PR worktree: passed.
- Codex ran `pnpm check` in the clean PR worktree after the final staged diff: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Live Tauri smoke from the original checkout selected a one-message Conversation row and reached usable input in 38 ms with zero Conversation loading spinners.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a bugfix for existing Conversation chat loading behavior and does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

After selecting a one-message Conversation chat:

![Conversation chat load proof](https://gist.githubusercontent.com/cha1latte/652c4c2a35c41be0919d02ca6f709240/raw/conversation-load-after-select.png)
