### PR TITLE
Protect remote bulk scan with Admin Access

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -561,6 +561,7 @@ fn is_privileged_remote_command(command: &str) -> bool {
             | "backup_delete"
             | "backup_download"
             | "import_list_directory"
+            | "import_st_bulk_scan"
             | "import_st_bulk_run"
             | "admin_expunge_command"
             | "admin_clear_all_command"
@@ -1695,6 +1696,36 @@ mod tests {
         )
         .is_ok());
         assert!(require_admin_access_for_command("storage_list", &headers, remote_ip).is_ok());
+    }
+
+    #[test]
+    fn remote_st_bulk_scan_requires_admin_access() {
+        let _guard = admin_secret_lock()
+            .lock()
+            .expect("admin secret test lock should acquire");
+        let _admin_secret = AdminSecretGuard::capture();
+        let remote_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+        env::remove_var("ADMIN_SECRET");
+
+        let missing_secret = require_admin_access_for_command(
+            "import_st_bulk_scan",
+            &HeaderMap::new(),
+            remote_ip,
+        )
+        .expect_err("non-loopback bulk scan should require ADMIN_SECRET");
+
+        assert_eq!(missing_secret.code, "admin_access_required");
+
+        env::set_var("ADMIN_SECRET", "expected-secret");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static(ADMIN_SECRET_HEADER_NAME),
+            HeaderValue::from_static("expected-secret"),
+        );
+
+        let result = require_admin_access_for_command("import_st_bulk_scan", &headers, remote_ip);
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -190,6 +190,7 @@ const PRIVILEGED_REMOTE_COMMANDS = new Set([
   "backup_delete",
   "backup_download",
   "import_list_directory",
+  "import_st_bulk_scan",
   "import_st_bulk_run",
   "admin_expunge_command",
   "admin_clear_all_command",


### PR DESCRIPTION
## Linked issue

Closes #2058

## Why this change

- Remote Runtime exposed `import_st_bulk_scan`, but the Admin Access privileged command sets only covered `import_st_bulk_run`. Off-loopback bulk scan calls could therefore reach the remote dispatcher without the same Admin Access requirement legacy applied to SillyTavern bulk scan and run.

## What changed

- Added `import_st_bulk_scan` to the TypeScript Remote Runtime privileged command set so web-shell calls include the stored Admin Access secret header.
- Added `import_st_bulk_scan` to the Rust HTTP runtime privileged command set so `/api/invoke` rejects off-loopback scan calls unless Admin Access is configured and the `x-admin-secret` header matches.
- Added a Rust regression test covering off-loopback scan rejection without `ADMIN_SECRET` and acceptance with the matching Admin Access header.

## Refactor impact

Primary owner:

- Remote runtime and Rust HTTP/import access control.

Impact areas reviewed:

- Shared API remote-runtime command routing.
- Rust HTTP runtime Admin Access guard.
- SillyTavern bulk import scan/run parity.

Boundary notes:

- No engine or React feature imports changed. Feature code continues to call the shared import API, which routes through the focused remote runtime wrapper.

Pressure points touched:

- `src/shared/api/remote-runtime.ts` privileged remote command set.
- `src-tauri/src/http_server.rs` Admin Access command guard and guard-level regression test.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Scratch repro before fix: `node scratch/repro-2058-bulk-scan-admin.mjs` exited 1 with `import_st_bulk_scan` remote-allowlisted and Rust-dispatched, but missing from both privileged sets.
- Scratch repro after fix: `node scratch/repro-2058-bulk-scan-admin.mjs` passed with `import_st_bulk_scan` present in both privileged sets.
- Targeted Rust test: `cargo test --manifest-path src-tauri/Cargo.toml remote_st_bulk_scan_requires_admin_access` passed.
- Rust lane check: `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- TypeScript lane check: `pnpm typecheck` passed after `pnpm install --frozen-lockfile` restored `node_modules` in the isolated worktree.
- Full baseline: `pnpm check` passed.
- Proof ledger: `scratch/bugfix-verification.json`.
- Tooling note: the documented proof-gate helper was unavailable at `C:\Users\celia\.codex\tools\marinara-proof-gate.mjs`, so that one local helper could not be run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is an internal remote-runtime access-control parity bugfix. It does not add a new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a Remote Runtime access-control bugfix with command/scratch/Rust test proof rather than visible UI behavior.
