### PR TITLE
Fix export toast feedback

### DIFF
--- a/src/features/catalog/characters/components/CharacterEditorDialogs.tsx
+++ b/src/features/catalog/characters/components/CharacterEditorDialogs.tsx
@@ -1,10 +1,9 @@
-import { toast } from "sonner";
-
 import type { CharacterData } from "../../../../engine/contracts/types/character";
 import { exportApi } from "../../../../shared/api/export-api";
 import { AvatarGenerationModal } from "../../../../shared/components/ui/AvatarGenerationModal";
 import { ExportFormatDialog, type ExportFormatChoice } from "../../../../shared/components/ui/ExportFormatDialog";
 import type { ImageGenerationConnectionOption } from "../../../../shared/types/image-generation";
+import { toastExportError, triggerDownloadWithToast } from "../../../shared/lib/export-feedback";
 
 type CharacterEditorDialogsProps = {
   characterId: string | null;
@@ -30,7 +29,7 @@ export function CharacterEditorDialogs({
   onUseGeneratedAvatar,
 }: CharacterEditorDialogsProps) {
   const handleExportError = (error: unknown) => {
-    toast.error(error instanceof Error ? error.message : "Failed to export character.");
+    toastExportError(error, "Failed to export character.");
   };
 
   return (
@@ -46,9 +45,15 @@ export function CharacterEditorDialogs({
           if (!characterId) return;
           onCloseExportDialog();
           if (format === "compatible-png") {
-            void exportApi.characterPng(characterId).then(exportApi.triggerDownload).catch(handleExportError);
+            void exportApi
+              .characterPng(characterId)
+              .then((payload) => triggerDownloadWithToast(payload, "Character PNG exported."))
+              .catch(handleExportError);
           } else {
-            void exportApi.character(characterId, format).then(exportApi.triggerDownload).catch(handleExportError);
+            void exportApi
+              .character(characterId, format)
+              .then((payload) => triggerDownloadWithToast(payload, "Character exported."))
+              .catch(handleExportError);
           }
         }}
       />

--- a/src/features/catalog/chats/hooks/use-bulk-export-chats.ts
+++ b/src/features/catalog/chats/hooks/use-bulk-export-chats.ts
@@ -1,7 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import type { Chat, Message } from "../../../../engine/contracts/types/chat";
 import { storageApi } from "../../../../shared/api/storage-api";
+import { getExportErrorMessage } from "../../../shared/lib/export-feedback";
 import { downloadBlobFile, downloadTextFile } from "../lib/download";
 import type { BulkChatExportFormat } from "../lib/chat-transcript-export";
 
@@ -45,7 +47,7 @@ export function useBulkExportChats() {
         ]);
         const files = buildChatTranscriptZipFiles(chats, format);
         downloadBlobFile(createStoredZip(files), `chat-transcripts-${format}-${exportedAt.slice(0, 10)}.zip`);
-        return;
+        return { count: chats.length };
       }
 
       downloadTextFile(
@@ -63,6 +65,13 @@ export function useBulkExportChats() {
         `marinara-chats-${exportedAt.slice(0, 10)}.json`,
         "application/json;charset=utf-8",
       );
+      return { count: chats.length };
+    },
+    onSuccess: ({ count }) => {
+      toast.success(`Exported ${count} chat${count === 1 ? "" : "s"}.`);
+    },
+    onError: (error) => {
+      toast.error(getExportErrorMessage(error, "Failed to export chats."));
     },
   });
 }

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -9,6 +9,7 @@ import {
   type InfiniteData,
   type QueryClient,
 } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { chatKeys } from "../query-keys";
 import {
   previewGenerationPrompt,
@@ -25,6 +26,7 @@ import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { ApiError } from "../../../../shared/api/api-errors";
+import { getExportErrorMessage } from "../../../shared/lib/export-feedback";
 import {
   chatExportFilename,
   formatChatJsonl,
@@ -1018,6 +1020,13 @@ export function useExportChat() {
       } else {
         downloadTextFile(formatChatJsonl(messages), filename, "application/x-ndjson;charset=utf-8");
       }
+      return { format };
+    },
+    onSuccess: ({ format }) => {
+      toast.success(format === "text" ? "Chat transcript exported as text." : "Chat transcript exported as JSONL.");
+    },
+    onError: (error) => {
+      toast.error(getExportErrorMessage(error, "Failed to export chat transcript."));
     },
   });
 }

--- a/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
@@ -30,6 +30,7 @@ import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { exportApi } from "../../../../../shared/api/export-api";
+import { toastExportError, triggerDownloadWithToast } from "../../../../shared/lib/export-feedback";
 import type { Lorebook, LorebookEntry, LorebookFolder } from "../../../../../engine/contracts/types/lorebook";
 import { testPrimaryKeys, testSecondaryKeys } from "../../../../../engine/shared/regex/lorebook-keyword-matching";
 import { LorebookEditorHeader } from "./LorebookEditorHeader";
@@ -528,10 +529,10 @@ export function LorebookEditor() {
       if (!lorebookId) return;
       try {
         const payload = await exportApi.lorebook(lorebookId, format);
-        exportApi.triggerDownload(payload);
+        triggerDownloadWithToast(payload, "Lorebook exported.");
         setExportDialogOpen(false);
       } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to export lorebook.");
+        toastExportError(error, "Failed to export lorebook.");
       }
     },
     [lorebookId],

--- a/src/features/catalog/personas/components/editor/PersonaEditor.tsx
+++ b/src/features/catalog/personas/components/editor/PersonaEditor.tsx
@@ -34,6 +34,7 @@ import { ExpandedTextarea } from "../../../../../shared/components/ui/ExpandedTe
 import { exportApi } from "../../../../../shared/api/export-api";
 import { AvatarGenerationModal } from "../../../../../shared/components/ui/AvatarGenerationModal";
 import { ExportFormatDialog, type ExportFormatChoice } from "../../../../../shared/components/ui/ExportFormatDialog";
+import { toastExportError, triggerDownloadWithToast } from "../../../../shared/lib/export-feedback";
 import {
   buildPersonaFormData,
   buildPersonaSavePayload,
@@ -237,7 +238,10 @@ export function PersonaEditor() {
         onSelect={(format: ExportFormatChoice) => {
           if (!personaId) return;
           setExportDialogOpen(false);
-          void exportApi.persona(personaId, format).then(exportApi.triggerDownload);
+          void exportApi
+            .persona(personaId, format)
+            .then((payload) => triggerDownloadWithToast(payload, "Persona exported."))
+            .catch((error) => toastExportError(error, "Failed to export persona."));
         }}
       />
       <AvatarGenerationModal

--- a/src/features/catalog/presets/components/PresetEditor.tsx
+++ b/src/features/catalog/presets/components/PresetEditor.tsx
@@ -61,6 +61,7 @@ import { cn } from "../../../../shared/lib/utils";
 import { HelpTooltip } from "../../../../shared/components/ui/HelpTooltip";
 import { DraftNumberInput } from "../../../../shared/components/ui/DraftNumberInput";
 import { exportApi } from "../../../../shared/api/export-api";
+import { toastExportError, triggerDownloadWithToast } from "../../../shared/lib/export-feedback";
 import { connectionsUtilityApi } from "../../../../shared/api/integration-utility-api";
 import { reviewPromptPreset } from "../../../../engine/generation/prompt-reviewer";
 import { llmApi } from "../../../../shared/api/llm-api";
@@ -391,7 +392,11 @@ export function PresetEditor() {
           <button
             onClick={async () => {
               if (!presetDetailId) return;
-              exportApi.triggerDownload(await exportApi.prompt(presetDetailId));
+              try {
+                triggerDownloadWithToast(await exportApi.prompt(presetDetailId), "Preset exported.");
+              } catch (error) {
+                toastExportError(error, "Failed to export preset.");
+              }
             }}
             className="rounded-xl p-2 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
             title="Export preset"

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -117,7 +117,7 @@ import { llmApi } from "../../../../../shared/api/llm-api";
 import { storageApi } from "../../../../../shared/api/storage-api";
 import { spotifyApi } from "../../../../../shared/api/integration-utility-api";
 import { spriteApi } from "../../../../../shared/api/image-generation-api";
-import { exportApi } from "../../../../../shared/api/export-api";
+import { toastExportError, triggerDownloadWithToast } from "../../../../shared/lib/export-feedback";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
 import { getConnectedChatDisplayName } from "../../../../../shared/lib/chat-display";
 import {
@@ -1921,10 +1921,17 @@ function ChatSettingsDrawerInner({
   const handleExportPreset = () => {
     if (!selectedChatPreset) return;
     const envelope = createChatPresetExportEnvelope(selectedChatPreset);
-    exportApi.triggerDownload({
-      blob: new Blob([JSON.stringify(envelope, null, 2)], { type: "application/json" }),
-      filename: `${selectedChatPreset.name}.marinara-chat-preset.json`,
-    });
+    try {
+      triggerDownloadWithToast(
+        {
+          blob: new Blob([JSON.stringify(envelope, null, 2)], { type: "application/json" }),
+          filename: `${selectedChatPreset.name}.marinara-chat-preset.json`,
+        },
+        "Chat preset exported.",
+      );
+    } catch (error) {
+      toastExportError(error, "Failed to export chat preset.");
+    }
   };
 
   const handleImportClick = () => {

--- a/src/features/shared/lib/export-feedback.ts
+++ b/src/features/shared/lib/export-feedback.ts
@@ -1,0 +1,16 @@
+import { toast } from "sonner";
+
+import { triggerDownload, type DownloadPayload } from "../../../shared/api/download-payload";
+
+export function getExportErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function toastExportError(error: unknown, fallback: string): void {
+  toast.error(getExportErrorMessage(error, fallback));
+}
+
+export function triggerDownloadWithToast(payload: DownloadPayload, successMessage: string): void {
+  triggerDownload(payload);
+  toast.success(successMessage);
+}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2001

## Why this change

- Several export flows triggered downloads without durable in-app feedback, so users could miss whether an export completed when the browser download UI was hidden or delayed.
- Bulk resource exports already showed toast feedback; this makes the issue-listed single-resource, chat transcript, bulk chat, and chat preset paths consistent with that pattern.

## What changed

- Added a small feature-layer export feedback helper that keeps `sonner` toast handling out of shared API wrappers.
- Wrapped character, persona, lorebook, preset, chat transcript, bulk chat, and chat preset export paths with success/failure toast feedback.
- Left export payload generation, filenames, storage commands, import behavior, and existing bulk resource export behavior unchanged.

## Refactor impact

Primary owner:

Catalog and shared mode UI

Impact areas reviewed:

- Catalog resource editor export actions
- Chat files transcript export actions
- Chat settings chat-preset and Memory Recall export feedback
- Existing bulk character/persona/lorebook/preset export toasts
- Feature/API boundary for download helpers

Boundary notes:

- Toasts stay in `src/features`; `src/shared/api` remains UI-neutral.
- The new helper imports the existing shared download payload helper but does not change payload conversion, native command routing, filenames, or storage behavior.
- No React-free engine, Rust, import, provider, or remote-runtime code changed.

Pressure points touched:

- Shared mode UI: `ChatSettingsDrawer.tsx`
- Catalog resource editors and chat export hooks
- Not touched: `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs`, import modules, storage commands, or export command implementations.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `node scratch/issue-2001-export-feedback-proof.mjs` - passed locally; confirms issue-listed export files contain expected success/error toast feedback and no forbidden raw single-export `triggerDownload` patterns.
- `pnpm typecheck` - passed locally.
- `git diff --check` - passed locally.
- `pnpm check` - passed locally: line endings, architecture, frontend, Rust, docs, discovery, and unused-code checks.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` - passed locally.
- Bunny review - passed for opening a draft PR with the visual-evidence limitation below.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for feedback on existing export actions; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes:

- No docs changes needed; this only adds toasts to existing export actions.

## UI evidence

No before/after app screenshots attached yet. This issue was filed from source inspection, and local proof was static plus TypeScript/full repo checks. Keep this PR draft until a maintainer or follow-up browser pass spot-checks the affected export surfaces if visual evidence is required.
