### PR TITLE
Fix remote backup list admin access

### DIFF
--- a/src-tauri/src/commands/storage/backup.rs
+++ b/src-tauri/src/commands/storage/backup.rs
@@ -132,7 +132,6 @@ fn backup_entry(path: &Path) -> AppResult<Value> {
     Ok(json!({
         "name": name,
         "createdAt": created_at,
-        "path": path.to_string_lossy(),
     }))
 }
 
@@ -340,6 +339,7 @@ mod tests {
             .clone();
         assert_eq!(backups.len(), 1);
         assert_eq!(backups[0]["name"], name);
+        assert!(backups[0].get("path").is_none());
 
         let downloaded =
             download_backup(&state, Some(name)).expect("managed backup should download");

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -557,6 +557,7 @@ fn is_privileged_remote_command(command: &str) -> bool {
             | "profile_import"
             | "profile_import_upload"
             | "backup_create"
+            | "backup_list"
             | "backup_delete"
             | "backup_download"
             | "import_list_directory"
@@ -1650,6 +1651,23 @@ mod tests {
             .expect_err("public remote IP should require auth");
         assert_eq!(rejection.status, StatusCode::FORBIDDEN);
         assert_eq!(rejection.code, "remote_auth_required");
+    }
+
+    #[test]
+    fn hostable_security_requires_admin_access_for_remote_backup_list() {
+        let headers = HeaderMap::new();
+        let remote_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        let error = require_admin_access_for_command("backup_list", &headers, remote_ip)
+            .expect_err("remote backup_list should require Admin Access");
+        assert_eq!(error.code, "admin_access_required");
+        assert!(require_admin_access_for_command(
+            "backup_list",
+            &headers,
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        )
+        .is_ok());
+        assert!(require_admin_access_for_command("storage_list", &headers, remote_ip).is_ok());
     }
 
     #[test]

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -74,7 +74,6 @@ async function importProfileUpload<T>(file: File): Promise<T> {
 export type ManagedBackup = {
   name: string;
   createdAt: string;
-  path?: string;
 };
 
 async function createBackup(): Promise<{ success: boolean; backupName: string }> {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -185,6 +185,7 @@ const PRIVILEGED_REMOTE_COMMANDS = new Set([
   "profile_import",
   "profile_import_upload",
   "backup_create",
+  "backup_list",
   "backup_delete",
   "backup_download",
   "import_list_directory",


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2039

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Remote `backup_list` was exposed through `/api/invoke` without the Admin Access tier even though listed backups included server-local filesystem paths.
- Legacy backup listing only returned non-sensitive metadata, so the refactor remote runtime should not let non-loopback callers enumerate backup paths.

## What changed

<!-- List the key changes in this PR. -->

- Added `backup_list` to the frontend privileged remote command set so remote web clients include the Admin Access header for the command.
- Added `backup_list` to the server privileged remote command set so non-loopback callers without Admin Access are rejected.
- Removed the local `path` field from managed backup list entries and tightened the frontend `ManagedBackup` type to match.
- Added focused Rust coverage for remote `backup_list` Admin Access enforcement and backup-list path redaction.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Remote runtime, shared API, Rust storage.

Impact areas reviewed:

- Remote invoke privileged-command header selection.
- `/api/invoke` Admin Access gate for non-loopback callers.
- Managed backup list response shape.
- Settings backup UI usage of backup `name` and `createdAt`.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine code is untouched.
- React feature UI is untouched; the shared backup API type no longer accepts `path`.
- Rust changes stay within the HTTP remote gate and storage backup metadata payload.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src/shared/api/remote-runtime.ts` privileged command set.
- `src-tauri/src/http_server.rs` privileged remote command gate.
- `src-tauri/src/commands/storage/backup.rs` managed backup list metadata.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Before fix, a focused invariant probe failed with `backup_list missing from frontend privileged remote command set`.
- After fix, the same invariant probe passed: `backup_list remote privilege and path redaction invariants passed`.
- `cargo test --manifest-path src-tauri/Cargo.toml backup::tests -- --nocapture` passed: 2 passed, 0 failed.
- `cargo test --manifest-path src-tauri/Cargo.toml http_server::tests::hostable_security_ -- --nocapture` passed: 11 passed, 0 failed.
- `pnpm typecheck` passed after installing locked dependencies with `pnpm install --frozen-lockfile`.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed.
- Bunny review pass completed locally before opening the draft.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed; this is a focused remote-runtime security/metadata fix.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A: no visible UI changed. This was verified through focused invariant, Rust security/storage tests, and the full `pnpm check` baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup list response no longer includes path metadata for each backup entry.

* **Security**
  * Remote requests to the backup list API now require admin authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->