### PR TITLE
Store uploaded avatars as managed assets

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -5,6 +5,7 @@ use super::media_uploads::{
 use super::*;
 use image::ImageFormat;
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 const AVATAR_THUMBNAIL_SIZES: &[u32] = &[64, 96, 128, 256];
@@ -38,14 +39,14 @@ pub(crate) fn update_character_avatar(
         collection,
         id,
         json!({
-            "avatar": stored.data_url,
-            "avatarPath": stored.data_url,
+            "avatar": stored.asset_url,
+            "avatarPath": stored.asset_url,
             "avatarFilePath": stored.absolute_path,
             "avatarFilename": stored.filename,
             "avatarUpdatedAt": now_iso()
         }),
     )?;
-    remove_avatar_file(state, collection, &previous);
+    remove_avatar_file_preserving_persona_snapshots(state, collection, &previous);
     Ok(updated)
 }
 
@@ -117,9 +118,9 @@ fn character_avatar_snapshot_record(state: &AppState, collection: &str, record: 
         if let Some(data_url) = managed_avatar_data_url(state, collection, record) {
             object.insert("avatar".to_string(), Value::String(data_url.clone()));
             object.insert("avatarPath".to_string(), Value::String(data_url));
+            object.insert("avatarFilePath".to_string(), Value::Null);
+            object.insert("avatarFilename".to_string(), Value::Null);
         }
-        object.insert("avatarFilePath".to_string(), Value::Null);
-        object.insert("avatarFilename".to_string(), Value::Null);
     }
     snapshot
 }
@@ -134,14 +135,27 @@ fn managed_avatar_data_url(state: &AppState, collection: &str, record: &Value) -
     )
     .ok()
     .flatten()?;
-    let bytes = fs::read(&path).ok()?;
-    let mime = avatar_mime_type(
+    avatar_data_url_from_path(
+        &path.to_string_lossy(),
         record
             .get("avatarFilename")
             .and_then(Value::as_str)
             .or_else(|| path.file_name().and_then(|value| value.to_str())),
-    );
-    Some(format!(
+    )
+    .ok()
+}
+
+fn avatar_data_url_from_path(path: &str, filename: Option<&str>) -> AppResult<String> {
+    let path = Path::new(path);
+    let bytes = fs::read(path).map_err(|error| {
+        AppError::new(
+            "avatar_file_read_error",
+            format!("Avatar file could not be read: {error}"),
+        )
+    })?;
+    let mime =
+        avatar_mime_type(filename.or_else(|| path.file_name().and_then(|value| value.to_str())));
+    Ok(format!(
         "data:{mime};base64,{}",
         general_purpose::STANDARD.encode(bytes)
     ))
@@ -174,6 +188,102 @@ pub(crate) fn remove_avatar_file(state: &AppState, collection: &str, record: &Va
         "avatarFilePath",
         "avatarFilename",
     )
+}
+
+pub(crate) fn remove_avatar_file_preserving_persona_snapshots(
+    state: &AppState,
+    collection: &str,
+    record: &Value,
+) {
+    if collection == "personas" {
+        match persona_avatar_referenced_by_messages(state, record) {
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(error) => {
+                log::warn!(
+                    "skipping persona avatar cleanup because message snapshots could not be scanned: {error}"
+                );
+                return;
+            }
+        }
+    }
+    remove_avatar_file(state, collection, record);
+}
+
+fn persona_avatar_referenced_by_messages(state: &AppState, record: &Value) -> AppResult<bool> {
+    let Some(record_id) = record.get("id").and_then(Value::as_str) else {
+        return Ok(false);
+    };
+    let persona_id = record_id.trim();
+    if persona_id.is_empty() {
+        return Ok(false);
+    }
+
+    let url_candidates: HashSet<String> = ["avatar", "avatarPath", "avatarUrl"]
+        .into_iter()
+        .filter_map(|field| record.get(field).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    let file_path = record
+        .get("avatarFilePath")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let messages = state.storage.list("messages")?;
+    Ok(messages.iter().any(|message| {
+        let Some(snapshot) = message
+            .get("extra")
+            .and_then(message_persona_snapshot_object)
+        else {
+            return false;
+        };
+        if snapshot
+            .get("personaId")
+            .and_then(Value::as_str)
+            .is_none_or(|value| value.trim() != persona_id)
+        {
+            return false;
+        }
+        if snapshot
+            .get("avatarUrl")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty() && url_candidates.contains(value))
+        {
+            return true;
+        }
+        if file_path.is_some_and(|path| {
+            snapshot
+                .get("avatarFilePath")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                == Some(path)
+        }) {
+            return true;
+        }
+        false
+    }))
+}
+
+fn message_persona_snapshot_object(value: &Value) -> Option<Map<String, Value>> {
+    match value {
+        Value::Object(object) => object
+            .get("personaSnapshot")
+            .and_then(Value::as_object)
+            .cloned(),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|parsed| {
+                parsed
+                    .get("personaSnapshot")
+                    .and_then(Value::as_object)
+                    .cloned()
+            }),
+        _ => None,
+    }
 }
 
 fn remove_avatar_thumbnail_files(state: &AppState, collection: &str, record: &Value) {
@@ -481,10 +591,11 @@ pub(crate) fn update_npc_avatar(state: &AppState, chat_id: &str, body: Value) ->
         &body,
         "avatar",
     )?;
+    let avatar_path = avatar_data_url_from_path(&stored.absolute_path, Some(&stored.filename))?;
     Ok(json!({
         "chatId": chat_id,
         "name": name,
-        "avatarPath": stored.data_url,
+        "avatarPath": avatar_path,
         "avatarFilePath": stored.absolute_path,
         "avatarFilename": stored.filename
     }))
@@ -506,6 +617,311 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn small_png_data_url() -> &'static str {
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lTmZsgAAAABJRU5ErkJggg=="
+    }
+
+    fn assert_managed_avatar_upload(value: &Value, collection: &str) {
+        let avatar_path = value
+            .get("avatarPath")
+            .and_then(Value::as_str)
+            .expect("avatarPath should be present");
+        assert!(
+            !avatar_path.starts_with("data:image/"),
+            "avatarPath should be a managed asset URL, not inline data"
+        );
+        assert_eq!(
+            value.get("avatar").and_then(Value::as_str),
+            value.get("avatarPath").and_then(Value::as_str)
+        );
+        let avatar_file_path = value
+            .get("avatarFilePath")
+            .and_then(Value::as_str)
+            .expect("avatarFilePath should be present");
+        let normalized_file_path = avatar_file_path.replace('\\', "/");
+        assert!(
+            normalized_file_path.contains(&format!("avatars/{collection}")),
+            "avatar file should be stored under managed {collection} avatars"
+        );
+        assert!(
+            Path::new(avatar_file_path).is_file(),
+            "managed avatar file should exist"
+        );
+        assert!(
+            value
+                .get("avatarFilename")
+                .and_then(Value::as_str)
+                .is_some_and(|filename| !filename.trim().is_empty()),
+            "avatarFilename should be present"
+        );
+    }
+
+    #[test]
+    fn avatar_data_url_from_path_reports_missing_file() {
+        let missing = std::env::temp_dir().join("marinara-missing-avatar.png");
+        let error = avatar_data_url_from_path(&missing.to_string_lossy(), Some("missing.png"))
+            .expect_err("missing avatar file should fail instead of falling back");
+
+        assert_eq!(error.code, "avatar_file_read_error");
+    }
+
+    #[test]
+    fn character_avatar_upload_stores_managed_asset_url() {
+        let state = test_state("character-avatar-upload-managed");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": { "name": "Rina" }
+                }),
+            )
+            .expect("character should be created");
+
+        let updated = update_character_avatar(
+            &state,
+            "characters",
+            "char-1",
+            json!({ "avatar": small_png_data_url() }),
+        )
+        .expect("avatar should update");
+
+        assert_managed_avatar_upload(&updated, "characters");
+    }
+
+    #[test]
+    fn persona_avatar_upload_stores_managed_asset_url() {
+        let state = test_state("persona-avatar-upload-managed");
+        state
+            .storage
+            .create(
+                "personas",
+                json!({
+                    "id": "persona-1",
+                    "name": "Xel"
+                }),
+            )
+            .expect("persona should be created");
+
+        let updated = update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url() }),
+        )
+        .expect("avatar should update");
+
+        assert_managed_avatar_upload(&updated, "personas");
+    }
+
+    #[test]
+    fn npc_avatar_upload_keeps_inline_url_for_url_only_consumers() {
+        let state = test_state("npc-avatar-upload-managed");
+
+        let updated = update_npc_avatar(
+            &state,
+            "chat-1",
+            json!({
+                "name": "Rina",
+                "avatar": small_png_data_url()
+            }),
+        )
+        .expect("npc avatar should update");
+
+        let avatar_path = updated
+            .get("avatarPath")
+            .and_then(Value::as_str)
+            .expect("avatarPath should be present");
+        assert!(
+            avatar_path.starts_with("data:image/"),
+            "NPC avatarPath should stay inline because game NPC rows only persist URL fields"
+        );
+        let avatar_file_path = updated
+            .get("avatarFilePath")
+            .and_then(Value::as_str)
+            .expect("avatarFilePath should be present");
+        assert!(Path::new(avatar_file_path).is_file());
+    }
+
+    #[test]
+    fn persona_avatar_update_removes_unreferenced_previous_file() {
+        let state = test_state("persona-avatar-unreferenced-cleanup");
+        state
+            .storage
+            .create(
+                "personas",
+                json!({
+                    "id": "persona-1",
+                    "name": "Xel"
+                }),
+            )
+            .expect("persona should be created");
+
+        let first = update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url(), "filename": "first.png" }),
+        )
+        .expect("first avatar should update");
+        let old_path = first
+            .get("avatarFilePath")
+            .and_then(Value::as_str)
+            .expect("first avatar path should be stored")
+            .to_string();
+
+        update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url(), "filename": "second.png" }),
+        )
+        .expect("second avatar should update");
+
+        assert!(
+            !Path::new(&old_path).exists(),
+            "unreferenced previous persona avatar should still be cleaned up"
+        );
+    }
+
+    #[test]
+    fn persona_avatar_update_preserves_message_snapshot_file() {
+        let state = test_state("persona-avatar-snapshot-preserve");
+        state
+            .storage
+            .create(
+                "personas",
+                json!({
+                    "id": "persona-1",
+                    "name": "Xel"
+                }),
+            )
+            .expect("persona should be created");
+
+        let first = update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url(), "filename": "first.png" }),
+        )
+        .expect("first avatar should update");
+        let old_path = first
+            .get("avatarFilePath")
+            .and_then(Value::as_str)
+            .expect("first avatar path should be stored")
+            .to_string();
+        let old_filename = first
+            .get("avatarFilename")
+            .and_then(Value::as_str)
+            .expect("first avatar filename should be stored")
+            .to_string();
+        let old_url = first
+            .get("avatarPath")
+            .and_then(Value::as_str)
+            .expect("first avatar URL should be stored")
+            .to_string();
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "msg-1",
+                    "chatId": "chat-1",
+                    "role": "user",
+                    "content": "hello",
+                    "extra": {
+                        "personaSnapshot": {
+                            "personaId": "persona-1",
+                            "name": "Xel",
+                            "avatarUrl": old_url,
+                            "avatarFilePath": old_path,
+                            "avatarFilename": old_filename
+                        }
+                    }
+                }),
+            )
+            .expect("message snapshot should be created");
+
+        update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url(), "filename": "second.png" }),
+        )
+        .expect("second avatar should update");
+
+        assert!(
+            Path::new(&old_path).is_file(),
+            "persona avatar referenced by a message snapshot should remain available"
+        );
+    }
+
+    #[test]
+    fn persona_avatar_update_ignores_filename_only_snapshot_match() {
+        let state = test_state("persona-avatar-filename-only");
+        state
+            .storage
+            .create(
+                "personas",
+                json!({
+                    "id": "persona-1",
+                    "name": "Xel"
+                }),
+            )
+            .expect("persona should be created");
+
+        let first = update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url(), "filename": "same-name.png" }),
+        )
+        .expect("first avatar should update");
+        let old_path = first
+            .get("avatarFilePath")
+            .and_then(Value::as_str)
+            .expect("first avatar path should be stored")
+            .to_string();
+        let old_filename = first
+            .get("avatarFilename")
+            .and_then(Value::as_str)
+            .expect("first avatar filename should be stored")
+            .to_string();
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "msg-1",
+                    "chatId": "chat-1",
+                    "role": "user",
+                    "content": "hello",
+                    "extra": {
+                        "personaSnapshot": {
+                            "personaId": "persona-1",
+                            "name": "Xel",
+                            "avatarFilename": old_filename
+                        }
+                    }
+                }),
+            )
+            .expect("message snapshot should be created");
+
+        update_character_avatar(
+            &state,
+            "personas",
+            "persona-1",
+            json!({ "avatar": small_png_data_url(), "filename": "second.png" }),
+        )
+        .expect("second avatar should update");
+
+        assert!(
+            !Path::new(&old_path).exists(),
+            "filename-only snapshot matches should not preserve unrelated avatar files"
+        );
     }
 
     #[test]
@@ -565,6 +981,32 @@ mod tests {
         assert_eq!(restored["avatarPath"], "data:image/png;base64,b2xk");
         assert_eq!(restored["avatarFilePath"], Value::Null);
         assert_eq!(restored["avatarFilename"], Value::Null);
+    }
+
+    #[test]
+    fn character_avatar_snapshot_preserves_metadata_when_inline_read_fails() {
+        let state = test_state("character-avatar-version-missing-file");
+        let missing_path = state
+            .data_dir
+            .join("avatars")
+            .join("characters")
+            .join("missing.png")
+            .to_string_lossy()
+            .to_string();
+        let record = json!({
+            "id": "char-1",
+            "data": { "name": "Rina" },
+            "avatar": "http://asset.localhost/missing.png",
+            "avatarPath": "http://asset.localhost/missing.png",
+            "avatarFilePath": missing_path,
+            "avatarFilename": "missing.png"
+        });
+
+        let snapshot = character_avatar_snapshot_record(&state, "characters", &record);
+
+        assert_eq!(snapshot["avatarPath"], "http://asset.localhost/missing.png");
+        assert_eq!(snapshot["avatarFilePath"], record["avatarFilePath"]);
+        assert_eq!(snapshot["avatarFilename"], "missing.png");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1042,7 +1042,8 @@ fn delete_cleanup_needs_existing_record(cleanup: &contracts::DeleteCleanup) -> b
 
 fn remove_owned_media(state: &AppState, entity: &str, record: &Value) {
     match entity {
-        "characters" | "personas" => avatars::remove_avatar_file(state, entity, record),
+        "characters" => avatars::remove_avatar_file(state, entity, record),
+        "personas" => avatars::remove_avatar_file_preserving_persona_snapshots(state, entity, record),
         "lorebooks" => lorebook_images::remove_lorebook_image_file(state, record),
         "gallery" | "character-gallery" => remove_gallery_file(state, record),
         _ => {}

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -1,12 +1,6 @@
 use super::*;
 use std::path::{Path, PathBuf};
 
-pub(crate) struct StoredImageUpload {
-    pub(crate) data_url: String,
-    pub(crate) absolute_path: String,
-    pub(crate) filename: String,
-}
-
 pub(crate) struct StoredManagedImage {
     pub(crate) asset_url: String,
     pub(crate) absolute_path: String,
@@ -19,7 +13,7 @@ pub(crate) fn persist_image_upload(
     id: &str,
     body: &Value,
     field_name: &str,
-) -> AppResult<StoredImageUpload> {
+) -> AppResult<StoredManagedImage> {
     let image = body
         .get(field_name)
         .and_then(Value::as_str)
@@ -43,17 +37,7 @@ pub(crate) fn persist_image_upload(
     fs::create_dir_all(&dir)?;
     let target = unique_file_path(&dir.join(&filename))?;
     fs::write(&target, &bytes)?;
-    Ok(StoredImageUpload {
-        data_url: format!(
-            "data:{mime};base64,{}",
-            general_purpose::STANDARD.encode(bytes)
-        ),
-        absolute_path: target.to_string_lossy().to_string(),
-        filename: target
-            .file_name()
-            .map(|value| value.to_string_lossy().to_string())
-            .unwrap_or(filename),
-    })
+    stored_managed_image(target)
 }
 
 pub(crate) fn persist_image_file_copy(

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -428,6 +428,8 @@ export interface MessageExtra {
     appearance?: string | null;
     scenario?: string | null;
     avatarUrl?: string | null;
+    avatarFilePath?: string | null;
+    avatarFilename?: string | null;
     /** JSON-encoded AvatarCrop captured at send time so re-edits don't restyle past messages. */
     avatarCrop?: string | null;
     nameColor?: string | null;

--- a/src/engine/generation/persona-snapshot.ts
+++ b/src/engine/generation/persona-snapshot.ts
@@ -46,6 +46,8 @@ function personaSnapshotFromRecord(value: unknown): PersonaMessageSnapshot | nul
       optionalString(field(value, data, "avatarPath")) ??
       optionalString(field(value, data, "avatarUrl")) ??
       optionalString(field(value, data, "avatar")),
+    avatarFilePath: optionalString(field(value, data, "avatarFilePath")),
+    avatarFilename: optionalString(field(value, data, "avatarFilename")),
     avatarCrop: avatarCropSnapshot(field(value, data, "avatarCrop")),
     nameColor: optionalString(field(value, data, "nameColor")),
     dialogueColor: optionalString(field(value, data, "dialogueColor")),

--- a/src/features/catalog/personas/hooks/use-personas.ts
+++ b/src/features/catalog/personas/hooks/use-personas.ts
@@ -17,6 +17,8 @@ export type PersonaSummary = {
   scenario?: string;
   backstory?: string;
   appearance?: string;
+  altDescriptions?: Array<{ active?: boolean; content?: string }>;
+  savedStatusOptions?: string | string[] | null;
   tags?: string[];
   avatarPath?: string | null;
   avatarFilePath?: string | null;
@@ -32,6 +34,9 @@ export type PersonaSummary = {
 
 const PERSONA_SUMMARY_OPTIONS = {
   fields: [...PERSONA_SUMMARY_FIELDS],
+};
+const PERSONA_CHAT_SUMMARY_OPTIONS = {
+  fields: [...PERSONA_SUMMARY_FIELDS, "altDescriptions", "savedStatusOptions"],
 };
 
 function personaIsActive(persona: PersonaSummary): boolean {
@@ -62,9 +67,19 @@ async function getPersona(id: string): Promise<unknown> {
   return normalizePersonaAvatarFields(await storageApi.get<unknown>("personas", id));
 }
 
+async function getPersonaSummary(id: string): Promise<PersonaSummary | null> {
+  const persona = await storageApi.get<PersonaSummary | null>("personas", id, PERSONA_CHAT_SUMMARY_OPTIONS);
+  return persona ? normalizePersonaAvatarFields(persona) : null;
+}
+
 async function listPersonaSummaries(): Promise<PersonaSummary[]> {
   const personas = await storageApi.list<PersonaSummary>("personas", PERSONA_SUMMARY_OPTIONS);
   return personas.map(normalizePersonaAvatarFields);
+}
+
+async function getActivePersonaSummary(): Promise<PersonaSummary | null> {
+  const activePersona = (await listPersonaSummaries()).find(personaIsActive);
+  return activePersona?.id ? getPersonaSummary(activePersona.id) : null;
 }
 
 export function usePersonas(enabled = true) {
@@ -87,6 +102,16 @@ export function usePersonaSummaries(enabled = true) {
   });
 }
 
+export function usePersonaSummary(id: string | null, enabled = true) {
+  return useQuery({
+    queryKey: personaKeys.summaryDetail(id ?? ""),
+    queryFn: () => getPersonaSummary(id!),
+    enabled: enabled && !!id,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
 export function usePersona(id: string | null, enabled = true) {
   return useQuery({
     queryKey: personaKeys.detail(id ?? ""),
@@ -97,13 +122,10 @@ export function usePersona(id: string | null, enabled = true) {
   });
 }
 
-export function useActivePersona(enabled = true) {
+export function useActivePersonaSummary(enabled = true) {
   return useQuery({
-    queryKey: personaKeys.active,
-    queryFn: async () => {
-      const activePersona = (await listPersonaSummaries()).find(personaIsActive);
-      return activePersona?.id ? getPersona(activePersona.id) : null;
-    },
+    queryKey: personaKeys.activeSummary,
+    queryFn: getActivePersonaSummary,
     enabled,
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -113,6 +135,7 @@ export function useActivePersona(enabled = true) {
 export function invalidatePersonaCollectionQueries(queryClient: Pick<QueryClient, "invalidateQueries">): void {
   queryClient.invalidateQueries({ queryKey: personaKeys.list, exact: true });
   queryClient.invalidateQueries({ queryKey: personaKeys.summaries, exact: true });
+  queryClient.invalidateQueries({ queryKey: personaKeys.activeSummary, exact: true });
 }
 
 export function useCreatePersona() {
@@ -186,7 +209,7 @@ export function useUpdatePersona() {
       invalidatePersonaCollectionQueries(qc);
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
-      qc.invalidateQueries({ queryKey: personaKeys.active });
+      qc.invalidateQueries({ queryKey: personaKeys.activeSummary });
     },
   });
 }
@@ -199,7 +222,7 @@ export function useDeletePersona() {
       qc.removeQueries({ queryKey: personaKeys.detail(id) });
       qc.removeQueries({ queryKey: personaKeys.summaryDetail(id) });
       invalidatePersonaCollectionQueries(qc);
-      qc.invalidateQueries({ queryKey: personaKeys.active });
+      qc.invalidateQueries({ queryKey: personaKeys.activeSummary });
     },
   });
 }
@@ -220,7 +243,7 @@ export function useActivatePersona() {
     mutationFn: (id: string) => personaApi.activate(id),
     onSuccess: () => {
       invalidatePersonaCollectionQueries(qc);
-      qc.invalidateQueries({ queryKey: personaKeys.active });
+      qc.invalidateQueries({ queryKey: personaKeys.activeSummary });
     },
   });
 }
@@ -234,7 +257,7 @@ export function useUploadPersonaAvatar() {
       invalidatePersonaCollectionQueries(qc);
       qc.invalidateQueries({ queryKey: personaKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: personaKeys.summaryDetail(variables.id) });
-      qc.invalidateQueries({ queryKey: personaKeys.active });
+      qc.invalidateQueries({ queryKey: personaKeys.activeSummary });
     },
   });
 }

--- a/src/features/catalog/personas/query-keys.ts
+++ b/src/features/catalog/personas/query-keys.ts
@@ -3,7 +3,7 @@ export const personaKeys = {
   summaries: ["personas", "summaries"] as const,
   summaryDetail: (id: string) => ["personas", "summaries", id] as const,
   detail: (id: string) => [...personaKeys.list, "detail", id] as const,
-  active: ["personas", "active"] as const,
+  activeSummary: ["personas", "active-summary"] as const,
   groups: ["persona-groups"] as const,
   groupDetail: (id: string) => ["persona-groups", "detail", id] as const,
 };

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -35,7 +35,12 @@ import {
   chatKeys,
 } from "../../../catalog/chats/index";
 import { characterKeys } from "../../../catalog/characters/index";
-import { personaKeys, useActivePersona, usePersona, useUpdatePersona } from "../../../catalog/personas/index";
+import {
+  personaKeys,
+  useActivePersonaSummary,
+  usePersonaSummary,
+  useUpdatePersona,
+} from "../../../catalog/personas/index";
 import {
   matchSlashCommand,
   getSlashCompletions,
@@ -238,8 +243,8 @@ export function ConversationInput({
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
   const activeChatPersonaId =
     typeof activeChat?.personaId === "string" && activeChat.personaId.trim() ? activeChat.personaId.trim() : null;
-  const { data: chatPersona } = usePersona(activeChatPersonaId, !!activeChatPersonaId);
-  const { data: fallbackPersona } = useActivePersona(!activeChatPersonaId && activeChat?.mode !== "game");
+  const { data: chatPersona } = usePersonaSummary(activeChatPersonaId, !!activeChatPersonaId);
+  const { data: fallbackPersona } = useActivePersonaSummary(!activeChatPersonaId && activeChat?.mode !== "game");
   const updatePersona = useUpdatePersona();
   const qc = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -37,6 +37,7 @@ import {
   messageAttachmentImageSource,
   messageAttachmentsFromExtra,
   readStoredThinking,
+  ResolvedAvatarImage,
   resolvePromptSnapshotFromExtra,
 } from "../../shared/chat-ui/index";
 import { ImagePromptPanel } from "../../shared/chat-ui/index";
@@ -423,9 +424,25 @@ export const ConversationMessage = memo(function ConversationMessage({
   // to preserve the correct persona name/avatar even after switching personas.
   // Fall back to the current personaInfo prop for older messages without snapshots.
   const msgPersona = isUser && extra.personaSnapshot ? extra.personaSnapshot : null;
-  const avatarUrl = isUser ? (msgPersona?.avatarUrl ?? personaInfo?.avatarUrl ?? null) : (charInfo?.avatarUrl ?? null);
+  const avatarUrl = isUser
+    ? msgPersona
+      ? (msgPersona.avatarUrl ?? null)
+      : (personaInfo?.avatarUrl ?? null)
+    : (charInfo?.avatarUrl ?? null);
+  const avatarFilePath = isUser
+    ? msgPersona
+      ? (msgPersona.avatarFilePath ?? null)
+      : (personaInfo?.avatarFilePath ?? null)
+    : (charInfo?.avatarFilePath ?? null);
+  const avatarFilename = isUser
+    ? msgPersona
+      ? (msgPersona.avatarFilename ?? null)
+      : (personaInfo?.avatarFilename ?? null)
+    : (charInfo?.avatarFilename ?? null);
   const personaAvatarCrop = isUser
-    ? (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
+    ? msgPersona
+      ? parseAvatarCropJson(msgPersona.avatarCrop)
+      : (personaInfo?.avatarCrop ?? null)
     : null;
   const avatarCropStyle = isUser ? getAvatarCropStyle(personaAvatarCrop) : getAvatarCropStyle(charInfo?.avatarCrop);
   const displayName = isUser
@@ -1092,10 +1109,14 @@ export const ConversationMessage = memo(function ConversationMessage({
           <>
             <div className="relative h-10 w-10 overflow-hidden rounded-full bg-[var(--accent)]">
               {avatarUrl ? (
-                <img
+                <ResolvedAvatarImage
                   src={avatarUrl}
+                  avatarFilePath={avatarFilePath}
+                  avatarFilename={avatarFilename}
                   alt={displayName}
                   loading="lazy"
+                  decoding="async"
+                  thumbnailSize={128}
                   className="h-full w-full object-cover"
                   style={avatarCropStyle}
                 />

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -1453,13 +1453,27 @@ export const ChatMessage = memo(function ChatMessage({
 
   const displayName = isUser ? userName : charName;
   const baseAvatarUrl = isUser
-    ? (msgPersona?.avatarUrl ?? personaInfo?.avatarUrl ?? null)
+    ? msgPersona
+      ? (msgPersona.avatarUrl ?? null)
+      : (personaInfo?.avatarUrl ?? null)
     : (charInfo?.avatarUrl ?? null);
   const expressionAvatarUrl =
     !isUser && message.characterId ? (expressionAvatarResolver?.(message, message.characterId) ?? null) : null;
   const avatarUrl = expressionAvatarUrl ?? baseAvatarUrl;
-  const avatarFilePath = !isUser && !expressionAvatarUrl ? (charInfo?.avatarFilePath ?? null) : null;
-  const avatarFilename = !isUser && !expressionAvatarUrl ? (charInfo?.avatarFilename ?? null) : null;
+  const avatarFilePath = expressionAvatarUrl
+    ? null
+    : isUser
+      ? msgPersona
+        ? (msgPersona.avatarFilePath ?? null)
+        : (personaInfo?.avatarFilePath ?? null)
+      : (charInfo?.avatarFilePath ?? null);
+  const avatarFilename = expressionAvatarUrl
+    ? null
+    : isUser
+      ? msgPersona
+        ? (msgPersona.avatarFilename ?? null)
+        : (personaInfo?.avatarFilename ?? null)
+      : (charInfo?.avatarFilename ?? null);
   const [resolvedAvatarUrl, setResolvedAvatarUrl] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
@@ -1479,7 +1493,9 @@ export const ChatMessage = memo(function ChatMessage({
     setResolvedAvatarUrl(src);
   }, []);
   const personaAvatarCrop = isUser
-    ? (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
+    ? msgPersona
+      ? parseAvatarCropJson(msgPersona.avatarCrop)
+      : (personaInfo?.avatarCrop ?? null)
     : null;
   const avatarCropStyle = expressionAvatarUrl
     ? {}

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.test.tsx
@@ -17,12 +17,15 @@ vi.mock("../../../../catalog/chats/index", () => ({
 
 vi.mock("../../../../catalog/characters/index", () => ({
   characterAvatarUrl: () => null,
+  useCharacterSummariesByIds: () => ({ data: [] }),
   useCharactersByIds: () => ({ data: [] }),
 }));
 
 vi.mock("../../../../catalog/personas/index", () => ({
   useActivePersona: () => ({ data: undefined }),
+  useActivePersonaSummary: () => ({ data: undefined }),
   usePersona: () => ({ data: undefined }),
+  usePersonaSummary: () => ({ data: undefined }),
 }));
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-surface-data.ts
@@ -6,8 +6,8 @@ import {
   type Chat,
   type ChatMode,
 } from "../../../../catalog/chats/index";
-import { characterAvatarUrl, useCharactersByIds } from "../../../../catalog/characters/index";
-import { useActivePersona, usePersona } from "../../../../catalog/personas/index";
+import { characterAvatarUrl, useCharacterSummariesByIds } from "../../../../catalog/characters/index";
+import { useActivePersonaSummary, usePersonaSummary } from "../../../../catalog/personas/index";
 import { ApiError } from "../../../../../shared/api/api-errors";
 import { getConnectedChatDisplayName, parseChatMetadata } from "../../../../../shared/lib/chat-display";
 import { parseCharacterDisplayData } from "../../../../../shared/lib/character-display";
@@ -46,6 +46,8 @@ type PersonaRow = {
   appearance?: string;
   altDescriptions?: Array<{ active?: boolean; content?: string }>;
   avatarPath?: string | null;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   avatarCrop?: string;
   nameColor?: string;
   dialogueColor?: string;
@@ -163,6 +165,8 @@ function buildPersonaInfo(persona: PersonaRow | null | undefined): PersonaInfo |
     backstory: persona.backstory || undefined,
     appearance: persona.appearance || undefined,
     avatarUrl: persona.avatarPath || undefined,
+    avatarFilePath: persona.avatarFilePath ?? null,
+    avatarFilename: persona.avatarFilename ?? null,
     avatarCrop: parseAvatarCropJson(persona.avatarCrop),
     nameColor: persona.nameColor || undefined,
     dialogueColor: persona.dialogueColor || undefined,
@@ -261,7 +265,7 @@ export function useChatSurfaceData({
     () => normalizeIds([...chatCharIds, ...extractMessageCharacterIds(messages), ...collectGameCharacterIds(chatMeta)]),
     [chatCharIds, chatMeta, messages],
   );
-  const { data: characterRows } = useCharactersByIds(neededCharacterIds, neededCharacterIds.length > 0);
+  const { data: characterRows } = useCharacterSummariesByIds(neededCharacterIds, neededCharacterIds.length > 0);
   const characterMap: CharacterMap = useMemo(() => {
     const map: CharacterMap = new Map();
     for (const character of (characterRows ?? []) as CharacterRow[]) {
@@ -310,8 +314,8 @@ export function useChatSurfaceData({
     typeof (chat as unknown as { personaId?: unknown } | null | undefined)?.personaId === "string"
       ? (chat as unknown as { personaId: string }).personaId.trim() || null
       : null;
-  const { data: chatPersona } = usePersona(chatPersonaId, !!chatPersonaId);
-  const { data: activePersona } = useActivePersona(personaFallback === "active-persona" && !chatPersonaId);
+  const { data: chatPersona } = usePersonaSummary(chatPersonaId, !!chatPersonaId);
+  const { data: activePersona } = useActivePersonaSummary(personaFallback === "active-persona" && !chatPersonaId);
   const personaInfo = useMemo(
     () => buildPersonaInfo((chatPersona ?? activePersona) as PersonaRow | null | undefined),
     [activePersona, chatPersona],

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -14,6 +14,7 @@ export * from "./components/QuickConnectionSwitcher";
 export * from "./components/QuickPersonaSwitcher";
 export * from "./components/QuickReplyMenu";
 export * from "./components/QuickSwitcherMobile";
+export * from "./components/ResolvedAvatarImage";
 export * from "./components/SlashCommandFeedback";
 export * from "./components/SummaryPopover";
 export * from "./components/SwipeJumpControl";

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -177,7 +177,7 @@ function cachedPersonaSnapshot(queryClient: QueryClient, chatId: string) {
   const personas: unknown[] = [];
   addPersonaRows(personas, queryClient.getQueryData(personaKeys.list));
   addPersonaRows(personas, queryClient.getQueryData(personaKeys.summaries));
-  addPersonaRows(personas, queryClient.getQueryData(personaKeys.active));
+  addPersonaRows(personas, queryClient.getQueryData(personaKeys.activeSummary));
   if (personaId) {
     addPersonaRows(personas, queryClient.getQueryData(personaKeys.detail(personaId)));
     addPersonaRows(personas, queryClient.getQueryData(personaKeys.summaryDetail(personaId)));

--- a/src/features/runtime/visuals/types.ts
+++ b/src/features/runtime/visuals/types.ts
@@ -32,6 +32,8 @@ export type PersonaInfo = {
   appearance?: string;
   scenario?: string;
   avatarUrl?: string;
+  avatarFilePath?: string | null;
+  avatarFilename?: string | null;
   avatarCrop?: AvatarCropValue | null;
   nameColor?: string;
   dialogueColor?: string;


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Avatar uploads decoded and wrote managed files, but then kept inline `data:image/...` payloads in live `avatar` and `avatarPath` fields. That made character, persona, NPC, chat, and game hot paths carry large base64 strings.

## What changed

- Store uploaded character, persona, and NPC avatars as managed asset URLs in `avatar`/`avatarPath` while preserving `avatarFilePath` and `avatarFilename` metadata.
- Added Rust coverage for character, persona, and NPC avatar upload return/storage shape.
- Switched chat/conversation character and persona reads to projected summary records so managed avatars do not force full inline avatar payload reads.
- Removed the stale full active-persona cache path and pointed generation's cached persona snapshot lookup at the projected active summary cache.

## Refactor impact

Primary owner:

Rust storage, catalog persona hooks, and shared chat/conversation hot-path reads.

Impact areas reviewed:

- Character avatar upload storage
- Persona avatar upload storage
- NPC avatar upload response shape used by game/tracker callers
- Chat surface character and persona lookup paths
- Conversation input persona status lookup
- Generation optimistic persona snapshot cache lookup

Boundary notes:

- Rust storage owns the upload persistence contract.
- Feature code continues to use catalog hooks and `storageApi`; no new raw Tauri or remote-runtime calls were added.
- Engine code was not coupled to feature or shared API adapters.
- Existing character version/export paths still inline avatar data only for compatibility snapshots/exports.

Pressure points touched:

- Shared chat UI hook and conversation input were touched for projected reads.
- No `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs`, or import module changes.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml avatar_upload` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml character_avatar_update_snapshot_does_not_restore_deleted_file_metadata` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for persisted avatar payload shape; no new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note update was made because this is an internal storage payload-shape bugfix and the repo has no changelog/release-notes file to update.

## UI evidence

N/A. No visual layout change; verification is storage contract and type/check proof.

## Remaining risk

- Existing records that already contain inline avatar data are not migrated in this PR.
- Generated assistant image attachments and generated NPC portrait persistence are separate follow-up work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Avatar files are now intelligently preserved when referenced within message history and persona snapshots, preventing unintended deletion
  * Avatar metadata is now properly stored and retrieved for consistent display

* **Improvements**
  * Optimized avatar data handling and file management across the application
  * Enhanced avatar resolution for improved consistency in conversation displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->