### PR TITLE
Fix lorebook semantic embedding source

### DIFF
--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -34,6 +34,9 @@ const lorebookScheduleSchema = z.object({
 });
 
 const lorebookEmbeddingSchema = z.array(z.number()).nullable();
+const lorebookEmbeddingModelSchema = z.string().nullable();
+const lorebookEmbeddingConnectionIdSchema = z.string().nullable();
+const lorebookEmbeddingUpdatedAtSchema = z.string().nullable();
 
 // ──────────────────────────────────────────────
 // Folders — collapsible containers for entries
@@ -181,6 +184,9 @@ export const createLorebookEntrySchema = z.object({
   schedule: lorebookScheduleSchema.nullable().default(null),
   excludeFromVectorization: z.boolean().default(false),
   embedding: lorebookEmbeddingSchema.optional(),
+  embeddingModel: lorebookEmbeddingModelSchema.optional(),
+  embeddingConnectionId: lorebookEmbeddingConnectionIdSchema.optional(),
+  embeddingUpdatedAt: lorebookEmbeddingUpdatedAtSchema.optional(),
 });
 
 export const updateLorebookEntrySchema = z.object({
@@ -228,6 +234,9 @@ export const updateLorebookEntrySchema = z.object({
   schedule: lorebookScheduleSchema.nullable().optional(),
   excludeFromVectorization: z.boolean().optional(),
   embedding: lorebookEmbeddingSchema.optional(),
+  embeddingModel: lorebookEmbeddingModelSchema.optional(),
+  embeddingConnectionId: lorebookEmbeddingConnectionIdSchema.optional(),
+  embeddingUpdatedAt: lorebookEmbeddingUpdatedAtSchema.optional(),
 });
 
 export type CreateLorebookInput = z.input<typeof createLorebookSchema>;

--- a/src/engine/contracts/types/lorebook.ts
+++ b/src/engine/contracts/types/lorebook.ts
@@ -194,6 +194,12 @@ export interface LorebookEntry {
   excludeFromVectorization: boolean;
   /** Pre-computed embedding vector for semantic matching (null if not vectorized) */
   embedding: number[] | null;
+  /** Embedding model used to generate the stored vector, when known. */
+  embeddingModel?: string | null;
+  /** Connection used to generate the stored vector, when known. */
+  embeddingConnectionId?: string | null;
+  /** ISO timestamp for the stored vector, when known. */
+  embeddingUpdatedAt?: string | null;
 
   createdAt: string;
   updatedAt: string;

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -74,8 +74,13 @@ export interface LorebookSemanticScanStatus {
   vectorizedEntryCount: number;
 }
 
+interface LorebookEmbeddingRequest {
+  connectionId?: string | null;
+  model?: string | null;
+}
+
 interface LorebookEmbeddingSource {
-  embed(texts: string[]): Promise<number[][] | null>;
+  embed(texts: string[], request?: LorebookEmbeddingRequest): Promise<number[][] | null>;
 }
 
 interface LoadedLorebookBudgetSkippedEntry {
@@ -202,6 +207,9 @@ function normalizeLorebookEntry(entry: JsonRecord): LorebookEntry {
     embedding: Array.isArray(entry.embedding)
       ? entry.embedding.filter((item): item is number => typeof item === "number")
       : null,
+    embeddingModel: readString(entry.embeddingModel).trim() || null,
+    embeddingConnectionId: readString(entry.embeddingConnectionId).trim() || null,
+    embeddingUpdatedAt: readString(entry.embeddingUpdatedAt).trim() || null,
     additionalMatchingSources: stringArray(
       entry.additionalMatchingSources,
     ) as LorebookEntry["additionalMatchingSources"],
@@ -557,11 +565,34 @@ function countSemanticCandidateEntries(entries: LorebookEntry[]): number {
   ).length;
 }
 
+function lorebookEntryHasEmbedding(entry: LorebookEntry): boolean {
+  return (
+    !entry.constant &&
+    !entry.excludeFromVectorization &&
+    Array.isArray(entry.embedding) &&
+    entry.embedding.some((value) => Number.isFinite(value))
+  );
+}
+
+function vectorEmbeddingRequest(entries: LorebookEntry[]): LorebookEmbeddingRequest | null {
+  const requests = entries.filter(lorebookEntryHasEmbedding).map((entry) => ({
+    connectionId: readString(entry.embeddingConnectionId).trim() || null,
+    model: readString(entry.embeddingModel).trim() || null,
+  }));
+  if (requests.length === 0) return null;
+  const unique = new Set(requests.map((request) => `${request.connectionId ?? ""}\0${request.model ?? ""}`));
+  if (unique.size !== 1) return null;
+  const [request] = requests;
+  if (!request || (!request.connectionId && !request.model)) return null;
+  return request;
+}
+
 async function resolveSemanticChatEmbedding(
   messages: ScanMessage[],
   latestUserInput: string | undefined,
   embeddingSource: LorebookEmbeddingSource | null | undefined,
   vectorizedEntryCount: number,
+  embeddingRequest: LorebookEmbeddingRequest | null,
 ): Promise<{ chatEmbedding: number[] | null; status: LorebookSemanticScanStatus }> {
   if (vectorizedEntryCount === 0) {
     return { chatEmbedding: null, status: { state: "not_applicable", vectorizedEntryCount } };
@@ -574,7 +605,7 @@ async function resolveSemanticChatEmbedding(
     return { chatEmbedding: null, status: { state: "empty_query", vectorizedEntryCount } };
   }
   try {
-    const sourceEmbedding = await embeddingSource.embed([query]);
+    const sourceEmbedding = await embeddingSource.embed([query], embeddingRequest ?? undefined);
     const vector = sourceEmbedding?.[0]?.filter((value): value is number => Number.isFinite(value));
     if (!vector?.length) {
       return { chatEmbedding: null, status: { state: "unavailable", vectorizedEntryCount } };
@@ -634,11 +665,13 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
     (sum, item) => sum + countSemanticCandidateEntries(item.entries),
     0,
   );
+  const embeddingRequest = vectorEmbeddingRequest(entriesByBook.flatMap((item) => item.entries));
   const semantic = await resolveSemanticChatEmbedding(
     messages,
     input.latestUserInput,
     input.embeddingSource,
     vectorizedEntryCount,
+    embeddingRequest,
   );
   const options: ScanOptions = {
     activeCharacterIds,

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -83,6 +83,11 @@ interface LorebookEmbeddingSource {
   embed(texts: string[], request?: LorebookEmbeddingRequest): Promise<number[][] | null>;
 }
 
+type LorebookEmbeddingRequestSelection =
+  | { type: "default" }
+  | { type: "target"; request: LorebookEmbeddingRequest }
+  | { type: "ambiguous" };
+
 interface LoadedLorebookBudgetSkippedEntry {
   activatedEntry: ActivatedEntry;
   lorebookName: string;
@@ -574,17 +579,17 @@ function lorebookEntryHasEmbedding(entry: LorebookEntry): boolean {
   );
 }
 
-function vectorEmbeddingRequest(entries: LorebookEntry[]): LorebookEmbeddingRequest | null {
+function vectorEmbeddingRequest(entries: LorebookEntry[]): LorebookEmbeddingRequestSelection {
   const requests = entries.filter(lorebookEntryHasEmbedding).map((entry) => ({
     connectionId: readString(entry.embeddingConnectionId).trim() || null,
     model: readString(entry.embeddingModel).trim() || null,
   }));
-  if (requests.length === 0) return null;
+  if (requests.length === 0) return { type: "default" };
   const unique = new Set(requests.map((request) => `${request.connectionId ?? ""}\0${request.model ?? ""}`));
-  if (unique.size !== 1) return null;
+  if (unique.size !== 1) return { type: "ambiguous" };
   const [request] = requests;
-  if (!request || (!request.connectionId && !request.model)) return null;
-  return request;
+  if (!request || (!request.connectionId && !request.model)) return { type: "default" };
+  return { type: "target", request };
 }
 
 async function resolveSemanticChatEmbedding(
@@ -592,7 +597,7 @@ async function resolveSemanticChatEmbedding(
   latestUserInput: string | undefined,
   embeddingSource: LorebookEmbeddingSource | null | undefined,
   vectorizedEntryCount: number,
-  embeddingRequest: LorebookEmbeddingRequest | null,
+  embeddingRequest: LorebookEmbeddingRequestSelection,
 ): Promise<{ chatEmbedding: number[] | null; status: LorebookSemanticScanStatus }> {
   if (vectorizedEntryCount === 0) {
     return { chatEmbedding: null, status: { state: "not_applicable", vectorizedEntryCount } };
@@ -600,12 +605,18 @@ async function resolveSemanticChatEmbedding(
   if (!embeddingSource) {
     return { chatEmbedding: null, status: { state: "missing_embedding_source", vectorizedEntryCount } };
   }
+  if (embeddingRequest.type === "ambiguous") {
+    return { chatEmbedding: null, status: { state: "unavailable", vectorizedEntryCount } };
+  }
   const query = semanticQueryText(messages, latestUserInput);
   if (!query) {
     return { chatEmbedding: null, status: { state: "empty_query", vectorizedEntryCount } };
   }
   try {
-    const sourceEmbedding = await embeddingSource.embed([query], embeddingRequest ?? undefined);
+    const sourceEmbedding = await embeddingSource.embed(
+      [query],
+      embeddingRequest.type === "target" ? embeddingRequest.request : undefined,
+    );
     const vector = sourceEmbedding?.[0]?.filter((value): value is number => Number.isFinite(value));
     if (!vector?.length) {
       return { chatEmbedding: null, status: { state: "unavailable", vectorizedEntryCount } };

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1515,11 +1515,11 @@ function memoizedEmbeddingSource(
   if (!source) return null;
   const cache = new Map<string, Promise<number[][] | null>>();
   return {
-    embed: (texts) => {
-      const key = JSON.stringify(texts);
+    embed: (texts, request) => {
+      const key = JSON.stringify([texts, request ?? null]);
       const existing = cache.get(key);
       if (existing) return existing;
-      const embedding = source.embed(texts);
+      const embedding = source.embed(texts, request);
       cache.set(key, embedding);
       return embedding;
     },

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -121,7 +121,12 @@ export interface PromptAssemblyInput {
   request: JsonRecord;
   latestUserInput: string;
   agentData?: Record<string, string>;
-  embeddingSource?: { embed(texts: string[]): Promise<number[][] | null> } | null;
+  embeddingSource?: {
+    embed(
+      texts: string[],
+      request?: { connectionId?: string | null; model?: string | null },
+    ): Promise<number[][] | null>;
+  } | null;
   persistPromptVariables?: boolean;
 }
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -30,7 +30,13 @@ import {
   type MainToolDefinitions,
   type ToolRuntimeInput,
 } from "./tools-runtime";
-import { llmParameters, loadChatMessage, loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
+import {
+  llmParameters,
+  loadChatMessage,
+  loadChatMessages,
+  requireRecord,
+  resolveGenerationConnection,
+} from "./context";
 import {
   appendReadableAttachmentsToContent,
   extractImageAttachmentDataUrls,
@@ -216,11 +222,11 @@ function generationEmbeddingSource(llm: LlmGateway, connection: JsonRecord) {
   const connectionId = readString(connection.id).trim() || null;
   const model = readString(connection.embeddingModel).trim() || null;
   return {
-    embed: (texts: string[]) =>
+    embed: (texts: string[], request?: { connectionId?: string | null; model?: string | null }) =>
       llm.embed!({
         texts,
-        connectionId,
-        model,
+        connectionId: request?.connectionId ?? connectionId,
+        model: request?.model ?? model,
       }),
   };
 }

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -225,8 +225,8 @@ function generationEmbeddingSource(llm: LlmGateway, connection: JsonRecord) {
     embed: (texts: string[], request?: { connectionId?: string | null; model?: string | null }) =>
       llm.embed!({
         texts,
-        connectionId: request?.connectionId ?? connectionId,
-        model: request?.model ?? model,
+        connectionId: request?.connectionId !== undefined ? request.connectionId : connectionId,
+        model: request?.model !== undefined ? request.model : model,
       }),
   };
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2054

## Why this change

- Lorebook vectorization stored the embedding connection/model on each entry, but runtime semantic scan normalized those fields away and embedded the query through the active generation connection without a saved embedding target. A lorebook vectorized with a separate embedding connection could then fall back to non-semantic matching during generation.

## What changed

- Preserved `embeddingModel`, `embeddingConnectionId`, and `embeddingUpdatedAt` on normalized lorebook entries.
- Let runtime lorebook semantic scan pass one unambiguous saved embedding connection/model into the query embedding call.
- Kept the existing active connection/default behavior when stored vectors have no metadata or mixed embedding targets.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Lorebook entry contracts and schemas.
- Runtime active lorebook scanning.
- Prompt assembly embedding source typing.
- Generation LLM embedding source.
- Tauri embedding command path.

Boundary notes:

- Engine remains React-free and does not import feature/runtime adapters.
- Frontend API wrappers and Rust command registration were not changed.
- No dependency, storage migration, or provider declaration changes.

Pressure points touched:

- Prompt assembly and runtime generation embedding source only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused scratch proof: `pnpm exec vitest run --config scratch/vitest.issue-2054.config.ts` passed. It proves runtime semantic scan sends `{ connectionId: "embedding-connection", model: "text-embedding-test" }` from saved vector metadata and activates a semantic-only lorebook entry. It also proves mixed embedding provenance skips semantic comparison instead of falling back to the chat connection and comparing incompatible vector spaces, and that prompt assembly memoization preserves the saved embedding request.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- Full `pnpm check` passed.
- Not run: live llama.cpp embedding server regression with the reporter's exact local ports/models.
- Proof-gate helper was unavailable at `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; this is runtime semantic matching behavior, not a visible UI layout change.
