### PR TITLE
fix: prevent DiscoverPanel from overflowing viewport on mobile

### DIFF
--- a/src/features/shell/discovery/components/DiscoverPanel.tsx
+++ b/src/features/shell/discovery/components/DiscoverPanel.tsx
@@ -91,7 +91,7 @@ export function DiscoverPanel() {
   const visibleEntries = shouldShowPreview ? entries.slice(0, DEFAULT_PREVIEW_COUNT) : entries;
 
   return (
-    <div className="flex min-h-full flex-col gap-3 p-3">
+    <div className="flex w-full flex-col gap-3 p-3">
       <div className="rounded-lg border border-[var(--border)] bg-[var(--card)]/65 p-3 shadow-sm">
         <div className="flex items-start gap-3">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[var(--primary)]/25 bg-[var(--primary)]/10 text-[var(--primary)]">


### PR DESCRIPTION
## Linked issue

Closes #2081

## Why this change

- On a 390 px screen the Discover Marinara panel expanded beyond the container width, triggering horizontal scroll.
- `min-h-full` on the outer div forced the panel to fill the full viewport height even when content was short, leaving a large blank area below.

## What changed

- Added `w-full` to the outer div of `DiscoverPanel` — constrains the panel to its container width on mobile.
- Removed `min-h-full` — panel height now follows content instead of forcing full-height fill.

## Refactor impact

Primary owner: app shell / discovery panel

Impact areas reviewed:

- Discovery panel rendering on mobile viewports

Boundary notes:

- None — isolated to a single CSS class change in the DiscoverPanel component.

Pressure points touched:

- None

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Verified visually at 390 px (iOS 26, WKWebView): panel no longer overflows, no blank space below when few results shown.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Visual polish / bugfix only — no new feature surface.

## Docs and release impact

- [x] No docs changes needed

## UI evidence

before
<img width="420" height="604" alt="discover overflow before" src="https://github.com/user-attachments/assets/50303554-2746-4ee0-8bb3-df7c3dcf5232" />
after
<img width="417" height="445" alt="discover after" src="https://github.com/user-attachments/assets/ac849cba-5927-404b-8b27-d23df70e617f" />