### PR TITLE
Fix Windows launcher browser auto-open

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -279,9 +279,9 @@ echo    Press Ctrl+C to stop
 echo  ==========================================
 echo.
 
-:: Open browser after a short delay (use explorer.exe as fallback)
+:: Open browser after a short delay.
 if defined AUTO_OPEN_BROWSER_ENABLED (
-    start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://127.0.0.1:%PORT% || explorer %PROTOCOL%://127.0.0.1:%PORT%"
+    start "" powershell -NoProfile -WindowStyle Hidden -Command "Start-Sleep -Seconds 4; Start-Process '%PROTOCOL%://127.0.0.1:%PORT%'"
 ) else (
     echo  [OK] Auto-open disabled ^(AUTO_OPEN_BROWSER=%AUTO_OPEN_BROWSER%^)
 )


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #2089

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- The Windows launcher auto-open command used a nested `cmd /c` delayed launch with `timeout`, `start`, and `explorer`; the issue reporter says that command chain is flagged as a virus.
- This keeps the launcher behavior but swaps the browser-open path to the PowerShell `Start-Sleep` / `Start-Process` approach suggested in the issue.

## What changed

<!-- List the key changes in this PR -->

- Replaced the `start.bat` auto-open command with an async hidden PowerShell process.
- Preserved the existing `AUTO_OPEN_BROWSER=0|false|no|off` disabled branch.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- Describe exactly what you tested in a real browser/app, step by step. -->
<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Codex proof: `node scratch\verify-start-bat-auto-open.mjs before` detected the old nested `cmd /c timeout/start/explorer` command before the fix.
- Codex proof: `node scratch\verify-start-bat-auto-open.mjs after` confirmed the old command is absent, the PowerShell delayed open command is present, and the disabled `AUTO_OPEN_BROWSER` branch remains.
- Codex proof: `pnpm check` passed locally.
- Codex proof: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review: pass before opening the draft PR.
- Limitation: this environment cannot verify every antivirus/reputation engine; the machine proof covers removal of the reported command pattern from `start.bat`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

- No docs or version files were changed.

## UI evidence (if applicable)

Not a UI change. Command-proof visual artifact:

![Issue 2089 start.bat proof](https://gist.githubusercontent.com/cha1latte/2f53c726b69d4f32e4fae5605023840c/raw/c1838456fd42eccf12998ecd177fe9687149874e/issue-2089-proof.svg)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the application startup procedure to enhance browser auto-launch reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->