### PR TITLE
Show boolean-enabled custom tools in selectors

### DIFF
--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -30,7 +30,7 @@ export interface CustomToolCapabilities {
 
 function isEnabledFlag(value: unknown): boolean {
   if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value !== 0;
+  if (typeof value === "number") return value === 1;
   if (typeof value === "string") {
     const normalized = value.trim().toLowerCase();
     if (normalized === "true" || normalized === "1") return true;

--- a/src/features/catalog/agents/hooks/use-custom-tools.ts
+++ b/src/features/catalog/agents/hooks/use-custom-tools.ts
@@ -17,7 +17,7 @@ export interface CustomToolRow {
   executionType: string;
   webhookUrl: string | null;
   staticResult: string | null;
-  enabled: string;
+  enabled: unknown;
   createdAt: string;
   updatedAt: string;
 }
@@ -28,9 +28,19 @@ export interface CustomToolCapabilities {
   scriptExecutionEnabled?: boolean;
 }
 
+function isEnabledFlag(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+  }
+  return false;
+}
+
 export function isCustomToolSelectable(tool: CustomToolRow, _capabilities?: CustomToolCapabilities | null): boolean {
-  const enabled = tool.enabled === "true" || tool.enabled === "1";
-  if (!enabled) return false;
+  if (!isEnabledFlag(tool.enabled)) return false;
   if (tool.executionType === "static") return !!tool.staticResult?.trim();
   if (tool.executionType === "webhook") return !!tool.webhookUrl?.trim();
   return false;


### PR DESCRIPTION
## Linked issue

Closes #2015

## Why this change

New refactor custom tools are saved with `enabled: true` as a boolean, but the selector helper only treated legacy string values as enabled. That made valid static and webhook tools disappear from Chat Settings and Agent tool pickers immediately after creation.

## What changed

- Updated the custom-tool selector row shape to accept non-string `enabled` values.
- Added selector-side enabled normalization for boolean values plus legacy `"true"` / `"1"` strings.
- Preserved disabled handling for boolean `false`, `"false"`, and `"0"`.
- Kept existing static/webhook selectability requirements: static tools need a result and webhook tools need a URL.

## Refactor impact

Primary owner:

Catalog agents custom-tool hooks.

Impact areas reviewed:

- Agent editor tool picker.
- Chat Settings custom-tool picker.
- Tool editor save payload for newly created custom tools.
- Runtime/Rust custom-tool enabled parsing for storage and execution parity.
- Legacy Marinara behavior: legacy persisted string enabled values, while refactor can persist booleans through generic storage.

Boundary notes:

- Feature/catalog hook only.
- No engine generation, shared API wrapper, Rust command, storage contract, or remote runtime boundary changed.

Pressure points touched:

None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused Vite SSR selector probe: boolean `true`, `"true"`, and `"1"` are selectable when static/webhook requirements are met; boolean `false`, `"false"`, `"0"`, and missing webhook URL are not selectable.
- `pnpm typecheck` passed.
- `pnpm check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for existing custom-tool selector behavior; no new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed for this focused selector fix.

## UI evidence

No screenshot captured. This was proved with selector-level module output, not a native UI walkthrough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom tool enabled/disabled state handling to correctly interpret and normalize multiple data formats including booleans, numbers, and string variations ("true"/"false", "1"/"0") for better compatibility and consistent tool selectability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->