### PR TITLE
Migrate legacy Admin Access browser secret

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -22,13 +22,15 @@
     "originalReproPassed": true,
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
-    "baselineEvidence": "pnpm check passed after rebase onto current origin/refactor",
+    "baselineEvidence": "pnpm check passed after Bunny storage-mutation fix",
     "edgeCases": {
       "0": "Legacy-only localStorage value is trimmed, returned, migrated to marinara-admin-secret, and legacy key removed",
       "1": "Current key wins when both current and legacy keys exist; stale legacy key is removed",
       "2": "Saving a nonblank Admin Access value trims it, writes the current key, and removes the legacy key",
       "3": "Saving blank Admin Access clears both current and legacy keys",
-      "4": "No-window/server-side read returns empty"
+      "4": "No-window/server-side read returns empty",
+      "5": "Current-key read survives failed legacy cleanup removeItem",
+      "6": "Legacy-only read returns the secret even if migration setItem throws"
     },
     "visualProof": "scratch/repro-2063-output.txt"
   },
@@ -38,7 +40,8 @@
     "1": "No local 2063 branch/worktree existed before worktree creation",
     "2": "Proof gate helper unavailable at C:\\Users\\celia\\.codex\\tools\\marinara-proof-gate.mjs",
     "3": "Rebased cleanly onto current origin/refactor before push",
-    "4": "PR body marks Feature Discoverability as N/A with reason for PR-aware discovery CI"
+    "4": "PR body marks Feature Discoverability as N/A with reason for PR-aware discovery CI",
+    "5": "Addressed Bunny finding: legacy read can fail on migration write"
   },
   "riskClaimMatrix": {
     "coreClaim": "Refactor web shell reads and migrates legacy Admin Access browser storage without requiring users to re-enter the secret.",

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 1,
+  "issue": {
+    "number": "2063",
+    "title": "Admin Access should migrate the legacy browser secret key",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2063"
+  },
+  "pr": {
+    "number": "2087",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2087"
+  },
+  "coreClaim": "Refactor web shell reads and migrates the legacy marinara_admin_secret Admin Access localStorage value to the current marinara-admin-secret key.",
+  "reproduction": {
+    "attempted": true,
+    "reproducedBeforeFix": true,
+    "method": "Static source repro plus scratch helper proof",
+    "evidence": {
+      "0": "origin/refactor remote-runtime has no marinara_admin_secret/readAdminSecretStorage/writeAdminSecretStorage matches"
+    }
+  },
+  "verification": {
+    "originalReproPassed": true,
+    "baselinePassed": true,
+    "baselineCommand": "pnpm check",
+    "baselineEvidence": "pnpm check passed after rebase onto current origin/refactor",
+    "edgeCases": {
+      "0": "Legacy-only localStorage value is trimmed, returned, migrated to marinara-admin-secret, and legacy key removed",
+      "1": "Current key wins when both current and legacy keys exist; stale legacy key is removed",
+      "2": "Saving a nonblank Admin Access value trims it, writes the current key, and removes the legacy key",
+      "3": "Saving blank Admin Access clears both current and legacy keys",
+      "4": "No-window/server-side read returns empty"
+    },
+    "visualProof": "scratch/repro-2063-output.txt"
+  },
+  "manualBlockers": [],
+  "notes": {
+    "0": "Issue assigned to cha1latte before edits",
+    "1": "No local 2063 branch/worktree existed before worktree creation",
+    "2": "Proof gate helper unavailable at C:\\Users\\celia\\.codex\\tools\\marinara-proof-gate.mjs",
+    "3": "Rebased cleanly onto current origin/refactor before push",
+    "4": "PR body marks Feature Discoverability as N/A with reason for PR-aware discovery CI"
+  },
+  "riskClaimMatrix": {
+    "coreClaim": "Refactor web shell reads and migrates legacy Admin Access browser storage without requiring users to re-enter the secret.",
+    "riskType": "legacy browser localStorage compatibility",
+    "entrypoints": {
+      "0": "Settings Advanced Admin Access field initialization/save/clear",
+      "1": "shared remote-runtime privileged command header"
+    },
+    "currentPathsOrFormats": {
+      "0": "marinara-admin-secret localStorage key"
+    },
+    "legacyPathsOrFormats": {
+      "0": "marinara_admin_secret localStorage key"
+    },
+    "positiveRowsTested": {
+      "0": "legacy-only value migrates and is read",
+      "1": "current+legacy prefers current and cleans legacy",
+      "2": "save writes current key and removes legacy"
+    },
+    "negativeRowsTested": {
+      "0": "blank save clears both keys",
+      "1": "no-window read returns empty"
+    },
+    "groundTruthFacts": {
+      "0": "origin/refactor had only marinara-admin-secret in SettingsPanel and remote-runtime"
+    },
+    "userActionCopy": "No user action required when a legacy browser secret exists; clearing Admin Access clears both browser keys."
+  },
+  "finalDoneGate": {
+    "didFixBug": true,
+    "hasProfessionalVisualProof": true,
+    "prWouldBeAccepted": true,
+    "claimBoundariesProven": true
+  }
+}

--- a/scratch/repro-2063-admin-secret-key.mjs
+++ b/scratch/repro-2063-admin-secret-key.mjs
@@ -23,11 +23,32 @@ function makeStorage(entries = {}) {
   };
 }
 
+function makeThrowingStorage(entries = {}, throws = {}) {
+  const storage = makeStorage(entries);
+  return {
+    ...storage,
+    setItem(key, value) {
+      if (throws.setItem) throw new Error("setItem blocked");
+      storage.setItem(key, value);
+    },
+    removeItem(key) {
+      if (throws.removeItem) throw new Error("removeItem blocked");
+      storage.removeItem(key);
+    },
+  };
+}
+
 const helperExports = {};
 const helperContext = { exports: helperExports };
 
 function installStorage(entries) {
   const localStorage = makeStorage(entries);
+  helperContext.window = { localStorage };
+  return localStorage;
+}
+
+function installThrowingStorage(entries, throws) {
+  const localStorage = makeThrowingStorage(entries, throws);
   helperContext.window = { localStorage };
   return localStorage;
 }
@@ -72,6 +93,12 @@ storage = installStorage({ [currentKey]: " current-secret ", [legacyKey]: "legac
 assert(readAdminSecretStorage() === "current-secret", "current key should take precedence when both keys exist");
 assert(storage.getItem(currentKey) === " current-secret ", "read should not rewrite an existing current key");
 assert(storage.getItem(legacyKey) === null, "read should clean stale legacy data when current exists");
+
+storage = installThrowingStorage({ [currentKey]: "current-secret", [legacyKey]: "legacy-secret" }, { removeItem: true });
+assert(readAdminSecretStorage() === "current-secret", "current read should survive failed legacy cleanup");
+
+storage = installThrowingStorage({ [legacyKey]: "legacy-secret" }, { setItem: true });
+assert(readAdminSecretStorage() === "legacy-secret", "legacy read should survive failed migration write");
 
 storage = installStorage({ [legacyKey]: "legacy-secret" });
 writeAdminSecretStorage(" saved-secret ");

--- a/scratch/repro-2063-admin-secret-key.mjs
+++ b/scratch/repro-2063-admin-secret-key.mjs
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import ts from "typescript";
+
+const currentKey = "marinara-admin-secret";
+const legacyKey = "marinara_admin_secret";
+
+function makeStorage(entries = {}) {
+  const values = new Map(Object.entries(entries));
+  return {
+    getItem(key) {
+      return values.has(key) ? values.get(key) : null;
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+    dump() {
+      return Object.fromEntries(values.entries());
+    },
+  };
+}
+
+const helperExports = {};
+const helperContext = { exports: helperExports };
+
+function installStorage(entries) {
+  const localStorage = makeStorage(entries);
+  helperContext.window = { localStorage };
+  return localStorage;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const remoteSource = readFileSync("src/shared/api/remote-runtime.ts", "utf8");
+const settingsSource = readFileSync("src/features/shell/settings/components/SettingsPanel.tsx", "utf8");
+
+assert(remoteSource.includes(legacyKey), "remote-runtime should know the legacy Admin Access key");
+assert(
+  remoteSource.includes("readAdminSecretStorage()"),
+  "remote-runtime privileged headers should read through the migration helper",
+);
+assert(settingsSource.includes("readAdminSecretStorage"), "Settings should initialize Admin Access from the helper");
+assert(settingsSource.includes("writeAdminSecretStorage"), "Settings should save Admin Access through the helper");
+
+const helperStart = remoteSource.indexOf("const ADMIN_SECRET_STORAGE_KEY");
+const helperEnd = remoteSource.indexOf("function adminSecretHeader");
+assert(helperStart >= 0 && helperEnd > helperStart, "storage helper source should be extractable");
+
+const helperSource = `${remoteSource.slice(helperStart, helperEnd)}
+exports.readAdminSecretStorage = readAdminSecretStorage;
+exports.writeAdminSecretStorage = writeAdminSecretStorage;
+`;
+const helperJs = ts.transpileModule(helperSource, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+}).outputText;
+vm.runInNewContext(helperJs, helperContext);
+const { readAdminSecretStorage, writeAdminSecretStorage } = helperExports;
+assert(typeof readAdminSecretStorage === "function", "readAdminSecretStorage should execute");
+assert(typeof writeAdminSecretStorage === "function", "writeAdminSecretStorage should execute");
+
+let storage = installStorage({ [legacyKey]: "  legacy-secret  " });
+assert(readAdminSecretStorage() === "legacy-secret", "legacy-only secret should be read and trimmed");
+assert(storage.getItem(currentKey) === "legacy-secret", "legacy secret should migrate to the current key");
+assert(storage.getItem(legacyKey) === null, "legacy key should be removed after migration");
+
+storage = installStorage({ [currentKey]: " current-secret ", [legacyKey]: "legacy-secret" });
+assert(readAdminSecretStorage() === "current-secret", "current key should take precedence when both keys exist");
+assert(storage.getItem(currentKey) === " current-secret ", "read should not rewrite an existing current key");
+assert(storage.getItem(legacyKey) === null, "read should clean stale legacy data when current exists");
+
+storage = installStorage({ [legacyKey]: "legacy-secret" });
+writeAdminSecretStorage(" saved-secret ");
+assert(storage.getItem(currentKey) === "saved-secret", "save should trim and write the current key");
+assert(storage.getItem(legacyKey) === null, "save should remove the legacy key");
+
+storage = installStorage({ [currentKey]: "current-secret", [legacyKey]: "legacy-secret" });
+writeAdminSecretStorage("   ");
+assert(storage.getItem(currentKey) === null, "blank save should clear the current key");
+assert(storage.getItem(legacyKey) === null, "blank save should clear the legacy key too");
+
+delete helperContext.window;
+assert(readAdminSecretStorage() === "", "server-side/no-window reads should be empty");
+
+console.log("Admin Access legacy-key migration proof passed.");

--- a/scratch/repro-2063-output.txt
+++ b/scratch/repro-2063-output.txt
@@ -1,0 +1,1 @@
+Admin Access legacy-key migration proof passed.

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -42,7 +42,9 @@ import {
 } from "../../../../shared/api/local-file-api";
 import {
   checkRemoteRuntimeHealth,
+  readAdminSecretStorage,
   unconfiguredRemoteRuntimeHealth,
+  writeAdminSecretStorage,
   type RemoteRuntimeHealthCheck,
 } from "../../../../shared/api/remote-runtime";
 import React, { useRef, useState, useCallback, useEffect } from "react";
@@ -170,8 +172,6 @@ const EXPUNGE_SCOPE_OPTIONS: Array<{ id: ExpungeScope; label: string; descriptio
     description: "Backgrounds, avatars, sprites, gallery items, fonts, and knowledge-source files.",
   },
 ];
-
-const ADMIN_SECRET_STORAGE_KEY = "marinara-admin-secret";
 
 const ROLEPLAY_AVATAR_STYLE_OPTIONS: Array<{ id: RoleplayAvatarStyle; label: string; desc: string }> = [
   {
@@ -3285,7 +3285,7 @@ function AdvancedSettings() {
   const [checkingUpdates, setCheckingUpdates] = useState(false);
   const [openingUpdate, setOpeningUpdate] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateCheckResponse | null>(null);
-  const [adminSecret, setAdminSecret] = useState(() => localStorage.getItem(ADMIN_SECRET_STORAGE_KEY) ?? "");
+  const [adminSecret, setAdminSecret] = useState(readAdminSecretStorage);
   const [quickRepliesDrawerOpen, setQuickRepliesDrawerOpen] = useState(true);
   const remoteRuntimeSectionRef = useRef<HTMLDivElement>(null);
   const remoteRuntimeHealthAbortRef = useRef<AbortController | null>(null);
@@ -3508,11 +3508,10 @@ function AdvancedSettings() {
 
   const saveAdminSecret = useCallback(() => {
     const trimmed = adminSecret.trim();
+    writeAdminSecretStorage(trimmed);
     if (trimmed) {
-      localStorage.setItem(ADMIN_SECRET_STORAGE_KEY, trimmed);
       toast.success("Admin secret saved for this browser");
     } else {
-      localStorage.removeItem(ADMIN_SECRET_STORAGE_KEY);
       toast.info("Admin secret cleared");
     }
   }, [adminSecret]);

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -272,19 +272,29 @@ export function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): Heade
   };
 }
 
+function tryWriteAdminSecretStorage(write: () => void): void {
+  try {
+    write();
+  } catch {
+    // Reading a usable Admin Access value should not depend on best-effort key migration.
+  }
+}
+
 export function readAdminSecretStorage(): string {
   if (typeof window === "undefined") return "";
   const current = window.localStorage.getItem(ADMIN_SECRET_STORAGE_KEY)?.trim() ?? "";
   if (current) {
-    window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY);
+    tryWriteAdminSecretStorage(() => window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY));
     return current;
   }
 
   const legacy = window.localStorage.getItem(LEGACY_ADMIN_SECRET_STORAGE_KEY)?.trim() ?? "";
   if (!legacy) return "";
 
-  window.localStorage.setItem(ADMIN_SECRET_STORAGE_KEY, legacy);
-  window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY);
+  tryWriteAdminSecretStorage(() => {
+    window.localStorage.setItem(ADMIN_SECRET_STORAGE_KEY, legacy);
+    window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY);
+  });
   return legacy;
 }
 

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -197,6 +197,7 @@ const PRIVILEGED_REMOTE_COMMANDS = new Set([
   "update_apply",
 ]);
 const ADMIN_SECRET_STORAGE_KEY = "marinara-admin-secret";
+const LEGACY_ADMIN_SECRET_STORAGE_KEY = "marinara_admin_secret";
 
 export type RuntimeTarget = {
   baseUrl: string;
@@ -271,9 +272,35 @@ export function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): Heade
   };
 }
 
+export function readAdminSecretStorage(): string {
+  if (typeof window === "undefined") return "";
+  const current = window.localStorage.getItem(ADMIN_SECRET_STORAGE_KEY)?.trim() ?? "";
+  if (current) {
+    window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY);
+    return current;
+  }
+
+  const legacy = window.localStorage.getItem(LEGACY_ADMIN_SECRET_STORAGE_KEY)?.trim() ?? "";
+  if (!legacy) return "";
+
+  window.localStorage.setItem(ADMIN_SECRET_STORAGE_KEY, legacy);
+  window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY);
+  return legacy;
+}
+
+export function writeAdminSecretStorage(secret: string): void {
+  if (typeof window === "undefined") return;
+  const trimmed = secret.trim();
+  if (trimmed) {
+    window.localStorage.setItem(ADMIN_SECRET_STORAGE_KEY, trimmed);
+  } else {
+    window.localStorage.removeItem(ADMIN_SECRET_STORAGE_KEY);
+  }
+  window.localStorage.removeItem(LEGACY_ADMIN_SECRET_STORAGE_KEY);
+}
+
 function adminSecretHeader(): HeadersInit {
-  if (typeof window === "undefined") return {};
-  const secret = window.localStorage.getItem(ADMIN_SECRET_STORAGE_KEY)?.trim();
+  const secret = readAdminSecretStorage();
   return secret ? { "X-Admin-Secret": secret } : {};
 }
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2063

## Why this change

- Legacy Marinara stored browser Admin Access under `marinara_admin_secret`, while refactor only read and wrote `marinara-admin-secret`.
- Users with an existing legacy browser secret could hit privileged remote-runtime flows and look unauthenticated until they re-entered the same secret.

## What changed

- Added shared Admin Access storage helpers in `src/shared/api/remote-runtime.ts`.
- The helpers read the current key first, migrate a legacy-only value to the current key, trim stored values, and clear stale legacy data.
- Settings now initializes, saves, and clears Admin Access through the shared helper so the visible field and privileged remote headers agree.

## Refactor impact

Primary owner:

- Shared API / remote runtime and shell settings.

Impact areas reviewed:

- Remote Runtime privileged command header generation.
- Settings Advanced Admin Access field initialization/save/clear behavior.
- Browser localStorage compatibility for legacy and refactor key names.

Boundary notes:

- Feature UI calls a focused shared API wrapper; no raw remote-runtime fetch or raw Tauri boundary was added.
- No engine, Rust, schema, dependency, prompt, or release metadata changes.
- The migration is browser-local only and does not change the remote `ADMIN_SECRET` contract or `x-admin-secret` header name.

Pressure points touched:

- `src/shared/api/remote-runtime.ts` Admin Access header helper.
- `SettingsPanel` Advanced Admin Access control.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Before fix: static source repro against `origin/refactor` showed `remote-runtime.ts` had no `marinara_admin_secret`, `readAdminSecretStorage`, or `writeAdminSecretStorage` handling.
- After fix: `node scratch/repro-2063-admin-secret-key.mjs` passed.
- Scratch proof covered: legacy-only migration, current-key precedence when both keys exist, nonblank save trimming/current-key write, blank save clearing both keys, and no-window read returning empty.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:line-endings` passed.
- Full `pnpm check` passed after rebase onto current `origin/refactor`.
- Bunny review pass: pass. Non-blocking tooling note: `C:\Users\celia\.codex\tools\marinara-proof-gate.mjs` was not available locally, so the optional proof-gate helper could not be run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only. It preserves an existing Admin Access setting across the legacy/refactor browser-storage key change.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a browser-storage compatibility bugfix for the existing Admin Access setting and remote-runtime header path; scratch command proof is recorded under `scratch/`.
