### PR TITLE
Route persona avatars through thumbnails

### DIFF
--- a/src/features/catalog/personas/components/PersonaAvatarImage.tsx
+++ b/src/features/catalog/personas/components/PersonaAvatarImage.tsx
@@ -39,6 +39,64 @@ function resolveAvatarCrop(crop: unknown): AvatarCropValue | null {
   }
 }
 
+function waitForImageResolveSlot(element: HTMLElement, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  const waitForViewport = new Promise<void>((resolve) => {
+    if (typeof IntersectionObserver !== "function") {
+      resolve();
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          observer.disconnect();
+          resolve();
+        }
+      },
+      { rootMargin: "240px" },
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+        resolve();
+      },
+      { once: true },
+    );
+    observer.observe(element);
+  });
+
+  return waitForViewport.then(
+    () =>
+      new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        const idleWindow = window as Window & {
+          requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+          cancelIdleCallback?: (handle: number) => void;
+        };
+        const requestIdle = idleWindow.requestIdleCallback;
+        let handle: number | null = null;
+        const finish = () => {
+          if (handle !== null && typeof idleWindow.cancelIdleCallback === "function") {
+            idleWindow.cancelIdleCallback(handle);
+          } else if (handle !== null) {
+            window.clearTimeout(handle);
+          }
+          resolve();
+        };
+        signal.addEventListener("abort", finish, { once: true });
+        if (typeof requestIdle === "function") {
+          handle = requestIdle(finish, { timeout: 600 });
+          return;
+        }
+        handle = window.setTimeout(finish, 80);
+      }),
+  );
+}
+
 export function PersonaAvatarImage({
   persona,
   alt,
@@ -74,6 +132,7 @@ export function PersonaAvatarImage({
 
   useEffect(() => {
     let cancelled = false;
+    const abort = new AbortController();
     setAsyncSrc(initialSrc);
     if (
       !hasResolvableAvatarInput ||
@@ -81,17 +140,24 @@ export function PersonaAvatarImage({
     ) {
       return () => {
         cancelled = true;
+        abort.abort();
       };
     }
-    const resolveUrl = effectiveThumbnailSize
-      ? resolveAvatarThumbnailFileUrl(
-          persona.avatarFilename,
-          persona.avatarFilePath,
-          effectiveThumbnailSize,
-          persona.avatarPath,
-        )
-      : resolveAvatarFileUrl(persona.avatarFilename, persona.avatarFilePath);
-    resolveUrl
+    const resolveUrl = async () => {
+      if (effectiveThumbnailSize && imageRef.current) {
+        await waitForImageResolveSlot(imageRef.current, abort.signal);
+      }
+      if (cancelled) return null;
+      return effectiveThumbnailSize
+        ? resolveAvatarThumbnailFileUrl(
+            persona.avatarFilename,
+            persona.avatarFilePath,
+            effectiveThumbnailSize,
+            persona.avatarPath,
+          )
+        : resolveAvatarFileUrl(persona.avatarFilename, persona.avatarFilePath);
+    };
+    resolveUrl()
       .then((url) => {
         if (!cancelled) setAsyncSrc(url ?? persona.avatarPath ?? null);
       })
@@ -100,6 +166,7 @@ export function PersonaAvatarImage({
       });
     return () => {
       cancelled = true;
+      abort.abort();
     };
   }, [
     effectiveThumbnailSize,

--- a/src/features/catalog/personas/components/PersonaAvatarImage.tsx
+++ b/src/features/catalog/personas/components/PersonaAvatarImage.tsx
@@ -1,0 +1,130 @@
+import type { CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  avatarFileUrlFromPath,
+  avatarThumbnailFileUrlFromPath,
+  canGenerateAvatarThumbnail,
+  resolveAvatarFileUrl,
+  resolveAvatarThumbnailFileUrl,
+} from "../../../../shared/api/local-file-api";
+import type { AvatarCropValue } from "../../../../shared/lib/utils";
+import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
+
+export type PersonaAvatarImageSource = {
+  name?: string | null;
+  avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+  avatarCrop?: unknown;
+};
+
+function isLikelyFilesystemPath(value: string): boolean {
+  const normalized = value.replace(/\\/g, "/");
+  return (
+    /^[a-z]:\//i.test(normalized) ||
+    normalized.startsWith("//") ||
+    /^\/(Users|home|var|data|tmp|opt|private)\//i.test(normalized)
+  );
+}
+
+function resolveAvatarCrop(crop: unknown): AvatarCropValue | null {
+  if (!crop) return null;
+  if (typeof crop === "string") return parseAvatarCropJson(crop);
+  if (typeof crop !== "object") return null;
+  try {
+    return parseAvatarCropJson(JSON.stringify(crop));
+  } catch {
+    return null;
+  }
+}
+
+export function PersonaAvatarImage({
+  persona,
+  alt,
+  className,
+  draggable = false,
+  style,
+  thumbnailSize = 128,
+}: {
+  persona: PersonaAvatarImageSource;
+  alt?: string;
+  className?: string;
+  draggable?: boolean;
+  style?: CSSProperties;
+  thumbnailSize?: 64 | 96 | 128 | 256;
+}) {
+  const imageRef = useRef<HTMLImageElement | null>(null);
+  const effectiveThumbnailSize =
+    thumbnailSize && canGenerateAvatarThumbnail(persona.avatarFilename, persona.avatarFilePath, persona.avatarPath)
+      ? thumbnailSize
+      : undefined;
+  const managedInitialSrc = effectiveThumbnailSize
+    ? avatarThumbnailFileUrlFromPath(
+        persona.avatarFilename,
+        persona.avatarFilePath,
+        effectiveThumbnailSize,
+        persona.avatarPath,
+      )
+    : avatarFileUrlFromPath(persona.avatarFilename, persona.avatarFilePath);
+  const hasManagedAvatarInput = Boolean(persona.avatarFilename || persona.avatarFilePath);
+  const hasResolvableAvatarInput = hasManagedAvatarInput || Boolean(effectiveThumbnailSize && persona.avatarPath);
+  const initialSrc = managedInitialSrc ?? persona.avatarPath ?? null;
+  const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAsyncSrc(initialSrc);
+    if (
+      !hasResolvableAvatarInput ||
+      (!effectiveThumbnailSize && managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))
+    ) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    const resolveUrl = effectiveThumbnailSize
+      ? resolveAvatarThumbnailFileUrl(
+          persona.avatarFilename,
+          persona.avatarFilePath,
+          effectiveThumbnailSize,
+          persona.avatarPath,
+        )
+      : resolveAvatarFileUrl(persona.avatarFilename, persona.avatarFilePath);
+    resolveUrl
+      .then((url) => {
+        if (!cancelled) setAsyncSrc(url ?? persona.avatarPath ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setAsyncSrc(persona.avatarPath ?? null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    effectiveThumbnailSize,
+    hasResolvableAvatarInput,
+    initialSrc,
+    managedInitialSrc,
+    persona.avatarFilePath,
+    persona.avatarFilename,
+    persona.avatarPath,
+  ]);
+
+  const resolvedSrc = asyncSrc ?? initialSrc;
+  if (!resolvedSrc) return null;
+
+  return (
+    <img
+      ref={imageRef}
+      src={resolvedSrc}
+      alt={alt ?? persona.name ?? ""}
+      loading="lazy"
+      decoding="async"
+      fetchPriority={effectiveThumbnailSize ? "low" : undefined}
+      draggable={draggable}
+      className={cn("h-full w-full object-cover", className)}
+      style={{ ...getAvatarCropStyle(resolveAvatarCrop(persona.avatarCrop)), ...style }}
+    />
+  );
+}

--- a/src/features/catalog/personas/components/panel/PersonaGroupsSection.tsx
+++ b/src/features/catalog/personas/components/panel/PersonaGroupsSection.tsx
@@ -16,6 +16,7 @@ import { useRef } from "react";
 
 import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../../shared/lib/utils";
+import { PersonaAvatarImage } from "../PersonaAvatarImage";
 import type { PersonaPanelGroup, PersonaPanelRow } from "../../lib/personas-panel-model";
 
 interface PersonaGroupsSectionProps {
@@ -233,10 +234,11 @@ export function PersonaGroupsSection({
                               <div key={personaId} className="flex items-center gap-2 rounded-lg px-1 py-1 text-xs">
                                 <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
                                   {persona.avatarPath ? (
-                                    <img
-                                      src={persona.avatarPath}
+                                    <PersonaAvatarImage
+                                      persona={persona}
                                       alt=""
                                       className="h-full w-full rounded-lg object-cover"
+                                      thumbnailSize={64}
                                     />
                                   ) : (
                                     <User size="0.625rem" />

--- a/src/features/catalog/personas/components/panel/PersonaListItem.tsx
+++ b/src/features/catalog/personas/components/panel/PersonaListItem.tsx
@@ -2,6 +2,7 @@ import type { KeyboardEvent, MouseEvent } from "react";
 import { Camera, Check, Copy, Star, Trash2, User } from "lucide-react";
 
 import { cn } from "../../../../../shared/lib/utils";
+import { PersonaAvatarImage } from "../PersonaAvatarImage";
 import type { PersonaPanelGroup, PersonaPanelRow } from "../../lib/personas-panel-model";
 
 interface PersonaListItemProps {
@@ -96,7 +97,7 @@ export function PersonaListItem({
         aria-label={`Change avatar for ${persona.name}`}
       >
         {persona.avatarPath ? (
-          <img src={persona.avatarPath} alt="" loading="lazy" className="h-full w-full rounded-xl object-cover" />
+          <PersonaAvatarImage persona={persona} alt="" className="h-full w-full rounded-xl object-cover" />
         ) : (
           <User size="1rem" />
         )}

--- a/src/features/catalog/personas/index.ts
+++ b/src/features/catalog/personas/index.ts
@@ -1,3 +1,4 @@
 export * from "./query-keys";
 export * from "./hooks/use-personas";
 export * from "./lib/persona-avatar-url";
+export * from "./components/PersonaAvatarImage";

--- a/src/features/catalog/personas/lib/personas-panel-model.ts
+++ b/src/features/catalog/personas/lib/personas-panel-model.ts
@@ -8,6 +8,9 @@ export type PersonaPanelRow = {
   backstory?: string;
   appearance?: string;
   avatarPath: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+  avatarCrop?: unknown;
   isActive: string | boolean;
   createdAt?: string;
   tags?: string[];

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -72,6 +72,7 @@ import {
   ROLEPLAY_PARAMETER_DEFAULTS,
 } from "../../../../../shared/components/ui/GenerationParametersEditor";
 import { ChoiceSelectionModal } from "../../../../catalog/presets/index";
+import { PersonaAvatarImage } from "../../../../catalog/personas/index";
 import { SummariesEditorModal } from "./SummariesEditorModal";
 import {
   AgentCategorySection,
@@ -267,6 +268,8 @@ type DrawerPersona = {
   name: string;
   comment: string;
   avatarPath: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   avatarCrop?: AvatarCrop | string | null;
 };
 
@@ -2478,11 +2481,11 @@ function ChatSettingsDrawerInner({
                       return p ? (
                         <>
                           {p.avatarPath ? (
-                            <img
-                              src={p.avatarPath}
+                            <PersonaAvatarImage
+                              persona={p}
                               alt={p.name}
-                              loading="lazy"
                               className="h-7 w-7 shrink-0 rounded-full object-cover"
+                              thumbnailSize={64}
                             />
                           ) : (
                             <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
@@ -2566,11 +2569,11 @@ function ChatSettingsDrawerInner({
                           )}
                         >
                           {p.avatarPath ? (
-                            <img
-                              src={p.avatarPath}
+                            <PersonaAvatarImage
+                              persona={p}
                               alt={p.name}
-                              loading="lazy"
                               className="h-6 w-6 shrink-0 rounded-full object-cover"
+                              thumbnailSize={64}
                             />
                           ) : (
                             <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
@@ -2737,11 +2740,11 @@ function ChatSettingsDrawerInner({
                     return p ? (
                       <>
                         {p.avatarPath ? (
-                          <img
-                            src={p.avatarPath}
+                          <PersonaAvatarImage
+                            persona={p}
                             alt={p.name}
-                            loading="lazy"
                             className="h-7 w-7 shrink-0 rounded-full object-cover"
+                            thumbnailSize={64}
                           />
                         ) : (
                           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
@@ -2827,11 +2830,11 @@ function ChatSettingsDrawerInner({
                         )}
                       >
                         {p.avatarPath ? (
-                          <img
-                            src={p.avatarPath}
+                          <PersonaAvatarImage
+                            persona={p}
                             alt={p.name}
-                            loading="lazy"
                             className="h-6 w-6 shrink-0 rounded-full object-cover"
+                            thumbnailSize={64}
                           />
                         ) : (
                           <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 text-white">

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -29,7 +29,7 @@ import {
   useCharacterSummaries,
   useCharacterSummariesByIds,
 } from "../../../../catalog/characters/index";
-import { usePersonaSummaries } from "../../../../catalog/personas/index";
+import { PersonaAvatarImage, usePersonaSummaries } from "../../../../catalog/personas/index";
 import { useLorebooks } from "../../../../catalog/lorebooks/index";
 import { useUpdateChat, useUpdateChatMetadata, useCreateMessage, chatKeys } from "../../../../catalog/chats/index";
 import { useChatPresets, useApplyChatPreset } from "../../../../catalog/chat-presets/index";
@@ -111,12 +111,18 @@ interface PersonaDisplayInfo {
   id?: string;
   name: string;
   avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+  avatarCrop?: unknown;
   comment?: string | null;
 }
 
 type PersonaSetupOption = PersonaDisplayInfo & {
   id: string;
   avatarPath: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+  avatarCrop?: unknown;
 };
 
 type ConnectionSetupOption = {
@@ -297,7 +303,12 @@ function CharacterAvatarImage({
 function PersonaAvatar({ persona }: { persona: PersonaDisplayInfo | null }) {
   if (persona?.avatarPath) {
     return (
-      <img src={persona.avatarPath} alt={persona.name} loading="lazy" className="h-7 w-7 rounded-full object-cover" />
+      <PersonaAvatarImage
+        persona={persona}
+        alt={persona.name}
+        className="h-7 w-7 rounded-full object-cover"
+        thumbnailSize={64}
+      />
     );
   }
 
@@ -495,6 +506,9 @@ function ConversationQuickSetup({ chat, onFinish, onCancel }: ChatSetupWizardPro
     id: string;
     name: string;
     avatarPath: string | null;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
+    avatarCrop?: unknown;
     comment?: string | null;
   }>;
   const metadata = useMemo(() => {

--- a/src/features/modes/shared/chat-ui/components/QuickPersonaSwitcher.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickPersonaSwitcher.tsx
@@ -4,10 +4,15 @@
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { ChevronDown, ChevronRight, FolderOpen, Folder } from "lucide-react";
-import { usePersona, usePersonaGroups, usePersonaSummaries } from "../../../../catalog/personas/index";
+import {
+  PersonaAvatarImage,
+  usePersona,
+  usePersonaGroups,
+  usePersonaSummaries,
+} from "../../../../catalog/personas/index";
 import { useUpdateChat, useChat } from "../../../../catalog/chats/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
-import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../../shared/lib/utils";
+import { cn } from "../../../../../shared/lib/utils";
 import {
   CHAT_INPUT_ICON_BUTTON_ACTIVE_CLASS,
   CHAT_INPUT_ICON_BUTTON_CLASS,
@@ -18,8 +23,10 @@ interface Persona {
   id: string;
   name: string;
   avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   /** JSON-encoded AvatarCrop from the persona row. */
-  avatarCrop?: string;
+  avatarCrop?: unknown;
   comment?: string | null;
   description?: string | null;
 }
@@ -172,12 +179,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
       >
         {persona.avatarPath ? (
           <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
-            <img
-              src={persona.avatarPath}
-              alt={persona.name}
-              className="h-full w-full object-cover"
-              style={getAvatarCropStyle(parseAvatarCropJson(persona.avatarCrop))}
-            />
+            <PersonaAvatarImage persona={persona} alt={persona.name} className="h-full w-full object-cover" />
           </div>
         ) : (
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
@@ -219,11 +221,10 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
         )}
       >
         {activePersona?.avatarPath ? (
-          <img
-            src={activePersona.avatarPath}
+          <PersonaAvatarImage
+            persona={activePersona}
             alt={activePersona.name}
-            className="h-full w-full object-cover rounded-full"
-            style={getAvatarCropStyle(parseAvatarCropJson(activePersona.avatarCrop))}
+            className="h-full w-full rounded-full object-cover"
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center rounded-full bg-[var(--secondary)] text-[0.75rem] font-semibold text-[var(--muted-foreground)]">
@@ -279,11 +280,10 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
                   >
                     {firstMember?.avatarPath ? (
                       <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
-                        <img
-                          src={firstMember.avatarPath}
+                        <PersonaAvatarImage
+                          persona={firstMember}
                           alt={group.name}
                           className="h-full w-full object-cover"
-                          style={getAvatarCropStyle(parseAvatarCropJson(firstMember.avatarCrop))}
                         />
                       </div>
                     ) : (

--- a/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
+++ b/src/features/modes/shared/chat-ui/components/QuickSwitcherMobile.tsx
@@ -6,11 +6,11 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { ChevronUp, ChevronDown, ChevronRight, Link, CircleUser, FolderOpen, Folder, Check } from "lucide-react";
 import { useConnections, useUpdateConnection } from "../../../../catalog/connections/index";
-import { usePersonaGroups, usePersonaSummaries } from "../../../../catalog/personas/index";
+import { PersonaAvatarImage, usePersonaGroups, usePersonaSummaries } from "../../../../catalog/personas/index";
 import { useUpdateChat, useChat } from "../../../../catalog/chats/index";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
-import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../../shared/lib/utils";
+import { cn } from "../../../../../shared/lib/utils";
 import { boolish as isRandomPoolEnabled } from "../../../../../engine/generation/runtime-records";
 import {
   CHAT_INPUT_ICON_BUTTON_ACTIVE_CLASS,
@@ -22,8 +22,10 @@ interface Persona {
   id: string;
   name: string;
   avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   /** JSON-encoded AvatarCrop from the persona row. */
-  avatarCrop?: string;
+  avatarCrop?: unknown;
   comment?: string | null;
 }
 
@@ -210,12 +212,7 @@ export function QuickSwitcherMobile() {
       >
         {persona.avatarPath ? (
           <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
-            <img
-              src={persona.avatarPath}
-              alt={persona.name}
-              className="h-full w-full object-cover"
-              style={getAvatarCropStyle(parseAvatarCropJson(persona.avatarCrop))}
-            />
+            <PersonaAvatarImage persona={persona} alt={persona.name} className="h-full w-full object-cover" />
           </div>
         ) : (
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
@@ -381,11 +378,10 @@ export function QuickSwitcherMobile() {
                       >
                         {firstMember?.avatarPath ? (
                           <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
-                            <img
-                              src={firstMember.avatarPath}
+                            <PersonaAvatarImage
+                              persona={firstMember}
                               alt={group.name}
                               className="h-full w-full object-cover"
-                              style={getAvatarCropStyle(parseAvatarCropJson(firstMember.avatarCrop))}
                             />
                           </div>
                         ) : (

--- a/src/features/shell/mari/components/ProfessorMariSurface.tsx
+++ b/src/features/shell/mari/components/ProfessorMariSurface.tsx
@@ -12,13 +12,14 @@ import {
 import { llmApi } from "../../../../shared/api/llm-api";
 import { mariApi, type ProfessorMariPreferences } from "../../../../shared/api/mari-api";
 import { useConnections } from "../../../catalog/connections/index";
-import { usePersonaSummaries } from "../../../catalog/personas/index";
+import { PersonaAvatarImage, usePersonaSummaries } from "../../../catalog/personas/index";
 import { ConversationMessage } from "../../../modes/conversation/message-shell";
 import type { CharacterMap, PersonaInfo } from "../../../modes/shared/chat-ui/types";
 import type { Message } from "../../../../engine/contracts/types/chat";
 import { filterLanguageGenerationConnections } from "../../../../shared/lib/connection-filters";
 import { isSendShortcut } from "../../../../shared/lib/send-shortcuts";
-import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../../../shared/lib/utils";
+import type { AvatarCropValue } from "../../../../shared/lib/utils";
+import { cn, parseAvatarCropJson } from "../../../../shared/lib/utils";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 
 const MARI_AVATAR_URL = "/sprites/mari/Mari_profile.png";
@@ -48,7 +49,9 @@ type MariPersona = {
   id: string;
   name: string;
   avatarPath?: string | null;
-  avatarCrop?: string;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
+  avatarCrop?: unknown;
   comment?: string | null;
   description?: string | null;
   personality?: string | null;
@@ -81,6 +84,17 @@ function formatDaySeparator(value: string) {
 function getDayKey(value: string) {
   const date = new Date(value);
   return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+
+function parseMariAvatarCrop(value: unknown): AvatarCropValue | null {
+  if (!value) return null;
+  if (typeof value === "string") return parseAvatarCropJson(value);
+  if (typeof value !== "object") return null;
+  try {
+    return parseAvatarCropJson(JSON.stringify(value));
+  } catch {
+    return null;
+  }
 }
 
 function toConversationMessage(message: MariMessage): Message {
@@ -174,7 +188,7 @@ export function ProfessorMariSurface() {
       name: selectedPersona.name,
       description: selectedPersona.description ?? undefined,
       avatarUrl: selectedPersona.avatarPath ?? undefined,
-      avatarCrop: parseAvatarCropJson(selectedPersona.avatarCrop),
+      avatarCrop: parseMariAvatarCrop(selectedPersona.avatarCrop),
     };
   }, [selectedPersona]);
   const welcomeMessage = useMemo<MariMessage>(
@@ -634,11 +648,10 @@ export function ProfessorMariSurface() {
             aria-label="Quick Persona Switcher"
           >
             {selectedPersona?.avatarPath ? (
-              <img
-                src={selectedPersona.avatarPath}
+              <PersonaAvatarImage
+                persona={selectedPersona}
                 alt=""
                 className="h-full w-full rounded-lg object-cover"
-                style={getAvatarCropStyle(parseAvatarCropJson(selectedPersona.avatarCrop))}
                 draggable={false}
               />
             ) : (
@@ -844,12 +857,12 @@ function MariContextMenu({
                 >
                   {persona.avatarPath ? (
                     <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
-                      <img
-                        src={persona.avatarPath}
+                      <PersonaAvatarImage
+                        persona={persona}
                         alt=""
                         className="h-full w-full object-cover"
-                        style={getAvatarCropStyle(parseAvatarCropJson(persona.avatarCrop))}
                         draggable={false}
+                        thumbnailSize={64}
                       />
                     </div>
                   ) : (


### PR DESCRIPTION
## Linked issue

Closes #1992

## Why this change

- Persona-heavy UI surfaces rendered `avatarPath` directly, so compact/repeated persona avatar cells could bypass the existing avatar thumbnail pipeline and load full-size or inline sources.

## What changed

- Added a persona-owned avatar image wrapper that routes `avatarPath`, managed avatar file metadata, inline sources, and crop data through the existing avatar thumbnail shared API.
- Replaced direct persona avatar `<img src={...avatarPath}>` usage in compact persona list, group, switcher, setup, chat settings, and Professor Mari selector surfaces.
- Carried `avatarFilePath`, `avatarFilename`, and crop metadata through persona display row types where those compact surfaces need thumbnail resolution.

## Refactor impact

Primary owner:

Catalog personas and shared chat UI persona selectors.

Impact areas reviewed:

- Catalog persona list and group rows
- Shared chat setup/settings persona pickers
- Desktop/mobile quick persona switchers
- Professor Mari persona selector
- Shared avatar thumbnail API call boundary

Boundary notes:

- React feature code now calls the existing typed shared avatar URL helpers through `src/shared/api/local-file-api.ts`.
- No engine, Rust storage, import/export, or remote-runtime command routing changes were needed.
- Inline `avatarPath` thumbnail support stays in the existing shared avatar thumbnail resolver; this PR wires persona UI surfaces into that path.

Pressure points touched:

- Shared mode UI persona picker/switcher surfaces
- Professor Mari shell surface
- Catalog persona panel rows

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed locally.
- `pnpm check:architecture` passed locally.
- `pnpm check` passed locally.
- No browser screenshot/manual UI validation was performed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing persona avatar rendering paths; no new user-discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots attached. This PR was validated with local static/type/architecture/full checks.
