### PR TITLE
Fix remote runtime new-chat readiness

### DIFF
--- a/src/app/shell/useStartNewChat.ts
+++ b/src/app/shell/useStartNewChat.ts
@@ -47,7 +47,13 @@ export function useStartNewChat() {
       }
 
       if (needsRemoteRuntime) {
-        const health = await checkRemoteRuntimeHealth(remoteRuntime);
+        let health: Awaited<ReturnType<typeof checkRemoteRuntimeHealth>>;
+        try {
+          health = await checkRemoteRuntimeHealth(remoteRuntime);
+        } catch {
+          if (isNewChatMode) setPendingNewChatMode(mode);
+          return;
+        }
         if (health.status !== "ok") {
           if (isNewChatMode) setPendingNewChatMode(mode);
           return;

--- a/src/app/shell/useStartNewChat.ts
+++ b/src/app/shell/useStartNewChat.ts
@@ -10,6 +10,7 @@ import {
 } from "../../features/catalog/chat-presets/index";
 import { useCreateChat } from "../../features/catalog/chats/sidebar";
 import { connectionKeys } from "../../features/catalog/connections/index";
+import { checkRemoteRuntimeHealth } from "../../shared/api/remote-runtime";
 import { storageApi } from "../../shared/api/storage-api";
 import { filterLanguageGenerationConnections } from "../../shared/lib/connection-filters";
 import { useChatStore } from "../../shared/stores/chat.store";
@@ -34,23 +35,41 @@ export function useStartNewChat() {
 
   return useCallback(
     async (mode: ChatMode) => {
-      if (!hasEmbeddedTauriIpc() && remoteRuntimeUrl.trim().length === 0) {
+      const isNewChatMode = mode === "conversation" || mode === "roleplay" || mode === "game";
+      const remoteRuntime = remoteRuntimeUrl.trim();
+      const needsRemoteRuntime = !hasEmbeddedTauriIpc();
+
+      if (needsRemoteRuntime && remoteRuntime.length === 0) {
         if (mode === "conversation" || mode === "roleplay" || mode === "game") {
           setPendingNewChatMode(mode);
         }
         return;
       }
 
-      const connections = await queryClient.fetchQuery({
-        queryKey: connectionKeys.list(),
-        queryFn: () => storageApi.list<Record<string, unknown>>("connections"),
-        staleTime: 5 * 60_000,
-      });
+      if (needsRemoteRuntime) {
+        const health = await checkRemoteRuntimeHealth(remoteRuntime);
+        if (health.status !== "ok") {
+          if (isNewChatMode) setPendingNewChatMode(mode);
+          return;
+        }
+      }
+
+      let connections: Record<string, unknown>[];
+      try {
+        connections = await queryClient.fetchQuery({
+          queryKey: connectionKeys.list(),
+          queryFn: () => storageApi.list<Record<string, unknown>>("connections"),
+          staleTime: 5 * 60_000,
+        });
+      } catch {
+        if (isNewChatMode) setPendingNewChatMode(mode);
+        return;
+      }
       const connectionRows = filterLanguageGenerationConnections(
         (connections ?? []) as Array<{ id: string; provider?: string }>,
       ).filter((connection) => !!connection.id);
       if (connectionRows.length === 0) {
-        if (mode === "conversation" || mode === "roleplay" || mode === "game") {
+        if (isNewChatMode) {
           setPendingNewChatMode(mode);
         }
         return;

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
@@ -162,10 +162,11 @@ async function setOnlyActivePreset(id: string): Promise<ChatPreset> {
   return { ...normalizeChatPresetFlags(selected), isActive: true, active: true } as ChatPreset;
 }
 
-export function useChatPresets(mode?: ChatMode | null) {
+export function useChatPresets(mode?: ChatMode | null, enabled = true) {
   return useQuery({
     queryKey: chatPresetKeys.list(mode ?? null),
     queryFn: () => listChatPresets(mode),
+    enabled,
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });

--- a/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
+++ b/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useId, useMemo, useState } from "react";
-import { BookOpen, Loader2, MessageCircle, Plug, Settings, X } from "lucide-react";
+import { AlertTriangle, BookOpen, Loader2, MessageCircle, Plug, Settings, X } from "lucide-react";
 import { useCreateChat } from "../../../../catalog/chats/index";
 import { findUserStarredChatPreset, useApplyChatPreset, useChatPresets } from "../../../../catalog/chat-presets/index";
 import { useConnections } from "../../../../catalog/connections/index";
+import { checkRemoteRuntimeHealth, type RemoteRuntimeHealthCheck } from "../../../../../shared/api/remote-runtime";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
 import { cn } from "../../../../../shared/lib/utils";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
@@ -15,6 +16,8 @@ const MODE_META: Record<Mode, { label: string; icon: React.ReactNode }> = {
   roleplay: { label: "Roleplay", icon: <BookOpen size="0.875rem" /> },
   game: { label: "Game", icon: <BookOpen size="0.875rem" /> },
 };
+
+type RemoteRuntimeGateState = RemoteRuntimeHealthCheck | { status: "checking"; message: string };
 
 function hasEmbeddedTauriIpc(): boolean {
   return (
@@ -31,14 +34,44 @@ interface NewChatConnectionGateProps {
 export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGateProps) {
   const dialogTitleId = useId();
   const dialogDescriptionId = useId();
-  const { data: connections, isLoading } = useConnections();
-  const createChat = useCreateChat();
-  const { data: chatPresetsData } = useChatPresets();
-  const applyChatPreset = useApplyChatPreset();
   const openRightPanel = useUIStore((state) => state.openRightPanel);
   const setSettingsTab = useUIStore((state) => state.setSettingsTab);
   const remoteRuntimeUrl = useUIStore((state) => state.remoteRuntimeUrl);
   const [connectionId, setConnectionId] = useState<string>("");
+  const [remoteRuntimeHealth, setRemoteRuntimeHealth] = useState<RemoteRuntimeGateState | null>(null);
+  const embeddedTauriIpc = hasEmbeddedTauriIpc();
+  const remoteRuntime = remoteRuntimeUrl.trim();
+  const needsRemoteRuntimeUrl = !embeddedTauriIpc && remoteRuntime.length === 0;
+  const shouldCheckRemoteRuntime = !embeddedTauriIpc && remoteRuntime.length > 0;
+  const remoteRuntimeReady = !shouldCheckRemoteRuntime || remoteRuntimeHealth?.status === "ok";
+  const { data: connections, isLoading, isError, error } = useConnections(remoteRuntimeReady);
+  const createChat = useCreateChat();
+  const { data: chatPresetsData } = useChatPresets(undefined, remoteRuntimeReady);
+  const applyChatPreset = useApplyChatPreset();
+
+  useEffect(() => {
+    if (!shouldCheckRemoteRuntime) {
+      setRemoteRuntimeHealth(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setRemoteRuntimeHealth({ status: "checking", message: "Checking Remote Runtime readiness..." });
+
+    void checkRemoteRuntimeHealth(remoteRuntime, { signal: controller.signal })
+      .then((result) => {
+        if (!controller.signal.aborted) setRemoteRuntimeHealth(result);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setRemoteRuntimeHealth({
+          status: "unreachable",
+          message: err instanceof Error ? err.message : "Remote runtime health check failed.",
+        });
+      });
+
+    return () => controller.abort();
+  }, [remoteRuntime, shouldCheckRemoteRuntime]);
 
   const connectionRows = useMemo(
     () =>
@@ -88,8 +121,13 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
     );
   };
 
-  const showEmptyState = !isLoading && connectionRows.length === 0;
-  const needsRemoteRuntimeUrl = showEmptyState && !hasEmbeddedTauriIpc() && remoteRuntimeUrl.trim().length === 0;
+  const remoteRuntimeBlocked =
+    needsRemoteRuntimeUrl ||
+    (shouldCheckRemoteRuntime && remoteRuntimeHealth !== null && remoteRuntimeHealth.status !== "ok");
+  const checkingRemoteRuntime =
+    shouldCheckRemoteRuntime && (remoteRuntimeHealth === null || remoteRuntimeHealth.status === "checking");
+  const showConnectionListError = remoteRuntimeReady && !isLoading && isError;
+  const showEmptyState = remoteRuntimeReady && !isLoading && !isError && connectionRows.length === 0;
 
   const handleOpenConnections = () => {
     openRightPanel("connections");
@@ -153,6 +191,50 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
                   Open Advanced Settings
                 </button>
               </div>
+            ) : checkingRemoteRuntime ? (
+              <div className="rounded-xl border border-[var(--primary)]/20 bg-[var(--primary)]/8 p-4">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                  <Loader2 size="0.875rem" className="animate-spin text-[var(--primary)]" />
+                  Checking Remote Runtime
+                </div>
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  Verifying that the configured runtime is reachable and storage is writable.
+                </p>
+              </div>
+            ) : remoteRuntimeBlocked ? (
+              <div className="rounded-xl border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 p-4">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                  <AlertTriangle size="0.875rem" className="text-[var(--destructive)]" />
+                  Remote Runtime unavailable
+                </div>
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  {remoteRuntimeHealth?.message ?? "Remote Runtime is not ready."}
+                </p>
+                <button
+                  onClick={handleOpenRemoteRuntimeSettings}
+                  className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/20"
+                >
+                  <Settings size="0.75rem" />
+                  Open Advanced Settings
+                </button>
+              </div>
+            ) : showConnectionListError ? (
+              <div className="rounded-xl border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 p-4">
+                <div className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                  <AlertTriangle size="0.875rem" className="text-[var(--destructive)]" />
+                  Connections unavailable
+                </div>
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  {error instanceof Error ? error.message : "Marinara could not load connections from storage."}
+                </p>
+                <button
+                  onClick={handleOpenRemoteRuntimeSettings}
+                  className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/20"
+                >
+                  <Settings size="0.75rem" />
+                  Open Advanced Settings
+                </button>
+              </div>
             ) : showEmptyState ? (
               <div className="rounded-xl border border-[var(--primary)]/20 bg-[var(--primary)]/8 p-4">
                 <div className="mb-2 flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
@@ -201,10 +283,12 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
             </button>
             <button
               onClick={handleCreate}
-              disabled={showEmptyState || !connectionId || createChat.isPending}
+              disabled={
+                remoteRuntimeBlocked || isLoading || isError || showEmptyState || !connectionId || createChat.isPending
+              }
               className={cn(
                 "flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-xs font-medium shadow-sm transition-all active:scale-95",
-                showEmptyState || !connectionId || createChat.isPending
+                remoteRuntimeBlocked || isLoading || isError || showEmptyState || !connectionId || createChat.isPending
                   ? "cursor-not-allowed bg-[var(--secondary)] text-[var(--muted-foreground)] opacity-60"
                   : "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90",
               )}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2061

## Why this change

- Web-shell new chat entrypoints treated a configured Remote Runtime URL as ready, then fell through to connection setup when the runtime was invalid or unreachable.
- Users starting conversation, roleplay, or game chats now see the same Remote Runtime readiness failure class used by startup and Settings before connection setup is entered.

## What changed

- `useStartNewChat` now checks `checkRemoteRuntimeHealth` before fetching connections in web-shell mode, and opens the setup gate instead of letting remote storage failures reject silently.
- `NewChatConnectionGate` now blocks connection and preset queries until remote readiness succeeds, shows checking/unavailable states, and routes failures to Advanced Settings.
- `useChatPresets` accepts an optional `enabled` flag so this setup gate can delay preset storage reads without changing existing callers.

## Refactor impact

Primary owner:

- App shell / shared mode UI / remote runtime

Impact areas reviewed:

- Sidebar new-chat flow for conversation, roleplay, and game
- Home quick-start setup gate
- Remote Runtime health contract and storage-backed connection/preset reads

Boundary notes:

- React UI remains in `src/app` and `src/features`.
- The fix reuses the focused `src/shared/api/remote-runtime` wrapper; it does not change engine code, raw remote fetch routing, Rust commands, storage schema, or remote command semantics.

Pressure points touched:

- `src/app/shell/useStartNewChat.ts`
- `src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx`

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Scratch repro before fix: `pnpm exec vitest run --dir scratch --config vite.config.ts --environment jsdom` failed because the gate showed `No connections found` instead of `Remote runtime is unreachable.`
- Scratch repro after fix: `pnpm exec vitest run --dir scratch --config vite.config.ts --environment jsdom` passed and asserted the gate checks `/health` before storage-backed setup queries.
- Browser proof before fix: Playwright against detached `origin/refactor` showed `No connections found` for the same bad Remote Runtime URL.
- Browser proof after fix: Playwright against this branch showed `Remote Runtime unavailable`, `Remote runtime is unreachable.`, and `Open Advanced Settings`.
- Full baseline: `pnpm check` passed locally.
- Workflow tooling note: `.agents/automation/scripts/workflow-health.mjs` and `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs` were not present in this checkout/environment.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; it changes the new-chat failure state for an existing Remote Runtime setup path.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Local proof captured:

- `scratch/issue-2061-before.png`
- `scratch/issue-2061-after.png`

These local screenshots should be uploaded/attached as GitHub-hosted image URLs before marking the draft ready for review.
