### PR TITLE
Fix message swipe sidecar storage regression

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -914,11 +914,7 @@ impl FileStorage {
         if let Some(rows) = self.cached_rows(collection)? {
             return Ok(rows
                 .into_iter()
-                .filter(|row| {
-                    row.get(filter_field)
-                        .and_then(Value::as_str)
-                        .is_some_and(|value| filter_values.contains(value))
-                })
+                .filter(|row| row_string_field_matches_in(row, filter_field, filter_values))
                 .collect());
         }
 
@@ -943,11 +939,7 @@ impl FileStorage {
                 };
                 Ok(rows
                     .into_iter()
-                    .filter(|row| {
-                        row.get(filter_field)
-                            .and_then(Value::as_str)
-                            .is_some_and(|value| filter_values.contains(value))
-                    })
+                    .filter(|row| row_string_field_matches_in(row, filter_field, filter_values))
                     .collect())
             }
         }
@@ -1070,11 +1062,7 @@ impl FileStorage {
         if let Some(rows) = self.cached_rows(collection)? {
             return Ok(rows
                 .into_iter()
-                .filter(|row| {
-                    row.get(filter_field)
-                        .and_then(Value::as_str)
-                        .is_some_and(|value| filter_values.contains(value))
-                })
+                .filter(|row| row_string_field_matches_in(row, filter_field, filter_values))
                 .map(|row| project_row(row, &field_set, &nested_field_sets))
                 .collect());
         }
@@ -1102,11 +1090,7 @@ impl FileStorage {
                 };
                 Ok(rows
                     .into_iter()
-                    .filter(|row| {
-                        row.get(filter_field)
-                            .and_then(Value::as_str)
-                            .is_some_and(|value| filter_values.contains(value))
-                    })
+                    .filter(|row| row_string_field_matches_in(row, filter_field, filter_values))
                     .map(|row| project_row(row, &field_set, &nested_field_sets))
                     .collect())
             }
@@ -1938,6 +1922,22 @@ fn row_matches_filters(row: &Value, filters: &Map<String, Value>) -> bool {
         .all(|(key, expected)| object.get(key) == Some(expected))
 }
 
+fn row_string_field_matches_in(
+    row: &Value,
+    filter_field: &str,
+    filter_values: &HashSet<String>,
+) -> bool {
+    row.get(filter_field)
+        .is_some_and(|value| string_value_matches_in(value, filter_values))
+}
+
+fn string_value_matches_in(value: &Value, filter_values: &HashSet<String>) -> bool {
+    value
+        .as_str()
+        .map(str::trim)
+        .is_some_and(|value| filter_values.contains(value))
+}
+
 struct FindRowByIdVisitor<'a> {
     id: &'a str,
 }
@@ -2296,9 +2296,7 @@ impl<'de, 'a> Visitor<'de> for FilteredRowWhereInVisitor<'a> {
         while let Some(key) = map.next_key::<String>()? {
             if key == self.filter_field {
                 let value = map.next_value::<Value>()?;
-                let is_match = value
-                    .as_str()
-                    .is_some_and(|value| self.filter_values.contains(value));
+                let is_match = string_value_matches_in(&value, self.filter_values);
                 matches_filter = Some(is_match);
                 if is_match {
                     object.insert(key, value);
@@ -2428,9 +2426,7 @@ impl<'de, 'a> Visitor<'de> for ProjectedRowWhereInVisitor<'a> {
         while let Some(key) = map.next_key::<String>()? {
             if key == self.filter_field {
                 let value = map.next_value::<Value>()?;
-                let is_match = value
-                    .as_str()
-                    .is_some_and(|value| self.filter_values.contains(value));
+                let is_match = string_value_matches_in(&value, self.filter_values);
                 matches_filter = Some(is_match);
                 if is_match && self.fields.contains(&key) {
                     object.insert(key, value);
@@ -4482,19 +4478,27 @@ mod tests {
                     "createdAt": "2026-01-01T00:00:01Z"
                 },
                 {
+                    "id": "message-1::swipe::2",
+                    "messageId": " message-1 ",
+                    "index": 2,
+                    "content": "trimmed legacy id",
+                    "extra": { "large": "ignored" },
+                    "createdAt": "2026-01-01T00:00:02Z"
+                },
+                {
                     "id": "message-2::swipe::0",
                     "messageId": "message-2",
                     "index": 0,
                     "content": "skip",
                     "extra": { "large": "ignored" },
-                    "createdAt": "2026-01-01T00:00:02Z"
+                    "createdAt": "2026-01-01T00:00:03Z"
                 },
                 {
                     "id": "missing-message-id",
                     "index": 0,
                     "content": "skip missing parent",
                     "extra": { "large": "ignored" },
-                    "createdAt": "2026-01-01T00:00:03Z"
+                    "createdAt": "2026-01-01T00:00:04Z"
                 }
             ]))
             .unwrap(),
@@ -4524,6 +4528,11 @@ mod tests {
                     "messageId": "message-1",
                     "index": 1,
                     "content": "second"
+                }),
+                json!({
+                    "messageId": " message-1 ",
+                    "index": 2,
+                    "content": "trimmed legacy id"
                 })
             ]
         );
@@ -4564,6 +4573,14 @@ mod tests {
                     "extra": { "thinking": "second thought" },
                     "createdAt": "2026-01-01T00:00:02Z",
                     "customField": "preserved"
+                },
+                {
+                    "id": "message-1::swipe::2",
+                    "messageId": " message-1 ",
+                    "index": 2,
+                    "content": "trimmed legacy id",
+                    "extra": { "thinking": "trimmed thought" },
+                    "createdAt": "2026-01-01T00:00:03Z"
                 }
             ]))
             .unwrap(),
@@ -4596,6 +4613,14 @@ mod tests {
                     "extra": { "thinking": "second thought" },
                     "createdAt": "2026-01-01T00:00:02Z",
                     "customField": "preserved"
+                }),
+                json!({
+                    "id": "message-1::swipe::2",
+                    "messageId": " message-1 ",
+                    "index": 2,
+                    "content": "trimmed legacy id",
+                    "extra": { "thinking": "trimmed thought" },
+                    "createdAt": "2026-01-01T00:00:03Z"
                 })
             ]
         );

--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -108,6 +108,24 @@ impl FileStorage {
         )
     }
 
+    pub fn list_where_in(
+        &self,
+        collection: &str,
+        filter_field: &str,
+        filter_values: &HashSet<String>,
+    ) -> AppResult<Vec<Value>> {
+        self.read_locked_or_recover(
+            || {
+                self.read_collection_where_in_no_recovery(
+                    collection,
+                    filter_field,
+                    filter_values,
+                )
+            },
+            || self.read_collection_where_in(collection, filter_field, filter_values),
+        )
+    }
+
     pub fn list_projected(
         &self,
         collection: &str,
@@ -863,6 +881,76 @@ impl FileStorage {
             .into_iter()
             .filter(|row| row_matches_filters(row, filters))
             .collect())
+    }
+
+    fn read_collection_where_in(
+        &self,
+        collection: &str,
+        filter_field: &str,
+        filter_values: &HashSet<String>,
+    ) -> AppResult<Vec<Value>> {
+        self.read_collection_where_in_inner(collection, filter_field, filter_values, true)
+    }
+
+    fn read_collection_where_in_no_recovery(
+        &self,
+        collection: &str,
+        filter_field: &str,
+        filter_values: &HashSet<String>,
+    ) -> AppResult<Vec<Value>> {
+        self.read_collection_where_in_inner(collection, filter_field, filter_values, false)
+    }
+
+    fn read_collection_where_in_inner(
+        &self,
+        collection: &str,
+        filter_field: &str,
+        filter_values: &HashSet<String>,
+        recover_on_fallback: bool,
+    ) -> AppResult<Vec<Value>> {
+        if filter_values.is_empty() {
+            return Ok(Vec::new());
+        }
+        if let Some(rows) = self.cached_rows(collection)? {
+            return Ok(rows
+                .into_iter()
+                .filter(|row| {
+                    row.get(filter_field)
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| filter_values.contains(value))
+                })
+                .collect());
+        }
+
+        let path = self.collection_path(collection)?;
+        if !path.exists() || fs::metadata(&path)?.len() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let file = fs::File::open(path)?;
+        let reader = BufReader::new(file);
+        let mut deserializer = serde_json::Deserializer::from_reader(reader);
+        match deserializer.deserialize_seq(FilteredRowsWhereInVisitor {
+            filter_field,
+            filter_values,
+        }) {
+            Ok(rows) => Ok(rows),
+            Err(_) => {
+                let rows = if recover_on_fallback {
+                    self.read_collection(collection)?
+                } else {
+                    self.read_collection_no_recovery(collection)?
+                };
+                Ok(rows
+                    .into_iter()
+                    .filter(|row| {
+                        row.get(filter_field)
+                            .and_then(Value::as_str)
+                            .is_some_and(|value| filter_values.contains(value))
+                    })
+                    .collect())
+            }
+        }
     }
 
     fn read_collection_projected(
@@ -2136,6 +2224,101 @@ fn object_value(value: &Value) -> Option<Map<String, Value>> {
             .ok()
             .and_then(|value| value.as_object().cloned()),
         _ => None,
+    }
+}
+
+struct FilteredRowsWhereInVisitor<'a> {
+    filter_field: &'a str,
+    filter_values: &'a HashSet<String>,
+}
+
+impl<'de, 'a> Visitor<'de> for FilteredRowsWhereInVisitor<'a> {
+    type Value = Vec<Value>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON array of filtered records")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut rows = Vec::new();
+        while let Some(row) = seq.next_element_seed(FilteredRowWhereInSeed {
+            filter_field: self.filter_field,
+            filter_values: self.filter_values,
+        })? {
+            if let Some(row) = row {
+                rows.push(row);
+            }
+        }
+        Ok(rows)
+    }
+}
+
+struct FilteredRowWhereInSeed<'a> {
+    filter_field: &'a str,
+    filter_values: &'a HashSet<String>,
+}
+
+impl<'de, 'a> DeserializeSeed<'de> for FilteredRowWhereInSeed<'a> {
+    type Value = Option<Value>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(FilteredRowWhereInVisitor {
+            filter_field: self.filter_field,
+            filter_values: self.filter_values,
+        })
+    }
+}
+
+struct FilteredRowWhereInVisitor<'a> {
+    filter_field: &'a str,
+    filter_values: &'a HashSet<String>,
+}
+
+impl<'de, 'a> Visitor<'de> for FilteredRowWhereInVisitor<'a> {
+    type Value = Option<Value>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a filtered record object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut object = Map::new();
+        let mut matches_filter = None;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == self.filter_field {
+                let value = map.next_value::<Value>()?;
+                let is_match = value
+                    .as_str()
+                    .is_some_and(|value| self.filter_values.contains(value));
+                matches_filter = Some(is_match);
+                if is_match {
+                    object.insert(key, value);
+                } else {
+                    object.clear();
+                }
+                continue;
+            }
+
+            if matches_filter == Some(false) {
+                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                continue;
+            }
+
+            object.insert(key, map.next_value::<Value>()?);
+        }
+
+        Ok(matches_filter
+            .unwrap_or(false)
+            .then_some(Value::Object(object)))
     }
 }
 
@@ -4341,6 +4524,78 @@ mod tests {
                     "messageId": "message-1",
                     "index": 1,
                     "content": "second"
+                })
+            ]
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn list_where_in_streams_full_legacy_sidecar_rows() {
+        let root = temp_storage_root("list-where-in-full-sidecars");
+        FileStorage::new(&root).unwrap();
+        let sidecar = root.join("collections").join("message-swipes.json");
+        fs::write(
+            &sidecar,
+            serde_json::to_vec_pretty(&json!([
+                {
+                    "id": "message-1::swipe::0",
+                    "messageId": "message-1",
+                    "index": 0,
+                    "content": "first",
+                    "extra": { "thinking": "first thought" },
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "providerMetadata": { "finishReason": "stop" }
+                },
+                {
+                    "id": "message-2::swipe::0",
+                    "messageId": "message-2",
+                    "index": 0,
+                    "content": "skip",
+                    "extra": { "thinking": "skip thought" },
+                    "createdAt": "2026-01-01T00:00:01Z"
+                },
+                {
+                    "id": "message-1::swipe::1",
+                    "messageId": "message-1",
+                    "index": 1,
+                    "content": "second",
+                    "extra": { "thinking": "second thought" },
+                    "createdAt": "2026-01-01T00:00:02Z",
+                    "customField": "preserved"
+                }
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let storage = FileStorage::new(&root).unwrap();
+        let values = HashSet::from(["message-1".to_string()]);
+        let rows = storage
+            .list_where_in("message-swipes", "messageId", &values)
+            .expect("filtered full rows should read");
+
+        assert_eq!(
+            rows,
+            vec![
+                json!({
+                    "id": "message-1::swipe::0",
+                    "messageId": "message-1",
+                    "index": 0,
+                    "content": "first",
+                    "extra": { "thinking": "first thought" },
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "providerMetadata": { "finishReason": "stop" }
+                }),
+                json!({
+                    "id": "message-1::swipe::1",
+                    "messageId": "message-1",
+                    "index": 1,
+                    "content": "second",
+                    "extra": { "thinking": "second thought" },
+                    "createdAt": "2026-01-01T00:00:02Z",
+                    "customField": "preserved"
                 })
             ]
         );

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -58,6 +58,8 @@ pub(crate) mod managed_thumbnails;
 pub(crate) mod mari;
 #[path = "storage/media_uploads.rs"]
 pub(crate) mod media_uploads;
+#[path = "storage/message_swipes.rs"]
+pub(crate) mod message_swipes;
 #[path = "storage/personas.rs"]
 pub(crate) mod personas;
 #[path = "storage/profile.rs"]

--- a/src-tauri/src/commands/storage/admin.rs
+++ b/src-tauri/src/commands/storage/admin.rs
@@ -26,6 +26,7 @@ pub(crate) fn admin_expunge(state: &AppState, body: Value) -> AppResult<Value> {
                     "chats",
                     "chat-folders",
                     "messages",
+                    "message-swipes",
                     "gallery",
                     "agent-runs",
                     "knowledge-sources",

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -1,5 +1,6 @@
 use super::game_state_snapshots;
 use super::media_uploads::remove_managed_record_file;
+use super::message_swipes as message_swipe_storage;
 use super::prompts;
 use super::shared::*;
 use super::*;
@@ -10,17 +11,13 @@ const MEMORY_CHUNK_SIZE: usize = 5;
 const MEMORY_EMBEDDING_DIMS: usize = 256;
 
 pub(crate) fn messages_for_chat(state: &AppState, chat_id: &str) -> AppResult<Vec<Value>> {
-    let mut filters = Map::new();
-    filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
-    let mut rows = state.storage.list_where("messages", &filters)?;
+    let mut rows = state.storage.list_messages_for_chat(chat_id)?;
     rows.sort_by(|a, b| {
         let a_time = a.get("createdAt").and_then(Value::as_str).unwrap_or("");
         let b_time = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
         a_time.cmp(b_time)
     });
-    for row in &mut rows {
-        materialize_message_swipe_fields(row);
-    }
+    message_swipe_storage::materialize_messages(state, &mut rows, true)?;
     Ok(rows)
 }
 
@@ -86,6 +83,7 @@ pub(crate) fn evict_prompt_snapshots(
     keep_last: usize,
 ) -> AppResult<Value> {
     let mut messages = state.storage.list_messages_for_chat(chat_id)?;
+    message_swipe_storage::materialize_messages(state, &mut messages, true)?;
     messages.sort_by(|a, b| {
         let a_time = a.get("createdAt").and_then(Value::as_str).unwrap_or("");
         let b_time = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
@@ -122,6 +120,9 @@ pub(crate) fn evict_prompt_snapshots(
             state.storage.patch("messages", id, patch)?;
             evicted += 1;
         }
+    }
+    if evicted > 0 {
+        message_swipe_storage::migrate_nested_message_swipes(&state.storage)?;
     }
     Ok(json!({ "evicted": evicted }))
 }
@@ -348,6 +349,7 @@ pub(crate) fn message_swipes(
     body: Value,
 ) -> AppResult<Value> {
     let mut message = get_required(state, "messages", message_id)?;
+    message_swipe_storage::materialize_message(state, &mut message, true)?;
     if body.is_null() {
         return Ok(message.get("swipes").cloned().unwrap_or_else(|| json!([])));
     }
@@ -443,9 +445,9 @@ pub(crate) fn message_swipes(
     if let Some(character_id) = active_character_id {
         object.insert("characterId".to_string(), character_id);
     }
-    compact_message_for_storage(&mut message)?;
-    let mut updated = state.storage.patch("messages", message_id, message)?;
-    materialize_message_swipe_fields(&mut updated);
+    let swipes = message_swipe_storage::take_swipes_for_storage(&mut message)?.unwrap_or_default();
+    let mut updated = message_swipe_storage::replace_message_with_swipes(state, message, swipes)?;
+    message_swipe_storage::materialize_message(state, &mut updated, true)?;
     Ok(updated)
 }
 
@@ -456,23 +458,13 @@ pub(crate) fn update_message_content_if_unchanged(
     expected_content: &str,
     content: &str,
 ) -> AppResult<Value> {
-    let content = collapse_excess_blank_lines(content);
-    let updated = state.storage.patch_if("messages", message_id, |message| {
-        let current_chat_id = message.get("chatId").and_then(Value::as_str).unwrap_or("");
-        if current_chat_id != chat_id {
-            return Ok(false);
-        }
-        let current_content = message.get("content").and_then(Value::as_str).unwrap_or("");
-        if current_content != expected_content {
-            return Ok(false);
-        }
-        message.insert("content".to_string(), Value::String(content.clone()));
-        let mut patch = Map::new();
-        patch.insert("content".to_string(), Value::String(content.clone()));
-        sync_message_patch_content_to_active_swipe(message, &patch);
-        compact_message_swipe_fields_for_storage(message);
-        Ok(true)
-    })?;
+    let updated = message_swipe_storage::update_message_content_if_unchanged(
+        state,
+        chat_id,
+        message_id,
+        expected_content,
+        content,
+    )?;
     Ok(match updated {
         Some(message) => json!({ "updated": true, "message": message }),
         None => json!({ "updated": false }),
@@ -491,6 +483,7 @@ pub(crate) fn set_active_swipe(
         .map(|value| value as usize)
         .unwrap_or(0);
     let mut message = get_required(state, "messages", message_id)?;
+    message_swipe_storage::materialize_message(state, &mut message, true)?;
     let object = message
         .as_object_mut()
         .ok_or_else(|| AppError::invalid_input("Message is not an object"))?;
@@ -554,9 +547,9 @@ pub(crate) fn set_active_swipe(
             clear_swipe_scoped_extra(object.get("extra")),
         );
     }
-    compact_message_for_storage(&mut message)?;
-    let mut updated = state.storage.patch("messages", message_id, message)?;
-    materialize_message_swipe_fields(&mut updated);
+    let swipes = message_swipe_storage::take_swipes_for_storage(&mut message)?.unwrap_or_default();
+    let mut updated = message_swipe_storage::replace_message_with_swipes(state, message, swipes)?;
+    message_swipe_storage::materialize_message(state, &mut updated, true)?;
     Ok(active_swipe_update_response(&updated))
 }
 
@@ -570,7 +563,7 @@ pub(crate) fn delete_swipe(
         .parse::<usize>()
         .map_err(|_| AppError::invalid_input("Invalid swipe index"))?;
     let mut message = get_required(state, "messages", message_id)?;
-    let mut removed_swipe = false;
+    message_swipe_storage::materialize_message(state, &mut message, true)?;
     {
         let object = message
             .as_object_mut()
@@ -580,45 +573,36 @@ pub(crate) fn delete_swipe(
             .and_then(Value::as_u64)
             .map(|value| value as usize)
             .unwrap_or(0);
-        if let Some(swipes) = object.get_mut("swipes").and_then(Value::as_array_mut) {
-            if index < swipes.len() {
-                swipes.remove(index);
-                removed_swipe = true;
-                let next_active_index = if swipes.is_empty() {
-                    0
-                } else if current_active_index > index {
-                    current_active_index - 1
-                } else if current_active_index == index {
-                    index.min(swipes.len().saturating_sub(1))
-                } else {
-                    current_active_index.min(swipes.len().saturating_sub(1))
-                };
-                object.insert("activeSwipeIndex".to_string(), json!(next_active_index));
-            }
+        let Some(swipes) = object.get_mut("swipes").and_then(Value::as_array_mut) else {
+            return Err(AppError::invalid_input(
+                "Cannot delete the last remaining swipe",
+            ));
+        };
+        if swipes.len() <= 1 {
+            return Err(AppError::invalid_input(
+                "Cannot delete the last remaining swipe",
+            ));
         }
+        if index >= swipes.len() {
+            return Err(AppError::not_found("Swipe not found"));
+        }
+        swipes.remove(index);
+        let next_active_index = if current_active_index > index {
+            current_active_index - 1
+        } else if current_active_index == index {
+            index.min(swipes.len().saturating_sub(1))
+        } else {
+            current_active_index.min(swipes.len().saturating_sub(1))
+        };
+        object.insert("activeSwipeIndex".to_string(), json!(next_active_index));
     }
     materialize_message_swipe_fields(&mut message);
-    compact_message_for_storage(&mut message)?;
-    let mut updated = state.storage.patch("messages", message_id, message)?;
-    materialize_message_swipe_fields(&mut updated);
-    if removed_swipe {
-        game_state_snapshots::delete_tracker_snapshot_swipe(
-            state,
-            chat_id,
-            message_id,
-            index as i64,
-        )?;
-        game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, chat_id)?;
-    }
+    let swipes = message_swipe_storage::take_swipes_for_storage(&mut message)?.unwrap_or_default();
+    let mut updated = message_swipe_storage::replace_message_with_swipes(state, message, swipes)?;
+    message_swipe_storage::materialize_message(state, &mut updated, true)?;
+    game_state_snapshots::delete_tracker_snapshot_swipe(state, chat_id, message_id, index as i64)?;
+    game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, chat_id)?;
     Ok(updated)
-}
-
-fn compact_message_for_storage(message: &mut Value) -> AppResult<()> {
-    let Some(object) = message.as_object_mut() else {
-        return Err(AppError::invalid_input("Message is not an object"));
-    };
-    compact_message_swipe_fields_for_storage(object);
-    Ok(())
 }
 
 pub(crate) fn bulk_delete_messages(
@@ -631,14 +615,19 @@ pub(crate) fn bulk_delete_messages(
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
-    let mut deleted = 0;
+    let mut deleted_ids = Vec::new();
     for id in ids.iter().filter_map(Value::as_str) {
-        if state.storage.delete("messages", id)? {
-            game_state_snapshots::delete_tracker_snapshots_for_message(state, chat_id, id)?;
-            deleted += 1;
+        if state.storage.get("messages", id)?.is_some() {
+            deleted_ids.push(id.to_string());
         }
     }
+    deleted_ids.sort_unstable();
+    deleted_ids.dedup();
+    let deleted = message_swipe_storage::delete_message_rows_with_swipes(state, &deleted_ids)?;
     if deleted > 0 {
+        for id in &deleted_ids {
+            game_state_snapshots::delete_tracker_snapshots_for_message(state, chat_id, id)?;
+        }
         game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, chat_id)?;
     }
     touch_chat(state, chat_id)?;
@@ -965,7 +954,7 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
             obj.remove("id");
             obj.insert("chatId".to_string(), Value::String(new_chat_id.clone()));
         }
-        let created = state.storage.create("messages", message)?;
+        let created = message_swipe_storage::create_message(state, message)?;
         let target_message_id = created
             .get("id")
             .and_then(Value::as_str)
@@ -1053,7 +1042,7 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
     game_state_snapshots::delete_tracker_snapshots_for_chats(state, &delete_ids)?;
     let delete_id_set = delete_ids.iter().cloned().collect::<HashSet<_>>();
     delete_gallery_for_chats(state, &delete_id_set)?;
-    state.storage.delete_messages_for_chats(&delete_id_set)?;
+    message_swipe_storage::delete_message_rows_for_chats_with_swipes(state, &delete_id_set)?;
 
     for delete_id in &delete_ids {
         state.storage.delete("chats", delete_id)?;
@@ -1804,17 +1793,21 @@ mod tests {
         assert_eq!(persisted["extra"]["hiddenFromAI"], json!(true));
         assert!(persisted["extra"].get("generationInfo").is_none());
         assert!(persisted["extra"].get("reasoning_content").is_none());
+        assert!(persisted.get("swipes").is_none());
+        let persisted_swipes = message_swipe_storage::swipes_for_message(&state, "message-1")
+            .expect("message sidecar swipes should read");
         assert_eq!(
-            persisted["swipes"][0]["extra"]["generationInfo"]["model"],
+            persisted_swipes[0]["extra"]["generationInfo"]["model"],
             json!("first-model")
         );
         assert_eq!(
-            persisted["swipes"][0]["extra"]["reasoning_content"],
+            persisted_swipes[0]["extra"]["reasoning_content"],
             json!("first reasoning")
         );
 
         let mut materialized = persisted.clone();
-        materialize_message_swipe_fields(&mut materialized);
+        message_swipe_storage::materialize_message(&state, &mut materialized, true)
+            .expect("message should materialize from sidecar swipes");
         assert_eq!(
             materialized["extra"]["generationInfo"]["model"],
             json!("first-model")
@@ -1868,12 +1861,15 @@ mod tests {
             .get("messages", "message-1")
             .expect("message lookup should succeed")
             .expect("message should exist");
+        assert!(persisted.get("swipes").is_none());
+        let persisted_swipes = message_swipe_storage::swipes_for_message(&state, "message-1")
+            .expect("message sidecar swipes should read");
         assert_eq!(
-            persisted["swipes"][0]["extra"]["attachments"][0]["galleryId"],
+            persisted_swipes[0]["extra"]["attachments"][0]["galleryId"],
             json!("gallery-1")
         );
         assert_eq!(
-            persisted["swipes"][0]["extra"]["generationInfo"]["model"],
+            persisted_swipes[0]["extra"]["generationInfo"]["model"],
             json!("first-model")
         );
 
@@ -1942,17 +1938,21 @@ mod tests {
         assert!(persisted["extra"]
             .get("generationPromptSnapshotsBySwipe")
             .is_none());
+        assert!(persisted.get("swipes").is_none());
+        let persisted_swipes = message_swipe_storage::swipes_for_message(&state, "message-1")
+            .expect("message sidecar swipes should read");
         assert_eq!(
-            persisted["swipes"][0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            persisted_swipes[0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-first")
         );
         assert_eq!(
-            persisted["swipes"][1]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            persisted_swipes[1]["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-second")
         );
 
         let mut materialized = persisted.clone();
-        materialize_message_swipe_fields(&mut materialized);
+        message_swipe_storage::materialize_message(&state, &mut materialized, true)
+            .expect("message should materialize from sidecar swipes");
         assert_eq!(
             materialized["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-first")
@@ -2298,6 +2298,97 @@ mod tests {
         assert_eq!(updated["swipeCount"], json!(2));
         assert_eq!(updated["content"], json!("first"));
         assert_eq!(updated["swipes"][1]["content"], json!("second"));
+    }
+
+    #[test]
+    fn set_active_swipe_clamps_invalid_index() {
+        let state = test_state("set-active-invalid-index");
+        message_swipe_storage::create_message(
+            &state,
+            json!({
+                "id": "message-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "activeSwipeIndex": 0,
+                "swipes": [
+                    { "content": "first" },
+                    { "content": "second" }
+                ]
+            }),
+        )
+        .expect("message should seed");
+
+        let missing = set_active_swipe(&state, "chat-1", "message-1", json!({ "index": 4 }))
+            .expect("missing swipe target should not fail transport");
+        let negative = set_active_swipe(&state, "chat-1", "message-1", json!({ "index": -1 }))
+            .expect("negative swipe target should not fail transport");
+
+        assert_eq!(missing["activeSwipeIndex"], json!(1));
+        assert_eq!(missing["content"], json!("second"));
+        assert_eq!(negative["activeSwipeIndex"], json!(0));
+        assert_eq!(negative["content"], json!("first"));
+        let persisted = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message should read")
+            .expect("message should exist");
+        assert_eq!(persisted["activeSwipeIndex"], json!(0));
+        assert_eq!(persisted["content"], json!("first"));
+    }
+
+    #[test]
+    fn delete_swipe_rejects_last_and_missing_swipes() {
+        let state = test_state("delete-swipe-guards");
+        message_swipe_storage::create_message(
+            &state,
+            json!({
+                "id": "single-message",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "only",
+                "swipes": [{ "content": "only" }]
+            }),
+        )
+        .expect("single-swipe message should seed");
+        message_swipe_storage::create_message(
+            &state,
+            json!({
+                "id": "multi-message",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "swipes": [
+                    { "content": "first" },
+                    { "content": "second" }
+                ]
+            }),
+        )
+        .expect("multi-swipe message should seed");
+
+        let last_error = delete_swipe(&state, "chat-1", "single-message", "0")
+            .expect_err("last swipe delete should fail");
+        let missing_error = delete_swipe(&state, "chat-1", "multi-message", "9")
+            .expect_err("missing swipe delete should fail");
+
+        assert_eq!(last_error.code, "invalid_input");
+        assert!(last_error
+            .message
+            .contains("Cannot delete the last remaining swipe"));
+        assert_eq!(missing_error.code, "not_found");
+        assert!(missing_error.message.contains("Swipe not found"));
+        assert_eq!(
+            message_swipe_storage::swipes_for_message(&state, "single-message")
+                .expect("single-message swipes should read")
+                .len(),
+            1
+        );
+        assert_eq!(
+            message_swipe_storage::swipes_for_message(&state, "multi-message")
+                .expect("multi-message swipes should read")
+                .len(),
+            2
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -2336,6 +2336,78 @@ mod tests {
     }
 
     #[test]
+    fn storage_list_search_materializes_active_sidecar_extra_without_returning_swipes() {
+        let state = test_state("message-search-sidecar-active-extra");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "Visible active message.",
+                    "activeSwipeIndex": 1,
+                    "extra": { "hiddenFromAI": true },
+                    "createdAt": "2026-01-01T00:00:00Z"
+                })],
+            )
+            .expect("message should seed");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "Search-only moonlit sidecar.",
+                        "extra": { "thinking": "inactive thought" }
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "Visible active message.",
+                        "extra": { "thinking": "active sidecar thought" }
+                    }),
+                ],
+            )
+            .expect("sidecar swipes should seed");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "filters": { "chatId": "chat-1" },
+                "fields": ["id", "content", "extra", "swipeCount", "swipePreviews"],
+                "fieldSelections": { "extra": ["hiddenFromAI", "thinking"] },
+                "search": "moonlit"
+            })),
+        )
+        .expect("message search should succeed");
+
+        assert_eq!(
+            result,
+            json!([
+                {
+                    "id": "message-1",
+                    "content": "Visible active message.",
+                    "extra": { "hiddenFromAI": true, "thinking": "active sidecar thought" },
+                    "swipeCount": 2,
+                    "swipePreviews": [
+                        { "content": "Search-only moonlit sidecar." },
+                        { "content": "Visible active message." }
+                    ]
+                }
+            ])
+        );
+    }
+
+    #[test]
     fn enabling_agent_default_connection_clears_previous_language_default() {
         let state = test_state("agent-default-exclusive-update");
         storage_create_inner(

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1,6 +1,6 @@
 use super::{
     avatars, characters, chats, connection_secrets, contracts, game_state_snapshots,
-    lorebook_images, media_uploads, prompts, shared,
+    lorebook_images, media_uploads, message_swipes, prompts, shared,
 };
 use crate::builtins::is_protected_record;
 use crate::state::AppState;
@@ -17,6 +17,15 @@ fn validate_storage_entity(entity: &str) -> Result<(), AppError> {
             "Unsupported storage entity: {entity}"
         )))
     }
+}
+
+fn reject_message_swipe_mutation(entity: &str) -> Result<(), AppError> {
+    if entity == message_swipes::COLLECTION {
+        return Err(AppError::invalid_input(
+            "message-swipes is internal sidecar storage; mutate swipes through message commands",
+        ));
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -125,6 +134,14 @@ pub(crate) fn storage_list_inner(
         (_, Some(filters)) if !filters.is_empty() => state.storage.list_where(&entity, filters)?,
         _ => state.storage.list(&entity)?,
     };
+    let message_materialization = message_swipes::MessageSwipeMaterialization::for_message_output(
+        options.as_ref(),
+        has_search,
+    );
+    let materialized_message_swipes_for_search = entity == "messages" && has_search;
+    if materialized_message_swipes_for_search {
+        message_swipes::materialize_messages_for_output(state, &mut rows, message_materialization)?;
+    }
     shared::apply_storage_search(&mut rows, options.as_ref());
 
     let order_by = options
@@ -159,8 +176,19 @@ pub(crate) fn storage_list_inner(
 
     if entity == "messages" {
         apply_message_pagination(&mut rows, options.as_ref());
+        if !materialized_message_swipes_for_search {
+            message_swipes::materialize_messages_for_output(
+                state,
+                &mut rows,
+                message_materialization,
+            )?;
+        }
         for row in &mut rows {
-            shared::materialize_message_swipe_fields(row);
+            if !message_materialization.include_swipes {
+                if let Some(object) = row.as_object_mut() {
+                    object.remove("swipes");
+                }
+            }
             shared::synthesize_legacy_prompt_snapshot(row);
         }
         return Ok(Value::Array(shared::project_list_rows(
@@ -225,23 +253,14 @@ fn message_projection_fields_for_materialization(
             projection.push(order_by.to_string());
         }
     }
-    let needs_swipes = fields.iter().any(|field| {
-        matches!(
-            field.as_str(),
-            "content"
-                | "characterId"
-                | "extra"
-                | "activeSwipeIndex"
-                | "swipeCount"
-                | "swipePreviews"
-        )
-    });
-    if needs_swipes {
-        for field in ["activeSwipeIndex", "swipes"] {
-            if !projection.iter().any(|existing| existing == field) {
-                projection.push(field.to_string());
-            }
-        }
+    if fields
+        .iter()
+        .any(|field| matches!(field.as_str(), "extra" | "swipes"))
+        && !projection
+            .iter()
+            .any(|existing| existing == "activeSwipeIndex")
+    {
+        projection.push("activeSwipeIndex".to_string());
     }
     projection
 }
@@ -297,7 +316,14 @@ pub(crate) fn storage_get_inner(
         state.storage.get(&entity, &id)?.unwrap_or(Value::Null)
     };
     if entity == "messages" {
-        shared::materialize_message_swipe_fields(&mut value);
+        message_swipes::materialize_message_for_output(
+            state,
+            &mut value,
+            message_swipes::MessageSwipeMaterialization::for_message_output(
+                options.as_ref(),
+                false,
+            ),
+        )?;
     }
     if entity == "connections" {
         connection_secrets::mask_connection_for_read(&mut value);
@@ -349,7 +375,16 @@ pub(crate) fn storage_create_inner(
     value: Value,
 ) -> Result<Value, AppError> {
     validate_storage_entity(&entity)?;
+    reject_message_swipe_mutation(&entity)?;
     validate_connection_folder_for_create(state, &entity, &value)?;
+    if entity == "messages" {
+        return Ok(shared::project_timeline_message(
+            message_swipes::create_message(
+                state,
+                prepare_entity_for_create(state, &entity, value)?,
+            )?,
+        ));
+    }
     let should_remove_prepared_gallery_file = gallery_create_persists_inline_image(&entity, &value);
     let prepared = prepare_entity_for_create(state, &entity, value)?;
     let created = match state.storage.create(&entity, prepared.clone()) {
@@ -361,9 +396,6 @@ pub(crate) fn storage_create_inner(
             return Err(error);
         }
     };
-    if entity == "messages" {
-        return Ok(shared::project_timeline_message(created));
-    }
     if entity == "connections" {
         clear_other_default_agent_connections(state, &created)?;
         let mut masked = created;
@@ -393,9 +425,10 @@ pub(crate) fn storage_update_inner(
     patch: Value,
 ) -> Result<Value, AppError> {
     validate_storage_entity(&entity)?;
+    reject_message_swipe_mutation(&entity)?;
     if entity == "messages" {
         return Ok(shared::project_timeline_message(
-            shared::patch_message_update(state, &id, patch)?,
+            message_swipes::patch_message_update(state, &id, patch)?,
         ));
     }
     if entity == "characters" {
@@ -637,6 +670,7 @@ pub(crate) fn delete_entity(
     force: bool,
 ) -> Result<Value, AppError> {
     validate_storage_entity(entity)?;
+    reject_message_swipe_mutation(entity)?;
     if entity == "connections" {
         return crate::connection_refs::delete_connection(state, id, force);
     }
@@ -668,7 +702,11 @@ pub(crate) fn delete_entity(
     } else {
         None
     };
-    let deleted = state.storage.delete(entity, id)?;
+    let deleted = if entity == "messages" {
+        message_swipes::delete_message_rows_with_swipes(state, &[id.to_string()])? > 0
+    } else {
+        state.storage.delete(entity, id)?
+    };
     if deleted {
         if entity == "lorebooks" {
             delete_lorebook_children(state, id)?;
@@ -946,6 +984,7 @@ pub(crate) fn duplicate_entity(
     id: &str,
 ) -> Result<Value, AppError> {
     validate_storage_entity(entity)?;
+    reject_message_swipe_mutation(entity)?;
     if entity == "characters" {
         return characters::duplicate_character(state, id);
     }
@@ -958,8 +997,22 @@ pub(crate) fn duplicate_entity(
     if entity == "connections" {
         return duplicate_connection(state, id);
     }
+    if entity == "messages" {
+        return duplicate_message(state, id);
+    }
     let duplicated = shared::duplicate_record(state, entity, id)?;
     Ok(duplicated)
+}
+
+fn duplicate_message(state: &AppState, id: &str) -> Result<Value, AppError> {
+    let mut record = shared::get_required(state, "messages", id)?;
+    message_swipes::materialize_message(state, &mut record, true)?;
+    let object = record
+        .as_object_mut()
+        .ok_or_else(|| AppError::invalid_input("Message is not an object"))?;
+    object.remove("id");
+    let duplicated = message_swipes::create_message(state, record)?;
+    Ok(shared::project_timeline_message(duplicated))
 }
 
 fn duplicate_connection(state: &AppState, id: &str) -> Result<Value, AppError> {
@@ -1317,6 +1370,111 @@ mod tests {
         assert!(
             !state.data_dir.join("gallery").join("rollback.png").exists(),
             "failed gallery create should remove the managed file it wrote"
+        );
+    }
+
+    #[test]
+    fn generic_storage_mutations_reject_message_swipe_sidecars() {
+        let state = test_state("message-swipe-sidecar-generic-mutation");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "chat-1",
+                    "messageId": "message-1",
+                    "index": 0,
+                    "content": "keep sidecar"
+                })],
+            )
+            .expect("sidecar should seed");
+
+        let create_error = storage_create_inner(
+            &state,
+            message_swipes::COLLECTION.to_string(),
+            json!({
+                "id": "message-2::swipe::0",
+                "chatId": "chat-1",
+                "messageId": "message-2",
+                "index": 0,
+                "content": "raw create"
+            }),
+        )
+        .expect_err("direct sidecar create should be rejected");
+        assert_eq!(create_error.code, "invalid_input");
+        assert!(create_error.message.contains("internal sidecar storage"));
+
+        let update_error = storage_update_inner(
+            &state,
+            message_swipes::COLLECTION.to_string(),
+            "message-1::swipe::0".to_string(),
+            json!({ "content": "raw update" }),
+        )
+        .expect_err("direct sidecar update should be rejected");
+        assert_eq!(update_error.code, "invalid_input");
+
+        let delete_error = delete_entity(
+            &state,
+            message_swipes::COLLECTION,
+            "message-1::swipe::0",
+            false,
+        )
+        .expect_err("direct sidecar delete should be rejected");
+        assert_eq!(delete_error.code, "invalid_input");
+
+        let duplicate_error =
+            duplicate_entity(&state, message_swipes::COLLECTION, "message-1::swipe::0")
+                .expect_err("direct sidecar duplicate should be rejected");
+        assert_eq!(duplicate_error.code, "invalid_input");
+
+        let sidecars = state
+            .storage
+            .list(message_swipes::COLLECTION)
+            .expect("sidecars should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["content"], "keep sidecar");
+    }
+
+    #[test]
+    fn generic_message_create_normalizes_parent_contract_fields() {
+        let state = test_state("message-create-normalizes-parent-fields");
+
+        storage_create_inner(
+            &state,
+            "messages".to_string(),
+            json!({
+                "id": "message-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "images": "[]",
+                "attachments": "[]",
+                "extra": "{\"thinking\":\"parent thought\"}",
+                "swipes": [{
+                    "content": "first",
+                    "extra": "{\"thinking\":\"swipe thought\"}"
+                }]
+            }),
+        )
+        .expect("message create should normalize parent fields");
+
+        let stored = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should be stored");
+        assert_eq!(stored["images"], json!([]));
+        assert_eq!(stored["attachments"], json!([]));
+        assert_eq!(stored["extra"], json!({}));
+        assert!(stored.get("swipes").is_none());
+
+        let sidecars = message_swipes::swipes_for_message(&state, "message-1")
+            .expect("message sidecars should read");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(
+            sidecars[0]["extra"],
+            json!({ "thinking": "parent thought" })
         );
     }
 
@@ -1740,6 +1898,11 @@ mod tests {
             .join("data")
             .join("collections")
             .join("messages.json");
+        let sidecar_collection = state
+            .data_dir
+            .join("data")
+            .join("collections")
+            .join(format!("{}.json", message_swipes::COLLECTION));
         std::fs::write(
             &collection,
             r#"[
@@ -1748,15 +1911,6 @@ mod tests {
     "chatId": "chat-1",
     "createdAt": "2026-01-01T00:00:01Z",
     "content": "stored older",
-    "activeSwipeIndex": 0,
-    "swipes": [
-      {
-        "content": "older swipe",
-        "extra": {
-          "thinking": "older thought"
-        }
-      }
-    ],
     "extra": {
       "thinking": "parent older",
       "large": {
@@ -1774,15 +1928,6 @@ mod tests {
     "chatId": "chat-1",
     "createdAt": "2026-01-01T00:00:02Z",
     "content": "stored target",
-    "activeSwipeIndex": 0,
-    "swipes": [
-      {
-        "content": "target swipe",
-        "extra": {
-          "thinking": "target thought"
-        }
-      }
-    ],
     "extra": {
       "thinking": "parent target",
       "large": {
@@ -1808,6 +1953,44 @@ mod tests {
 ]"#,
         )
         .expect("messages should be written");
+        std::fs::write(
+            &sidecar_collection,
+            r#"[
+  {
+    "id": "older::swipe::0",
+    "chatId": "chat-1",
+    "messageId": "older",
+    "index": 0,
+    "content": "older swipe",
+    "extra": {
+      "thinking": "older thought",
+      "unrequested": "ignored"
+    }
+  },
+  {
+    "id": "target::swipe::0",
+    "chatId": "chat-1",
+    "messageId": "target",
+    "index": 0,
+    "content": "target swipe",
+    "extra": {
+      "thinking": "target thought",
+      "unrequested": "ignored"
+    }
+  },
+  {
+    "id": "newer::swipe::0",
+    "chatId": "chat-1",
+    "messageId": "newer",
+    "index": 0,
+    "content": "newer swipe",
+    "extra": {
+      "unrequested": "ignored"
+    }
+  }
+]"#,
+        )
+        .expect("message swipe sidecars should be written");
 
         let result = storage_list_inner(
             &state,
@@ -1827,17 +2010,69 @@ mod tests {
             json!([
                 {
                     "id": "older",
-                    "content": "older swipe",
-                    "extra": { "thinking": "older thought" },
+                    "content": "stored older",
+                    "extra": { "thinking": "parent older" },
                     "swipeCount": 1,
                     "swipePreviews": [{ "content": "older swipe" }]
                 },
                 {
                     "id": "target",
-                    "content": "target swipe",
-                    "extra": { "thinking": "target thought" },
+                    "content": "stored target",
+                    "extra": { "thinking": "parent target" },
                     "swipeCount": 1,
                     "swipePreviews": [{ "content": "target swipe" }]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn storage_list_projected_embedded_swipes_materializes_without_swipes_field() {
+        let state = test_state("message-projection-embedded-swipe-materialization");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "content": "parent content",
+                    "activeSwipeIndex": 1,
+                    "extra": { "thinking": "parent thought" },
+                    "swipes": [
+                        { "content": "first swipe", "extra": { "thinking": "first thought" } },
+                        { "content": "active swipe", "extra": { "thinking": "active thought" } }
+                    ]
+                })],
+            )
+            .expect("message should be seeded");
+        message_swipes::migrate_nested_message_swipes(&state.storage)
+            .expect("embedded message swipes should migrate before projected reads");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "filters": { "chatId": "chat-1" },
+                "fields": ["id", "content", "extra", "swipeCount", "swipePreviews"],
+                "fieldSelections": { "extra": ["thinking"] }
+            })),
+        )
+        .expect("projected message list should materialize embedded swipes");
+
+        assert_eq!(
+            result,
+            json!([
+                {
+                    "id": "message-1",
+                    "content": "active swipe",
+                    "extra": { "thinking": "active thought" },
+                    "swipeCount": 2,
+                    "swipePreviews": [
+                        { "content": "first swipe" },
+                        { "content": "active swipe" }
+                    ]
                 }
             ])
         );
@@ -1851,25 +2086,22 @@ mod tests {
             Some(&json!({ "orderBy": "score" })),
         );
 
-        for field in [
-            "content",
-            "id",
-            "sortOrder",
-            "order",
-            "createdAt",
-            "score",
-            "activeSwipeIndex",
-            "swipes",
-        ] {
+        for field in ["content", "id", "sortOrder", "order", "createdAt", "score"] {
             assert!(
                 projection.iter().any(|existing| existing == field),
                 "projection should include {field}"
             );
         }
+        for field in ["activeSwipeIndex", "swipes"] {
+            assert!(
+                !projection.iter().any(|existing| existing == field),
+                "projection should not include sidecar field {field}"
+            );
+        }
     }
 
     #[test]
-    fn projected_message_get_materializes_active_swipe_fields() {
+    fn projected_message_get_materializes_swipe_summary_without_swipes_field() {
         let state = test_state("message-projection-get-swipe-materialization");
         state
             .storage
@@ -1889,6 +2121,8 @@ mod tests {
                 })],
             )
             .expect("message should be seeded");
+        message_swipes::migrate_nested_message_swipes(&state.storage)
+            .expect("nested message swipes should migrate");
 
         let read = storage_get_inner(
             &state,
@@ -1912,6 +2146,193 @@ mod tests {
         assert!(read.get("swipes").is_none());
         assert!(read.get("activeSwipeIndex").is_none());
         assert!(read.get("largePayload").is_none());
+    }
+
+    #[test]
+    fn projected_message_get_reads_parent_active_fields_without_sidecar_payload() {
+        let state = test_state("message-projection-parent-active-fields");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "content": "parent active content",
+                    "activeSwipeIndex": 1,
+                    "extra": { "thinking": "parent active thought", "large": "parent payload" }
+                })],
+            )
+            .expect("message should be seeded");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "first sidecar",
+                        "extra": { "thinking": "first sidecar thought" }
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "stale active sidecar",
+                        "extra": { "thinking": "stale sidecar thought" }
+                    }),
+                ],
+            )
+            .expect("sidecars should be seeded");
+
+        let read = storage_get_inner(
+            &state,
+            "messages".to_string(),
+            "message-1".to_string(),
+            Some(json!({
+                "fields": ["id", "content", "extra"],
+                "fieldSelections": { "extra": ["thinking"] }
+            })),
+        )
+        .expect("projected message should read");
+
+        assert_eq!(
+            read,
+            json!({
+                "id": "message-1",
+                "content": "parent active content",
+                "extra": { "thinking": "parent active thought" }
+            })
+        );
+    }
+
+    #[test]
+    fn projected_message_list_materializes_swipe_summary_without_sidecar_extra() {
+        let state = test_state("message-projection-sidecar-summary");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "content": "parent active content",
+                    "activeSwipeIndex": 1,
+                    "extra": { "thinking": "parent active thought", "large": "parent payload" }
+                })],
+            )
+            .expect("message should be seeded");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "first sidecar",
+                        "extra": { "thinking": "first sidecar thought", "large": "ignored" }
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "second sidecar",
+                        "characterId": "character-1",
+                        "extra": { "thinking": "second sidecar thought", "large": "ignored" }
+                    }),
+                ],
+            )
+            .expect("sidecars should be seeded");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "filters": { "chatId": "chat-1" },
+                "fields": ["id", "content", "extra", "swipeCount", "swipePreviews"],
+                "fieldSelections": { "extra": ["thinking"] }
+            })),
+        )
+        .expect("projected message list should read");
+
+        assert_eq!(
+            result,
+            json!([
+                {
+                    "id": "message-1",
+                    "content": "parent active content",
+                    "extra": { "thinking": "parent active thought" },
+                    "swipeCount": 2,
+                    "swipePreviews": [
+                        { "content": "first sidecar" },
+                        { "content": "second sidecar", "characterId": "character-1" }
+                    ]
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn storage_list_searches_sidecar_message_swipes_without_returning_unrequested_swipes() {
+        let state = test_state("message-search-sidecar-swipes");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "Visible active message.",
+                    "activeSwipeIndex": 0,
+                    "createdAt": "2026-01-01T00:00:00Z"
+                })],
+            )
+            .expect("message should seed");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "chat-1",
+                    "messageId": "message-1",
+                    "index": 0,
+                    "content": "Alternate route through the moonlit archive."
+                })],
+            )
+            .expect("sidecar swipe should seed");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "filters": { "chatId": "chat-1" },
+                "fields": ["id", "content", "swipeCount"],
+                "search": "moonlit"
+            })),
+        )
+        .expect("message search should succeed");
+
+        assert_eq!(
+            result,
+            json!([
+                {
+                    "id": "message-1",
+                    "content": "Visible active message.",
+                    "swipeCount": 1
+                }
+            ])
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -55,6 +55,7 @@ const MESSAGE_FIELDS: &[TypedJsonField] = &[
     array("attachments"),
     nullable_object("extra"),
 ];
+const MESSAGE_SWIPE_FIELDS: &[TypedJsonField] = &[nullable_object("extra")];
 const CHARACTER_GROUP_FIELDS: &[TypedJsonField] = &[array("characterIds")];
 const PERSONA_GROUP_FIELDS: &[TypedJsonField] = &[array("personaIds")];
 const LOREBOOK_FIELDS: &[TypedJsonField] =
@@ -385,6 +386,14 @@ pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
         EMPTY_DEFAULTS,
         MESSAGE_FIELDS,
         MESSAGE_CLEANUP,
+    ),
+    contract(
+        "message-swipes",
+        true,
+        true,
+        EMPTY_DEFAULTS,
+        MESSAGE_SWIPE_FIELDS,
+        EMPTY_CLEANUP,
     ),
     contract(
         "custom-tools",

--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -18,7 +18,10 @@ pub(crate) fn export_record(
     id: &str,
     format: Option<&str>,
 ) -> AppResult<Value> {
-    let record = get_required(state, collection, id)?;
+    let mut record = get_required(state, collection, id)?;
+    if collection == "messages" {
+        message_swipes::materialize_message(state, &mut record, true)?;
+    }
     if format == Some("compatible") {
         return compatible_record(collection, &record);
     }
@@ -39,7 +42,10 @@ pub(crate) fn export_records(
 
     let mut items = Vec::new();
     for id in ids {
-        if let Some(record) = state.storage.get(collection, &id)? {
+        if let Some(mut record) = state.storage.get(collection, &id)? {
+            if collection == "messages" {
+                message_swipes::materialize_message(state, &mut record, true)?;
+            }
             items.push(if format == Some("compatible") {
                 compatible_record(collection, &record)?
             } else {

--- a/src-tauri/src/commands/storage/game_state_snapshots.rs
+++ b/src-tauri/src/commands/storage/game_state_snapshots.rs
@@ -4,7 +4,8 @@ use marinara_core::{ensure_object, AppError, AppResult};
 use serde_json::{json, Map, Value};
 use std::collections::HashSet;
 
-use super::shared::{materialize_message_swipe_fields, non_negative_i64_value, swipe_index_value};
+use super::message_swipes;
+use super::shared::{non_negative_i64_value, swipe_index_value};
 
 const SNAPSHOT_COLLECTION: &str = "game-state-snapshots";
 const TRACKER_KIND: &str = "tracker";
@@ -333,9 +334,7 @@ fn visible_tracker_snapshot(state: &AppState, chat_id: &str) -> AppResult<Option
         let b_time = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
         a_time.cmp(b_time)
     });
-    for message in &mut messages {
-        materialize_message_swipe_fields(message);
-    }
+    message_swipes::materialize_messages(state, &mut messages, true)?;
     for message in messages.into_iter().rev() {
         if message.get("role").and_then(Value::as_str) != Some("assistant") {
             continue;

--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -975,7 +975,8 @@ fn import_st_chat_text(
                     object.insert("updatedAt".to_string(), Value::String(created_at));
                 }
             }
-            let message = state.storage.create("messages", message_payload)?;
+            let message =
+                crate::storage_commands::message_swipes::create_message(state, message_payload)?;
             created_message_ids.push(created_record_id(&message, "message")?);
             imported += 1;
         }
@@ -1898,10 +1899,12 @@ mod tests {
             Some("individual")
         );
 
-        let messages = state
+        let mut messages = state
             .storage
             .list("messages")
             .expect("messages should list");
+        crate::storage_commands::message_swipes::materialize_messages(&state, &mut messages, true)
+            .expect("messages should materialize sidecar swipes");
         let rendered_alice = row_with_content(&messages, "Raw Alice");
         assert_eq!(
             rendered_alice.get("characterId").and_then(Value::as_str),

--- a/src-tauri/src/commands/storage/imports/marinara_rollback.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_rollback.rs
@@ -78,6 +78,13 @@ pub(super) fn rollback_created_records_collect(
     record_ids: &[String],
     rollback_errors: &mut Vec<String>,
 ) {
+    if collection == "messages" {
+        if let Err(error) =
+            crate::storage_commands::message_swipes::delete_for_messages(state, record_ids)
+        {
+            rollback_errors.push(format!("message-swipes for messages: {error}"));
+        }
+    }
     for record_id in record_ids.iter().rev() {
         if let Err(rollback_error) = state.storage.delete(collection, record_id) {
             rollback_errors.push(format!("{record_id}: {rollback_error}"));

--- a/src-tauri/src/commands/storage/imports/rollback.rs
+++ b/src-tauri/src/commands/storage/imports/rollback.rs
@@ -37,6 +37,13 @@ pub(super) fn rollback_created_records(
     record_ids: &[String],
     rollback_errors: &mut Vec<String>,
 ) {
+    if collection == "messages" {
+        if let Err(error) =
+            crate::storage_commands::message_swipes::delete_for_messages(state, record_ids)
+        {
+            rollback_errors.push(format!("message-swipes for messages: {error}"));
+        }
+    }
     for record_id in record_ids.iter().rev() {
         if let Err(error) = state.storage.delete(collection, record_id) {
             rollback_errors.push(format!("{collection}/{record_id}: {error}"));

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -522,6 +522,11 @@ fn apply_sidecar_swipes(
         materialize_message_swipe_fields(message);
     } else if materialization.materialize_active_swipe {
         materialize_missing_active_swipe_extra(message);
+        if !materialization.search_swipes {
+            if let Some(object) = message.as_object_mut() {
+                object.remove("swipes");
+            }
+        }
     }
 }
 
@@ -665,7 +670,7 @@ pub(crate) fn materialize_messages_for_output(
     }
     let mut grouped: HashMap<String, Vec<Value>> = HashMap::new();
     let sidecars = if materialization.include_swipes {
-        state.storage.list(COLLECTION)?
+        state.storage.list_where_in(COLLECTION, "messageId", &ids)?
     } else {
         let fields = sidecar_summary_fields(materialization);
         state.storage.list_projected_where_in(
@@ -1285,6 +1290,71 @@ mod tests {
             .expect("stored message should exist")
             .get("swipes")
             .is_none());
+    }
+
+    #[test]
+    fn active_extra_projection_uses_sidecar_without_returning_swipes() {
+        let state = test_state("active-extra-projection-strips-sidecars");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "active parent",
+                    "activeSwipeIndex": 1,
+                    "extra": { "persistent": "keep" }
+                })],
+            )
+            .expect("messages should seed");
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "first",
+                        "extra": { "thinking": "first thought" }
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "active parent",
+                        "extra": { "thinking": "active thought" }
+                    }),
+                ],
+            )
+            .expect("sidecars should seed");
+
+        let mut message = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should exist");
+        materialize_message_for_output(
+            &state,
+            &mut message,
+            MessageSwipeMaterialization {
+                include_swipes: false,
+                include_swipe_count: false,
+                include_swipe_previews: false,
+                search_swipes: false,
+                materialize_active_swipe: true,
+            },
+        )
+        .expect("message should materialize");
+
+        assert!(message.get("swipes").is_none());
+        assert_eq!(message["extra"]["persistent"], "keep");
+        assert_eq!(message["extra"]["thinking"], "active thought");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -57,7 +57,7 @@ impl MessageSwipeMaterialization {
             include_swipe_count: has_field("swipeCount"),
             include_swipe_previews: has_field("swipePreviews"),
             search_swipes: has_search,
-            materialize_active_swipe: has_field("swipes") || (!has_search && has_field("extra")),
+            materialize_active_swipe: has_field("swipes") || has_field("extra"),
         }
     }
 

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -100,6 +100,17 @@ fn sidecar_index(row: &Value) -> usize {
         .unwrap_or(0)
 }
 
+fn sidecar_message_id(row: &Value) -> Option<&str> {
+    row.get("messageId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+}
+
+fn sidecar_matches_message_id(row: &Value, message_id: &str) -> bool {
+    sidecar_message_id(row) == Some(message_id)
+}
+
 fn sort_swipes(swipes: &mut [Value]) {
     swipes.sort_by(|a, b| {
         sidecar_index(a).cmp(&sidecar_index(b)).then_with(|| {
@@ -370,9 +381,7 @@ fn write_message_and_swipes(
             }
 
             let sidecars = collections[1].rows_mut();
-            sidecars.retain(|row| {
-                row.get("messageId").and_then(Value::as_str) != Some(message_id.as_str())
-            });
+            sidecars.retain(|row| !sidecar_matches_message_id(row, &message_id));
             sidecars.extend(replacement);
             sort_sidecar_rows(sidecars);
 
@@ -592,7 +601,9 @@ pub(crate) fn materialize_message_for_output(
     let Some(id) = message
         .get("id")
         .and_then(Value::as_str)
-        .map(str::to_string)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
     else {
         return Ok(());
     };
@@ -609,17 +620,13 @@ pub(crate) fn materialize_message_for_output(
         }
         return Ok(());
     }
-    let mut filters = Map::new();
-    filters.insert("messageId".to_string(), Value::String(id));
+    let filter_values = HashSet::from([id.clone()]);
     let mut swipes = if materialization.include_swipes {
-        state.storage.list_where(COLLECTION, &filters)?
+        state
+            .storage
+            .list_where_in(COLLECTION, "messageId", &filter_values)?
     } else {
         let fields = sidecar_summary_fields(materialization);
-        let filter_values = HashSet::from([filters
-            .get("messageId")
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .to_string()]);
         state.storage.list_projected_where_in(
             COLLECTION,
             "messageId",
@@ -717,12 +724,8 @@ pub(crate) fn materialize_messages_for_output(
 
 #[cfg(test)]
 pub(crate) fn swipes_for_message(state: &AppState, message_id: &str) -> AppResult<Vec<Value>> {
-    let mut filters = Map::new();
-    filters.insert(
-        "messageId".to_string(),
-        Value::String(message_id.to_string()),
-    );
-    let mut swipes = state.storage.list_where(COLLECTION, &filters)?;
+    let ids = HashSet::from([message_id.to_string()]);
+    let mut swipes = state.storage.list_where_in(COLLECTION, "messageId", &ids)?;
     sort_swipes(&mut swipes);
     Ok(public_swipes_from_rows(&swipes))
 }
@@ -736,9 +739,7 @@ pub(crate) fn delete_for_messages(state: &AppState, message_ids: &[String]) -> A
         .map(String::as_str)
         .collect::<HashSet<_>>();
     state.storage.delete_where_matching(COLLECTION, |row| {
-        row.get("messageId")
-            .and_then(Value::as_str)
-            .is_some_and(|message_id| ids.contains(message_id))
+        sidecar_message_id(row).is_some_and(|message_id| ids.contains(message_id))
     })
 }
 
@@ -778,9 +779,7 @@ pub(crate) fn delete_message_rows_with_swipes(
 
             let sidecars = collections[1].rows_mut();
             sidecars.retain(|row| {
-                row.get("messageId")
-                    .and_then(Value::as_str)
-                    .is_none_or(|message_id| !deleted_ids.contains(message_id))
+                sidecar_message_id(row).is_none_or(|message_id| !deleted_ids.contains(message_id))
             });
 
             Ok(deleted)
@@ -820,9 +819,7 @@ pub(crate) fn delete_message_rows_for_chats_with_swipes(
                     .get("chatId")
                     .and_then(Value::as_str)
                     .is_some_and(|chat_id| chat_ids.contains(chat_id));
-                let matches_deleted_message = row
-                    .get("messageId")
-                    .and_then(Value::as_str)
+                let matches_deleted_message = sidecar_message_id(row)
                     .is_some_and(|message_id| deleted_message_ids.contains(message_id));
                 !(matches_chat || matches_deleted_message)
             });
@@ -1388,7 +1385,145 @@ mod tests {
         assert_eq!(messages[0]["content"], "legacy padded message id");
         assert_eq!(messages[0]["swipeCount"], json!(1));
         assert_eq!(messages[0]["extra"]["thinking"], "trimmed thought");
-        assert_eq!(messages[0]["swipes"][0]["content"], "legacy padded message id");
+        assert_eq!(
+            messages[0]["swipes"][0]["content"],
+            "legacy padded message id"
+        );
+    }
+
+    #[test]
+    fn single_full_materialization_accepts_trimmed_legacy_sidecar_message_ids() {
+        let state = test_state("single-full-materialize-trimmed-sidecar-message-id");
+        let mut message = json!({
+            "id": "message-1",
+            "chatId": "chat-1",
+            "role": "assistant",
+            "content": "active parent",
+            "activeSwipeIndex": 0
+        });
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "chat-1",
+                    "messageId": " message-1 ",
+                    "index": 0,
+                    "content": "legacy padded message id",
+                    "extra": { "thinking": "trimmed thought" }
+                })],
+            )
+            .expect("sidecars should seed");
+
+        materialize_message_for_output(&state, &mut message, MessageSwipeMaterialization::full())
+            .expect("message should materialize");
+
+        assert_eq!(message["content"], "legacy padded message id");
+        assert_eq!(message["swipeCount"], json!(1));
+        assert_eq!(message["extra"]["thinking"], "trimmed thought");
+        assert_eq!(message["swipes"][0]["messageId"], " message-1 ");
+        assert_eq!(message["swipes"][0]["content"], "legacy padded message id");
+    }
+
+    #[test]
+    fn replacing_message_swipes_removes_trimmed_legacy_sidecar_rows() {
+        let state = test_state("replace-trimmed-legacy-sidecar-message-id");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "old",
+                    "activeSwipeIndex": 0
+                })],
+            )
+            .expect("message should seed");
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "chat-1",
+                    "messageId": " message-1 ",
+                    "index": 0,
+                    "content": "legacy padded message id"
+                })],
+            )
+            .expect("sidecars should seed");
+
+        replace_message_with_swipes(
+            &state,
+            json!({
+                "id": "message-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "replacement",
+                "activeSwipeIndex": 0
+            }),
+            vec![json!({ "content": "replacement" })],
+        )
+        .expect("message should replace");
+
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecars should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["messageId"], "message-1");
+        assert_eq!(sidecars[0]["content"], "replacement");
+    }
+
+    #[test]
+    fn deleting_message_rows_removes_trimmed_legacy_sidecar_rows() {
+        let state = test_state("delete-trimmed-legacy-sidecar-message-id");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({ "id": "message-1", "chatId": "chat-1", "content": "delete me" }),
+                    json!({ "id": "message-2", "chatId": "chat-1", "content": "keep me" }),
+                ],
+            )
+            .expect("messages should seed");
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "stale-chat-id",
+                        "messageId": " message-1 ",
+                        "index": 0,
+                        "content": "delete sidecar"
+                    }),
+                    json!({
+                        "id": "message-2::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-2",
+                        "index": 0,
+                        "content": "keep sidecar"
+                    }),
+                ],
+            )
+            .expect("sidecars should seed");
+
+        let deleted = delete_message_rows_with_swipes(&state, &["message-1".to_string()])
+            .expect("message and trimmed sidecar should delete together");
+
+        assert_eq!(deleted, 1);
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecars should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["messageId"], "message-2");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -1358,6 +1358,40 @@ mod tests {
     }
 
     #[test]
+    fn batched_full_materialization_accepts_trimmed_legacy_sidecar_message_ids() {
+        let state = test_state("batch-full-materialize-trimmed-sidecar-message-id");
+        let mut messages = vec![json!({
+            "id": "message-1",
+            "chatId": "chat-1",
+            "role": "assistant",
+            "content": "active parent",
+            "activeSwipeIndex": 0
+        })];
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "chat-1",
+                    "messageId": " message-1 ",
+                    "index": 0,
+                    "content": "legacy padded message id",
+                    "extra": { "thinking": "trimmed thought" }
+                })],
+            )
+            .expect("sidecars should seed");
+
+        materialize_messages_for_output(&state, &mut messages, MessageSwipeMaterialization::full())
+            .expect("messages should materialize");
+
+        assert_eq!(messages[0]["content"], "legacy padded message id");
+        assert_eq!(messages[0]["swipeCount"], json!(1));
+        assert_eq!(messages[0]["extra"]["thinking"], "trimmed thought");
+        assert_eq!(messages[0]["swipes"][0]["content"], "legacy padded message id");
+    }
+
+    #[test]
     fn create_message_keeps_response_compatible_but_persists_sidecar_swipes() {
         let state = test_state("create");
         let created = create_message(

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -1,0 +1,1385 @@
+use super::shared::{
+    collapse_excess_blank_lines, compact_message_swipe_fields_for_storage, json_object_value,
+    materialize_message_swipe_fields, normalize_typed_json_fields, swipe_scoped_extra,
+    sync_message_patch_content_to_active_swipe,
+};
+use crate::state::AppState;
+use marinara_core::{ensure_object, new_id, now_iso, AppError, AppResult};
+use marinara_storage::FileStorage;
+use serde_json::{json, Map, Value};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+pub(crate) const COLLECTION: &str = "message-swipes";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct MessageSwipeMaterialization {
+    pub(crate) include_swipes: bool,
+    pub(crate) include_swipe_count: bool,
+    pub(crate) include_swipe_previews: bool,
+    pub(crate) search_swipes: bool,
+    pub(crate) materialize_active_swipe: bool,
+}
+
+impl MessageSwipeMaterialization {
+    pub(crate) fn summary() -> Self {
+        Self {
+            include_swipes: false,
+            include_swipe_count: true,
+            include_swipe_previews: true,
+            search_swipes: false,
+            materialize_active_swipe: false,
+        }
+    }
+
+    pub(crate) fn full() -> Self {
+        Self {
+            include_swipes: true,
+            include_swipe_count: true,
+            include_swipe_previews: true,
+            search_swipes: false,
+            materialize_active_swipe: true,
+        }
+    }
+
+    pub(crate) fn for_message_output(options: Option<&Value>, has_search: bool) -> Self {
+        let Some(fields) = options
+            .and_then(|value| value.get("fields"))
+            .and_then(Value::as_array)
+        else {
+            return Self {
+                search_swipes: has_search,
+                ..Self::full()
+            };
+        };
+        let has_field = |name: &str| fields.iter().any(|field| field.as_str() == Some(name));
+        Self {
+            include_swipes: has_field("swipes"),
+            include_swipe_count: has_field("swipeCount"),
+            include_swipe_previews: has_field("swipePreviews"),
+            search_swipes: has_search,
+            materialize_active_swipe: has_field("swipes") || (!has_search && has_field("extra")),
+        }
+    }
+
+    fn needs_sidecars(self) -> bool {
+        self.include_swipes
+            || self.include_swipe_count
+            || self.include_swipe_previews
+            || self.search_swipes
+            || self.materialize_active_swipe
+    }
+}
+
+fn message_id(message: &Value) -> AppResult<String> {
+    message
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| AppError::invalid_input("Message is missing an id"))
+}
+
+fn optional_chat_id(message: &Value) -> Option<String> {
+    message
+        .get("chatId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn sidecar_row_id(message_id: &str, index: usize) -> String {
+    format!("{message_id}::swipe::{index}")
+}
+
+fn sidecar_index(row: &Value) -> usize {
+    row.get("index")
+        .and_then(Value::as_u64)
+        .map(|index| index as usize)
+        .unwrap_or(0)
+}
+
+fn sort_swipes(swipes: &mut [Value]) {
+    swipes.sort_by(|a, b| {
+        sidecar_index(a).cmp(&sidecar_index(b)).then_with(|| {
+            let a_created = a.get("createdAt").and_then(Value::as_str).unwrap_or("");
+            let b_created = b.get("createdAt").and_then(Value::as_str).unwrap_or("");
+            a_created.cmp(b_created)
+        })
+    });
+}
+
+fn sidecar_summary_fields(materialization: MessageSwipeMaterialization) -> Vec<String> {
+    let mut fields = ["messageId", "index", "createdAt", "content", "characterId"]
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if materialization.materialize_active_swipe {
+        fields.push("extra".to_string());
+    }
+    fields
+}
+
+fn strip_message_derived_fields(object: &mut Map<String, Value>) -> bool {
+    let mut changed = false;
+    for field in ["swipes", "swipeCount", "swipePreviews"] {
+        changed |= object.remove(field).is_some();
+    }
+    changed
+}
+
+pub(crate) fn take_swipes_for_storage(message: &mut Value) -> AppResult<Option<Vec<Value>>> {
+    let Some(object) = message.as_object_mut() else {
+        return Ok(None);
+    };
+    compact_message_swipe_fields_for_storage(object);
+    let swipes = match object.remove("swipes") {
+        Some(Value::Array(swipes)) => Some(swipes),
+        Some(_) => {
+            return Err(AppError::invalid_input(
+                "Message swipes must be a JSON array",
+            ));
+        }
+        None => None,
+    };
+    object.remove("swipeCount");
+    object.remove("swipePreviews");
+    Ok(swipes)
+}
+
+fn normalize_swipe_row(
+    message_id: &str,
+    chat_id: Option<&str>,
+    message_created_at: Option<&str>,
+    index: usize,
+    swipe: &Value,
+) -> AppResult<Value> {
+    let mut object = swipe.as_object().cloned().unwrap_or_default();
+    let now = now_iso();
+    object.insert(
+        "id".to_string(),
+        Value::String(sidecar_row_id(message_id, index)),
+    );
+    object.insert(
+        "messageId".to_string(),
+        Value::String(message_id.to_string()),
+    );
+    if let Some(chat_id) = chat_id {
+        object.insert("chatId".to_string(), Value::String(chat_id.to_string()));
+    }
+    object.insert("index".to_string(), json!(index));
+    if let Some(Value::String(content)) = object.get_mut("content") {
+        *content = collapse_excess_blank_lines(content);
+    }
+    object
+        .entry("createdAt".to_string())
+        .or_insert_with(|| Value::String(message_created_at.unwrap_or(&now).to_string()));
+    object
+        .entry("updatedAt".to_string())
+        .or_insert_with(|| Value::String(now));
+    normalize_typed_json_fields(COLLECTION, &mut object)?;
+    Ok(Value::Object(object))
+}
+
+fn swipe_rows_for_message(message: &Value, swipes: &[Value]) -> AppResult<Vec<Value>> {
+    let message_id = message_id(message)?;
+    let chat_id = optional_chat_id(message);
+    let created_at = message.get("createdAt").and_then(Value::as_str);
+    swipes
+        .iter()
+        .enumerate()
+        .map(|(index, swipe)| {
+            normalize_swipe_row(&message_id, chat_id.as_deref(), created_at, index, swipe)
+        })
+        .collect()
+}
+
+fn sort_sidecar_rows(rows: &mut [Value]) {
+    rows.sort_by(|a, b| {
+        a.get("messageId")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .cmp(b.get("messageId").and_then(Value::as_str).unwrap_or(""))
+            .then_with(|| sidecar_index(a).cmp(&sidecar_index(b)))
+    });
+}
+
+pub(crate) fn normalize_message_rows_and_sidecars(
+    messages: Vec<Value>,
+    sidecars: Vec<Value>,
+) -> AppResult<(Vec<Value>, Vec<Value>)> {
+    let (messages, sidecars, _) = normalize_message_rows_and_sidecars_inner(messages, sidecars)?;
+    Ok((messages, sidecars))
+}
+
+fn normalize_message_rows_and_sidecars_inner(
+    mut messages: Vec<Value>,
+    sidecars: Vec<Value>,
+) -> AppResult<(Vec<Value>, Vec<Value>, bool)> {
+    let message_ids = messages
+        .iter()
+        .filter_map(|message| {
+            message
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(ToOwned::to_owned)
+        })
+        .collect::<HashSet<_>>();
+    let mut changed = false;
+    let mut sidecar_by_key: BTreeMap<(String, usize), Value> = BTreeMap::new();
+    for row in sidecars {
+        let Some(message_id) = row
+            .get("messageId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            changed = true;
+            continue;
+        };
+        if !message_ids.contains(&message_id) {
+            changed = true;
+            continue;
+        }
+        let key = (message_id, sidecar_index(&row));
+        if sidecar_by_key.insert(key, row).is_some() {
+            changed = true;
+        }
+    }
+
+    for message in &mut messages {
+        let Some(object) = message.as_object_mut() else {
+            continue;
+        };
+        let message_id = match object.get("id").and_then(Value::as_str) {
+            Some(id) if !id.trim().is_empty() => id.trim().to_string(),
+            _ => continue,
+        };
+        let Some(mut swipes) = object.get("swipes").and_then(Value::as_array).cloned() else {
+            if strip_message_derived_fields(object) {
+                changed = true;
+            }
+            continue;
+        };
+        let active_index = object
+            .get("activeSwipeIndex")
+            .and_then(Value::as_u64)
+            .map(|index| index as usize)
+            .unwrap_or(0);
+        let parent_extra = object.get("extra").cloned();
+        preserve_parent_active_extra(&mut swipes, active_index, parent_extra.as_ref());
+        object.insert("swipes".to_string(), Value::Array(swipes.clone()));
+        materialize_message_swipe_fields(message);
+        if let Some(object) = message.as_object_mut() {
+            compact_message_swipe_fields_for_storage(object);
+            let compacted_swipes = object.get("swipes").and_then(Value::as_array).cloned();
+            if let Some(compacted_swipes) = compacted_swipes {
+                swipes = compacted_swipes;
+            }
+        }
+        sidecar_by_key.retain(|(existing_message_id, _), _| existing_message_id != &message_id);
+        let rows = swipe_rows_for_message(message, &swipes)?;
+        for (index, row) in rows.into_iter().enumerate() {
+            sidecar_by_key.insert((message_id.clone(), index), row);
+        }
+        if let Some(object) = message.as_object_mut() {
+            strip_message_derived_fields(object);
+        }
+        changed = true;
+    }
+
+    let sidecars = sidecar_by_key.into_values().collect::<Vec<_>>();
+    Ok((messages, sidecars, changed))
+}
+
+fn prepare_message_create_row(state: &AppState, value: Value) -> AppResult<Value> {
+    let mut object = ensure_object(value)?;
+    let had_id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.trim().is_empty());
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(new_id);
+    if had_id && state.storage.get("messages", &id)?.is_some() {
+        return Err(AppError::invalid_input(format!(
+            "messages/{id} already exists"
+        )));
+    }
+    let now = now_iso();
+    object.insert("id".to_string(), Value::String(id));
+    object
+        .entry("createdAt".to_string())
+        .or_insert_with(|| Value::String(now.clone()));
+    object
+        .entry("updatedAt".to_string())
+        .or_insert_with(|| Value::String(now));
+    normalize_typed_json_fields("messages", &mut object)?;
+    Ok(Value::Object(object))
+}
+
+fn message_row_for_write(message: Value, force_updated_at: bool) -> AppResult<(String, Value)> {
+    let id = message_id(&message)?;
+    let mut object = ensure_object(message)?;
+    let now = now_iso();
+    object.insert("id".to_string(), Value::String(id.clone()));
+    object
+        .entry("createdAt".to_string())
+        .or_insert_with(|| Value::String(now.clone()));
+    if force_updated_at {
+        object.insert("updatedAt".to_string(), Value::String(now));
+    } else {
+        object
+            .entry("updatedAt".to_string())
+            .or_insert_with(|| Value::String(now));
+    }
+    normalize_typed_json_fields("messages", &mut object)?;
+    Ok((id, Value::Object(object)))
+}
+
+fn write_message_and_swipes(
+    state: &AppState,
+    message: Value,
+    swipes: Vec<Value>,
+    force_updated_at: bool,
+) -> AppResult<Value> {
+    let (message_id, message) = message_row_for_write(message, force_updated_at)?;
+    let replacement = swipe_rows_for_message(&message, &swipes)?;
+    state
+        .storage
+        .update_collections_atomically(vec!["messages", COLLECTION], move |collections| {
+            let messages = collections[0].rows_mut();
+            let mut replaced = false;
+            for row in messages.iter_mut() {
+                if row.get("id").and_then(Value::as_str) == Some(message_id.as_str()) {
+                    *row = message.clone();
+                    replaced = true;
+                    break;
+                }
+            }
+            if !replaced {
+                messages.push(message.clone());
+            }
+
+            let sidecars = collections[1].rows_mut();
+            sidecars.retain(|row| {
+                row.get("messageId").and_then(Value::as_str) != Some(message_id.as_str())
+            });
+            sidecars.extend(replacement);
+            sort_sidecar_rows(sidecars);
+
+            Ok(message)
+        })
+}
+
+pub(crate) fn replace_message_with_swipes(
+    state: &AppState,
+    message: Value,
+    swipes: Vec<Value>,
+) -> AppResult<Value> {
+    write_message_and_swipes(state, message, swipes, true)
+}
+
+fn preserve_parent_active_extra(swipes: &mut [Value], active_index: usize, extra: Option<&Value>) {
+    let Some(extra) = swipe_scoped_extra(extra) else {
+        return;
+    };
+    if swipes.is_empty() {
+        return;
+    }
+    let active_index = active_index.min(swipes.len().saturating_sub(1));
+    let Some(Value::Object(swipe)) = swipes.get_mut(active_index) else {
+        return;
+    };
+    let mut merged = json_object_value(swipe.get("extra"))
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    let Some(parent) = extra.as_object() else {
+        return;
+    };
+    for (key, value) in parent {
+        merged.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+    swipe.insert("extra".to_string(), Value::Object(merged));
+}
+
+fn preserve_embedded_parent_active_extra(message: &mut Value) {
+    let Some(object) = message.as_object_mut() else {
+        return;
+    };
+    let Some(mut swipes) = object.get("swipes").and_then(Value::as_array).cloned() else {
+        return;
+    };
+    let active_index = object
+        .get("activeSwipeIndex")
+        .and_then(Value::as_u64)
+        .map(|index| index as usize)
+        .unwrap_or(0);
+    let parent_extra = object.get("extra").cloned();
+    preserve_parent_active_extra(&mut swipes, active_index, parent_extra.as_ref());
+    object.insert("swipes".to_string(), Value::Array(swipes));
+}
+
+fn initial_swipe_for_message(message: &Value) -> Value {
+    let mut swipe = Map::new();
+    swipe.insert(
+        "content".to_string(),
+        Value::String(
+            message
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        ),
+    );
+    if let Some(extra) = swipe_scoped_extra(message.get("extra")) {
+        swipe.insert("extra".to_string(), extra);
+    }
+    Value::Object(swipe)
+}
+
+fn public_swipes_from_rows(rows: &[Value]) -> Vec<Value> {
+    rows.iter()
+        .enumerate()
+        .map(|(index, row)| {
+            let mut object = row.as_object().cloned().unwrap_or_default();
+            object.insert("index".to_string(), json!(index));
+            Value::Object(object)
+        })
+        .collect()
+}
+
+fn swipe_previews_from_rows(rows: &[Value]) -> Vec<Value> {
+    rows.iter()
+        .map(|row| {
+            let mut preview = Map::new();
+            preview.insert(
+                "content".to_string(),
+                Value::String(
+                    row.get("content")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                ),
+            );
+            if let Some(character_id) = row.get("characterId") {
+                preview.insert("characterId".to_string(), character_id.clone());
+            }
+            Value::Object(preview)
+        })
+        .collect()
+}
+
+fn apply_sidecar_swipes(
+    message: &mut Value,
+    swipes: &[Value],
+    materialization: MessageSwipeMaterialization,
+) {
+    if swipes.is_empty() {
+        if let Some(object) = message.as_object_mut() {
+            if materialization.include_swipes || materialization.search_swipes {
+                object.remove("swipes");
+            }
+            if materialization.include_swipe_count {
+                object.insert("swipeCount".to_string(), json!(0));
+            }
+            if materialization.include_swipe_previews {
+                object.insert("swipePreviews".to_string(), Value::Array(Vec::new()));
+            }
+        }
+        return;
+    }
+
+    let should_insert_swipes = materialization.include_swipes
+        || materialization.search_swipes
+        || materialization.materialize_active_swipe;
+    if let Some(object) = message.as_object_mut() {
+        if should_insert_swipes {
+            object.insert(
+                "swipes".to_string(),
+                Value::Array(public_swipes_from_rows(swipes)),
+            );
+        }
+        if materialization.include_swipe_count {
+            object.insert("swipeCount".to_string(), json!(swipes.len()));
+        }
+        if materialization.include_swipe_previews {
+            object.insert(
+                "swipePreviews".to_string(),
+                Value::Array(swipe_previews_from_rows(swipes)),
+            );
+        }
+    }
+    if materialization.include_swipes {
+        materialize_message_swipe_fields(message);
+    } else if materialization.materialize_active_swipe {
+        materialize_missing_active_swipe_extra(message);
+    }
+}
+
+fn materialize_missing_active_swipe_extra(message: &mut Value) {
+    let Some(object) = message.as_object_mut() else {
+        return;
+    };
+    let active_index = object
+        .get("activeSwipeIndex")
+        .and_then(Value::as_u64)
+        .map(|index| index as usize)
+        .unwrap_or(0);
+    let Some(swipes) = object.get("swipes").and_then(Value::as_array) else {
+        return;
+    };
+    let Some(active_swipe) = swipes.get(active_index.min(swipes.len().saturating_sub(1))) else {
+        return;
+    };
+    let Some(active_extra) = swipe_scoped_extra(active_swipe.get("extra")) else {
+        return;
+    };
+    let Some(active_extra) = active_extra.as_object() else {
+        return;
+    };
+    let mut merged = json_object_value(object.get("extra"))
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    for (key, value) in active_extra {
+        merged.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+    object.insert("extra".to_string(), Value::Object(merged));
+}
+
+pub(crate) fn migrate_nested_message_swipes(storage: &FileStorage) -> AppResult<()> {
+    let messages = storage.list("messages")?;
+    let sidecars = storage.list(COLLECTION)?;
+    let (messages, sidecars, changed) =
+        normalize_message_rows_and_sidecars_inner(messages, sidecars)?;
+    if changed {
+        storage.replace_all_many(vec![(COLLECTION, sidecars), ("messages", messages)])?;
+    }
+    Ok(())
+}
+
+pub(crate) fn materialize_message(
+    state: &AppState,
+    message: &mut Value,
+    include_swipes: bool,
+) -> AppResult<()> {
+    let materialization = if include_swipes {
+        MessageSwipeMaterialization::full()
+    } else {
+        MessageSwipeMaterialization::summary()
+    };
+    materialize_message_for_output(state, message, materialization)
+}
+
+pub(crate) fn materialize_message_for_output(
+    state: &AppState,
+    message: &mut Value,
+    materialization: MessageSwipeMaterialization,
+) -> AppResult<()> {
+    let Some(id) = message
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return Ok(());
+    };
+    if !materialization.needs_sidecars() {
+        return Ok(());
+    }
+    if message.get("swipes").and_then(Value::as_array).is_some() {
+        preserve_embedded_parent_active_extra(message);
+        materialize_message_swipe_fields(message);
+        if !materialization.include_swipes {
+            if let Some(object) = message.as_object_mut() {
+                object.remove("swipes");
+            }
+        }
+        return Ok(());
+    }
+    let mut filters = Map::new();
+    filters.insert("messageId".to_string(), Value::String(id));
+    let mut swipes = if materialization.include_swipes {
+        state.storage.list_where(COLLECTION, &filters)?
+    } else {
+        let fields = sidecar_summary_fields(materialization);
+        let filter_values = HashSet::from([filters
+            .get("messageId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()]);
+        state.storage.list_projected_where_in(
+            COLLECTION,
+            "messageId",
+            &filter_values,
+            &fields,
+            &Map::new(),
+        )?
+    };
+    sort_swipes(&mut swipes);
+    apply_sidecar_swipes(message, &swipes, materialization);
+    Ok(())
+}
+
+pub(crate) fn materialize_messages(
+    state: &AppState,
+    messages: &mut [Value],
+    include_swipes: bool,
+) -> AppResult<()> {
+    let materialization = if include_swipes {
+        MessageSwipeMaterialization::full()
+    } else {
+        MessageSwipeMaterialization::summary()
+    };
+    materialize_messages_for_output(state, messages, materialization)
+}
+
+pub(crate) fn materialize_messages_for_output(
+    state: &AppState,
+    messages: &mut [Value],
+    materialization: MessageSwipeMaterialization,
+) -> AppResult<()> {
+    if !materialization.needs_sidecars() {
+        return Ok(());
+    }
+    let ids = messages
+        .iter()
+        .filter_map(|message| {
+            message
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(ToOwned::to_owned)
+        })
+        .collect::<HashSet<_>>();
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let mut grouped: HashMap<String, Vec<Value>> = HashMap::new();
+    let sidecars = if materialization.include_swipes {
+        state.storage.list(COLLECTION)?
+    } else {
+        let fields = sidecar_summary_fields(materialization);
+        state.storage.list_projected_where_in(
+            COLLECTION,
+            "messageId",
+            &ids,
+            &fields,
+            &Map::new(),
+        )?
+    };
+    for row in sidecars {
+        let Some(message_id) = row
+            .get("messageId")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| ids.contains(*id))
+        else {
+            continue;
+        };
+        grouped.entry(message_id.to_string()).or_default().push(row);
+    }
+    for swipes in grouped.values_mut() {
+        sort_swipes(swipes);
+    }
+    for message in messages {
+        if message.get("swipes").and_then(Value::as_array).is_some() {
+            preserve_embedded_parent_active_extra(message);
+            materialize_message_swipe_fields(message);
+            if !materialization.include_swipes {
+                if let Some(object) = message.as_object_mut() {
+                    object.remove("swipes");
+                }
+            }
+            continue;
+        }
+        let Some(id) = message.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let swipes = grouped.get(id).map(Vec::as_slice).unwrap_or(&[]);
+        apply_sidecar_swipes(message, swipes, materialization);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn swipes_for_message(state: &AppState, message_id: &str) -> AppResult<Vec<Value>> {
+    let mut filters = Map::new();
+    filters.insert(
+        "messageId".to_string(),
+        Value::String(message_id.to_string()),
+    );
+    let mut swipes = state.storage.list_where(COLLECTION, &filters)?;
+    sort_swipes(&mut swipes);
+    Ok(public_swipes_from_rows(&swipes))
+}
+
+pub(crate) fn delete_for_messages(state: &AppState, message_ids: &[String]) -> AppResult<usize> {
+    if message_ids.is_empty() {
+        return Ok(0);
+    }
+    let ids = message_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    state.storage.delete_where_matching(COLLECTION, |row| {
+        row.get("messageId")
+            .and_then(Value::as_str)
+            .is_some_and(|message_id| ids.contains(message_id))
+    })
+}
+
+pub(crate) fn delete_message_rows_with_swipes(
+    state: &AppState,
+    message_ids: &[String],
+) -> AppResult<usize> {
+    if message_ids.is_empty() {
+        return Ok(0);
+    }
+    let requested_ids = message_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    state
+        .storage
+        .update_collections_atomically(vec!["messages", COLLECTION], move |collections| {
+            let messages = collections[0].rows_mut();
+            let original_message_count = messages.len();
+            let mut deleted_ids = HashSet::new();
+            messages.retain(|row| {
+                let should_delete = row
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|id| requested_ids.contains(id));
+                if should_delete {
+                    if let Some(id) = row.get("id").and_then(Value::as_str) {
+                        deleted_ids.insert(id.to_string());
+                    }
+                }
+                !should_delete
+            });
+            let deleted = original_message_count.saturating_sub(messages.len());
+            if deleted == 0 {
+                return Ok(0);
+            }
+
+            let sidecars = collections[1].rows_mut();
+            sidecars.retain(|row| {
+                row.get("messageId")
+                    .and_then(Value::as_str)
+                    .is_none_or(|message_id| !deleted_ids.contains(message_id))
+            });
+
+            Ok(deleted)
+        })
+}
+
+pub(crate) fn delete_message_rows_for_chats_with_swipes(
+    state: &AppState,
+    chat_ids: &HashSet<String>,
+) -> AppResult<usize> {
+    if chat_ids.is_empty() {
+        return Ok(0);
+    }
+    state
+        .storage
+        .update_collections_atomically(vec!["messages", COLLECTION], move |collections| {
+            let messages = collections[0].rows_mut();
+            let original_message_count = messages.len();
+            let mut deleted_message_ids = HashSet::new();
+            messages.retain(|row| {
+                let should_delete = row
+                    .get("chatId")
+                    .and_then(Value::as_str)
+                    .is_some_and(|chat_id| chat_ids.contains(chat_id));
+                if should_delete {
+                    if let Some(id) = row.get("id").and_then(Value::as_str) {
+                        deleted_message_ids.insert(id.to_string());
+                    }
+                }
+                !should_delete
+            });
+            let deleted = original_message_count.saturating_sub(messages.len());
+
+            let sidecars = collections[1].rows_mut();
+            sidecars.retain(|row| {
+                let matches_chat = row
+                    .get("chatId")
+                    .and_then(Value::as_str)
+                    .is_some_and(|chat_id| chat_ids.contains(chat_id));
+                let matches_deleted_message = row
+                    .get("messageId")
+                    .and_then(Value::as_str)
+                    .is_some_and(|message_id| deleted_message_ids.contains(message_id));
+                !(matches_chat || matches_deleted_message)
+            });
+
+            Ok(deleted)
+        })
+}
+
+pub(crate) fn create_message(state: &AppState, message: Value) -> AppResult<Value> {
+    let message = prepare_message_create_row(state, message)?;
+    persist_created_message_swipes(state, message)
+}
+
+fn persist_created_message_swipes(state: &AppState, mut message: Value) -> AppResult<Value> {
+    if message.get("swipes").is_some() {
+        preserve_embedded_parent_active_extra(&mut message);
+        materialize_message_swipe_fields(&mut message);
+        let swipes = take_swipes_for_storage(&mut message)?.unwrap_or_default();
+        let mut updated = write_message_and_swipes(state, message, swipes, false)?;
+        materialize_message(state, &mut updated, true)?;
+        return Ok(updated);
+    }
+    let swipes = vec![initial_swipe_for_message(&message)];
+    let mut updated = write_message_and_swipes(state, message, swipes, false)?;
+    materialize_message(state, &mut updated, true)?;
+    Ok(updated)
+}
+
+pub(crate) fn patch_message_update(
+    state: &AppState,
+    message_id: &str,
+    patch: Value,
+) -> AppResult<Value> {
+    let normalized = super::shared::normalize_update_patch("messages", patch)?;
+    let patch_object = normalized.as_object().cloned().unwrap_or_default();
+    let mut message = state
+        .storage
+        .get("messages", message_id)?
+        .ok_or_else(|| AppError::not_found(format!("messages/{message_id} was not found")))?;
+    materialize_message(state, &mut message, true)?;
+    {
+        let object = message
+            .as_object_mut()
+            .ok_or_else(|| AppError::invalid_input("Message is not an object"))?;
+        for (key, value) in patch_object.clone() {
+            object.insert(key, value);
+        }
+        sync_message_patch_content_to_active_swipe(object, &patch_object);
+    }
+    materialize_message_swipe_fields(&mut message);
+    let swipes = take_swipes_for_storage(&mut message)?.unwrap_or_default();
+    let mut updated = write_message_and_swipes(state, message, swipes, true)?;
+    materialize_message(state, &mut updated, true)?;
+    Ok(updated)
+}
+
+pub(crate) fn update_message_content_if_unchanged(
+    state: &AppState,
+    chat_id: &str,
+    message_id: &str,
+    expected_content: &str,
+    content: &str,
+) -> AppResult<Option<Value>> {
+    let content = collapse_excess_blank_lines(content);
+    let mut message = state
+        .storage
+        .get("messages", message_id)?
+        .ok_or_else(|| AppError::not_found(format!("messages/{message_id} was not found")))?;
+    materialize_message(state, &mut message, true)?;
+    {
+        let object = message
+            .as_object_mut()
+            .ok_or_else(|| AppError::invalid_input("Message is not an object"))?;
+        let current_chat_id = object.get("chatId").and_then(Value::as_str).unwrap_or("");
+        if current_chat_id != chat_id {
+            return Ok(None);
+        }
+        let current_content = object.get("content").and_then(Value::as_str).unwrap_or("");
+        if current_content != expected_content {
+            return Ok(None);
+        }
+        let mut patch = Map::new();
+        patch.insert("content".to_string(), Value::String(content.clone()));
+        object.insert("content".to_string(), Value::String(content));
+        sync_message_patch_content_to_active_swipe(object, &patch);
+    }
+    materialize_message_swipe_fields(&mut message);
+    let swipes = take_swipes_for_storage(&mut message)?.unwrap_or_default();
+    let mut updated = write_message_and_swipes(state, message, swipes, true)?;
+    materialize_message(state, &mut updated, true)?;
+    Ok(Some(updated))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(label: &str) -> std::path::PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("marinara-message-swipes-{label}-{nonce}"));
+        if path.exists() {
+            std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
+        }
+        path
+    }
+
+    fn test_state(label: &str) -> AppState {
+        AppState::from_data_dir(temp_root(label), Vec::new())
+            .expect("test app state should initialize")
+    }
+
+    #[test]
+    fn migration_moves_nested_swipes_to_sidecar_and_strips_message_rows() {
+        let root = temp_root("migrate");
+        let storage = FileStorage::new(root.join("data")).expect("storage should initialize");
+        storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "old active",
+                    "activeSwipeIndex": 1,
+                    "extra": { "persistent": "keep", "thinking": "old" },
+                    "swipeCount": 2,
+                    "swipePreviews": [{ "content": "stale" }],
+                    "swipes": [
+                        { "content": "first", "extra": { "thinking": "first thought" } },
+                        { "content": "second", "extra": { "thinking": "second thought" } }
+                    ]
+                })],
+            )
+            .expect("messages should seed");
+
+        migrate_nested_message_swipes(&storage).expect("migration should succeed");
+        migrate_nested_message_swipes(&storage).expect("migration should be idempotent");
+
+        let messages = storage.list("messages").expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].get("swipes").is_none());
+        assert!(messages[0].get("swipeCount").is_none());
+        assert!(messages[0].get("swipePreviews").is_none());
+        assert_eq!(messages[0]["content"], "second");
+        assert_eq!(messages[0]["extra"]["persistent"], "keep");
+        assert!(messages[0]["extra"].get("thinking").is_none());
+
+        let sidecars = storage
+            .list(COLLECTION)
+            .expect("message swipes should list");
+        assert_eq!(sidecars.len(), 2);
+        assert_eq!(sidecars[0]["messageId"], "message-1");
+        assert_eq!(sidecars[0]["chatId"], "chat-1");
+        assert_eq!(sidecars[0]["index"], json!(0));
+        assert_eq!(sidecars[0]["content"], "first");
+        assert_eq!(sidecars[0]["extra"]["thinking"], "first thought");
+        assert_eq!(sidecars[1]["index"], json!(1));
+        assert_eq!(sidecars[1]["content"], "second");
+        assert_eq!(sidecars[1]["extra"]["thinking"], "second thought");
+    }
+
+    #[test]
+    fn migration_replaces_stale_sidecars_for_nested_message_swipes() {
+        let root = temp_root("migrate-replace-stale-sidecars");
+        let storage = FileStorage::new(root.join("data")).expect("storage should initialize");
+        storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "fresh",
+                    "activeSwipeIndex": 0,
+                    "swipes": [{ "content": "fresh" }]
+                })],
+            )
+            .expect("messages should seed");
+        storage
+            .replace_all(
+                COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "stale first"
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "stale extra"
+                    }),
+                    json!({
+                        "id": "orphan::swipe::0",
+                        "chatId": "chat-old",
+                        "messageId": "orphan",
+                        "index": 0,
+                        "content": "orphaned old content"
+                    }),
+                ],
+            )
+            .expect("sidecars should seed");
+
+        migrate_nested_message_swipes(&storage).expect("migration should replace stale sidecars");
+
+        let sidecars = storage
+            .list(COLLECTION)
+            .expect("message swipes should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["messageId"], "message-1");
+        assert_eq!(sidecars[0]["index"], json!(0));
+        assert_eq!(sidecars[0]["content"], "fresh");
+    }
+
+    #[test]
+    fn normalize_strips_stale_derived_fields_when_message_has_no_sidecars() {
+        let (messages, sidecars) = normalize_message_rows_and_sidecars(
+            vec![json!({
+                "id": "message-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "fresh",
+                "activeSwipeIndex": 0,
+                "swipeCount": 2,
+                "swipePreviews": [{ "content": "stale child" }]
+            })],
+            Vec::new(),
+        )
+        .expect("message rows should normalize");
+
+        assert!(sidecars.is_empty());
+        assert!(messages[0].get("swipes").is_none());
+        assert!(messages[0].get("swipeCount").is_none());
+        assert!(messages[0].get("swipePreviews").is_none());
+        assert_eq!(messages[0]["content"], "fresh");
+    }
+
+    #[test]
+    fn materialize_without_sidecars_clears_stale_swipes_and_reports_empty_summary() {
+        let state = test_state("materialize-empty-sidecars-strip-derived");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "fresh",
+                    "activeSwipeIndex": 0,
+                    "swipeCount": 2,
+                    "swipePreviews": [{ "content": "stale child" }]
+                })],
+            )
+            .expect("messages should seed");
+
+        let mut message = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should exist");
+        materialize_message(&state, &mut message, true).expect("message should materialize");
+
+        assert!(message.get("swipes").is_none());
+        assert_eq!(message["swipeCount"], json!(0));
+        assert_eq!(message["swipePreviews"], json!([]));
+        assert_eq!(message["content"], "fresh");
+    }
+
+    #[test]
+    fn malformed_top_level_swipes_are_rejected_before_sidecar_write() {
+        let mut message = json!({
+            "id": "message-1",
+            "chatId": "chat-1",
+            "role": "assistant",
+            "content": "fresh",
+            "swipes": {}
+        });
+
+        let error = take_swipes_for_storage(&mut message)
+            .expect_err("malformed top-level swipes should reject");
+
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn delete_message_rows_with_swipes_replaces_parent_and_sidecar_together() {
+        let state = test_state("delete-message-row-with-sidecar");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({ "id": "message-1", "chatId": "chat-1", "content": "delete me" }),
+                    json!({ "id": "message-2", "chatId": "chat-1", "content": "keep me" }),
+                ],
+            )
+            .expect("messages should seed");
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "delete sidecar"
+                    }),
+                    json!({
+                        "id": "message-2::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-2",
+                        "index": 0,
+                        "content": "keep sidecar"
+                    }),
+                ],
+            )
+            .expect("sidecars should seed");
+
+        let deleted = delete_message_rows_with_swipes(&state, &["message-1".to_string()])
+            .expect("message and sidecar should delete together");
+
+        assert_eq!(deleted, 1);
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["id"], "message-2");
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("message swipes should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["messageId"], "message-2");
+    }
+
+    #[test]
+    fn delete_message_rows_for_chats_with_swipes_removes_sidecars_by_deleted_message_id() {
+        let state = test_state("delete-chat-message-sidecars");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![
+                    json!({ "id": "message-1", "chatId": "chat-1", "content": "delete me" }),
+                    json!({ "id": "message-2", "chatId": "chat-2", "content": "keep me" }),
+                ],
+            )
+            .expect("messages should seed");
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "stale-chat-id",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "delete by message id"
+                    }),
+                    json!({
+                        "id": "message-2::swipe::0",
+                        "chatId": "chat-2",
+                        "messageId": "message-2",
+                        "index": 0,
+                        "content": "keep sidecar"
+                    }),
+                ],
+            )
+            .expect("sidecars should seed");
+        let chat_ids = HashSet::from(["chat-1".to_string()]);
+
+        let deleted = delete_message_rows_for_chats_with_swipes(&state, &chat_ids)
+            .expect("chat messages and sidecars should delete together");
+
+        assert_eq!(deleted, 1);
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["id"], "message-2");
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("message swipes should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["messageId"], "message-2");
+    }
+
+    #[test]
+    fn materialize_message_adds_sidecar_summary_without_replacing_parent_fields() {
+        let state = test_state("materialize");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "second",
+                    "activeSwipeIndex": 1,
+                    "extra": { "persistent": "keep" }
+                })],
+            )
+            .expect("messages should seed");
+        state
+            .storage
+            .replace_all(
+                COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "first"
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "second",
+                        "extra": { "thinking": "second thought" }
+                    }),
+                ],
+            )
+            .expect("sidecar rows should seed");
+
+        let mut message = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should exist");
+        materialize_message(&state, &mut message, false).expect("message should materialize");
+
+        assert!(message.get("swipes").is_none());
+        assert_eq!(message["swipeCount"], json!(2));
+        assert_eq!(message["activeSwipeIndex"], json!(1));
+        assert_eq!(message["content"], "second");
+        assert_eq!(message["extra"]["persistent"], "keep");
+        assert!(message["extra"].get("thinking").is_none());
+        assert_eq!(
+            message["swipePreviews"],
+            json!([{ "content": "first" }, { "content": "second" }])
+        );
+        assert!(state
+            .storage
+            .get("messages", "message-1")
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist")
+            .get("swipes")
+            .is_none());
+    }
+
+    #[test]
+    fn create_message_keeps_response_compatible_but_persists_sidecar_swipes() {
+        let state = test_state("create");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "activeSwipeIndex": 1,
+                "extra": { "persistent": "keep" },
+                "swipes": [
+                    { "content": "first" },
+                    { "content": "second", "extra": { "thinking": "second thought" } }
+                ]
+            }),
+        )
+        .expect("message should create");
+        let message_id = created
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("created message should have id")
+            .to_string();
+
+        assert_eq!(created["content"], "second");
+        assert_eq!(created["swipeCount"], json!(2));
+        assert_eq!(
+            created["swipes"]
+                .as_array()
+                .expect("response should include swipes")
+                .len(),
+            2
+        );
+
+        let stored = state
+            .storage
+            .get("messages", &message_id)
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist");
+        assert!(stored.get("swipes").is_none());
+        assert_eq!(stored["content"], "second");
+
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecar rows should list");
+        assert_eq!(sidecars.len(), 2);
+        assert_eq!(sidecars[0]["messageId"], message_id);
+    }
+
+    #[test]
+    fn create_message_without_embedded_swipes_creates_initial_sidecar_swipe() {
+        let state = test_state("create-initial-sidecar");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "extra": {
+                    "hiddenFromAI": true,
+                    "generationInfo": { "model": "first-model" }
+                }
+            }),
+        )
+        .expect("message should create");
+        let message_id = created
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("created message should have id")
+            .to_string();
+
+        assert_eq!(created["swipeCount"], json!(1));
+        assert_eq!(created["swipes"][0]["content"], json!("first"));
+        assert_eq!(created["extra"]["hiddenFromAI"], json!(true));
+        assert_eq!(
+            created["swipes"][0]["extra"]["generationInfo"]["model"],
+            json!("first-model")
+        );
+
+        let stored = state
+            .storage
+            .get("messages", &message_id)
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist");
+        assert!(stored.get("swipes").is_none());
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecar rows should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["messageId"], message_id);
+        assert_eq!(sidecars[0]["index"], json!(0));
+        assert_eq!(sidecars[0]["content"], json!("first"));
+    }
+}

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -207,6 +207,9 @@ pub(super) fn validate_native_profile_import(
                 )));
             }
             None => {
+                if collection == message_swipes::COLLECTION {
+                    continue;
+                }
                 return Err(AppError::invalid_input(format!(
                     "Native profile export is missing collection `{collection}`"
                 )));
@@ -261,6 +264,13 @@ where
         imported.insert(collection.to_string(), json!(rows.len()));
         replacements.push((collection, rows));
     }
+    if collections.get("messages").is_some()
+        && collections.get(message_swipes::COLLECTION).is_none()
+    {
+        imported.insert(message_swipes::COLLECTION.to_string(), json!(0));
+        replacements.push((message_swipes::COLLECTION, Vec::new()));
+    }
+    normalize_message_swipe_replacements(&mut replacements, &mut imported)?;
     state
         .storage
         .replace_all_many_and_then(replacements, install_assets)?;
@@ -273,6 +283,39 @@ where
     }
     insert_profile_import_aliases(&mut imported);
     Ok(json!({ "success": true, "imported": imported }))
+}
+
+pub(super) fn normalize_message_swipe_replacements(
+    replacements: &mut Vec<(&'static str, Vec<Value>)>,
+    imported: &mut Map<String, Value>,
+) -> AppResult<()> {
+    let Some(message_index) = replacements
+        .iter()
+        .position(|(collection, _)| *collection == "messages")
+    else {
+        return Ok(());
+    };
+    let sidecar_index = match replacements
+        .iter()
+        .position(|(collection, _)| *collection == message_swipes::COLLECTION)
+    {
+        Some(index) => index,
+        None => {
+            imported.insert(message_swipes::COLLECTION.to_string(), json!(0));
+            replacements.push((message_swipes::COLLECTION, Vec::new()));
+            replacements.len() - 1
+        }
+    };
+
+    let messages = std::mem::take(&mut replacements[message_index].1);
+    let sidecars = std::mem::take(&mut replacements[sidecar_index].1);
+    let (messages, sidecars) =
+        message_swipes::normalize_message_rows_and_sidecars(messages, sidecars)?;
+    let sidecar_count = sidecars.len();
+    replacements[message_index].1 = messages;
+    replacements[sidecar_index].1 = sidecars;
+    imported.insert(message_swipes::COLLECTION.to_string(), json!(sidecar_count));
+    Ok(())
 }
 
 fn normalize_profile_json_fields(collection: &str, rows: &mut [Value]) -> AppResult<()> {
@@ -499,6 +542,228 @@ mod tests {
             .get("characters", "char-1")
             .expect("character lookup should not fail")
             .is_some());
+    }
+
+    #[test]
+    fn native_profile_import_rejects_bad_swipes_without_wiping_existing_rows() {
+        let state = test_state("bad-message-swipes-no-wipe");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "old-message",
+                    "chatId": "old-chat",
+                    "content": "old content"
+                })],
+            )
+            .expect("old message should seed");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "messages".to_string(),
+            json!([{
+                "id": "new-message",
+                "chatId": "new-chat",
+                "role": "assistant",
+                "content": "fresh import",
+                "activeSwipeIndex": 0,
+                "swipes": [{ "content": "bad swipe", "extra": "not json" }]
+            }]),
+        );
+
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }),
+        )
+        .expect_err("bad nested swipe should reject before import commit");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(state
+            .storage
+            .get("messages", "old-message")
+            .expect("old message lookup should not fail")
+            .is_some());
+        assert!(state
+            .storage
+            .get("messages", "new-message")
+            .expect("new message lookup should not fail")
+            .is_none());
+    }
+
+    #[test]
+    fn native_profile_import_without_message_swipes_clears_stale_sidecars() {
+        let state = test_state("missing-message-swipes-clears-stale");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "old-chat",
+                    "messageId": "message-1",
+                    "index": 0,
+                    "content": "stale private sidecar"
+                })],
+            )
+            .expect("stale sidecar should seed");
+        let mut collections = complete_empty_profile_collections();
+        collections.remove(message_swipes::COLLECTION);
+        collections.insert(
+            "messages".to_string(),
+            json!([{
+                "id": "message-1",
+                "chatId": "new-chat",
+                "role": "assistant",
+                "content": "fresh import",
+                "activeSwipeIndex": 0
+            }]),
+        );
+
+        import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }),
+        )
+        .expect("old native profile without message-swipes should import");
+
+        assert!(state
+            .storage
+            .list(message_swipes::COLLECTION)
+            .expect("message swipes should list")
+            .is_empty());
+        let mut message = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should import");
+        message_swipes::materialize_message(&state, &mut message, true)
+            .expect("message should materialize");
+        assert_eq!(message["content"], "fresh import");
+        assert!(message.get("swipes").is_none());
+    }
+
+    #[test]
+    fn legacy_profile_import_without_message_swipes_clears_stale_sidecars() {
+        let state = test_state("legacy-missing-message-swipes-clears-stale");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![json!({
+                    "id": "message-1::swipe::0",
+                    "chatId": "old-chat",
+                    "messageId": "message-1",
+                    "index": 0,
+                    "content": "stale legacy sidecar"
+                })],
+            )
+            .expect("stale sidecar should seed");
+
+        import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "fileStorage": {
+                        "tables": {
+                            "messages": [{
+                                "id": "message-1",
+                                "chatId": "new-chat",
+                                "role": "assistant",
+                                "content": "fresh legacy import",
+                                "activeSwipeIndex": 0
+                            }]
+                        }
+                    }
+                }
+            }),
+        )
+        .expect("legacy profile without message_swipes should import");
+
+        assert!(state
+            .storage
+            .list(message_swipes::COLLECTION)
+            .expect("message swipes should list")
+            .is_empty());
+        let mut message = state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
+            .expect("message should import");
+        message_swipes::materialize_message(&state, &mut message, true)
+            .expect("message should materialize");
+        assert_eq!(message["content"], "fresh legacy import");
+        assert!(message.get("swipes").is_none());
+    }
+
+    #[test]
+    fn legacy_profile_import_rejects_bad_swipes_without_wiping_existing_rows() {
+        let state = test_state("legacy-bad-message-swipes-no-wipe");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "old-message",
+                    "chatId": "old-chat",
+                    "content": "old content"
+                })],
+            )
+            .expect("old message should seed");
+
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "fileStorage": {
+                        "tables": {
+                            "messages": [{
+                                "id": "new-message",
+                                "chatId": "new-chat",
+                                "role": "assistant",
+                                "content": "fresh legacy import",
+                                "activeSwipeIndex": 0
+                            }],
+                            "message_swipes": [{
+                                "messageId": "new-message",
+                                "index": 0,
+                                "content": "bad legacy swipe",
+                                "extra": "not json"
+                            }]
+                        }
+                    }
+                }
+            }),
+        )
+        .expect_err("bad legacy swipe should reject before import commit");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(state
+            .storage
+            .get("messages", "old-message")
+            .expect("old message lookup should not fail")
+            .is_some());
+        assert!(state
+            .storage
+            .get("messages", "new-message")
+            .expect("new message lookup should not fail")
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    game_state_snapshots, new_id, now_iso,
+    game_state_snapshots, message_swipes, new_id, now_iso,
     shared::{
         agent_run_config_info_from_rows, materialize_message_swipe_fields, non_negative_i64_value,
         normalize_agent_run_row_fields, normalize_legacy_text_array_fields,
@@ -149,6 +149,11 @@ where
         imported.insert((*collection).to_string(), json!(rows.len()));
         replacements.push((*collection, rows));
     }
+    if tables.get("messages").is_some() {
+        imported.insert(message_swipes::COLLECTION.to_string(), json!(0));
+        replacements.push((message_swipes::COLLECTION, Vec::new()));
+    }
+    super::normalize_message_swipe_replacements(&mut replacements, &mut imported)?;
     state
         .storage
         .replace_all_many_and_then(replacements, install_assets)?;

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -569,6 +569,7 @@ pub(crate) fn normalize_update_patch(collection: &str, patch: Value) -> AppResul
     Ok(Value::Object(object))
 }
 
+#[cfg(test)]
 pub(crate) fn patch_message_update(
     state: &AppState,
     message_id: &str,

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1342,6 +1342,8 @@ mod tests {
                 ],
             )
             .expect("messages should be installed");
+        crate::storage_commands::message_swipes::migrate_nested_message_swipes(&state.storage)
+            .expect("nested message swipes should migrate");
 
         let result = dispatch(
             &state,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -72,6 +72,7 @@ impl AppState {
         Self::seed_defaults(&storage, &game_assets, &backgrounds, default_data_roots)?;
         migrate_storage_json_fields(&storage)?;
         migrate_message_prompt_snapshots_once(&storage)?;
+        crate::storage_commands::message_swipes::migrate_nested_message_swipes(&storage)?;
         migrate_agent_run_rows(&storage)?;
         migrate_legacy_chat_group_roots(&storage)?;
         migrate_local_media_references(&storage, &data_dir)?;
@@ -1404,12 +1405,16 @@ mod tests {
         assert!(persisted["extra"]
             .get("generationPromptSnapshotsBySwipe")
             .is_none());
+        assert!(persisted.get("swipes").is_none());
+        let sidecar_swipes =
+            crate::storage_commands::message_swipes::swipes_for_message(&state, "message-1")
+                .expect("sidecar swipes should load");
         assert_eq!(
-            persisted["swipes"][0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            sidecar_swipes[0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-first")
         );
         assert_eq!(
-            persisted["swipes"][1]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            sidecar_swipes[1]["extra"]["generationPromptSnapshot"]["promptPresetId"],
             json!("preset-second")
         );
 
@@ -1466,7 +1471,7 @@ mod tests {
     }
 
     #[test]
-    fn app_state_startup_skips_message_compaction_after_marker() {
+    fn app_state_startup_compacts_embedded_swipes_after_message_compaction_marker() {
         let root = temp_root("message-prompt-snapshot-marker");
         let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
         let mut marker = Map::new();
@@ -1509,17 +1514,18 @@ mod tests {
             .expect("message should load")
             .expect("message should exist");
 
-        assert_eq!(
-            persisted["extra"]["generationPromptSnapshot"]["promptPresetId"],
-            json!("preset-first")
-        );
-        assert_eq!(
-            persisted["extra"]["generationPromptSnapshotsBySwipe"]["0"]["promptPresetId"],
-            json!("preset-first")
-        );
-        assert!(persisted["swipes"][0]["extra"]
-            .get("generationPromptSnapshot")
+        assert!(persisted["extra"].get("generationPromptSnapshot").is_none());
+        assert!(persisted["extra"]
+            .get("generationPromptSnapshotsBySwipe")
             .is_none());
+        assert!(persisted.get("swipes").is_none());
+        let sidecar_swipes =
+            crate::storage_commands::message_swipes::swipes_for_message(&state, "message-1")
+                .expect("sidecar swipes should load");
+        assert_eq!(
+            sidecar_swipes[0]["extra"]["generationPromptSnapshot"]["promptPresetId"],
+            json!("preset-first")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #1923

## Why this change

- Message swipe persistence had drifted between embedded message rows and the intended sidecar storage model.
- The stale PR history mixed this work with changes that have already landed separately, so this replacement PR keeps the review focused on the regression: swipe-specific payloads belong in `message-swipes` sidecars while reads/search/imports still expose legacy-compatible active swipe data.

## What changed

- Added sidecar storage handling for message swipes, including startup migration from embedded `message.swipes` rows.
- Routed message create/update/delete, bulk chat deletion, imports, profile import/export, and rollback cleanup through sidecar-aware helpers.
- Preserved projected read/search behavior: sidecar text can be searched without returning unrequested swipes, and active swipe `extra` materializes when requested.
- Added regression coverage for startup compaction, projected message reads, sidecar search, ST bulk imports, and parent/sidecar cleanup.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Chat message swipe commands
- Generic storage create/read/update/delete commands
- Startup storage migration
- Profile import/export
- ST bulk import rollback and rendered-message behavior
- HTTP dispatch storage reads

Boundary notes:

- Stays in `src-tauri` Rust storage and command routing.
- No React, engine, or shared API boundary changes.
- Uses existing storage atomic update helpers instead of adding UI guards or broad fallbacks.

Pressure points touched:

- `src-tauri/src/state.rs` startup migration ordering
- `src-tauri/src/http_dispatch.rs` storage command dispatch coverage
- `src-tauri/src/commands/storage/imports/*` import and rollback paths

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo nextest run --manifest-path src-tauri/Cargo.toml --workspace` - 480 passed locally
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` - passed locally
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` - passed locally
- `pnpm check:architecture` - passed locally
- `git diff --check` - passed locally

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Regression/compatibility fix for existing message swipe storage behavior; no new discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: no repo-defined release note source applies here, and no user-facing docs changed.

## UI evidence

N/A - Rust storage behavior only; no visible UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message alternative handling in exports, imports, and chat operations
  * Improved consistency of message variants across profile imports and chat branching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->