### PR TITLE
Map remote storage IO failures to 503

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -794,18 +794,7 @@ impl From<AppError> for HttpError {
 
 impl IntoResponse for HttpError {
     fn into_response(self) -> Response {
-        let status = match self.0.code.as_str() {
-            "not_found" => StatusCode::NOT_FOUND,
-            "invalid_input" => StatusCode::BAD_REQUEST,
-            "admin_access_invalid" => StatusCode::UNAUTHORIZED,
-            "admin_access_required" => StatusCode::FORBIDDEN,
-            "custom_tool_script_unsupported" => StatusCode::UNPROCESSABLE_ENTITY,
-            "embedding_network_error" | "embedding_provider_error" | "embedding_response_error" => {
-                StatusCode::BAD_GATEWAY
-            }
-            "unsupported_command" => StatusCode::NOT_IMPLEMENTED,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
+        let status = http_status_for_app_error(&self.0);
         let payload = json!({
             "code": self.0.code,
             "message": self.0.message,
@@ -813,6 +802,50 @@ impl IntoResponse for HttpError {
         });
         (status, Json(payload)).into_response()
     }
+}
+
+fn http_status_for_app_error(error: &AppError) -> StatusCode {
+    match error.code.as_str() {
+        "not_found" => StatusCode::NOT_FOUND,
+        "invalid_input" => StatusCode::BAD_REQUEST,
+        "admin_access_invalid" => StatusCode::UNAUTHORIZED,
+        "admin_access_required" => StatusCode::FORBIDDEN,
+        "custom_tool_script_unsupported" => StatusCode::UNPROCESSABLE_ENTITY,
+        "embedding_network_error" | "embedding_provider_error" | "embedding_response_error" => {
+            StatusCode::BAD_GATEWAY
+        }
+        "unsupported_command" => StatusCode::NOT_IMPLEMENTED,
+        "io_error" if is_storage_unavailable_io_error(error) => StatusCode::SERVICE_UNAVAILABLE,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+fn is_storage_unavailable_io_error(error: &AppError) -> bool {
+    let details = error
+        .details
+        .as_ref()
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let message = error.message.to_ascii_lowercase();
+
+    matches!(
+        details.as_str(),
+        "permission denied"
+            | "read-only filesystem"
+            | "resource busy"
+            | "operation would block"
+            | "timed out"
+            | "operation interrupted"
+            | "storage full"
+            | "quota exceeded"
+            | "write zero"
+    ) || message.contains("read-only")
+        || message.contains("readonly")
+        || message.contains("database is locked")
+        || message.contains("database is busy")
+        || message.contains("resource busy")
+        || message.contains("storage is unavailable")
 }
 
 #[derive(Debug, Clone)]
@@ -1495,6 +1528,45 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&root).expect("health test directory should be removed");
+    }
+
+    #[test]
+    fn io_errors_map_to_storage_unavailable_http_status() {
+        let error = AppError::with_details(
+            "io_error",
+            "database is read-only",
+            std::io::ErrorKind::PermissionDenied.to_string(),
+        );
+
+        let response = HttpError::from(error).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn locked_database_io_errors_map_to_storage_unavailable_http_status() {
+        let error = AppError::with_details(
+            "io_error",
+            "database is locked",
+            std::io::ErrorKind::Other.to_string(),
+        );
+
+        let response = HttpError::from(error).into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn uncategorized_io_errors_keep_internal_server_error_status() {
+        let error = AppError::with_details(
+            "io_error",
+            "Collection path is not a regular file",
+            std::io::ErrorKind::Other.to_string(),
+        );
+
+        let response = HttpError::from(error).into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[test]

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -829,6 +829,23 @@ fn is_storage_unavailable_io_error(error: &AppError) -> bool {
         .to_ascii_lowercase();
     let message = error.message.to_ascii_lowercase();
 
+    let storage_unavailable_message = [
+        "permission denied",
+        "read-only",
+        "read only",
+        "readonly",
+        "database is locked",
+        "database is busy",
+        "resource busy",
+        "storage is unavailable",
+        "storage full",
+        "no space left on device",
+        "disk full",
+        "quota exceeded",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle));
+
     matches!(
         details.as_str(),
         "permission denied"
@@ -840,12 +857,7 @@ fn is_storage_unavailable_io_error(error: &AppError) -> bool {
             | "storage full"
             | "quota exceeded"
             | "write zero"
-    ) || message.contains("read-only")
-        || message.contains("readonly")
-        || message.contains("database is locked")
-        || message.contains("database is busy")
-        || message.contains("resource busy")
-        || message.contains("storage is unavailable")
+    ) || storage_unavailable_message
 }
 
 #[derive(Debug, Clone)]
@@ -1554,6 +1566,15 @@ mod tests {
         let response = HttpError::from(error).into_response();
 
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn message_only_storage_io_errors_map_to_storage_unavailable_http_status() {
+        for message in ["Permission denied", "No space left on device"] {
+            let response = HttpError::from(AppError::new("io_error", message)).into_response();
+
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2060

## Why this change

- Remote Runtime storage-backed `/api/invoke` commands could return a generic HTTP 500 when the underlying storage failed because it was read-only, locked, busy, full, or otherwise unavailable at command time.
- Legacy handling exposed comparable storage availability failures as actionable 503-class responses, so this restores that behavior without changing unrelated internal IO failures.

## What changed

- Extracted the hostable HTTP `AppError` status mapping into a small helper in `src-tauri/src/http_server.rs`.
- Mapped storage-availability `io_error` signals to HTTP 503 Service Unavailable.
- Kept generic uncategorized `io_error` responses on HTTP 500 so unrelated internal IO errors are not masked.
- Added Rust unit coverage for read-only/permission-denied storage IO, locked database IO, and a should-not-match uncategorized IO case.

## Refactor impact

Primary owner:

Rust storage / remote runtime

Impact areas reviewed:

- Hostable Remote Runtime HTTP error mapping.
- Storage-backed command error surface for `/api/invoke`.
- Existing JSON error payload shape (`code`, `message`, `details`) remains unchanged.

Boundary notes:

- This stays in `src-tauri/src/http_server.rs`; no React, engine, shared API, schema, dependency, prompt, auth, or storage format changes.
- The mapper only changes HTTP status selection. It does not rewrite the underlying `AppError`.

Pressure points touched:

- Remote Runtime HTTP `HttpError::into_response`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Before fix: `cargo test --manifest-path src-tauri/Cargo.toml io_errors_map_to_storage_unavailable_http_status` failed with `left: 500`, `right: 503`.
- After fix: `cargo test --manifest-path src-tauri/Cargo.toml http_status` passed for read-only/permission-denied and locked-database IO status mapping.
- After fix: `cargo test --manifest-path src-tauri/Cargo.toml uncategorized_io_errors_keep_internal_server_error_status` passed for the generic IO negative control.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check:architecture` passed.
- `pnpm check:frontend` passed.
- `pnpm check:rust` passed.
- `pnpm check:docs` passed.
- `pnpm check:discovery` passed.
- `pnpm check:unused` passed.
- `git diff --check` passed.
- Full `pnpm check` is currently blocked before code checks by unrelated CRLF line-ending baseline failures in `.github/workflows/bunny-review-command.yml`, `DESIGN.md`, and `custom_components/marinara_engine/{button.py,http.py,select.py,webhook.py}`.
- Bunny review pass: draft boundary accepted with the full-check limitation above disclosed; not ready-for-review until the baseline line-ending gate is clean or explicitly accepted.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only. No new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a non-UI Remote Runtime HTTP error-mapping fix.
