### PR TITLE
Fix loopback admin secret hardening

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -614,7 +614,10 @@ fn require_admin_access_for_command(
     headers: &HeaderMap,
     ip: IpAddr,
 ) -> Result<(), AppError> {
-    if !is_privileged_remote_command(command) || is_loopback(ip) {
+    if !is_privileged_remote_command(command) {
+        return Ok(());
+    }
+    if is_loopback(ip) && !env_flag_enabled("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK") {
         return Ok(());
     }
 
@@ -1788,22 +1791,31 @@ mod tests {
     }
 
     struct AdminSecretGuard {
-        original: Option<String>,
+        original_admin_secret: Option<String>,
+        original_loopback_secret_required: Option<String>,
     }
 
     impl AdminSecretGuard {
         fn capture() -> Self {
             Self {
-                original: env::var("ADMIN_SECRET").ok(),
+                original_admin_secret: env::var("ADMIN_SECRET").ok(),
+                original_loopback_secret_required: env::var(
+                    "MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK",
+                )
+                .ok(),
             }
         }
     }
 
     impl Drop for AdminSecretGuard {
         fn drop(&mut self) {
-            match &self.original {
+            match &self.original_admin_secret {
                 Some(value) => env::set_var("ADMIN_SECRET", value),
                 None => env::remove_var("ADMIN_SECRET"),
+            }
+            match &self.original_loopback_secret_required {
+                Some(value) => env::set_var("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK", value),
+                None => env::remove_var("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK"),
             }
         }
     }
@@ -2378,6 +2390,11 @@ mod tests {
 
     #[test]
     fn hostable_security_requires_admin_access_for_remote_backup_list() {
+        let _guard = admin_secret_lock()
+            .lock()
+            .expect("admin secret test lock should acquire");
+        let _admin_secret = AdminSecretGuard::capture();
+        env::remove_var("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK");
         let headers = HeaderMap::new();
         let remote_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
 
@@ -2391,6 +2408,37 @@ mod tests {
         )
         .is_ok());
         assert!(require_admin_access_for_command("storage_list", &headers, remote_ip).is_ok());
+    }
+
+    #[test]
+    fn hostable_security_can_require_admin_access_for_loopback_privileged_commands() {
+        let _guard = admin_secret_lock()
+            .lock()
+            .expect("admin secret test lock should acquire");
+        let _admin_secret = AdminSecretGuard::capture();
+        env::set_var("ADMIN_SECRET", "expected-secret");
+        env::set_var("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK", "true");
+        let loopback_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let mut headers = HeaderMap::new();
+
+        let missing_secret = require_admin_access_for_command("backup_list", &headers, loopback_ip)
+            .expect_err("loopback backup_list should require Admin Access when hardened");
+
+        assert_eq!(missing_secret.code, "admin_access_required");
+        headers.insert(
+            HeaderName::from_static(ADMIN_SECRET_HEADER_NAME),
+            HeaderValue::from_static("expected-secret"),
+        );
+        assert!(require_admin_access_for_command("backup_list", &headers, loopback_ip).is_ok());
+        assert!(require_admin_access_for_command("storage_list", &HeaderMap::new(), loopback_ip)
+            .is_ok());
+
+        env::set_var("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK", "false");
+        assert!(
+            require_admin_access_for_command("backup_list", &HeaderMap::new(), loopback_ip)
+                .is_ok(),
+            "explicit false should keep the legacy loopback bypass"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2065

## Why this change

- Refactor remote runtime dropped the legacy `MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK` hardening knob, so loopback privileged commands bypassed Admin Access even when operators configured `ADMIN_SECRET` and explicitly wanted loopback calls to require it.

## What changed

- Split privileged-command detection from the loopback exemption in `require_admin_access_for_command`.
- Preserve the default legacy loopback bypass unless `MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK` is truthy.
- Added a regression test covering hardened loopback rejection/acceptance, explicit false bypass, and unprivileged loopback behavior.

## Refactor impact

Primary owner:

- Rust remote runtime / Admin Access gate.

Impact areas reviewed:

- Privileged remote command Admin Access.
- Loopback versus non-loopback request handling.
- Neighboring hostable security tests for basic auth, IP allowlist, origin, CSRF, and security headers.

Boundary notes:

- Fix stays in `src-tauri/src/http_server.rs`; no React, engine, shared API, storage data format, schema, dependency, prompt, or release metadata changes.
- Remote runtime remains the enforcing owner; no UI-only guard was added.

Pressure points touched:

- `src-tauri/src/http_server.rs` privileged command gate and its Rust unit tests.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the bug before the production fix with `cargo test --manifest-path src-tauri\Cargo.toml hostable_security_can_require_admin_access_for_loopback_privileged_commands`; the test failed because loopback `backup_list` returned success with `MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK=true`.
- Codex verified the fix after rebasing onto current `upstream/refactor`:
  - `cargo test --manifest-path src-tauri\Cargo.toml hostable_security` passed, 12 tests.
  - `cargo test --manifest-path src-tauri\Cargo.toml remote_admin_clear_all` passed, 3 tests.
  - `pnpm check` passed.
  - `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- No human-only verification blocker is known; this is a non-UI Rust security gate covered by command tests.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for a legacy remote-runtime security env knob; no new in-app discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A: non-UI Rust Admin Access gate. Command proof is listed under validation.
