### PR TITLE
fix: expand QuickStart cards to full width on mobile

### DIFF
--- a/src/features/modes/router/components/ModeHomeSurface.tsx
+++ b/src/features/modes/router/components/ModeHomeSurface.tsx
@@ -111,7 +111,7 @@ export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?
           </div>
 
           <div
-            className={cn("flex flex-wrap justify-center gap-2 sm:gap-3", showEmptyStateEffects && "stagger-children")}
+            className={cn("grid w-full grid-cols-3 gap-2 px-3 sm:flex sm:w-auto sm:justify-center sm:gap-3 sm:px-0", showEmptyStateEffects && "stagger-children")}
           >
             <QuickStartCard
               icon={<MessageSquare size="1.125rem" />}
@@ -281,7 +281,7 @@ function QuickStartCard({
       title={tooltip}
       aria-label={`${comingSoon && !onClick ? "Show status for" : "Start"} ${label} chat`}
       className={cn(
-        "group card-3d-tilt btn-scanlines relative flex w-20 sm:w-28 flex-col items-center justify-center gap-1.5 sm:gap-2 rounded-xl border-2 border-[var(--border)] bg-[var(--card)] p-2.5 sm:p-4 text-center transition-all",
+        "group card-3d-tilt btn-scanlines relative flex w-full sm:w-28 flex-col items-center justify-center gap-1.5 sm:gap-2 rounded-xl border-2 border-[var(--border)] bg-[var(--card)] p-2.5 sm:p-4 text-center transition-all",
         "cursor-pointer hover:-translate-y-1 hover:border-[var(--primary)]/40 hover:shadow-lg",
       )}
       style={shadowColor ? { ["--tw-shadow-color" as string]: shadowColor } : undefined}


### PR DESCRIPTION
## Linked issue

Closes #2077

## Why this change

- The three QuickStart cards had a fixed `w-20` (80 px) width on all screen sizes.
- On a 390 px phone the cards occupied only ~260 px, leaving large dead margins on both sides and reducing tap target size unnecessarily.

## What changed

- **Container (`ModeHomeSurface.tsx`):** `flex flex-wrap justify-center` → `grid w-full grid-cols-3 gap-2 px-3` on mobile. Cards stretch to fill available width with consistent side padding matching RecentChats and DiscoverPanel. Desktop reverts to `sm:flex sm:w-auto sm:justify-center sm:gap-3 sm:px-0` (behaviour unchanged).
- **Card width:** `w-20` → `w-full` on mobile; `sm:w-28` on desktop (unchanged).

## Refactor impact

Primary owner: chat mode / mode router

Impact areas reviewed:

- Mode home surface QuickStart card layout

Boundary notes:

- None — two CSS class changes in `ModeHomeSurface.tsx`. No store, catalog, or shared API changes.

Pressure points touched:

- `ModeHomeSurface` — layout change to QuickStart card container and individual card width classes.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Verified at 390 px: three cards fill full width with consistent side padding.
- Verified on desktop: three fixed-width centered cards, layout unchanged.
- All three cards tappable and navigate to the correct mode.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Visual polish / mobile usability fix — no new feature surface added.

## Docs and release impact

- [x] No docs changes needed

## UI evidence

before
<img width="426" height="103" alt="3buttons before" src="https://github.com/user-attachments/assets/e2441a43-88dd-4edf-bcf7-d9ef8849ec42" />
after
<img width="419" height="103" alt="3 buttons after" src="https://github.com/user-attachments/assets/abc4393c-893d-4d99-838b-262345334bb4" />