### PR TITLE
Fix startup bloat from prompt snapshots

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -443,7 +443,9 @@ pub(crate) fn message_swipes(
     if let Some(character_id) = active_character_id {
         object.insert("characterId".to_string(), character_id);
     }
-    let updated = state.storage.patch("messages", message_id, message)?;
+    compact_message_for_storage(&mut message)?;
+    let mut updated = state.storage.patch("messages", message_id, message)?;
+    materialize_message_swipe_fields(&mut updated);
     Ok(updated)
 }
 
@@ -468,6 +470,7 @@ pub(crate) fn update_message_content_if_unchanged(
         let mut patch = Map::new();
         patch.insert("content".to_string(), Value::String(content.clone()));
         sync_message_patch_content_to_active_swipe(message, &patch);
+        compact_message_swipe_fields_for_storage(message);
         Ok(true)
     })?;
     Ok(match updated {
@@ -524,11 +527,12 @@ pub(crate) fn set_active_swipe(
                 }
             })
     else {
-        let updated = state.storage.patch(
+        let mut updated = state.storage.patch(
             "messages",
             message_id,
             json!({ "activeSwipeIndex": requested_index }),
         )?;
+        materialize_message_swipe_fields(&mut updated);
         return Ok(active_swipe_update_response(&updated));
     };
     object.insert("activeSwipeIndex".to_string(), json!(active_index));
@@ -550,7 +554,9 @@ pub(crate) fn set_active_swipe(
             clear_swipe_scoped_extra(object.get("extra")),
         );
     }
-    let updated = state.storage.patch("messages", message_id, message)?;
+    compact_message_for_storage(&mut message)?;
+    let mut updated = state.storage.patch("messages", message_id, message)?;
+    materialize_message_swipe_fields(&mut updated);
     Ok(active_swipe_update_response(&updated))
 }
 
@@ -592,7 +598,9 @@ pub(crate) fn delete_swipe(
         }
     }
     materialize_message_swipe_fields(&mut message);
-    let updated = state.storage.patch("messages", message_id, message)?;
+    compact_message_for_storage(&mut message)?;
+    let mut updated = state.storage.patch("messages", message_id, message)?;
+    materialize_message_swipe_fields(&mut updated);
     if removed_swipe {
         game_state_snapshots::delete_tracker_snapshot_swipe(
             state,
@@ -603,6 +611,14 @@ pub(crate) fn delete_swipe(
         game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, chat_id)?;
     }
     Ok(updated)
+}
+
+fn compact_message_for_storage(message: &mut Value) -> AppResult<()> {
+    let Some(object) = message.as_object_mut() else {
+        return Err(AppError::invalid_input("Message is not an object"));
+    };
+    compact_message_swipe_fields_for_storage(object);
+    Ok(())
 }
 
 pub(crate) fn bulk_delete_messages(
@@ -1786,12 +1802,25 @@ mod tests {
             .expect("message lookup should succeed")
             .expect("message should exist");
         assert_eq!(persisted["extra"]["hiddenFromAI"], json!(true));
+        assert!(persisted["extra"].get("generationInfo").is_none());
+        assert!(persisted["extra"].get("reasoning_content").is_none());
         assert_eq!(
-            persisted["extra"]["generationInfo"]["model"],
+            persisted["swipes"][0]["extra"]["generationInfo"]["model"],
             json!("first-model")
         );
         assert_eq!(
-            persisted["extra"]["reasoning_content"],
+            persisted["swipes"][0]["extra"]["reasoning_content"],
+            json!("first reasoning")
+        );
+
+        let mut materialized = persisted.clone();
+        materialize_message_swipe_fields(&mut materialized);
+        assert_eq!(
+            materialized["extra"]["generationInfo"]["model"],
+            json!("first-model")
+        );
+        assert_eq!(
+            materialized["extra"]["reasoning_content"],
             json!("first reasoning")
         );
     }
@@ -1859,7 +1888,7 @@ mod tests {
     }
 
     #[test]
-    fn message_swipes_keep_prompt_snapshot_map_global_while_switching_active_snapshot() {
+    fn message_swipes_store_prompt_snapshots_on_swipes_while_switching_active_snapshot() {
         let state = test_state("swipe-prompt-snapshots");
         state
             .storage
@@ -1909,17 +1938,24 @@ mod tests {
 
         assert_eq!(persisted["content"], json!("first"));
         assert_eq!(persisted["extra"]["hiddenFromAI"], json!(true));
+        assert!(persisted["extra"].get("generationPromptSnapshot").is_none());
+        assert!(persisted["extra"]
+            .get("generationPromptSnapshotsBySwipe")
+            .is_none());
         assert_eq!(
-            persisted["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            persisted["swipes"][0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-first")
         );
         assert_eq!(
-            persisted["extra"]["generationPromptSnapshotsBySwipe"]["0"]["promptPresetId"],
-            json!("preset-first")
-        );
-        assert_eq!(
-            persisted["extra"]["generationPromptSnapshotsBySwipe"]["1"]["promptPresetId"],
+            persisted["swipes"][1]["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-second")
+        );
+
+        let mut materialized = persisted.clone();
+        materialize_message_swipe_fields(&mut materialized);
+        assert_eq!(
+            materialized["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
         );
     }
 

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -381,7 +381,7 @@ pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
     contract(
         "messages",
         true,
-        true,
+        false,
         EMPTY_DEFAULTS,
         MESSAGE_FIELDS,
         MESSAGE_CLEANUP,

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -159,6 +159,90 @@ pub(crate) fn materialize_message_swipe_fields(message: &mut Value) {
     }
 }
 
+pub(crate) fn compact_message_swipe_fields_for_storage(object: &mut Map<String, Value>) {
+    compact_message_legacy_prompt_snapshots(object);
+    let has_swipes = object
+        .get("swipes")
+        .and_then(Value::as_array)
+        .is_some_and(|swipes| !swipes.is_empty());
+    if !has_swipes {
+        return;
+    }
+    let Some(active_extra) = swipe_scoped_extra(object.get("extra")) else {
+        object.insert(
+            "extra".to_string(),
+            clear_swipe_scoped_extra(object.get("extra")),
+        );
+        return;
+    };
+    let active_index = object
+        .get("activeSwipeIndex")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(0);
+    let Some(swipes) = object.get_mut("swipes").and_then(Value::as_array_mut) else {
+        return;
+    };
+    let active_index = active_index.min(swipes.len().saturating_sub(1));
+    merge_swipe_extra_at_index(swipes, active_index, &active_extra);
+    object.insert(
+        "extra".to_string(),
+        clear_swipe_scoped_extra(object.get("extra")),
+    );
+}
+
+pub(crate) fn compact_message_legacy_prompt_snapshots(object: &mut Map<String, Value>) {
+    let parent_extra = json_object_value(object.get("extra"));
+    let requested_active_index = object
+        .get("activeSwipeIndex")
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(0);
+    let Some(swipes) = object.get_mut("swipes").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if swipes.is_empty() {
+        return;
+    }
+
+    let snapshots_by_swipe = parent_extra
+        .as_ref()
+        .and_then(|extra| extra.get("generationPromptSnapshotsBySwipe"))
+        .and_then(json_object_value_from_value);
+    if let Some(Value::Object(snapshots)) = snapshots_by_swipe {
+        for (index, snapshot) in snapshots {
+            let Ok(index) = index.parse::<usize>() else {
+                continue;
+            };
+            if index >= swipes.len() {
+                continue;
+            }
+            insert_swipe_prompt_snapshot_if_missing(swipes, index, snapshot);
+        }
+    }
+
+    let active_index = requested_active_index.min(swipes.len().saturating_sub(1));
+    if let Some(snapshot) = parent_extra
+        .as_ref()
+        .and_then(|extra| extra.get("generationPromptSnapshot"))
+        .cloned()
+    {
+        insert_swipe_prompt_snapshot_if_missing(swipes, active_index, snapshot);
+    }
+
+    let active_snapshot = swipe_prompt_snapshot(swipes, active_index);
+    let Some(extra) = object.get_mut("extra").and_then(Value::as_object_mut) else {
+        return;
+    };
+    extra.remove("generationPromptSnapshotsBySwipe");
+    if active_snapshot
+        .as_ref()
+        .is_some_and(|snapshot| extra.get("generationPromptSnapshot") == Some(snapshot))
+    {
+        extra.remove("generationPromptSnapshot");
+    }
+}
+
 const TIMELINE_MESSAGE_FIELDS: [&str; 14] = [
     "id",
     "chatId",
@@ -346,6 +430,62 @@ pub(crate) fn json_object_value(value: Option<&Value>) -> Option<Value> {
     }
 }
 
+fn json_object_value_from_value(value: &Value) -> Option<Value> {
+    json_object_value(Some(value))
+}
+
+fn merge_swipe_extra_at_index(swipes: &mut [Value], index: usize, extra: &Value) {
+    let Some(extra) = json_object_value(Some(extra)) else {
+        return;
+    };
+    let Some(extra) = extra.as_object() else {
+        return;
+    };
+    let Some(swipe) = swipes.get_mut(index) else {
+        return;
+    };
+    if !swipe.is_object() {
+        *swipe = json!({});
+    }
+    let Some(swipe) = swipe.as_object_mut() else {
+        return;
+    };
+    let mut merged = json_object_value(swipe.get("extra"))
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    for (key, value) in extra {
+        merged.insert(key.clone(), value.clone());
+    }
+    swipe.insert("extra".to_string(), Value::Object(merged));
+}
+
+fn insert_swipe_prompt_snapshot_if_missing(swipes: &mut [Value], index: usize, snapshot: Value) {
+    let Some(swipe) = swipes.get_mut(index) else {
+        return;
+    };
+    if !swipe.is_object() {
+        *swipe = json!({});
+    }
+    let Some(swipe) = swipe.as_object_mut() else {
+        return;
+    };
+    let mut extra = json_object_value(swipe.get("extra"))
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    extra
+        .entry("generationPromptSnapshot".to_string())
+        .or_insert(snapshot);
+    swipe.insert("extra".to_string(), Value::Object(extra));
+}
+
+fn swipe_prompt_snapshot(swipes: &[Value], index: usize) -> Option<Value> {
+    swipes
+        .get(index)
+        .and_then(|swipe| swipe.get("extra"))
+        .and_then(json_object_value_from_value)
+        .and_then(|extra| extra.get("generationPromptSnapshot").cloned())
+}
+
 pub(crate) fn non_negative_i64_value(value: Option<&Value>) -> Option<i64> {
     match value {
         Some(Value::Number(number)) => number
@@ -439,6 +579,7 @@ pub(crate) fn patch_message_update(
         .storage
         .patch_with("messages", message_id, normalized, |message, patch| {
             sync_message_patch_content_to_active_swipe(message, patch);
+            compact_message_swipe_fields_for_storage(message);
             Ok(())
         })
 }
@@ -526,6 +667,7 @@ pub(crate) fn normalize_typed_json_fields(
     }
     if collection == "messages" {
         normalize_message_text_fields(object);
+        compact_message_swipe_fields_for_storage(object);
     }
     Ok(())
 }
@@ -1314,6 +1456,103 @@ mod tests {
         assert_eq!(
             message["extra"]["cachedPrompt"][0]["content"],
             json!("old prompt")
+        );
+    }
+
+    #[test]
+    fn message_defaults_compact_parent_prompt_snapshots_into_swipe_extra() {
+        let mut row = with_entity_defaults(
+            "messages",
+            json!({
+                "id": "message-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "activeSwipeIndex": 0,
+                "extra": {
+                    "hiddenFromAI": true,
+                    "generationPromptSnapshot": { "promptPresetId": "preset-first" },
+                    "generationPromptSnapshotsBySwipe": {
+                        "0": { "promptPresetId": "preset-first" }
+                    }
+                },
+                "swipes": [{ "content": "first", "extra": {} }]
+            }),
+        )
+        .expect("message should normalize");
+
+        assert_eq!(row["extra"]["hiddenFromAI"], json!(true));
+        assert!(row["extra"].get("generationPromptSnapshot").is_none());
+        assert!(row["extra"]
+            .get("generationPromptSnapshotsBySwipe")
+            .is_none());
+        assert_eq!(
+            row["swipes"][0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
+
+        materialize_message_swipe_fields(&mut row);
+        assert_eq!(
+            row["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
+    }
+
+    #[test]
+    fn message_extra_update_patch_compacts_parent_prompt_snapshot_after_syncing_swipe() {
+        let root = temp_root("message-patch-prompt-snapshot");
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        state
+            .storage
+            .create(
+                "messages",
+                with_entity_defaults(
+                    "messages",
+                    json!({
+                        "id": "message-1",
+                        "chatId": "chat-1",
+                        "role": "assistant",
+                        "content": "first",
+                        "activeSwipeIndex": 0,
+                        "extra": { "hiddenFromAI": true },
+                        "swipes": [{ "content": "first", "extra": {} }]
+                    }),
+                )
+                .expect("message defaults should apply"),
+            )
+            .expect("message should be created");
+
+        let mut updated = patch_message_update(
+            &state,
+            "message-1",
+            json!({
+                "extra": {
+                    "generationPromptSnapshot": { "promptPresetId": "preset-first" },
+                    "generationReplay": { "userMessage": "again" }
+                }
+            }),
+        )
+        .expect("message should update");
+
+        assert!(updated["extra"].get("generationPromptSnapshot").is_none());
+        assert!(updated["extra"].get("generationReplay").is_none());
+        assert_eq!(
+            updated["swipes"][0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
+        assert_eq!(
+            updated["swipes"][0]["extra"]["generationReplay"]["userMessage"],
+            json!("again")
+        );
+
+        materialize_message_swipe_fields(&mut updated);
+        assert_eq!(
+            updated["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
+        assert_eq!(
+            updated["extra"]["generationReplay"]["userMessage"],
+            json!("again")
         );
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -16,8 +16,8 @@ use crate::storage_commands::{
     images::percent_encode_component,
     media_uploads::{file_path_asset_url, safe_filename, unique_file_path},
     shared::{
-        agent_run_config_info_from_rows, normalize_agent_run_row_fields,
-        normalize_typed_json_fields,
+        agent_run_config_info_from_rows, compact_message_legacy_prompt_snapshots,
+        normalize_agent_run_row_fields, normalize_typed_json_fields,
     },
 };
 
@@ -37,6 +37,8 @@ struct LlmStreamCancellations {
     pending: HashMap<String, Instant>,
 }
 
+const STARTUP_MIGRATIONS_SETTINGS_ID: &str = "startup-migrations";
+const MESSAGE_PROMPT_SNAPSHOT_COMPACTION_KEY: &str = "messagePromptSnapshotCompactionV1";
 const LLM_STREAM_PENDING_CANCEL_TTL: Duration = Duration::from_secs(60);
 
 impl AppState {
@@ -69,6 +71,7 @@ impl AppState {
         let backgrounds = AssetService::new(data_dir.join("backgrounds"))?;
         Self::seed_defaults(&storage, &game_assets, &backgrounds, default_data_roots)?;
         migrate_storage_json_fields(&storage)?;
+        migrate_message_prompt_snapshots_once(&storage)?;
         migrate_agent_run_rows(&storage)?;
         migrate_legacy_chat_group_roots(&storage)?;
         migrate_local_media_references(&storage, &data_dir)?;
@@ -221,6 +224,72 @@ fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> Ap
         storage.replace_all(collection, normalized_rows)?;
     }
     Ok(())
+}
+
+fn migrate_message_prompt_snapshots_once(storage: &FileStorage) -> AppResult<()> {
+    if startup_migration_applied(storage, MESSAGE_PROMPT_SNAPSHOT_COMPACTION_KEY)? {
+        return Ok(());
+    }
+    compact_message_prompt_snapshots(storage)?;
+    mark_startup_migration_applied(storage, MESSAGE_PROMPT_SNAPSHOT_COMPACTION_KEY)
+}
+
+fn compact_message_prompt_snapshots(storage: &FileStorage) -> AppResult<()> {
+    let rows = storage.list("messages")?;
+    let mut changed = false;
+    let mut compacted_rows = Vec::with_capacity(rows.len());
+    for mut row in rows {
+        let before = row.clone();
+        if let Some(object) = row.as_object_mut() {
+            normalize_typed_json_fields("messages", object)?;
+            compact_message_legacy_prompt_snapshots(object);
+        }
+        changed = changed || row != before;
+        compacted_rows.push(row);
+    }
+    if changed {
+        storage.replace_all("messages", compacted_rows)?;
+    }
+    Ok(())
+}
+
+fn startup_migration_applied(storage: &FileStorage, key: &str) -> AppResult<bool> {
+    Ok(startup_migration_flags(storage)?
+        .get(key)
+        .and_then(Value::as_bool)
+        == Some(true))
+}
+
+fn mark_startup_migration_applied(storage: &FileStorage, key: &str) -> AppResult<()> {
+    let mut flags = startup_migration_flags(storage)?;
+    flags.insert(key.to_string(), Value::Bool(true));
+    storage.upsert_with_id(
+        "app-settings",
+        STARTUP_MIGRATIONS_SETTINGS_ID,
+        json!({ "value": Value::Object(flags) }),
+    )?;
+    Ok(())
+}
+
+fn startup_migration_flags(storage: &FileStorage) -> AppResult<Map<String, Value>> {
+    let Some(record) = storage.get("app-settings", STARTUP_MIGRATIONS_SETTINGS_ID)? else {
+        return Ok(Map::new());
+    };
+    Ok(record
+        .get("value")
+        .and_then(json_object_from_value)
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default())
+}
+
+fn json_object_from_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::Object(_) => Some(value.clone()),
+        Value::String(raw) => serde_json::from_str::<Value>(raw)
+            .ok()
+            .filter(Value::is_object),
+        _ => None,
+    }
 }
 
 fn migrate_agent_run_rows(storage: &FileStorage) -> AppResult<()> {
@@ -1291,6 +1360,166 @@ mod tests {
         assert_eq!(root_chat["groupId"], "root-1");
         assert_eq!(unrelated.get("groupId"), Some(&Value::Null));
         assert_eq!(already_grouped["groupId"], "existing-group");
+    }
+
+    #[test]
+    fn app_state_startup_compacts_legacy_message_prompt_snapshots_once() {
+        let root = temp_root("message-prompt-snapshot-compaction");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "second",
+                    "activeSwipeIndex": 1,
+                    "extra": {
+                        "hiddenFromAI": true,
+                        "generationPromptSnapshot": { "promptPresetId": "preset-second" },
+                        "generationPromptSnapshotsBySwipe": {
+                            "0": { "promptPresetId": "preset-first" },
+                            "1": { "promptPresetId": "preset-second" }
+                        }
+                    },
+                    "swipes": [
+                        { "content": "first", "extra": {} },
+                        { "content": "second", "extra": {} }
+                    ]
+                }),
+            )
+            .expect("message should be inserted");
+        persist_fixture_storage(&storage);
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let persisted = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message should load")
+            .expect("message should exist");
+
+        assert_eq!(persisted["extra"]["hiddenFromAI"], json!(true));
+        assert!(persisted["extra"].get("generationPromptSnapshot").is_none());
+        assert!(persisted["extra"]
+            .get("generationPromptSnapshotsBySwipe")
+            .is_none());
+        assert_eq!(
+            persisted["swipes"][0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
+        assert_eq!(
+            persisted["swipes"][1]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-second")
+        );
+
+        let flags = state
+            .storage
+            .get("app-settings", STARTUP_MIGRATIONS_SETTINGS_ID)
+            .expect("migration marker should load")
+            .expect("migration marker should exist");
+        assert_eq!(
+            flags["value"][MESSAGE_PROMPT_SNAPSHOT_COMPACTION_KEY],
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn app_state_startup_preserves_legacy_no_swipe_message_prompt_snapshots() {
+        let root = temp_root("message-prompt-snapshot-no-swipes");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "legacy",
+                    "extra": {
+                        "generationPromptSnapshot": { "promptPresetId": "preset-legacy" },
+                        "generationPromptSnapshotsBySwipe": {
+                            "0": { "promptPresetId": "preset-legacy" }
+                        }
+                    }
+                }),
+            )
+            .expect("message should be inserted");
+        persist_fixture_storage(&storage);
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let persisted = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message should load")
+            .expect("message should exist");
+
+        assert!(persisted.get("swipes").is_none());
+        assert_eq!(
+            persisted["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-legacy")
+        );
+        assert_eq!(
+            persisted["extra"]["generationPromptSnapshotsBySwipe"]["0"]["promptPresetId"],
+            json!("preset-legacy")
+        );
+    }
+
+    #[test]
+    fn app_state_startup_skips_message_compaction_after_marker() {
+        let root = temp_root("message-prompt-snapshot-marker");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        let mut marker = Map::new();
+        marker.insert(
+            MESSAGE_PROMPT_SNAPSHOT_COMPACTION_KEY.to_string(),
+            Value::Bool(true),
+        );
+        storage
+            .upsert_with_id(
+                "app-settings",
+                STARTUP_MIGRATIONS_SETTINGS_ID,
+                json!({ "value": Value::Object(marker) }),
+            )
+            .expect("marker should be inserted");
+        storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "first",
+                    "activeSwipeIndex": 0,
+                    "extra": {
+                        "generationPromptSnapshot": { "promptPresetId": "preset-first" },
+                        "generationPromptSnapshotsBySwipe": {
+                            "0": { "promptPresetId": "preset-first" }
+                        }
+                    },
+                    "swipes": [{ "content": "first", "extra": {} }]
+                }),
+            )
+            .expect("message should be inserted");
+        persist_fixture_storage(&storage);
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let persisted = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message should load")
+            .expect("message should exist");
+
+        assert_eq!(
+            persisted["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
+        assert_eq!(
+            persisted["extra"]["generationPromptSnapshotsBySwipe"]["0"]["promptPresetId"],
+            json!("preset-first")
+        );
+        assert!(persisted["swipes"][0]["extra"]
+            .get("generationPromptSnapshot")
+            .is_none());
     }
 
     #[test]

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -461,7 +461,7 @@ export interface MessageExtra {
   } | null;
   /** Exact main-generation LLM request saved for Peek Prompt on the active response. */
   generationPromptSnapshot?: GenerationPromptSnapshot | null;
-  /** Exact main-generation LLM requests keyed by swipe index for regenerated alternatives. */
+  /** @deprecated Legacy input only. Prompt snapshots now live on swipes[index].extra. */
   generationPromptSnapshotsBySwipe?: Record<string, GenerationPromptSnapshot>;
 }
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1860,7 +1860,6 @@ async function saveAssistantMessage(args: {
         ...(promptSnapshot
           ? {
               generationPromptSnapshot: promptSnapshot,
-              generationPromptSnapshotsBySwipe: { "0": promptSnapshot },
             }
           : {}),
         chatSummaryFingerprint: args.chatSummaryFingerprint,
@@ -1900,7 +1899,6 @@ async function saveAssistantMessage(args: {
       ...(promptSnapshot
         ? {
             generationPromptSnapshot: promptSnapshot,
-            generationPromptSnapshotsBySwipe: { "0": promptSnapshot },
           }
         : {}),
       chatSummaryFingerprint: args.chatSummaryFingerprint,
@@ -1936,14 +1934,12 @@ async function saveRegeneratedMessage(args: {
     spriteExpressions: args.spriteExpressions,
     agentExtra: args.agentExtra,
   });
-  const updated = await args.storage.addChatMessageSwipe(
+  await args.storage.addChatMessageSwipe(
     args.chatId,
     args.messageId,
     collapseExcessBlankLines(args.content),
     swipeOptionsWithCharacterId(swipeExtra, args),
   );
-  const updatedRecord = isRecord(updated) ? updated : {};
-  const activeSwipeIndex = Math.max(0, Math.trunc(readNumber(updatedRecord.activeSwipeIndex, 0)));
   const extraPatch = generationReplayExtraPatch({
     generationReplay: args.generationReplay,
     chatSummaryFingerprint: args.chatSummaryFingerprint,
@@ -1951,8 +1947,6 @@ async function saveRegeneratedMessage(args: {
     promptSnapshot: args.promptSnapshot,
     spriteExpressions: args.spriteExpressions,
     agentExtra: args.agentExtra,
-    activeSwipeIndex,
-    existingExtra: parseRecord(updatedRecord.extra),
   });
   return args.storage.patchChatMessageExtra(args.messageId, extraPatch);
 }
@@ -1996,8 +1990,6 @@ function generationReplayExtraPatch(args: {
   promptSnapshot?: GenerationPromptSnapshot | null;
   spriteExpressions?: Record<string, string> | null;
   agentExtra?: Record<string, unknown> | null;
-  activeSwipeIndex?: number | null;
-  existingExtra?: JsonRecord | null;
 }): Record<string, unknown> {
   const extraPatch: Record<string, unknown> = {};
   if (args.generationReplay) extraPatch.generationReplay = args.generationReplay;
@@ -2009,15 +2001,7 @@ function generationReplayExtraPatch(args: {
   }
   if (args.agentExtra) Object.assign(extraPatch, args.agentExtra);
   if (args.promptSnapshot) {
-    const activeSwipeIndex =
-      typeof args.activeSwipeIndex === "number" && Number.isFinite(args.activeSwipeIndex)
-        ? Math.max(0, Math.trunc(args.activeSwipeIndex))
-        : 0;
     extraPatch.generationPromptSnapshot = args.promptSnapshot;
-    extraPatch.generationPromptSnapshotsBySwipe = {
-      ...parseRecord(args.existingExtra?.generationPromptSnapshotsBySwipe),
-      [String(activeSwipeIndex)]: args.promptSnapshot,
-    };
   }
   return extraPatch;
 }

--- a/src/features/modes/shared/chat-ui/lib/prompt-snapshot.ts
+++ b/src/features/modes/shared/chat-ui/lib/prompt-snapshot.ts
@@ -3,12 +3,14 @@ import type { Message } from "../../../../../engine/contracts/types/chat";
 type GenerationPromptSnapshot = Message["extra"]["generationPromptSnapshot"];
 
 /**
- * Resolve the prompt snapshot to show for a message, honoring per-swipe history.
+ * Resolve the prompt snapshot to show for a message, honoring legacy per-swipe
+ * history.
  *
- * Generation stores a snapshot per swipe in `generationPromptSnapshotsBySwipe`
- * (keyed by swipe index) plus a singular `generationPromptSnapshot` tracking the
- * active swipe. Prefer the entry for the active swipe, then fall back to the
- * singular field. Returns null when neither is present (caller then rebuilds).
+ * Newer storage records keep prompt snapshots on `swipes[].extra`; the storage
+ * projection materializes the active swipe into the singular
+ * `generationPromptSnapshot`. Prefer legacy `generationPromptSnapshotsBySwipe`
+ * only when it is still present on older records, then fall back to the singular
+ * field. Returns null when neither is present (caller then rebuilds).
  *
  * Imported legacy (v1.6.1-era) prompts live under `extra.cachedPrompt` and are
  * synthesized into `generationPromptSnapshot` at the storage projection boundary


### PR DESCRIPTION
## Linked issue

N/A - found during local refactor startup investigation.

## Why this change

- Refactor startup was slow because `messages.json` could grow huge when generated assistant messages persisted duplicate full prompt snapshots on the parent message and in per-swipe maps.

## What changed

- Keep swipe-scoped generation metadata canonical in `swipes[].extra`, including prompt snapshots, replay data, thinking, attachments, token info, and generation info.
- Stop new generation writes from producing `extra.generationPromptSnapshotsBySwipe`.
- Compact legacy parent prompt snapshots into swipe extras while preserving active-swipe prompt materialization on reads.
- Add a one-time startup migration marker so message prompt snapshot compaction runs once, then later launches skip whole-file message migration.
- Remove `messages` from unconditional startup JSON repair while preserving paged/projected message reads.

## Refactor impact

Primary owner:

Rust storage / engine generation

Impact areas reviewed:

- Message create/update defaults
- Regenerate/add-swipe storage flow
- Active swipe materialization
- Legacy prompt snapshot fallback
- Startup storage migration and marker behavior
- Paged/projected message reads

Boundary notes:

- Engine generation still writes through the storage API; canonical persistence is enforced in Rust storage normalization/compaction.
- Feature UI keeps using the existing prompt snapshot resolver with legacy fallback.
- No new public frontend API.

Pressure points touched:

- Rust storage message normalization and chat swipe commands
- App startup migration path
- Shared chat UI prompt snapshot resolver

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `node scratch\message-snapshot-bloat-proof.mjs`: 500-message fixture compacted from 85,400,891 bytes to 28,520,891 bytes, saving 66.6%.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml prompt_snapshot -- --nocapture`: passed.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml startup_skips_message_compaction_after_marker -- --nocapture`: passed.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml --workspace`: passed.
- Bunny review passed locally on the current diff.
- Human/manual app startup validation is still pending.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this is internal storage compaction and startup performance recovery.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - storage/startup performance fix with no visible UI change.
