### PR TITLE
Fix transcript scroll measurement thrash

### DIFF
--- a/src/features/catalog/characters/components/CharacterLibraryView.tsx
+++ b/src/features/catalog/characters/components/CharacterLibraryView.tsx
@@ -41,11 +41,30 @@ function useElementWidth(ref: RefObject<HTMLElement | null>): number {
   useEffect(() => {
     const element = ref.current;
     if (!element) return;
-    const update = () => setWidth(element.clientWidth);
-    update();
-    const observer = new ResizeObserver(update);
+    let frame: number | null = null;
+    const setMeasuredWidth = (nextWidth: number) => {
+      const roundedWidth = Math.round(nextWidth);
+      setWidth((current) => (current === roundedWidth ? current : roundedWidth));
+    };
+    const scheduleWidth = (nextWidth: number) => {
+      if (frame != null) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        setMeasuredWidth(nextWidth);
+      });
+    };
+
+    scheduleWidth(element.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      const borderBox = entry?.borderBoxSize?.[0];
+      scheduleWidth(borderBox?.inlineSize ?? entry?.contentRect.width ?? element.clientWidth);
+    });
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (frame != null) window.cancelAnimationFrame(frame);
+    };
   }, [ref]);
   return width;
 }
@@ -179,9 +198,11 @@ export function CharacterLibraryView() {
     getScrollElement: () => listScrollRef.current,
     estimateSize: () => (columnCount === 1 ? 150 : 360),
     overscan: 5,
+    useAnimationFrameWithResizeObserver: true,
   });
   useEffect(() => {
-    rowVirtualizer.measure();
+    const frame = window.requestAnimationFrame(() => rowVirtualizer.measure());
+    return () => window.cancelAnimationFrame(frame);
   }, [rowVirtualizer, selectedCharacterDetail, selectedCharacterId]);
 
   const handleSortChange = (value: string) => {

--- a/src/features/catalog/characters/components/CharactersListSection.tsx
+++ b/src/features/catalog/characters/components/CharactersListSection.tsx
@@ -62,6 +62,7 @@ export function CharactersListSection({
     getScrollElement: () => listScrollRef.current,
     estimateSize: () => 74,
     overscan: 10,
+    useAnimationFrameWithResizeObserver: true,
   });
 
   return (

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -28,7 +28,14 @@ import {
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "../../shared/scene-ui";
-import { ChatBranchSelector } from "../../shared/chat-ui/index";
+import {
+  ChatBranchSelector,
+  isNearTranscriptBottom,
+  preserveTranscriptScrollAfterPrepend,
+  readTranscriptScrollMetrics,
+  scheduleTranscriptScrollWrite,
+  scrollTranscriptToBottom,
+} from "../../shared/chat-ui/index";
 import { ActiveWorldInfoButton, ActiveWorldInfoModal } from "../../../runtime/visuals/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
@@ -507,9 +514,9 @@ export function ConversationView({
     const el = scrollRef.current;
     if (!el) return;
     const onScroll = () => {
-      const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      const nearBottom = distFromBottom < 150;
-      if (isStreaming && el.scrollTop < lastScrollTopRef.current - 10) {
+      const metrics = readTranscriptScrollMetrics(el);
+      const nearBottom = isNearTranscriptBottom(metrics);
+      if (isStreaming && metrics.scrollTop < lastScrollTopRef.current - 10) {
         userScrolledAwayRef.current = true;
       }
       // Re-engage auto-scroll when the user returns to the bottom,
@@ -519,7 +526,7 @@ export function ConversationView({
       if (nearBottom && Date.now() - userScrolledAtRef.current > 300) {
         userScrolledAwayRef.current = false;
       }
-      lastScrollTopRef.current = el.scrollTop;
+      lastScrollTopRef.current = metrics.scrollTop;
       isNearBottomRef.current = nearBottom;
     };
     el.addEventListener("scroll", onScroll, { passive: true });
@@ -549,11 +556,14 @@ export function ConversationView({
     if (openedAtBottomChatIdRef.current === chatId || !messages?.length || isLoadingMoreRef.current) return;
     const el = scrollRef.current;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
-    lastScrollTopRef.current = el.scrollTop;
-    isNearBottomRef.current = true;
-    userScrolledAwayRef.current = false;
-    openedAtBottomChatIdRef.current = chatId;
+    return scheduleTranscriptScrollWrite(() => {
+      const currentElement = scrollRef.current;
+      if (!currentElement || currentElement !== el || isLoadingMoreRef.current) return;
+      lastScrollTopRef.current = scrollTranscriptToBottom(currentElement);
+      isNearBottomRef.current = true;
+      userScrolledAwayRef.current = false;
+      openedAtBottomChatIdRef.current = chatId;
+    });
   }, [chatId, messages?.length, newestMsgId]);
 
   useEffect(() => {
@@ -567,15 +577,18 @@ export function ConversationView({
   // Preserve scroll on load-more
   useLayoutEffect(() => {
     if (isLoadingMoreRef.current && scrollRef.current && !isFetchingNextPage) {
-      const newScrollHeight = scrollRef.current.scrollHeight;
-      scrollRef.current.scrollTop += newScrollHeight - prevScrollHeightRef.current;
-      isLoadingMoreRef.current = false;
+      return scheduleTranscriptScrollWrite(() => {
+        const element = scrollRef.current;
+        if (!element || !isLoadingMoreRef.current) return;
+        preserveTranscriptScrollAfterPrepend(element, prevScrollHeightRef.current);
+        isLoadingMoreRef.current = false;
+      });
     }
   }, [pageCount, isFetchingNextPage]);
 
   const handleLoadMore = useCallback(() => {
     if (!scrollRef.current || !hasNextPage || isFetchingNextPage) return;
-    prevScrollHeightRef.current = scrollRef.current.scrollHeight;
+    prevScrollHeightRef.current = readTranscriptScrollMetrics(scrollRef.current).scrollHeight;
     isLoadingMoreRef.current = true;
     fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);

--- a/src/features/modes/roleplay/hooks/use-roleplay-transcript-scroll.ts
+++ b/src/features/modes/roleplay/hooks/use-roleplay-transcript-scroll.ts
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
 import { useChatStore } from "../../../../shared/stores/chat.store";
+import {
+  isNearTranscriptBottom,
+  preserveTranscriptScrollAfterPrepend,
+  readTranscriptScrollMetrics,
+  scheduleTranscriptScrollWrite,
+  scrollTranscriptToBottom,
+} from "../../shared/chat-ui";
 import type { MessageWithSwipes } from "../../shared/chat-ui/types";
 
 type UseRoleplayTranscriptScrollOptions = {
@@ -44,17 +51,17 @@ export function useRoleplayTranscriptScroll({
     const element = scrollRef.current;
     if (!element) return;
     const onScroll = () => {
-      const distFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
-      const nearBottom = distFromBottom < 150;
+      const metrics = readTranscriptScrollMetrics(element);
+      const nearBottom = isNearTranscriptBottom(metrics);
 
-      if (isStreaming && element.scrollTop < lastScrollTopRef.current - 10) {
+      if (isStreaming && metrics.scrollTop < lastScrollTopRef.current - 10) {
         userScrolledAwayRef.current = true;
       }
       if (nearBottom && Date.now() - userScrolledAtRef.current > 300) {
         userScrolledAwayRef.current = false;
       }
 
-      lastScrollTopRef.current = element.scrollTop;
+      lastScrollTopRef.current = metrics.scrollTop;
       isNearBottomRef.current = nearBottom;
     };
 
@@ -88,11 +95,14 @@ export function useRoleplayTranscriptScroll({
     if (openedAtBottomChatIdRef.current === activeChatId || !messages?.length || isLoadingMoreRef.current) return;
     const element = scrollRef.current;
     if (!element) return;
-    element.scrollTop = element.scrollHeight;
-    lastScrollTopRef.current = element.scrollTop;
-    isNearBottomRef.current = true;
-    userScrolledAwayRef.current = false;
-    openedAtBottomChatIdRef.current = activeChatId;
+    return scheduleTranscriptScrollWrite(() => {
+      const currentElement = scrollRef.current;
+      if (!currentElement || currentElement !== element || isLoadingMoreRef.current) return;
+      lastScrollTopRef.current = scrollTranscriptToBottom(currentElement);
+      isNearBottomRef.current = true;
+      userScrolledAwayRef.current = false;
+      openedAtBottomChatIdRef.current = activeChatId;
+    });
   }, [activeChatId, messages?.length, newestMsgId]);
 
   useEffect(() => {
@@ -104,15 +114,18 @@ export function useRoleplayTranscriptScroll({
 
   useLayoutEffect(() => {
     if (isLoadingMoreRef.current && scrollRef.current && !isFetchingNextPage) {
-      const newScrollHeight = scrollRef.current.scrollHeight;
-      scrollRef.current.scrollTop += newScrollHeight - prevScrollHeightRef.current;
-      isLoadingMoreRef.current = false;
+      return scheduleTranscriptScrollWrite(() => {
+        const element = scrollRef.current;
+        if (!element || !isLoadingMoreRef.current) return;
+        preserveTranscriptScrollAfterPrepend(element, prevScrollHeightRef.current);
+        isLoadingMoreRef.current = false;
+      });
     }
   }, [pageCount, isFetchingNextPage]);
 
   const handleLoadMore = useCallback(() => {
     if (!scrollRef.current || !hasNextPage || isFetchingNextPage) return;
-    prevScrollHeightRef.current = scrollRef.current.scrollHeight;
+    prevScrollHeightRef.current = readTranscriptScrollMetrics(scrollRef.current).scrollHeight;
     isLoadingMoreRef.current = true;
     fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
@@ -149,7 +162,7 @@ export function useRoleplayTranscriptScroll({
 
     if (hasNextPage && !isFetchingNextPage) {
       if (scrollRef.current) {
-        prevScrollHeightRef.current = scrollRef.current.scrollHeight;
+        prevScrollHeightRef.current = readTranscriptScrollMetrics(scrollRef.current).scrollHeight;
         isLoadingMoreRef.current = true;
       }
       fetchNextPage();

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -29,3 +29,4 @@ export * from "./hooks/use-sprite-metadata-state";
 export * from "./lib/message-thinking";
 export * from "./lib/message-attachments";
 export * from "./lib/prompt-snapshot";
+export * from "./lib/transcript-scroll-geometry";

--- a/src/features/modes/shared/chat-ui/lib/transcript-scroll-geometry.ts
+++ b/src/features/modes/shared/chat-ui/lib/transcript-scroll-geometry.ts
@@ -1,0 +1,37 @@
+export type TranscriptScrollMetrics = {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+};
+
+export function readTranscriptScrollMetrics(element: HTMLElement): TranscriptScrollMetrics {
+  return {
+    scrollHeight: element.scrollHeight,
+    scrollTop: element.scrollTop,
+    clientHeight: element.clientHeight,
+  };
+}
+
+export function isNearTranscriptBottom(metrics: TranscriptScrollMetrics, thresholdPx = 150): boolean {
+  return metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight < thresholdPx;
+}
+
+export function scheduleTranscriptScrollWrite(write: () => void): () => void {
+  if (typeof window === "undefined") {
+    write();
+    return () => {};
+  }
+
+  const frame = window.requestAnimationFrame(write);
+  return () => window.cancelAnimationFrame(frame);
+}
+
+export function scrollTranscriptToBottom(element: HTMLElement): number {
+  element.scrollTop = element.scrollHeight;
+  return element.scrollTop;
+}
+
+export function preserveTranscriptScrollAfterPrepend(element: HTMLElement, previousScrollHeight: number): void {
+  const nextScrollHeight = element.scrollHeight;
+  element.scrollTop += nextScrollHeight - previousScrollHeight;
+}


### PR DESCRIPTION
## Linked issue

Closes #2007

## Why this change

- Transcript scroll and character list measurement paths still had synchronous geometry read/write patterns that could trigger forced reflow during transcript opening, load-more preservation, and virtualized character list measurement.

## What changed

- Added a shared transcript scroll geometry helper that centralizes scroll metrics reads and schedules scroll writes through `requestAnimationFrame`.
- Updated conversation and roleplay transcript scroll handling to use the shared helper while preserving existing bottom-scroll and load-more behavior.
- Enabled TanStack Virtual's rAF-backed ResizeObserver measurement for character library virtualizers.
- Deferred the character library detail remeasure call through `requestAnimationFrame`.
- Batched character library width observer updates and used ResizeObserver-provided box sizes before falling back to `clientWidth`.

## Refactor impact

Primary owner:

shared mode UI, chat mode, roleplay mode, catalog characters

Impact areas reviewed:

- Conversation transcript scroll tracking, initial bottom positioning, and load-more preservation.
- Roleplay transcript scroll tracking, initial bottom positioning, goto/load-more preservation, and streaming auto-scroll.
- Character library grid virtualization and compact character list virtualization.

Boundary notes:

- Shared transcript scroll geometry is exported through `src/features/modes/shared/chat-ui/index.ts`.
- No engine, shared API, Rust, storage, provider, or remote-runtime boundaries changed.

Pressure points touched:

- Shared mode UI transcript scroll helper.
- Conversation transcript surface.
- Roleplay transcript scroll hook.
- Character catalog virtualized list surfaces.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- Focused static proof passed: transcript direct scroll writes are centralized in the scheduled helper, and both character virtualizers opt into rAF ResizeObserver measurement.
- No browser performance trace was captured.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal performance-risk fix only; no new user-facing feature or discoverable workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshots or recordings; this is a timing/performance-risk fix with intended visual behavior unchanged.
