### PR TITLE
Enable Bunny dispatch for draft PRs

### DIFF
--- a/.github/workflows/bunny-review-auto.yml
+++ b/.github/workflows/bunny-review-auto.yml
@@ -2,7 +2,7 @@ name: Bunny Review Auto Dispatch
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, edited]
 
 permissions:
   actions: write
@@ -16,8 +16,8 @@ concurrency:
 jobs:
   dispatch:
     if: >
-      github.event.pull_request.base.ref == 'refactor' &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.base.ref == 'refactor' ||
+      github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch trusted Bunny reviewer


### PR DESCRIPTION
## Summary
- allow the default-branch Bunny auto dispatcher to run for draft PR events
- allow dispatcher activation for PRs targeting either main or refactor
- keep the trusted reviewer workflow dispatch pinned to refactor, where Bunny Review currently lives

## Verification
- git diff --check

## Notes
- This PR targets main because pull_request_target dispatcher workflows are discovered from the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated the automated pull request review workflow to trigger on additional events, including when pull requests are converted to draft or edited. Extended review dispatch logic to include pull requests targeting the main branch alongside the refactor branch, improving automation coverage across development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/2026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->