### PR TITLE
Fix Memory Recall read-behind filtering

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -719,10 +719,33 @@ pub(crate) async fn refresh_chat_memories(state: &AppState, chat_id: &str) -> Ap
             .collect::<Vec<_>>()
             .join("\n");
         let mut memory = Map::new();
+        let message_ids = chunk
+            .iter()
+            .filter_map(|message| message.get("id").and_then(Value::as_str))
+            .filter(|id| !id.trim().is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
         memory.insert("id".to_string(), Value::String(new_id()));
         memory.insert("chatId".to_string(), Value::String(chat_id.to_string()));
         memory.insert("content".to_string(), Value::String(content.clone()));
         memory.insert("messageCount".to_string(), json!(chunk.len()));
+        memory.insert("messageIds".to_string(), json!(message_ids));
+        memory.insert(
+            "firstMessageId".to_string(),
+            chunk
+                .first()
+                .and_then(|message| message.get("id"))
+                .cloned()
+                .unwrap_or(Value::Null),
+        );
+        memory.insert(
+            "lastMessageId".to_string(),
+            chunk
+                .last()
+                .and_then(|message| message.get("id"))
+                .cloned()
+                .unwrap_or(Value::Null),
+        );
         memory.insert(
             "firstMessageAt".to_string(),
             chunk
@@ -2555,6 +2578,9 @@ mod tests {
 
         assert_eq!(memories.len(), 1);
         assert_eq!(memories[0]["content"], json!("user: visible memory"));
+        assert_eq!(memories[0]["messageIds"], json!(["visible-1"]));
+        assert_eq!(memories[0]["firstMessageId"], json!("visible-1"));
+        assert_eq!(memories[0]["lastMessageId"], json!("visible-1"));
     }
 
     #[tokio::test]

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -200,6 +200,8 @@ export interface ChatMetadata {
   manualTrackers?: boolean;
   /** Whether to recall memories from this chat during generation. Default: true for conversation/scenes, false for roleplay. */
   enableMemoryRecall?: boolean;
+  /** How many newest visible messages Memory Recall should ignore when selecting recalled chunks. Default: 1. */
+  memoryRecallReadBehindMessages?: number;
   /** Discord webhook URL to mirror messages to a Discord channel. */
   discordWebhookUrl?: string;
   /** Per-chat ephemeral / enabled overrides for lorebook entries (entryId → state).

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1360,6 +1360,8 @@ const MAX_MEMORY_RECALL_BUDGET_TOKENS = 2048;
 const MAX_RECALLED_MEMORY_TOKENS = 384;
 const MIN_RECALLED_MEMORY_TOKENS = 96;
 const MEMORY_RECALL_CONTEXT_SHARE = 0.15;
+const DEFAULT_MEMORY_RECALL_READ_BEHIND_MESSAGES = 1;
+const MAX_MEMORY_RECALL_READ_BEHIND_MESSAGES = 100;
 const RECALL_TRUNCATION_MARKER = "\n...[recalled memory truncated]...\n";
 
 function estimateTextTokens(text: string): number {
@@ -1445,9 +1447,67 @@ function memoryRecallEnabled(chat: JsonRecord): boolean {
   return mode === "conversation" || meta.sceneStatus === "active";
 }
 
+function memoryRecallReadBehind(chat: JsonRecord): number {
+  const meta = parseRecord(chat.metadata);
+  const raw = readNumber(meta.memoryRecallReadBehindMessages, DEFAULT_MEMORY_RECALL_READ_BEHIND_MESSAGES);
+  if (!Number.isFinite(raw)) return DEFAULT_MEMORY_RECALL_READ_BEHIND_MESSAGES;
+  return Math.max(0, Math.min(MAX_MEMORY_RECALL_READ_BEHIND_MESSAGES, Math.trunc(raw)));
+}
+
+function memoryRecallEligibleMessages(messages: JsonRecord[]): JsonRecord[] {
+  return messages.filter((message) => !hiddenFromAi(message) && !!readString(message.content).trim());
+}
+
+function recentMemoryRecallMessages(messages: JsonRecord[], readBehind: number): JsonRecord[] {
+  if (readBehind <= 0) return [];
+  return memoryRecallEligibleMessages(messages).slice(-readBehind);
+}
+
+function messageIdSet(messages: JsonRecord[]): Set<string> {
+  return new Set(messages.map((message) => readString(message.id).trim()).filter(Boolean));
+}
+
+function memoryChunkMessageIds(memory: JsonRecord): Set<string> {
+  const ids = new Set<string>();
+  for (const value of Array.isArray(memory.messageIds) ? memory.messageIds : []) {
+    const id = readString(value).trim();
+    if (id) ids.add(id);
+  }
+  for (const value of [memory.firstMessageId, memory.lastMessageId]) {
+    const id = readString(value).trim();
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+function memoryOverlapsRecentMessages(memory: JsonRecord, recentIds: Set<string>, recentStartAt: string): boolean {
+  if (recentIds.size === 0) return false;
+  const chunkIds = memoryChunkMessageIds(memory);
+  if (chunkIds.size > 0) {
+    for (const id of chunkIds) {
+      if (recentIds.has(id)) return true;
+    }
+    return false;
+  }
+
+  const lastMessageAt = readString(memory.lastMessageAt).trim();
+  return !!lastMessageAt && !!recentStartAt && lastMessageAt >= recentStartAt;
+}
+
+function memoriesAfterReadBehind(chat: JsonRecord, storedMessages: JsonRecord[], memories: JsonRecord[]): JsonRecord[] {
+  const readBehind = memoryRecallReadBehind(chat);
+  if (readBehind <= 0 || memories.length === 0) return memories;
+
+  const recentMessages = recentMemoryRecallMessages(storedMessages, readBehind);
+  const recentIds = messageIdSet(recentMessages);
+  const recentStartAt = readString(recentMessages[0]?.createdAt).trim();
+  return memories.filter((memory) => !memoryOverlapsRecentMessages(memory, recentIds, recentStartAt));
+}
+
 async function buildMemoryRecallBlock(
   storage: StorageGateway,
   chat: JsonRecord,
+  storedMessages: JsonRecord[],
   latestUserInput: string,
   maxContext?: number,
   embeddingSource?: { embed(texts: string[]): Promise<number[][] | null> } | null,
@@ -1462,6 +1522,7 @@ async function buildMemoryRecallBlock(
   } catch {
     memories = Array.isArray(chat.memories) ? chat.memories.filter(isRecord) : [];
   }
+  memories = memoriesAfterReadBehind(chat, storedMessages, memories);
   if (memories.length === 0) return null;
 
   let semanticQueryVector: number[] | null = null;
@@ -2416,6 +2477,7 @@ export async function assembleGenerationPrompt(
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
     input.chat,
+    input.storedMessages,
     input.latestUserInput,
     readNumber(input.connection.maxContext, 0) || undefined,
     embeddingSource,

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -906,6 +906,7 @@ function ChatSettingsDrawerInner({
     0,
     100,
   );
+  const memoryRecallReadBehindMessages = normalizeNonNegativeInteger(metadata.memoryRecallReadBehindMessages, 1, 100);
   const lorebookKeeperReviewRequired = metadata.lorebookKeeperReviewRequired !== false;
 
   // Build the available tool list: built-in + custom tools from DB
@@ -1998,6 +1999,29 @@ function ChatSettingsDrawerInner({
             />
           </div>
         </button>
+        <label className="flex min-w-0 flex-col gap-1 text-[0.625rem] text-[var(--muted-foreground)]">
+          <span className="font-medium text-[var(--foreground)]">Read Behind</span>
+          <input
+            type="number"
+            min={0}
+            max={100}
+            step={1}
+            value={memoryRecallReadBehindMessages}
+            onChange={(e) => {
+              const nextValue = e.target.value === "" ? 1 : Number.parseInt(e.target.value, 10);
+              updateMeta.mutate({
+                id: chat.id,
+                memoryRecallReadBehindMessages: Number.isFinite(nextValue)
+                  ? Math.max(0, Math.min(100, nextValue))
+                  : 1,
+              });
+            }}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+          />
+          <span>
+            Ignore memory chunks from the newest messages. 1 protects the latest generated reply during swipes.
+          </span>
+        </label>
         <button
           type="button"
           onClick={() => setShowMemoriesModal(true)}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2049

## Why this change

- Memory Recall could inject a chunk rebuilt from the newest generated assistant message. During swipes/regeneration, that allowed details from the previous active swipe to come back as recalled memory, causing echoing and alternate-response bleed.
- The issue also requested a Read Behind offset so Memory Recall can skip immediate-context messages instead of spending prompt budget on fragments already visible in chat history.

## What changed

- Added message provenance to rebuilt Memory Recall chunks: `messageIds`, `firstMessageId`, and `lastMessageId`.
- Added per-chat `memoryRecallReadBehindMessages` filtering in prompt assembly. The default is `1`, so chunks sourced from the newest eligible visible message are skipped unless the user sets Read Behind to `0`.
- Added a Memory Recall Read Behind number control in chat settings.

## Refactor impact

Primary owner:

- Engine prompt assembly, Rust storage, shared chat settings UI

Impact areas reviewed:

- Memory Recall prompt injection
- Chat memory refresh/rebuild
- Existing hidden-from-AI memory refresh filtering
- Chat settings metadata persistence

Boundary notes:

- Engine filtering stays in `src/engine/generation/prompt-assembly.ts`.
- Rust storage only adds provenance fields while rebuilding `chat.memories`.
- Feature UI only patches chat metadata through the existing settings mutation path.
- No raw Tauri/fetch calls were added.

Pressure points touched:

- None of the listed pressure points were touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Scratch repro: `pnpm exec vitest run --config scratch/vitest.issue-2049.config.ts`
  - Before the fix, this failed because the assembled prompt included the latest assistant memory chunk despite Read Behind = 1.
  - After the fix, it passed and the latest-assistant memory chunk was excluded.
- Targeted Rust test: `cargo test --manifest-path src-tauri/Cargo.toml refresh_chat_memories_skips_legacy_and_current_hidden_flags` passed.
- TypeScript lane: `pnpm typecheck` passed.
- Full pre-PR gate: `pnpm check` passed.
- Bunny review gate: passed before opening the draft PR; optional `marinara-proof-gate.mjs` helper was not installed locally, so the scratch ledger gate could not be run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing Memory Recall setting surface; no new discovery entry added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A for the bug behavior; the core claim is prompt assembly filtering, proven by the scratch repro. The settings drawer received a small numeric control matching the existing Read Behind control pattern.


