### PR TITLE
Accept amend guide source in generate request schema

### DIFF
--- a/src/engine/contracts/schemas/chat.schema.ts
+++ b/src/engine/contracts/schemas/chat.schema.ts
@@ -2,6 +2,7 @@
 // Chat Zod Schemas
 // ──────────────────────────────────────────────
 import { z } from "zod";
+import { GENERATION_GUIDE_SOURCES } from "../../shared/text/generation-guide";
 
 const canonicalChatModeSchema = z.enum(["conversation", "roleplay", "game"]);
 
@@ -44,7 +45,7 @@ export const generateRequestSchema = z.object({
   forCharacterId: z.string().nullable().optional().default(null),
   generationGuide: z.string().nullable().optional().default(null),
   generationGuideSource: z
-    .enum(["narrator", "guide", "game_start", "game_turn", "game_retry"])
+    .enum(GENERATION_GUIDE_SOURCES)
     .nullable()
     .optional()
     .default(null),

--- a/src/engine/generation/generation-replay.ts
+++ b/src/engine/generation/generation-replay.ts
@@ -1,4 +1,8 @@
-import { stripGenerationGuideInstruction, type GenerationGuideSource } from "../shared/text/generation-guide";
+import {
+  GENERATION_GUIDE_SOURCES,
+  stripGenerationGuideInstruction,
+  type GenerationGuideSource,
+} from "../shared/text/generation-guide";
 
 type GenerationReplayGuideSource = GenerationGuideSource;
 
@@ -24,14 +28,7 @@ export interface GenerationReplayInput {
   impersonatePromptTemplate?: string | null;
 }
 
-const GUIDE_SOURCES = new Set<GenerationReplayGuideSource>([
-  "narrator",
-  "guide",
-  "amend",
-  "game_start",
-  "game_turn",
-  "game_retry",
-]);
+const GUIDE_SOURCES = new Set<GenerationReplayGuideSource>(GENERATION_GUIDE_SOURCES);
 
 function asNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;

--- a/src/engine/shared/text/generation-guide.ts
+++ b/src/engine/shared/text/generation-guide.ts
@@ -1,4 +1,6 @@
-export type GenerationGuideSource = "narrator" | "guide" | "amend" | "game_start" | "game_turn" | "game_retry";
+export const GENERATION_GUIDE_SOURCES = ["narrator", "guide", "amend", "game_start", "game_turn", "game_retry"] as const;
+
+export type GenerationGuideSource = (typeof GENERATION_GUIDE_SOURCES)[number];
 
 export interface ProseGuardianAvoidanceSource {
   agentType?: string | null;


### PR DESCRIPTION
## Linked issue

Closes #2013

## Why this change

`/amend` is a current refactor generation guide source, but `generateRequestSchema` rejected it. That left the request contract behind the runtime, slash-command, and replay paths.

## What changed

- Added `GENERATION_GUIDE_SOURCES` as the shared runtime list for guide-source values.
- Updated `generateRequestSchema` to validate against that shared list.
- Updated generation replay validation to reuse the same guide-source list.

## Refactor impact

Primary owner:

Engine generation contracts.

Impact areas reviewed:

- `/amend` slash-command request shape.
- Generation replay persistence and replay application.
- Legacy guide-source behavior pattern: shared type, request schema, and replay validator stay aligned.
- Existing legacy-compatible `narrator`, `guide`, and `game_start` values remain accepted.
- Current game guide sources `game_turn` and `game_retry` remain accepted.

Boundary notes:

- Engine-only contract/helper change.
- No React UI, shared API wrapper, Rust command, HTTP dispatch, storage, or provider transport boundary changed.

Pressure points touched:

None.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused Vite SSR schema probe: `narrator`, `guide`, `amend`, `game_start`, `game_turn`, and `game_retry` accepted; invalid source rejected.
- Focused Vite SSR replay probe: `/amend` guide stored as `amend`, stripped back to the revision instruction, and reapplied during replay.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for an existing generation contract; no new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed for this internal contract alignment.

## UI evidence

No visible UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal generation guide source definitions into a centralized constant for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->