### PR TITLE
Align generic storage entity contract

### DIFF
--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -1,39 +1,41 @@
-export type StorageEntity =
-  | "agents"
-  | "app-settings"
-  | "backgrounds"
-  | "characters"
-  | "character-groups"
-  | "character-gallery"
-  | "chat-folders"
-  | "chat-presets"
-  | "chats"
-  | "connections"
-  | "connection-folders"
-  | "custom-tools"
-  | "extensions"
-  | "gallery"
-  | "game-assets"
-  | "game-checkpoints"
-  | "game-state"
-  | "game-state-snapshots"
-  | "knowledge-sources"
-  | "agent-memory"
-  | "agent-runs"
-  | "character-versions"
-  | "lorebook-entries"
-  | "lorebook-folders"
-  | "lorebooks"
-  | "messages"
-  | "personas"
-  | "persona-groups"
-  | "prompt-groups"
-  | "prompt-overrides"
-  | "prompt-sections"
-  | "prompt-variables"
-  | "prompts"
-  | "regex-scripts"
-  | "themes";
+const GENERIC_STORAGE_ENTITIES = [
+  "characters",
+  "character-groups",
+  "character-versions",
+  "personas",
+  "persona-groups",
+  "lorebooks",
+  "lorebook-entries",
+  "lorebook-folders",
+  "prompts",
+  "prompt-groups",
+  "prompt-sections",
+  "prompt-variables",
+  "prompt-overrides",
+  "chat-presets",
+  "agents",
+  "agent-runs",
+  "agent-memory",
+  "themes",
+  "extensions",
+  "connections",
+  "connection-folders",
+  "chats",
+  "chat-folders",
+  "messages",
+  "custom-tools",
+  "regex-scripts",
+  "app-settings",
+  "gallery",
+  "character-gallery",
+  "background-metadata",
+  "sprites",
+  "knowledge-sources",
+  "game-state-snapshots",
+  "game-checkpoints",
+] as const;
+
+export type StorageEntity = (typeof GENERIC_STORAGE_ENTITIES)[number];
 
 export interface StorageListOptions {
   filters?: Record<string, unknown>;
@@ -53,15 +55,15 @@ export interface AddChatMessageSwipeOptions {
 }
 
 export interface StorageGateway {
-  list<T = unknown>(entity: StorageEntity | string, options?: StorageListOptions): Promise<T[]>;
+  list<T = unknown>(entity: StorageEntity, options?: StorageListOptions): Promise<T[]>;
   get<T = unknown>(
-    entity: StorageEntity | string,
+    entity: StorageEntity,
     id: string,
     options?: Pick<StorageListOptions, "fields" | "fieldSelections">,
   ): Promise<T | null>;
-  create<T = unknown>(entity: StorageEntity | string, value: Record<string, unknown>): Promise<T>;
-  update<T = unknown>(entity: StorageEntity | string, id: string, patch: Record<string, unknown>): Promise<T>;
-  delete(entity: StorageEntity | string, id: string): Promise<{ deleted: boolean }>;
+  create<T = unknown>(entity: StorageEntity, value: Record<string, unknown>): Promise<T>;
+  update<T = unknown>(entity: StorageEntity, id: string, patch: Record<string, unknown>): Promise<T>;
+  delete(entity: StorageEntity, id: string): Promise<{ deleted: boolean }>;
   listChatMessages<T = unknown>(chatId: string, options?: Omit<StorageListOptions, "filters">): Promise<T[]>;
   createChatMessage<T = unknown>(chatId: string, value: Record<string, unknown>): Promise<T>;
   updateChatMessage<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T>;

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -1,4 +1,4 @@
-import type { StorageGateway } from "../capabilities/storage";
+import type { StorageEntity, StorageGateway } from "../capabilities/storage";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway } from "../capabilities/llm";
 import type { VisualAssetGateway } from "../capabilities/visual-assets";
@@ -71,7 +71,7 @@ function matchesName(row: JsonRecord, name: string): boolean {
   return nameOf(row).trim().toLowerCase() === name.trim().toLowerCase();
 }
 
-async function findByName(storage: StorageGateway, entity: string, name: string): Promise<JsonRecord | null> {
+async function findByName(storage: StorageGateway, entity: StorageEntity, name: string): Promise<JsonRecord | null> {
   const rows = await storage.list<JsonRecord>(entity);
   return rows.find((row) => matchesName(row, name)) ?? null;
 }

--- a/src/engine/modes/roleplay/encounter/encounter-service.ts
+++ b/src/engine/modes/roleplay/encounter/encounter-service.ts
@@ -1,5 +1,5 @@
 import type { LlmGateway, LlmMessage } from "../../../capabilities/llm";
-import type { StorageGateway } from "../../../capabilities/storage";
+import type { StorageEntity, StorageGateway } from "../../../capabilities/storage";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
 import { parseGameJsonish } from "../../../shared/parsing-jsonish";
 import { readString as stringValue } from "../../../shared/value-readers";
@@ -879,7 +879,7 @@ async function requireChat(storage: StorageGateway, chatId: string): Promise<Jso
 
 async function requireStorageRecord(
   storage: StorageGateway,
-  entity: string,
+  entity: StorageEntity,
   id: string,
   label: string,
 ): Promise<JsonRecord> {
@@ -890,7 +890,7 @@ async function requireStorageRecord(
 
 async function safeList<T extends JsonRecord>(
   storage: StorageGateway,
-  entity: string,
+  entity: StorageEntity,
   filters?: Record<string, unknown>,
 ): Promise<T[]> {
   try {

--- a/src/features/catalog/presets/hooks/use-presets.ts
+++ b/src/features/catalog/presets/hooks/use-presets.ts
@@ -12,6 +12,7 @@ import {
   updatePromptSectionSchema,
 } from "../../../../engine/contracts/schemas/prompt.schema";
 import { boolish } from "../../../../engine/generation/runtime-records";
+import type { StorageEntity } from "../../../../engine/capabilities/storage";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import type { PromptPreset, PromptGroup, PromptSection, ChoiceBlock } from "../../../../engine/contracts/types/prompt";
@@ -45,7 +46,7 @@ const PRESET_SUMMARY_OPTIONS = {
   fields: ["id", "name", "isDefault", "default"],
 };
 
-const promptNestedEntity: Record<PromptNestedKind, string> = {
+const promptNestedEntity: Record<PromptNestedKind, StorageEntity> = {
   groups: "prompt-groups",
   sections: "prompt-sections",
   variables: "prompt-variables",

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -116,6 +116,8 @@ function storageWriteInvalidationKinds(entity: StorageEntity, value?: Record<str
     case "gallery":
     case "character-gallery":
       return ["gallery"];
+    case "background-metadata":
+      return ["background"];
     case "lorebooks":
     case "lorebook-entries":
       return value && ("image" in value || "imagePath" in value || "imageFilename" in value) ? ["lorebook"] : [];
@@ -139,6 +141,8 @@ function storageDeleteInvalidationKinds(entity: StorageEntity): RemoteManagedAss
     case "gallery":
     case "character-gallery":
       return ["gallery"];
+    case "background-metadata":
+      return ["background"];
     case "lorebooks":
     case "lorebook-entries":
       return ["lorebook"];

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -1,4 +1,9 @@
-import type { AddChatMessageSwipeOptions, StorageGateway, StorageListOptions } from "../../engine/capabilities/storage";
+import type {
+  AddChatMessageSwipeOptions,
+  StorageEntity,
+  StorageGateway,
+  StorageListOptions,
+} from "../../engine/capabilities/storage";
 import { collapseExcessBlankLines } from "../../engine/shared/text/newlines";
 import { ApiError } from "./api-errors";
 import { invalidateRemoteManagedAssetObjectUrlsAfter, type RemoteManagedAssetKind } from "./local-file-api";
@@ -52,7 +57,7 @@ function normalizeObjectField(
   }
 }
 
-function normalizeStorageRecord(entity: string, value: unknown): unknown {
+function normalizeStorageRecord(entity: StorageEntity, value: unknown): unknown {
   if (!value || typeof value !== "object" || Array.isArray(value)) return value;
   const record = { ...(value as Record<string, unknown>) };
 
@@ -102,17 +107,15 @@ function normalizeMessageWrite(value: Record<string, unknown>): Record<string, u
   return next;
 }
 
-function normalizeStorageWrite(entity: string, value: Record<string, unknown>): Record<string, unknown> {
+function normalizeStorageWrite(entity: StorageEntity, value: Record<string, unknown>): Record<string, unknown> {
   return entity === "messages" ? normalizeMessageWrite(value) : value;
 }
 
-function storageWriteInvalidationKinds(entity: string, value?: Record<string, unknown>): RemoteManagedAssetKind[] {
+function storageWriteInvalidationKinds(entity: StorageEntity, value?: Record<string, unknown>): RemoteManagedAssetKind[] {
   switch (entity) {
     case "gallery":
     case "character-gallery":
       return ["gallery"];
-    case "backgrounds":
-      return ["background"];
     case "lorebooks":
     case "lorebook-entries":
       return value && ("image" in value || "imagePath" in value || "imageFilename" in value) ? ["lorebook"] : [];
@@ -124,18 +127,18 @@ function storageWriteInvalidationKinds(entity: string, value?: Record<string, un
       return value && ("avatarPath" in value || "avatarFilePath" in value || "avatarFilename" in value)
         ? ["avatar", "avatar-thumbnail"]
         : [];
+    case "sprites":
+      return ["sprite"];
     default:
       return [];
   }
 }
 
-function storageDeleteInvalidationKinds(entity: string): RemoteManagedAssetKind[] {
+function storageDeleteInvalidationKinds(entity: StorageEntity): RemoteManagedAssetKind[] {
   switch (entity) {
     case "gallery":
     case "character-gallery":
       return ["gallery"];
-    case "backgrounds":
-      return ["background"];
     case "lorebooks":
     case "lorebook-entries":
       return ["lorebook"];
@@ -143,12 +146,14 @@ function storageDeleteInvalidationKinds(entity: string): RemoteManagedAssetKind[
       return ["avatar", "avatar-thumbnail", "gallery", "sprite"];
     case "personas":
       return ["avatar", "avatar-thumbnail", "sprite"];
+    case "sprites":
+      return ["sprite"];
     default:
       return [];
   }
 }
 
-function normalizeStorageReadResult(entity: string, value: unknown): unknown {
+function normalizeStorageReadResult(entity: StorageEntity, value: unknown): unknown {
   if (Array.isArray(value)) return value.map((item) => normalizeStorageRecord(entity, item));
   return normalizeStorageRecord(entity, value);
 }
@@ -203,7 +208,7 @@ async function patchChatSummariesField<T>(chatId: string, patch: Record<string, 
 }
 
 export const storageApi: StorageGateway = {
-  list: async (entity: string, options?: StorageListOptions) =>
+  list: async (entity: StorageEntity, options?: StorageListOptions) =>
     normalizeStorageReadResult(
       entity,
       await invokeTauri("storage_list", {
@@ -211,7 +216,7 @@ export const storageApi: StorageGateway = {
         options: options ?? null,
       }),
     ) as never,
-  get: async (entity: string, id: string, options?: Pick<StorageListOptions, "fields" | "fieldSelections">) =>
+  get: async (entity: StorageEntity, id: string, options?: Pick<StorageListOptions, "fields" | "fieldSelections">) =>
     normalizeStorageReadResult(
       entity,
       await invokeTauri("storage_get", {
@@ -220,7 +225,7 @@ export const storageApi: StorageGateway = {
         options: options ?? null,
       }),
     ) as never,
-  create: async (entity: string, value: Record<string, unknown>) => {
+  create: async (entity: StorageEntity, value: Record<string, unknown>) => {
     const result = await invalidateRemoteManagedAssetObjectUrlsAfter(
       invokeTauri("storage_create", {
         entity,
@@ -230,7 +235,7 @@ export const storageApi: StorageGateway = {
     );
     return normalizeStorageReadResult(entity, result) as never;
   },
-  update: async (entity: string, id: string, patch: Record<string, unknown>) => {
+  update: async (entity: StorageEntity, id: string, patch: Record<string, unknown>) => {
     const result = await invalidateRemoteManagedAssetObjectUrlsAfter(
       invokeTauri("storage_update", {
         entity,
@@ -241,7 +246,7 @@ export const storageApi: StorageGateway = {
     );
     return normalizeStorageReadResult(entity, result) as never;
   },
-  delete: (entity: string, id: string) =>
+  delete: (entity: StorageEntity, id: string) =>
     invalidateRemoteManagedAssetObjectUrlsAfter(
       invokeTauri("storage_delete", {
         entity,


### PR DESCRIPTION
## Linked issue

Closes #2017

## Why this change

- TypeScript generic storage types advertised entity names that Rust generic storage commands reject, so new callers could compile and then fail at runtime with `Unsupported storage entity`.

## What changed

- Rebuilt `StorageEntity` from a local generic-entity tuple that mirrors the Rust storage contract registry.
- Removed non-generic `backgrounds`, `game-assets`, and `game-state` from generic storage types.
- Added registry-backed generic names `background-metadata` and `sprites`.
- Tightened `StorageGateway` and dynamic helper call sites to use `StorageEntity` instead of loose `string`.
- Kept backgrounds, game assets, and world-state behavior behind their focused APIs.

## Refactor impact

Primary owner:

Storage capability contract and shared storage API wrapper.

Impact areas reviewed:

- Rust storage contract registry and generic storage command validation.
- Shared API generic storage wrapper and cache invalidation handling.
- Engine storage gateway callers that pass dynamic entity names.
- Dedicated backgrounds, game assets, and world-state API paths.

Boundary notes:

- No Rust behavior changed; Rust already rejects unsupported generic storage entities.
- Engine code still uses a storage capability port, not concrete Tauri or shared API adapters.
- Shared API remains the runtime wrapper for embedded and remote generic storage calls.
- Backgrounds, game assets, and world state remain on focused command/API paths.

Pressure points touched:

- None. Did not touch ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` command registration, or import modules.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check:unused`
- `cargo test --manifest-path src-tauri/Cargo.toml generic_storage_commands`
- `cargo test --manifest-path src-tauri/Cargo.toml registry_`
- Local TS/Rust registry mirror probe: 34 TypeScript entities and 34 Rust registry entries, with no missing or extra names.
- `pnpm check`
- No UI/manual validation run; this is an internal storage contract typing fix.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A because this is an internal storage contract typing fix and does not add a user-discoverable feature, workflow, setting, mode, panel, import path, media capability, or tool.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- No docs changes needed. This does not change user-facing behavior or restore release/package claims.

## UI evidence

Not applicable; no visible UI changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal storage entity type consistency across the codebase for stricter validation.
  * Enhanced asset invalidation logic to better manage cached resources during storage operations.
  * Tightened storage operation signatures to enforce type safety for entity parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/2024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->