### PR TITLE
feat: redesign RecentChats as tappable cards for mobile

### DIFF
--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -23,7 +23,7 @@ export function RecentChats() {
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
 
   const recentCharacterIds = useMemo(
-    () => Array.from(new Set((recentChats ?? []).flatMap((c) => c.characterIds ?? []))),
+    () => Array.from(new Set((recentChats ?? []).flatMap((c) => Array.isArray(c.characterIds) ? c.characterIds : []))),
     [recentChats],
   );
   const { data: recentCharacters } = useCharacterSummariesByIds(recentCharacterIds, recentCharacterIds.length > 0);

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -73,7 +73,7 @@ function RecentChatCard({
 }) {
   const mode = MODE_BADGE[chat.mode] ?? MODE_BADGE.conversation;
 
-  const firstAvatar = (chat.characterIds ?? []).map((id) => charLookup.get(id)).find(Boolean) ?? null;
+  const firstAvatar = (Array.isArray(chat.characterIds) ? chat.characterIds : []).map((id) => charLookup.get(id)).find(Boolean) ?? null;
 
   return (
     <button

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -3,7 +3,7 @@ import { MessageSquare, BookOpen, Theater } from "lucide-react";
 import { useRecentChatSummaries, type ChatListItem } from "../../../catalog/chats/index";
 import { CharacterAvatarImage, characterAvatarUrl, useCharacterSummariesByIds } from "../../../catalog/characters/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
-import { cn, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
+import { parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
 
 const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: string }> = {
   conversation: { icon: <MessageSquare size="0.75rem" />, bg: "linear-gradient(135deg, #4de5dd, #3ab8b1)", label: "Conversation" },
@@ -134,7 +134,7 @@ function RecentChatAvatar({
         alt={avatar.name}
         className="h-full w-full object-cover"
         crop={avatar.avatarCrop}
-        thumbnailSize={80}
+        thumbnailSize={96}
         onError={() => setImageFailed(true)}
       />
     </span>

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -1,7 +1,3 @@
-// ──────────────────────────────────────────────
-// Chat: Recent Chats — shows 3 most recently
-// interacted chats on the homepage (compact row)
-// ──────────────────────────────────────────────
 import { useEffect, useMemo, useState } from "react";
 import { MessageSquare, BookOpen, Theater } from "lucide-react";
 import { useRecentChatSummaries, type ChatListItem } from "../../../catalog/chats/index";
@@ -10,72 +6,37 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { cn, parseAvatarCropJson, type AvatarCropValue } from "../../../../shared/lib/utils";
 
 const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: string }> = {
-  conversation: {
-    icon: <MessageSquare size="0.375rem" />,
-    bg: "linear-gradient(135deg, #4de5dd, #3ab8b1)",
-    label: "Conversation",
-  },
-  roleplay: {
-    icon: <BookOpen size="0.375rem" />,
-    bg: "linear-gradient(135deg, #eb8951, #d97530)",
-    label: "Roleplay",
-  },
-  game: {
-    icon: <Theater size="0.375rem" />,
-    bg: "linear-gradient(135deg, #e15c8c, #c94776)",
-    label: "Game",
-  },
+  conversation: { icon: <MessageSquare size="0.75rem" />, bg: "linear-gradient(135deg, #4de5dd, #3ab8b1)", label: "Conversation" },
+  roleplay: { icon: <BookOpen size="0.75rem" />, bg: "linear-gradient(135deg, #eb8951, #d97530)", label: "Roleplay" },
+  game: { icon: <Theater size="0.75rem" />, bg: "linear-gradient(135deg, #e15c8c, #c94776)", label: "Game" },
 };
 
 function readAvatarCrop(value: unknown): AvatarCropValue | null {
   if (!value) return null;
   if (typeof value === "string") return parseAvatarCropJson(value);
   if (typeof value !== "object" || Array.isArray(value)) return null;
-  try {
-    return parseAvatarCropJson(JSON.stringify(value));
-  } catch {
-    return null;
-  }
+  try { return parseAvatarCropJson(JSON.stringify(value)); } catch { return null; }
 }
 
 export function RecentChats() {
   const { data: recentChats } = useRecentChatSummaries(3);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+
   const recentCharacterIds = useMemo(
-    () =>
-      Array.from(
-        new Set((recentChats ?? []).flatMap((chat) => (Array.isArray(chat.characterIds) ? chat.characterIds : []))),
-      ),
+    () => Array.from(new Set((recentChats ?? []).flatMap((c) => c.characterIds ?? []))),
     [recentChats],
   );
   const { data: recentCharacters } = useCharacterSummariesByIds(recentCharacterIds, recentCharacterIds.length > 0);
 
   const charLookup = useMemo(() => {
-    const map = new Map<
-      string,
-      {
-        name: string;
-        avatarUrl: string | null;
-        avatarFilePath?: string | null;
-        avatarFilename?: string | null;
-        avatarCrop?: AvatarCropValue | null;
-      }
-    >();
+    const map = new Map<string, { name: string; avatarUrl: string | null; avatarFilePath?: string | null; avatarFilename?: string | null; avatarCrop?: AvatarCropValue | null }>();
     if (!recentCharacters) return map;
-    for (const char of recentCharacters as Array<{
-      id: string;
-      data: Record<string, unknown>;
-      avatarPath?: string | null;
-      avatarFilePath?: string | null;
-      avatarFilename?: string | null;
-    }>) {
-      const parsed = char.data ?? {};
-      const extensions =
-        parsed.extensions && typeof parsed.extensions === "object" && !Array.isArray(parsed.extensions)
-          ? (parsed.extensions as Record<string, unknown>)
-          : {};
+    for (const char of recentCharacters as Array<{ id: string; data: Record<string, unknown>; avatarPath?: string | null; avatarFilePath?: string | null; avatarFilename?: string | null }>) {
+      const extensions = (char.data?.extensions && typeof char.data.extensions === "object" && !Array.isArray(char.data.extensions))
+        ? (char.data.extensions as Record<string, unknown>)
+        : {};
       map.set(char.id, {
-        name: typeof parsed.name === "string" ? parsed.name : "Unknown",
+        name: typeof char.data?.name === "string" ? char.data.name : "Unknown",
         avatarUrl: characterAvatarUrl(char),
         avatarFilePath: char.avatarFilePath,
         avatarFilename: char.avatarFilename,
@@ -88,117 +49,84 @@ export function RecentChats() {
   if (!recentChats || recentChats.length === 0) return null;
 
   return (
-    <div className="flex w-full max-w-md flex-col items-center gap-1.5">
-      <p className="text-[0.625rem] font-medium text-[var(--muted-foreground)]/50 tracking-wide uppercase">
-        Recent Chats
+    <div className="flex w-full flex-col gap-1.5 px-3 pt-3">
+      <p className="text-center text-[0.625rem] font-medium uppercase tracking-wide text-[var(--muted-foreground)]/50">
+        Recent
       </p>
-      <div className="flex w-full items-center justify-center gap-1.5">
+      <div className="flex w-full flex-col gap-1.5 sm:flex-row">
         {recentChats.map((chat) => (
-          <RecentChatChip key={chat.id} chat={chat} charLookup={charLookup} onClick={() => setActiveChatId(chat.id)} />
+          <RecentChatCard key={chat.id} chat={chat} charLookup={charLookup} onClick={() => setActiveChatId(chat.id)} />
         ))}
       </div>
     </div>
   );
 }
 
-function RecentChatChip({
+function RecentChatCard({
   chat,
   charLookup,
   onClick,
 }: {
   chat: ChatListItem;
-  charLookup: Map<
-    string,
-    {
-      name: string;
-      avatarUrl: string | null;
-      avatarFilePath?: string | null;
-      avatarFilename?: string | null;
-      avatarCrop?: AvatarCropValue | null;
-    }
-  >;
+  charLookup: Map<string, { name: string; avatarUrl: string | null; avatarFilePath?: string | null; avatarFilename?: string | null; avatarCrop?: AvatarCropValue | null }>;
   onClick: () => void;
 }) {
   const mode = MODE_BADGE[chat.mode] ?? MODE_BADGE.conversation;
 
-  const charIds: string[] = useMemo(() => {
-    if (!chat.characterIds) return [];
-    return chat.characterIds;
-  }, [chat.characterIds]);
-
-  const firstAvatar = useMemo(() => {
-    for (const id of charIds) {
-      const c = charLookup.get(id);
-      if (c) return c;
-    }
-    return null;
-  }, [charIds, charLookup]);
+  const firstAvatar = (chat.characterIds ?? []).map((id) => charLookup.get(id)).find(Boolean) ?? null;
 
   return (
     <button
       onClick={onClick}
-      className={cn(
-        "group relative flex max-w-[8rem] items-center gap-1.5 rounded-lg border border-[var(--border)]/50 bg-[var(--card)]/50 px-2 py-1.5",
-        "transition-all duration-150 hover:border-[var(--primary)]/40 hover:bg-[var(--card)] hover:shadow-sm",
-        "cursor-pointer",
-      )}
+      className="group flex flex-1 min-w-0 items-center gap-3 rounded-xl border border-[var(--border)]/50 bg-[var(--card)]/50 px-3 py-2.5 text-left transition-all duration-150 hover:border-[var(--primary)]/40 hover:bg-[var(--card)] hover:shadow-sm"
     >
-      {/* Small avatar with mode dot */}
       <div className="relative flex-shrink-0">
-        {firstAvatar ? (
-          <RecentChatAvatar avatar={firstAvatar} />
-        ) : (
-          <div
-            className="flex h-5 w-5 items-center justify-center rounded-md text-white"
-            style={{ background: mode.bg }}
-          >
-            {mode.icon}
-          </div>
-        )}
-
-        {/* Tiny mode dot */}
+        <RecentChatAvatar avatar={firstAvatar} mode={mode} />
         <div
-          className="absolute -top-0.5 -left-0.5 flex h-3 w-3 items-center justify-center rounded-full text-white ring-1 ring-[var(--card)]"
+          className="absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full text-white ring-1 ring-[var(--card)]"
           style={{ background: mode.bg }}
           title={mode.label}
         >
           {mode.icon}
         </div>
       </div>
-
-      {/* Chat name only */}
-      <span className="truncate text-[0.625rem] font-medium text-[var(--foreground)]">{chat.name}</span>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-[var(--foreground)]">{chat.name}</p>
+        <p className="text-xs text-[var(--muted-foreground)]">{mode.label}</p>
+      </div>
     </button>
   );
 }
 
 function RecentChatAvatar({
   avatar,
+  mode,
 }: {
-  avatar: {
-    name: string;
-    avatarUrl: string | null;
-    avatarFilePath?: string | null;
-    avatarFilename?: string | null;
-    avatarCrop?: AvatarCropValue | null;
-  };
+  avatar: { name: string; avatarUrl: string | null; avatarFilePath?: string | null; avatarFilename?: string | null; avatarCrop?: AvatarCropValue | null } | null;
+  mode: { bg: string; icon: React.ReactNode; label: string };
 }) {
   const [imageFailed, setImageFailed] = useState(false);
 
-  useEffect(() => {
-    setImageFailed(false);
-  }, [avatar.avatarUrl]);
+  useEffect(() => { setImageFailed(false); }, [avatar?.avatarUrl]);
+
+  if (!avatar) {
+    return (
+      <div className="flex h-10 w-10 items-center justify-center rounded-xl text-white" style={{ background: mode.bg }}>
+        {mode.icon}
+      </div>
+    );
+  }
 
   if (!avatar.avatarUrl || imageFailed) {
     return (
-      <div className="flex h-5 w-5 items-center justify-center rounded-md bg-[var(--secondary)] text-[0.5rem] font-bold text-[var(--muted-foreground)]">
+      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--secondary)] text-sm font-bold text-[var(--muted-foreground)]">
         {avatar.name[0]}
       </div>
     );
   }
 
   return (
-    <span className="relative block h-5 w-5 overflow-hidden rounded-md">
+    <span className="relative block h-10 w-10 overflow-hidden rounded-xl">
       <CharacterAvatarImage
         src={avatar.avatarUrl}
         avatarFilePath={avatar.avatarFilePath}
@@ -206,7 +134,7 @@ function RecentChatAvatar({
         alt={avatar.name}
         className="h-full w-full object-cover"
         crop={avatar.avatarCrop}
-        thumbnailSize={64}
+        thumbnailSize={80}
         onError={() => setImageFailed(true)}
       />
     </span>

--- a/src/features/modes/router/components/RecentChats.tsx
+++ b/src/features/modes/router/components/RecentChats.tsx
@@ -73,7 +73,8 @@ function RecentChatCard({
 }) {
   const mode = MODE_BADGE[chat.mode] ?? MODE_BADGE.conversation;
 
-  const firstAvatar = (Array.isArray(chat.characterIds) ? chat.characterIds : []).map((id) => charLookup.get(id)).find(Boolean) ?? null;
+  const characterIds = Array.isArray(chat.characterIds) ? chat.characterIds : [];
+  const firstAvatar = characterIds.map((id) => charLookup.get(id)).find(Boolean) ?? null;
 
   return (
     <button


### PR DESCRIPTION
## Linked issue

Closes #2076

## Why this change

- The Recent Chats row rendered as tiny compact chips (~32 px tall, 20 px avatar) on mobile — avatars were illegible and touch targets were well under the 44 px minimum.
- No mode label was shown, making it hard to tell at a glance what type of chat each entry was.

## What changed

- Replaced chip row with full-width tappable cards in `RecentChats.tsx`.
- Avatar: 40×40 px (`h-10 w-10`), rounded-xl; thumbnail size bumped to 80.
- Mode dot moved to bottom-right of avatar (was top-left), sized up to 16×16 px.
- Mode label added as secondary text below the chat name.
- `min-w-0` on card button — all three cards share width equally regardless of text length.
- Touch target: full card width, `py-2.5` — well over 44 px.
- Layout: stacked column on mobile, side-by-side row on `sm+`; inner row is `w-full`.
- Container: `w-full px-3 pt-3` — aligns side padding with QuickStart and DiscoverPanel; adds breathing room above section.
- "Recent" label centered.

## Refactor impact

Primary owner: chat mode / mode router

Impact areas reviewed:

- Mode home surface recent chats display

Boundary notes:

- None — isolated to `RecentChats.tsx`. No store, catalog, or shared API changes.

Pressure points touched:

- `ModeSurface` / `ModeHomeSurface` — `RecentChats` is rendered inline; layout change only.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Verified at 390 px: three equal-width cards, avatars readable, touch targets comfortable.
- Verified on desktop: cards render side by side, full width, long names truncate correctly.
- Clicking a card navigates to the correct chat.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Visual polish / mobile usability fix — no new feature surface added.

## Docs and release impact

- [x] No docs changes needed

## UI evidence

before mobile:
<img width="427" height="62" alt="chips before" src="https://github.com/user-attachments/assets/586e256e-85f2-4d35-8fdf-d758fb5adf34" />

mobile:
<img width="422" height="360" alt="chips after mobile" src="https://github.com/user-attachments/assets/745f1bf6-58ac-499b-835c-b5bf657d6c0e" />

desktop:
<img width="739" height="277" alt="chips after desktop" src="https://github.com/user-attachments/assets/84e2167a-a59a-41b0-9a60-898ee963b6ed" />