### PR TITLE
Fix remote runtime API cache policy

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,75 +1,85 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": "2063",
-    "title": "Admin Access should migrate the legacy browser secret key",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2063"
+    "number": 2070,
+    "title": "[Issue]: remote runtime JSON API calls lack legacy no-store cache policy",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2070"
   },
-  "pr": {
-    "number": "2087",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2087"
+  "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
+  "assignment": {
+    "assignee": "cha1latte",
+    "assignedBeforeWork": true
   },
-  "coreClaim": "Refactor web shell reads and migrates the legacy marinara_admin_secret Admin Access localStorage value to the current marinara-admin-secret key.",
+  "preflight": {
+    "noAssociatedPr": true,
+    "details": "workflow-health did not flag a duplicate for #2070; gh PR search for direct #2070 links returned no matches."
+  },
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "method": "Static source repro plus scratch helper proof",
-    "evidence": {
-      "0": "origin/refactor remote-runtime has no marinara_admin_secret/readAdminSecretStorage/writeAdminSecretStorage matches"
-    }
+    "method": "Static source repro plus regression test coverage",
+    "evidence": "Baseline HEAD src/shared/api/remote-runtime.ts did not contain cache: \"no-store\" fetch options; current tests assert the restored policy on every remote JSON/SSE fetch path."
   },
   "verification": {
     "originalReproPassed": true,
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
-    "baselineEvidence": "pnpm check passed after Bunny storage-mutation fix",
-    "edgeCases": {
-      "0": "Legacy-only localStorage value is trimmed, returned, migrated to marinara-admin-secret, and legacy key removed",
-      "1": "Current key wins when both current and legacy keys exist; stale legacy key is removed",
-      "2": "Saving a nonblank Admin Access value trims it, writes the current key, and removes the legacy key",
-      "3": "Saving blank Admin Access clears both current and legacy keys",
-      "4": "No-window/server-side read returns empty",
-      "5": "Current-key read survives failed legacy cleanup removeItem",
-      "6": "Legacy-only read returns the secret even if migration setItem throws"
-    },
-    "visualProof": "scratch/repro-2063-output.txt"
-  },
-  "manualBlockers": [],
-  "notes": {
-    "0": "Issue assigned to cha1latte before edits",
-    "1": "No local 2063 branch/worktree existed before worktree creation",
-    "2": "Proof gate helper unavailable at C:\\Users\\celia\\.codex\\tools\\marinara-proof-gate.mjs",
-    "3": "Rebased cleanly onto current origin/refactor before push",
-    "4": "PR body marks Feature Discoverability as N/A with reason for PR-aware discovery CI",
-    "5": "Addressed Bunny finding: legacy read can fail on migration write"
+    "baselineEvidence": "pnpm check passed after the final diff.",
+    "focusedProof": [
+      "pnpm test -- src/shared/api/remote-runtime.test.ts: passed 5 tests.",
+      "cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses: passed 1 test."
+    ],
+    "edgeCases": [
+      "Health and invoke readiness probes set cache: \"no-store\".",
+      "Normal /api/invoke command calls set cache: \"no-store\".",
+      "Generic JSON event streams, including /api/import/st-bulk/run, set cache: \"no-store\".",
+      "LLM stream and cancel calls set cache: \"no-store\".",
+      "Rust hostable response helper preserves explicit managed asset cache headers while applying no-store to JSON API responses."
+    ],
+    "visualProof": "Backend/logic proof captured as focused terminal command output in Codex transcript; no UI state exists for this cache-policy regression."
   },
   "riskClaimMatrix": {
-    "coreClaim": "Refactor web shell reads and migrates legacy Admin Access browser storage without requiring users to re-enter the secret.",
-    "riskType": "legacy browser localStorage compatibility",
-    "entrypoints": {
-      "0": "Settings Advanced Admin Access field initialization/save/clear",
-      "1": "shared remote-runtime privileged command header"
-    },
-    "currentPathsOrFormats": {
-      "0": "marinara-admin-secret localStorage key"
-    },
-    "legacyPathsOrFormats": {
-      "0": "marinara_admin_secret localStorage key"
-    },
-    "positiveRowsTested": {
-      "0": "legacy-only value migrates and is read",
-      "1": "current+legacy prefers current and cleans legacy",
-      "2": "save writes current key and removes legacy"
-    },
-    "negativeRowsTested": {
-      "0": "blank save clears both keys",
-      "1": "no-window read returns empty"
-    },
-    "groundTruthFacts": {
-      "0": "origin/refactor had only marinara-admin-secret in SettingsPanel and remote-runtime"
-    },
-    "userActionCopy": "No user action required when a legacy browser secret exists; clearing Admin Access clears both browser keys."
+    "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
+    "riskType": "remote runtime cache-policy compatibility",
+    "entrypoints": [
+      "src/shared/api/remote-runtime.ts health probe",
+      "src/shared/api/remote-runtime.ts /api/invoke calls",
+      "src/shared/api/remote-runtime.ts generic JSON/SSE stream calls",
+      "src/shared/api/remote-runtime.ts LLM stream and cancel calls",
+      "src-tauri/src/http_server.rs hostable HTTP response middleware"
+    ],
+    "currentPathsOrFormats": [
+      "/health",
+      "/api/invoke",
+      "/api/import/st-bulk/run",
+      "/api/llm/stream",
+      "/api/llm/stream/:stream_id/cancel",
+      "/api/assets/:kind/*path"
+    ],
+    "legacyPathsOrFormats": [
+      "legacy client shared API fetch cache: \"no-store\"",
+      "legacy server /api/* Cache-Control: no-store hook"
+    ],
+    "positiveRowsTested": [
+      "client health fetch",
+      "client invoke readiness fetch",
+      "client invoke fetch",
+      "client generic JSON event stream fetch",
+      "client LLM stream fetch",
+      "client LLM stream cancel fetch",
+      "server /api/invoke response helper"
+    ],
+    "negativeRowsTested": [
+      "server managed asset route preserves explicit public/no-cache headers",
+      "server non-api asset path does not receive API no-store header"
+    ],
+    "groundTruthFacts": [
+      "Harness-proven by cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses: http_server.rs applies no-store to API headers and preserves explicit managed asset cache headers.",
+      "Derived from git show HEAD:src/shared/api/remote-runtime.ts plus Select-String: baseline remote-runtime.ts lacked cache: \"no-store\" fetch options before this patch."
+    ],
+    "userActionCopy": "No user action required."
   },
+  "manualBlockers": [],
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -5,6 +5,10 @@
     "title": "[Issue]: remote runtime JSON API calls lack legacy no-store cache policy",
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2070"
   },
+  "pr": {
+    "number": 2090,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2090"
+  },
   "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
   "assignment": {
     "assignee": "cha1latte",

--- a/src/shared/api/remote-runtime.test.ts
+++ b/src/shared/api/remote-runtime.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "./api-errors";
 import { apiQueryRetryDelay, shouldRetryApiQuery } from "./query-retry";
-import { invokeRemote } from "./remote-runtime";
+import {
+  cancelRemoteLlmStream,
+  checkRemoteRuntimeHealth,
+  invokeRemote,
+  streamRemoteJsonEvents,
+  streamRemoteLlm,
+  type RuntimeTarget,
+} from "./remote-runtime";
 import { useUIStore } from "../stores/ui.store";
 
 describe("remote runtime retry metadata", () => {
@@ -46,5 +53,88 @@ describe("remote runtime retry metadata", () => {
     });
     expect(shouldRetryApiQuery(0, error)).toBe(true);
     expect(apiQueryRetryDelay(0, error)).toBe(2000);
+  });
+});
+
+describe("remote runtime cache policy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useUIStore.setState({ remoteRuntimeUrl: "" });
+  });
+
+  it("uses no-store for health and invoke readiness probes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, runtime: "marinara-server", writable: true }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await checkRemoteRuntimeHealth("http://runtime.example");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/health",
+      expect.objectContaining({ cache: "no-store", method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/api/invoke",
+      expect.objectContaining({ cache: "no-store", method: "POST" }),
+    );
+  });
+
+  it("uses no-store for remote invoke calls", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.example" });
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ id: "chat-1" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await invokeRemote("storage_get", { entity: "chats", id: "chat-1" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/api/invoke",
+      expect.objectContaining({ cache: "no-store", method: "POST" }),
+    );
+  });
+
+  it("uses no-store for generic JSON event streams", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.example" });
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ code: "failed", message: "stream failed" }), {
+        headers: { "content-type": "application/json" },
+        status: 503,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(streamRemoteJsonEvents("/api/import/st-bulk/run", { batchId: "batch-1" }).next()).rejects.toThrow(
+      ApiError,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/api/import/st-bulk/run",
+      expect.objectContaining({ cache: "no-store", method: "POST" }),
+    );
+  });
+
+  it("uses no-store for LLM stream and cancel calls", async () => {
+    const target: RuntimeTarget = { baseUrl: "http://runtime.example" };
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = streamRemoteLlm("stream-1", {} as Parameters<typeof streamRemoteLlm>[1], target);
+    await stream.next();
+    await cancelRemoteLlmStream("stream-1", target);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/api/llm/stream",
+      expect.objectContaining({ cache: "no-store", method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://runtime.example/api/llm/stream/stream-1/cancel",
+      expect.objectContaining({ cache: "no-store", method: "POST" }),
+    );
   });
 });

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -272,6 +272,13 @@ export function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): Heade
   };
 }
 
+function remoteFetchInit(init: RequestInit): RequestInit {
+  return {
+    ...init,
+    cache: "no-store",
+  };
+}
+
 function tryWriteAdminSecretStorage(write: () => void): void {
   try {
     write();
@@ -357,11 +364,11 @@ export async function checkRemoteRuntimeHealth(
   }
 
   try {
-    const response = await fetch(`${target.baseUrl}/health`, {
+    const response = await fetch(`${target.baseUrl}/health`, remoteFetchInit({
       method: "GET",
       headers: remoteHeaders(target, { accept: "application/json" }),
       signal: options.signal,
-    });
+    }));
 
     if (!response.ok) {
       return { status: "unreachable", message: `Remote runtime returned ${response.status}.` };
@@ -380,7 +387,7 @@ export async function checkRemoteRuntimeHealth(
       };
     }
 
-    const invokeReady = await fetch(`${target.baseUrl}/api/invoke`, {
+    const invokeReady = await fetch(`${target.baseUrl}/api/invoke`, remoteFetchInit({
       method: "POST",
       headers: remoteHeaders(target, { "content-type": "application/json" }),
       body: JSON.stringify({
@@ -391,7 +398,7 @@ export async function checkRemoteRuntimeHealth(
         },
       }),
       signal: options.signal,
-    });
+    }));
 
     if (!invokeReady.ok) {
       return {
@@ -454,11 +461,11 @@ function normalizeRemoteLlmChunk(event: LlmChunk): LlmChunk {
 export async function invokeRemote<T>(command: string, args?: Record<string, unknown>): Promise<T> {
   const target = remoteRuntimeTarget();
   if (!target) throw new ApiError("Remote runtime URL is not configured", 400);
-  const response = await fetch(`${target.baseUrl}/api/invoke`, {
+  const response = await fetch(`${target.baseUrl}/api/invoke`, remoteFetchInit({
     method: "POST",
     headers: remoteInvokeHeaders(target, command),
     body: JSON.stringify({ command, args: args ?? null }),
-  });
+  }));
   if (!response.ok) throw await readRemoteError(response);
   return (await response.json()) as T;
 }
@@ -470,7 +477,7 @@ export async function* streamRemoteJsonEvents(
 ): AsyncGenerator<{ type: string; data: unknown }> {
   const target = remoteRuntimeTarget();
   if (!target) throw new ApiError("Remote runtime URL is not configured", 400);
-  const response = await fetch(`${target.baseUrl}${path}`, {
+  const response = await fetch(`${target.baseUrl}${path}`, remoteFetchInit({
     method: "POST",
     headers: remoteHeaders(target, {
       "content-type": "application/json",
@@ -479,7 +486,7 @@ export async function* streamRemoteJsonEvents(
     }),
     body: JSON.stringify(body ?? null),
     signal: options.signal,
-  });
+  }));
   if (!response.ok) throw await readRemoteError(response);
   if (!response.body) throw new ApiError("Remote runtime did not return an event stream", 500);
 
@@ -548,12 +555,12 @@ export async function* streamRemoteLlm(
   target: RuntimeTarget,
   signal?: AbortSignal,
 ): AsyncGenerator<LlmChunk> {
-  const response = await fetch(`${target.baseUrl}/api/llm/stream`, {
+  const response = await fetch(`${target.baseUrl}/api/llm/stream`, remoteFetchInit({
     method: "POST",
     headers: remoteHeaders(target, { "content-type": "application/json", accept: "text/event-stream" }),
     body: JSON.stringify({ streamId, request }),
     signal,
-  });
+  }));
   if (!response.ok) throw await readRemoteError(response);
   if (!response.body) throw new ApiError("Remote runtime did not return a stream", 500);
 
@@ -584,10 +591,10 @@ export async function cancelRemoteLlmStream(streamId: string, target: RuntimeTar
     "remote",
     streamId,
     (async () => {
-      const response = await fetch(`${target.baseUrl}/api/llm/stream/${encodeURIComponent(streamId)}/cancel`, {
+      const response = await fetch(`${target.baseUrl}/api/llm/stream/${encodeURIComponent(streamId)}/cancel`, remoteFetchInit({
         method: "POST",
         headers: remoteHeaders(target),
-      });
+      }));
       if (!response.ok) throw await readRemoteError(response);
     })(),
   );


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2070

## Why this change

- Restores legacy no-store parity for remote runtime JSON/SSE client fetches so health checks, command calls, import streams, LLM streams, and cancel requests do not reuse stale browser/proxy cache entries.
- The hostable response-side no-store behavior is already present on current `refactor`; this PR keeps that behavior covered while fixing the remaining client fetch policy gap.

## What changed

- Added a shared `remoteFetchInit` helper that applies `cache: "no-store"` to remote runtime fetch calls.
- Routed health, `/api/invoke`, generic JSON/SSE event streams, `/api/llm/stream`, and stream cancel fetches through that helper.
- Added regression coverage for every changed remote fetch path.
- Updated `scratch/bugfix-verification.json` with the issue-2070 proof ledger.

## Refactor impact

Primary owner:

- Shared API wrapper / remote runtime.

Impact areas reviewed:

- `src/shared/api/remote-runtime.ts`
- `src/shared/api/remote-runtime.test.ts`
- Existing `src-tauri/src/http_server.rs` no-store/managed-asset cache header coverage

Boundary notes:

- Client-side remote fetch policy stays in `src/shared/api`.
- Hostable HTTP response cache policy remains in `src-tauri`; this PR does not change managed asset headers.
- No React feature UI, engine behavior, storage schema, auth, dependency, or release metadata changes.

Pressure points touched:

- Remote runtime health probe, invoke calls, JSON/SSE stream calls, LLM stream calls, and stream cancel calls.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm test -- src/shared/api/remote-runtime.test.ts`: passed, 5 tests.
- Codex ran `cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses`: passed, 1 test.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Codex ran `pnpm check`: passed.
- Codex ran Bunny before opening this draft: pass.
- Manual verification needed: none for the core claim; this is a cache-policy wrapper/header behavior with no visible UI state.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix for remote runtime cache policy; no new user-discoverable feature or setting is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a remote runtime cache-policy fix with no visible UI state; proof is command/test output plus the issue-2070 verification ledger.
