### PR TITLE
Fix native prompt preset import order remap

### DIFF
--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -187,6 +187,33 @@ fn array_from_envelope(data: &Value, envelope: &Map<String, Value>, key: &str) -
         .unwrap_or_default()
 }
 
+fn remap_imported_child_order(
+    value: Option<&Value>,
+    id_map: &HashMap<String, String>,
+    fallback: &[String],
+) -> Vec<String> {
+    let mut ordered = Vec::new();
+    if let Some(items) = value.and_then(Value::as_array) {
+        for item in items {
+            let Some(old_id) = item.as_str() else {
+                continue;
+            };
+            let Some(new_id) = id_map.get(old_id) else {
+                continue;
+            };
+            if !ordered.iter().any(|id| id == new_id) {
+                ordered.push(new_id.clone());
+            }
+        }
+    }
+    for new_id in fallback {
+        if !ordered.iter().any(|id| id == new_id) {
+            ordered.push(new_id.clone());
+        }
+    }
+    ordered
+}
+
 fn native_character_avatar_payload(data: &Value) -> Value {
     let mut payload = data.clone();
     let Some(avatar) = data_image_string(data.get("avatar")) else {
@@ -455,7 +482,7 @@ fn import_marinara_lorebook(
         let record = state.storage.create("lorebooks", lorebook)?;
         let lorebook_id = created_record_id(&record, "lorebook")?;
         created_lorebook_id = Some(lorebook_id.clone());
-        let folder_id_map = import_parented_records(
+        let (folder_id_map, folder_order) = import_parented_records(
             state,
             array_from_envelope(&data, envelope, "folders"),
             "lorebook-folders",
@@ -464,7 +491,7 @@ fn import_marinara_lorebook(
             "parentFolderId",
             "lorebook folder",
         )?;
-        created_folder_ids.extend(folder_id_map.values().cloned());
+        created_folder_ids.extend(folder_order);
 
         let mut exported_entries = array_from_envelope(&data, envelope, "entries");
         if exported_entries.is_empty() {
@@ -547,7 +574,7 @@ fn import_marinara_preset(
         let record = state.storage.create("prompts", record_value)?;
         let preset_id = created_record_id(&record, "preset")?;
         created_preset_id = Some(preset_id.clone());
-        let group_id_map = import_parented_records(
+        let (group_id_map, group_order) = import_parented_records(
             state,
             array_from_envelope(&data, envelope, "groups"),
             "prompt-groups",
@@ -556,10 +583,16 @@ fn import_marinara_preset(
             "parentGroupId",
             "prompt group",
         )?;
-        created_group_ids.extend(group_id_map.values().cloned());
+        created_group_ids.extend(group_order.iter().cloned());
 
         let mut sections_imported = 0usize;
+        let mut section_id_map = HashMap::new();
+        let mut section_order = Vec::new();
         for section in array_from_envelope(&data, envelope, "sections") {
+            let old_section_id = section
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
             let mut section_record = ensure_object(section)?;
             section_record.remove("id");
             section_record.remove("presetId");
@@ -576,16 +609,27 @@ fn import_marinara_preset(
             let section = state
                 .storage
                 .create("prompt-sections", Value::Object(section_record))?;
-            created_section_ids.push(created_record_id(&section, "prompt section")?);
+            let section_id = created_record_id(&section, "prompt section")?;
+            created_section_ids.push(section_id.clone());
+            section_order.push(section_id.clone());
+            if let Some(old_section_id) = old_section_id {
+                section_id_map.insert(old_section_id, section_id);
+            }
             sections_imported += 1;
         }
 
         let mut variables_imported = 0usize;
+        let mut variable_id_map = HashMap::new();
+        let mut variable_order = Vec::new();
         let mut variables = array_from_envelope(&data, envelope, "choiceBlocks");
         if variables.is_empty() {
             variables = array_from_envelope(&data, envelope, "variables");
         }
         for variable in variables {
+            let old_variable_id = variable
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
             let mut variable_record = ensure_object(variable)?;
             variable_record.remove("id");
             variable_record.remove("presetId");
@@ -593,9 +637,24 @@ fn import_marinara_preset(
             let variable = state
                 .storage
                 .create("prompt-variables", Value::Object(variable_record))?;
-            created_variable_ids.push(created_record_id(&variable, "prompt variable")?);
+            let variable_id = created_record_id(&variable, "prompt variable")?;
+            created_variable_ids.push(variable_id.clone());
+            variable_order.push(variable_id.clone());
+            if let Some(old_variable_id) = old_variable_id {
+                variable_id_map.insert(old_variable_id, variable_id);
+            }
             variables_imported += 1;
         }
+
+        let record = state.storage.patch(
+            "prompts",
+            &preset_id,
+            json!({
+                "groupOrder": remap_imported_child_order(preset_data.get("groupOrder"), &group_id_map, &group_order),
+                "sectionOrder": remap_imported_child_order(preset_data.get("sectionOrder"), &section_id_map, &section_order),
+                "variableOrder": remap_imported_child_order(preset_data.get("variableOrder"), &variable_id_map, &variable_order)
+            }),
+        )?;
 
         flush_import_writes(state)?;
         Ok(json!({

--- a/src-tauri/src/commands/storage/imports/marinara_rollback.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_rollback.rs
@@ -8,9 +8,9 @@ pub(super) fn import_parented_records(
     owner_id: &str,
     parent_field: &str,
     label: &str,
-) -> AppResult<HashMap<String, String>> {
+) -> AppResult<(HashMap<String, String>, Vec<String>)> {
     let mut created_ids = Vec::new();
-    let result = (|| -> AppResult<HashMap<String, String>> {
+    let result = (|| -> AppResult<(HashMap<String, String>, Vec<String>)> {
         let mut id_map = HashMap::new();
         let mut pending_parents = Vec::new();
         for item in items {
@@ -51,7 +51,7 @@ pub(super) fn import_parented_records(
                     .patch(collection, &record_id, Value::Object(patch))?;
             }
         }
-        Ok(id_map)
+        Ok((id_map, created_ids.clone()))
     })();
 
     result.map_err(|error| rollback_created_records_error(state, collection, &created_ids, error))

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -465,3 +465,120 @@ fn marinara_preset_import_remaps_nested_groups_and_section_groups() {
     assert_eq!(orphan.get("groupId"), Some(&Value::Null));
     assert_eq!(malformed.get("groupId"), Some(&Value::Null));
 }
+
+#[test]
+fn marinara_preset_import_remaps_root_child_order_arrays() {
+    let state = test_state("preset-order");
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_preset",
+            "version": 1,
+            "data": {
+                "preset": {
+                    "id": "old-preset",
+                    "name": "Ordered Preset",
+                    "groupOrder": ["old-child", "missing-group", "old-child"],
+                    "sectionOrder": ["old-second", "missing-section", "old-first", "old-second"],
+                    "variableOrder": ["old-variable-b", "missing-variable", "old-variable-a"]
+                },
+                "groups": [
+                    { "id": "old-root", "name": "Root", "presetId": "old-preset" },
+                    { "id": "old-child", "name": "Child", "parentGroupId": "old-root", "presetId": "old-preset" }
+                ],
+                "sections": [
+                    { "id": "old-first", "name": "First", "content": "first", "groupId": "old-root", "presetId": "old-preset" },
+                    { "id": "old-second", "name": "Second", "content": "second", "groupId": "old-child", "presetId": "old-preset" }
+                ],
+                "variables": [
+                    { "id": "old-variable-a", "name": "Tone", "presetId": "old-preset" },
+                    { "id": "old-variable-b", "name": "Style", "presetId": "old-preset" }
+                ]
+            }
+        }),
+    )
+    .expect("preset import should succeed");
+    let preset_id = test_string(&imported, "id");
+
+    let preset = state
+        .storage
+        .get("prompts", preset_id)
+        .expect("preset should be readable")
+        .expect("preset should exist");
+    let groups = state
+        .storage
+        .list("prompt-groups")
+        .expect("groups should be readable")
+        .into_iter()
+        .filter(|group| group.get("presetId").and_then(Value::as_str) == Some(preset_id))
+        .collect::<Vec<_>>();
+    let sections = state
+        .storage
+        .list("prompt-sections")
+        .expect("sections should be readable")
+        .into_iter()
+        .filter(|section| section.get("presetId").and_then(Value::as_str) == Some(preset_id))
+        .collect::<Vec<_>>();
+    let variables = state
+        .storage
+        .list("prompt-variables")
+        .expect("variables should be readable")
+        .into_iter()
+        .filter(|variable| variable.get("presetId").and_then(Value::as_str) == Some(preset_id))
+        .collect::<Vec<_>>();
+
+    let root_group_id = test_string(record_with_field(&groups, "name", "Root"), "id");
+    let child_group_id = test_string(record_with_field(&groups, "name", "Child"), "id");
+    let first_section_id = test_string(record_with_field(&sections, "name", "First"), "id");
+    let second_section_id = test_string(record_with_field(&sections, "name", "Second"), "id");
+    let tone_variable_id = test_string(record_with_field(&variables, "name", "Tone"), "id");
+    let style_variable_id = test_string(record_with_field(&variables, "name", "Style"), "id");
+
+    assert_eq!(
+        preset.get("groupOrder"),
+        Some(&json!([child_group_id, root_group_id]))
+    );
+    assert_eq!(
+        preset.get("sectionOrder"),
+        Some(&json!([second_section_id, first_section_id]))
+    );
+    assert_eq!(
+        preset.get("variableOrder"),
+        Some(&json!([style_variable_id, tone_variable_id]))
+    );
+    for stale_id in [
+        "old-root",
+        "old-child",
+        "old-first",
+        "old-second",
+        "old-variable-a",
+        "old-variable-b",
+        "missing-group",
+        "missing-section",
+        "missing-variable",
+    ] {
+        assert!(
+            !preset
+                .get("groupOrder")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .chain(
+                    preset
+                        .get("sectionOrder")
+                        .and_then(Value::as_array)
+                        .into_iter()
+                        .flatten(),
+                )
+                .chain(
+                    preset
+                        .get("variableOrder")
+                        .and_then(Value::as_array)
+                        .into_iter()
+                        .flatten(),
+                )
+                .any(|id| id.as_str() == Some(stale_id)),
+            "preset order arrays should not keep stale id {stale_id}"
+        );
+    }
+}


### PR DESCRIPTION
## Linked issue

Closes #2000

## Why this change

- Native `marinara_preset` imports recreated prompt groups, sections, and variables with new IDs, but left the preset root `groupOrder`, `sectionOrder`, and `variableOrder` arrays pointing at exported child IDs.
- The preset editor trusts those root order arrays, so imported prompt sections could disappear from the ordered editor view even though the child rows were created.

## What changed

- Preserve created child order from native parented-record imports so fallback order is deterministic.
- Track old-to-new section and variable IDs during native prompt preset import.
- Patch the created preset root with remapped `groupOrder`, `sectionOrder`, and `variableOrder` before flushing import writes.
- Add a regression test covering remapped IDs, duplicate exported IDs, missing exported IDs, and fallback append order.

## Refactor impact

Primary owner:

- Rust storage/imports

Impact areas reviewed:

- Native Marinara prompt preset import
- Prompt group, section, and variable persistence
- Import rollback behavior for created preset children
- Preset editor consumer expectation that root order arrays contain persisted child IDs

Boundary notes:

- No React/UI changes. The fix is in the producer path that saves imported preset data.
- No shared API or remote runtime routing changes.

Pressure points touched:

- `src-tauri/src/commands/storage/imports/marinara.rs`
- `src-tauri/src/commands/storage/imports/marinara_rollback.rs`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the stale-order bug before the fix with:
  - `cargo test --manifest-path src-tauri/Cargo.toml marinara_preset_import_remaps_root_child_order_arrays`
- Codex verified the fix with:
  - `cargo test --manifest-path src-tauri/Cargo.toml marinara_preset_import_remaps_root_child_order_arrays`
  - `cargo test --manifest-path src-tauri/Cargo.toml marinara_preset_import`
  - `cargo check --manifest-path src-tauri/Cargo.toml`
  - `pnpm check`
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed locally.
- Bunny review passed locally on the current diff.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only. It restores existing native preset import behavior and does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a Rust storage/import fix; the focused test reads the saved prompt preset and child records directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ordering preservation in Marinara lorebook and preset imports to ensure folder, group, section, and variable ordering is correctly maintained when mapping to newly created record IDs during import operations.

* **Tests**
  * Added test coverage to verify Marinara preset imports properly remap all ordering arrays to match newly created records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->