### PR TITLE
Fix SillyTavern hidden chat import rows

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -352,6 +352,8 @@ fn push_unique_string(values: &mut Vec<String>, value: impl Into<String>) {
     }
 }
 
+type CharacterLookup = HashMap<String, Option<String>>;
+
 fn character_record_name(record: &Value) -> Option<String> {
     record
         .get("data")
@@ -364,20 +366,24 @@ fn character_record_name(record: &Value) -> Option<String> {
 }
 
 fn add_character_lookup_alias(
-    lookup: &mut HashMap<String, String>,
+    lookup: &mut CharacterLookup,
     alias: impl AsRef<str>,
     character_id: &str,
 ) {
     let key = normalized_st_lookup_key(alias.as_ref());
     if !key.is_empty() {
-        lookup
-            .entry(key)
-            .or_insert_with(|| character_id.to_string());
+        match lookup.get_mut(&key) {
+            Some(existing) if existing.as_deref() == Some(character_id) => {}
+            Some(existing) => *existing = None,
+            None => {
+                lookup.insert(key, Some(character_id.to_string()));
+            }
+        }
     }
 }
 
 fn add_character_lookup_record(
-    lookup: &mut HashMap<String, String>,
+    lookup: &mut CharacterLookup,
     record: &Value,
     filename: Option<&str>,
 ) {
@@ -397,7 +403,7 @@ fn add_character_lookup_record(
     }
 }
 
-fn character_lookup_from_state(state: &AppState) -> HashMap<String, String> {
+fn character_lookup_from_state(state: &AppState) -> CharacterLookup {
     let mut lookup = HashMap::new();
     if let Ok(characters) = state.storage.list("characters") {
         for character in characters {
@@ -407,12 +413,12 @@ fn character_lookup_from_state(state: &AppState) -> HashMap<String, String> {
     lookup
 }
 
-fn lookup_character_id(lookup: &HashMap<String, String>, alias: impl AsRef<str>) -> Option<String> {
+fn lookup_character_id(lookup: &CharacterLookup, alias: impl AsRef<str>) -> Option<String> {
     let key = normalized_st_lookup_key(alias.as_ref());
     if key.is_empty() {
         None
     } else {
-        lookup.get(&key).cloned()
+        lookup.get(&key).and_then(Clone::clone)
     }
 }
 
@@ -540,7 +546,7 @@ fn st_group_metadata_for_chat(
 }
 
 fn resolve_member_character_ids(
-    lookup: &HashMap<String, String>,
+    lookup: &CharacterLookup,
     members: impl IntoIterator<Item = impl AsRef<str>>,
 ) -> Vec<String> {
     let mut character_ids = Vec::new();
@@ -612,9 +618,19 @@ fn st_message_timestamp(row: &Value) -> Option<String> {
     None
 }
 
+fn st_message_hidden_from_ai(row: &Value) -> bool {
+    row.get("is_system")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || bool_option(row.get("extra").and_then(|extra| extra.get("hiddenFromAI")))
+            .unwrap_or(false)
+        || bool_option(row.get("extra").and_then(|extra| extra.get("hiddenFromAi")))
+            .unwrap_or(false)
+}
+
 #[derive(Clone, Default)]
 struct StChatImportContext {
-    character_lookup: HashMap<String, String>,
+    character_lookup: CharacterLookup,
     default_character_id: Option<String>,
 }
 
@@ -664,6 +680,10 @@ fn st_message_extra(row: &Value) -> Value {
             "sillyTavernSpeaker".to_string(),
             Value::String(speaker.to_string()),
         );
+    }
+    if st_message_hidden_from_ai(row) {
+        extra.insert("hiddenFromAI".to_string(), Value::Bool(true));
+        extra.insert("hiddenFromAi".to_string(), Value::Bool(true));
     }
     Value::Object(extra)
 }
@@ -893,13 +913,6 @@ fn import_st_chat_text(
         push_unique_string(&mut character_ids, default_character_id.clone());
     }
     let has_importable_message = parsed_rows.iter().any(|row| {
-        if row
-            .get("is_system")
-            .and_then(Value::as_bool)
-            .unwrap_or(false)
-        {
-            return false;
-        }
         row.get("mes")
             .or_else(|| row.get("content"))
             .and_then(Value::as_str)
@@ -941,13 +954,6 @@ fn import_st_chat_text(
         created_chat_id = Some(chat_id.clone());
         let mut imported = 0usize;
         for row in parsed_rows {
-            if row
-                .get("is_system")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-            {
-                continue;
-            }
             let content = row
                 .get("mes")
                 .or_else(|| row.get("content"))
@@ -2081,6 +2087,153 @@ mod tests {
             messages[0].get("role").and_then(Value::as_str),
             Some("assistant"),
             "unknown JSONL roles should not be persisted verbatim"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_preserves_sillytavern_system_rows_as_hidden_from_ai() {
+        let app_root = temp_path("chat-st-system-hidden");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        let result = import_st_chat_text(
+            &state,
+            r#"{"is_system":true,"mes":"hidden note","character_name":"Bot"}"#,
+            "Imported Chat".to_string(),
+            None,
+            StChatImportContext::default(),
+        )
+        .expect("ST system transcript rows with content should import");
+
+        assert_eq!(result.get("messagesImported"), Some(&json!(1)));
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].get("content").and_then(Value::as_str),
+            Some("hidden note")
+        );
+        assert_eq!(messages[0]["extra"]["hiddenFromAI"], json!(true));
+        assert_eq!(messages[0]["extra"]["hiddenFromAi"], json!(true));
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_links_sillytavern_speaker_names_from_context_lookup() {
+        let app_root = temp_path("chat-st-speaker-lookup");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        let character = state
+            .storage
+            .create("characters", json!({ "data": { "name": "Bot" } }))
+            .expect("character should create");
+        let character_id = character
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("character should include id")
+            .to_string();
+        let context = StChatImportContext {
+            character_lookup: character_lookup_from_state(&state),
+            default_character_id: None,
+        };
+
+        let result = import_st_chat_text(
+            &state,
+            concat!(
+                r#"{"character_name":"Bot","mes":"character name"}"#,
+                "\n",
+                r#"{"name":"Bot","mes":"name"}"#,
+                "\n",
+                r#"{"extra":{"name":"Bot"},"mes":"extra name"}"#
+            ),
+            "Imported Chat".to_string(),
+            None,
+            context,
+        )
+        .expect("ST speaker names should import");
+
+        let chat_id = result
+            .get("chatId")
+            .and_then(Value::as_str)
+            .expect("import result should include chat id");
+        let chat = state
+            .storage
+            .get("chats", chat_id)
+            .expect("chat should be readable")
+            .expect("chat should exist");
+        assert_eq!(
+            shared::string_array_from_value(chat.get("characterIds")),
+            vec![character_id.clone()]
+        );
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 3);
+        assert!(
+            messages
+                .iter()
+                .all(|message| message.get("characterId").and_then(Value::as_str)
+                    == Some(character_id.as_str())),
+            "each ST speaker field should resolve to the matched character"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_keeps_ambiguous_sillytavern_speaker_names_unlinked() {
+        let app_root = temp_path("chat-st-ambiguous-speaker");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        state
+            .storage
+            .create("characters", json!({ "data": { "name": "Bot" } }))
+            .expect("first character should create");
+        state
+            .storage
+            .create("characters", json!({ "data": { "name": "Bot" } }))
+            .expect("second character should create");
+        let context = StChatImportContext {
+            character_lookup: character_lookup_from_state(&state),
+            default_character_id: None,
+        };
+
+        let result = import_st_chat_text(
+            &state,
+            r#"{"character_name":"Bot","mes":"ambiguous"}"#,
+            "Imported Chat".to_string(),
+            None,
+            context,
+        )
+        .expect("ambiguous ST speaker row should still import");
+
+        let chat_id = result
+            .get("chatId")
+            .and_then(Value::as_str)
+            .expect("import result should include chat id");
+        let chat = state
+            .storage
+            .get("chats", chat_id)
+            .expect("chat should be readable")
+            .expect("chat should exist");
+        assert!(
+            shared::string_array_from_value(chat.get("characterIds")).is_empty(),
+            "ambiguous ST speaker names should not guess a chat character id"
+        );
+        let messages = state
+            .storage
+            .list("messages")
+            .expect("messages should list");
+        assert_eq!(messages.len(), 1);
+        assert!(
+            messages[0].get("characterId").is_none_or(Value::is_null),
+            "ambiguous ST speaker names should keep transcript messages unlinked"
         );
 
         let _ = fs::remove_dir_all(app_root);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2002

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- SillyTavern JSONL chat import skipped rows marked `is_system`, which dropped hidden/system transcript messages instead of preserving them as hidden-from-AI messages.
- Speaker-name alias lookup could also guess a character when duplicate aliases existed, which risks attaching imported chat messages to the wrong avatar.

## What changed

<!-- List the key changes in this PR. -->

- Preserve importable SillyTavern `is_system` rows and mark their message `extra` with both `hiddenFromAI` and `hiddenFromAi`.
- Keep SillyTavern speaker-name linking for `character_name`, `name`, and `extra.name` when the alias has one unique character match.
- Treat duplicate character aliases as ambiguous so imported messages stay unlinked instead of guessing.
- Add focused Rust coverage for hidden/system row preservation, unique speaker-name linking, ambiguous-name negative control, and existing no-lookup behavior.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

- Rust storage imports

Impact areas reviewed:

- SillyTavern chat JSONL import
- Bulk character/chat/group chat import speaker lookup
- Message `extra.hiddenFromAI` / `extra.hiddenFromAi` handling

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Touched only `src-tauri` import/storage logic and Rust unit coverage; no React, engine, shared API, or remote-runtime routing changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src-tauri/src/commands/storage/imports/bulk_imports.rs`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Reproduced before the fix with `cargo test --manifest-path src-tauri/Cargo.toml import_st_chat_text_ -- --nocapture`: hidden `is_system` row failed with `Chat import JSONL must contain at least one message`, and duplicate `Bot` aliases guessed a character ID.
- After the fix, `cargo test --manifest-path src-tauri/Cargo.toml import_st_chat_text_ -- --nocapture` passed: 9 targeted import tests.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed.
- `node C:/Users/celia/.codex/tools/marinara-proof-gate.mjs scratch/bugfix-verification.json` could not run because the proof-gate helper is not present in this checkout.
- No UI screenshot: this is backend/Rust import behavior with no meaningful visible UI state.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. The changed behavior is covered by Rust import tests and full repo validation.
