### PR TITLE
Bound generation history hot-path reads

### DIFF
--- a/src/engine/generation/context.ts
+++ b/src/engine/generation/context.ts
@@ -81,6 +81,11 @@ export async function loadChatMessages(
   return Array.isArray(messages) ? messages.filter(isRecord) : [];
 }
 
+export async function loadChatMessage(storage: StorageGateway, messageId: string): Promise<JsonRecord | null> {
+  const message = await storage.get<unknown>("messages", messageId, withGenerationMessageProjection());
+  return isRecord(message) ? message : null;
+}
+
 export function llmParameters(
   connection: JsonRecord,
   input: { parameters?: Record<string, unknown> | null },

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -30,7 +30,7 @@ import {
   type MainToolDefinitions,
   type ToolRuntimeInput,
 } from "./tools-runtime";
-import { llmParameters, loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
+import { llmParameters, loadChatMessage, loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
 import {
   appendReadableAttachmentsToContent,
   extractImageAttachmentDataUrls,
@@ -149,6 +149,12 @@ interface CyoaChoice {
   label: string;
   text: string;
 }
+
+const DEFAULT_GENERATION_HISTORY_LIMIT = 300;
+const GENERATION_MESSAGE_LOAD_MARGIN = 20;
+const MIN_GENERATION_MESSAGE_LOAD_LIMIT = 40;
+const MAX_GENERATION_MESSAGE_LOAD_LIMIT = DEFAULT_GENERATION_HISTORY_LIMIT + GENERATION_MESSAGE_LOAD_MARGIN;
+const LOREBOOK_KEEPER_BACKFILL_TARGET_SCAN_FIELDS = ["id", "chatId", "role", "extra", "createdAt"];
 
 const LOREBOOK_KEEPER_AGENT_TYPE = "lorebook-keeper";
 const DEFAULT_LOREBOOK_KEEPER_RUN_INTERVAL = BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[LOREBOOK_KEEPER_AGENT_TYPE] ?? 8;
@@ -847,11 +853,49 @@ function generationMessageLoadOptions(
   chat: JsonRecord,
   input: StartGenerationInput,
 ): Parameters<StorageGateway["listChatMessages"]>[1] {
-  if (readString(input.regenerateMessageId).trim()) return undefined;
   const chatLimit = readNumber(parseRecord(chat.metadata).contextMessageLimit, 0);
-  if (chatLimit <= 0 && !Number.isFinite(Number(input.historyLimit))) return undefined;
-  const historyLimit = Math.max(1, Math.min(9999, chatLimit || readNumber(input.historyLimit, 300)));
-  return { limit: Math.max(40, Math.min(340, historyLimit + 20)) };
+  const requestedLimit = readNumber(input.historyLimit, DEFAULT_GENERATION_HISTORY_LIMIT);
+  const historyLimit = Math.max(
+    1,
+    Math.min(DEFAULT_GENERATION_HISTORY_LIMIT, chatLimit || requestedLimit || DEFAULT_GENERATION_HISTORY_LIMIT),
+  );
+  return {
+    limit: Math.max(
+      MIN_GENERATION_MESSAGE_LOAD_LIMIT,
+      Math.min(MAX_GENERATION_MESSAGE_LOAD_LIMIT, historyLimit + GENERATION_MESSAGE_LOAD_MARGIN),
+    ),
+  };
+}
+
+function messageCursor(message: JsonRecord): string | null {
+  const createdAt = readString(message.createdAt).trim();
+  const id = readString(message.id).trim();
+  return createdAt && id ? `${createdAt}|${id}` : null;
+}
+
+function targetBelongsToChat(target: JsonRecord | null, chatId: string): target is JsonRecord {
+  return !!target && readString(target.chatId).trim() === chatId;
+}
+
+async function loadMessagesForGenerationTarget(args: {
+  storage: StorageGateway;
+  chatId: string;
+  chat: JsonRecord;
+  input: StartGenerationInput;
+  targetMessageId?: string | null;
+}): Promise<JsonRecord[]> {
+  const options = generationMessageLoadOptions(args.chat, args.input);
+  const targetId = readString(args.targetMessageId ?? args.input.regenerateMessageId).trim();
+  if (!targetId) return loadChatMessages(args.storage, args.chatId, options);
+
+  const target = await loadChatMessage(args.storage, targetId).catch(() => null);
+  if (!targetBelongsToChat(target, args.chatId)) return loadChatMessages(args.storage, args.chatId);
+
+  const before = messageCursor(target);
+  if (!before) return loadChatMessages(args.storage, args.chatId);
+
+  const previousMessages = await loadChatMessages(args.storage, args.chatId, { ...options, before });
+  return [...previousMessages, target];
 }
 
 function withImageAttachments(messages: LlmMessage[], images: string[]): LlmMessage[] {
@@ -2186,7 +2230,11 @@ function lorebookKeeperBackfillTargets(
   const assistantMessages = storedMessages
     .filter((message) => !hiddenFromAi(message))
     .filter((message) => readString(message.role).trim() === "assistant")
-    .filter((message) => readString(message.id).trim() && readString(message.content).trim());
+    .filter((message) => {
+      if (!readString(message.id).trim()) return false;
+      if (!Object.prototype.hasOwnProperty.call(message, "content")) return true;
+      return !!readString(message.content).trim();
+    });
   const eligibleCount = Math.max(0, assistantMessages.length - options.readBehind);
   const targets: LorebookKeeperTarget[] = [];
 
@@ -2369,7 +2417,14 @@ async function runLorebookKeeperBackfill(
   const agent = await lorebookKeeperAgent(deps.storage, args.chat);
   if (!agent) return [];
 
-  const storedMessages = args.storedMessages ?? (await loadChatMessages(deps.storage, chatId));
+  const storedMessages =
+    args.storedMessages ??
+    (
+      await deps.storage.listChatMessages<unknown>(chatId, {
+        fields: LOREBOOK_KEEPER_BACKFILL_TARGET_SCAN_FIELDS,
+        fieldSelections: { extra: ["hiddenFromAI", "hiddenFromAi"] },
+      })
+    ).filter(isRecord);
   const processedMessageIds = await successfulLorebookKeeperMessageIds(deps.storage, chatId);
   const targets = lorebookKeeperBackfillTargets(storedMessages, processedMessageIds, {
     readBehind: lorebookKeeperReadBehind(args.chat),
@@ -2379,6 +2434,17 @@ async function runLorebookKeeperBackfill(
   const allResults: AgentResult[] = [];
 
   for (const target of targets) {
+    const targetMessages = await loadMessagesForGenerationTarget({
+      storage: deps.storage,
+      chatId,
+      chat: args.chat,
+      input,
+      targetMessageId: readString(target.message.id).trim(),
+    });
+    const hydratedTarget =
+      targetMessages.find((message) => readString(message.id).trim() === readString(target.message.id).trim()) ??
+      target.message;
+    if (!readString(hydratedTarget.content).trim()) continue;
     allResults.push(
       ...(
         await runGenerationAgentsForTarget({
@@ -2386,8 +2452,8 @@ async function runLorebookKeeperBackfill(
           input,
           chat: args.chat,
           connection: args.connection,
-          storedMessages,
-          target: target.message,
+          storedMessages: targetMessages,
+          target: hydratedTarget,
           agentTypes,
           signal: args.signal,
         })
@@ -2411,13 +2477,20 @@ export async function retryGenerationAgents(
   const chat = requireRecord(await deps.storage.get("chats", chatId), "Chat");
   assertChatCanGenerate(chat);
   const connection = await resolveGenerationConnection(deps.storage, chat, input);
-  const storedMessages = await loadChatMessages(deps.storage, chatId);
   if (isLorebookKeeperBackfill(input)) {
     return {
-      results: await runLorebookKeeperBackfill(deps, input, { chat, connection, storedMessages, signal }),
+      results: await runLorebookKeeperBackfill(deps, input, { chat, connection, signal }),
       events: [],
     };
   }
+  const targetMessageId = readString(input.options?.forMessageId).trim();
+  const storedMessages = await loadMessagesForGenerationTarget({
+    storage: deps.storage,
+    chatId,
+    chat,
+    input,
+    targetMessageId,
+  });
   const target = targetAssistantMessage(storedMessages, input.options);
   return runGenerationAgentsForTarget({ deps, input, chat, connection, storedMessages, target, agentTypes, signal });
 }
@@ -2460,7 +2533,7 @@ export async function* startGeneration(
       ? [...(storedMessages ?? []), savedTimelineMessage]
       : await loadChatMessages(deps.storage, chatId, messageLoadOptions);
   } else {
-    storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
+    storedMessages = await loadMessagesForGenerationTarget({ storage: deps.storage, chatId, chat, input });
   }
   let generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
   const latestUserInput =
@@ -2545,7 +2618,7 @@ export async function* startGeneration(
       };
       await abortableDelay(availability.delayMs, signal);
       throwIfAborted(signal);
-      storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
+      storedMessages = await loadMessagesForGenerationTarget({ storage: deps.storage, chatId, chat, input });
       generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
     }
     if (characterNames.length > 0) {

--- a/src/engine/modes/chat/autonomous/autonomous.service.ts
+++ b/src/engine/modes/chat/autonomous/autonomous.service.ts
@@ -39,6 +39,9 @@ type StoredMessage = {
 
 type UserStatus = "active" | "idle" | "dnd";
 
+const AUTONOMOUS_ACTIVITY_MESSAGE_LIMIT = 80;
+const AUTONOMOUS_ACTIVITY_MESSAGE_FIELDS = ["role", "createdAt", "characterId"];
+
 function metadataRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
     try {
@@ -64,7 +67,10 @@ async function requireChat(storage: StorageGateway, chatId: string): Promise<Sto
 }
 
 async function chatMessages(storage: StorageGateway, chatId: string): Promise<StoredMessage[]> {
-  const rows = await storage.listChatMessages<unknown>(chatId);
+  const rows = await storage.listChatMessages<unknown>(chatId, {
+    limit: AUTONOMOUS_ACTIVITY_MESSAGE_LIMIT,
+    fields: AUTONOMOUS_ACTIVITY_MESSAGE_FIELDS,
+  });
   return Array.isArray(rows) ? (rows as StoredMessage[]) : [];
 }
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2034

## Why this change

- Generation, targeted retry/lorebook keeper, and autonomous background checks still had hot paths that could request full chat message history. Large chats could therefore make routine generation and polling scale with total transcript size instead of the prompt/activity window.

## What changed

- Normal generation now always passes a bounded message load limit that matches the prompt assembly default history window plus margin.
- Regeneration and targeted agent retry fetch the target message by id, then load only the bounded page before that target cursor.
- Lorebook keeper backfill now scans lightweight message metadata to find candidate targets, then hydrates only each target's bounded generation context.
- Autonomous activity initialization now requests only a recent projected message slice with `role`, `createdAt`, and `characterId`.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- `startGeneration` normal and regenerate message loading
- `retryGenerationAgents` targeted and lorebook keeper paths
- autonomous conversation activity initialization
- storage message pagination/projection behavior

Boundary notes:

- Engine-only change. No React, shared API wrapper, Tauri command, schema, dependency, version, import/export, or release metadata changes.
- Storage remains the consumer contract; callers now pass bounded/projected options instead of relying on unbounded defaults.

Pressure points touched:

- `src/engine/generation/start-generation.ts`
- `src/engine/generation/context.ts`
- `src/engine/modes/chat/autonomous/autonomous.service.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run --config scratch\vitest.issue-2034.config.ts` passed. The scratch proof asserts normal generation limit `320`, regenerate and targeted retry `before` cursor pages, lorebook keeper metadata scan without `content` payload plus bounded target context, and autonomous activity limit `80` with `role`/`createdAt`/`characterId` fields.
- `pnpm check` passed on current `upstream/refactor`: line endings, architecture, frontend `tsc -b`, Rust workspace `cargo check`, docs, discovery metadata, and unused-code.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review pass completed before opening this draft. No blocking findings.
- No separate human-only verification is required for the core claim; this is an engine read-shape change proven by the scratch harness and full repo check.
- Non-blocking note: lorebook keeper candidate scans avoid reading full message content. Blank assistant targets are skipped after target hydration, which preserves the no-empty-target guard without restoring full-payload scans.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal engine performance/read-shape fix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no visible UI changes.
