### PR TITLE
Defer quick-start setup overlay work

### DIFF
--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 
 type IdleWindow = Window & {
@@ -47,21 +47,43 @@ export function useChatOverlays(activeChatId: string) {
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [spriteArrangeMode, setSpriteArrangeMode] = useState(false);
+  const cancelSetupOverlayOpenRef = useRef<(() => void) | null>(null);
+  const pendingSetupOverlayKeyRef = useRef<string | null>(null);
 
   const newChatSetupIntent = useChatStore((state) => state.newChatSetupIntent);
   const shouldOpenSettings = useChatStore((state) => state.shouldOpenSettings);
   const shouldOpenWizard = useChatStore((state) => state.shouldOpenWizard);
 
+  const queueSetupOverlayOpen = useCallback((key: string, run: () => void) => {
+    if (pendingSetupOverlayKeyRef.current === key) return;
+    cancelSetupOverlayOpenRef.current?.();
+    pendingSetupOverlayKeyRef.current = key;
+    cancelSetupOverlayOpenRef.current = scheduleSetupOverlayOpen(() => {
+      pendingSetupOverlayKeyRef.current = null;
+      cancelSetupOverlayOpenRef.current = null;
+      run();
+    });
+  }, []);
+
   useEffect(() => {
     setSpriteArrangeMode(false);
   }, [activeChatId]);
+
+  useEffect(
+    () => () => {
+      cancelSetupOverlayOpenRef.current?.();
+      cancelSetupOverlayOpenRef.current = null;
+      pendingSetupOverlayKeyRef.current = null;
+    },
+    [activeChatId],
+  );
 
   useEffect(() => {
     if (!activeChatId) return;
 
     const intent = useChatStore.getState().consumeNewChatSetupIntent(activeChatId);
     if (intent) {
-      return scheduleSetupOverlayOpen(() => {
+      queueSetupOverlayOpen(`intent:${intent.chatId}`, () => {
         if (intent.openWizard) {
           if (intent.shortcutMode) useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
           setWizardOpen(true);
@@ -69,17 +91,18 @@ export function useChatOverlays(activeChatId: string) {
           setSettingsOpen(true);
         }
       });
+      return;
     }
 
     if (shouldOpenSettings && !newChatSetupIntent) {
-      useChatStore.getState().setShouldOpenWizard(false);
-      useChatStore.getState().setShouldOpenSettings(false);
-      return scheduleSetupOverlayOpen(() => {
+      queueSetupOverlayOpen(`legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`, () => {
         if (shouldOpenWizard) setWizardOpen(true);
         else setSettingsOpen(true);
+        useChatStore.getState().setShouldOpenWizard(false);
+        useChatStore.getState().setShouldOpenSettings(false);
       });
     }
-  }, [newChatSetupIntent, shouldOpenSettings, shouldOpenWizard, activeChatId]);
+  }, [newChatSetupIntent, queueSetupOverlayOpen, shouldOpenSettings, shouldOpenWizard, activeChatId]);
 
   return {
     settingsOpen,

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -1,6 +1,46 @@
 import { useEffect, useState } from "react";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 
+type IdleWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+function scheduleSetupOverlayOpen(run: () => void): () => void {
+  if (typeof window === "undefined") {
+    run();
+    return () => {};
+  }
+
+  let canceled = false;
+  let idleHandle: number | null = null;
+  const idleWindow = window as IdleWindow;
+  const frameHandle = window.requestAnimationFrame(() => {
+    if (canceled) return;
+    if (typeof idleWindow.requestIdleCallback === "function") {
+      idleHandle = idleWindow.requestIdleCallback(
+        () => {
+          if (!canceled) run();
+        },
+        { timeout: 350 },
+      );
+      return;
+    }
+    idleHandle = window.setTimeout(() => {
+      if (!canceled) run();
+    }, 48);
+  });
+
+  return () => {
+    canceled = true;
+    window.cancelAnimationFrame(frameHandle);
+    if (idleHandle != null) {
+      if (typeof idleWindow.cancelIdleCallback === "function") idleWindow.cancelIdleCallback(idleHandle);
+      else window.clearTimeout(idleHandle);
+    }
+  };
+}
+
 export function useChatOverlays(activeChatId: string) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [filesOpen, setFilesOpen] = useState(false);
@@ -21,20 +61,23 @@ export function useChatOverlays(activeChatId: string) {
 
     const intent = useChatStore.getState().consumeNewChatSetupIntent(activeChatId);
     if (intent) {
-      if (intent.openWizard) {
-        if (intent.shortcutMode) useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
-        setWizardOpen(true);
-      } else if (intent.openSettings) {
-        setSettingsOpen(true);
-      }
-      return;
+      return scheduleSetupOverlayOpen(() => {
+        if (intent.openWizard) {
+          if (intent.shortcutMode) useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
+          setWizardOpen(true);
+        } else if (intent.openSettings) {
+          setSettingsOpen(true);
+        }
+      });
     }
 
     if (shouldOpenSettings && !newChatSetupIntent) {
-      if (shouldOpenWizard) setWizardOpen(true);
-      else setSettingsOpen(true);
       useChatStore.getState().setShouldOpenWizard(false);
       useChatStore.getState().setShouldOpenSettings(false);
+      return scheduleSetupOverlayOpen(() => {
+        if (shouldOpenWizard) setWizardOpen(true);
+        else setSettingsOpen(true);
+      });
     }
   }, [newChatSetupIntent, shouldOpenSettings, shouldOpenWizard, activeChatId]);
 

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -6,6 +6,11 @@ type IdleWindow = Window & {
   cancelIdleCallback?: (handle: number) => void;
 };
 
+type PendingSetupOverlayOpen = {
+  key: string;
+  cancel: () => void;
+};
+
 function scheduleSetupOverlayOpen(run: () => void): () => void {
   if (typeof window === "undefined") {
     run();
@@ -47,22 +52,32 @@ export function useChatOverlays(activeChatId: string) {
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [spriteArrangeMode, setSpriteArrangeMode] = useState(false);
-  const cancelSetupOverlayOpenRef = useRef<(() => void) | null>(null);
-  const pendingSetupOverlayKeyRef = useRef<string | null>(null);
+  const pendingSetupOverlayOpenRef = useRef<PendingSetupOverlayOpen | null>(null);
 
   const newChatSetupIntent = useChatStore((state) => state.newChatSetupIntent);
   const shouldOpenSettings = useChatStore((state) => state.shouldOpenSettings);
   const shouldOpenWizard = useChatStore((state) => state.shouldOpenWizard);
 
-  const queueSetupOverlayOpen = useCallback((key: string, run: () => void): boolean => {
-    if (pendingSetupOverlayKeyRef.current === key) return false;
-    cancelSetupOverlayOpenRef.current?.();
-    pendingSetupOverlayKeyRef.current = key;
-    cancelSetupOverlayOpenRef.current = scheduleSetupOverlayOpen(() => {
-      pendingSetupOverlayKeyRef.current = null;
-      cancelSetupOverlayOpenRef.current = null;
+  const queueSetupOverlayOpen = useCallback((key: string, run: () => void, onCancel?: () => void): boolean => {
+    if (pendingSetupOverlayOpenRef.current?.key === key) return false;
+    pendingSetupOverlayOpenRef.current?.cancel();
+
+    let settled = false;
+    const cancelScheduledOpen = scheduleSetupOverlayOpen(() => {
+      settled = true;
+      pendingSetupOverlayOpenRef.current = null;
       run();
     });
+    pendingSetupOverlayOpenRef.current = {
+      key,
+      cancel: () => {
+        if (settled) return;
+        settled = true;
+        cancelScheduledOpen();
+        if (pendingSetupOverlayOpenRef.current?.key === key) pendingSetupOverlayOpenRef.current = null;
+        onCancel?.();
+      },
+    };
     return true;
   }, []);
 
@@ -72,9 +87,8 @@ export function useChatOverlays(activeChatId: string) {
 
   useEffect(
     () => () => {
-      cancelSetupOverlayOpenRef.current?.();
-      cancelSetupOverlayOpenRef.current = null;
-      pendingSetupOverlayKeyRef.current = null;
+      pendingSetupOverlayOpenRef.current?.cancel();
+      pendingSetupOverlayOpenRef.current = null;
     },
     [activeChatId],
   );
@@ -96,14 +110,19 @@ export function useChatOverlays(activeChatId: string) {
     }
 
     if (shouldOpenSettings && !newChatSetupIntent) {
-      const queued = queueSetupOverlayOpen(`legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`, () => {
-        if (shouldOpenWizard) setWizardOpen(true);
-        else setSettingsOpen(true);
-      });
-      if (queued) {
+      const clearLegacyFlags = () => {
         useChatStore.getState().setShouldOpenWizard(false);
         useChatStore.getState().setShouldOpenSettings(false);
-      }
+      };
+      queueSetupOverlayOpen(
+        `legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`,
+        () => {
+          if (shouldOpenWizard) setWizardOpen(true);
+          else setSettingsOpen(true);
+          clearLegacyFlags();
+        },
+        clearLegacyFlags,
+      );
     }
   }, [newChatSetupIntent, queueSetupOverlayOpen, shouldOpenSettings, shouldOpenWizard, activeChatId]);
 

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -54,8 +54,8 @@ export function useChatOverlays(activeChatId: string) {
   const shouldOpenSettings = useChatStore((state) => state.shouldOpenSettings);
   const shouldOpenWizard = useChatStore((state) => state.shouldOpenWizard);
 
-  const queueSetupOverlayOpen = useCallback((key: string, run: () => void) => {
-    if (pendingSetupOverlayKeyRef.current === key) return;
+  const queueSetupOverlayOpen = useCallback((key: string, run: () => void): boolean => {
+    if (pendingSetupOverlayKeyRef.current === key) return false;
     cancelSetupOverlayOpenRef.current?.();
     pendingSetupOverlayKeyRef.current = key;
     cancelSetupOverlayOpenRef.current = scheduleSetupOverlayOpen(() => {
@@ -63,6 +63,7 @@ export function useChatOverlays(activeChatId: string) {
       cancelSetupOverlayOpenRef.current = null;
       run();
     });
+    return true;
   }, []);
 
   useEffect(() => {
@@ -95,12 +96,14 @@ export function useChatOverlays(activeChatId: string) {
     }
 
     if (shouldOpenSettings && !newChatSetupIntent) {
-      queueSetupOverlayOpen(`legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`, () => {
+      const queued = queueSetupOverlayOpen(`legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`, () => {
         if (shouldOpenWizard) setWizardOpen(true);
         else setSettingsOpen(true);
+      });
+      if (queued) {
         useChatStore.getState().setShouldOpenWizard(false);
         useChatStore.getState().setShouldOpenSettings(false);
-      });
+      }
     }
   }, [newChatSetupIntent, queueSetupOverlayOpen, shouldOpenSettings, shouldOpenWizard, activeChatId]);
 


### PR DESCRIPTION
## Linked issue

Closes #2007

## Why this change

- Quick-start navigation creates a chat, switches into the mode route, and immediately opens setup/settings overlays. That can make the first navigation response compete with heavy lazy-loaded setup/settings work.

## What changed

- Added a small scheduler for new-chat setup overlays that waits for the route paint via `requestAnimationFrame`, then opens setup/settings through `requestIdleCallback` with a timeout fallback.
- Kept the user-facing quick-start behavior intact: the chat still opens and the setup/settings flow still appears, just sequenced after the initial navigation response.
- Preserved shortcut-mode setup intent handling so character quick-start flows still land in the intended wizard view.

## Refactor impact

Primary owner:

shared mode UI

Impact areas reviewed:

- Quick-start new chat setup intent handling
- Conversation and roleplay overlay routing through `useChatOverlays`
- Settings/setup lazy overlay entrypoints

Boundary notes:

- React feature/shared UI only. No engine, shared API, Rust, storage, provider, or remote-runtime boundary changes.

Pressure points touched:

- Shared mode UI overlay scheduling in `src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Ran `pnpm typecheck` locally: passed.
- Ran `pnpm check:architecture` locally: passed.
- Ran `git diff --check`: clean.
- Reviewed the focused diff against `upstream/refactor`; only `use-chat-overlays.ts` changed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal quick-start sequencing fix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshots attached. This is a sequencing/performance fix that preserves the existing visible flow.
