### PR TITLE
Harden card CSS sanitizer against escape-sequence evasion

### DIFF
--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -104,6 +104,48 @@ function stripComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
+/** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
+function decodeCssEscapes(input: string): string {
+  return input.replace(/\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g, (_m, hex: string | undefined, ch: string | undefined) => {
+    if (hex) {
+      const cp = parseInt(hex, 16);
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+    }
+    return ch ?? "";
+  });
+}
+
+// Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
+// scanner steps over them, leaving their contents untouched.
+const STRING_OR_ESCAPE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\\(?:[0-9a-fA-F]{1,6}\s?|[\s\S])/g;
+
+/**
+ * Canonicalize CSS escapes that spell a token character, so the literal-text guards in
+ * sanitizeChatCss can't be evaded by escaping. CSS escapes are decoded by the engine, so
+ * `po\73ition` is `position`, `\75rl(` is `url(`, `\40 import` is `@import`, and
+ * `\2d-background` is `--background` — and the raw-text regexes below would otherwise miss
+ * every one of them.
+ *
+ * We decode escapes resolving to ASCII letters, `@`, or `-`. Letters and `@` spell the keyword
+ * guards (url, @import, @font-face, :has, position, content…). `-` is included because the only
+ * punctuation-led forbidden tokens are hyphen-prefixed identifiers — custom-property / theme
+ * tokens (`--…`) and the `-moz-binding` vendor prefix; no benign card CSS escapes a hyphen
+ * (hyphens never need escaping in identifiers), so decoding it stays equivalent.
+ *
+ * Escapes resolving to other punctuation or digits are left byte-exact. They legitimately appear
+ * in selectors (`.\32 xl`, `.w-1\/2`) where decoding would change meaning, and — crucially — they
+ * cannot disguise a forbidden token: by CSS/HTML tokenization an escaped `:` / `!` / `/` becomes
+ * an identifier character, not a declaration separator, an `!important` delimiter, or a `</style`
+ * breakout. Escapes inside string literals are always preserved.
+ */
+function canonicalizeKeywordEscapes(css: string): string {
+  return css.replace(STRING_OR_ESCAPE, (match: string, stringLiteral: string | undefined) => {
+    if (stringLiteral !== undefined) return stringLiteral;
+    const decoded = decodeCssEscapes(match);
+    return /^[-A-Za-z@]$/.test(decoded) ? decoded : match;
+  });
+}
+
 /**
  * Remove dangerous constructs from CSS.
  *
@@ -117,6 +159,12 @@ function stripComments(css: string): string {
  */
 function sanitizeChatCss(css: string): string {
   let out = stripComments(css);
+
+  // ── Escape normalization ──
+  // Canonicalize escaped keyword characters up front so every literal-text guard below sees the
+  // tokens a browser would actually parse (e.g. `\75rl(` → `url(`, `po\73ition` → `position`).
+  // Benign escapes in selectors (digits/punctuation) and string contents are preserved (#1989).
+  out = canonicalizeKeywordEscapes(out);
 
   // ── Network exfiltration prevention ──
   // Strip ALL url() except data:image/* (no external network requests)


### PR DESCRIPTION
## Linked issue

Closes #1989

## Why this change

- The card CSS sanitizer (`src/shared/lib/chat-css.ts`) is a regex blocklist over raw text. CSS escape sequences (`\XX` hex, `\c`) are decoded by the engine, so a guard that matches literal keyword text can be bypassed by spelling the token with escapes. Examples: `\75rl(https://tracker.test)` bypasses the `url()` network guard, `po\73ition: fixed` bypasses the overlay guard, `--back\67round` bypasses the theme-token blocklist, and `:h\61s(` re-enables scope probing.

## What changed

- Add `canonicalizeKeywordEscapes()`, a string-aware pass at the top of `sanitizeChatCss` that decodes browser-equivalent escapes for token characters before the existing guards run.
- Decode escapes resolving to ASCII letters, `@`, or `-`, so guards see escaped `url()`, at-rules, `position: fixed`, `content`, `!important`, theme tokens, and `-moz-binding` as the browser parses them.
- Preserve escapes resolving to digits or other punctuation, plus all escapes inside string literals, so benign selectors such as `.\32 xl` and `.w-1\/2` remain byte-exact.

## Refactor impact

Primary owner: shared lib (card CSS sanitizer)

Impact areas reviewed:

- `src/shared/lib/chat-css.ts` - change is confined to `sanitizeChatCss`; `scopeChatCss` and `filterCssByMode` behavior is unchanged.

Boundary notes:

- Shared lib only. No engine, shared-API, Rust, remote-runtime, or feature-layer changes.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` command registration, or import modules touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Run locally on the cleaned candidate:

- `pnpm --dir C:/tmp/marinara-pr-2020-clean exec vitest run src/shared/lib/chat-css.proof.test.ts` - clean, 3 proof rows passed from ignored scratch proof
- `pnpm --dir C:/tmp/marinara-pr-2020-clean typecheck` - clean
- `pnpm --dir C:/tmp/marinara-pr-2020-clean check:architecture` - clean, no dependency violations
- `pnpm --dir C:/tmp/marinara-pr-2020-clean check` - clean

Proof rows covered:

- Escaped forbidden constructs are neutralized: `url()`, `@import`, `:has()`, `position: fixed`, `content`, and `!important`.
- Escaped hyphen declaration bypasses are neutralized: theme-token declarations and `-moz-binding`.
- Benign selector and string escapes are preserved: `.w-1\/2`, `.\32 xl`, non-theme custom properties, and string contents.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A - this hardens the existing CSS sanitizer against escape-based evasion. Legitimate card CSS behaves identically; there is no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - internal sanitizer hardening with no visible UI change.
