### PR TITLE
Limit mounted chat transcript rows

### DIFF
--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -28,7 +28,11 @@ import {
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "../../shared/scene-ui";
-import { ChatBranchSelector } from "../../shared/chat-ui/index";
+import {
+  ChatBranchSelector,
+  getTranscriptRenderWindow,
+  TRANSCRIPT_RENDER_WINDOW_STEP,
+} from "../../shared/chat-ui/index";
 import { ActiveWorldInfoButton, ActiveWorldInfoModal } from "../../../runtime/visuals/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
@@ -496,6 +500,7 @@ export function ConversationView({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef(0);
   const isLoadingMoreRef = useRef(false);
+  const [transcriptWindowStart, setTranscriptWindowStart] = useState<number | null>(null);
   const isNearBottomRef = useRef(true);
   const userScrolledAwayRef = useRef(false);
   const lastScrollTopRef = useRef(0);
@@ -580,6 +585,10 @@ export function ConversationView({
     fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
+  useEffect(() => {
+    setTranscriptWindowStart(null);
+  }, [chatId]);
+
   // ── Build message list with day separators ──
   // Assistant messages with multiple lines are split into separate visual
   // messages so each line appears as its own bubble (Discord-style).
@@ -590,26 +599,56 @@ export function ConversationView({
       .replace(/^(\s*\[\d{1,2}[:.]\d{2}\]\s*)+/gm, "")
       .replace(/^(\s*\[\d{1,2}\.\d{1,2}\.\d{4}\]\s*)+/gm, "")
       .trim();
+  const transcriptWindow = useMemo(
+    () => getTranscriptRenderWindow(messages, { startIndex: transcriptWindowStart }),
+    [messages, transcriptWindowStart],
+  );
+
+  const handleShowOlderMessages = useCallback(() => {
+    if (transcriptWindow.hiddenBeforeCount > 0) {
+      setTranscriptWindowStart(Math.max(0, transcriptWindow.startIndex - TRANSCRIPT_RENDER_WINDOW_STEP));
+      return;
+    }
+    if (!hasNextPage || isFetchingNextPage) return;
+    setTranscriptWindowStart(0);
+    handleLoadMore();
+  }, [
+    handleLoadMore,
+    hasNextPage,
+    isFetchingNextPage,
+    transcriptWindow.hiddenBeforeCount,
+    transcriptWindow.startIndex,
+  ]);
+
+  const handleShowNewerMessages = useCallback(() => {
+    setTranscriptWindowStart((currentStart) => {
+      const current = currentStart ?? transcriptWindow.startIndex;
+      const next = Math.min(transcriptWindow.latestStartIndex, current + TRANSCRIPT_RENDER_WINDOW_STEP);
+      return next >= transcriptWindow.latestStartIndex ? null : next;
+    });
+  }, [transcriptWindow.latestStartIndex, transcriptWindow.startIndex]);
 
   const renderedItems = useMemo(() => {
-    if (!messages) return [];
+    const visibleMessages = transcriptWindow.messages;
+    if (!visibleMessages) return [];
     // Offset so message numbers reflect absolute position in the full chat history,
     // not just the position within the paginated window.
-    const messageOffset = totalMessageCount - messages.length;
+    const messageOffset = totalMessageCount - transcriptWindow.totalLoadedCount;
     const items: Array<
       | { type: "separator"; key: string; label: string }
       | { type: "message"; key: string; msg: Message; isGrouped: boolean; index: number }
     > = [];
     let lastDay = "";
-    for (let i = 0; i < messages.length; i++) {
-      const msg = messages[i]!;
+    for (let i = 0; i < visibleMessages.length; i++) {
+      const msg = visibleMessages[i]!;
+      const originalIndex = transcriptWindow.startIndex + i;
       if (isHiddenFromUser(msg)) continue;
       const day = getDayKey(msg.createdAt);
       if (day !== lastDay) {
         items.push({ type: "separator", key: `sep-${day}`, label: formatDaySeparator(msg.createdAt) });
         lastDay = day;
       }
-      const prev = i > 0 ? messages[i - 1]! : null;
+      const prev = i > 0 ? visibleMessages[i - 1]! : null;
       // Break grouping if >5 minutes apart (like Discord)
       const TIME_GAP_MS = 5 * 60 * 1000;
       const timeTooFar = prev
@@ -660,7 +699,7 @@ export function ConversationView({
                     extra: { displayText: null, isGenerated: false, tokenCount: null, generationInfo: null },
                   },
               isGrouped: bi === 0 ? grouped : true,
-              index: messageOffset + i,
+              index: messageOffset + originalIndex,
             });
           });
           continue;
@@ -678,10 +717,16 @@ export function ConversationView({
         }
       }
       const displayMsg = displayContent !== msg.content ? { ...msg, content: displayContent } : msg;
-      items.push({ type: "message", key: msg.id, msg: displayMsg, isGrouped: grouped, index: messageOffset + i });
+      items.push({
+        type: "message",
+        key: msg.id,
+        msg: displayMsg,
+        isGrouped: grouped,
+        index: messageOffset + originalIndex,
+      });
     }
     return items;
-  }, [messages, characterMap, chatCharIds, totalMessageCount]);
+  }, [transcriptWindow, characterMap, chatCharIds, totalMessageCount]);
 
   // ── Staggered reveal for split assistant lines ──
   // When a new multi-line assistant message arrives, show lines one by one
@@ -973,15 +1018,15 @@ export function ConversationView({
         </div>
 
         {/* Load More */}
-        {hasNextPage && (
+        {(hasNextPage || transcriptWindow.hiddenBeforeCount > 0) && (
           <div className="flex justify-center py-3">
             <button
-              onClick={handleLoadMore}
+              onClick={handleShowOlderMessages}
               disabled={isFetchingNextPage}
               className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] disabled:opacity-50"
             >
               {isFetchingNextPage ? <Loader2 size="0.75rem" className="animate-spin" /> : <ChevronUp size="0.75rem" />}
-              Load More
+              {transcriptWindow.hiddenBeforeCount > 0 ? "Older Messages" : "Load More"}
             </button>
           </div>
         )}
@@ -1119,6 +1164,17 @@ export function ConversationView({
           }
           return elements;
         })()}
+
+        {transcriptWindow.hiddenAfterCount > 0 && (
+          <div className="flex justify-center py-3">
+            <button
+              onClick={handleShowNewerMessages}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+            >
+              Newer Messages
+            </button>
+          </div>
+        )}
 
         {/* Delayed indicator (DND/idle — waiting for character to become available) */}
         {delayedCharacterInfo && isStreaming && !streamBuffer && !thinkingBuffer && (

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -506,6 +506,10 @@ export function ConversationView({
   const lastScrollTopRef = useRef(0);
   const userScrolledAtRef = useRef(0);
   const openedAtBottomChatIdRef = useRef<string | null>(null);
+  const previousTailRef = useRef<{ messageId: string | undefined; isStreaming: boolean }>({
+    messageId: undefined,
+    isStreaming: false,
+  });
 
   // ── Scroll tracking ──
   useEffect(() => {
@@ -550,6 +554,17 @@ export function ConversationView({
   // Auto-scroll on new messages / streaming / staggered reveals
   const newestMsgId = messages?.[messages.length - 1]?.id;
   const isOptimistic = newestMsgId?.startsWith("__optimistic_");
+  useEffect(() => {
+    const previousTail = previousTailRef.current;
+    const tailMessageChanged =
+      !!newestMsgId && !!previousTail.messageId && previousTail.messageId !== newestMsgId;
+    const streamingStarted = isStreaming && !previousTail.isStreaming;
+    if (transcriptWindowStart !== null && !isLoadingMoreRef.current && (tailMessageChanged || streamingStarted)) {
+      setTranscriptWindowStart(null);
+    }
+    previousTailRef.current = { messageId: newestMsgId, isStreaming };
+  }, [isStreaming, newestMsgId, transcriptWindowStart]);
+
   useLayoutEffect(() => {
     if (openedAtBottomChatIdRef.current === chatId || !messages?.length || isLoadingMoreRef.current) return;
     const el = scrollRef.current;

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -748,6 +748,10 @@ export function ChatRoleplaySurface({
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
   const [transcriptWindowStart, setTranscriptWindowStart] = useState<number | null>(null);
+  const previousTailRef = useRef<{ messageId: string | undefined; isStreaming: boolean }>({
+    messageId: undefined,
+    isStreaming: false,
+  });
   const inactiveCharacterIdSet = useMemo(
     () => new Set(metadataStringArray(chatMeta.inactiveCharacterIds)),
     [chatMeta.inactiveCharacterIds],
@@ -764,6 +768,18 @@ export function ChatRoleplaySurface({
     () => getTranscriptRenderWindow(messages, { startIndex: transcriptWindowStart }),
     [messages, transcriptWindowStart],
   );
+  const newestMsgId = messages?.[messages.length - 1]?.id;
+  useEffect(() => {
+    const previousTail = previousTailRef.current;
+    const tailMessageChanged =
+      !!newestMsgId && !!previousTail.messageId && previousTail.messageId !== newestMsgId;
+    const streamingStarted = isStreaming && !previousTail.isStreaming;
+    if (transcriptWindowStart !== null && (tailMessageChanged || streamingStarted)) {
+      setTranscriptWindowStart(null);
+    }
+    previousTailRef.current = { messageId: newestMsgId, isStreaming };
+  }, [isStreaming, newestMsgId, transcriptWindowStart]);
+
   const handleShowOlderMessages = () => {
     if (transcriptWindow.hiddenBeforeCount > 0) {
       setTranscriptWindowStart(Math.max(0, transcriptWindow.startIndex - TRANSCRIPT_RENDER_WINDOW_STEP));

--- a/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
+++ b/src/features/modes/roleplay/components/ChatRoleplaySurface.tsx
@@ -32,7 +32,7 @@ import { resolveManagedLocalAssetUrl } from "../../../../shared/api/local-file-a
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useGameStateStore } from "../../../runtime/world-state/index";
-import { ChatMessage } from "../../shared/chat-ui/index";
+import { ChatMessage, getTranscriptRenderWindow, TRANSCRIPT_RENDER_WINDOW_STEP } from "../../shared/chat-ui/index";
 import { ChatInput } from "../../shared/chat-ui/index";
 import { CyoaChoices } from "./CyoaChoices";
 import { ChatBranchSelector } from "../../shared/chat-ui/index";
@@ -92,8 +92,7 @@ const PANEL_BACKDROP =
   "fixed inset-0 z-[9999] flex items-center justify-center p-4 max-md:pt-[max(1rem,env(safe-area-inset-top))]";
 const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
   "pl-[var(--tracker-chat-avoid-left)] pr-[var(--tracker-chat-avoid-right)] transition-[padding] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]";
-const TRACKER_SCROLL_AVOIDANCE_CLASS =
-  "transition-[padding] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]";
+const TRACKER_SCROLL_AVOIDANCE_CLASS = "transition-[padding] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]";
 const PANEL_CONTAINER =
   "relative max-h-[calc(100dvh-4rem)] w-full max-w-sm overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 shadow-2xl shadow-black/40 animate-message-in";
 
@@ -748,6 +747,7 @@ export function ChatRoleplaySurface({
       };
   const hideEchoChamberOnMobile =
     sidebarOpen || rightPanelOpen || settingsOpen || filesOpen || galleryOpen || wizardOpen;
+  const [transcriptWindowStart, setTranscriptWindowStart] = useState<number | null>(null);
   const inactiveCharacterIdSet = useMemo(
     () => new Set(metadataStringArray(chatMeta.inactiveCharacterIds)),
     [chatMeta.inactiveCharacterIds],
@@ -760,6 +760,26 @@ export function ChatRoleplaySurface({
     () => activeChatCharIds.map((id) => characterMap.get(id)?.name).filter((name): name is string => !!name),
     [activeChatCharIds, characterMap],
   );
+  const transcriptWindow = useMemo(
+    () => getTranscriptRenderWindow(messages, { startIndex: transcriptWindowStart }),
+    [messages, transcriptWindowStart],
+  );
+  const handleShowOlderMessages = () => {
+    if (transcriptWindow.hiddenBeforeCount > 0) {
+      setTranscriptWindowStart(Math.max(0, transcriptWindow.startIndex - TRANSCRIPT_RENDER_WINDOW_STEP));
+      return;
+    }
+    if (!hasNextPage || isFetchingNextPage) return;
+    setTranscriptWindowStart(0);
+    onLoadMore();
+  };
+  const handleShowNewerMessages = () => {
+    setTranscriptWindowStart((currentStart) => {
+      const current = currentStart ?? transcriptWindow.startIndex;
+      const next = Math.min(transcriptWindow.latestStartIndex, current + TRANSCRIPT_RENDER_WINDOW_STEP);
+      return next >= transcriptWindow.latestStartIndex ? null : next;
+    });
+  };
   const overlaySpriteDisplayModes = useMemo(
     () => (expressionAvatarsEnabled ? spriteDisplayModes.filter((mode) => mode !== "expressions") : spriteDisplayModes),
     [expressionAvatarsEnabled, spriteDisplayModes],
@@ -769,6 +789,7 @@ export function ChatRoleplaySurface({
 
   useEffect(() => {
     setAddonsReady(false);
+    setTranscriptWindowStart(null);
     const id = window.setTimeout(() => setAddonsReady(true), 180);
     return () => window.clearTimeout(id);
   }, [activeChatId]);
@@ -1007,10 +1028,10 @@ export function ChatRoleplaySurface({
                   centerCompact ? "px-3" : "px-3 md:px-[15%]",
                 )}
               >
-                {hasNextPage && (
+                {(hasNextPage || transcriptWindow.hiddenBeforeCount > 0) && (
                   <div className="mb-3 flex justify-center">
                     <button
-                      onClick={onLoadMore}
+                      onClick={handleShowOlderMessages}
                       disabled={isFetchingNextPage}
                       className="inline-flex items-center gap-1.5 rounded-lg border border-foreground/10 bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-foreground/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] hover:text-foreground/90 disabled:opacity-50"
                     >
@@ -1019,7 +1040,7 @@ export function ChatRoleplaySurface({
                       ) : (
                         <ChevronUp size="0.75rem" />
                       )}
-                      Load More
+                      {transcriptWindow.hiddenBeforeCount > 0 ? "Older Messages" : "Load More"}
                     </button>
                   </div>
                 )}
@@ -1030,9 +1051,13 @@ export function ChatRoleplaySurface({
                   </div>
                 )}
 
-                {messages?.map((msg, i) => {
+                {transcriptWindow.messages?.map((msg, i) => {
                   if (isHiddenFromUser(msg)) return null;
                   const isRegenerating = isStreaming && regenerateMessageId === msg.id;
+                  const originalIndex = transcriptWindow.startIndex + i;
+                  const messageOrderIndex = totalMessageCount - transcriptWindow.totalLoadedCount + originalIndex;
+                  const messageDepth = transcriptWindow.totalLoadedCount - 1 - originalIndex;
+                  const grouped = i > 0 && isGrouped(originalIndex);
                   return (
                     <div
                       key={msg.id}
@@ -1060,10 +1085,10 @@ export function ChatRoleplaySurface({
                           characterMap={characterMap}
                           personaInfo={personaInfo}
                           chatMode={chatMode}
-                          messageDepth={messages.length - 1 - i}
-                          messageIndex={totalMessageCount - messages.length + i + 1}
-                          messageOrderIndex={totalMessageCount - messages.length + i}
-                          isGrouped={isGrouped(i)}
+                          messageDepth={messageDepth}
+                          messageIndex={messageOrderIndex + 1}
+                          messageOrderIndex={messageOrderIndex}
+                          isGrouped={grouped}
                           groupChatMode={groupChatMode}
                           chatCharacterIds={chatCharIds}
                           expressionAvatarResolver={expressionAvatarResolver}
@@ -1089,10 +1114,10 @@ export function ChatRoleplaySurface({
                           characterMap={characterMap}
                           personaInfo={personaInfo}
                           chatMode={chatMode}
-                          messageDepth={messages.length - 1 - i}
-                          messageIndex={totalMessageCount - messages.length + i + 1}
-                          messageOrderIndex={totalMessageCount - messages.length + i}
-                          isGrouped={isGrouped(i)}
+                          messageDepth={messageDepth}
+                          messageIndex={messageOrderIndex + 1}
+                          messageOrderIndex={messageOrderIndex}
+                          isGrouped={grouped}
                           groupChatMode={groupChatMode}
                           chatCharacterIds={chatCharIds}
                           expressionAvatarResolver={expressionAvatarResolver}
@@ -1106,6 +1131,17 @@ export function ChatRoleplaySurface({
                 })}
 
                 {!isConcludedScene && !isStreaming && <CyoaChoices messages={messages} />}
+
+                {transcriptWindow.hiddenAfterCount > 0 && (
+                  <div className="flex justify-center py-3">
+                    <button
+                      onClick={handleShowNewerMessages}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-foreground/10 bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-foreground/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] hover:text-foreground/90"
+                    >
+                      Newer Messages
+                    </button>
+                  </div>
+                )}
 
                 {isStreaming && !regenerateMessageId && (
                   <StreamingIndicator

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -29,3 +29,4 @@ export * from "./hooks/use-sprite-metadata-state";
 export * from "./lib/message-thinking";
 export * from "./lib/message-attachments";
 export * from "./lib/prompt-snapshot";
+export * from "./lib/transcript-render-window";

--- a/src/features/modes/shared/chat-ui/lib/transcript-render-window.ts
+++ b/src/features/modes/shared/chat-ui/lib/transcript-render-window.ts
@@ -1,0 +1,51 @@
+const MAX_MOUNTED_TRANSCRIPT_MESSAGES = 160;
+export const TRANSCRIPT_RENDER_WINDOW_STEP = 80;
+
+export type TranscriptRenderWindow<T> = {
+  messages: T[] | undefined;
+  startIndex: number;
+  endIndex: number;
+  latestStartIndex: number;
+  hiddenBeforeCount: number;
+  hiddenAfterCount: number;
+  totalLoadedCount: number;
+  isWindowed: boolean;
+};
+
+export function getTranscriptRenderWindow<T>(
+  messages: readonly T[] | undefined,
+  options: { maxMountedMessages?: number; startIndex?: number | null } = {},
+): TranscriptRenderWindow<T> {
+  if (!messages) {
+    return {
+      messages: undefined,
+      startIndex: 0,
+      endIndex: 0,
+      latestStartIndex: 0,
+      hiddenBeforeCount: 0,
+      hiddenAfterCount: 0,
+      totalLoadedCount: 0,
+      isWindowed: false,
+    };
+  }
+
+  const maxMountedMessages = options.maxMountedMessages ?? MAX_MOUNTED_TRANSCRIPT_MESSAGES;
+  const safeMax = Number.isFinite(maxMountedMessages) && maxMountedMessages > 0 ? Math.floor(maxMountedMessages) : 1;
+  const latestStartIndex = Math.max(0, messages.length - safeMax);
+  const requestedStartIndex =
+    typeof options.startIndex === "number" && Number.isFinite(options.startIndex)
+      ? Math.floor(options.startIndex)
+      : latestStartIndex;
+  const startIndex = Math.max(0, Math.min(latestStartIndex, requestedStartIndex));
+  const endIndex = Math.min(messages.length, startIndex + safeMax);
+  return {
+    messages: messages.slice(startIndex, endIndex),
+    startIndex,
+    endIndex,
+    latestStartIndex,
+    hiddenBeforeCount: startIndex,
+    hiddenAfterCount: Math.max(0, messages.length - endIndex),
+    totalLoadedCount: messages.length,
+    isWindowed: messages.length > safeMax,
+  };
+}


### PR DESCRIPTION
## Linked issue

Closes #2007

## Why this change

- Long conversation and roleplay transcripts could keep too many loaded message rows mounted at once, increasing DOM size and making long chats heavier to render and interact with.

## What changed

- Added a shared transcript render-window helper that caps mounted transcript message rows to 160 while preserving loaded transcript data for mode logic.
- Updated Conversation mode to render a bounded message window with Older Messages / Newer Messages paging through already-loaded transcript chunks.
- Updated Roleplay mode with the same bounded row mounting while keeping roleplay-specific UI, sprites, trackers, CYOA, and actions in the roleplay owner.

## Refactor impact

Primary owner:

shared mode UI helper, conversation mode UI, roleplay mode UI

Impact areas reviewed:

- Conversation transcript rendering, message numbering, split assistant blocks, message selection order indexes, and load-more controls.
- Roleplay transcript rendering, message numbering, grouping, message depth, CYOA placement, streaming rows, and load-more controls.
- Shared chat-ui public exports and dependency-boundary rules.

Boundary notes:

- No engine, shared API, storage, generation, prompt assembly, Rust capability, or remote-runtime behavior changed.
- Shared code is limited to mode-neutral transcript window math exported through `src/features/modes/shared/chat-ui`.
- Conversation and roleplay keep separate surface owners; game mode is untouched.

Pressure points touched:

- Shared mode UI public entrypoint and shared chat-ui helper.
- Conversation and roleplay surface render loops.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused helper proof: 250 synthetic messages mount 160 latest rows (`m90..m249`) and Older Messages window moves to `m10..m169` with newer rows tracked as hidden after the current window.
- `pnpm check` passed locally after fixing the unused export reported by `knip`.
- Browser/manual transcript scrolling proof was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a performance/DOM-growth bugfix for existing conversation and roleplay transcript surfaces.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured. The fix is structural DOM bounding for existing transcript surfaces.
