### PR TITLE
Polish swipe jump controls

### DIFF
--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -935,6 +935,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             onCreateNextSwipe={onRegenerate ? () => onRegenerate(message.id) : undefined}
             className="ml-14 mt-2 px-1 text-[0.6875rem] text-[var(--muted-foreground)]"
             buttonClassName="rounded p-0.5 transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
+            inputClassName="h-[1.5rem] w-[3rem] text-[0.6875rem]"
           />
         )}
 
@@ -1261,6 +1262,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             onCreateNextSwipe={onRegenerate ? () => onRegenerate(message.id) : undefined}
             className="mt-1.5 text-[0.6875rem] text-[var(--muted-foreground)]"
             buttonClassName="rounded p-0.5 transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
+            inputClassName="h-[1.5rem] w-[3rem] text-[0.6875rem]"
           />
         )}
       </div>

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -2253,6 +2253,7 @@ export const ChatMessage = memo(function ChatMessage({
                 }
                 className="px-1 text-[0.75rem] text-white/40"
                 buttonClassName="rounded-md p-[0.25em] transition-colors hover:bg-white/10 disabled:opacity-30"
+                inputClassName="border-white/10 bg-white/5 text-white/70 [color-scheme:dark]"
                 iconSize={MESSAGE_SWIPE_ICON_SIZE}
               />
             )}

--- a/src/features/modes/shared/chat-ui/components/SwipeJumpControl.tsx
+++ b/src/features/modes/shared/chat-ui/components/SwipeJumpControl.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "../../../../../shared/lib/utils";
 
@@ -8,6 +9,7 @@ interface SwipeJumpControlProps {
   onCreateNextSwipe?: () => void;
   className?: string;
   buttonClassName?: string;
+  inputClassName?: string;
   iconSize?: string;
 }
 
@@ -18,15 +20,34 @@ export function SwipeJumpControl({
   onCreateNextSwipe,
   className,
   buttonClassName,
+  inputClassName,
   iconSize = "0.75rem",
 }: SwipeJumpControlProps) {
+  const inputId = useId();
+  const [inputValue, setInputValue] = useState(() => String(activeSwipeIndex + 1));
+
+  useEffect(() => {
+    setInputValue(String(activeSwipeIndex + 1));
+  }, [activeSwipeIndex]);
+
   if (swipeCount <= 1) return null;
 
   const setActiveIndex = (index: number) => {
     const nextIndex = Math.min(Math.max(index, 0), swipeCount - 1);
+    setInputValue(String(nextIndex + 1));
     if (nextIndex !== activeSwipeIndex) {
       onSetActiveSwipe(nextIndex);
     }
+  };
+  const setSwipeByDisplayIndex = (displayIndex: number) => {
+    if (!Number.isFinite(displayIndex)) return;
+    setActiveIndex(displayIndex - 1);
+  };
+  const handleInputChange = (value: string) => {
+    setInputValue(value);
+    const displayIndex = Number.parseInt(value, 10);
+    if (Number.isNaN(displayIndex) || displayIndex < 1 || displayIndex > swipeCount) return;
+    setSwipeByDisplayIndex(displayIndex);
   };
   const isLastSwipe = activeSwipeIndex >= swipeCount - 1;
   const canCreateNextSwipe = Boolean(onCreateNextSwipe);
@@ -41,19 +62,39 @@ export function SwipeJumpControl({
           setActiveIndex(activeSwipeIndex - 1);
         }}
         disabled={activeSwipeIndex <= 0}
-        aria-label="Previous retry"
-        title="Previous retry"
+        aria-label="Previous swipe"
+        title="Previous swipe"
       >
         <ChevronLeft size={iconSize} />
       </button>
-      <span
-        className="min-w-[2.75rem] text-center tabular-nums"
+      <label className="sr-only" htmlFor={inputId}>
+        Jump to swipe
+      </label>
+      <input
+        id={inputId}
+        type="text"
+        min={1}
+        max={swipeCount}
+        inputMode="numeric"
+        pattern="[0-9]*"
+        value={inputValue}
+        onChange={(event) => handleInputChange(event.target.value)}
+        onBlur={() => setSwipeByDisplayIndex(Number.parseInt(inputValue, 10) || activeSwipeIndex + 1)}
         onClick={(event) => event.stopPropagation()}
-        aria-label={`Retry ${activeSwipeIndex + 1} of ${swipeCount}`}
-        title={`Retry ${activeSwipeIndex + 1} of ${swipeCount}`}
-        aria-live="polite"
-      >
-        {activeSwipeIndex + 1}/{swipeCount}
+        onFocus={(event) => event.currentTarget.select()}
+        onKeyDown={(event) => event.stopPropagation()}
+        className={cn(
+          "h-[1.625rem] w-[3.25rem] rounded border border-[var(--border)] bg-[var(--background)]/70 px-1 text-center text-[0.75rem] tabular-nums outline-none transition-colors focus:border-[var(--primary)] focus:ring-1 focus:ring-[var(--primary)]/40",
+          inputClassName,
+        )}
+        aria-label={`Jump to swipe, 1 through ${swipeCount}`}
+        title={`Jump to swipe 1-${swipeCount}`}
+      />
+      <span className="tabular-nums" aria-hidden="true">
+        /{swipeCount}
+      </span>
+      <span className="sr-only" aria-live="polite">
+        Swipe {activeSwipeIndex + 1} of {swipeCount}
       </span>
       <button
         type="button"
@@ -67,8 +108,8 @@ export function SwipeJumpControl({
           setActiveIndex(activeSwipeIndex + 1);
         }}
         disabled={isLastSwipe && !canCreateNextSwipe}
-        aria-label={isLastSwipe && canCreateNextSwipe ? "Generate next retry" : "Next retry"}
-        title={isLastSwipe && canCreateNextSwipe ? "Generate next retry" : "Next retry"}
+        aria-label={isLastSwipe && canCreateNextSwipe ? "Generate next swipe" : "Next swipe"}
+        title={isLastSwipe && canCreateNextSwipe ? "Generate next swipe" : "Next swipe"}
       >
         <ChevronRight size={iconSize} />
       </button>

--- a/src/features/modes/shared/chat-ui/components/SwipeJumpControl.tsx
+++ b/src/features/modes/shared/chat-ui/components/SwipeJumpControl.tsx
@@ -43,9 +43,10 @@ export function SwipeJumpControl({
     if (!Number.isFinite(displayIndex)) return;
     setActiveIndex(displayIndex - 1);
   };
+  const parseDisplayIndex = (value: string) => (/^\d+$/.test(value) ? Number.parseInt(value, 10) : Number.NaN);
   const handleInputChange = (value: string) => {
     setInputValue(value);
-    const displayIndex = Number.parseInt(value, 10);
+    const displayIndex = parseDisplayIndex(value);
     if (Number.isNaN(displayIndex) || displayIndex < 1 || displayIndex > swipeCount) return;
     setSwipeByDisplayIndex(displayIndex);
   };
@@ -79,7 +80,7 @@ export function SwipeJumpControl({
         pattern="[0-9]*"
         value={inputValue}
         onChange={(event) => handleInputChange(event.target.value)}
-        onBlur={() => setSwipeByDisplayIndex(Number.parseInt(inputValue, 10) || activeSwipeIndex + 1)}
+        onBlur={() => setSwipeByDisplayIndex(parseDisplayIndex(inputValue) || activeSwipeIndex + 1)}
         onClick={(event) => event.stopPropagation()}
         onFocus={(event) => event.currentTarget.select()}
         onKeyDown={(event) => event.stopPropagation()}

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -121,6 +121,7 @@ export function useChatTimelineActions({
   const messagesRef = useLatestRef(messages);
 
   const swipeActionSeq = useRef(0);
+  const destructiveTimelineActionSeq = useRef(0);
   const peekPromptActionSeq = useRef(0);
   const pendingSwipeMutationsRef = useRef(new Map<string, Promise<void>>());
   const swipeRequestSeqCounterRef = useRef(0);
@@ -211,6 +212,7 @@ export function useChatTimelineActions({
     const messageId = deleteDialogMessageId;
     setDeleteDialogMessageId(null);
     if (!messageId) return;
+    destructiveTimelineActionSeq.current += 1;
     const actionId = ++swipeActionSeq.current;
     void (async () => {
       try {
@@ -238,6 +240,7 @@ export function useChatTimelineActions({
     const index = deleteDialogActiveSwipeIndex;
     setDeleteDialogMessageId(null);
     if (!messageId || !deleteDialogCanDeleteSwipe) return;
+    destructiveTimelineActionSeq.current += 1;
     const actionId = ++swipeActionSeq.current;
     void (async () => {
       try {
@@ -312,6 +315,7 @@ export function useChatTimelineActions({
   const handleBulkDelete = useCallback(() => {
     const messageIds = [...selectedMessageIds];
     if (messageIds.length === 0) return;
+    destructiveTimelineActionSeq.current += 1;
     const actionId = ++swipeActionSeq.current;
     void (async () => {
       try {
@@ -469,6 +473,7 @@ export function useChatTimelineActions({
     (messageId: string, index: number) => {
       const actionId = ++swipeActionSeq.current;
       const requestId = ++swipeRequestSeqCounterRef.current;
+      const destructiveTimelineActionId = destructiveTimelineActionSeq.current;
       const previousMutation = pendingSwipeMutationsRef.current.get(messageId);
       let resolvePendingTransition: () => void = () => undefined;
       const pendingTransition = new Promise<void>((resolve) => {
@@ -477,7 +482,9 @@ export function useChatTimelineActions({
       swipeRequestSeqRef.current.set(messageId, requestId);
       pendingSwipeMutationsRef.current.set(messageId, pendingTransition);
       const isLatestSwipeRequest = () => swipeRequestSeqRef.current.get(messageId) === requestId;
-      const isActiveSwipeAction = () => swipeActionSeq.current === actionId && isLatestSwipeRequest();
+      const canPersistSwipeRequest = () =>
+        destructiveTimelineActionSeq.current === destructiveTimelineActionId && isLatestSwipeRequest();
+      const ownsTimelineSideEffects = () => swipeActionSeq.current === actionId && isLatestSwipeRequest();
       void (async () => {
         try {
           if (
@@ -485,12 +492,12 @@ export function useChatTimelineActions({
             !(await flushTrackerPatchesForTimelineAction(
               actionId,
               "Could not save tracker changes before switching swipes.",
-              isActiveSwipeAction,
+              canPersistSwipeRequest,
             ))
           ) {
             return;
           }
-          if (!isActiveSwipeAction()) return;
+          if (!canPersistSwipeRequest()) return;
           if (previousMutation) {
             try {
               await previousMutation;
@@ -498,13 +505,13 @@ export function useChatTimelineActions({
               // The active action below will report its own failure if needed.
             }
           }
-          if (!isActiveSwipeAction()) return;
+          if (!canPersistSwipeRequest()) return;
           const mutation = setActiveSwipeRef.current.mutateAsync({ messageId, index });
           await mutation;
-          if (!isActiveSwipeAction()) return;
+          if (!ownsTimelineSideEffects()) return;
           scheduleVisibleWorldStateRefresh(actionId);
         } catch (error) {
-          if (isActiveSwipeAction()) {
+          if (canPersistSwipeRequest()) {
             toast.error(error instanceof Error ? error.message : "Could not switch swipes.");
           }
         } finally {

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -118,6 +118,7 @@ export function useChatTimelineActions({
   const setActiveSwipeRef = useLatestRef(setActiveSwipe);
   const peekPromptRef = useLatestRef(peekPrompt);
   const branchChatRef = useLatestRef(branchChat);
+  const messagesRef = useLatestRef(messages);
 
   const swipeActionSeq = useRef(0);
   const peekPromptActionSeq = useRef(0);
@@ -468,23 +469,28 @@ export function useChatTimelineActions({
     (messageId: string, index: number) => {
       const actionId = ++swipeActionSeq.current;
       const requestId = ++swipeRequestSeqCounterRef.current;
+      const previousMutation = pendingSwipeMutationsRef.current.get(messageId);
+      let resolvePendingTransition: () => void = () => undefined;
+      const pendingTransition = new Promise<void>((resolve) => {
+        resolvePendingTransition = resolve;
+      });
       swipeRequestSeqRef.current.set(messageId, requestId);
+      pendingSwipeMutationsRef.current.set(messageId, pendingTransition);
       const isLatestSwipeRequest = () => swipeRequestSeqRef.current.get(messageId) === requestId;
+      const isActiveSwipeAction = () => swipeActionSeq.current === actionId && isLatestSwipeRequest();
       void (async () => {
-        let trackedMutation: Promise<void> | null = null;
         try {
           if (
             refreshWorldStateOnTimelineChange &&
             !(await flushTrackerPatchesForTimelineAction(
               actionId,
               "Could not save tracker changes before switching swipes.",
-              isLatestSwipeRequest,
+              isActiveSwipeAction,
             ))
           ) {
             return;
           }
-          if (!isLatestSwipeRequest()) return;
-          const previousMutation = pendingSwipeMutationsRef.current.get(messageId);
+          if (!isActiveSwipeAction()) return;
           if (previousMutation) {
             try {
               await previousMutation;
@@ -492,22 +498,18 @@ export function useChatTimelineActions({
               // The active action below will report its own failure if needed.
             }
           }
-          if (!isLatestSwipeRequest()) return;
+          if (!isActiveSwipeAction()) return;
           const mutation = setActiveSwipeRef.current.mutateAsync({ messageId, index });
-          trackedMutation = mutation.then(
-            () => undefined,
-            () => undefined,
-          );
-          pendingSwipeMutationsRef.current.set(messageId, trackedMutation);
           await mutation;
-          if (swipeActionSeq.current !== actionId) return;
+          if (!isActiveSwipeAction()) return;
           scheduleVisibleWorldStateRefresh(actionId);
         } catch (error) {
-          if (isLatestSwipeRequest()) {
+          if (isActiveSwipeAction()) {
             toast.error(error instanceof Error ? error.message : "Could not switch swipes.");
           }
         } finally {
-          if (trackedMutation && pendingSwipeMutationsRef.current.get(messageId) === trackedMutation) {
+          resolvePendingTransition();
+          if (pendingSwipeMutationsRef.current.get(messageId) === pendingTransition) {
             pendingSwipeMutationsRef.current.delete(messageId);
           }
           if (isLatestSwipeRequest()) {
@@ -582,9 +584,9 @@ export function useChatTimelineActions({
           if (pendingSwipeMutationsRef.current.get(messageId) === pendingSwipeMutation) break;
         }
         if (peekPromptActionSeq.current !== actionId) return;
+        const latestMessage = messageId ? messagesRef.current?.find((message) => message.id === messageId) : undefined;
         const savedSnapshot =
-          promptSnapshotToPeekPromptData(options?.promptSnapshot) ??
-          promptSnapshotForMessage(messages?.find((message) => message.id === messageId));
+          promptSnapshotForMessage(latestMessage) ?? promptSnapshotToPeekPromptData(options?.promptSnapshot);
         if (savedSnapshot) {
           setPeekPromptData(savedSnapshot);
           return;
@@ -621,7 +623,7 @@ export function useChatTimelineActions({
         );
       })();
     },
-    [activeChatId, messages, peekPromptRef],
+    [activeChatId, messagesRef, peekPromptRef],
   );
 
   const closePeekPrompt = useCallback(() => {

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -212,7 +212,6 @@ export function useChatTimelineActions({
     const messageId = deleteDialogMessageId;
     setDeleteDialogMessageId(null);
     if (!messageId) return;
-    destructiveTimelineActionSeq.current += 1;
     const actionId = ++swipeActionSeq.current;
     void (async () => {
       try {
@@ -225,6 +224,7 @@ export function useChatTimelineActions({
           return;
         }
         if (swipeActionSeq.current !== actionId) return;
+        destructiveTimelineActionSeq.current += 1;
         await deleteMessage.mutateAsync(messageId);
         if (swipeActionSeq.current !== actionId) return;
         scheduleVisibleWorldStateRefresh(actionId);
@@ -240,7 +240,6 @@ export function useChatTimelineActions({
     const index = deleteDialogActiveSwipeIndex;
     setDeleteDialogMessageId(null);
     if (!messageId || !deleteDialogCanDeleteSwipe) return;
-    destructiveTimelineActionSeq.current += 1;
     const actionId = ++swipeActionSeq.current;
     void (async () => {
       try {
@@ -253,6 +252,7 @@ export function useChatTimelineActions({
           return;
         }
         if (swipeActionSeq.current !== actionId) return;
+        destructiveTimelineActionSeq.current += 1;
         await deleteSwipe.mutateAsync({ messageId, index });
         if (swipeActionSeq.current !== actionId) return;
         scheduleVisibleWorldStateRefresh(actionId);
@@ -315,7 +315,6 @@ export function useChatTimelineActions({
   const handleBulkDelete = useCallback(() => {
     const messageIds = [...selectedMessageIds];
     if (messageIds.length === 0) return;
-    destructiveTimelineActionSeq.current += 1;
     const actionId = ++swipeActionSeq.current;
     void (async () => {
       try {
@@ -328,6 +327,7 @@ export function useChatTimelineActions({
           return;
         }
         if (swipeActionSeq.current !== actionId) return;
+        destructiveTimelineActionSeq.current += 1;
         await deleteMessages.mutateAsync(messageIds);
         if (swipeActionSeq.current !== actionId) return;
         scheduleVisibleWorldStateRefresh(actionId);

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-timeline-actions.ts
@@ -122,6 +122,8 @@ export function useChatTimelineActions({
   const swipeActionSeq = useRef(0);
   const peekPromptActionSeq = useRef(0);
   const pendingSwipeMutationsRef = useRef(new Map<string, Promise<void>>());
+  const swipeRequestSeqCounterRef = useRef(0);
+  const swipeRequestSeqRef = useRef(new Map<string, number>());
   const [deleteDialogMessageId, setDeleteDialogMessageId] = useState<string | null>(null);
   const [multiSelectMode, setMultiSelectMode] = useState(false);
   const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(new Set());
@@ -150,19 +152,26 @@ export function useChatTimelineActions({
     [activeChatId, refreshWorldStateOnTimelineChange],
   );
 
-  const flushTrackerPatchesForTimelineAction = useCallback(async (actionId: number, errorMessage: string) => {
-    const flushPatch = useGameStateStore.getState().flushPatch;
-    if (!flushPatch) return true;
-    try {
-      await flushPatch();
-      return true;
-    } catch {
-      if (swipeActionSeq.current === actionId) {
-        toast.error(errorMessage);
+  const flushTrackerPatchesForTimelineAction = useCallback(
+    async (
+      actionId: number,
+      errorMessage: string,
+      shouldReportFailure: () => boolean = () => swipeActionSeq.current === actionId,
+    ) => {
+      const flushPatch = useGameStateStore.getState().flushPatch;
+      if (!flushPatch) return true;
+      try {
+        await flushPatch();
+        return true;
+      } catch {
+        if (shouldReportFailure()) {
+          toast.error(errorMessage);
+        }
+        return false;
       }
-      return false;
-    }
-  }, []);
+    },
+    [],
+  );
 
   const clearRefreshingTimeline = useCallback(
     (actionId: number) => {
@@ -458,27 +467,61 @@ export function useChatTimelineActions({
   const handleSetActiveSwipe = useCallback(
     (messageId: string, index: number) => {
       const actionId = ++swipeActionSeq.current;
-      const mutation = setActiveSwipeRef.current.mutateAsync({ messageId, index });
-      const trackedMutation = mutation.then(
-        () => undefined,
-        () => undefined,
-      );
-      pendingSwipeMutationsRef.current.set(messageId, trackedMutation);
+      const requestId = ++swipeRequestSeqCounterRef.current;
+      swipeRequestSeqRef.current.set(messageId, requestId);
+      const isLatestSwipeRequest = () => swipeRequestSeqRef.current.get(messageId) === requestId;
       void (async () => {
+        let trackedMutation: Promise<void> | null = null;
         try {
+          if (
+            refreshWorldStateOnTimelineChange &&
+            !(await flushTrackerPatchesForTimelineAction(
+              actionId,
+              "Could not save tracker changes before switching swipes.",
+              isLatestSwipeRequest,
+            ))
+          ) {
+            return;
+          }
+          if (!isLatestSwipeRequest()) return;
+          const previousMutation = pendingSwipeMutationsRef.current.get(messageId);
+          if (previousMutation) {
+            try {
+              await previousMutation;
+            } catch {
+              // The active action below will report its own failure if needed.
+            }
+          }
+          if (!isLatestSwipeRequest()) return;
+          const mutation = setActiveSwipeRef.current.mutateAsync({ messageId, index });
+          trackedMutation = mutation.then(
+            () => undefined,
+            () => undefined,
+          );
+          pendingSwipeMutationsRef.current.set(messageId, trackedMutation);
           await mutation;
+          if (swipeActionSeq.current !== actionId) return;
+          scheduleVisibleWorldStateRefresh(actionId);
         } catch (error) {
-          if (swipeActionSeq.current === actionId) {
+          if (isLatestSwipeRequest()) {
             toast.error(error instanceof Error ? error.message : "Could not switch swipes.");
           }
         } finally {
-          if (pendingSwipeMutationsRef.current.get(messageId) === trackedMutation) {
+          if (trackedMutation && pendingSwipeMutationsRef.current.get(messageId) === trackedMutation) {
             pendingSwipeMutationsRef.current.delete(messageId);
+          }
+          if (isLatestSwipeRequest()) {
+            swipeRequestSeqRef.current.delete(messageId);
           }
         }
       })();
     },
-    [setActiveSwipeRef],
+    [
+      flushTrackerPatchesForTimelineAction,
+      refreshWorldStateOnTimelineChange,
+      scheduleVisibleWorldStateRefresh,
+      setActiveSwipeRef,
+    ],
   );
 
   const handleEdit = useCallback(


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Make the refactor swipe jump controls match the legacy editable jump behavior while avoiding a dropped-switch regression in tracker-enabled timelines.

## What changed

- Replaced the passive swipe counter with an editable jump input in shared chat UI.
- Added per-surface input sizing for conversation and shared chat message layouts.
- Flush tracker/world-state patches before switching swipes, then refresh visible world state after the switch.
- Scope delayed swipe cancellation to the same message so unrelated timeline actions do not silently drop a pending switch.
- Preserve accessible current-swipe announcements and avoid mouse-wheel value changes on the jump field.

## Refactor impact

Primary owner:

Shared mode UI and shared chat timeline actions.

Impact areas reviewed:

- Conversation, roleplay, and game paths that consume `useChatTimelineActions`.
- Shared `SwipeJumpControl` render sites in conversation and shared chat message components.
- Legacy counterpart in `C:\MarinaraEngine` for swipe jump UI and active swipe handling.

Boundary notes:

- No engine, shared API, Rust command, or remote-runtime boundary changes.
- Shared mode UI still receives mode-owned callbacks and does not import concrete mode orchestration.

Pressure points touched:

- Shared mode UI.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `git diff --check` passed.
- `pnpm check` passed after rebasing onto current `origin/refactor`.
- Native Tauri/manual UI verification not run; visual behavior and interaction feel still need a human pass.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing swipe controls are polished/fixed; no new discoverable shell feature, setting, mode, panel, or workflow is added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not captured. This needs a native/manual UI pass before checking the human validation box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input field to swipe jump control, allowing users to navigate directly to specific swipes by entering a number.

* **Improvements**
  * Enhanced accessibility labels and descriptions for swipe navigation.
  * Improved request sequencing when switching between swipes for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->