### PR TITLE
Fix Claude subscription model catalog

### DIFF
--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -16,6 +16,8 @@ const OPENAI_CHATGPT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/cod
 const OPENAI_CHATGPT_REFRESH_URL: &str = "https://auth.openai.com/oauth/token";
 const OPENAI_CHATGPT_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const APP_VERSION: &str = "1.6.1";
+const CLAUDE_SUBSCRIPTION_1M_SUFFIX: &str = "[1m]";
+const CLAUDE_SUBSCRIPTION_1M_BETA: &str = "context-1m-2025-08-07";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SseBlockStatus {
@@ -1621,6 +1623,43 @@ fn claude_subscription_command() -> String {
         .unwrap_or_else(|| "claude".to_string())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClaudeSubscriptionModelSelection {
+    configured_model: String,
+    cli_model: String,
+    long_context_beta: bool,
+}
+
+fn claude_subscription_model_selection(model: &str) -> ClaudeSubscriptionModelSelection {
+    let configured_model = model.trim().to_string();
+    let Some(base_model) = configured_model
+        .strip_suffix(CLAUDE_SUBSCRIPTION_1M_SUFFIX)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return ClaudeSubscriptionModelSelection {
+            cli_model: configured_model.clone(),
+            configured_model,
+            long_context_beta: false,
+        };
+    };
+    let cli_model = base_model.to_string();
+    ClaudeSubscriptionModelSelection {
+        configured_model,
+        cli_model,
+        long_context_beta: true,
+    }
+}
+
+fn claude_subscription_model_args(selection: &ClaudeSubscriptionModelSelection) -> Vec<String> {
+    let mut args = vec!["--model".to_string(), selection.cli_model.clone()];
+    if selection.long_context_beta {
+        args.push("--betas".to_string());
+        args.push(CLAUDE_SUBSCRIPTION_1M_BETA.to_string());
+    }
+    args
+}
+
 pub fn check_claude_subscription_available() -> AppResult<String> {
     let command_name = claude_subscription_command();
     let mut command = Command::new(&command_name);
@@ -1833,8 +1872,8 @@ fn parse_claude_subscription_json_output(raw: &str) -> Option<Value> {
 }
 
 pub fn diagnose_claude_subscription_model(model: &str, fast_mode: bool) -> AppResult<Value> {
-    let requested_model = model.trim();
-    if requested_model.is_empty() {
+    let selection = claude_subscription_model_selection(model);
+    if selection.configured_model.is_empty() {
         return Err(AppError::invalid_input(
             "No model configured. Pick a model first.",
         ));
@@ -1843,8 +1882,6 @@ pub fn diagnose_claude_subscription_model(model: &str, fast_mode: bool) -> AppRe
     let mut command = Command::new(claude_subscription_command());
     command
         .arg("-p")
-        .arg("--model")
-        .arg(requested_model)
         .arg("--output-format")
         .arg("json")
         .arg("--permission-mode")
@@ -1858,6 +1895,7 @@ pub fn diagnose_claude_subscription_model(model: &str, fast_mode: bool) -> AppRe
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    command.args(claude_subscription_model_args(&selection));
     command.env("ENABLE_CLAUDEAI_MCP_SERVERS", "false");
     #[cfg(windows)]
     {
@@ -1916,15 +1954,17 @@ pub fn diagnose_claude_subscription_model(model: &str, fast_mode: bool) -> AppRe
                 "model": model,
                 "inputTokens": usage.get("input_tokens").and_then(Value::as_u64),
                 "outputTokens": usage.get("output_tokens").and_then(Value::as_u64),
-                "role": if model == requested_model { "requested" } else { "auxiliary" },
+                "role": if model == &selection.cli_model { "requested" } else { "auxiliary" },
             })
         })
         .collect::<Vec<_>>();
     let response = claude_subscription_text_from_json(&value).unwrap_or_default();
-    let downgraded = !model_usage.is_empty() && !model_usage.contains_key(requested_model);
+    let downgraded = !model_usage.is_empty() && !model_usage.contains_key(&selection.cli_model);
     Ok(json!({
         "success": !downgraded,
-        "requestedModel": requested_model,
+        "requestedModel": selection.cli_model,
+        "configuredModel": selection.configured_model,
+        "longContextBeta": selection.long_context_beta,
         "modelsBilled": models_billed,
         "modelUsageDetail": model_usage_detail,
         "fastModeState": value.get("fast_mode_state").and_then(Value::as_str),
@@ -1936,11 +1976,10 @@ pub fn diagnose_claude_subscription_model(model: &str, fast_mode: bool) -> AppRe
 
 async fn complete_claude_subscription(request: LlmRequest) -> AppResult<String> {
     let prompt_selection = claude_subscription_prompt(&request);
+    let model_selection = claude_subscription_model_selection(&request.connection.model);
     let mut command = Command::new(claude_subscription_command());
     command
         .arg("-p")
-        .arg("--model")
-        .arg(&request.connection.model)
         .arg("--output-format")
         .arg("json")
         .arg("--permission-mode")
@@ -1953,6 +1992,7 @@ async fn complete_claude_subscription(request: LlmRequest) -> AppResult<String> 
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    command.args(claude_subscription_model_args(&model_selection));
     if let Some(system_prompt) = prompt_selection.system_prompt.as_ref() {
         command.arg("--append-system-prompt").arg(system_prompt);
     }
@@ -1973,7 +2013,9 @@ async fn complete_claude_subscription(request: LlmRequest) -> AppResult<String> 
         "claude-code://local",
         &request,
         &json!({
-            "model": request.connection.model.clone(),
+            "model": model_selection.cli_model.clone(),
+            "configuredModel": model_selection.configured_model.clone(),
+            "longContextBeta": model_selection.long_context_beta,
             "outputFormat": "json",
             "permissionMode": "bypassPermissions",
             "fastMode": request.connection.claude_fast_mode,
@@ -2020,7 +2062,7 @@ async fn complete_claude_subscription(request: LlmRequest) -> AppResult<String> 
             })),
         ));
     }
-    parse_claude_subscription_output(&stdout, &request.connection.model)
+    parse_claude_subscription_output(&stdout, &model_selection.cli_model)
 }
 
 fn build_anthropic_body(request: &LlmRequest, stream: bool) -> Value {
@@ -3614,6 +3656,36 @@ data: {"type":"content_block_delta","index":0,"delta":{"thinking":"summary witho
         assert_eq!(prompt.prompt, "User: Regenerate from here.");
         assert_eq!(prompt.session_id, None);
         assert_eq!(prompt.prompt_shape, "transcript-fold");
+    }
+
+    #[test]
+    fn claude_subscription_1m_suffix_maps_to_beta_arg_and_base_model() {
+        let selection = claude_subscription_model_selection("claude-opus-4-8[1m]");
+
+        assert_eq!(selection.configured_model, "claude-opus-4-8[1m]");
+        assert_eq!(selection.cli_model, "claude-opus-4-8");
+        assert!(selection.long_context_beta);
+        assert_eq!(
+            claude_subscription_model_args(&selection),
+            vec![
+                "--model".to_string(),
+                "claude-opus-4-8".to_string(),
+                "--betas".to_string(),
+                "context-1m-2025-08-07".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn claude_subscription_plain_model_does_not_add_beta_arg() {
+        let selection = claude_subscription_model_selection("claude-sonnet-4-6");
+
+        assert_eq!(selection.cli_model, "claude-sonnet-4-6");
+        assert!(!selection.long_context_beta);
+        assert_eq!(
+            claude_subscription_model_args(&selection),
+            vec!["--model".to_string(), "claude-sonnet-4-6".to_string()]
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -771,12 +771,12 @@ fn provider_model_catalog(provider: &str) -> Vec<Value> {
         ],
         "claude_subscription" => &[
             "claude-opus-4-8",
-            "claude-opus-4-7",
-            "claude-opus-4-6",
+            "claude-opus-4-8[1m]",
             "claude-sonnet-4-6",
-            "claude-opus-4-5",
-            "claude-sonnet-4-5",
             "claude-haiku-4-5",
+            "claude-opus-4-7",
+            "claude-opus-4-7[1m]",
+            "claude-opus-4-6",
         ],
         "google" | "google_vertex" => &["gemini-1.5-pro", "gemini-1.5-flash", "text-embedding-004"],
         "openrouter" => &[

--- a/src/engine/contracts/constants/model-lists.test.ts
+++ b/src/engine/contracts/constants/model-lists.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { MODEL_LISTS } from "./model-lists";
+
+describe("Claude subscription model catalog", () => {
+  it("matches the Claude Code subscription selector order", () => {
+    expect(MODEL_LISTS.claude_subscription.map((model) => model.id)).toEqual([
+      "claude-opus-4-8",
+      "claude-opus-4-8[1m]",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      "claude-opus-4-7",
+      "claude-opus-4-7[1m]",
+      "claude-opus-4-6",
+    ]);
+  });
+
+  it("does not surface retired 4.5 subscription aliases", () => {
+    const ids = MODEL_LISTS.claude_subscription.map((model) => model.id);
+
+    expect(ids).not.toContain("claude-opus-4-5");
+    expect(ids).not.toContain("claude-sonnet-4-5");
+  });
+});

--- a/src/engine/contracts/constants/model-lists.ts
+++ b/src/engine/contracts/constants/model-lists.ts
@@ -133,12 +133,17 @@ const ANTHROPIC_MODELS: KnownModel[] = [
 // ── Claude (Subscription via local Claude Code auth) ──
 const CLAUDE_SUBSCRIPTION_MODELS: KnownModel[] = [
   { id: "claude-opus-4-8", name: "Claude Opus 4.8", context: 1000000, maxOutput: 128000 },
-  { id: "claude-opus-4-7", name: "Claude Opus 4.7", context: 1000000, maxOutput: 128000 },
-  { id: "claude-opus-4-6", name: "Claude Opus 4.6", context: 1000000, maxOutput: 32000 },
-  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", context: 1000000, maxOutput: 32000 },
-  { id: "claude-opus-4-5", name: "Claude Opus 4.5", context: 1000000, maxOutput: 32000 },
-  { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", context: 1000000, maxOutput: 16000 },
-  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", context: 200000, maxOutput: 8192 },
+  { id: "claude-opus-4-8[1m]", name: "Claude Opus 4.8 (1M context)", context: 1000000, maxOutput: 128000 },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", context: 1000000, maxOutput: 64000 },
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", context: 200000, maxOutput: 64000 },
+  { id: "claude-opus-4-7", name: "Claude Opus 4.7 (Legacy)", context: 1000000, maxOutput: 128000 },
+  {
+    id: "claude-opus-4-7[1m]",
+    name: "Claude Opus 4.7 (1M context, Legacy)",
+    context: 1000000,
+    maxOutput: 128000,
+  },
+  { id: "claude-opus-4-6", name: "Claude Opus 4.6 (Legacy)", context: 1000000, maxOutput: 128000 },
 ];
 
 // ── OpenAI (ChatGPT login via local Codex auth) ──


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2032

## Why this change

- Claude (Subscription) users need the local Claude Code model picker to expose the current subscription choices, including Opus 4.8 and explicit 1M-context options, without forwarding `[1m]` as a fake Claude model id.

## What changed

- Updated the frontend Claude Subscription static catalog to match the requested selector order, add the `[1m]` Opus entries, mark legacy Opus entries, and remove retired 4.5 subscription aliases.
- Updated the Rust model fallback catalog for Claude Subscription so API-backed model lookup returns the same ids.
- Added Claude Subscription runtime mapping that strips a `[1m]` suffix before `--model` and adds `--betas context-1m-2025-08-07` for Claude Code.
- Added regression coverage for the catalog order, stale alias removal, and `[1m]`/plain model CLI arg behavior.

## Refactor impact

Primary owner:

- runtime generation / Rust storage

Impact areas reviewed:

- Claude Subscription connection model catalog
- Claude Code generation command construction
- Claude Subscription diagnosis command construction

Boundary notes:

- Engine constants remain React-free.
- Feature UI continues to consume `MODEL_LISTS`; no new raw Tauri calls or remote-runtime fetch paths.
- Rust runtime changes stay inside the existing Claude Subscription provider path.
- Independent implementation from `upstream/refactor`; existing PR #2031 was not used as source material.

Pressure points touched:

- None of the mode surfaces, command registration, imports, or remote-runtime routing paths were changed.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex proof: `node scratch\issue-2032-repro.mjs` failed before the fix and passed after the fix.
- Codex proof: `pnpm exec vitest run src\engine\contracts\constants\model-lists.test.ts` passed.
- Codex proof: `cargo test --manifest-path src-tauri\Cargo.toml -p marinara-llm claude_subscription_` passed.
- Codex proof: `pnpm typecheck` passed.
- Codex proof: `cargo check --manifest-path src-tauri\Cargo.toml --workspace` passed.
- Codex proof: `pnpm check` passed.
- Live Claude Code generation was not run because it requires authenticated external provider usage; the app-owned contract proof covers the emitted CLI args and catalog options.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This only refreshes an existing provider's model choices and request mapping.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A; this is a catalog/runtime mapping fix. Raw command proof is recorded under `scratch/issue-2032-proof.txt` in the local worktree.
