### PR TITLE
Add remote retry metadata regression coverage

### DIFF
--- a/src/shared/api/remote-runtime.test.ts
+++ b/src/shared/api/remote-runtime.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "./api-errors";
+import { apiQueryRetryDelay, shouldRetryApiQuery } from "./query-retry";
+import { invokeRemote } from "./remote-runtime";
+import { useUIStore } from "../stores/ui.store";
+
+describe("remote runtime retry metadata", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useUIStore.setState({ remoteRuntimeUrl: "" });
+  });
+
+  it("preserves Retry-After on 429 API errors for query retry handling", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.example" });
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ code: "rate_limited", message: "Too many requests" }), {
+        headers: {
+          "content-type": "application/json",
+          "retry-after": "2",
+        },
+        status: 429,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let error: unknown;
+    try {
+      await invokeRemote("storage_list", { entity: "chats" });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/api/invoke",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      details: {
+        code: "rate_limited",
+        retryAfterMs: 2000,
+      },
+      status: 429,
+    });
+    expect(shouldRetryApiQuery(0, error)).toBe(true);
+    expect(apiQueryRetryDelay(0, error)).toBe(2000);
+  });
+});


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2066

## Why this change

- Issue #2066 asks for legacy-equivalent hostable API abuse/body/cache policy plus proof that `429` retry metadata reaches the remote client.
- Current `refactor` already has the server-side policy controls and Rust coverage from the related merged #2059 work, but this branch adds the missing tracked shared API regression proof for the client `Retry-After` consumer.

## What changed

- Added a focused `invokeRemote` regression test for `429` JSON responses with `Retry-After`.
- Verified the parsed `ApiError.details.retryAfterMs` value feeds `shouldRetryApiQuery` and `apiQueryRetryDelay`.

## Refactor impact

Primary owner:

- Shared API wrapper / remote runtime client.

Impact areas reviewed:

- `src/shared/api/remote-runtime.ts`
- `src/shared/api/query-retry.ts`
- `src-tauri/src/http_server.rs` API policy tests already present on current `refactor`

Boundary notes:

- The change stays in shared API test coverage. No React UI, engine behavior, Rust runtime code, schema, storage, dependency, or release metadata changed.
- Server-side rate/body/cache policy controls were not reworked here because current `upstream/refactor` already includes them from merged PR #2073.

Pressure points touched:

- Remote `/api/invoke` error parsing and retry metadata handling.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm exec vitest run src/shared/api/remote-runtime.test.ts`: passed, 1 test.
- Codex ran `cargo test --manifest-path src-tauri\Cargo.toml http_server::tests::api_ --lib`: passed, 9 tests.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Codex ran `pnpm check`: passed.
- Bunny pre-PR review: pass. The diff is one focused shared API regression test, current Rust policy tests cover the server-side policy rows, and no production/runtime boundary changed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal regression coverage only; no discoverable user surface is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is backend/shared API regression coverage with command proof, not a visible UI change.
