### PR TITLE
Add managed asset thumbnail delivery

### DIFF
--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -52,6 +52,8 @@ pub(crate) mod knowledge;
 pub(crate) mod llm;
 #[path = "storage/lorebook_images.rs"]
 pub(crate) mod lorebook_images;
+#[path = "storage/managed_thumbnails.rs"]
+pub(crate) mod managed_thumbnails;
 #[path = "storage/mari.rs"]
 pub(crate) mod mari;
 #[path = "storage/media_uploads.rs"]

--- a/src-tauri/src/commands/storage/commands/assets.rs
+++ b/src-tauri/src/commands/storage/commands/assets.rs
@@ -1,4 +1,4 @@
-use super::{backgrounds, fonts, game_assets, http, lorebook_images, shared};
+use super::{backgrounds, fonts, game_assets, http, lorebook_images, managed_thumbnails, shared};
 use crate::state::AppState;
 use marinara_core::AppError;
 use serde_json::{json, Value};
@@ -258,6 +258,16 @@ pub fn lorebook_image_file_path(
     filename: String,
 ) -> Result<Value, AppError> {
     lorebook_images::lorebook_image_file_path(&state, &filename)
+}
+
+#[tauri::command]
+pub fn managed_asset_thumbnail_file_path(
+    state: State<'_, AppState>,
+    kind: String,
+    path: String,
+    size: Option<u32>,
+) -> Result<Value, AppError> {
+    managed_thumbnails::managed_asset_thumbnail_file_path(&state, &kind, &path, size)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/managed_thumbnails.rs
+++ b/src-tauri/src/commands/storage/managed_thumbnails.rs
@@ -1,0 +1,260 @@
+use super::media_uploads::safe_filename;
+use super::*;
+use image::ImageFormat;
+use std::path::{Path, PathBuf};
+
+const MANAGED_THUMBNAIL_SIZES: &[u32] = &[64, 128, 256, 512];
+
+#[derive(Clone, Copy)]
+pub(crate) enum ManagedThumbnailKind {
+    Background,
+    Gallery,
+    Game,
+    Lorebook,
+}
+
+impl ManagedThumbnailKind {
+    pub(crate) fn parse(value: &str) -> AppResult<Self> {
+        match value {
+            "background" => Ok(Self::Background),
+            "gallery" => Ok(Self::Gallery),
+            "game" => Ok(Self::Game),
+            "lorebook" => Ok(Self::Lorebook),
+            _ => Err(AppError::not_found("Managed thumbnail type was not found")),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Background => "background",
+            Self::Gallery => "gallery",
+            Self::Game => "game",
+            Self::Lorebook => "lorebook",
+        }
+    }
+
+    fn root(self, state: &AppState) -> PathBuf {
+        match self {
+            Self::Background => state.data_dir.join("backgrounds"),
+            Self::Gallery => state.data_dir.join("gallery"),
+            Self::Game => state.data_dir.join("game-assets"),
+            Self::Lorebook => state.data_dir.join("lorebooks").join("images"),
+        }
+    }
+
+    fn source(self, state: &AppState, path: &str) -> AppResult<PathBuf> {
+        match self {
+            Self::Background => Ok(PathBuf::from(state.backgrounds.absolute_path_string(path)?)),
+            Self::Gallery => Ok(state.data_dir.join("gallery").join(safe_filename(path))),
+            Self::Game => Ok(PathBuf::from(state.game_assets.absolute_path_string(path)?)),
+            Self::Lorebook => {
+                let response = super::lorebook_images::lorebook_image_file_path(state, path)?;
+                response
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .map(PathBuf::from)
+                    .ok_or_else(|| AppError::not_found("Lorebook image was not found"))
+            }
+        }
+    }
+}
+
+pub(crate) fn managed_asset_thumbnail_file_path(
+    state: &AppState,
+    kind: &str,
+    path: &str,
+    size: Option<u32>,
+) -> AppResult<Value> {
+    let kind = ManagedThumbnailKind::parse(kind)?;
+    let path = managed_thumbnail_path(state, kind, path, size.unwrap_or(256))?;
+    Ok(json!({ "path": path.to_string_lossy() }))
+}
+
+pub(crate) fn managed_thumbnail_path(
+    state: &AppState,
+    kind: ManagedThumbnailKind,
+    path: &str,
+    size: u32,
+) -> AppResult<PathBuf> {
+    if !MANAGED_THUMBNAIL_SIZES.contains(&size) {
+        return Err(AppError::invalid_input(
+            "Unsupported managed thumbnail size",
+        ));
+    }
+
+    let source = canonical_source(state, kind, path)?;
+    if !is_resizable_image_file(&source) {
+        return Ok(source);
+    }
+
+    let root = canonical_root(state, kind)?;
+    let relative = source.strip_prefix(&root).map_err(|_| {
+        AppError::invalid_input("Managed thumbnail source is outside managed assets")
+    })?;
+    let target = thumbnail_target_path(state, kind, size, relative);
+    if thumbnail_is_fresh(&source, &target)? {
+        return Ok(target);
+    }
+
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    write_thumbnail(&source, &target, size)?;
+    Ok(target)
+}
+
+fn canonical_source(
+    state: &AppState,
+    kind: ManagedThumbnailKind,
+    path: &str,
+) -> AppResult<PathBuf> {
+    let source = kind.source(state, path)?;
+    let source = fs::canonicalize(source).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            AppError::not_found("Managed thumbnail source was not found")
+        }
+        _ => AppError::from(error),
+    })?;
+    let root = canonical_root(state, kind)?;
+    if !source.starts_with(root) {
+        return Err(AppError::invalid_input(
+            "Managed thumbnail source is outside managed assets",
+        ));
+    }
+    Ok(source)
+}
+
+fn canonical_root(state: &AppState, kind: ManagedThumbnailKind) -> AppResult<PathBuf> {
+    let root = kind.root(state);
+    fs::create_dir_all(&root)?;
+    fs::canonicalize(root).map_err(AppError::from)
+}
+
+fn thumbnail_target_path(
+    state: &AppState,
+    kind: ManagedThumbnailKind,
+    size: u32,
+    relative: &Path,
+) -> PathBuf {
+    let mut target = state
+        .data_dir
+        .join(".managed-thumbnails")
+        .join(kind.as_str())
+        .join(size.to_string())
+        .join(relative);
+    let filename = target
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "asset".to_string());
+    target.set_file_name(format!("{filename}.thumb.png"));
+    target
+}
+
+fn is_resizable_image_file(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "png" | "jpg" | "jpeg" | "webp" | "gif"
+    )
+}
+
+fn thumbnail_is_fresh(source: &Path, target: &Path) -> AppResult<bool> {
+    let source_modified = fs::metadata(source)?.modified()?;
+    let Ok(target_modified) = fs::metadata(target).and_then(|metadata| metadata.modified()) else {
+        return Ok(false);
+    };
+    Ok(target_modified >= source_modified)
+}
+
+fn write_thumbnail(source: &Path, target: &Path, size: u32) -> AppResult<()> {
+    let image = image::open(source).map_err(|error| {
+        AppError::invalid_input(format!("Managed thumbnail could not be decoded: {error}"))
+    })?;
+    let temp = thumbnail_temp_path(target);
+    image
+        .thumbnail(size, size)
+        .save_with_format(&temp, ImageFormat::Png)
+        .map_err(|error| {
+            let _ = fs::remove_file(&temp);
+            AppError::new("managed_thumbnail_error", error.to_string())
+        })?;
+    replace_thumbnail_file(&temp, target).map_err(|error| {
+        let _ = fs::remove_file(&temp);
+        AppError::from(error)
+    })
+}
+
+fn thumbnail_temp_path(target: &Path) -> PathBuf {
+    let filename = target
+        .file_name()
+        .map(|value| value.to_string_lossy().to_string())
+        .unwrap_or_else(|| "asset.thumb.png".to_string());
+    target.with_file_name(format!(".{filename}.{}.tmp", new_id()))
+}
+
+fn replace_thumbnail_file(temp: &Path, target: &Path) -> std::io::Result<()> {
+    match fs::rename(temp, target) {
+        Ok(()) => Ok(()),
+        Err(_) if target.exists() => {
+            let _ = fs::remove_file(target);
+            fs::rename(temp, target)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Rgba};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_state(label: &str) -> AppState {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-thumbnails-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
+        }
+        AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn write_png(path: &Path, width: u32, height: u32) {
+        let image = ImageBuffer::from_pixel(width, height, Rgba([40u8, 80u8, 120u8, 255u8]));
+        image.save(path).expect("test image should be saved");
+    }
+
+    #[test]
+    fn managed_thumbnail_creates_cache_without_overwriting_source() {
+        let state = test_state("background-cache");
+        let source = state.data_dir.join("backgrounds").join("wide.png");
+        write_png(&source, 640, 320);
+
+        let response =
+            managed_asset_thumbnail_file_path(&state, "background", "wide.png", Some(128))
+                .expect("thumbnail should be created");
+        let thumbnail = PathBuf::from(response["path"].as_str().expect("path should be returned"));
+
+        assert!(thumbnail.starts_with(state.data_dir.join(".managed-thumbnails")));
+        assert!(thumbnail.is_file());
+        assert!(source.is_file());
+        assert_ne!(thumbnail, source);
+    }
+
+    #[test]
+    fn managed_thumbnail_rejects_sources_outside_managed_assets() {
+        let state = test_state("outside");
+        let outside = state.data_dir.join("outside.png");
+        write_png(&outside, 64, 64);
+        let error =
+            managed_thumbnail_path(&state, ManagedThumbnailKind::Gallery, "../outside.png", 128)
+                .expect_err("path traversal should be rejected");
+
+        assert_eq!(error.code, "not_found");
+    }
+}

--- a/src-tauri/src/commands/storage/managed_thumbnails.rs
+++ b/src-tauri/src/commands/storage/managed_thumbnails.rs
@@ -86,6 +86,11 @@ pub(crate) fn managed_thumbnail_path(
     if !is_resizable_image_file(&source) {
         return Ok(source);
     }
+    if is_unsupported_thumbnail_file(&source) {
+        return Err(AppError::invalid_input(
+            "AVIF managed thumbnails are unsupported by the current image decoder",
+        ));
+    }
 
     let root = canonical_root(state, kind)?;
     let relative = source.strip_prefix(&root).map_err(|_| {
@@ -157,7 +162,18 @@ fn is_resizable_image_file(path: &Path) -> bool {
             .unwrap_or_default()
             .to_ascii_lowercase()
             .as_str(),
-        "png" | "jpg" | "jpeg" | "webp" | "gif"
+        "png" | "jpg" | "jpeg" | "webp" | "gif" | "avif"
+    )
+}
+
+fn is_unsupported_thumbnail_file(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "avif"
     )
 }
 
@@ -256,5 +272,21 @@ mod tests {
                 .expect_err("path traversal should be rejected");
 
         assert_eq!(error.code, "not_found");
+    }
+
+    #[test]
+    fn managed_thumbnail_rejects_avif_sources_until_decoder_support_exists() {
+        let state = test_state("avif");
+        let source = state.data_dir.join("backgrounds").join("still.avif");
+        std::fs::write(&source, b"not-an-avif").expect("avif fixture should be written");
+
+        let error = managed_asset_thumbnail_file_path(&state, "background", "still.avif", Some(128))
+            .expect_err("avif thumbnails should currently reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(
+            error.message.contains("AVIF"),
+            "error should explain current avif thumbnail contract"
+        );
     }
 }

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -59,6 +59,18 @@ fn optional_u32(args: &Map<String, Value>, key: &str) -> Option<u32> {
         .and_then(|value| u32::try_from(value).ok())
 }
 
+fn optional_u32_strict(args: &Map<String, Value>, key: &str) -> AppResult<Option<u32>> {
+    let Some(value) = args.get(key) else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_u64() else {
+        return Err(AppError::invalid_input(format!("{key} must be a positive integer")));
+    };
+    u32::try_from(value)
+        .map(Some)
+        .map_err(|_| AppError::invalid_input(format!("{key} is too large")))
+}
+
 fn required_string_vec(args: &Map<String, Value>, key: &str) -> AppResult<Vec<String>> {
     let values = args
         .get(key)
@@ -278,7 +290,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
                 state,
                 required_string(&args, "kind")?,
                 required_string(&args, "path")?,
-                optional_u32(&args, "size"),
+                optional_u32_strict(&args, "size")?,
             )
         }
         "gif_search" => gif_search(&args).await,
@@ -1578,6 +1590,30 @@ mod tests {
         assert_eq!(
             result.get("originalName").and_then(Value::as_str),
             Some("background.png")
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_rejects_invalid_managed_thumbnail_size_arguments() {
+        let state = test_state("managed-thumbnail-size");
+        let error = dispatch(
+            &state,
+            InvokeRequest {
+                command: "managed_asset_thumbnail_file_path".to_string(),
+                args: Some(json!({
+                    "kind": "gallery",
+                    "path": "scene.png",
+                    "size": "256"
+                })),
+            },
+        )
+        .await
+        .expect_err("invalid size should be rejected before command defaults");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(
+            error.message.contains("size"),
+            "size validation error should mention size"
         );
     }
 

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -2,8 +2,8 @@ use crate::state::AppState;
 use crate::storage_commands::{
     admin, agents, avatars, backgrounds, backup, bot_browser, characters, chats, custom_tools,
     entity_commands, exports, fonts, game_assets, game_state_snapshots, generation, http, images,
-    imports, integrations, knowledge, llm, lorebook_images, mari, personas, profile,
-    profile_commands, prompts, shared, sprites, translation, updates,
+    imports, integrations, knowledge, llm, lorebook_images, managed_thumbnails, mari, personas,
+    profile, profile_commands, prompts, shared, sprites, translation, updates,
 };
 use marinara_core::{AppError, AppResult};
 use serde::Deserialize;
@@ -272,6 +272,14 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         ),
         "game_assets_upload" => {
             game_assets::game_assets_upload(state, optional_value(&args, "body"))
+        }
+        "managed_asset_thumbnail_file_path" => {
+            managed_thumbnails::managed_asset_thumbnail_file_path(
+                state,
+                required_string(&args, "kind")?,
+                required_string(&args, "path")?,
+                optional_u32(&args, "size"),
+            )
         }
         "gif_search" => gif_search(&args).await,
         "tts_config" => integrations::tts_call(state, "GET", &["config"], Value::Null).await,

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1,6 +1,8 @@
 use crate::http_dispatch::{dispatch, InvokeRequest};
 use crate::state::AppState;
-use crate::storage_commands::{avatars, fonts, imports, llm, lorebook_images, prompts};
+use crate::storage_commands::{
+    avatars, fonts, imports, llm, lorebook_images, managed_thumbnails, prompts,
+};
 use axum::body::Body;
 use axum::extract::{ConnectInfo, Path, State};
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
@@ -216,7 +218,7 @@ fn apply_managed_asset_headers(
 
 fn cache_control_for_managed_asset(kind: &str) -> &'static str {
     match kind {
-        "avatar" | "avatar-thumbnail" => "no-cache",
+        "avatar" | "avatar-thumbnail" | "thumbnail" => "no-cache",
         _ => "public, max-age=86400",
     }
 }
@@ -247,9 +249,34 @@ fn managed_asset_path(state: &AppState, kind: &str, path: &str) -> Result<PathBu
                 .map(PathBuf::from)
                 .ok_or_else(|| AppError::not_found("Lorebook image was not found"))
         }
+        "thumbnail" => managed_thumbnail_asset_path(state, path),
         "sprite" => sprite_asset_path(state, path),
         _ => Err(AppError::not_found("Managed asset type was not found")),
     }
+}
+
+fn managed_thumbnail_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {
+    let mut segments = path.split('/');
+    let kind = managed_asset_path_segment(
+        segments
+            .next()
+            .ok_or_else(|| AppError::not_found("Managed thumbnail asset was not found"))?,
+        "Managed thumbnail asset was not found",
+    )?;
+    let size = managed_asset_path_segment(
+        segments
+            .next()
+            .ok_or_else(|| AppError::not_found("Managed thumbnail asset was not found"))?,
+        "Managed thumbnail asset was not found",
+    )?
+    .parse::<u32>()
+    .map_err(|_| AppError::invalid_input("Unsupported managed thumbnail size"))?;
+    let asset_path = segments.collect::<Vec<_>>().join("/");
+    if asset_path.trim().is_empty() {
+        return Err(AppError::not_found("Managed thumbnail asset was not found"));
+    }
+    let kind = managed_thumbnails::ManagedThumbnailKind::parse(&kind)?;
+    managed_thumbnails::managed_thumbnail_path(state, kind, &asset_path, size)
 }
 
 fn sprite_asset_path(state: &AppState, path: &str) -> Result<PathBuf, AppError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run() {
             storage_commands::asset_commands::game_assets_open_folder,
             storage_commands::asset_commands::background_file_path,
             storage_commands::asset_commands::lorebook_image_file_path,
+            storage_commands::asset_commands::managed_asset_thumbnail_file_path,
             storage_commands::asset_commands::gif_search,
             storage_commands::integration_commands::tts_config,
             storage_commands::integration_commands::tts_update_config,

--- a/src/features/catalog/characters/components/CharacterGalleryTab.tsx
+++ b/src/features/catalog/characters/components/CharacterGalleryTab.tsx
@@ -228,12 +228,12 @@ function CharacterGalleryThumbnail({
   image: CharacterGalleryImage;
   alt: string;
 }) {
-  const [src, setSrc] = useState(image.url);
+  const [src, setSrc] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const path = galleryThumbnailPath(image.filename, image.filePath);
-    setSrc(image.url);
+    setSrc(null);
     resolveManagedAssetThumbnailFileUrl("gallery", path, 256)
       .then((url) => {
         if (!cancelled) setSrc(url || image.url);
@@ -246,5 +246,6 @@ function CharacterGalleryThumbnail({
     };
   }, [image.filePath, image.filename, image.url]);
 
+  if (!src) return <div className="h-full w-full bg-[var(--secondary)]" aria-hidden="true" />;
   return <img src={src} alt={alt} className="h-full w-full object-cover" loading="lazy" />;
 }

--- a/src/features/catalog/characters/components/CharacterGalleryTab.tsx
+++ b/src/features/catalog/characters/components/CharacterGalleryTab.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { Camera, Download, Trash2, Upload, X } from "lucide-react";
 
 import { ImageUploadDropzone } from "../../../../shared/components/ui/ImageUploadDropzone";
+import { galleryThumbnailPath, resolveManagedAssetThumbnailFileUrl } from "../../../../shared/api/local-file-api";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import {
   type CharacterGalleryImage,
@@ -127,11 +128,7 @@ export function CharacterGalleryTab({ characterId, characterName }: { characterI
                 className="block aspect-square w-full bg-[var(--secondary)]"
                 onClick={() => setLightbox(image)}
               >
-                <img
-                  src={image.url}
-                  alt={image.prompt || characterName || "Character image"}
-                  className="h-full w-full object-cover"
-                />
+                <CharacterGalleryThumbnail image={image} alt={image.prompt || characterName || "Character image"} />
               </button>
               <div className="absolute inset-x-0 bottom-0 flex items-center justify-between bg-gradient-to-t from-black/75 via-black/25 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100 max-md:opacity-100">
                 <span className="max-w-[8rem] truncate text-[0.6875rem] font-medium text-white/85">
@@ -222,4 +219,32 @@ export function CharacterGalleryTab({ characterId, characterName }: { characterI
       )}
     </div>
   );
+}
+
+function CharacterGalleryThumbnail({
+  image,
+  alt,
+}: {
+  image: CharacterGalleryImage;
+  alt: string;
+}) {
+  const [src, setSrc] = useState(image.url);
+
+  useEffect(() => {
+    let cancelled = false;
+    const path = galleryThumbnailPath(image.filename, image.filePath);
+    setSrc(image.url);
+    resolveManagedAssetThumbnailFileUrl("gallery", path, 256)
+      .then((url) => {
+        if (!cancelled) setSrc(url || image.url);
+      })
+      .catch(() => {
+        if (!cancelled) setSrc(image.url);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [image.filePath, image.filename, image.url]);
+
+  return <img src={src} alt={alt} className="h-full w-full object-cover" loading="lazy" />;
 }

--- a/src/features/catalog/lorebooks/components/panel/LorebookRow.tsx
+++ b/src/features/catalog/lorebooks/components/panel/LorebookRow.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { BookOpen, Camera, Trash2, UserRound } from "lucide-react";
 import type { Lorebook } from "../../../../../engine/contracts/types/lorebook";
-import { resolveManagedLocalAssetUrl } from "../../../../../shared/api/local-file-api";
+import { resolveManagedLocalAssetThumbnailUrl } from "../../../../../shared/api/local-file-api";
 import { cn } from "../../../../../shared/lib/utils";
 import { LOREBOOK_CATEGORY_COLORS, LOREBOOK_PANEL_CATEGORIES } from "./lorebook-panel-config";
 
@@ -34,7 +34,7 @@ export function LorebookRow({
     let cancelled = false;
     setResolvedImagePath(null);
     if (!lorebook.imagePath) return;
-    resolveManagedLocalAssetUrl(lorebook.imagePath)
+    resolveManagedLocalAssetThumbnailUrl(lorebook.imagePath, 64)
       .then((url) => {
         if (!cancelled) setResolvedImagePath(url);
       })

--- a/src/features/modes/game-assets/components/AssetGrid.tsx
+++ b/src/features/modes/game-assets/components/AssetGrid.tsx
@@ -6,7 +6,10 @@ import { useEffect, useState } from "react";
 import type { TreeNode } from "../hooks/use-game-assets";
 import type { GameAssetSelectionStatus } from "../../game/assets";
 import { formatBytes, formatDate } from "../../../../shared/lib/format";
-import { gameAssetFileUrlFromPath, resolveGameAssetFileUrl } from "../../../../shared/api/local-file-api";
+import {
+  gameAssetFileUrlFromPath,
+  resolveManagedAssetThumbnailFileUrl,
+} from "../../../../shared/api/local-file-api";
 import { CATEGORY_ICONS } from "./constants";
 import { FileIcon, isImage } from "./utils";
 
@@ -68,7 +71,7 @@ function GameAssetImage({ node, alt, className }: { node: TreeNode; alt: string;
   useEffect(() => {
     let cancelled = false;
     setSrc(gameAssetFileUrlFromPath(node.path, node.absolutePath));
-    resolveGameAssetFileUrl(node.path)
+    resolveManagedAssetThumbnailFileUrl("game", node.path, 256)
       .then((url) => {
         if (!cancelled) setSrc(url || gameAssetFileUrlFromPath(node.path, node.absolutePath));
       })

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -36,8 +36,7 @@ import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../../
 import {
   backgroundFileUrlFromPath,
   gameAssetFileUrlFromPath,
-  resolveBackgroundFileUrl,
-  resolveGameAssetFileUrl,
+  resolveManagedAssetThumbnailFileUrl,
   resolveManagedLocalAssetUrl,
   userBackgroundUrl,
 } from "../../../../shared/api/local-file-api";
@@ -2164,7 +2163,7 @@ function BackgroundThumbnail({ item }: { item: BackgroundLibraryItem }) {
     let cancelled = false;
     if (gameAssetPath) {
       setSrc(gameAssetFileUrlFromPath(gameAssetPath, item.absolutePath));
-      resolveGameAssetFileUrl(gameAssetPath)
+      resolveManagedAssetThumbnailFileUrl("game", gameAssetPath, 256)
         .then((url) => {
           if (!cancelled) setSrc(url || gameAssetFileUrlFromPath(gameAssetPath, item.absolutePath));
         })
@@ -2177,7 +2176,7 @@ function BackgroundThumbnail({ item }: { item: BackgroundLibraryItem }) {
     }
     if (filename) {
       setSrc(backgroundFileUrlFromPath(filename, item.absolutePath));
-      resolveBackgroundFileUrl(filename)
+      resolveManagedAssetThumbnailFileUrl("background", filename, 256)
         .then((url) => {
           if (!cancelled) setSrc(url || backgroundFileUrlFromPath(filename, item.absolutePath));
         })

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -115,11 +115,28 @@ function remoteAssetPathVersionKey(kind: RemoteManagedAssetKind, encodedPath: st
   return `path:${kind}:${encodedPath}`;
 }
 
+function sourceThumbnailPathVersionKey(kind: RemoteManagedAssetKind, encodedPath: string): string {
+  return `thumbnail:${kind}:${encodedPath}`;
+}
+
 function remoteManagedAssetInvalidationVersion(kind: RemoteManagedAssetKind, encodedPath: string): number {
+  const thumbnailSourceVersion =
+    kind === "thumbnail" ? remoteManagedAssetThumbnailSourceInvalidationVersion(encodedPath) : 0;
   return Math.max(
     remoteAssetGlobalInvalidationVersion,
     remoteAssetInvalidationVersions.get(remoteAssetKindVersionKey(kind)) ?? 0,
     remoteAssetInvalidationVersions.get(remoteAssetPathVersionKey(kind, encodedPath)) ?? 0,
+    thumbnailSourceVersion,
+  );
+}
+
+function remoteManagedAssetThumbnailSourceInvalidationVersion(encodedPath: string): number {
+  const [kind, , ...sourceSegments] = encodedPath.split("/");
+  const sourcePath = sourceSegments.join("/");
+  if (!kind || !sourcePath) return 0;
+  return Math.max(
+    remoteAssetInvalidationVersions.get(remoteAssetKindVersionKey(kind as RemoteManagedAssetKind)) ?? 0,
+    remoteAssetInvalidationVersions.get(sourceThumbnailPathVersionKey(kind as RemoteManagedAssetKind, sourcePath)) ?? 0,
   );
 }
 
@@ -171,8 +188,19 @@ function managedAssetThumbnailRemotePath(
   path: string | null | undefined,
   size: number,
 ): string | null {
-  const encodedPath = remoteManagedAssetPath(path);
-  return encodedPath ? `${kind}/${size}/${encodedPath}` : null;
+  const normalizedPath = remoteManagedAssetRawPath(path);
+  return normalizedPath ? `${kind}/${size}/${normalizedPath}` : null;
+}
+
+function remoteManagedAssetRawPath(path: string | null | undefined): string | null {
+  if (!path?.trim()) return null;
+  const normalizedPath = path
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment && segment !== "." && segment !== "..")
+    .join("/");
+  return normalizedPath || null;
 }
 
 async function fetchRemoteManagedAssetBlobUrl(asset: RemoteManagedAsset): Promise<string> {
@@ -237,6 +265,10 @@ export function invalidateRemoteManagedAssetObjectUrls(kind?: RemoteManagedAsset
     if (encodedPath) {
       remoteAssetInvalidationVersions.set(
         remoteAssetPathVersionKey(kind, encodedPath),
+        nextRemoteAssetInvalidationVersion(),
+      );
+      remoteAssetInvalidationVersions.set(
+        sourceThumbnailPathVersionKey(kind, encodedPath),
         nextRemoteAssetInvalidationVersion(),
       );
     }

--- a/src/shared/api/local-file-api.ts
+++ b/src/shared/api/local-file-api.ts
@@ -82,7 +82,10 @@ export type RemoteManagedAssetKind =
   | "gallery"
   | "game"
   | "lorebook"
-  | "sprite";
+  | "sprite"
+  | "thumbnail";
+
+export type ManagedAssetThumbnailKind = "background" | "gallery" | "game" | "lorebook";
 
 function remoteManagedAssetPath(path: string | null | undefined): string | null {
   if (!path?.trim()) return null;
@@ -163,6 +166,15 @@ async function remoteManagedAssetResolvableUrl(
   return fetchRemoteManagedAssetBlobUrl(asset);
 }
 
+function managedAssetThumbnailRemotePath(
+  kind: ManagedAssetThumbnailKind,
+  path: string | null | undefined,
+  size: number,
+): string | null {
+  const encodedPath = remoteManagedAssetPath(path);
+  return encodedPath ? `${kind}/${size}/${encodedPath}` : null;
+}
+
 async function fetchRemoteManagedAssetBlobUrl(asset: RemoteManagedAsset): Promise<string> {
   const cacheKey = remoteManagedAssetCacheKey(asset);
   const cached = remoteAssetObjectUrls.get(cacheKey);
@@ -229,13 +241,18 @@ export function invalidateRemoteManagedAssetObjectUrls(kind?: RemoteManagedAsset
       );
     }
     if (asset) deleteRemoteAssetObjectUrl(remoteManagedAssetCacheKey(asset));
+    const routeMarker = `/api/assets/thumbnail/${kind}/`;
+    for (const cacheKey of [...remoteAssetObjectUrls.keys()]) {
+      if (cacheKey.includes(routeMarker)) deleteRemoteAssetObjectUrl(cacheKey);
+    }
     return;
   }
   if (kind) {
     remoteAssetInvalidationVersions.set(remoteAssetKindVersionKey(kind), nextRemoteAssetInvalidationVersion());
     const routeMarker = `/api/assets/${kind}/`;
+    const thumbnailRouteMarker = `/api/assets/thumbnail/${kind}/`;
     for (const cacheKey of [...remoteAssetObjectUrls.keys()]) {
-      if (cacheKey.includes(routeMarker)) {
+      if (cacheKey.includes(routeMarker) || cacheKey.includes(thumbnailRouteMarker)) {
         deleteRemoteAssetObjectUrl(cacheKey);
       }
     }
@@ -429,7 +446,22 @@ export async function resolveGameAssetFileUrl(path: string): Promise<string> {
   return filePathToAssetUrl(response.path ?? "");
 }
 
-export async function resolveBackgroundFileUrl(filename: string): Promise<string> {
+export async function resolveManagedAssetThumbnailFileUrl(
+  kind: ManagedAssetThumbnailKind,
+  path: string | null | undefined,
+  size = 256,
+): Promise<string | null> {
+  const remoteUrl = await remoteManagedAssetResolvableUrl(
+    "thumbnail",
+    managedAssetThumbnailRemotePath(kind, path, size),
+  );
+  if (remoteUrl) return remoteUrl;
+  if (!path?.trim()) return null;
+  const response = await invokeTauri<PathResponse>("managed_asset_thumbnail_file_path", { kind, path, size });
+  return filePathToAssetUrl(response.path ?? "");
+}
+
+async function resolveBackgroundFileUrl(filename: string): Promise<string> {
   const remoteUrl = await remoteManagedAssetResolvableUrl("background", filename);
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("background_file_path", { filename });
@@ -458,6 +490,13 @@ export async function resolveGalleryFileUrl(
   const remoteUrl = await remoteManagedAssetResolvableUrl("gallery", galleryRemoteManagedPath(filename, absolutePath));
   if (remoteUrl) return remoteUrl;
   return absolutePath && isAbsoluteFilesystemPath(absolutePath) ? filePathToAssetUrl(absolutePath) : null;
+}
+
+export function galleryThumbnailPath(
+  filename: string | null | undefined,
+  absolutePath?: string | null,
+): string | null {
+  return galleryRemoteManagedPath(filename, absolutePath);
 }
 
 function spriteRemoteManagedPath(
@@ -550,6 +589,31 @@ async function resolveLorebookImageFileUrl(filename: string): Promise<string> {
   if (remoteUrl) return remoteUrl;
   const response = await invokeTauri<PathResponse>("lorebook_image_file_path", { filename });
   return filePathToAssetUrl(response.path ?? "");
+}
+
+export async function resolveManagedLocalAssetThumbnailUrl(
+  url: string | null | undefined,
+  size = 128,
+): Promise<string | null> {
+  if (!url) return null;
+  if (url.startsWith(USER_BACKGROUND_URL_PREFIX)) {
+    return resolveManagedAssetThumbnailFileUrl(
+      "background",
+      decodeLocalAssetPath(url.slice(USER_BACKGROUND_URL_PREFIX.length)),
+      size,
+    );
+  }
+  if (url.startsWith(GAME_ASSET_URL_PREFIX)) {
+    return resolveManagedAssetThumbnailFileUrl("game", decodeLocalAssetPath(url.slice(GAME_ASSET_URL_PREFIX.length)), size);
+  }
+  if (url.startsWith(LOREBOOK_IMAGE_URL_PREFIX)) {
+    return resolveManagedAssetThumbnailFileUrl(
+      "lorebook",
+      decodeLocalAssetPath(url.slice(LOREBOOK_IMAGE_URL_PREFIX.length)),
+      size,
+    );
+  }
+  return filePathToAssetUrl(url);
 }
 
 export async function resolveManagedLocalAssetUrl(url: string | null | undefined): Promise<string | null> {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -166,6 +166,7 @@ const REMOTE_COMMANDS = new Set([
   "character_avatar_upload",
   "character_avatar_remove",
   "avatar_thumbnail_file_path",
+  "managed_asset_thumbnail_file_path",
   "character_restore_version",
   "persona_avatar_upload",
   "npc_avatar_upload",


### PR DESCRIPTION
## Linked issue

Closes #1994

## Why this change

- Repeated managed image grids were loading full-size background, gallery, game asset, and lorebook files into small thumbnail cells, which wasted transfer, decode, and memory work across repeated surfaces.

## What changed

- Added Rust-owned managed thumbnail generation and cache storage for `background`, `gallery`, `game`, and `lorebook` assets with stable bucket sizes.
- Added embedded and remote-runtime thumbnail delivery through `managed_asset_thumbnail_file_path` and `/api/assets/thumbnail/...`.
- Updated game asset grid, settings background picker, character gallery grid, and lorebook rows to request thumbnails while keeping original files for full preview and download flows.
- Extended managed asset invalidation so cached remote thumbnail blob URLs refresh when source assets change.

## Refactor impact

Primary owner:

- Shared API, Rust storage, remote runtime, catalog resources, game mode, shared mode UI

Impact areas reviewed:

- Managed asset URL resolution in `src/shared/api/local-file-api.ts`
- Remote runtime command allowlist and HTTP managed asset serving
- Repeated image surfaces in settings, game assets, character gallery, and lorebook rows

Boundary notes:

- Feature UI selects repeated thumbnail surfaces only.
- Shared API owns embedded vs remote thumbnail URL resolution.
- Rust owns managed asset path validation, thumbnail generation, cache freshness, and HTTP file delivery.
- Original full-size asset routes remain in place for preview and download paths.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration
- `src-tauri/src/http_dispatch.rs` remote invoke exposure
- `src-tauri/src/http_server.rs` managed asset route handling

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Ran `pnpm typecheck`
- Ran `cargo check --manifest-path src-tauri/Cargo.toml`
- Ran `pnpm check:architecture`
- Ran `cargo test --manifest-path src-tauri/Cargo.toml managed_thumbnail`
- Ran full `pnpm check`

## Feature Discoverability

Check exactly one:

- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing image surfaces now request smaller managed thumbnails; no new user-discoverable workflow or setting was added.

## Docs and release impact

- [x] No docs changes needed
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured in this session.
