### PR TITLE
Fix inline thinking orphan close parsing

### DIFF
--- a/src/engine/generation-core/llm/inline-thinking.test.ts
+++ b/src/engine/generation-core/llm/inline-thinking.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { createInlineThinkingStreamParser } from "./inline-thinking";
+
+function parseInlineThinking(chunks: string[]): { content: string; thinking: string } {
+  const parser = createInlineThinkingStreamParser();
+  let content = "";
+  let thinking = "";
+
+  for (const chunk of chunks) {
+    for (const part of parser.push(chunk)) {
+      if (part.type === "content") content += part.text;
+      else thinking += part.text;
+    }
+  }
+
+  for (const part of parser.flush()) {
+    if (part.type === "content") content += part.text;
+    else thinking += part.text;
+  }
+
+  return { content, thinking };
+}
+
+describe("createInlineThinkingStreamParser", () => {
+  it("keeps reply text after a closed thinking block as content", () => {
+    expect(parseInlineThinking(["<thinking>\ninternal reasoning\n</thinking>\nThis is visible."])).toEqual({
+      thinking: "\ninternal reasoning\n",
+      content: "\nThis is visible.",
+    });
+  });
+
+  it("handles think tags followed by visible content without whitespace", () => {
+    expect(parseInlineThinking(["<think>reasoning</think>reply"])).toEqual({
+      thinking: "reasoning",
+      content: "reply",
+    });
+  });
+
+  it("preserves content when closing tags are split across stream chunks", () => {
+    expect(parseInlineThinking(["<thinking>reason", "ing</thin", "king>visible reply"])).toEqual({
+      thinking: "reasoning",
+      content: "visible reply",
+    });
+  });
+
+  it("accepts mismatched thinking close tag forms", () => {
+    expect(parseInlineThinking(["<thinking>reasoning</think>reply", "<think>more</thinking> text"])).toEqual({
+      thinking: "reasoningmore",
+      content: "reply text",
+    });
+  });
+
+  it("drops orphan closing thinking tags while preserving following reply text", () => {
+    expect(parseInlineThinking(["</thinking>reply"])).toEqual({
+      thinking: "",
+      content: "reply",
+    });
+  });
+
+  it("waits for split orphan closing tags before emitting following content", () => {
+    expect(parseInlineThinking(["</thin", "king>reply"])).toEqual({
+      thinking: "",
+      content: "reply",
+    });
+  });
+
+  it("keeps unrelated tags as visible content", () => {
+    expect(parseInlineThinking(["</not-thinking>reply <xml>visible</xml>"])).toEqual({
+      thinking: "",
+      content: "</not-thinking>reply <xml>visible</xml>",
+    });
+  });
+});

--- a/src/engine/generation-core/llm/inline-thinking.ts
+++ b/src/engine/generation-core/llm/inline-thinking.ts
@@ -41,6 +41,12 @@ export function createInlineThinkingStreamParser() {
           buffer = buffer.slice(opening[0].length);
           continue;
         }
+        const orphanClosing = buffer.match(CLOSE_THINKING_TAG_RE);
+        if (orphanClosing) {
+          buffer = buffer.slice(orphanClosing[0].length);
+          continue;
+        }
+        if (!final && possibleTagPrefix(buffer, true)) break;
         if (!final && possibleTagPrefix(buffer, false)) break;
         parts.push({ type: "content", text: buffer[0]! });
         buffer = buffer.slice(1);


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2092

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Some providers can emit inline thinking/reasoning close tags followed by visible reply text. If a close tag appears at content position, including an orphan close tag such as `</thinking>reply`, Marinara should drop only the tag markup and keep the reply as message content instead of exposing or losing the response body.

## What changed

<!-- List the key changes in this PR. -->

- Treat orphan inline thinking close tags as parser control markup while the stream parser is in content mode.
- Wait for split orphan close tags across stream chunks before emitting following visible content.
- Added focused parser regression coverage for `<thinking>`, `<think>`, mismatched tag forms, split close tags, orphan close tags, and unrelated tag negative controls.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

- Engine generation.

Impact areas reviewed:

- `src/engine/generation/start-generation.ts` inline token stream handling.
- `src/engine/generation-core/llm/inline-thinking.ts` push/flush parser behavior.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only parser change. No React feature imports, shared API adapters, Tauri commands, storage, provider configuration, or remote-runtime boundaries changed.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Runtime generation stream parsing only; no shell/mode surfaces, command registration, imports, or storage paths touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `node --experimental-strip-types scratch\issue-2092-inline-thinking-repro.ts`; the focused repro failed before the fix on `</thinking>reply` and passed after the fix.
- Codex ran `pnpm test -- src\engine\generation-core\llm\inline-thinking.test.ts`; 7 parser tests passed.
- Codex ran `pnpm check`; line endings, architecture, frontend typecheck, Rust check, docs, discovery, and unused-code checks passed.
- No browser UI validation was run because this is a parser-only engine generation fix with no visible UI layout or interaction change.
- Existing PR #2093 also references #2092, but targets `staging` from another fork and includes broader legacy/package paths. This draft is the focused `refactor`-targeted fix.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable user-facing feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A - parser-only engine generation fix. Proof is the focused stream-parser repro plus Vitest coverage above.
