### PR TITLE
Add remote API body limit proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Set `CORS_ORIGINS` or `CSRF_TRUSTED_ORIGINS` when the desktop client origin is n
 runtime defaults. Use exact origins; `CORS_ORIGINS=*` does not grant browser-origin trust for
 mutating API requests.
 
+Remote API JSON and upload-style requests use an explicit 256 MiB request body limit. This matches
+the legacy server-level upload policy for `/api/invoke` and dedicated JSON API routes such as bulk
+import, embeddings, and LLM streaming. Requests over that limit return `413` with
+`request_body_too_large`; managed asset downloads keep their own cache and streaming behavior.
+
 With Docker Compose:
 
 ```sh

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1924,9 +1924,14 @@ mod tests {
         assert!(asset_headers.get(header::CACHE_CONTROL).is_none());
     }
 
-    #[test]
-    fn api_body_size_rejects_oversized_unsafe_api_requests() {
-        for path in ["/api/invoke", "/api/import/st-bulk/run", "/api/llm/stream"] {
+    #[tokio::test]
+    async fn api_body_size_rejects_oversized_unsafe_api_requests() {
+        for path in [
+            "/api/invoke",
+            "/api/import/st-bulk/run",
+            "/api/sidecar/v1/embeddings",
+            "/api/llm/stream",
+        ] {
             let request = request(
                 Method::POST,
                 path,
@@ -1937,13 +1942,21 @@ mod tests {
             let response = reject_oversized_api_body(&request)
                 .unwrap_or_else(|| panic!("{path} should reject oversized API bodies"));
             assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+            let cache_control = response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned);
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("oversized body response should be readable");
+            let payload: Value =
+                serde_json::from_slice(&bytes).expect("oversized body response should be JSON");
             assert_eq!(
-                response
-                    .headers()
-                    .get(header::CACHE_CONTROL)
-                    .and_then(|value| value.to_str().ok()),
-                Some("no-store")
+                payload.get("code").and_then(Value::as_str),
+                Some("request_body_too_large")
             );
+            assert_eq!(cache_control.as_deref(), Some("no-store"));
         }
     }
 

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1926,23 +1926,47 @@ mod tests {
 
     #[test]
     fn api_body_size_rejects_oversized_unsafe_api_requests() {
-        let request = request(
-            Method::POST,
-            "/api/invoke",
-            IpAddr::V4(Ipv4Addr::LOCALHOST),
-            &[("content-length", &(MAX_API_BODY_BYTES + 1).to_string())],
-        );
+        for path in ["/api/invoke", "/api/import/st-bulk/run", "/api/llm/stream"] {
+            let request = request(
+                Method::POST,
+                path,
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                &[("content-length", &(MAX_API_BODY_BYTES + 1).to_string())],
+            );
 
-        let response =
-            reject_oversized_api_body(&request).expect("oversized API body should reject");
-        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
-        assert_eq!(
-            response
-                .headers()
-                .get(header::CACHE_CONTROL)
-                .and_then(|value| value.to_str().ok()),
-            Some("no-store")
-        );
+            let response = reject_oversized_api_body(&request)
+                .unwrap_or_else(|| panic!("{path} should reject oversized API bodies"));
+            assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+            assert_eq!(
+                response
+                    .headers()
+                    .get(header::CACHE_CONTROL)
+                    .and_then(|value| value.to_str().ok()),
+                Some("no-store")
+            );
+        }
+    }
+
+    #[test]
+    fn api_body_size_allows_legacy_limit_boundary_for_json_upload_routes() {
+        for path in [
+            "/api/invoke",
+            "/api/import/st-bulk/run",
+            "/api/sidecar/v1/embeddings",
+            "/api/llm/stream",
+        ] {
+            let request = request(
+                Method::POST,
+                path,
+                IpAddr::V4(Ipv4Addr::LOCALHOST),
+                &[("content-length", &MAX_API_BODY_BYTES.to_string())],
+            );
+
+            assert!(
+                reject_oversized_api_body(&request).is_none(),
+                "{path} should allow API bodies at the legacy 256 MiB boundary"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2069

## Why this change

- The hostable Remote Runtime body-limit implementation already landed with the broader hostable API controls work, but the split body/upload issue still needed direct boundary proof and visible policy documentation.
- The split issue asks for an explicit default request body/upload policy, focused accepted/rejected boundary proof, and route coverage for large JSON/upload-style API paths.

## What changed

- Expanded `api_body_size_rejects_oversized_unsafe_api_requests` so oversized bodies are rejected on `/api/invoke` and dedicated JSON API routes.
- Added exact-boundary proof that `/api/invoke`, bulk import, embeddings, and LLM streaming allow requests at the legacy 256 MiB policy boundary.
- Documented the Remote Runtime 256 MiB JSON/upload-style request body policy, `413` response, and `request_body_too_large` code in `README.md`.

## Refactor impact

Primary owner:

- Remote runtime / hostable HTTP dispatch in `src-tauri`.

Impact areas reviewed:

- Hostable `/api/invoke`
- Dedicated hostable JSON API routes: `/api/import/st-bulk/run`, `/api/sidecar/v1/embeddings`, `/api/llm/stream`
- Remote Runtime README setup guidance

Boundary notes:

- The runtime behavior stays in `src-tauri/src/http_server.rs`; no React UI, engine, shared API wrapper, schema, dependency, auth, storage, prompt, or release metadata changed.
- This follow-up does not change the 256 MiB runtime policy added by the merged hostable controls work; it adds the split issue's proof and docs.

Pressure points touched:

- `src-tauri/src/http_server.rs` hostable API body-size tests.
- `README.md` Remote Runtime section.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Local proof ran `cargo test --manifest-path src-tauri/Cargo.toml api_body_size --lib`: 3 passed.
- Local proof ran `cargo check --manifest-path src-tauri/Cargo.toml`: passed.
- Local proof ran `pnpm check`: passed.
- Bunny pre-PR review: pass.
- The local proof-gate helper path from workflow notes was unavailable on this machine: `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal remote-runtime proof/docs follow-up only; no user-discoverable app surface is added.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a backend/hostable HTTP runtime proof and README update with command-level validation, not visible UI behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification regarding remote API request limits. Remote API JSON and upload-style requests are documented to have a 256 MiB maximum request body size. Requests exceeding this limit return HTTP 413 error code. Managed asset downloads retain their own independent caching and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->