### PR TITLE
Require confirm for admin clear all

### DIFF
--- a/src-tauri/src/commands/storage/admin.rs
+++ b/src-tauri/src/commands/storage/admin.rs
@@ -1,7 +1,10 @@
 use super::shared::*;
 use super::*;
 
-pub(crate) fn admin_clear_all(state: &AppState) -> AppResult<Value> {
+pub(crate) fn admin_clear_all(state: &AppState, body: Value) -> AppResult<Value> {
+    if body.get("confirm").and_then(Value::as_bool) != Some(true) {
+        return Err(AppError::invalid_input("confirm must be true"));
+    }
     state.storage.clear_all()?;
     clear_runtime_media(state)?;
     Ok(json!({ "success": true, "cleared": "all" }))
@@ -154,6 +157,67 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp admin dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn seed_character(state: &AppState, id: &str) {
+        state
+            .storage
+            .upsert_with_id(
+                "characters",
+                id,
+                json!({
+                    "id": id,
+                    "name": "Seed Character"
+                }),
+            )
+            .expect("character should write");
+    }
+
+    fn character_exists(state: &AppState, id: &str) -> bool {
+        state
+            .storage
+            .get("characters", id)
+            .expect("characters should be readable")
+            .is_some()
+    }
+
+    #[test]
+    fn admin_clear_all_rejects_missing_confirmation_without_clearing_storage() {
+        let state = test_state("clear-all-missing-confirm");
+        seed_character(&state, "character-1");
+
+        let error = admin_clear_all(&state, json!({}))
+            .expect_err("clear all should reject missing confirmation");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("confirm must be true"));
+        assert!(character_exists(&state, "character-1"));
+    }
+
+    #[test]
+    fn admin_clear_all_rejects_false_confirmation_without_clearing_storage() {
+        let state = test_state("clear-all-false-confirm");
+        seed_character(&state, "character-1");
+
+        let error = admin_clear_all(&state, json!({ "confirm": false }))
+            .expect_err("clear all should reject false confirmation");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("confirm must be true"));
+        assert!(character_exists(&state, "character-1"));
+    }
+
+    #[test]
+    fn admin_clear_all_clears_storage_when_confirmed() {
+        let state = test_state("clear-all-confirmed");
+        seed_character(&state, "character-1");
+
+        let result =
+            admin_clear_all(&state, json!({ "confirm": true })).expect("clear all should succeed");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["cleared"], "all");
+        assert!(!character_exists(&state, "character-1"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/agents.rs
+++ b/src-tauri/src/commands/storage/commands/agents.rs
@@ -52,8 +52,11 @@ pub fn admin_expunge_command(
 }
 
 #[tauri::command]
-pub fn admin_clear_all_command(state: State<'_, AppState>) -> Result<Value, AppError> {
-    admin::admin_clear_all(&state)
+pub fn admin_clear_all_command(
+    state: State<'_, AppState>,
+    confirm: Option<bool>,
+) -> Result<Value, AppError> {
+    admin::admin_clear_all(&state, json!({ "confirm": confirm }))
 }
 
 #[tauri::command]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -616,7 +616,9 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             state,
             json!({ "confirm": true, "scopes": required_string_vec(&args, "scopes")? }),
         ),
-        "admin_clear_all_command" => admin::admin_clear_all(state),
+        "admin_clear_all_command" => {
+            admin::admin_clear_all(state, json!({ "confirm": optional_bool(&args, "confirm") }))
+        }
         "agent_memory_get" => agents::agent_memory(
             state,
             "GET",
@@ -1180,6 +1182,28 @@ mod tests {
             .unwrap_or(false)
     }
 
+    fn seed_character(state: &AppState, id: &str) {
+        state
+            .storage
+            .upsert_with_id(
+                "characters",
+                id,
+                json!({
+                    "id": id,
+                    "name": "Seed Character"
+                }),
+            )
+            .expect("character should write");
+    }
+
+    fn character_exists(state: &AppState, id: &str) -> bool {
+        state
+            .storage
+            .get("characters", id)
+            .expect("characters should be readable")
+            .is_some()
+    }
+
     fn quoted_commands(source: &str) -> BTreeSet<String> {
         source
             .split('"')
@@ -1315,6 +1339,51 @@ mod tests {
             result.get("mimeType"),
             Some(&Value::String("image/png".into()))
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_admin_clear_all_requires_confirmation_without_clearing_storage() {
+        for (label, args) in [
+            ("admin-clear-all-missing-confirm", json!({})),
+            ("admin-clear-all-false-confirm", json!({ "confirm": false })),
+        ] {
+            let state = test_state(label);
+            seed_character(&state, "character-1");
+
+            let error = dispatch(
+                &state,
+                InvokeRequest {
+                    command: "admin_clear_all_command".to_string(),
+                    args: Some(args),
+                },
+            )
+            .await
+            .expect_err("remote clear all should reject missing or false confirmation");
+
+            assert_eq!(error.code, "invalid_input");
+            assert!(error.message.contains("confirm must be true"));
+            assert!(character_exists(&state, "character-1"));
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_admin_clear_all_clears_storage_when_confirmed() {
+        let state = test_state("admin-clear-all-confirmed");
+        seed_character(&state, "character-1");
+
+        let result = dispatch(
+            &state,
+            InvokeRequest {
+                command: "admin_clear_all_command".to_string(),
+                args: Some(json!({ "confirm": true })),
+            },
+        )
+        .await
+        .expect("remote clear all should accept explicit confirmation");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["cleared"], "all");
+        assert!(!character_exists(&state, "character-1"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1323,6 +1323,7 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
 
     fn test_state(label: &str) -> AppState {
         let root = std::env::temp_dir().join(format!(
@@ -1374,6 +1375,32 @@ mod tests {
                 general_purpose::STANDARD.encode(format!("{user}:{pass}"))
             )
             .into_bytes(),
+        }
+    }
+
+    fn admin_secret_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct AdminSecretGuard {
+        original: Option<String>,
+    }
+
+    impl AdminSecretGuard {
+        fn capture() -> Self {
+            Self {
+                original: env::var("ADMIN_SECRET").ok(),
+            }
+        }
+    }
+
+    impl Drop for AdminSecretGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => env::set_var("ADMIN_SECRET", value),
+                None => env::remove_var("ADMIN_SECRET"),
+            }
         }
     }
 
@@ -1688,6 +1715,70 @@ mod tests {
             &[("authorization", "Basic dXNlcjpwYXNz")],
         );
         assert!(security.evaluate_request(&correct).is_ok());
+    }
+
+    #[test]
+    fn remote_admin_clear_all_rejects_non_loopback_without_admin_secret() {
+        let _guard = admin_secret_lock()
+            .lock()
+            .expect("admin secret test lock should acquire");
+        let _admin_secret = AdminSecretGuard::capture();
+        env::remove_var("ADMIN_SECRET");
+        let headers = HeaderMap::new();
+
+        let error = require_admin_access_for_command(
+            "admin_clear_all_command",
+            &headers,
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+        )
+        .expect_err("non-loopback clear all should require ADMIN_SECRET");
+
+        assert_eq!(error.code, "admin_access_required");
+    }
+
+    #[test]
+    fn remote_admin_clear_all_rejects_invalid_admin_secret() {
+        let _guard = admin_secret_lock()
+            .lock()
+            .expect("admin secret test lock should acquire");
+        let _admin_secret = AdminSecretGuard::capture();
+        env::set_var("ADMIN_SECRET", "expected-secret");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(ADMIN_SECRET_HEADER_NAME),
+            HeaderValue::from_static("wrong-secret"),
+        );
+
+        let error = require_admin_access_for_command(
+            "admin_clear_all_command",
+            &headers,
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+        )
+        .expect_err("non-loopback clear all should reject invalid ADMIN_SECRET");
+
+        assert_eq!(error.code, "admin_access_invalid");
+    }
+
+    #[test]
+    fn remote_admin_clear_all_accepts_valid_admin_secret() {
+        let _guard = admin_secret_lock()
+            .lock()
+            .expect("admin secret test lock should acquire");
+        let _admin_secret = AdminSecretGuard::capture();
+        env::set_var("ADMIN_SECRET", "expected-secret");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(ADMIN_SECRET_HEADER_NAME),
+            HeaderValue::from_static("expected-secret"),
+        );
+
+        let result = require_admin_access_for_command(
+            "admin_clear_all_command",
+            &headers,
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+        );
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/shared/api/admin-api.ts
+++ b/src/shared/api/admin-api.ts
@@ -2,5 +2,5 @@ import { invokeTauri } from "./tauri-client";
 
 export const adminApi = {
   expunge: (scopes: readonly string[]) => invokeTauri<{ success: boolean }>("admin_expunge_command", { scopes }),
-  clearAll: () => invokeTauri<{ success: boolean }>("admin_clear_all_command"),
+  clearAll: () => invokeTauri<{ success: boolean }>("admin_clear_all_command", { confirm: true }),
 };


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2029

## Why this change

- Refactor clear-all had UI confirmation, but the backend destructive command had no confirmation argument to validate once invoked. This restores a backend guard so missing or false confirmation returns `invalid_input` before storage/media deletion.

## What changed

- Require `confirm: true` inside `admin_clear_all` before clearing storage/runtime media.
- Thread the confirmation argument through `admin_clear_all_command` and remote `/api/invoke` dispatch.
- Update the shared admin API wrapper so the existing UI-confirmed clear-all action sends `{ confirm: true }`.
- Add Rust coverage for missing/false confirmation preserving seeded storage, confirmed clear-all deleting, remote dispatch behavior, remote admin-secret rejection, and the existing expunge control.

## Refactor impact

Primary owner:

Rust storage / remote runtime

Impact areas reviewed:

- `src-tauri` admin storage command helper
- Tauri IPC command wrapper
- remote `/api/invoke` dispatch
- remote non-loopback admin-secret access guard
- shared admin API wrapper used by settings reset UI

Boundary notes:

- Product behavior remains in `src-tauri` storage/admin command code.
- Feature UI still calls the focused shared API wrapper and does not import raw Tauri APIs.
- Remote dispatch continues through the existing HTTP pipeline and privileged-command secret gate.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration was reviewed; no registration change needed because the command name stayed the same.
- Destructive storage deletion now has backend confirmation validation before `state.storage.clear_all()`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml admin_clear_all -- --nocapture` passed: 8 tests.
- `cargo test --manifest-path src-tauri/Cargo.toml admin_expunge -- --nocapture` passed: 1 test.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- `git diff --check` passed.
- Workflow note: `node C:/Users/celia/.codex/tools/marinara-proof-gate.mjs scratch/bugfix-verification.json` could not run because that local tool path does not exist in this environment.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing destructive admin action; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: backend destructive-command guard and remote dispatch coverage only; no visible UI changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added confirmation requirement to the clear all storage command to prevent accidental data loss. Users must now explicitly confirm the destructive action before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->