### PR TITLE
Restore custom tool webhook safety guards

### DIFF
--- a/src-tauri/crates/security/src/lib.rs
+++ b/src-tauri/crates/security/src/lib.rs
@@ -1,6 +1,7 @@
 use marinara_core::{AppError, AppResult};
 use regex::{Captures, Regex};
 use serde_json::Value;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 use url::Url;
@@ -92,7 +93,64 @@ pub fn is_allowed_outbound_url(raw: &str, allow_local: bool) -> bool {
     let Some(host) = url.host_str() else {
         return false;
     };
-    !matches!(host, "localhost" | "127.0.0.1" | "::1")
+    !is_local_or_reserved_host(host)
+}
+
+fn is_local_or_reserved_host(host: &str) -> bool {
+    let normalized = host.trim().trim_matches(['[', ']']).to_ascii_lowercase();
+    if normalized.is_empty()
+        || matches!(
+            normalized.as_str(),
+            "localhost" | "localhost.localdomain" | "ip6-localhost" | "ip6-loopback"
+        )
+        || normalized.ends_with(".localhost")
+        || normalized.ends_with(".local")
+        || normalized.ends_with(".internal")
+    {
+        return true;
+    }
+    normalized
+        .parse::<IpAddr>()
+        .is_ok_and(is_local_or_reserved_ip)
+}
+
+pub fn is_local_or_reserved_ip(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => is_local_or_reserved_ipv4(address),
+        IpAddr::V6(address) => is_local_or_reserved_ipv6(address),
+    }
+}
+
+fn is_local_or_reserved_ipv4(address: Ipv4Addr) -> bool {
+    let [a, b, c, _d] = address.octets();
+    matches!(a, 0 | 10 | 127)
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 169 && b == 254)
+        || (a == 172 && (16..=31).contains(&b))
+        || (a == 192 && ((b == 0 && (c == 0 || c == 2)) || b == 168))
+        || (a == 198 && (b == 18 || b == 19))
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113)
+        || (224..=255).contains(&a)
+}
+
+fn is_local_or_reserved_ipv6(address: Ipv6Addr) -> bool {
+    if let Some(mapped) = address.to_ipv4_mapped() {
+        return is_local_or_reserved_ipv4(mapped);
+    }
+    let segments = address.segments();
+    address.is_unspecified()
+        || address.is_loopback()
+        || (segments[0] & 0xfe00) == 0xfc00
+        || (segments[0] & 0xffc0) == 0xfe80
+        || (segments[0] & 0xff00) == 0xff00
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        || (segments[0] == 0x0064
+            && segments[1] == 0xff9b
+            && segments[2] == 0
+            && segments[3] == 0
+            && segments[4] == 0
+            && segments[5] == 0)
 }
 
 fn sensitive_pair_regex() -> &'static Regex {
@@ -160,8 +218,7 @@ fn sensitive_phrase_regex() -> &'static Regex {
 fn bearer_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
     REGEX.get_or_init(|| {
-        Regex::new(r#"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{4,}"#)
-            .expect("bearer regex should compile")
+        Regex::new(r#"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{4,}"#).expect("bearer regex should compile")
     })
 }
 
@@ -190,8 +247,10 @@ fn provider_key_regex() -> &'static Regex {
 fn sensitive_url_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
     REGEX.get_or_init(|| {
-        Regex::new(r#"(?i)https?://[^\s"'<>)]*(?:payment|billing|checkout|invoice|retriev)[^\s"'<>)]*"#)
-            .expect("sensitive URL regex should compile")
+        Regex::new(
+            r#"(?i)https?://[^\s"'<>)]*(?:payment|billing|checkout|invoice|retriev)[^\s"'<>)]*"#,
+        )
+        .expect("sensitive URL regex should compile")
     })
 }
 
@@ -224,7 +283,9 @@ fn looks_sensitive_fragment(value: &str) -> bool {
     let trimmed = value.trim_matches(|character: char| !character.is_ascii_alphanumeric());
     trimmed.len() >= 4
         && (trimmed.chars().any(|character| character.is_ascii_digit())
-            || trimmed.chars().any(|character| matches!(character, '-' | '_' | '.'))
+            || trimmed
+                .chars()
+                .any(|character| matches!(character, '-' | '_' | '.'))
             || trimmed.len() >= 16)
 }
 
@@ -278,7 +339,9 @@ pub fn redact_sensitive_json(value: Value) -> Value {
                 })
                 .collect(),
         ),
-        Value::Array(values) => Value::Array(values.into_iter().map(redact_sensitive_json).collect()),
+        Value::Array(values) => {
+            Value::Array(values.into_iter().map(redact_sensitive_json).collect())
+        }
         Value::String(value) => Value::String(redact_sensitive_text(&value)),
         other => other,
     }
@@ -302,8 +365,9 @@ mod tests {
 
     #[test]
     fn redact_sensitive_text_keeps_non_secret_session_and_token_counts() {
-        let redacted =
-            redact_sensitive_text("Invalid session. API key is invalid. usage input_tokens=12 output_tokens=3.");
+        let redacted = redact_sensitive_text(
+            "Invalid session. API key is invalid. usage input_tokens=12 output_tokens=3.",
+        );
 
         assert_eq!(
             redacted,
@@ -348,5 +412,35 @@ mod tests {
         assert_eq!(redacted["api_key"], "[REDACTED]");
         assert_eq!(redacted["usage"]["input_tokens"], 12);
         assert!(!redacted.to_string().contains("sk-test-secret"));
+    }
+
+    #[test]
+    fn outbound_url_policy_blocks_local_and_reserved_targets_when_local_disabled() {
+        for url in [
+            "http://localhost:3000/hook",
+            "http://127.0.0.1:3000/hook",
+            "http://10.1.2.3/hook",
+            "http://172.16.0.5/hook",
+            "http://192.168.1.5/hook",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[::1]:3000/hook",
+            "http://[fc00::1]/hook",
+        ] {
+            assert!(
+                !is_allowed_outbound_url(url, false),
+                "local-disabled policy should reject {url}"
+            );
+            assert!(
+                is_allowed_outbound_url(url, true),
+                "local-enabled policy should accept {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn outbound_url_policy_keeps_public_https_targets_allowed() {
+        assert!(is_allowed_outbound_url("https://example.com/hook", false));
+        assert!(is_allowed_outbound_url("http://example.com/hook", false));
+        assert!(!is_allowed_outbound_url("file:///etc/passwd", true));
     }
 }

--- a/src-tauri/crates/security/src/lib.rs
+++ b/src-tauri/crates/security/src/lib.rs
@@ -97,7 +97,11 @@ pub fn is_allowed_outbound_url(raw: &str, allow_local: bool) -> bool {
 }
 
 fn is_local_or_reserved_host(host: &str) -> bool {
-    let normalized = host.trim().trim_matches(['[', ']']).to_ascii_lowercase();
+    let normalized = host
+        .trim()
+        .trim_matches(['[', ']'])
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
     if normalized.is_empty()
         || matches!(
             normalized.as_str(),
@@ -106,6 +110,7 @@ fn is_local_or_reserved_host(host: &str) -> bool {
         || normalized.ends_with(".localhost")
         || normalized.ends_with(".local")
         || normalized.ends_with(".internal")
+        || normalized.ends_with(".onion")
     {
         return true;
     }
@@ -135,7 +140,7 @@ fn is_local_or_reserved_ipv4(address: Ipv4Addr) -> bool {
 }
 
 fn is_local_or_reserved_ipv6(address: Ipv6Addr) -> bool {
-    if let Some(mapped) = address.to_ipv4_mapped() {
+    if let Some(mapped) = embedded_ipv4(address) {
         return is_local_or_reserved_ipv4(mapped);
     }
     let segments = address.segments();
@@ -144,6 +149,7 @@ fn is_local_or_reserved_ipv6(address: Ipv6Addr) -> bool {
         || (segments[0] & 0xfe00) == 0xfc00
         || (segments[0] & 0xffc0) == 0xfe80
         || (segments[0] & 0xff00) == 0xff00
+        || (segments[0] == 0x2001 && segments[1] == 0)
         || (segments[0] == 0x2001 && segments[1] == 0x0db8)
         || (segments[0] == 0x0064
             && segments[1] == 0xff9b
@@ -151,6 +157,16 @@ fn is_local_or_reserved_ipv6(address: Ipv6Addr) -> bool {
             && segments[3] == 0
             && segments[4] == 0
             && segments[5] == 0)
+}
+
+fn embedded_ipv4(address: Ipv6Addr) -> Option<Ipv4Addr> {
+    let segments = address.segments();
+    if segments[..5] != [0, 0, 0, 0, 0] || !matches!(segments[5], 0 | 0xffff) {
+        return None;
+    }
+    let [a, b] = segments[6].to_be_bytes();
+    let [c, d] = segments[7].to_be_bytes();
+    Some(Ipv4Addr::new(a, b, c, d))
 }
 
 fn sensitive_pair_regex() -> &'static Regex {
@@ -425,6 +441,12 @@ mod tests {
             "http://169.254.169.254/latest/meta-data",
             "http://[::1]:3000/hook",
             "http://[fc00::1]/hook",
+            "http://[::127.0.0.1]/hook",
+            "http://[::ffff:127.0.0.1]/hook",
+            "http://[::ffff:10.0.0.1]/hook",
+            "http://[2001::1]/hook",
+            "https://hidden-service.onion/hook",
+            "https://hidden-service.onion./hook",
         ] {
             assert!(
                 !is_allowed_outbound_url(url, false),

--- a/src-tauri/src/commands/storage/custom_tools.rs
+++ b/src-tauri/src/commands/storage/custom_tools.rs
@@ -1,6 +1,10 @@
 use super::shared::*;
 use super::*;
-use marinara_security::is_allowed_outbound_url;
+use marinara_security::{is_allowed_outbound_url, is_local_or_reserved_ip};
+
+const WEBHOOK_LOCAL_URLS_ENABLED_FLAG: &str = "WEBHOOK_LOCAL_URLS_ENABLED";
+const CUSTOM_TOOL_WEBHOOK_MAX_RESPONSE_BYTES: usize = 512 * 1024;
+const CUSTOM_TOOL_WEBHOOK_MAX_REDIRECTS: usize = 5;
 
 pub(crate) fn custom_tool_capabilities() -> Value {
     json!({
@@ -66,48 +70,226 @@ fn string_bool(value: Option<&Value>) -> Option<bool> {
 }
 
 async fn execute_webhook_tool(tool: &Value, tool_name: &str, arguments: Value) -> AppResult<Value> {
+    execute_webhook_tool_with_policy(tool, tool_name, arguments, webhook_local_urls_enabled()).await
+}
+
+async fn execute_webhook_tool_with_policy(
+    tool: &Value,
+    tool_name: &str,
+    arguments: Value,
+    allow_local_urls: bool,
+) -> AppResult<Value> {
     let url = tool
         .get("webhookUrl")
         .and_then(Value::as_str)
+        .map(str::trim)
         .filter(|url| !url.trim().is_empty())
         .ok_or_else(|| {
             AppError::invalid_input(format!(
                 "Webhook URL is missing for custom tool: {tool_name}"
             ))
         })?;
-    if !is_allowed_outbound_url(url, true) {
-        return Err(AppError::invalid_input(format!(
-            "Custom tool webhook URL is not allowed: {url}"
-        )));
+    let mut current_url = validate_custom_tool_webhook_url(url, allow_local_urls)?;
+    let payload = json!({ "tool": tool_name, "arguments": arguments });
+
+    for redirects_followed in 0..=CUSTOM_TOOL_WEBHOOK_MAX_REDIRECTS {
+        let response =
+            send_custom_tool_webhook_request(&current_url, &payload, allow_local_urls).await?;
+        if response.status().is_redirection()
+            && response.headers().contains_key(reqwest::header::LOCATION)
+        {
+            if redirects_followed == CUSTOM_TOOL_WEBHOOK_MAX_REDIRECTS {
+                return Err(AppError::new(
+                    "custom_tool_redirect_limit",
+                    "Custom tool webhook exceeded redirect limit",
+                ));
+            }
+            current_url =
+                redirected_custom_tool_webhook_url(&current_url, &response, allow_local_urls)?;
+            continue;
+        }
+
+        let status = response.status();
+        let text = read_limited_webhook_text(response).await?;
+        if !status.is_success() {
+            return Err(AppError::with_details(
+                "custom_tool_webhook_failed",
+                format!("Custom tool webhook returned HTTP {status}"),
+                json!({ "body": text.chars().take(1000).collect::<String>() }),
+            ));
+        }
+
+        return Ok(json!({
+            "success": true,
+            "result": text
+        }));
     }
 
-    let response = reqwest::Client::builder()
+    Err(AppError::new(
+        "custom_tool_redirect_limit",
+        "Custom tool webhook exceeded redirect limit",
+    ))
+}
+
+async fn send_custom_tool_webhook_request(
+    parsed_url: &reqwest::Url,
+    payload: &Value,
+    allow_local_urls: bool,
+) -> AppResult<reqwest::Response> {
+    let resolved_addresses =
+        custom_tool_webhook_resolved_addresses(parsed_url, allow_local_urls).await?;
+
+    let mut client_builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none());
+    if let (Some(host), Some(addresses)) = (parsed_url.host_str(), resolved_addresses.as_deref()) {
+        client_builder = client_builder.resolve_to_addrs(host, addresses);
+    }
+    client_builder
         .build()
         .map_err(|error| AppError::new("custom_tool_client_error", error.to_string()))?
-        .post(url)
-        .json(&json!({ "tool": tool_name, "arguments": arguments }))
+        .post(parsed_url.clone())
+        .json(payload)
         .send()
         .await
-        .map_err(|error| AppError::new("custom_tool_webhook_error", error.to_string()))?;
+        .map_err(|error| AppError::new("custom_tool_webhook_error", error.to_string()))
+}
 
-    let status = response.status();
-    let text = response
-        .text()
-        .await
-        .map_err(|error| AppError::new("custom_tool_response_error", error.to_string()))?;
-    if !status.is_success() {
-        return Err(AppError::with_details(
-            "custom_tool_webhook_failed",
-            format!("Custom tool webhook returned HTTP {status}"),
-            json!({ "body": text.chars().take(1000).collect::<String>() }),
+fn redirected_custom_tool_webhook_url(
+    current_url: &reqwest::Url,
+    response: &reqwest::Response,
+    allow_local_urls: bool,
+) -> AppResult<reqwest::Url> {
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .ok_or_else(|| {
+            AppError::new(
+                "custom_tool_redirect_error",
+                "Webhook redirect is missing a Location header",
+            )
+        })?
+        .to_str()
+        .map_err(|error| AppError::new("custom_tool_redirect_error", error.to_string()))?;
+    validate_redirected_custom_tool_webhook_url(current_url, location, allow_local_urls)
+}
+
+fn validate_redirected_custom_tool_webhook_url(
+    current_url: &reqwest::Url,
+    location: &str,
+    allow_local_urls: bool,
+) -> AppResult<reqwest::Url> {
+    let redirected = current_url
+        .join(location)
+        .map_err(|error| AppError::new("custom_tool_redirect_error", error.to_string()))?;
+    validate_custom_tool_webhook_url(redirected.as_str(), allow_local_urls)
+}
+
+fn validate_custom_tool_webhook_url(url: &str, allow_local_urls: bool) -> AppResult<reqwest::Url> {
+    let parsed = reqwest::Url::parse(url).map_err(|error| {
+        AppError::invalid_input(format!("Custom tool webhook URL is invalid: {error}"))
+    })?;
+    match parsed.scheme() {
+        "https" => {}
+        "http" if allow_local_urls => {}
+        "http" => {
+            return Err(AppError::invalid_input(format!(
+                "Custom tool webhook URL must use https unless {WEBHOOK_LOCAL_URLS_ENABLED_FLAG}=true is set."
+            )));
+        }
+        scheme => {
+            return Err(AppError::invalid_input(format!(
+                "Custom tool webhook URL uses unsupported protocol '{scheme}'. Use https, or http only with {WEBHOOK_LOCAL_URLS_ENABLED_FLAG}=true."
+            )));
+        }
+    }
+    if !is_allowed_outbound_url(url, allow_local_urls) {
+        return Err(AppError::invalid_input(format!(
+            "Custom tool webhook URL points to a local, private, or reserved address. Set {WEBHOOK_LOCAL_URLS_ENABLED_FLAG}=true only if you trust that target."
+        )));
+    }
+    Ok(parsed)
+}
+
+async fn custom_tool_webhook_resolved_addresses(
+    url: &reqwest::Url,
+    allow_local_urls: bool,
+) -> AppResult<Option<Vec<std::net::SocketAddr>>> {
+    if allow_local_urls {
+        return Ok(None);
+    }
+    let Some(host) = url.host_str() else {
+        return Err(AppError::invalid_input(
+            "Custom tool webhook URL is missing a hostname",
         ));
+    };
+    if host.parse::<std::net::IpAddr>().is_ok() {
+        return Ok(None);
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let mut addresses = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|error| {
+            AppError::invalid_input(format!(
+                "Custom tool webhook host '{host}' did not resolve: {error}"
+            ))
+        })?;
+    let mut resolved_addresses = Vec::new();
+    for address in addresses.by_ref() {
+        if is_local_or_reserved_ip(address.ip()) {
+            return Err(AppError::invalid_input(format!(
+                "Custom tool webhook URL resolves to a local, private, or reserved address. Set {WEBHOOK_LOCAL_URLS_ENABLED_FLAG}=true only if you trust that target."
+            )));
+        }
+        resolved_addresses.push(address);
+    }
+    if resolved_addresses.is_empty() {
+        return Err(AppError::invalid_input(format!(
+            "Custom tool webhook host '{host}' did not resolve"
+        )));
+    }
+    Ok(Some(resolved_addresses))
+}
+
+fn webhook_local_urls_enabled() -> bool {
+    std::env::var(WEBHOOK_LOCAL_URLS_ENABLED_FLAG).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+async fn read_limited_webhook_text(mut response: reqwest::Response) -> AppResult<String> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > CUSTOM_TOOL_WEBHOOK_MAX_RESPONSE_BYTES as u64)
+    {
+        return Err(webhook_response_too_large_error());
     }
 
-    Ok(json!({
-        "success": true,
-        "result": text
-    }))
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| AppError::new("custom_tool_response_error", error.to_string()))?
+    {
+        if body.len().saturating_add(chunk.len()) > CUSTOM_TOOL_WEBHOOK_MAX_RESPONSE_BYTES {
+            return Err(webhook_response_too_large_error());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+fn webhook_response_too_large_error() -> AppError {
+    AppError::new(
+        "custom_tool_response_too_large",
+        format!(
+            "Custom tool webhook response exceeds {} bytes",
+            CUSTOM_TOOL_WEBHOOK_MAX_RESPONSE_BYTES
+        ),
+    )
 }
 
 #[cfg(test)]
@@ -116,6 +298,8 @@ mod tests {
     use crate::state::AppState;
     use serde_json::Map;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn test_state(label: &str) -> AppState {
         let nonce = SystemTime::now()
@@ -134,6 +318,45 @@ mod tests {
             .storage
             .create("custom-tools", Value::Object(row))
             .expect("storage create should succeed");
+    }
+
+    fn webhook_tool(url: &str) -> Value {
+        json!({
+            "name": "webhook_tool",
+            "description": "test webhook",
+            "executionType": "webhook",
+            "webhookUrl": url,
+            "enabled": true
+        })
+    }
+
+    async fn serve_single_webhook_response(body: String) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test webhook server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test webhook server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test webhook server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test webhook server should read request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test webhook server should write response");
+        });
+        format!("http://{address}/hook")
     }
 
     #[test]
@@ -198,6 +421,98 @@ mod tests {
                 .message
                 .contains("Unsupported custom tool execution type"),
             "unknown types must keep the generic message, got: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn webhook_policy_rejects_local_urls_without_legacy_opt_in() {
+        let error = validate_custom_tool_webhook_url("https://127.0.0.1:32123/hook", false)
+            .expect_err("local custom tool webhook should require explicit opt-in");
+        assert_eq!(error.code, "invalid_input");
+        assert!(
+            error.message.contains(WEBHOOK_LOCAL_URLS_ENABLED_FLAG),
+            "error should name the legacy opt-in flag, got: {}",
+            error.message
+        );
+        assert!(
+            error.message.contains("local, private, or reserved"),
+            "error should identify local/private policy, got: {}",
+            error.message
+        );
+
+        validate_custom_tool_webhook_url("http://127.0.0.1:32123/hook", true)
+            .expect("legacy local opt-in should allow loopback http webhook URLs");
+    }
+
+    #[test]
+    fn webhook_policy_rejects_private_https_urls_without_legacy_opt_in() {
+        let error = validate_custom_tool_webhook_url("https://192.168.1.20/hook", false)
+            .expect_err("private custom tool webhook should require explicit opt-in");
+        assert_eq!(error.code, "invalid_input");
+        assert!(
+            error.message.contains("local, private, or reserved"),
+            "error should identify local/private policy, got: {}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn webhook_redirect_policy_rejects_private_locations_without_legacy_opt_in() {
+        let current_url = reqwest::Url::parse("https://webhook.example.test/hook")
+            .expect("test URL should parse");
+        for location in [
+            "http://169.254.169.254/latest/meta-data",
+            "https://169.254.169.254/latest/meta-data",
+        ] {
+            let error = validate_redirected_custom_tool_webhook_url(&current_url, location, false)
+                .expect_err("redirected private target should require explicit opt-in");
+
+            assert_eq!(error.code, "invalid_input");
+            assert!(
+                error.message.contains(WEBHOOK_LOCAL_URLS_ENABLED_FLAG),
+                "error should name the legacy opt-in flag, got: {}",
+                error.message
+            );
+            assert!(
+                error.message.contains("https")
+                    || error.message.contains("local, private, or reserved"),
+                "error should identify redirected URL policy, got: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_redirect_policy_allows_public_relative_locations() {
+        let current_url = reqwest::Url::parse("https://webhook.example.test/hook")
+            .expect("test URL should parse");
+        let redirected = validate_redirected_custom_tool_webhook_url(&current_url, "/next", false)
+            .expect("public same-origin relative redirect should remain allowed");
+
+        assert_eq!(redirected.as_str(), "https://webhook.example.test/next");
+    }
+
+    #[tokio::test]
+    async fn webhook_response_body_is_capped_to_legacy_limit() {
+        let url =
+            serve_single_webhook_response("x".repeat(CUSTOM_TOOL_WEBHOOK_MAX_RESPONSE_BYTES + 1))
+                .await;
+        let error = execute_webhook_tool_with_policy(
+            &webhook_tool(&url),
+            "webhook_tool",
+            json!({ "input": "oversized" }),
+            true,
+        )
+        .await
+        .expect_err("oversized custom tool webhook response must be rejected");
+
+        assert_eq!(error.code, "custom_tool_response_too_large");
+        assert!(
+            error
+                .message
+                .contains(&CUSTOM_TOOL_WEBHOOK_MAX_RESPONSE_BYTES.to_string()),
+            "error should include the response byte limit, got: {}",
             error.message
         );
     }

--- a/src-tauri/src/commands/storage/custom_tools.rs
+++ b/src-tauri/src/commands/storage/custom_tools.rs
@@ -215,15 +215,19 @@ async fn custom_tool_webhook_resolved_addresses(
     url: &reqwest::Url,
     allow_local_urls: bool,
 ) -> AppResult<Option<Vec<std::net::SocketAddr>>> {
-    if allow_local_urls {
-        return Ok(None);
-    }
     let Some(host) = url.host_str() else {
         return Err(AppError::invalid_input(
             "Custom tool webhook URL is missing a hostname",
         ));
     };
-    if host.parse::<std::net::IpAddr>().is_ok() {
+    let requires_local_target = url.scheme() == "http" && allow_local_urls;
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        if requires_local_target && !is_local_or_reserved_ip(ip) {
+            return Err(public_http_webhook_error());
+        }
+        return Ok(None);
+    }
+    if allow_local_urls && !requires_local_target {
         return Ok(None);
     }
     let port = url.port_or_known_default().unwrap_or(443);
@@ -236,7 +240,11 @@ async fn custom_tool_webhook_resolved_addresses(
         })?;
     let mut resolved_addresses = Vec::new();
     for address in addresses.by_ref() {
-        if is_local_or_reserved_ip(address.ip()) {
+        let is_local_or_reserved = is_local_or_reserved_ip(address.ip());
+        if requires_local_target && !is_local_or_reserved {
+            return Err(public_http_webhook_error());
+        }
+        if !requires_local_target && is_local_or_reserved {
             return Err(AppError::invalid_input(format!(
                 "Custom tool webhook URL resolves to a local, private, or reserved address. Set {WEBHOOK_LOCAL_URLS_ENABLED_FLAG}=true only if you trust that target."
             )));
@@ -249,6 +257,12 @@ async fn custom_tool_webhook_resolved_addresses(
         )));
     }
     Ok(Some(resolved_addresses))
+}
+
+fn public_http_webhook_error() -> AppError {
+    AppError::invalid_input(
+        "Custom tool webhook URL uses public http. Use https for public webhooks; WEBHOOK_LOCAL_URLS_ENABLED=true only allows http for local or reserved targets.",
+    )
 }
 
 fn webhook_local_urls_enabled() -> bool {
@@ -455,6 +469,26 @@ mod tests {
             "error should identify local/private policy, got: {}",
             error.message
         );
+    }
+
+    #[tokio::test]
+    async fn webhook_local_opt_in_does_not_allow_public_http_targets() {
+        let public_http =
+            reqwest::Url::parse("http://93.184.216.34/hook").expect("test URL should parse");
+        let error = custom_tool_webhook_resolved_addresses(&public_http, true)
+            .await
+            .expect_err("public http target should stay rejected with local opt-in");
+        assert!(
+            error.message.contains("public http"),
+            "error should identify insecure public http, got: {}",
+            error.message
+        );
+
+        let local_http =
+            reqwest::Url::parse("http://127.0.0.1:32123/hook").expect("test URL should parse");
+        custom_tool_webhook_resolved_addresses(&local_http, true)
+            .await
+            .expect("local http target should be allowed with local opt-in");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/custom_tools.rs
+++ b/src-tauri/src/commands/storage/custom_tools.rs
@@ -221,7 +221,7 @@ async fn custom_tool_webhook_resolved_addresses(
         ));
     };
     let requires_local_target = url.scheme() == "http" && allow_local_urls;
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+    if let Some(ip) = custom_tool_webhook_host_ip(host) {
         if requires_local_target && !is_local_or_reserved_ip(ip) {
             return Err(public_http_webhook_error());
         }
@@ -257,6 +257,14 @@ async fn custom_tool_webhook_resolved_addresses(
         )));
     }
     Ok(Some(resolved_addresses))
+}
+
+fn custom_tool_webhook_host_ip(host: &str) -> Option<std::net::IpAddr> {
+    let unbracketed_host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    unbracketed_host.parse::<std::net::IpAddr>().ok()
 }
 
 fn public_http_webhook_error() -> AppError {
@@ -489,6 +497,24 @@ mod tests {
         custom_tool_webhook_resolved_addresses(&local_http, true)
             .await
             .expect("local http target should be allowed with local opt-in");
+
+        let bracketed_local_http =
+            reqwest::Url::parse("http://[::1]:32123/hook").expect("test URL should parse");
+        custom_tool_webhook_resolved_addresses(&bracketed_local_http, true)
+            .await
+            .expect("bracketed local IPv6 http target should be allowed with local opt-in");
+
+        let bracketed_public_http =
+            reqwest::Url::parse("http://[2606:2800:220:1:248:1893:25c8:1946]/hook")
+                .expect("test URL should parse");
+        let error = custom_tool_webhook_resolved_addresses(&bracketed_public_http, true)
+            .await
+            .expect_err("bracketed public IPv6 http target should stay rejected");
+        assert!(
+            error.message.contains("public http"),
+            "error should identify insecure public http, got: {}",
+            error.message
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #2016

## Why this change

- Refactor custom tool webhooks no longer matched the legacy safe-fetch behavior.
- Legacy allowed public webhook calls by default, required `WEBHOOK_LOCAL_URLS_ENABLED=true` for local/private targets, capped success bodies at 512 KiB, and validated redirect hops.
- The refactor path accepted local/private targets too broadly and read webhook responses without the legacy body cap.

## What changed

- Restored the legacy local/private webhook opt-in policy for custom tools.
- Added local, private, reserved, and metadata-address detection for outbound URL checks.
- DNS-checks and pins non-local webhook host resolutions before sending the request.
- Disabled automatic reqwest redirects and follows redirects manually with per-hop URL validation plus a five-hop limit.
- Restored the 512 KiB custom-tool webhook response cap.
- Added focused Rust coverage for local/private rejection, redirected private targets, public relative redirects, and oversized responses.

## Refactor impact

Primary owner:

Rust storage / custom tool executor

Impact areas reviewed:

- Custom tool execution command
- Shared Rust outbound URL policy helper
- Embedded Tauri custom-tool execution path
- Remote `/api/invoke` custom-tool execution path

Boundary notes:

- Behavior stays in `src-tauri`; no React, engine, shared API, or command registration changes.
- Embedded and remote execution already route through the same Rust executor, so both paths share the restored policy.
- The security helper remains a Rust capability helper and does not introduce feature-layer coupling.

Pressure points touched:

- `src-tauri/src/commands/storage/custom_tools.rs`
- `src-tauri/crates/security/src/lib.rs`
- Not touched: ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` command registration, import modules.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml custom_tool` - passed locally
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-security outbound_url_policy` - passed locally
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` - passed locally
- `pnpm check` - passed locally
- `git diff --check` - clean

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores existing custom-tool webhook safety behavior; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: no docs changes needed; this restores existing legacy safety behavior for an existing custom-tool webhook path and does not alter contributor workflow or public docs.

## UI evidence

N/A - Rust custom tool webhook policy only; no visible UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment flag to control webhook access to local and reserved network addresses.
  * Implemented automatic redirect handling for webhooks with policy-based validation.
  * Enforced response size limits on webhook payloads.

* **Bug Fixes**
  * Enhanced outbound URL validation for local and reserved IP addresses.
  * Improved webhook scheme enforcement (HTTPS always allowed; HTTP conditional).

* **Tests**
  * Expanded test coverage for webhook URL policy validation and redirect handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pasta-Devs/Marinara-Engine/pull/2027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->