### PR TITLE
Fix remote managed asset invalidation

### DIFF
--- a/src/shared/api/assets-api.ts
+++ b/src/shared/api/assets-api.ts
@@ -1,7 +1,7 @@
 import { fileToUploadPayload, GAME_ASSET_SIZE_ERROR } from "./file-payload";
 import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
 import { invokeTauri } from "./tauri-client";
-import { invalidateRemoteManagedAssetObjectUrls } from "./local-file-api";
+import { invalidateRemoteManagedAssetObjectUrlsAfter } from "./local-file-api";
 
 interface GameAssetFileInfo {
   name: string;
@@ -27,7 +27,7 @@ async function uploadGameAsset({
   category: string;
   subcategory?: string;
 }) {
-  return invalidateGameAssetObjectUrlsAfter(
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
     invokeTauri("game_assets_upload", {
       body: {
         category,
@@ -38,13 +38,8 @@ async function uploadGameAsset({
         }),
       },
     }),
+    "game",
   );
-}
-
-async function invalidateGameAssetObjectUrlsAfter<T>(operation: Promise<T>): Promise<T> {
-  const result = await operation;
-  invalidateRemoteManagedAssetObjectUrls("game");
-  return result;
 }
 
 const gameAssetCommands = {
@@ -53,33 +48,38 @@ const gameAssetCommands = {
   list: (path?: string) => invokeTauri<unknown[]>("game_assets_list", { path: path ?? null }),
   createFolder: (path: string) => invokeTauri("game_assets_create_folder", { path }),
   deleteFolder: (path: string, recursive?: boolean) =>
-    invalidateGameAssetObjectUrlsAfter(
+    invalidateRemoteManagedAssetObjectUrlsAfter(
       invokeTauri("game_assets_delete_folder", { path, recursive: recursive ?? false }),
+      "game",
     ),
   rename: (path: string, newName: string) =>
-    invalidateGameAssetObjectUrlsAfter(invokeTauri("game_assets_rename", { path, newName })),
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri("game_assets_rename", { path, newName }), "game"),
   move: (path: string, targetFolder: string) =>
-    invalidateGameAssetObjectUrlsAfter(invokeTauri("game_assets_move", { path, targetFolder })),
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri("game_assets_move", { path, targetFolder }), "game"),
   copy: (path: string, targetFolder: string) => invokeTauri("game_assets_copy", { path, targetFolder }),
   deleteFile: (path: string) =>
-    invalidateGameAssetObjectUrlsAfter(invokeTauri<void>("game_assets_delete_file", { path })),
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<void>("game_assets_delete_file", { path }), "game"),
   openFolder: (subfolder?: string) => invokeTauri<void>("game_assets_open_folder", { subfolder: subfolder ?? null }),
-  rescan: () => invalidateGameAssetObjectUrlsAfter(invokeTauri("game_assets_rescan")),
+  rescan: () => invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri("game_assets_rescan"), "game"),
   upload: uploadGameAsset,
   updateFolderDescription: (path: string, description: string) =>
     invokeTauri("game_assets_folder_description", { path, description }),
   readText: <T = { content: string }>(path: string) => invokeTauri<T>("game_assets_read_text", { path }),
   writeText: (path: string, content: string) =>
-    invalidateGameAssetObjectUrlsAfter(invokeTauri<void>("game_assets_write_text", { path, content })),
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<void>("game_assets_write_text", { path, content }), "game"),
   fileInfo: (path: string) => invokeTauri<GameAssetFileInfo>("game_assets_file_info", { path }),
   moveBulk: (paths: string[], targetFolder: string) =>
-    invalidateGameAssetObjectUrlsAfter(
+    invalidateRemoteManagedAssetObjectUrlsAfter(
       invokeTauri<BulkOperationResult & { targetFolder: string }>("game_assets_move_bulk", { paths, targetFolder }),
+      "game",
     ),
   copyBulk: (paths: string[], targetFolder: string) =>
     invokeTauri<BulkOperationResult & { targetFolder: string }>("game_assets_copy_bulk", { paths, targetFolder }),
   deleteBulk: (paths: string[]) =>
-    invalidateGameAssetObjectUrlsAfter(invokeTauri<BulkOperationResult>("game_assets_delete_bulk", { paths })),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<BulkOperationResult>("game_assets_delete_bulk", { paths }),
+      "game",
+    ),
 };
 
 export const gameAssetsApi = {

--- a/src/shared/api/avatar-api.ts
+++ b/src/shared/api/avatar-api.ts
@@ -1,9 +1,13 @@
 import { invokeTauri } from "./tauri-client";
+import { invalidateRemoteManagedAssetObjectUrlsAfter } from "./local-file-api";
 
 export const npcAvatarApi = {
   upload: (chatId: string, name: string, avatar: string) =>
-    invokeTauri<{ avatarPath: string; avatarFilePath?: string; avatarFilename?: string }>("npc_avatar_upload", {
-      chatId,
-      body: { name, avatar },
-    }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<{ avatarPath: string; avatarFilePath?: string; avatarFilename?: string }>("npc_avatar_upload", {
+        chatId,
+        body: { name, avatar },
+      }),
+      ["avatar", "avatar-thumbnail"],
+    ),
 };

--- a/src/shared/api/character-api.ts
+++ b/src/shared/api/character-api.ts
@@ -1,5 +1,6 @@
 import { invokeTauri } from "./tauri-client";
 import { storageApi } from "./storage-api";
+import { invalidateRemoteManagedAssetObjectUrlsAfter } from "./local-file-api";
 
 export type EmbeddedLorebookImportResult = {
   success: boolean;
@@ -13,9 +14,22 @@ export type CharacterUpdatePatch = Record<string, unknown>;
 export const characterApi = {
   update: (id: string, patch: CharacterUpdatePatch) => storageApi.update("characters", id, patch),
   restoreVersion: (characterId: string, versionId: string) =>
-    invokeTauri("character_restore_version", { characterId, versionId }),
-  uploadAvatar: (id: string, avatar: string) => invokeTauri("character_avatar_upload", { id, body: { avatar } }),
-  removeAvatar: (id: string) => invokeTauri("character_avatar_remove", { id }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri("character_restore_version", { characterId, versionId }), [
+      "avatar",
+      "avatar-thumbnail",
+      "gallery",
+      "sprite",
+    ]),
+  uploadAvatar: (id: string, avatar: string) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri("character_avatar_upload", { id, body: { avatar } }), [
+      "avatar",
+      "avatar-thumbnail",
+    ]),
+  removeAvatar: (id: string) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri("character_avatar_remove", { id }), [
+      "avatar",
+      "avatar-thumbnail",
+    ]),
   importEmbeddedLorebook: (id: string) =>
     invokeTauri<EmbeddedLorebookImportResult>("character_embedded_lorebook_import", { id }),
 };

--- a/src/shared/api/image-generation-api.ts
+++ b/src/shared/api/image-generation-api.ts
@@ -1,6 +1,6 @@
 import { invokeTauri } from "./tauri-client";
 import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
-import { resolveSpriteFileUrl } from "./local-file-api";
+import { invalidateRemoteManagedAssetObjectUrlsAfter, resolveSpriteFileUrl } from "./local-file-api";
 
 export type SpriteOwnerType = "character" | "persona";
 
@@ -92,7 +92,7 @@ export const spriteApi = {
   upload: async <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) => {
     const owner = spriteOwnerArgs(characterId, options);
     return resolveSpriteResponse(
-      await invokeTauri<T>("sprite_upload", { ...owner, body }),
+      await invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<T>("sprite_upload", { ...owner, body }), "sprite"),
       owner.characterId,
       owner.ownerType,
     );
@@ -100,13 +100,19 @@ export const spriteApi = {
   bulkUpload: async <T = unknown>(characterId: string, body: Record<string, unknown>, options?: SpriteOwnerOptions) => {
     const owner = spriteOwnerArgs(characterId, options);
     return resolveSpriteResponse(
-      await invokeTauri<T>("sprite_upload_bulk", { ...owner, body }),
+      await invalidateRemoteManagedAssetObjectUrlsAfter(
+        invokeTauri<T>("sprite_upload_bulk", { ...owner, body }),
+        "sprite",
+      ),
       owner.characterId,
       owner.ownerType,
     );
   },
   delete: <T = unknown>(characterId: string, expression: string, options?: SpriteOwnerOptions) =>
-    invokeTauri<T>("sprite_delete", { ...spriteOwnerArgs(characterId, options), expression }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("sprite_delete", { ...spriteOwnerArgs(characterId, options), expression }),
+      "sprite",
+    ),
   cleanupSaved: async <T = unknown>(
     characterId: string,
     body: Record<string, unknown>,
@@ -114,7 +120,10 @@ export const spriteApi = {
   ) => {
     const owner = spriteOwnerArgs(characterId, options);
     return resolveSpriteResponse(
-      await invokeTauri<T>("sprite_cleanup_saved", { ...owner, body }),
+      await invalidateRemoteManagedAssetObjectUrlsAfter(
+        invokeTauri<T>("sprite_cleanup_saved", { ...owner, body }),
+        "sprite",
+      ),
       owner.characterId,
       owner.ownerType,
     );
@@ -126,7 +135,10 @@ export const spriteApi = {
   ) => {
     const owner = spriteOwnerArgs(characterId, options);
     return resolveSpriteResponse(
-      await invokeTauri<T>("sprite_cleanup_restore", { ...owner, body }),
+      await invalidateRemoteManagedAssetObjectUrlsAfter(
+        invokeTauri<T>("sprite_cleanup_restore", { ...owner, body }),
+        "sprite",
+      ),
       owner.characterId,
       owner.ownerType,
     );
@@ -146,13 +158,19 @@ export const galleryApi = {
       maxBytes: MAX_IMAGE_UPLOAD_BYTES,
       tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
     });
-    return invokeTauri<T>("character_gallery_upload", { characterId, body: { file: payload } });
+    return invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("character_gallery_upload", { characterId, body: { file: payload } }),
+      "gallery",
+    );
   },
   uploadChat: async <T = unknown>(chatId: string, file: File) => {
     const payload = await fileToUploadPayload(file, {
       maxBytes: MAX_IMAGE_UPLOAD_BYTES,
       tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
     });
-    return invokeTauri<T>("chat_gallery_upload", { chatId, body: { file: payload } });
+    return invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("chat_gallery_upload", { chatId, body: { file: payload } }),
+      "gallery",
+    );
   },
 };

--- a/src/shared/api/import-api.ts
+++ b/src/shared/api/import-api.ts
@@ -119,9 +119,25 @@ export const importApi = {
     signal?: AbortSignal,
   ): AsyncGenerator<{ type: string; data: unknown }> {
     if (signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
+    let importCompleted = false;
+    let importFailed = false;
     if (remoteRuntimeTarget()) {
-      yield* streamRemoteJsonEvents("/api/import/st-bulk/run", payload, { signal, privileged: true });
-      invalidateImportManagedAssetObjectUrls();
+      try {
+        for await (const event of streamRemoteJsonEvents("/api/import/st-bulk/run", payload, {
+          signal,
+          privileged: true,
+        })) {
+          if (event.type === "done") importCompleted = true;
+          yield event;
+        }
+      } catch (error) {
+        importFailed = true;
+        throw error;
+      } finally {
+        if (importCompleted && !importFailed && !signal?.aborted) {
+          invalidateImportManagedAssetObjectUrls();
+        }
+      }
       return;
     }
     const queue: Array<{ type?: unknown; data?: unknown; text?: unknown; [key: string]: unknown }> = [];
@@ -133,6 +149,7 @@ export const importApi = {
       wake = null;
     };
     const abort = () => {
+      importFailed = true;
       failure = new DOMException("The operation was aborted.", "AbortError");
       notify();
     };
@@ -159,13 +176,20 @@ export const importApi = {
         }
         const event = queue.shift()!;
         const type = typeof event.type === "string" ? event.type : "message";
+        if (type === "done") importCompleted = true;
+        if (type === "error") importFailed = true;
         yield { type, data: "data" in event ? event.data : "text" in event ? event.text : event };
       }
       await command;
-      if (failure) throw failure;
-      invalidateImportManagedAssetObjectUrls();
+      if (failure) {
+        importFailed = true;
+        throw failure;
+      }
     } finally {
       signal?.removeEventListener("abort", abort);
+      if (importCompleted && !importFailed && !signal?.aborted) {
+        invalidateImportManagedAssetObjectUrls();
+      }
     }
   },
   listDirectory: <T>(path: string, options?: { pickerSelected?: boolean }) =>

--- a/src/shared/api/import-api.ts
+++ b/src/shared/api/import-api.ts
@@ -2,6 +2,11 @@ import { formDataToJson, CHAT_IMPORT_SIZE_ERROR, type FilePayloadOptions } from 
 import { MAX_FILE_SIZES } from "../../engine/contracts/constants/defaults";
 import { Channel } from "@tauri-apps/api/core";
 import { invokeTauri } from "./tauri-client";
+import {
+  invalidateRemoteManagedAssetObjectUrls,
+  invalidateRemoteManagedAssetObjectUrlsAfter,
+  type RemoteManagedAssetKind,
+} from "./local-file-api";
 import { remoteRuntimeTarget, streamRemoteJsonEvents } from "./remote-runtime";
 
 export interface ImportFilePayload {
@@ -13,6 +18,21 @@ const CHAT_IMPORT_LIMIT: FilePayloadOptions = {
   maxBytes: MAX_FILE_SIZES.CHAT_JSONL,
   tooLargeMessage: CHAT_IMPORT_SIZE_ERROR,
 };
+
+const IMPORT_MANAGED_ASSET_KINDS: RemoteManagedAssetKind[] = [
+  "avatar",
+  "avatar-thumbnail",
+  "background",
+  "gallery",
+  "lorebook",
+  "sprite",
+];
+
+function invalidateImportManagedAssetObjectUrls(): void {
+  for (const kind of IMPORT_MANAGED_ASSET_KINDS) {
+    invalidateRemoteManagedAssetObjectUrls(kind);
+  }
+}
 
 async function filePayload(
   payload: ImportFilePayload | File,
@@ -39,29 +59,61 @@ async function filesPayload(
 }
 
 export const importApi = {
-  marinara: <T>(envelope: unknown) => invokeTauri<T>("import_marinara", { envelope }),
+  marinara: <T>(envelope: unknown) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("import_marinara", { envelope }),
+      IMPORT_MANAGED_ASSET_KINDS,
+    ),
   marinaraFile: async <T>(payload: ImportFilePayload | File) =>
-    invokeTauri<T>("import_marinara_file", { body: await filePayload(payload) }),
-  stCharacterJson: <T>(body: unknown) => invokeTauri<T>("import_st_character", { body }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("import_marinara_file", { body: await filePayload(payload) }),
+      IMPORT_MANAGED_ASSET_KINDS,
+    ),
+  stCharacterJson: <T>(body: unknown) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<T>("import_st_character", { body }), [
+      "avatar",
+      "avatar-thumbnail",
+      "gallery",
+      "sprite",
+    ]),
   stCharacterFile: async <T>(payload: ImportFilePayload) =>
-    invokeTauri<T>("import_st_character", { body: await filePayload(payload) }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("import_st_character", { body: await filePayload(payload) }),
+      ["avatar", "avatar-thumbnail", "gallery", "sprite"],
+    ),
   stCharacterBatch: async <T>(payload: ImportFilePayload | File[] | FormData) => {
     const body =
       Array.isArray(payload) || payload instanceof FormData ? await filesPayload(payload) : await filePayload(payload);
-    return invokeTauri<T>("import_st_character_batch", { body });
+    return invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<T>("import_st_character_batch", { body }), [
+      "avatar",
+      "avatar-thumbnail",
+      "gallery",
+      "sprite",
+    ]);
   },
   stCharacterInspect: async <T>(payload: File[] | FormData) =>
     invokeTauri<T>("import_st_character_inspect", { body: await filesPayload(payload) }),
   stChat: async <T>(file: File) =>
-    invokeTauri<T>("import_st_chat", { body: await filePayload(file, CHAT_IMPORT_LIMIT) }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("import_st_chat", { body: await filePayload(file, CHAT_IMPORT_LIMIT) }),
+      ["avatar", "avatar-thumbnail", "background", "gallery"],
+    ),
   stChatIntoGroup: async <T>(chatId: string, file: File) =>
-    invokeTauri<T>("import_st_chat_into_group", {
-      body: await filePayload({ file, fields: { chatId } }, CHAT_IMPORT_LIMIT),
-    }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("import_st_chat_into_group", {
+        body: await filePayload({ file, fields: { chatId } }, CHAT_IMPORT_LIMIT),
+      }),
+      ["avatar", "avatar-thumbnail", "background", "gallery"],
+    ),
   stPreset: <T>(payload: unknown) => invokeTauri<T>("import_st_preset", { payload }),
-  stLorebook: <T>(payload: unknown) => invokeTauri<T>("import_st_lorebook", { payload }),
+  stLorebook: <T>(payload: unknown) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<T>("import_st_lorebook", { payload }), "lorebook"),
   stBulkScan: <T>(payload: unknown) => invokeTauri<T>("import_st_bulk_scan", { payload }),
-  stBulkRun: <T>(payload: unknown) => invokeTauri<T>("import_st_bulk_run", { payload }),
+  stBulkRun: <T>(payload: unknown) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("import_st_bulk_run", { payload }),
+      IMPORT_MANAGED_ASSET_KINDS,
+    ),
   stBulkRunEvents: async function* (
     payload: unknown,
     signal?: AbortSignal,
@@ -69,6 +121,7 @@ export const importApi = {
     if (signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
     if (remoteRuntimeTarget()) {
       yield* streamRemoteJsonEvents("/api/import/st-bulk/run", payload, { signal, privileged: true });
+      invalidateImportManagedAssetObjectUrls();
       return;
     }
     const queue: Array<{ type?: unknown; data?: unknown; text?: unknown; [key: string]: unknown }> = [];
@@ -110,6 +163,7 @@ export const importApi = {
       }
       await command;
       if (failure) throw failure;
+      invalidateImportManagedAssetObjectUrls();
     } finally {
       signal?.removeEventListener("abort", abort);
     }

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -17,7 +17,11 @@ type RemoteAssetObjectUrlEntry = {
   objectUrl?: string;
 };
 
+const REMOTE_MANAGED_ASSET_INVALIDATION_QUERY = "mriAssetV";
 const remoteAssetObjectUrls = new Map<string, RemoteAssetObjectUrlEntry>();
+const remoteAssetInvalidationVersions = new Map<string, number>();
+let remoteAssetInvalidationVersion = 0;
+let remoteAssetGlobalInvalidationVersion = 0;
 const pendingAvatarThumbnailResolutions = new Map<string, Promise<string | null>>();
 let activeAvatarThumbnailResolutions = 0;
 const queuedAvatarThumbnailResolutions: Array<() => void> = [];
@@ -70,7 +74,7 @@ function filePathToAssetUrl(path: string | null | undefined): string {
   }
 }
 
-type RemoteManagedAssetKind =
+export type RemoteManagedAssetKind =
   | "avatar"
   | "avatar-thumbnail"
   | "background"
@@ -80,13 +84,8 @@ type RemoteManagedAssetKind =
   | "lorebook"
   | "sprite";
 
-function remoteManagedAsset(
-  kind: RemoteManagedAssetKind,
-  path: string | null | undefined,
-  query?: string,
-): RemoteManagedAsset | null {
-  const target = remoteRuntimeTarget();
-  if (!target || !path?.trim()) return null;
+function remoteManagedAssetPath(path: string | null | undefined): string | null {
+  if (!path?.trim()) return null;
   const encodedPath = path
     .replace(/\\/g, "/")
     .split("/")
@@ -94,7 +93,52 @@ function remoteManagedAsset(
     .filter((segment) => segment && segment !== "." && segment !== "..")
     .map(encodeURIComponent)
     .join("/");
-  const querySuffix = query ? `?${query}` : "";
+  return encodedPath || null;
+}
+
+function nextRemoteAssetInvalidationVersion(): number {
+  remoteAssetInvalidationVersion += 1;
+  if (!Number.isSafeInteger(remoteAssetInvalidationVersion)) {
+    remoteAssetInvalidationVersion = 1;
+  }
+  return remoteAssetInvalidationVersion;
+}
+
+function remoteAssetKindVersionKey(kind: RemoteManagedAssetKind): string {
+  return `kind:${kind}`;
+}
+
+function remoteAssetPathVersionKey(kind: RemoteManagedAssetKind, encodedPath: string): string {
+  return `path:${kind}:${encodedPath}`;
+}
+
+function remoteManagedAssetInvalidationVersion(kind: RemoteManagedAssetKind, encodedPath: string): number {
+  return Math.max(
+    remoteAssetGlobalInvalidationVersion,
+    remoteAssetInvalidationVersions.get(remoteAssetKindVersionKey(kind)) ?? 0,
+    remoteAssetInvalidationVersions.get(remoteAssetPathVersionKey(kind, encodedPath)) ?? 0,
+  );
+}
+
+function mergeQueryParts(...parts: Array<string | undefined>): string | undefined {
+  const query = parts.filter((part): part is string => Boolean(part)).join("&");
+  return query || undefined;
+}
+
+function remoteManagedAsset(
+  kind: RemoteManagedAssetKind,
+  path: string | null | undefined,
+  query?: string,
+): RemoteManagedAsset | null {
+  const target = remoteRuntimeTarget();
+  const encodedPath = remoteManagedAssetPath(path);
+  if (!target || !encodedPath) return null;
+  const invalidationVersion = remoteManagedAssetInvalidationVersion(kind, encodedPath);
+  const invalidationQuery = invalidationVersion
+    ? `${REMOTE_MANAGED_ASSET_INVALIDATION_QUERY}=${invalidationVersion}`
+    : undefined;
+  const mergedQuery = mergeQueryParts(query, invalidationQuery);
+  const querySuffix = mergedQuery ? `?${mergedQuery}` : "";
   return encodedPath ? { url: `${target.baseUrl}/api/assets/${kind}/${encodedPath}${querySuffix}`, target } : null;
 }
 
@@ -177,10 +221,18 @@ function deleteRemoteAssetObjectUrl(cacheKey: string): void {
 export function invalidateRemoteManagedAssetObjectUrls(kind?: RemoteManagedAssetKind, path?: string | null): void {
   if (kind && path) {
     const asset = remoteManagedAsset(kind, path);
+    const encodedPath = remoteManagedAssetPath(path);
+    if (encodedPath) {
+      remoteAssetInvalidationVersions.set(
+        remoteAssetPathVersionKey(kind, encodedPath),
+        nextRemoteAssetInvalidationVersion(),
+      );
+    }
     if (asset) deleteRemoteAssetObjectUrl(remoteManagedAssetCacheKey(asset));
     return;
   }
   if (kind) {
+    remoteAssetInvalidationVersions.set(remoteAssetKindVersionKey(kind), nextRemoteAssetInvalidationVersion());
     const routeMarker = `/api/assets/${kind}/`;
     for (const cacheKey of [...remoteAssetObjectUrls.keys()]) {
       if (cacheKey.includes(routeMarker)) {
@@ -190,9 +242,21 @@ export function invalidateRemoteManagedAssetObjectUrls(kind?: RemoteManagedAsset
     return;
   }
 
+  remoteAssetGlobalInvalidationVersion = nextRemoteAssetInvalidationVersion();
   for (const cacheKey of [...remoteAssetObjectUrls.keys()]) {
     deleteRemoteAssetObjectUrl(cacheKey);
   }
+}
+
+export async function invalidateRemoteManagedAssetObjectUrlsAfter<T>(
+  operation: Promise<T>,
+  kinds: RemoteManagedAssetKind | RemoteManagedAssetKind[],
+): Promise<T> {
+  const result = await operation;
+  for (const kind of Array.isArray(kinds) ? kinds : [kinds]) {
+    invalidateRemoteManagedAssetObjectUrls(kind);
+  }
+  return result;
 }
 
 function filenameFromPath(path: string | null | undefined): string | null {
@@ -252,11 +316,7 @@ function inlineImageDataUrl(value: string | null | undefined): string | null {
 }
 
 function inlineAvatarThumbnailRemotePath(path: string | null | undefined, size: number): string | null {
-  const filename = path
-    ?.replace(/\\/g, "/")
-    .split("/")
-    .filter(Boolean)
-    .pop();
+  const filename = path?.replace(/\\/g, "/").split("/").filter(Boolean).pop();
   if (!filename || !/^[a-f0-9]{64}\.thumb\.png$/i.test(filename)) return null;
   return `${size}/inline/${filename}`;
 }
@@ -475,11 +535,13 @@ export async function resolveAvatarThumbnailFileUrl(
     return filePathToAssetUrl(response.path ?? "");
   });
   pendingAvatarThumbnailResolutions.set(cacheKey, promise);
-  promise.finally(() => {
-    if (pendingAvatarThumbnailResolutions.get(cacheKey) === promise) {
-      pendingAvatarThumbnailResolutions.delete(cacheKey);
-    }
-  }).catch(() => {});
+  promise
+    .finally(() => {
+      if (pendingAvatarThumbnailResolutions.get(cacheKey) === promise) {
+        pendingAvatarThumbnailResolutions.delete(cacheKey);
+      }
+    })
+    .catch(() => {});
   return promise;
 }
 

--- a/src/shared/api/lorebook-command-api.ts
+++ b/src/shared/api/lorebook-command-api.ts
@@ -1,4 +1,5 @@
 import { invokeTauri } from "./tauri-client";
+import { invalidateRemoteManagedAssetObjectUrlsAfter } from "./local-file-api";
 
 export interface LorebookVectorizeInput {
   connectionId?: string;
@@ -9,7 +10,10 @@ export interface LorebookVectorizeInput {
 
 export const lorebookCommandApi = {
   uploadImage: <T = unknown>(id: string, image: string, filename?: string) =>
-    invokeTauri<T>("lorebook_image_upload", { id, body: { image, filename } }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("lorebook_image_upload", { id, body: { image, filename } }),
+      "lorebook",
+    ),
   vectorize: <T = unknown>(id: string, body: LorebookVectorizeInput) =>
     invokeTauri<T>("lorebook_vectorize", { id, body }),
 };

--- a/src/shared/api/persona-api.ts
+++ b/src/shared/api/persona-api.ts
@@ -1,7 +1,11 @@
 import { invokeTauri } from "./tauri-client";
+import { invalidateRemoteManagedAssetObjectUrlsAfter } from "./local-file-api";
 
 export const personaApi = {
   activate: (id: string) => invokeTauri("persona_activate", { id }),
   uploadAvatar: (id: string, avatar: string, filename?: string) =>
-    invokeTauri("persona_avatar_upload", { id, body: { avatar, filename } }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri("persona_avatar_upload", { id, body: { avatar, filename } }),
+      ["avatar", "avatar-thumbnail"],
+    ),
 };

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -1,6 +1,7 @@
 import { invokeTauri } from "./tauri-client";
 import { ApiError } from "./api-errors";
 import { downloadPayloadFromApiValue, type DownloadPayload } from "./download-payload";
+import { invalidateRemoteManagedAssetObjectUrlsAfter, type RemoteManagedAssetKind } from "./local-file-api";
 import { remoteRuntimeTarget } from "./remote-runtime";
 
 export type ProfileExportFormat = "native" | "compatible" | "zip";
@@ -10,6 +11,16 @@ const PROFILE_EXPORT_FALLBACKS: Record<ProfileExportFormat, { filename: string; 
   compatible: { filename: "marinara-compatible-export.zip", contentType: "application/zip" },
   zip: { filename: "marinara-profile.zip", contentType: "application/zip" },
 };
+
+const PROFILE_IMPORT_MANAGED_ASSET_KINDS: RemoteManagedAssetKind[] = [
+  "avatar",
+  "avatar-thumbnail",
+  "background",
+  "gallery",
+  "game",
+  "lorebook",
+  "sprite",
+];
 
 function readFileAsBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -30,7 +41,10 @@ async function exportProfile(format: ProfileExportFormat = "native"): Promise<Do
 }
 
 async function importProfile<T>(envelope: unknown): Promise<T> {
-  return invokeTauri<T>("profile_import", { envelope });
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
+    invokeTauri<T>("profile_import", { envelope }),
+    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
+  );
 }
 
 async function importProfileFile<T>(path: string): Promise<T> {
@@ -41,14 +55,20 @@ async function importProfileFile<T>(path: string): Promise<T> {
       { code: "remote_local_path_unsupported" },
     );
   }
-  return invokeTauri<T>("profile_import_file", { path });
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
+    invokeTauri<T>("profile_import_file", { path }),
+    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
+  );
 }
 
 async function importProfileUpload<T>(file: File): Promise<T> {
-  return invokeTauri<T>("profile_import_upload", {
-    filename: file.name,
-    base64: await readFileAsBase64(file),
-  });
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
+    invokeTauri<T>("profile_import_upload", {
+      filename: file.name,
+      base64: await readFileAsBase64(file),
+    }),
+    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
+  );
 }
 
 export type ManagedBackup = {

--- a/src/shared/api/settings-assets-api.ts
+++ b/src/shared/api/settings-assets-api.ts
@@ -1,5 +1,6 @@
 import { fileToUploadPayload, IMAGE_UPLOAD_SIZE_ERROR, MAX_IMAGE_UPLOAD_BYTES } from "./file-payload";
 import { invokeTauri } from "./tauri-client";
+import { invalidateRemoteManagedAssetObjectUrlsAfter } from "./local-file-api";
 
 export const fontsApi = {
   list: <T = unknown>() => invokeTauri<T>("fonts_list"),
@@ -15,10 +16,15 @@ export const backgroundsApi = {
       maxBytes: MAX_IMAGE_UPLOAD_BYTES,
       tooLargeMessage: IMAGE_UPLOAD_SIZE_ERROR,
     });
-    return invokeTauri<T>("background_upload", { body: { file: payload } });
+    return invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("background_upload", { body: { file: payload } }),
+      "background",
+    );
   },
-  delete: <T = unknown>(filename: string) => invokeTauri<T>("background_delete", { filename }),
+  delete: <T = unknown>(filename: string) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<T>("background_delete", { filename }), "background"),
   updateTags: <T = unknown>(filename: string, tags: string[]) =>
     invokeTauri<T>("background_tags_update", { filename, tags }),
-  rename: <T = unknown>(filename: string, name: string) => invokeTauri<T>("background_rename", { filename, name }),
+  rename: <T = unknown>(filename: string, name: string) =>
+    invalidateRemoteManagedAssetObjectUrlsAfter(invokeTauri<T>("background_rename", { filename, name }), "background"),
 };

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -1,6 +1,7 @@
 import type { AddChatMessageSwipeOptions, StorageGateway, StorageListOptions } from "../../engine/capabilities/storage";
 import { collapseExcessBlankLines } from "../../engine/shared/text/newlines";
 import { ApiError } from "./api-errors";
+import { invalidateRemoteManagedAssetObjectUrlsAfter, type RemoteManagedAssetKind } from "./local-file-api";
 import { invokeTauri } from "./tauri-client";
 import { trackerSnapshotApi, type TrackerSnapshotInput } from "./tracker-snapshot-api";
 
@@ -105,6 +106,48 @@ function normalizeStorageWrite(entity: string, value: Record<string, unknown>): 
   return entity === "messages" ? normalizeMessageWrite(value) : value;
 }
 
+function storageWriteInvalidationKinds(entity: string, value?: Record<string, unknown>): RemoteManagedAssetKind[] {
+  switch (entity) {
+    case "gallery":
+    case "character-gallery":
+      return ["gallery"];
+    case "backgrounds":
+      return ["background"];
+    case "lorebooks":
+    case "lorebook-entries":
+      return value && ("image" in value || "imagePath" in value || "imageFilename" in value) ? ["lorebook"] : [];
+    case "characters":
+      return value && ("avatarPath" in value || "avatarFilePath" in value || "avatarFilename" in value)
+        ? ["avatar", "avatar-thumbnail"]
+        : [];
+    case "personas":
+      return value && ("avatarPath" in value || "avatarFilePath" in value || "avatarFilename" in value)
+        ? ["avatar", "avatar-thumbnail"]
+        : [];
+    default:
+      return [];
+  }
+}
+
+function storageDeleteInvalidationKinds(entity: string): RemoteManagedAssetKind[] {
+  switch (entity) {
+    case "gallery":
+    case "character-gallery":
+      return ["gallery"];
+    case "backgrounds":
+      return ["background"];
+    case "lorebooks":
+    case "lorebook-entries":
+      return ["lorebook"];
+    case "characters":
+      return ["avatar", "avatar-thumbnail", "gallery", "sprite"];
+    case "personas":
+      return ["avatar", "avatar-thumbnail", "sprite"];
+    default:
+      return [];
+  }
+}
+
 function normalizeStorageReadResult(entity: string, value: unknown): unknown {
   if (Array.isArray(value)) return value.map((item) => normalizeStorageRecord(entity, item));
   return normalizeStorageRecord(entity, value);
@@ -177,28 +220,35 @@ export const storageApi: StorageGateway = {
         options: options ?? null,
       }),
     ) as never,
-  create: async (entity: string, value: Record<string, unknown>) =>
-    normalizeStorageReadResult(
-      entity,
-      await invokeTauri("storage_create", {
+  create: async (entity: string, value: Record<string, unknown>) => {
+    const result = await invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri("storage_create", {
         entity,
         value: normalizeStorageWrite(entity, value),
       }),
-    ) as never,
-  update: async (entity: string, id: string, patch: Record<string, unknown>) =>
-    normalizeStorageReadResult(
-      entity,
-      await invokeTauri("storage_update", {
+      storageWriteInvalidationKinds(entity, value),
+    );
+    return normalizeStorageReadResult(entity, result) as never;
+  },
+  update: async (entity: string, id: string, patch: Record<string, unknown>) => {
+    const result = await invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri("storage_update", {
         entity,
         id,
         patch: normalizeStorageWrite(entity, patch),
       }),
-    ) as never,
+      storageWriteInvalidationKinds(entity, patch),
+    );
+    return normalizeStorageReadResult(entity, result) as never;
+  },
   delete: (entity: string, id: string) =>
-    invokeTauri("storage_delete", {
-      entity,
-      id,
-    }),
+    invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri("storage_delete", {
+        entity,
+        id,
+      }),
+      storageDeleteInvalidationKinds(entity),
+    ),
   listChatMessages: (chatId, options) =>
     storageApi.list("messages", {
       ...options,


### PR DESCRIPTION
## Linked issue

Closes #1993

## Why this change

- Remote managed asset URLs could stay stale after uploads, imports, deletes, restores, and storage writes because the existing invalidation only revoked authenticated blob object URLs. Unauthenticated remote runtime asset URLs still used stable `/api/assets/...` paths that the HTTP server can cache for mutable asset kinds.

## What changed

- Added shared remote managed asset invalidation versions that append a cache-busting query to future managed asset URLs after kind, path, or global invalidation.
- Added a shared `invalidateRemoteManagedAssetObjectUrlsAfter` wrapper and applied it to asset-mutating shared API calls for avatars, backgrounds, galleries, sprites, game assets, lorebook images, imports, profile imports, and generic storage writes/deletes.
- Preserved existing sprite cache-key query behavior while merging the new invalidation query.

## Refactor impact

Primary owner:

shared API / remote runtime managed asset URL resolution

Impact areas reviewed:

- Remote managed asset URL generation for avatar, avatar-thumbnail, background, gallery, game, lorebook, and sprite assets.
- Shared API wrappers for asset mutation, imports, profile import, and storage writes/deletes.
- Remote runtime dispatch boundary, Tauri command wrapper, and HTTP managed asset cache headers.

Boundary notes:

- Behavior stays in `src/shared/api` runtime wrappers and URL resolution.
- No engine, React feature, or Rust ownership boundary was moved.
- Hostable HTTP command routing remains explicit; this only changes client-side invalidation/cache-busting behavior.

Pressure points touched:

- `src/shared/api/local-file-api.ts`
- Shared API mutation wrappers for assets/imports/profile/storage.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `git diff --check` passed.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- Temporary scratch Vitest proof passed: raw unauthenticated remote asset URLs change after kind invalidation, existing sprite `v=` query is preserved, and path invalidation leaves a neighboring path unchanged. The scratch test file was deleted before commit.
- `pnpm check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal remote managed asset cache invalidation bugfix; no new user-discoverable feature, workflow, setting, mode, panel, import path, or advanced tool.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI layout change; no screenshots required.
