### PR TITLE
Fix projected storage cache reads

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -677,6 +677,19 @@ impl FileStorage {
             .map(|cached| cached.rows.clone()))
     }
 
+    fn cached_dirty_rows(&self, collection: &str) -> AppResult<Option<Vec<Value>>> {
+        validate_collection_name(collection)?;
+        let cache = self
+            .cache
+            .read()
+            .map_err(|_| AppError::new("lock_error", "Storage cache lock poisoned"))?;
+        Ok(cache
+            .collections
+            .get(collection)
+            .filter(|cached| cached.dirty)
+            .map(|cached| cached.rows.clone()))
+    }
+
     fn is_collection_cached(&self, collection: &str) -> AppResult<bool> {
         validate_collection_name(collection)?;
         let cache = self
@@ -895,7 +908,7 @@ impl FileStorage {
         }
         let field_set: HashSet<String> = fields.iter().cloned().collect();
         let nested_field_sets = selected_nested_fields(field_selections);
-        if let Some(rows) = self.cached_rows(collection)? {
+        if let Some(rows) = self.cached_dirty_rows(collection)? {
             return Ok(rows
                 .into_iter()
                 .map(|row| project_row(row, &field_set, &nested_field_sets))
@@ -979,7 +992,7 @@ impl FileStorage {
         }
         let field_set: HashSet<String> = fields.iter().cloned().collect();
         let nested_field_sets = selected_nested_fields(field_selections);
-        if let Some(rows) = self.cached_rows(collection)? {
+        if let Some(rows) = self.cached_dirty_rows(collection)? {
             return Ok(rows
                 .into_iter()
                 .filter(|row| {
@@ -1121,7 +1134,7 @@ impl FileStorage {
 
         let field_set: HashSet<String> = fields.iter().cloned().collect();
         let nested_field_sets = selected_nested_fields(field_selections);
-        if let Some(rows) = self.cached_rows(collection)? {
+        if let Some(rows) = self.cached_dirty_rows(collection)? {
             return Ok(rows
                 .into_iter()
                 .find(|row| row.get("id").and_then(Value::as_str) == Some(id))
@@ -1204,7 +1217,7 @@ impl FileStorage {
         }
         let field_set: HashSet<String> = fields.iter().cloned().collect();
         let nested_field_sets = selected_nested_fields(field_selections);
-        if let Some(rows) = self.cached_rows("messages")? {
+        if let Some(rows) = self.cached_dirty_rows("messages")? {
             return Ok(rows
                 .into_iter()
                 .filter(|row| row.get("chatId").and_then(Value::as_str) == Some(chat_id))
@@ -1287,7 +1300,7 @@ impl FileStorage {
         chat_id: &str,
         recover_on_fallback: bool,
     ) -> AppResult<Vec<Value>> {
-        if let Some(rows) = self.cached_rows("messages")? {
+        if let Some(rows) = self.cached_dirty_rows("messages")? {
             return Ok(rows
                 .into_iter()
                 .filter(|row| row.get("chatId").and_then(Value::as_str) == Some(chat_id))
@@ -3336,6 +3349,11 @@ fn read_pretty_projected_nested_value<R: BufRead>(
         if fields.contains(&field) {
             let value = read_pretty_json_value(reader, value_start)?;
             projected.insert(field, value);
+        } else if let Some(child_fields) = selected_child_paths(fields, &field) {
+            let value = read_pretty_projected_nested_value(reader, value_start, &child_fields)?;
+            if !value.as_object().is_some_and(Map::is_empty) {
+                projected.insert(field, value);
+            }
         } else {
             skip_pretty_json_value(reader, value_start)?;
         }
@@ -4074,6 +4092,96 @@ mod tests {
         assert_eq!(
             record,
             json!({ "id": "target", "data": { "name": "Rina" } })
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn get_projected_bypasses_clean_full_row_cache() {
+        let root = temp_storage_root("get-projected-bypasses-clean-cache");
+        let storage = FileStorage::new(&root).unwrap();
+
+        storage
+            .replace_all(
+                "characters",
+                vec![json!({
+                    "id": "target",
+                    "data": { "name": "Cached", "description": "cached prompt" },
+                    "avatar": "cached image payload"
+                })],
+            )
+            .unwrap();
+
+        let collection = root.join("collections").join("characters.json");
+        fs::write(
+            &collection,
+            serde_json::to_vec_pretty(&json!([
+                {
+                    "id": "target",
+                    "data": { "name": "Disk", "description": "disk prompt" },
+                    "avatar": "disk image payload"
+                }
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let fields = vec!["id".to_string(), "data".to_string()];
+        let mut selections = Map::new();
+        selections.insert("data".to_string(), json!(["name"]));
+
+        let record = storage
+            .get_projected("characters", "target", &fields, &selections)
+            .expect("projected get should read from disk when cache is clean")
+            .expect("target row should exist");
+
+        assert_eq!(
+            record,
+            json!({ "id": "target", "data": { "name": "Disk" } })
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn list_projected_uses_dirty_cache_before_disk() {
+        let root = temp_storage_root("list-projected-uses-dirty-cache");
+        let storage = FileStorage::new(&root).unwrap();
+
+        storage
+            .replace_all(
+                "characters",
+                vec![json!({
+                    "id": "target",
+                    "data": { "name": "Disk", "description": "disk prompt" },
+                    "avatar": "disk image payload"
+                })],
+            )
+            .unwrap();
+        storage
+            .cache_collection(
+                "characters",
+                &[json!({
+                    "id": "target",
+                    "data": { "name": "Dirty", "description": "dirty prompt" },
+                    "avatar": "dirty image payload"
+                })],
+                true,
+            )
+            .unwrap();
+
+        let fields = vec!["id".to_string(), "data".to_string()];
+        let mut selections = Map::new();
+        selections.insert("data".to_string(), json!(["name"]));
+
+        let rows = storage
+            .list_projected("characters", &fields, &selections)
+            .expect("projected list should honor dirty cache");
+
+        assert_eq!(
+            rows,
+            vec![json!({ "id": "target", "data": { "name": "Dirty" } })]
         );
 
         fs::remove_dir_all(root).unwrap();

--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -3106,7 +3106,7 @@ fn read_projected_pretty_message_record(
             }
             _ if fields.contains(&field) => {
                 let value = if let Some(nested_fields) = field_selections.get(&field) {
-                    read_pretty_projected_nested_value(&mut reader, value_start, nested_fields)?
+                    read_pretty_projected_nested_value(&mut reader, value_start, nested_fields, 6)?
                 } else {
                     read_pretty_json_value(&mut reader, value_start)?
                 };
@@ -3310,7 +3310,7 @@ fn read_pretty_projected_record_by_id_from_file(
 
         if fields.contains(&field) {
             let value = if let Some(nested_fields) = field_selections.get(&field) {
-                read_pretty_projected_nested_value(&mut reader, value_start, nested_fields)?
+                read_pretty_projected_nested_value(&mut reader, value_start, nested_fields, 6)?
             } else {
                 read_pretty_json_value(&mut reader, value_start)?
             };
@@ -3330,6 +3330,7 @@ fn read_pretty_projected_nested_value<R: BufRead>(
     reader: &mut R,
     first_value: String,
     fields: &HashSet<String>,
+    field_indent: usize,
 ) -> AppResult<Value> {
     let trimmed = first_value.trim();
     if !trimmed.starts_with('{') || json_container_depth_delta(trimmed) <= 0 {
@@ -3337,20 +3338,26 @@ fn read_pretty_projected_nested_value<R: BufRead>(
             .map(|value| project_nested_value(value, fields));
     }
 
+    let end_indent = field_indent.saturating_sub(2);
     let mut projected = Map::new();
     while let Some(line) = read_json_line(reader)? {
-        if is_pretty_nested_object_end(&line) {
+        if is_pretty_object_end(&line, end_indent) {
             return Ok(Value::Object(projected));
         }
 
-        let Some((field, value_start)) = pretty_json_field(&line, 6)? else {
+        let Some((field, value_start)) = pretty_json_field(&line, field_indent)? else {
             continue;
         };
         if fields.contains(&field) {
             let value = read_pretty_json_value(reader, value_start)?;
             projected.insert(field, value);
         } else if let Some(child_fields) = selected_child_paths(fields, &field) {
-            let value = read_pretty_projected_nested_value(reader, value_start, &child_fields)?;
+            let value = read_pretty_projected_nested_value(
+                reader,
+                value_start,
+                &child_fields,
+                field_indent + 2,
+            )?;
             if !value.as_object().is_some_and(Map::is_empty) {
                 projected.insert(field, value);
             }
@@ -3420,10 +3427,15 @@ fn pretty_json_field(line: &str, indent: usize) -> AppResult<Option<(String, Str
     Ok(Some((key, raw_value.trim_start().to_string())))
 }
 
-fn is_pretty_nested_object_end(line: &str) -> bool {
+fn is_pretty_object_end(line: &str, indent: usize) -> bool {
     let bytes = line.as_bytes();
-    bytes.get(..5) == Some(b"    }")
-        && matches!(bytes.get(5), None | Some(b','))
+    let value_index = indent;
+    let suffix_index = value_index + 1;
+    bytes
+        .get(..indent)
+        .is_some_and(|prefix| prefix.iter().all(|byte| *byte == b' '))
+        && bytes.get(value_index) == Some(&b'}')
+        && matches!(bytes.get(suffix_index), None | Some(b','))
         && matches!(line.trim(), "}" | "},")
 }
 
@@ -4246,6 +4258,63 @@ mod tests {
                             "card": { "spec": "chara_card_v2" }
                         },
                         "nameColor": "#ff99aa"
+                    }
+                }
+            })
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn get_projected_pretty_fast_path_returns_deep_dotted_field_from_disk() {
+        let root = temp_storage_root("get-projected-pretty-fast-path-deep-dotted-field");
+        let storage = FileStorage::new(&root).unwrap();
+        let collection_dir = root.join("collections");
+        fs::create_dir_all(&collection_dir).unwrap();
+        fs::write(
+            collection_dir.join("characters.json"),
+            serde_json::to_vec_pretty(&json!([
+                {
+                    "id": "target",
+                    "data": {
+                        "name": "Rina",
+                        "extensions": {
+                            "importMetadata": {
+                                "card": { "spec": "chara_card_v2" },
+                                "embeddedLorebook": { "entries": ["ignore"] }
+                            },
+                            "backstory": "ignore"
+                        }
+                    },
+                    "avatar": "ignore"
+                }
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let fields = vec!["id".to_string(), "data".to_string()];
+        let mut selections = Map::new();
+        selections.insert(
+            "data".to_string(),
+            json!(["extensions.importMetadata.card"]),
+        );
+
+        let record = storage
+            .get_projected("characters", "target", &fields, &selections)
+            .expect("projected get should use pretty fast path")
+            .expect("target row should exist");
+
+        assert_eq!(
+            record,
+            json!({
+                "id": "target",
+                "data": {
+                    "extensions": {
+                        "importMetadata": {
+                            "card": { "spec": "chara_card_v2" }
+                        }
                     }
                 }
             })


### PR DESCRIPTION
## Linked issue

Closes #2018

## Why this change

- Projected storage reads were fast until a clean full-row collection cache existed. After that, `storage_get` and `storage_list` projected from cached full rows instead of using the streaming projected readers that skip unrequested heavy fields.

## What changed

- Added a dirty-cache-only read helper for projected storage paths.
- Kept dirty cached rows authoritative so unflushed writes remain visible.
- Let clean-cache projected reads continue through disk streaming projection.
- Fixed pretty JSON nested projection so dotted nested selections like `extensions.avatarCrop` work when clean-cache bypass exposes the streaming path.
- Added focused Rust storage tests for clean-cache bypass and dirty-cache precedence.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- `storage_get` projected row reads
- `storage_list` projected collection reads
- projected filtered reads
- projected message reads and message ID-only reads
- dirty write cache behavior
- pretty JSON nested projection

Boundary notes:

- Change stays inside `src-tauri/crates/storage`; no React, engine, shared API, command registration, or remote-runtime boundary changes.

Pressure points touched:

- Rust storage projection internals only.
- No ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` command registration, or import modules touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-storage projected`
- `cargo test --manifest-path src-tauri/Cargo.toml projected`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal Rust storage performance regression fix only; no new user-discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not applicable; no visible UI changes.
