### PR TITLE
Improve front navigation avatar performance

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -216,8 +216,11 @@ fn apply_managed_asset_headers(
     }
 }
 
-fn cache_control_for_managed_asset(_kind: &str) -> &'static str {
-    "public, max-age=86400"
+fn cache_control_for_managed_asset(kind: &str) -> &'static str {
+    match kind {
+        "avatar" | "avatar-thumbnail" | "thumbnail" => "no-cache",
+        _ => "public, max-age=86400",
+    }
 }
 
 fn asset_etag(metadata: &std::fs::Metadata) -> Option<HeaderValue> {
@@ -1432,7 +1435,7 @@ mod tests {
             headers
                 .get(header::CACHE_CONTROL)
                 .and_then(|value| value.to_str().ok()),
-            Some("public, max-age=86400")
+            Some("no-cache")
         );
         assert!(
             headers.get(header::ETAG).is_some(),

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -216,11 +216,8 @@ fn apply_managed_asset_headers(
     }
 }
 
-fn cache_control_for_managed_asset(kind: &str) -> &'static str {
-    match kind {
-        "avatar" | "avatar-thumbnail" | "thumbnail" => "no-cache",
-        _ => "public, max-age=86400",
-    }
+fn cache_control_for_managed_asset(_kind: &str) -> &'static str {
+    "public, max-age=86400"
 }
 
 fn asset_etag(metadata: &std::fs::Metadata) -> Option<HeaderValue> {
@@ -1435,7 +1432,7 @@ mod tests {
             headers
                 .get(header::CACHE_CONTROL)
                 .and_then(|value| value.to_str().ok()),
-            Some("no-cache")
+            Some("public, max-age=86400")
         );
         assert!(
             headers.get(header::ETAG).is_some(),

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -117,10 +117,12 @@ export function CharacterAvatarImage({
   const hasResolvableAvatarInput = hasManagedAvatarInput || Boolean(effectiveThumbnailSize && src);
   const initialSrc = managedInitialSrc ?? src ?? null;
   const [asyncSrc, setAsyncSrc] = useState<string | null>(initialSrc);
+  const failedThumbnailSrcRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     const abort = new AbortController();
+    failedThumbnailSrcRef.current = null;
     setAsyncSrc(initialSrc);
     if (!hasResolvableAvatarInput || (!effectiveThumbnailSize && managedInitialSrc && !isLikelyFilesystemPath(managedInitialSrc))) {
       return () => {
@@ -139,7 +141,9 @@ export function CharacterAvatarImage({
     };
     resolveUrl()
       .then((url) => {
-        if (!cancelled) setAsyncSrc(url ?? src ?? null);
+        if (cancelled) return;
+        const nextSrc = url ?? src ?? null;
+        setAsyncSrc(nextSrc && nextSrc !== failedThumbnailSrcRef.current ? nextSrc : src ?? null);
       })
       .catch(() => {
         if (!cancelled) setAsyncSrc(src ?? null);
@@ -153,6 +157,15 @@ export function CharacterAvatarImage({
   const resolvedSrc = asyncSrc ?? initialSrc;
   if (!resolvedSrc) return null;
 
+  const handleImageError = () => {
+    if (effectiveThumbnailSize && src && resolvedSrc !== src) {
+      failedThumbnailSrcRef.current = resolvedSrc;
+      setAsyncSrc(src);
+      return;
+    }
+    onError?.();
+  };
+
   return (
     <img
       ref={imageRef}
@@ -164,7 +177,7 @@ export function CharacterAvatarImage({
       draggable={false}
       className={cn("h-full w-full object-cover", className)}
       style={getAvatarCropStyle(resolveAvatarCrop(crop))}
-      onError={onError}
+      onError={handleImageError}
     />
   );
 }

--- a/src/features/catalog/characters/components/CharacterAvatarImage.tsx
+++ b/src/features/catalog/characters/components/CharacterAvatarImage.tsx
@@ -96,6 +96,7 @@ export function CharacterAvatarImage({
   crop,
   className,
   thumbnailSize,
+  onError,
 }: {
   src?: string | null;
   avatarFilePath?: string | null;
@@ -104,6 +105,7 @@ export function CharacterAvatarImage({
   crop?: unknown;
   className?: string;
   thumbnailSize?: 64 | 96 | 128 | 256;
+  onError?: () => void;
 }) {
   const imageRef = useRef<HTMLImageElement | null>(null);
   const effectiveThumbnailSize =
@@ -162,6 +164,7 @@ export function CharacterAvatarImage({
       draggable={false}
       className={cn("h-full w-full object-cover", className)}
       style={getAvatarCropStyle(resolveAvatarCrop(crop))}
+      onError={onError}
     />
   );
 }

--- a/src/features/catalog/characters/index.ts
+++ b/src/features/catalog/characters/index.ts
@@ -2,3 +2,4 @@ export * from "./query-keys";
 export * from "./hooks/use-characters";
 export * from "./hooks/use-start-chat-from-character";
 export * from "./lib/character-avatar-url";
+export * from "./components/CharacterAvatarImage";

--- a/src/features/modes/game/components/GameSetupWizard.tsx
+++ b/src/features/modes/game/components/GameSetupWizard.tsx
@@ -23,7 +23,7 @@ import {
 import type { GameSetupConfig, GameGmMode } from "../../../../engine/contracts/types/game";
 import { getCharacterTitle, parseCharacterDisplayData } from "../../../../shared/lib/character-display";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
-import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
+import { cn, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
 import { Modal } from "../../../../shared/components/ui/Modal";
 import {
   GenerationParametersFields,
@@ -34,6 +34,7 @@ import {
 import { useConnections } from "../../../catalog/connections/index";
 import {
   characterAvatarUrl,
+  CharacterAvatarImage,
   useCharacterSummaries,
   useCharacterSummariesByIds,
   type CharacterSummary,
@@ -65,6 +66,8 @@ type SetupCharacterInfo = {
   name: string;
   comment?: string | null;
   avatarUrl?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   avatarCrop?: AvatarCropValue | null;
   searchText: string[];
 };
@@ -99,6 +102,8 @@ function CharacterAvatar({
   character: {
     name: string;
     avatarUrl?: string | null;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
     avatarCrop?: AvatarCropValue | null;
   };
   className?: string;
@@ -112,12 +117,14 @@ function CharacterAvatar({
   }
   return (
     <span className={cn("relative block shrink-0 overflow-hidden", className)}>
-      <img
+      <CharacterAvatarImage
         src={character.avatarUrl}
+        avatarFilePath={character.avatarFilePath}
+        avatarFilename={character.avatarFilename}
         alt={character.name}
-        loading="lazy"
         className="h-full w-full object-cover"
-        style={getAvatarCropStyle(character.avatarCrop)}
+        crop={character.avatarCrop}
+        thumbnailSize={64}
       />
     </span>
   );
@@ -484,6 +491,8 @@ export function GameSetupWizard({ error, onComplete, onCancel, isLoading }: Game
           name: display.name,
           comment: display.comment,
           avatarUrl: characterAvatarUrl(character),
+          avatarFilePath: character.avatarFilePath,
+          avatarFilename: character.avatarFilename,
           avatarCrop: parseAvatarCropValue(rawCrop),
           searchText: characterSearchValues(character, display),
         };

--- a/src/features/modes/router/components/ModeHomeSurface.tsx
+++ b/src/features/modes/router/components/ModeHomeSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { BookOpen, HelpCircle, MessageSquare, Theater } from "lucide-react";
 import { APP_VERSION } from "../../../../engine/contracts/constants/defaults";
 import { useConnections } from "../../../catalog/connections/index";
@@ -12,10 +12,44 @@ import { RecentChats } from "./RecentChats";
 
 type QuickStartMode = "conversation" | "roleplay" | "game";
 
+const quickStartModePreloads: Record<QuickStartMode, () => Promise<unknown>> = {
+  conversation: () => import("../../conversation/index"),
+  roleplay: () => import("../../roleplay/index"),
+  game: () => import("../../game/index"),
+};
+const preloadedQuickStartModes = new Set<QuickStartMode>();
+
+function prewarmQuickStartMode(mode: QuickStartMode): void {
+  if (preloadedQuickStartModes.has(mode)) return;
+  preloadedQuickStartModes.add(mode);
+  quickStartModePreloads[mode]().catch(() => preloadedQuickStartModes.delete(mode));
+}
+
+function prewarmAllQuickStartModes(): void {
+  prewarmQuickStartMode("conversation");
+  prewarmQuickStartMode("roleplay");
+  prewarmQuickStartMode("game");
+}
+
 export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?: ReactNode }) {
   const { data: connections } = useConnections();
   const createChat = useCreateChat();
   const pendingNewChatMode = useChatStore((state) => state.pendingNewChatMode);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+    const requestIdle = idleWindow.requestIdleCallback;
+    if (typeof requestIdle === "function") {
+      const handle = requestIdle(prewarmAllQuickStartModes, { timeout: 1800 });
+      return () => idleWindow.cancelIdleCallback?.(handle);
+    }
+    const handle = window.setTimeout(prewarmAllQuickStartModes, 600);
+    return () => window.clearTimeout(handle);
+  }, []);
 
   const handleQuickStart = useCallback(
     (mode: QuickStartMode) => {
@@ -85,6 +119,7 @@ export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?
               bg="linear-gradient(135deg, #4de5dd, #3ab8b1)"
               shadowColor="rgba(77,229,221,0.15)"
               tooltip="General chat with one or more characters, or a model itself"
+              onPrewarm={() => prewarmQuickStartMode("conversation")}
               onClick={() => handleQuickStart("conversation")}
             />
             <QuickStartCard
@@ -93,6 +128,7 @@ export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?
               bg="linear-gradient(135deg, #eb8951, #d97530)"
               shadowColor="rgba(235,137,81,0.15)"
               tooltip="For roleplaying or creative writing with one or more characters"
+              onPrewarm={() => prewarmQuickStartMode("roleplay")}
               onClick={() => handleQuickStart("roleplay")}
             />
             <QuickStartCard
@@ -101,6 +137,7 @@ export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?
               bg="linear-gradient(135deg, #e15c8c, #c94776)"
               shadowColor="rgba(225,92,140,0.15)"
               tooltip="AI-managed singleplayer RPG with a Game Master, party, dice, maps, and quests"
+              onPrewarm={() => prewarmQuickStartMode("game")}
               onClick={() => handleQuickStart("game")}
             />
           </div>
@@ -210,6 +247,7 @@ function QuickStartCard({
   bg,
   shadowColor,
   onClick,
+  onPrewarm,
   comingSoon,
   tooltip,
 }: {
@@ -218,6 +256,7 @@ function QuickStartCard({
   bg: string;
   shadowColor?: string;
   onClick?: () => void;
+  onPrewarm?: () => void;
   comingSoon?: boolean;
   tooltip?: string;
 }) {
@@ -229,6 +268,7 @@ function QuickStartCard({
       setTimeout(() => setShowComingSoon(false), 1500);
       return;
     }
+    onPrewarm?.();
     onClick?.();
   };
 
@@ -236,6 +276,8 @@ function QuickStartCard({
     <button
       type="button"
       onClick={handleClick}
+      onPointerEnter={onPrewarm}
+      onFocus={onPrewarm}
       title={tooltip}
       aria-label={`${comingSoon && !onClick ? "Show status for" : "Start"} ${label} chat`}
       className={cn(

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -5,9 +5,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { MessageSquare, BookOpen, Theater } from "lucide-react";
 import { useRecentChatSummaries, type ChatListItem } from "../../../catalog/chats/index";
-import { characterAvatarUrl, useCharacterSummariesByIds } from "../../../catalog/characters/index";
+import { CharacterAvatarImage, characterAvatarUrl, useCharacterSummariesByIds } from "../../../catalog/characters/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
-import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
+import { cn, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
 
 const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: string }> = {
   conversation: {
@@ -51,7 +51,16 @@ export function RecentChats() {
   const { data: recentCharacters } = useCharacterSummariesByIds(recentCharacterIds, recentCharacterIds.length > 0);
 
   const charLookup = useMemo(() => {
-    const map = new Map<string, { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null }>();
+    const map = new Map<
+      string,
+      {
+        name: string;
+        avatarUrl: string | null;
+        avatarFilePath?: string | null;
+        avatarFilename?: string | null;
+        avatarCrop?: AvatarCropValue | null;
+      }
+    >();
     if (!recentCharacters) return map;
     for (const char of recentCharacters as Array<{
       id: string;
@@ -68,6 +77,8 @@ export function RecentChats() {
       map.set(char.id, {
         name: typeof parsed.name === "string" ? parsed.name : "Unknown",
         avatarUrl: characterAvatarUrl(char),
+        avatarFilePath: char.avatarFilePath,
+        avatarFilename: char.avatarFilename,
         avatarCrop: readAvatarCrop(extensions.avatarCrop),
       });
     }
@@ -96,7 +107,16 @@ function RecentChatChip({
   onClick,
 }: {
   chat: ChatListItem;
-  charLookup: Map<string, { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null }>;
+  charLookup: Map<
+    string,
+    {
+      name: string;
+      avatarUrl: string | null;
+      avatarFilePath?: string | null;
+      avatarFilename?: string | null;
+      avatarCrop?: AvatarCropValue | null;
+    }
+  >;
   onClick: () => void;
 }) {
   const mode = MODE_BADGE[chat.mode] ?? MODE_BADGE.conversation;
@@ -155,7 +175,13 @@ function RecentChatChip({
 function RecentChatAvatar({
   avatar,
 }: {
-  avatar: { name: string; avatarUrl: string | null; avatarCrop?: AvatarCropValue | null };
+  avatar: {
+    name: string;
+    avatarUrl: string | null;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
+    avatarCrop?: AvatarCropValue | null;
+  };
 }) {
   const [imageFailed, setImageFailed] = useState(false);
 
@@ -173,11 +199,14 @@ function RecentChatAvatar({
 
   return (
     <span className="relative block h-5 w-5 overflow-hidden rounded-md">
-      <img
+      <CharacterAvatarImage
         src={avatar.avatarUrl}
+        avatarFilePath={avatar.avatarFilePath}
+        avatarFilename={avatar.avatarFilename}
         alt={avatar.name}
         className="h-full w-full object-cover"
-        style={getAvatarCropStyle(avatar.avatarCrop)}
+        crop={avatar.avatarCrop}
+        thumbnailSize={64}
         onError={() => setImageFailed(true)}
       />
     </span>

--- a/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSetupWizard.tsx
@@ -21,10 +21,11 @@ import {
   ArrowLeft,
   UserRound,
 } from "lucide-react";
-import { cn, getAvatarCropStyle, type AvatarCrop } from "../../../../../shared/lib/utils";
+import { cn, type AvatarCrop } from "../../../../../shared/lib/utils";
 import { useConnections } from "../../../../catalog/connections/index";
 import { usePresets, usePresetFull, useDefaultPreset } from "../../../../catalog/presets/index";
 import {
+  CharacterAvatarImage as CatalogCharacterAvatarImage,
   characterAvatarUrl,
   useCharacterSummaries,
   useCharacterSummariesByIds,
@@ -282,19 +283,25 @@ function CharacterAvatarImage({
   alt,
   className,
 }: {
-  character: { data: unknown };
+  character: {
+    data: unknown;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
+  };
   src: string;
   alt: string;
   className: string;
 }) {
   return (
     <span className={cn("relative block shrink-0 overflow-hidden", className)}>
-      <img
+      <CatalogCharacterAvatarImage
         src={src}
+        avatarFilePath={character.avatarFilePath}
+        avatarFilename={character.avatarFilename}
         alt={alt}
-        loading="lazy"
         className="h-full w-full object-cover"
-        style={getAvatarCropStyle(getCharacterAvatarCrop(character))}
+        crop={getCharacterAvatarCrop(character)}
+        thumbnailSize={64}
       />
     </span>
   );


### PR DESCRIPTION
## Linked issue

Closes #2007

## Why this change

- Front page quick-start navigation could push mode route chunk loading and small-avatar image work onto the first click. Recent chat chips and setup wizard rows also used full avatar URLs in tiny image slots, and remote managed avatar/thumb assets had cache headers that encouraged repeated transfer.

## What changed

- Prewarms Conversation, Roleplay, and Game mode route chunks from the home screen during idle time and on quick-start button hover/focus.
- Routes recent chat, shared chat setup, and game setup character avatars through the catalog thumbnail-aware avatar component at 64px.
- Exposes the catalog character avatar image component through the character package index and lets it report image load errors to callers.
- Gives managed asset HTTP responses a reusable cache lifetime while keeping ETags and existing app-side invalidation query behavior.

## Refactor impact

Primary owner:

App shell mode routing, shared mode UI, game setup UI, catalog character avatar UI, and Rust managed asset HTTP delivery.

Impact areas reviewed:

- Home mode quick-start navigation
- Recent chat chips on the home surface
- Chat setup wizard avatar rows
- Game setup wizard avatar rows
- Character avatar thumbnail resolver behavior
- Remote managed asset cache/invalidation behavior

Boundary notes:

- Feature UI now reuses the catalog-owned thumbnail-aware avatar component instead of adding new image resolution logic.
- Engine contracts and mode orchestration were not changed.
- Rust change stays inside the managed asset HTTP response boundary and relies on the existing frontend invalidation query for app-managed edits.

Pressure points touched:

- `ModeHomeSurface`
- `RecentChats`
- `ChatSetupWizard`
- `GameSetupWizard`
- `CharacterAvatarImage`
- `src-tauri/src/http_server.rs` managed asset headers

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck`
- `pnpm check:architecture`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml managed_asset_headers_include_cache_and_validation_metadata`
- `pnpm check`
- Browser performance recording not captured in this pass.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Performance bugfix only; no new user-facing feature or discoverable workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not captured; this is a perf/image-delivery fix with local command validation.
