### PR TITLE
Fix selfie prompt connection routing

### DIFF
--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -265,4 +265,58 @@ describe("persistConnectedCommandTags", () => {
     expect(llmCalls[0]?.connectionId).toBe("chat-llm");
     expect(imageCalls[0]?.connectionId).toBe("selfie-image");
   });
+
+  it("emits a selfie error instead of falling back when agent configuration cannot be read", async () => {
+    const llmCalls: LlmRequest[] = [];
+    const imageCalls: Row[] = [];
+    const baseStorage = createStorage({
+      characters: [{ id: "char-1", data: { name: "Robin", appearance: "green jacket" } }],
+      connections: [
+        { id: "chat-llm", provider: "openai" },
+        { id: "selfie-image", provider: "image_generation" },
+      ],
+      gallery: [],
+    });
+    const storage: StorageGateway = {
+      ...baseStorage,
+      async list<T = unknown>(entity: StorageEntity, options?: StorageListOptions): Promise<T[]> {
+        if (entity === "agents") throw new Error("agent configuration unavailable");
+        return baseStorage.list<T>(entity, options);
+      },
+    };
+    const llm: LlmGateway = {
+      async complete(request) {
+        llmCalls.push(request);
+        return "Robin selfie, green jacket";
+      },
+      async *stream() {
+        yield { type: "done" };
+      },
+      async listModels() {
+        return [];
+      },
+    };
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      {
+        id: "chat-1",
+        mode: "conversation",
+        characterIds: ["char-1"],
+        metadata: { characterCommands: true, imageGenConnectionId: "selfie-image" },
+      },
+      "[selfie]",
+      createImageIntegration(imageCalls),
+      llm,
+      "chat-llm",
+    );
+
+    expect(result.executedCommands).toEqual([]);
+    expect(result.events).toContainEqual({
+      type: "selfie_error",
+      data: { characterId: "char-1", error: "agent configuration unavailable" },
+    });
+    expect(llmCalls).toHaveLength(0);
+    expect(imageCalls).toHaveLength(0);
+  });
 });

--- a/src/engine/generation/connected-commands.test.ts
+++ b/src/engine/generation/connected-commands.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+
+import type { StorageEntity, StorageGateway, StorageListOptions } from "../capabilities/storage";
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmGateway, LlmRequest } from "../capabilities/llm";
+import { persistConnectedCommandTags } from "./connected-commands";
+
+type Row = Record<string, unknown>;
+
+function createStorage(seed: Partial<Record<StorageEntity, Row[]>>): StorageGateway {
+  const rows = new Map<StorageEntity, Row[]>();
+  for (const [entity, values] of Object.entries(seed) as Array<[StorageEntity, Row[]]>) {
+    rows.set(
+      entity,
+      values.map((value) => ({ ...value })),
+    );
+  }
+
+  const listRows = (entity: StorageEntity) => rows.get(entity) ?? [];
+  const nextId = (entity: StorageEntity) => `${entity}-${listRows(entity).length + 1}`;
+
+  return {
+    async list<T = unknown>(entity: StorageEntity, options?: StorageListOptions): Promise<T[]> {
+      const values = listRows(entity);
+      if (!options?.filters) return values.map((value) => ({ ...value })) as T[];
+      return values
+        .filter((value) =>
+          Object.entries(options.filters ?? {}).every(([key, expected]) => value[key] === expected),
+        )
+        .map((value) => ({ ...value })) as T[];
+    },
+    async get<T = unknown>(entity: StorageEntity, id: string): Promise<T | null> {
+      const row = listRows(entity).find((value) => value.id === id);
+      return row ? ({ ...row } as T) : null;
+    },
+    async create<T = unknown>(entity: StorageEntity, value: Row): Promise<T> {
+      const row = { id: value.id ?? nextId(entity), ...value };
+      rows.set(entity, [...listRows(entity), row]);
+      return { ...row } as T;
+    },
+    async update<T = unknown>(entity: StorageEntity, id: string, patch: Row): Promise<T> {
+      const next = listRows(entity).map((value) => (value.id === id ? { ...value, ...patch } : value));
+      rows.set(entity, next);
+      return { ...(next.find((value) => value.id === id) ?? { id, ...patch }) } as T;
+    },
+    async delete(): Promise<{ deleted: boolean }> {
+      return { deleted: true };
+    },
+    async listChatMessages<T = unknown>(): Promise<T[]> {
+      return [];
+    },
+    async createChatMessage<T = unknown>(_chatId: string, value: Row): Promise<T> {
+      return { id: "message-1", ...value } as T;
+    },
+    async updateChatMessage<T = unknown>(_messageId: string, patch: Row): Promise<T> {
+      return { ...patch } as T;
+    },
+    async deleteChatMessage(): Promise<{ deleted: boolean }> {
+      return { deleted: true };
+    },
+    async patchChatMessageExtra<T = unknown>(_messageId: string, patch: Row): Promise<T> {
+      return { ...patch } as T;
+    },
+    async addChatMessageSwipe<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async patchChatMetadata<T = unknown>(chatId: string, patch: Row): Promise<T> {
+      return this.update("chats", chatId, {
+        metadata: {
+          ...(listRows("chats").find((chat) => chat.id === chatId)?.metadata as Row | undefined),
+          ...patch,
+        },
+      });
+    },
+    async patchChatSummaries<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async listChatMemories<T = unknown>(): Promise<T[]> {
+      return [];
+    },
+    async getWorldState<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+    async saveTrackerSnapshot<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async listLorebookEntries<T = unknown>(): Promise<T[]> {
+      return [];
+    },
+    async createLorebookEntries<T = unknown>(): Promise<T[]> {
+      return [];
+    },
+    async promptFull<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+  };
+}
+
+function createImageIntegration(calls: Row[]): IntegrationGateway {
+  return {
+    spotify: {} as IntegrationGateway["spotify"],
+    haptic: {} as IntegrationGateway["haptic"],
+    customTools: {} as IntegrationGateway["customTools"],
+    image: {
+      async generate<T = unknown>(input: Row): Promise<T> {
+        calls.push(input);
+        return {
+          base64: "aW1hZ2U=",
+          mimeType: "image/png",
+          provider: "test-image-provider",
+          model: "test-image-model",
+        } as T;
+      },
+    },
+  };
+}
+
+describe("persistConnectedCommandTags", () => {
+  it("uses the Illustrator agent LLM connection for chat selfie prompt generation", async () => {
+    const llmCalls: LlmRequest[] = [];
+    const imageCalls: Row[] = [];
+    const storage = createStorage({
+      agents: [
+        {
+          id: "illustrator",
+          type: "illustrator",
+          enabled: true,
+          connectionId: "illustrator-llm",
+          settings: {},
+        },
+      ],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Robin",
+            appearance: "short auburn hair, green jacket",
+          },
+        },
+      ],
+      connections: [
+        { id: "chat-llm", provider: "openai" },
+        { id: "illustrator-llm", provider: "openai" },
+        { id: "selfie-image", provider: "image_generation" },
+      ],
+      gallery: [],
+    });
+    const llm: LlmGateway = {
+      async complete(request) {
+        llmCalls.push(request);
+        return "Robin holding up a casual phone selfie, short auburn hair, green jacket";
+      },
+      async *stream() {
+        yield { type: "done" };
+      },
+      async listModels() {
+        return [];
+      },
+    };
+
+    const result = await persistConnectedCommandTags(
+      storage,
+      {
+        id: "chat-1",
+        mode: "conversation",
+        characterIds: ["char-1"],
+        metadata: { characterCommands: true, imageGenConnectionId: "selfie-image" },
+      },
+      "[selfie]",
+      createImageIntegration(imageCalls),
+      llm,
+      "chat-llm",
+    );
+
+    expect(result.executedCommands).toEqual(["selfie"]);
+    expect(llmCalls).toHaveLength(1);
+    expect(llmCalls[0]?.connectionId).toBe("illustrator-llm");
+    expect(imageCalls).toHaveLength(1);
+    expect(imageCalls[0]?.connectionId).toBe("selfie-image");
+  });
+
+  it("falls back to the default non-image agent connection when Illustrator has no override", async () => {
+    const llmCalls: LlmRequest[] = [];
+    const imageCalls: Row[] = [];
+    const storage = createStorage({
+      agents: [{ id: "illustrator", type: "illustrator", enabled: true, connectionId: null, settings: {} }],
+      characters: [{ id: "char-1", data: { name: "Robin", appearance: "green jacket" } }],
+      connections: [
+        { id: "chat-llm", provider: "openai" },
+        { id: "agent-default-llm", provider: "openai", defaultForAgents: true },
+        { id: "selfie-image", provider: "image_generation" },
+      ],
+      gallery: [],
+    });
+    const llm: LlmGateway = {
+      async complete(request) {
+        llmCalls.push(request);
+        return "Robin selfie, green jacket";
+      },
+      async *stream() {
+        yield { type: "done" };
+      },
+      async listModels() {
+        return [];
+      },
+    };
+
+    await persistConnectedCommandTags(
+      storage,
+      {
+        id: "chat-1",
+        mode: "conversation",
+        characterIds: ["char-1"],
+        metadata: { characterCommands: true, imageGenConnectionId: "selfie-image" },
+      },
+      "[selfie]",
+      createImageIntegration(imageCalls),
+      llm,
+      "chat-llm",
+    );
+
+    expect(llmCalls[0]?.connectionId).toBe("agent-default-llm");
+    expect(imageCalls[0]?.connectionId).toBe("selfie-image");
+  });
+
+  it("keeps the chat LLM fallback when no Illustrator or default agent connection is configured", async () => {
+    const llmCalls: LlmRequest[] = [];
+    const imageCalls: Row[] = [];
+    const storage = createStorage({
+      agents: [],
+      characters: [{ id: "char-1", data: { name: "Robin", appearance: "green jacket" } }],
+      connections: [
+        { id: "chat-llm", provider: "openai" },
+        { id: "selfie-image", provider: "image_generation" },
+      ],
+      gallery: [],
+    });
+    const llm: LlmGateway = {
+      async complete(request) {
+        llmCalls.push(request);
+        return "Robin selfie, green jacket";
+      },
+      async *stream() {
+        yield { type: "done" };
+      },
+      async listModels() {
+        return [];
+      },
+    };
+
+    await persistConnectedCommandTags(
+      storage,
+      {
+        id: "chat-1",
+        mode: "conversation",
+        characterIds: ["char-1"],
+        metadata: { characterCommands: true, imageGenConnectionId: "selfie-image" },
+      },
+      "[selfie]",
+      createImageIntegration(imageCalls),
+      llm,
+      "chat-llm",
+    );
+
+    expect(llmCalls[0]?.connectionId).toBe("chat-llm");
+    expect(imageCalls[0]?.connectionId).toBe("selfie-image");
+  });
+});

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -257,6 +257,30 @@ function activeCharacterId(chat: JsonRecord): string | null {
   return stringArray(chat.characterIds)[0] ?? null;
 }
 
+function isIllustratorAgent(agent: JsonRecord): boolean {
+  return (
+    readString(agent.id).trim() === "illustrator" ||
+    readString(agent.type || agent.agentType).trim() === "illustrator"
+  );
+}
+
+async function resolveIllustratorLlmConnectionId(
+  storage: StorageGateway,
+  fallbackConnectionId: string | null | undefined,
+): Promise<string | null> {
+  const agents = await storage.list<JsonRecord>("agents").catch(() => []);
+  const illustratorAgent = agents.find((agent) => boolish(agent.enabled, true) && isIllustratorAgent(agent));
+  const agentConnectionId = readString(illustratorAgent?.connectionId).trim();
+  if (agentConnectionId) return agentConnectionId;
+
+  const connections = await storage.list<JsonRecord>("connections").catch(() => []);
+  const defaultAgentConnection = connections.find(
+    (connection) =>
+      readString(connection.provider).trim() !== "image_generation" && boolish(connection.defaultForAgents, false),
+  );
+  return readString(defaultAgentConnection?.id).trim() || readString(fallbackConnectionId).trim() || null;
+}
+
 function parseSelfieSize(value: unknown): { width: number; height: number } {
   const text = readString(value).trim();
   const match = text.match(/^(\d{2,5})x(\d{2,5})$/i);
@@ -336,10 +360,13 @@ async function buildSelfiePrompt(args: {
     : `Generate a casual selfie of ${characterName} based on the current conversation context.`;
 
   let prompt = "";
-  if (args.llm && args.llmConnectionId) {
+  const promptConnectionId = args.llm
+    ? await resolveIllustratorLlmConnectionId(args.storage, args.llmConnectionId)
+    : null;
+  if (args.llm && promptConnectionId) {
     prompt = (
       await args.llm.complete({
-        connectionId: args.llmConnectionId,
+        connectionId: promptConnectionId,
         messages: [
           { role: "system", content: systemPrompt },
           {

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -268,12 +268,12 @@ async function resolveIllustratorLlmConnectionId(
   storage: StorageGateway,
   fallbackConnectionId: string | null | undefined,
 ): Promise<string | null> {
-  const agents = await storage.list<JsonRecord>("agents").catch(() => []);
+  const agents = await storage.list<JsonRecord>("agents");
   const illustratorAgent = agents.find((agent) => boolish(agent.enabled, true) && isIllustratorAgent(agent));
   const agentConnectionId = readString(illustratorAgent?.connectionId).trim();
   if (agentConnectionId) return agentConnectionId;
 
-  const connections = await storage.list<JsonRecord>("connections").catch(() => []);
+  const connections = await storage.list<JsonRecord>("connections");
   const defaultAgentConnection = connections.find(
     (connection) =>
       readString(connection.provider).trim() !== "image_generation" && boolish(connection.defaultForAgents, false),


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2056

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Chat-triggered selfies were building the image prompt through the active chat LLM connection, so the provider log showed the chat endpoint/model instead of the Illustrator agent's configured connection.

## What changed

<!-- List the key changes in this PR. -->

- Resolves the LLM connection for conversation selfie prompt generation from the enabled Illustrator agent first.
- Falls back to the default non-image agent connection, then the active chat connection when no agent/default override exists.
- Keeps the actual selfie image-generation request on the chat's configured `metadata.imageGenConnectionId`.
- Adds focused regression coverage for Illustrator override, default-agent fallback, chat fallback, and the image-provider connection boundary.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

engine generation

Impact areas reviewed:

- `persistConnectedCommandTags` `[selfie]` command path.
- Illustrator/default-agent LLM connection fallback behavior.
- Chat-level selfie image-generation connection payload.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only change; no React, shared API wrapper, Rust command, storage schema, or remote-runtime boundary changes.
- Existing chat metadata still owns the image-generation connection for command selfies.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src/engine/generation/connected-commands.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex machine proof:
- `pnpm test src/engine/generation/connected-commands.test.ts` passed on the final rebased branch: 3 tests.
- `pnpm typecheck` passed before final full check.
- `pnpm check` passed on the final rebased branch: line endings, architecture, frontend, Rust, docs, discovery, unused.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review passed before opening this draft.
- No human-only manual verification is blocking the core claim; this is a non-UI command-routing bug proven with a focused harness.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or setting.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is a non-UI engine-generation routing fix. The direct evidence is the focused harness recording the LLM and image-generation connection IDs before/after the fix.
