### PR TITLE
Fix(claude-subscription): refresh model list to match Claude Code menu

### DIFF
--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -267,13 +267,21 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
   }
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
+    // Model IDs may carry a `[1m]` suffix mirroring the Claude CLI's
+    // "(1M context)" selector entries. The suffix isn't a real model string, so
+    // strip it to a plain ID the SDK accepts and enable the 1M-context beta
+    // below instead. Everything downstream (resume JSONL, SDK model, downgrade
+    // detection) must use the resolved ID, never the suffixed one.
+    const oneMContext = options.model.endsWith("[1m]");
+    const model = oneMContext ? options.model.slice(0, -"[1m]".length) : options.model;
+
     const configuredMaxTokens = options.maxTokens ?? 4096;
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
-    this.logContextTrim(contextFit, options.model);
+    this.logContextTrim(contextFit, model);
 
     const { promptArg, systemPrompt, resumeSessionId, resumeCwd, sessionStore } = selectPromptPath(
       contextFit.messages,
-      options.model,
+      model,
     );
 
     const { query } = await loadSdk();
@@ -291,7 +299,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
     // Opus 4.7+ is adaptive-only (sampling parameters rejected); other models
     // accept temperature etc. but the Agent SDK doesn't expose those knobs
     // directly, so we skip them and rely on the SDK defaults.
-    const modelLower = options.model.toLowerCase();
+    const modelLower = model.toLowerCase();
     const isAdaptiveOnly = /claude-opus-4-(?:[7-9]|\d{2,})/.test(modelLower);
 
     // Outbound-context strip strategy: this provider is a text-chat surface
@@ -326,7 +334,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
 
     const sdkOptions: Parameters<SdkModule["query"]>[0]["options"] = {
       abortController,
-      model: options.model,
+      model,
       includePartialMessages: options.stream ?? true,
       tools: [],
       skills: [],
@@ -341,6 +349,12 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
       settings: { fastMode: this.fastMode },
     };
     if (systemPrompt !== undefined) sdkOptions.systemPrompt = systemPrompt;
+
+    // 1M-context selections enable Anthropic's long-context beta. The plain
+    // model ID is already set above; the beta is what actually widens the
+    // window. The SDK rejects it with a clear error if the plan/model can't run
+    // it, so no extra gating is needed here.
+    if (oneMContext) sdkOptions.betas = ["context-1m-2025-08-07"];
 
     if (options.enableThinking) {
       sdkOptions.thinking = { type: "adaptive" };
@@ -513,7 +527,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
             const fastModeState = message.fast_mode_state;
             finalUsedModels = usedModels;
             finalFastModeState = fastModeState ?? null;
-            const billedDifferent = usedModels.length > 0 && !usedModels.includes(options.model);
+            const billedDifferent = usedModels.length > 0 && !usedModels.includes(model);
             if (billedDifferent) {
               logger.warn(
                 "[claude-subscription] Requested %s but SDK billed against %s (fast_mode_state=%s, session=%s) — check `claude` CLI fast mode / rate-limit cooldown",

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -130,18 +130,23 @@ export const ANTHROPIC_MODELS: KnownModel[] = [
 ];
 
 // ── Claude (Subscription via Claude Agent SDK) ──
-// Models reachable through the local `claude` CLI auth (Pro / Max). Anthropic
-// gates which model IDs are available per plan tier; the SDK surfaces a clear
-// error if the signed-in plan can't run the requested model. We keep this list
-// to the current tool-eligible families to avoid offering retired aliases that
-// the subscription path no longer accepts.
+// Models reachable through the local `claude` CLI auth (Pro / Max). This mirrors
+// the Claude Code model selector — current models first, then `(Legacy)` ones —
+// so the picker matches what the signed-in CLI actually offers. Anthropic gates
+// which model IDs are available per plan tier; the SDK surfaces a clear error if
+// the signed-in plan can't run the requested model.
+//
+// The `[1m]` suffix is NOT a real model string — it mirrors the CLI's
+// "(1M context)" entries. `ClaudeSubscriptionProvider` strips it and enables the
+// SDK's `context-1m-2025-08-07` beta instead (see the provider's chat()).
 export const CLAUDE_SUBSCRIPTION_MODELS: KnownModel[] = [
-  { id: "claude-opus-4-7", name: "Claude Opus 4.7", context: 1000000, maxOutput: 128000 },
-  { id: "claude-opus-4-6", name: "Claude Opus 4.6", context: 1000000, maxOutput: 32000 },
-  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", context: 1000000, maxOutput: 32000 },
-  { id: "claude-opus-4-5", name: "Claude Opus 4.5", context: 1000000, maxOutput: 32000 },
-  { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", context: 1000000, maxOutput: 16000 },
-  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", context: 200000, maxOutput: 8192 },
+  { id: "claude-opus-4-8", name: "Claude Opus 4.8", context: 200000, maxOutput: 64000 },
+  { id: "claude-opus-4-8[1m]", name: "Claude Opus 4.8 (1M context)", context: 1000000, maxOutput: 64000 },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", context: 1000000, maxOutput: 64000 },
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", context: 200000, maxOutput: 32000 },
+  { id: "claude-opus-4-7", name: "Claude Opus 4.7 (Legacy)", context: 200000, maxOutput: 64000 },
+  { id: "claude-opus-4-7[1m]", name: "Claude Opus 4.7 (1M context, Legacy)", context: 1000000, maxOutput: 64000 },
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6 (Legacy)", context: 200000, maxOutput: 32000 },
 ];
 
 // ── OpenAI (ChatGPT login via Codex auth) ──


### PR DESCRIPTION
## Linked issue

Closes #2032

## Why this change

The Claude (Subscription) connection's model dropdown was stale: it topped out at Opus 4.7 and still listed retired aliases (Opus 4.5 / Sonnet 4.5) that the subscription path no longer surfaces. After the Claude Agent SDK bump, the local `claude` CLI offers Opus 4.8 (and a 1M-context variant), but there was no way to pick them in Marinara — so subscription users were stuck on older models and had no access to the 1M context window.

## What changed

- **Shared** — `CLAUDE_SUBSCRIPTION_MODELS` now mirrors the current Claude Code model selector, current-first then legacy: Opus 4.8, Opus 4.8 (1M context), Sonnet 4.6, Haiku 4.5, Opus 4.7 (Legacy), Opus 4.7 (1M context, Legacy), Opus 4.6 (Legacy).
- **Server** — the provider learns the `[1m]` model-id suffix. The suffix mirrors the CLI's "(1M context)" entries but is not a real model string, so the provider strips it to a plain id the SDK accepts and enables the SDK's `context-1m-2025-08-07` beta instead. The resolved id is threaded through the resume JSONL, the SDK `model` option, and the billed-model downgrade check — otherwise a 1M selection would be misread as a silent model downgrade.

Existing connections pinned to `claude-opus-4-7` keep working and now render as "Claude Opus 4.7 (Legacy)". `isAdaptiveOnly` already matched Opus 4.8, so adaptive thinking is unchanged.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Built and launched the app; opened a Claude (Subscription) connection and confirmed the model dropdown now lists Opus 4.8, Opus 4.8 (1M context), Sonnet 4.6, Haiku 4.5, and the three legacy entries in that order.
- Generated with Opus 4.8 and with Opus 4.8 (1M context); both produced output and the 1M selection did not raise a false model-downgrade warning in the server logs.
- Confirmed an existing connection pinned to `claude-opus-4-7` still loads and renders as "Claude Opus 4.7 (Legacy)".

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No layout changes — this only updates the entries inside the existing themed model dropdown.
