### PR TITLE
Fix Memory Recall hidden flag compatibility

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -258,18 +258,10 @@ fn insert_memory_embedding_fields(memory: &mut Map<String, Value>, result: Memor
 }
 
 fn is_hidden_from_ai(message: &Value) -> bool {
-    let extra = match message.get("extra") {
-        Some(Value::Object(object)) => Some(object.clone()),
-        Some(Value::String(raw)) => serde_json::from_str::<Value>(raw)
-            .ok()
-            .and_then(|value| value.as_object().cloned()),
-        _ => None,
-    };
-    extra
-        .as_ref()
-        .and_then(|object| object.get("hiddenFromAi"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    let extra = object_or_parse(message.get("extra"));
+    ["hiddenFromAI", "hiddenFromAi"]
+        .iter()
+        .any(|key| extra.get(*key).and_then(Value::as_bool).unwrap_or(false))
 }
 
 fn active_swipe_index(message: &Value) -> i64 {
@@ -2494,6 +2486,75 @@ mod tests {
 
         assert_eq!(context.connection_id, "embedding-connection");
         assert_eq!(context.model, "text-embedding-3-small");
+    }
+
+    #[tokio::test]
+    async fn refresh_chat_memories_skips_legacy_and_current_hidden_flags() {
+        let state = test_state("memory-hidden-flags");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Memory chat"
+                }),
+            )
+            .expect("chat should be created");
+
+        for message in [
+            json!({
+                "id": "visible-1",
+                "chatId": "chat-1",
+                "role": "user",
+                "content": "visible memory",
+                "createdAt": "2026-06-01T10:00:00.000Z"
+            }),
+            json!({
+                "id": "legacy-hidden-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "legacy hidden memory",
+                "createdAt": "2026-06-01T10:01:00.000Z",
+                "extra": { "hiddenFromAI": true }
+            }),
+            json!({
+                "id": "legacy-hidden-string-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "string hidden memory",
+                "createdAt": "2026-06-01T10:02:00.000Z",
+                "extra": r#"{"hiddenFromAI":true}"#
+            }),
+            json!({
+                "id": "current-hidden-1",
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "current hidden memory",
+                "createdAt": "2026-06-01T10:03:00.000Z",
+                "extra": { "hiddenFromAi": true }
+            }),
+        ] {
+            state
+                .storage
+                .create("messages", message)
+                .expect("message should be created");
+        }
+
+        refresh_chat_memories(&state, "chat-1")
+            .await
+            .expect("memory refresh should succeed");
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat lookup should succeed")
+            .expect("chat should exist");
+        let memories = chat["memories"]
+            .as_array()
+            .expect("memories should be an array");
+
+        assert_eq!(memories.len(), 1);
+        assert_eq!(memories[0]["content"], json!("user: visible memory"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2030

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Memory Recall refresh already skipped messages hidden with the current `hiddenFromAi` flag, but legacy/imported messages can carry only `hiddenFromAI`, letting hidden content into rebuilt memory chunks.

## What changed

<!-- List the key changes in this PR. -->

- Updated the Rust Memory Recall hidden-message helper to parse object or stringified `extra` values and treat either `hiddenFromAI` or `hiddenFromAi` as hidden.
- Added a focused Rust regression covering legacy object extras, stringified legacy extras, current extras, and a visible-message negative control.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Rust storage / Memory Recall

Impact areas reviewed:

- Chat mode Memory Recall refresh
- Rust storage message filtering
- Existing prompt/memory hidden-message flag compatibility

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Change is contained to `src-tauri/src/commands/storage/chats.rs`.
- No React feature, engine, shared API wrapper, command registration, dependency, schema, or remote-runtime routing changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `chat_memories_refresh` / `refresh_chat_memories` filtering path only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Before fix: `cargo test --manifest-path src-tauri/Cargo.toml refresh_chat_memories_skips_legacy_and_current_hidden_flags` failed because rebuilt memory content included `legacy hidden memory` and `string hidden memory`.
- After fix: `cargo test --manifest-path src-tauri/Cargo.toml refresh_chat_memories_skips_legacy_and_current_hidden_flags` passed.
- Raw targeted test result after fix: `1 passed; 0 failed; 404 filtered out`.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed after `pnpm install --frozen-lockfile` supplied missing `node_modules` in the isolated worktree.
- CI Rust Capability Layer passed.
- Bunny pass completed locally for issue match, proof quality, claim boundary, diff scope, whitespace, dependency, and debug-marker checks.
- Local workflow helpers `workflow-health.mjs` and `marinara-proof-gate.mjs` were not present on this machine, so those specific helper gates could not be run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a storage compatibility bugfix for existing Memory Recall behavior, not a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - no visible UI surface changed. The affected path is Rust storage filtering for Memory Recall refresh, verified by targeted Rust regression and `pnpm check`.
