### PR TITLE
Fix Avatar Crop mount sizing

### DIFF
--- a/src/shared/components/ui/AvatarCropWidget.tsx
+++ b/src/shared/components/ui/AvatarCropWidget.tsx
@@ -235,74 +235,83 @@ export function AvatarCropWidget({ src, alt, crop, onChange }: AvatarCropWidgetP
       </p>
 
       <div className="flex gap-4 max-md:flex-col max-md:items-center">
-        {/* Crop canvas — sized to fit the displayed image exactly so overlay
-            coords are also image coords. */}
+        {/* Crop stage reserves stable bounds while the measured image frame
+            stays exact, so overlay coords remain image coords. */}
         <div
-          className="relative overflow-hidden rounded-lg bg-black/40 select-none"
+          className="relative flex items-center justify-center overflow-hidden rounded-lg bg-black/40 select-none"
           style={{
-            width: imgRect?.w ?? MAX_DISPLAY_W,
-            height: imgRect?.h ?? MAX_DISPLAY_H,
+            width: MAX_DISPLAY_W,
+            height: MAX_DISPLAY_H,
           }}
         >
-          {/* key={src} forces remount when the source changes (e.g. switching
-              between personas/characters in the editor). Without this, only the
-              `src` attribute updates on the existing element, and if the new
-              image is already in browser cache the `load` event never fires for
-              React's onLoad listener — so `handleImgLoad` doesn't run and the
-              crop overlay never initializes. */}
-          <img
-            key={src}
-            ref={imgRef}
-            src={src}
-            alt={alt}
-            onLoad={handleImgLoad}
-            draggable={false}
-            className="block h-full w-full"
-            style={{ objectFit: "fill" }}
-          />
-          {cropPx && imgRect && (
-            <div
-              className="absolute touch-none"
-              style={{
-                left: cropPx.x,
-                top: cropPx.y,
-                width: cropPx.size,
-                height: cropPx.size,
-                boxShadow: "0 0 0 9999px rgba(0,0,0,0.55)",
-                outline: "2px solid white",
-                cursor: "move",
-              }}
-              onPointerDown={(e) => onPointerDown(e, "pan")}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
-              onPointerCancel={onPointerUp}
-            >
-              <CornerHandle
-                pos="tl"
-                onPointerDown={(e) => onPointerDown(e, "tl")}
+          <div
+            className="relative overflow-hidden"
+            style={{
+              width: imgRect?.w ?? MAX_DISPLAY_W,
+              height: imgRect?.h ?? MAX_DISPLAY_H,
+              visibility: imgRect ? "visible" : "hidden",
+            }}
+          >
+            {/* key={src} forces remount when the source changes (e.g. switching
+                between personas/characters in the editor). Without this, only the
+                `src` attribute updates on the existing element, and if the new
+                image is already in browser cache the `load` event never fires for
+                React's onLoad listener — so `handleImgLoad` doesn't run and the
+                crop overlay never initializes. */}
+            <img
+              key={src}
+              ref={imgRef}
+              src={src}
+              alt={alt}
+              onLoad={handleImgLoad}
+              draggable={false}
+              className="block h-full w-full"
+              style={{ objectFit: "fill" }}
+            />
+            {cropPx && imgRect && (
+              <div
+                className="absolute touch-none"
+                style={{
+                  left: cropPx.x,
+                  top: cropPx.y,
+                  width: cropPx.size,
+                  height: cropPx.size,
+                  boxShadow: "0 0 0 9999px rgba(0,0,0,0.55)",
+                  outline: "2px solid white",
+                  cursor: "move",
+                }}
+                onPointerDown={(e) => onPointerDown(e, "pan")}
                 onPointerMove={onPointerMove}
                 onPointerUp={onPointerUp}
-              />
-              <CornerHandle
-                pos="tr"
-                onPointerDown={(e) => onPointerDown(e, "tr")}
-                onPointerMove={onPointerMove}
-                onPointerUp={onPointerUp}
-              />
-              <CornerHandle
-                pos="bl"
-                onPointerDown={(e) => onPointerDown(e, "bl")}
-                onPointerMove={onPointerMove}
-                onPointerUp={onPointerUp}
-              />
-              <CornerHandle
-                pos="br"
-                onPointerDown={(e) => onPointerDown(e, "br")}
-                onPointerMove={onPointerMove}
-                onPointerUp={onPointerUp}
-              />
-            </div>
-          )}
+                onPointerCancel={onPointerUp}
+              >
+                <CornerHandle
+                  pos="tl"
+                  onPointerDown={(e) => onPointerDown(e, "tl")}
+                  onPointerMove={onPointerMove}
+                  onPointerUp={onPointerUp}
+                />
+                <CornerHandle
+                  pos="tr"
+                  onPointerDown={(e) => onPointerDown(e, "tr")}
+                  onPointerMove={onPointerMove}
+                  onPointerUp={onPointerUp}
+                />
+                <CornerHandle
+                  pos="bl"
+                  onPointerDown={(e) => onPointerDown(e, "bl")}
+                  onPointerMove={onPointerMove}
+                  onPointerUp={onPointerUp}
+                />
+                <CornerHandle
+                  pos="br"
+                  onPointerDown={(e) => onPointerDown(e, "br")}
+                  onPointerMove={onPointerMove}
+                  onPointerUp={onPointerUp}
+                />
+              </div>
+            )}
+          </div>
         </div>
 
         {/* Live preview — circle avatar at typical sidebar size */}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2003

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Opening the character editor Metadata tab can briefly show Avatar Crop at the fallback square size before image measurement finishes, then snap down to the measured avatar dimensions.

## What changed

<!-- List the key changes in this PR. -->

- Keeps Avatar Crop's outer crop stage at stable bounded dimensions during image load.
- Moves the measured avatar image and crop handles into an inner frame that matches the loaded image dimensions.
- Hides the image while `imgRect` is not initialized, preventing the fallback `360x360` image from painting as a visible oversized first frame.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Catalog / shared UI.

Impact areas reviewed:

- Character Metadata tab Avatar Crop usage.
- Persona Description tab Avatar Crop usage through the shared widget.
- Small, wide, tall, and same-widget source-switch avatar geometry.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- React UI-only change in `src/shared/components/ui/AvatarCropWidget.tsx`.
- No engine, shared API, Tauri/Rust, storage, provider, import/export, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- `node scratch/avatar-crop-measure.mjs` against unpatched `origin/refactor`: reproduced visible pre-measure `360x360` crop image for small, wide, tall, and same-widget source-switch cases; after load, the stage snapped to `120x240`, `360x180`, or `180x360`.
- `node scratch/avatar-crop-measure.mjs` against this branch: pre-measure image is hidden inside a stable `360x360` stage; loaded inner frames resolve to `120x240`, `360x180`, and `180x360`; same-widget source switch stays stable and hidden until the new image resolves to `360x180`.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- Workflow note: `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs` is referenced by local workflow docs but is not present on this machine, so that optional artifact gate could not be run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing editor widget; no new discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

Reviewer-visible image upload is still pending for this draft. Local proof screenshots from the verification run are in `scratch/avatar-crop-broken-before.png`, `scratch/avatar-crop-before.png`, and `scratch/avatar-crop-after.png`; `gh gist create` could not upload binary PNG files from this environment, so the PR remains draft until these are attached through a GitHub-renderable upload path.
