### PR TITLE
Fix neutral chat summary prompt

### DIFF
--- a/src/engine/contracts/constants/agent-prompts.test.ts
+++ b/src/engine/contracts/constants/agent-prompts.test.ts
@@ -21,4 +21,18 @@ describe("DEFAULT_AGENT_PROMPTS", () => {
     expect(prompt).toMatch(/content[^.]+concise neutral lore note/i);
     expect(prompt).toMatch(/each bullet/i);
   });
+
+  it("instructs Chat Summary to summarize neutrally instead of continuing the scene", () => {
+    const prompt = DEFAULT_AGENT_PROMPTS["chat-summary"];
+
+    expect(prompt).toMatch(/neutral factual recap/i);
+    expect(prompt).toMatch(/do not continue the scene/i);
+    expect(prompt).toMatch(/do not speak as/i);
+    expect(prompt).toMatch(/do not write new dialogue/i);
+    expect(prompt).toMatch(/do not match the roleplay/i);
+    expect(prompt).toMatch(/appended to the existing summary/i);
+    expect(prompt).toMatch(/new events only/i);
+    expect(prompt).not.toMatch(/a continuation, not a rewrite/i);
+    expect(prompt).not.toMatch(/match the tone and style/i);
+  });
 });

--- a/src/engine/contracts/constants/agent-prompts.ts
+++ b/src/engine/contracts/constants/agent-prompts.ts
@@ -459,20 +459,22 @@ Schema:
   html: `If fitting, include inline HTML, CSS, and JS segments whenever they enhance visual storytelling (in-world screens, posters, books, letters, signs, crests, labels, maps, and so on). Style them to match the setting's theme (fantasy parchment, sci-fi terminals, etc.), keep text readable, and embed all assets directly (inline SVGs only, no external scripts, libraries, or fonts). Use these elements freely and naturally as characters would encounter them: animations, 3D effects, pop-ups, dropdowns, mock websites, and anything that brings the world to life. Do NOT wrap HTML/CSS/JS in code fences.`,
 
   /* ────────────────────────────────────────── */
-  "chat-summary": `Stop the roleplay immediately. You are now about to create a summary. Produce NEW summary content covering ONLY the latest events not yet captured in the existing summary.
+  "chat-summary": `Stop the roleplay immediately. You are now about to create a neutral factual recap. Produce NEW summary content covering ONLY the latest events not yet captured in the existing summary.
 1. Do NOT rewrite or rephrase the existing summary. Do NOT repeat information already covered.
 2. Focus on:
    - New plot events and turning points since the last summary.
    - Fresh character developments, revelations, or relationship changes.
    - Changes to the current situation: new locations, actions, unresolved tensions.
    - New quests, goals, threats, or resolutions.
-3. Your output will be APPENDED to the existing summary, not replace it. Write only the new content — a continuation, not a rewrite.
-4. If the previous summary already covers everything, respond with an empty string.
-5. Match the tone and style of the existing summary.
+3. Your output will be APPENDED to the existing summary, not replace it. Write only factual summary content for newly covered events.
+4. Do NOT continue the scene, advance time, or invent new events.
+5. Do NOT write new dialogue. Do NOT speak as the user, any persona, or any character.
+6. Do NOT match the roleplay, character voice, prose style, or emotional narration. Use concise neutral summary prose even if the source messages are stylized.
+7. If the previous summary already covers everything, respond with an empty string.
 Respond ONLY with valid JSON.
 Schema:
 {
-  "summary": "string — NEW events only, to be appended (1–3 paragraphs, or empty string if nothing new)."
+  "summary": "string — neutral factual summary of NEW events only, to be appended (1–3 paragraphs, or empty string if nothing new)."
 }`,
 
   /* ────────────────────────────────────────── */


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2064

## Why this change

- Auto Chat Summary could ask the model for summary text using wording that still invited scene continuation and style matching. In the reported failure, the generated summary read like persona/narrative output instead of a neutral recap.

## What changed

- Tightened the built-in `chat-summary` prompt so it asks for a neutral factual recap of new events only.
- Removed the old "continuation" and "match tone/style" cues from the default summary prompt.
- Added a regression test that requires the neutral-summary guardrails and forbids reintroducing the risky continuation/style wording.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Built-in chat-summary default prompt.
- Manual/default summary prompt selection via `getDefaultAgentPrompt("chat-summary")`.
- Agent executor fallback behavior for built-in agents with empty `promptTemplate`.

Boundary notes:

- Engine-only prompt contract change. No React UI, shared API, Tauri/Rust storage, remote runtime, schema, dependency, or migration changes.
- Existing user-authored/custom summary prompt templates are intentionally not rewritten. Users who copied the old wording into a custom prompt template may still need to edit that custom text manually.

Pressure points touched:

- None. This does not touch ModeSurface, GameSurface, shared mode UI, command registration, imports, or remote runtime.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `node scratch/check-chat-summary-prompt.mjs`: passed after the fix, proving the default prompt now requires neutral recap behavior and blocks persona-style continuation cues.
- Codex ran `node scratch/capture-issue-2064-proof.mjs`: before/base prompt failed for missing neutral/do-not-continue/do-not-speak/do-not-dialogue/do-not-match-roleplay guardrails and still contained continuation/style cues; current patch passed.
- Codex ran `pnpm exec vitest run src/engine/contracts/constants/agent-prompts.test.ts`: 1 file passed, 3 tests passed.
- Codex ran `pnpm typecheck`: passed.
- Codex ran full `pnpm check`: passed line endings, architecture/import rules, frontend TypeScript, Rust cargo check, docs, discovery metadata, and unused-code checks.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Bunny review before PR: pass. Diff is limited to the built-in prompt and its regression test; no dependency/schema/storage/auth/release/prompt-pipeline expansion beyond the intended summary prompt contract.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only. No new user-discoverable feature or workflow was added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a non-visual prompt-contract fix; proof is command-based and recorded above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test validation for chat summary functionality, verifying enforcement of neutral, factual append-only summaries while preventing scene continuation, dialogue injection, or roleplay voice.

* **Bug Fixes**
  * Updated chat summary prompt template to enforce strictly neutral, factual summarization with explicit constraints preventing scene advancement, new events, or stylistic matching requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->