### PR TITLE
Fix batched lorebook activation entry reads

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -216,6 +216,47 @@ pub(crate) fn storage_list_inner(
     )))
 }
 
+#[tauri::command]
+pub async fn lorebook_entries_list_by_lorebook_ids(
+    state: State<'_, AppState>,
+    lorebook_ids: Vec<String>,
+) -> Result<Value, AppError> {
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        lorebook_entries_list_by_lorebook_ids_inner(&state, lorebook_ids)
+    })
+    .await
+    .map_err(|error| AppError::new("task_join_error", error.to_string()))?
+}
+
+pub(crate) fn lorebook_entries_list_by_lorebook_ids_inner(
+    state: &AppState,
+    lorebook_ids: Vec<String>,
+) -> Result<Value, AppError> {
+    let lorebook_ids: HashSet<String> = lorebook_ids
+        .into_iter()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect();
+    if lorebook_ids.is_empty() {
+        return Ok(Value::Array(Vec::new()));
+    }
+    let mut rows = state
+        .storage
+        .list_where_in("lorebook-entries", "lorebookId", &lorebook_ids)?;
+    rows.sort_by(|a, b| {
+        compare_json_values(
+            a.get("sortOrder")
+                .or_else(|| a.get("order"))
+                .or_else(|| a.get("createdAt")),
+            b.get("sortOrder")
+                .or_else(|| b.get("order"))
+                .or_else(|| b.get("createdAt")),
+        )
+    });
+    Ok(Value::Array(rows))
+}
+
 fn message_id_projection_only(options: Option<&Value>) -> bool {
     let Some(options) = options else {
         return false;
@@ -1303,6 +1344,36 @@ mod tests {
         let read = storage_get_inner(&state, "characters".to_string(), "char-1".to_string(), None)
             .expect("supported get should succeed");
         assert_eq!(read["id"], "char-1");
+    }
+
+    #[test]
+    fn lorebook_entries_list_by_lorebook_ids_reads_matching_books_once() {
+        let state = test_state("lorebook-entries-where-in");
+        state
+            .storage
+            .replace_all(
+                "lorebook-entries",
+                vec![
+                    json!({ "id": "entry-b", "lorebookId": "book-b", "content": "B", "order": 2 }),
+                    json!({ "id": "entry-a", "lorebookId": "book-a", "content": "A", "order": 1 }),
+                    json!({ "id": "entry-c", "lorebookId": "book-c", "content": "C", "order": 3 }),
+                ],
+            )
+            .expect("entries should seed");
+
+        let result = lorebook_entries_list_by_lorebook_ids_inner(
+            &state,
+            vec!["book-b".to_string(), "book-a".to_string()],
+        )
+        .expect("batched lorebook entries should read");
+
+        let ids: Vec<_> = result
+            .as_array()
+            .expect("result should be an array")
+            .iter()
+            .filter_map(|row| row.get("id").and_then(Value::as_str))
+            .collect();
+        assert_eq!(ids, vec!["entry-a", "entry-b"]);
     }
 
     #[test]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -64,7 +64,9 @@ fn optional_u32_strict(args: &Map<String, Value>, key: &str) -> AppResult<Option
         return Ok(None);
     };
     let Some(value) = value.as_u64() else {
-        return Err(AppError::invalid_input(format!("{key} must be a positive integer")));
+        return Err(AppError::invalid_input(format!(
+            "{key} must be a positive integer"
+        )));
     };
     u32::try_from(value)
         .map(Some)
@@ -524,6 +526,9 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             required_string(&args, "chatId")?,
         ),
         "storage_list" => storage_list(state, &args),
+        "lorebook_entries_list_by_lorebook_ids" => {
+            lorebook_entries_list_by_lorebook_ids(state, &args)
+        }
         "storage_get" => storage_get(state, &args),
         "storage_create" => storage_create(state, &args),
         "storage_update" => storage_update(state, &args),
@@ -899,6 +904,16 @@ fn storage_list(state: &AppState, args: &Map<String, Value>) -> AppResult<Value>
         args.get("options")
             .filter(|value| !value.is_null())
             .cloned(),
+    )
+}
+
+fn lorebook_entries_list_by_lorebook_ids(
+    state: &AppState,
+    args: &Map<String, Value>,
+) -> AppResult<Value> {
+    entity_commands::lorebook_entries_list_by_lorebook_ids_inner(
+        state,
+        required_string_vec(args, "lorebookIds")?,
     )
 }
 
@@ -1372,6 +1387,40 @@ mod tests {
                 "extra": { "thinking": "swipe thought" }
             }])
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_lorebook_entries_list_by_lorebook_ids_reads_matching_books() {
+        let state = test_state("remote-lorebook-entries-where-in");
+        state
+            .storage
+            .replace_all(
+                "lorebook-entries",
+                vec![
+                    json!({ "id": "entry-a", "lorebookId": "book-a", "content": "A" }),
+                    json!({ "id": "entry-b", "lorebookId": "book-b", "content": "B" }),
+                    json!({ "id": "entry-c", "lorebookId": "book-c", "content": "C" }),
+                ],
+            )
+            .expect("entries should seed");
+
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "lorebook_entries_list_by_lorebook_ids".to_string(),
+                args: Some(json!({ "lorebookIds": ["book-a", "book-c"] })),
+            },
+        )
+        .await
+        .expect("remote batched lorebook entries should dispatch");
+
+        let ids: Vec<_> = result
+            .as_array()
+            .expect("result should be an array")
+            .iter()
+            .filter_map(|row| row.get("id").and_then(Value::as_str))
+            .collect();
+        assert_eq!(ids, vec!["entry-a", "entry-c"]);
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -195,6 +195,7 @@ pub fn run() {
             storage_commands::agent_commands::agent_toggle_by_type,
             storage_commands::agent_commands::agent_cadence_status,
             storage_commands::entity_commands::storage_list,
+            storage_commands::entity_commands::lorebook_entries_list_by_lorebook_ids,
             storage_commands::entity_commands::storage_get,
             storage_commands::entity_commands::storage_create,
             storage_commands::entity_commands::storage_update,

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -95,6 +95,7 @@ export interface StorageGateway {
   getWorldState<T = unknown>(chatId: string): Promise<T | null>;
   saveTrackerSnapshot<T = unknown>(chatId: string, snapshot: Record<string, unknown>): Promise<T>;
   listLorebookEntries<T = unknown>(lorebookId: string): Promise<T[]>;
+  listLorebookEntriesByLorebookIds?<T = unknown>(lorebookIds: string[]): Promise<T[]>;
   createLorebookEntries<T = unknown>(lorebookId: string, entries: Array<Record<string, unknown>>): Promise<T[]>;
   knowledgeSourceText?<T = unknown>(id: string): Promise<T | null>;
   promptFull<T = unknown>(presetId: string): Promise<T | null>;

--- a/src/engine/generation/active-lorebook-scanner.test.ts
+++ b/src/engine/generation/active-lorebook-scanner.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { StorageGateway } from "../capabilities/storage";
+import { scanActiveLorebooks } from "./active-lorebook-scanner";
+
+type RowMap = Record<string, Array<Record<string, unknown>>>;
+
+function storageWithRows(rows: RowMap, calls: { batchedEntryReads: number; singleEntryReads: number }): StorageGateway {
+  return {
+    list: async <T = unknown>(entity: string) => (rows[entity] ?? []) as T[],
+    get: async <T = unknown>(entity: string, id: string) =>
+      ((rows[entity]?.find((row) => row.id === id) ?? null) as T | null),
+    create: async <T = unknown>() => ({} as T),
+    update: async <T = unknown>() => ({} as T),
+    delete: async () => ({ deleted: true }),
+    listChatMessages: async <T = unknown>() => [] as T[],
+    createChatMessage: async <T = unknown>() => ({} as T),
+    updateChatMessage: async <T = unknown>() => ({} as T),
+    deleteChatMessage: async () => ({ deleted: true }),
+    patchChatMessageExtra: async <T = unknown>() => ({} as T),
+    addChatMessageSwipe: async <T = unknown>() => ({} as T),
+    patchChatMetadata: async <T = unknown>() => ({} as T),
+    patchChatSummaries: async <T = unknown>() => ({} as T),
+    listChatMemories: async <T = unknown>() => [] as T[],
+    getWorldState: async <T = unknown>() => null as T | null,
+    saveTrackerSnapshot: async <T = unknown>() => ({} as T),
+    listLorebookEntries: async <T = unknown>(lorebookId: string) => {
+      calls.singleEntryReads += 1;
+      return (rows["lorebook-entries"] ?? []).filter((row) => row.lorebookId === lorebookId) as T[];
+    },
+    listLorebookEntriesByLorebookIds: async <T = unknown>(lorebookIds: string[]) => {
+      calls.batchedEntryReads += 1;
+      const ids = new Set(lorebookIds);
+      return (rows["lorebook-entries"] ?? []).filter((row) => ids.has(String(row.lorebookId))) as T[];
+    },
+    createLorebookEntries: async <T = unknown>() => [] as T[],
+    promptFull: async <T = unknown>() => null as T | null,
+  };
+}
+
+describe("scanActiveLorebooks", () => {
+  it("reads entries for active lorebooks in one batched storage call", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const storage = storageWithRows(
+      {
+        lorebooks: [
+          { id: "book-a", name: "Book A", enabled: true, isGlobal: true },
+          { id: "book-b", name: "Book B", enabled: true, isGlobal: true },
+          { id: "book-c", name: "Book C", enabled: true, isGlobal: true },
+        ],
+        "lorebook-folders": [{ id: "disabled-folder", lorebookId: "book-b", enabled: false }],
+        "lorebook-entries": [
+          {
+            id: "entry-a",
+            lorebookId: "book-a",
+            name: "Entry A",
+            content: "alpha lore",
+            constant: true,
+            enabled: true,
+          },
+          {
+            id: "entry-b-hidden",
+            lorebookId: "book-b",
+            folderId: "disabled-folder",
+            name: "Entry B hidden",
+            content: "hidden lore",
+            constant: true,
+            enabled: true,
+          },
+          {
+            id: "entry-c",
+            lorebookId: "book-c",
+            name: "Entry C",
+            content: "gamma lore",
+            constant: true,
+            enabled: true,
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "hello" }],
+      embeddingSource: null,
+    });
+
+    expect(calls).toEqual({ batchedEntryReads: 1, singleEntryReads: 0 });
+    expect(result.entriesForTiming.map((entry) => entry.id)).toEqual(["entry-a", "entry-c"]);
+  });
+});

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -416,7 +416,7 @@ function lorebookTimingStatesChanged(
   return false;
 }
 
-export async function loadLorebookEntriesForActivation(
+async function loadLorebookEntriesForActivation(
   storage: StorageGateway,
   lorebook: JsonRecord,
 ): Promise<LorebookEntry[]> {
@@ -426,6 +426,14 @@ export async function loadLorebookEntriesForActivation(
     storage.listLorebookEntries<JsonRecord>(id),
     storage.list<JsonRecord>("lorebook-folders", { filters: { lorebookId: id } }),
   ]);
+  return normalizeLorebookEntriesForActivation(lorebook, rows, folders);
+}
+
+function normalizeLorebookEntriesForActivation(
+  lorebook: JsonRecord,
+  rows: JsonRecord[],
+  folders: JsonRecord[],
+): LorebookEntry[] {
   const disabledFolderIds = new Set(
     folders
       .filter((folder) => !boolish(folder.enabled, true))
@@ -442,6 +450,64 @@ export async function loadLorebookEntriesForActivation(
     }))
     .filter((entry) => entry.enabled && entry.content.trim())
     .filter((entry) => !entry.folderId || !disabledFolderIds.has(entry.folderId));
+}
+
+export async function loadLorebookEntriesForActivationBatch(
+  storage: StorageGateway,
+  lorebooks: JsonRecord[],
+): Promise<Map<string, LorebookEntry[]>> {
+  const lorebooksById = new Map(
+    lorebooks
+      .map((book) => [readString(book.id), book] as const)
+      .filter((entry): entry is readonly [string, JsonRecord] => Boolean(entry[0])),
+  );
+  const lorebookIds = [...lorebooksById.keys()];
+  if (lorebookIds.length === 0) return new Map();
+
+  if (!storage.listLorebookEntriesByLorebookIds) {
+    return new Map(
+      await Promise.all(
+        lorebookIds.map(
+          async (id) => [id, await loadLorebookEntriesForActivation(storage, lorebooksById.get(id) ?? {})] as const,
+        ),
+      ),
+    );
+  }
+
+  const lorebookIdSet = new Set(lorebookIds);
+  const [rows, folders] = await Promise.all([
+    storage.listLorebookEntriesByLorebookIds<JsonRecord>(lorebookIds),
+    storage.list<JsonRecord>("lorebook-folders"),
+  ]);
+
+  const rowsByLorebookId = new Map<string, JsonRecord[]>();
+  for (const row of rows) {
+    const lorebookId = readString(row.lorebookId);
+    if (!lorebookIdSet.has(lorebookId)) continue;
+    const bucket = rowsByLorebookId.get(lorebookId) ?? [];
+    bucket.push(row);
+    rowsByLorebookId.set(lorebookId, bucket);
+  }
+
+  const foldersByLorebookId = new Map<string, JsonRecord[]>();
+  for (const folder of folders) {
+    const lorebookId = readString(folder.lorebookId);
+    if (!lorebookIdSet.has(lorebookId)) continue;
+    const bucket = foldersByLorebookId.get(lorebookId) ?? [];
+    bucket.push(folder);
+    foldersByLorebookId.set(lorebookId, bucket);
+  }
+
+  return new Map(
+    lorebookIds.map((id) => [
+      id,
+      normalizeLorebookEntriesForActivation(
+        lorebooksById.get(id) ?? {},
+        rowsByLorebookId.get(id) ?? [],
+        foldersByLorebookId.get(id) ?? [],
+      ),
+    ]),
+  );
 }
 
 function scanLorebookEntries(
@@ -554,14 +620,16 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
       return [id, readString(book.name, id || "Lorebook")] as const;
     }),
   );
-  const entriesByBook = await Promise.all(
-    lorebooks.map(async (book) => ({
+  const entriesForActivationByBookId = await loadLorebookEntriesForActivationBatch(input.storage, lorebooks);
+  const entriesByBook = lorebooks.map((book) => {
+    const id = readString(book.id);
+    return {
       book,
-      entries: (await loadLorebookEntriesForActivation(input.storage, book)).map((entry) =>
+      entries: (entriesForActivationByBookId.get(id) ?? []).map((entry) =>
         entryWithChatState(entry, previousEntryStateOverrides),
       ),
-    })),
-  );
+    };
+  });
   const vectorizedEntryCount = entriesByBook.reduce(
     (sum, item) => sum + countSemanticCandidateEntries(item.entries),
     0,

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -6,7 +6,7 @@ import type { LorebookEntry } from "../contracts/types/lorebook";
 import type { LLMToolCall, LLMToolDefinition } from "../generation-core/llm/base-provider";
 import { lorebookEntryPassesContextFilters } from "../generation-core/lorebooks/keyword-scanner";
 import { appendChatSummaryEntryToMetadata } from "../shared/text/chat-summary-entries";
-import { loadLorebookEntriesForActivation, lorebookAppliesToContext } from "./active-lorebook-scanner";
+import { loadLorebookEntriesForActivationBatch, lorebookAppliesToContext } from "./active-lorebook-scanner";
 import type { GenerationCharacterContext, GenerationPersonaContext } from "./prompt-assembly";
 import {
   boolish,
@@ -244,8 +244,8 @@ async function loadSearchableStoredLorebookEntries(
   const lorebooks = (await storage.list<JsonRecord>("lorebooks")).filter((book) =>
     lorebookAppliesToContext(book, input.chat, input.characters, input.persona),
   );
-  const entries = await Promise.all(lorebooks.map((book) => loadLorebookEntriesForActivation(storage, book)));
-  return entries.flat().filter((entry) => lorebookToolEntryPassesContext(entry, input));
+  const entriesByBook = await loadLorebookEntriesForActivationBatch(storage, lorebooks);
+  return [...entriesByBook.values()].flat().filter((entry) => lorebookToolEntryPassesContext(entry, input));
 }
 
 async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInput, args: JsonRecord) {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -100,6 +100,7 @@ const REMOTE_COMMANDS = new Set([
   "agent_toggle_by_type",
   "agent_cadence_status",
   "storage_list",
+  "lorebook_entries_list_by_lorebook_ids",
   "storage_get",
   "storage_create",
   "storage_update",

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -111,7 +111,10 @@ function normalizeStorageWrite(entity: StorageEntity, value: Record<string, unkn
   return entity === "messages" ? normalizeMessageWrite(value) : value;
 }
 
-function storageWriteInvalidationKinds(entity: StorageEntity, value?: Record<string, unknown>): RemoteManagedAssetKind[] {
+function storageWriteInvalidationKinds(
+  entity: StorageEntity,
+  value?: Record<string, unknown>,
+): RemoteManagedAssetKind[] {
   switch (entity) {
     case "gallery":
     case "character-gallery":
@@ -308,6 +311,12 @@ export const storageApi: StorageGateway = {
   saveTrackerSnapshot: <T = unknown>(chatId: string, snapshot: Record<string, unknown>) =>
     trackerSnapshotApi.save(chatId, snapshot as unknown as TrackerSnapshotInput) as Promise<T>,
   listLorebookEntries: (lorebookId) => storageApi.list("lorebook-entries", { filters: { lorebookId } }),
+  listLorebookEntriesByLorebookIds: (lorebookIds) =>
+    lorebookIds.length
+      ? invokeTauri("lorebook_entries_list_by_lorebook_ids", {
+          lorebookIds: Array.from(new Set(lorebookIds.map((id) => id.trim()).filter(Boolean))),
+        })
+      : Promise.resolve([]),
   createLorebookEntries: async (lorebookId, entries) =>
     Promise.all(entries.map((entry) => storageApi.create("lorebook-entries", { ...entry, lorebookId }))) as Promise<
       never[]


### PR DESCRIPTION
## Linked issue

Closes #2035

## Why this change

- Active lorebook activation was reading entries once per active lorebook, which multiplies the collection scan cost on large profiles.

## What changed

- Added a focused batched lorebook-entry read command backed by the existing Rust `list_where_in` storage primitive.
- Added a shared API wrapper and optional `StorageGateway` method for batched lorebook-entry reads.
- Updated active lorebook scanning and stored lorebook tool search to group batched entries by lorebook in memory while preserving disabled-folder filtering and the single-book fallback for lightweight gateways.
- Added focused TypeScript and Rust coverage for the batched scanner path plus desktop/remote command dispatch.

## Refactor impact

Primary owner:

- Engine generation, shared API, Rust storage/remote runtime.

Impact areas reviewed:

- Active lorebook prompt assembly.
- Active lorebook info scans through `scanActiveLorebooks`.
- Stored lorebook search used by generation tool runtime.
- Embedded Tauri command registration and remote runtime command dispatch.

Boundary notes:

- Engine code still depends only on the `StorageGateway` capability.
- Feature/runtime code continues through shared API wrappers, not raw Tauri.
- The new Rust command is focused on lorebook entries and is also exposed through the remote runtime allowlist/dispatch path.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration.
- `src-tauri/src/http_dispatch.rs` remote command dispatch.
- `src/engine/generation/active-lorebook-scanner.ts` prompt assembly scanner.
- `src/engine/generation/tools-runtime.ts` stored lorebook search.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts`: passed. The scanner read three active lorebooks with one batched entry read and zero single-book entry reads, while excluding an entry in a disabled folder.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml lorebook_entries_list_by_lorebook_ids -- --nocapture`: passed. Covers the native command helper and remote dispatch path with should-not-match lorebook rows.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Codex ran `pnpm check`: passed after the final staged diff, including the new test file.
- Bunny review: pass before PR open. Boundary and proof were reviewed against the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A: this is an internal read-path performance regression fix and does not add user-discoverable behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a backend/prompt-assembly read-path fix with no visible UI state. Verification is command-based and recorded above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch retrieval capability for lorebook entries from multiple lorebooks in a single operation, improving performance during lore activation and search operations.

* **Tests**
  * Added tests verifying correct batch loading of lorebook entries with proper filtering of active entries across multiple lorebooks and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->