### PR TITLE
Move storage cleanup and defaults into contracts

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -708,33 +708,63 @@ pub(crate) fn delete_entity(
         state.storage.delete(entity, id)?
     };
     if deleted {
-        if entity == "lorebooks" {
-            delete_lorebook_children(state, id)?;
-            clear_deleted_lorebook_references(state, id)?;
-        }
-        if entity == "prompts" {
-            prompts::delete_prompt_preset_children(state, id)?;
-        }
-        if entity == "chat-presets" {
-            if let Some(record) = existing.as_ref() {
-                activate_default_chat_preset_if_needed(state, record)?;
-            }
-        }
-        if entity == "connection-folders" {
-            unfile_connections_in_folder(state, id)?;
-        }
-        if let Some(record) = existing.as_ref() {
-            remove_owned_media(state, entity, record);
-        }
-        if entity == "characters" {
-            delete_character_gallery(state, id)?;
-        }
-        if let Some(chat_id) = message_chat_id {
-            game_state_snapshots::delete_tracker_snapshots_for_message(state, &chat_id, id)?;
-            game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, &chat_id)?;
-        }
+        apply_delete_cleanup(
+            state,
+            entity,
+            id,
+            existing.as_ref(),
+            message_chat_id.as_deref(),
+        )?;
     }
     Ok(json!({ "deleted": deleted }))
+}
+
+fn apply_delete_cleanup(
+    state: &AppState,
+    entity: &str,
+    id: &str,
+    existing: Option<&Value>,
+    message_chat_id: Option<&str>,
+) -> Result<(), AppError> {
+    let Some(contract) = contracts::collection_contract(entity) else {
+        return Ok(());
+    };
+    for cleanup in contract.delete_cleanup {
+        match cleanup {
+            contracts::DeleteCleanup::ActivateDefaultChatPreset => {
+                if let Some(record) = existing {
+                    activate_default_chat_preset_if_needed(state, record)?;
+                }
+            }
+            contracts::DeleteCleanup::ClearConnectionFolder => {
+                unfile_connections_in_folder(state, id)?
+            }
+            contracts::DeleteCleanup::ClearLorebookReferences => {
+                clear_deleted_lorebook_references(state, id)?;
+            }
+            contracts::DeleteCleanup::DeleteCharacterGallery => {
+                delete_character_gallery(state, id)?
+            }
+            contracts::DeleteCleanup::DeleteLorebookChildren => {
+                delete_lorebook_children(state, id)?
+            }
+            contracts::DeleteCleanup::DeleteMessageTrackerSnapshots => {
+                if let Some(chat_id) = message_chat_id {
+                    game_state_snapshots::delete_tracker_snapshots_for_message(state, chat_id, id)?;
+                    game_state_snapshots::sync_chat_game_state_to_visible_tracker(state, chat_id)?;
+                }
+            }
+            contracts::DeleteCleanup::DeletePromptChildren => {
+                prompts::delete_prompt_preset_children(state, id)?;
+            }
+            contracts::DeleteCleanup::RemoveOwnedMedia => {
+                if let Some(record) = existing {
+                    remove_owned_media(state, entity, record);
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -946,11 +976,27 @@ fn owned_record_for_delete(
     entity: &str,
     id: &str,
 ) -> Result<Option<Value>, AppError> {
-    match entity {
-        "characters" | "personas" | "lorebooks" | "messages" | "gallery" | "character-gallery"
-        | "chat-presets" => state.storage.get(entity, id),
-        _ => Ok(None),
+    let Some(contract) = contracts::collection_contract(entity) else {
+        return Ok(None);
+    };
+    if contract
+        .delete_cleanup
+        .iter()
+        .any(delete_cleanup_needs_existing_record)
+    {
+        state.storage.get(entity, id)
+    } else {
+        Ok(None)
     }
+}
+
+fn delete_cleanup_needs_existing_record(cleanup: &contracts::DeleteCleanup) -> bool {
+    matches!(
+        cleanup,
+        contracts::DeleteCleanup::ActivateDefaultChatPreset
+            | contracts::DeleteCleanup::DeleteMessageTrackerSnapshots
+            | contracts::DeleteCleanup::RemoveOwnedMedia
+    )
 }
 
 fn remove_owned_media(state: &AppState, entity: &str, record: &Value) {
@@ -1246,6 +1292,13 @@ mod tests {
             .expect("connection should read")
             .and_then(|row| row.get("defaultForAgents").and_then(Value::as_bool))
             .unwrap_or(false)
+    }
+
+    fn cleanup_registered(collection: &str, cleanup: contracts::DeleteCleanup) -> bool {
+        contracts::collection_contract(collection)
+            .expect("collection should be registered")
+            .delete_cleanup
+            .contains(&cleanup)
     }
 
     #[test]
@@ -1717,6 +1770,203 @@ mod tests {
         assert!(character
             .pointer("/data/extensions/importMetadata/embeddedLorebook")
             .is_none());
+    }
+
+    #[test]
+    fn deleting_prompt_uses_registered_child_cleanup() {
+        assert!(cleanup_registered(
+            "prompts",
+            contracts::DeleteCleanup::DeletePromptChildren
+        ));
+        let state = test_state("prompt-delete-children");
+        state
+            .storage
+            .create(
+                "prompts",
+                json!({ "id": "prompt-delete", "name": "Delete me" }),
+            )
+            .expect("prompt should be created");
+        state
+            .storage
+            .create("prompts", json!({ "id": "prompt-keep", "name": "Keep me" }))
+            .expect("other prompt should be created");
+        for (collection, delete_id, keep_id) in [
+            ("prompt-groups", "group-delete", "group-keep"),
+            ("prompt-sections", "section-delete", "section-keep"),
+            ("prompt-variables", "variable-delete", "variable-keep"),
+        ] {
+            state
+                .storage
+                .create(
+                    collection,
+                    json!({ "id": delete_id, "presetId": "prompt-delete", "name": "Delete" }),
+                )
+                .expect("prompt child should be created");
+            state
+                .storage
+                .create(
+                    collection,
+                    json!({ "id": keep_id, "presetId": "prompt-keep", "name": "Keep" }),
+                )
+                .expect("other prompt child should be created");
+        }
+
+        delete_entity(&state, "prompts", "prompt-delete", false).expect("delete should succeed");
+
+        for (collection, keep_id) in [
+            ("prompt-groups", "group-keep"),
+            ("prompt-sections", "section-keep"),
+            ("prompt-variables", "variable-keep"),
+        ] {
+            let mut delete_filters = Map::new();
+            delete_filters.insert(
+                "presetId".to_string(),
+                Value::String("prompt-delete".to_string()),
+            );
+            assert!(
+                state
+                    .storage
+                    .list_where(collection, &delete_filters)
+                    .expect("prompt child collection should be readable")
+                    .is_empty(),
+                "{collection} rows for deleted prompt should be removed"
+            );
+            assert!(state
+                .storage
+                .get(collection, keep_id)
+                .expect("kept prompt child should read")
+                .is_some());
+        }
+    }
+
+    #[test]
+    fn deleting_active_chat_preset_uses_registered_default_activation() {
+        assert!(cleanup_registered(
+            "chat-presets",
+            contracts::DeleteCleanup::ActivateDefaultChatPreset
+        ));
+        let state = test_state("chat-preset-delete-activate-default");
+        state
+            .storage
+            .patch(
+                "chat-presets",
+                "default-chat-preset-roleplay",
+                json!({ "isActive": false, "active": false }),
+            )
+            .expect("seeded default preset should be deactivated");
+        state
+            .storage
+            .create(
+                "chat-presets",
+                json!({
+                    "id": "custom-roleplay",
+                    "name": "Custom Roleplay",
+                    "mode": "roleplay",
+                    "isDefault": false,
+                    "default": false,
+                    "isActive": true,
+                    "active": true
+                }),
+            )
+            .expect("active preset should be created");
+
+        delete_entity(&state, "chat-presets", "custom-roleplay", false)
+            .expect("active preset delete should succeed");
+
+        let default = state
+            .storage
+            .get("chat-presets", "default-chat-preset-roleplay")
+            .expect("default preset should read")
+            .expect("default preset should remain");
+        assert_eq!(default["isActive"], json!(true));
+        assert_eq!(default["active"], json!(true));
+    }
+
+    #[test]
+    fn deleting_gallery_row_uses_registered_managed_media_cleanup() {
+        assert!(cleanup_registered(
+            "gallery",
+            contracts::DeleteCleanup::RemoveOwnedMedia
+        ));
+        let state = test_state("gallery-delete-managed-file");
+        let gallery_dir = state.data_dir.join("gallery");
+        std::fs::create_dir_all(&gallery_dir).expect("gallery dir should be created");
+        let image_path = gallery_dir.join("gallery.png");
+        std::fs::write(&image_path, b"managed").expect("managed image should be written");
+        state
+            .storage
+            .create(
+                "gallery",
+                json!({
+                    "id": "gallery-image",
+                    "chatId": "chat-1",
+                    "filePath": "gallery.png",
+                    "filename": "gallery.png",
+                    "url": "tauri-api:/gallery/gallery.png"
+                }),
+            )
+            .expect("gallery row should be created");
+
+        delete_entity(&state, "gallery", "gallery-image", false).expect("delete should succeed");
+
+        assert!(
+            !image_path.exists(),
+            "managed gallery file should be removed"
+        );
+    }
+
+    #[test]
+    fn deleting_message_uses_registered_tracker_snapshot_cleanup() {
+        assert!(cleanup_registered(
+            "messages",
+            contracts::DeleteCleanup::DeleteMessageTrackerSnapshots
+        ));
+        let state = test_state("message-delete-tracker-snapshots");
+        state
+            .storage
+            .create("chats", json!({ "id": "chat-1", "name": "Chat" }))
+            .expect("chat should be created");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "tracked"
+                }),
+            )
+            .expect("message should be created");
+        game_state_snapshots::save_tracker_snapshot(
+            &state,
+            "chat-1",
+            json!({
+                "messageId": "message-1",
+                "location": "Harbor"
+            }),
+        )
+        .expect("tracker snapshot should save");
+
+        delete_entity(&state, "messages", "message-1", false).expect("delete should succeed");
+
+        let mut filters = Map::new();
+        filters.insert("chatId".to_string(), Value::String("chat-1".to_string()));
+        filters.insert(
+            "messageId".to_string(),
+            Value::String("message-1".to_string()),
+        );
+        assert!(state
+            .storage
+            .list_where("game-state-snapshots", &filters)
+            .expect("snapshots should be readable")
+            .is_empty());
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat should read")
+            .expect("chat should remain");
+        assert!(chat["gameState"].is_null());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -785,213 +785,134 @@ fn normalize_json_field(
     )))
 }
 
+fn insert_default(object: &mut Map<String, Value>, field: &str, value: Value) {
+    object.entry(field.to_string()).or_insert(value);
+}
+
+fn insert_character_data_default(object: &mut Map<String, Value>) -> AppResult<()> {
+    if let Some(data) = object.get("data") {
+        normalize_character_data_for_storage(data)?;
+        return Ok(());
+    }
+
+    let mut data = Map::new();
+    let name = object
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("New Character");
+    data.insert("name".to_string(), Value::String(name.to_string()));
+    data.insert("description".to_string(), Value::String(String::new()));
+    data.insert("personality".to_string(), Value::String(String::new()));
+    data.insert("scenario".to_string(), Value::String(String::new()));
+    data.insert("first_mes".to_string(), Value::String(String::new()));
+    data.insert("mes_example".to_string(), Value::String(String::new()));
+    data.insert("creator_notes".to_string(), Value::String(String::new()));
+    data.insert("system_prompt".to_string(), Value::String(String::new()));
+    data.insert(
+        "post_history_instructions".to_string(),
+        Value::String(String::new()),
+    );
+    data.insert("tags".to_string(), json!([]));
+    data.insert("creator".to_string(), Value::String(String::new()));
+    data.insert(
+        "character_version".to_string(),
+        Value::String("1.0".to_string()),
+    );
+    data.insert("alternate_greetings".to_string(), json!([]));
+    data.insert("extensions".to_string(), json!({ "altDescriptions": [] }));
+    data.insert("character_book".to_string(), Value::Null);
+    object.insert("data".to_string(), Value::Object(data));
+    Ok(())
+}
+
+fn apply_create_default_field(
+    collection: &str,
+    field: &str,
+    object: &mut Map<String, Value>,
+) -> AppResult<()> {
+    match (collection, field) {
+        ("chats", "metadata") | ("chats", "gameState") => {
+            insert_default(object, field, json!({}));
+        }
+        ("chats", "characterIds") => insert_default(object, field, json!([])),
+        ("connections", "enabled") => insert_default(object, field, Value::Bool(true)),
+        ("connection-folders", "color") => {
+            insert_default(object, field, Value::String("#38bdf8".to_string()));
+        }
+        ("connection-folders", "collapsed") => insert_default(object, field, Value::Bool(false)),
+        ("connection-folders", "sortOrder") | ("connection-folders", "order") => {
+            insert_default(object, field, json!(0));
+        }
+        ("characters", "data") => insert_character_data_default(object)?,
+        ("characters", "comment") => insert_default(object, field, Value::String(String::new())),
+        ("characters", "avatarPath") => insert_default(object, field, Value::Null),
+        ("lorebooks", "description")
+        | ("personas", "description")
+        | ("personas", "comment")
+        | ("personas", "personality")
+        | ("personas", "scenario")
+        | ("personas", "backstory")
+        | ("personas", "appearance")
+        | ("prompts", "description") => insert_default(object, field, Value::String(String::new())),
+        ("lorebooks", "category") => {
+            insert_default(object, field, Value::String("uncategorized".to_string()));
+        }
+        ("lorebooks", "imagePath")
+        | ("lorebooks", "characterId")
+        | ("lorebooks", "personaId")
+        | ("lorebooks", "chatId")
+        | ("lorebooks", "generatedBy")
+        | ("lorebooks", "sourceAgentId")
+        | ("personas", "avatarPath")
+        | ("personas", "avatarCrop") => insert_default(object, field, Value::Null),
+        ("lorebooks", "scanDepth") => insert_default(object, field, json!(2)),
+        ("lorebooks", "tokenBudget") => insert_default(object, field, json!(2048)),
+        ("lorebooks", "maxRecursionDepth") => insert_default(object, field, json!(3)),
+        ("lorebooks", "recursiveScanning")
+        | ("lorebooks", "isGlobal")
+        | ("lorebooks", "excludeFromVectorization")
+        | ("personas", "isActive")
+        | ("prompts", "isDefault")
+        | ("chat-presets", "isDefault")
+        | ("chat-presets", "default")
+        | ("chat-presets", "isActive")
+        | ("chat-presets", "active") => insert_default(object, field, Value::Bool(false)),
+        ("lorebooks", "enabled") | ("agents", "enabled") => {
+            insert_default(object, field, Value::Bool(true));
+        }
+        ("lorebooks", "characterIds")
+        | ("lorebooks", "personaIds")
+        | ("lorebooks", "tags")
+        | ("personas", "tags")
+        | ("personas", "altDescriptions")
+        | ("prompts", "sectionOrder")
+        | ("prompts", "groupOrder")
+        | ("prompts", "variableGroups") => insert_default(object, field, json!([])),
+        ("prompts", "variableValues")
+        | ("prompts", "parameters")
+        | ("prompts", "defaultChoices")
+        | ("chat-presets", "settings") => insert_default(object, field, json!({})),
+        ("agents", "credit") => insert_default(
+            object,
+            field,
+            Value::String("Marinara Dev Team".to_string()),
+        ),
+        _ => {
+            return Err(AppError::invalid_input(format!(
+                "No executable create default registered for {collection}.{field}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> AppResult<Value> {
     let mut object = ensure_object(body)?;
-    match collection {
-        "chats" => {
-            object
-                .entry("metadata".to_string())
-                .or_insert_with(|| json!({}));
-            object
-                .entry("gameState".to_string())
-                .or_insert_with(|| json!({}));
-            object
-                .entry("characterIds".to_string())
-                .or_insert_with(|| json!([]));
+    if let Some(contract) = contracts::collection_contract(collection) {
+        for field in contract.create_default_fields {
+            apply_create_default_field(collection, field, &mut object)?;
         }
-        "connections" => {
-            object
-                .entry("enabled".to_string())
-                .or_insert(Value::Bool(true));
-        }
-        "connection-folders" => {
-            object
-                .entry("color".to_string())
-                .or_insert_with(|| Value::String("#38bdf8".to_string()));
-            object
-                .entry("collapsed".to_string())
-                .or_insert(Value::Bool(false));
-            object.entry("sortOrder".to_string()).or_insert(json!(0));
-            object.entry("order".to_string()).or_insert(json!(0));
-        }
-        "characters" => {
-            if let Some(data) = object.get("data") {
-                normalize_character_data_for_storage(data)?;
-            } else {
-                let mut data = Map::new();
-                let name = object
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .filter(|value| !value.trim().is_empty())
-                    .unwrap_or("New Character");
-                data.insert("name".to_string(), Value::String(name.to_string()));
-                data.insert("description".to_string(), Value::String(String::new()));
-                data.insert("personality".to_string(), Value::String(String::new()));
-                data.insert("scenario".to_string(), Value::String(String::new()));
-                data.insert("first_mes".to_string(), Value::String(String::new()));
-                data.insert("mes_example".to_string(), Value::String(String::new()));
-                data.insert("creator_notes".to_string(), Value::String(String::new()));
-                data.insert("system_prompt".to_string(), Value::String(String::new()));
-                data.insert(
-                    "post_history_instructions".to_string(),
-                    Value::String(String::new()),
-                );
-                data.insert("tags".to_string(), json!([]));
-                data.insert("creator".to_string(), Value::String(String::new()));
-                data.insert(
-                    "character_version".to_string(),
-                    Value::String("1.0".to_string()),
-                );
-                data.insert("alternate_greetings".to_string(), json!([]));
-                data.insert("extensions".to_string(), json!({ "altDescriptions": [] }));
-                data.insert("character_book".to_string(), Value::Null);
-                object.insert("data".to_string(), Value::Object(data));
-            }
-            object
-                .entry("comment".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("avatarPath".to_string())
-                .or_insert(Value::Null);
-        }
-        "lorebooks" => {
-            object
-                .entry("description".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("category".to_string())
-                .or_insert(Value::String("uncategorized".to_string()));
-            object.entry("imagePath".to_string()).or_insert(Value::Null);
-            object.entry("scanDepth".to_string()).or_insert(json!(2));
-            object
-                .entry("tokenBudget".to_string())
-                .or_insert(json!(2048));
-            object
-                .entry("recursiveScanning".to_string())
-                .or_insert(Value::Bool(false));
-            object
-                .entry("maxRecursionDepth".to_string())
-                .or_insert(json!(3));
-            object
-                .entry("characterId".to_string())
-                .or_insert(Value::Null);
-            object
-                .entry("characterIds".to_string())
-                .or_insert(json!([]));
-            object.entry("personaId".to_string()).or_insert(Value::Null);
-            object.entry("personaIds".to_string()).or_insert(json!([]));
-            object.entry("chatId".to_string()).or_insert(Value::Null);
-            object
-                .entry("isGlobal".to_string())
-                .or_insert(Value::Bool(false));
-            object
-                .entry("enabled".to_string())
-                .or_insert(Value::Bool(true));
-            object
-                .entry("excludeFromVectorization".to_string())
-                .or_insert(Value::Bool(false));
-            object.entry("tags".to_string()).or_insert(json!([]));
-            object
-                .entry("generatedBy".to_string())
-                .or_insert(Value::Null);
-            object
-                .entry("sourceAgentId".to_string())
-                .or_insert(Value::Null);
-        }
-        "personas" => {
-            normalize_typed_json_fields(collection, &mut object)?;
-            object
-                .entry("description".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("comment".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("personality".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("scenario".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("backstory".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("appearance".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("avatarPath".to_string())
-                .or_insert(Value::Null);
-            object
-                .entry("isActive".to_string())
-                .or_insert(Value::Bool(false));
-            object
-                .entry("tags".to_string())
-                .or_insert_with(|| json!([]));
-            object
-                .entry("altDescriptions".to_string())
-                .or_insert_with(|| json!([]));
-            object
-                .entry("avatarCrop".to_string())
-                .or_insert(Value::Null);
-        }
-        "prompts" => {
-            normalize_typed_json_fields(collection, &mut object)?;
-            object
-                .entry("description".to_string())
-                .or_insert(Value::String(String::new()));
-            object
-                .entry("sectionOrder".to_string())
-                .or_insert_with(|| json!([]));
-            object
-                .entry("groupOrder".to_string())
-                .or_insert_with(|| json!([]));
-            object
-                .entry("variableGroups".to_string())
-                .or_insert_with(|| json!([]));
-            object
-                .entry("variableValues".to_string())
-                .or_insert_with(|| json!({}));
-            object
-                .entry("parameters".to_string())
-                .or_insert_with(|| json!({}));
-            object
-                .entry("defaultChoices".to_string())
-                .or_insert_with(|| json!({}));
-            object
-                .entry("isDefault".to_string())
-                .or_insert(Value::Bool(false));
-        }
-        "chat-presets" => {
-            normalize_typed_json_fields(collection, &mut object)?;
-            object
-                .entry("settings".to_string())
-                .or_insert_with(|| json!({}));
-            object
-                .entry("isDefault".to_string())
-                .or_insert(Value::Bool(false));
-            object
-                .entry("default".to_string())
-                .or_insert(Value::Bool(false));
-            object
-                .entry("isActive".to_string())
-                .or_insert(Value::Bool(false));
-            object
-                .entry("active".to_string())
-                .or_insert(Value::Bool(false));
-        }
-        "prompt-sections" | "prompt-variables" => {
-            normalize_typed_json_fields(collection, &mut object)?;
-        }
-        "agents" => {
-            normalize_typed_json_fields(collection, &mut object)?;
-            object
-                .entry("enabled".to_string())
-                .or_insert(Value::Bool(true));
-            object
-                .entry("credit".to_string())
-                .or_insert_with(|| Value::String("Marinara Dev Team".to_string()));
-        }
-        _ => {}
     }
     normalize_typed_json_fields(collection, &mut object)?;
     Ok(Value::Object(object))
@@ -1788,6 +1709,27 @@ mod tests {
             .expect("lorebook defaults should apply");
 
         assert_eq!(row["excludeFromVectorization"], json!(false));
+    }
+
+    #[test]
+    fn registered_create_defaults_are_executable() {
+        for contract in contracts::COLLECTIONS {
+            let row = with_entity_defaults(contract.name, json!({ "name": "Defaults" }))
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} defaults should apply from the contract registry: {}",
+                        contract.name, error.message
+                    )
+                });
+            for field in contract.create_default_fields {
+                assert!(
+                    row.get(*field).is_some(),
+                    "{} registered default field {} should be present",
+                    contract.name,
+                    field
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #2006

## Why this change

- Storage create defaults and delete cleanup were still executed through inline entity-name branching even though the collection contract registry already describes those behaviors.

## What changed

- Added contract-driven delete cleanup dispatch for registered storage cleanup actions.
- Applied registered `create_default_fields` through `with_entity_defaults`.
- Added Rust coverage for registered create defaults, delete cleanup actions, and hostable storage delete dispatch.

## Refactor impact

Primary owner:

Rust storage commands.

Impact areas reviewed:

- Generic storage create/delete commands.
- Collection contract registry defaults and cleanup actions.
- Message tracker snapshot cleanup through embedded and hostable storage delete paths.
- Managed media cleanup for avatars, lorebook images, gallery rows, and character gallery rows.

Boundary notes:

- Behavior stays inside `src-tauri`; no React, engine, or shared API boundary changes.
- Hostable HTTP dispatch continues through the existing storage command path and is covered by focused dispatch tests.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `git diff --check origin/refactor...HEAD`
- `cargo test --manifest-path src-tauri/Cargo.toml registered_create_defaults_are_executable`
- `cargo test --manifest-path src-tauri/Cargo.toml deleting_`
- `cargo test --manifest-path src-tauri/Cargo.toml dispatch_storage_delete`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal Rust storage wiring only; no new user-discoverable feature, workflow, setting, mode, panel, import path, media capability, or advanced tool.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Reason:

- No docs or release-note change needed because this keeps existing storage create/delete behavior contract-driven without changing user-facing workflows.

## UI evidence

N/A; no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Entity deletion cleanup now uses a contract-driven architecture for consistency
  * Default field creation for collections now uses contracts instead of hardcoded logic

* **Tests**
  * Extended test coverage for deletion cleanup behaviors and default field creation across all collection types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->