### PR TITLE
Add lorebook context to Conversation schedule generation

### DIFF
--- a/src/engine/modes/chat/schedules/schedule.service.test.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.test.ts
@@ -161,7 +161,7 @@ describe("generateConversationSchedules lorebook context", () => {
             id: "entry-city",
             lorebookId: "active-lorebook",
             name: "Observatory District",
-            content: "The observatory district is busiest from midnight until dawn.",
+            content: "The observatory district is busiest from midnight until dawn.\n- Weekends have public tours.",
             enabled: true,
           },
           "entry-character": {
@@ -200,6 +200,7 @@ describe("generateConversationSchedules lorebook context", () => {
 
     expect(prompt).toContain("<schedule_lorebook_context>");
     expect(prompt).toContain("The observatory district is busiest from midnight until dawn.");
+    expect(prompt).toContain("- Weekends have public tours.");
     expect(prompt).toContain("Mira works the night shift at the observatory every weekday.");
     expect(prompt).not.toContain("This disabled entry should not appear.");
     expect(prompt).not.toContain("This inactive lorebook should not appear.");

--- a/src/engine/modes/chat/schedules/schedule.service.test.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import type { StorageGateway, StorageEntity, StorageListOptions } from "../../../capabilities/storage";
+import { generateConversationSchedules } from "./schedule.service";
+
+const scheduleResponse = JSON.stringify({
+  talkativeness: 50,
+  inactivityThresholdMinutes: 120,
+  days: {
+    Monday: [{ time: "00:00-00:00", activity: "free time", status: "online" }],
+  },
+});
+
+type Store = Partial<Record<StorageEntity, Record<string, Record<string, unknown>>>>;
+
+function createStorage(store: Store): StorageGateway {
+  return {
+    async list<T = unknown>(entity: StorageEntity, options?: StorageListOptions): Promise<T[]> {
+      const rows = Object.values(store[entity] ?? {});
+      if (!options?.filters) return rows as T[];
+      return rows.filter((row) =>
+        Object.entries(options.filters ?? {}).every(([key, value]) => row[key] === value),
+      ) as T[];
+    },
+    async get<T = unknown>(entity: StorageEntity, id: string): Promise<T | null> {
+      return ((store[entity] ?? {})[id] as T | undefined) ?? null;
+    },
+    async create<T = unknown>(entity: StorageEntity, value: Record<string, unknown>): Promise<T> {
+      const id = String(value.id ?? `${entity}-${Object.keys(store[entity] ?? {}).length + 1}`);
+      store[entity] = { ...(store[entity] ?? {}), [id]: { ...value, id } };
+      return store[entity]![id] as T;
+    },
+    async update<T = unknown>(entity: StorageEntity, id: string, patch: Record<string, unknown>): Promise<T> {
+      store[entity] = {
+        ...(store[entity] ?? {}),
+        [id]: { ...((store[entity] ?? {})[id] ?? {}), ...patch },
+      };
+      return store[entity]![id] as T;
+    },
+    async delete(): Promise<{ deleted: boolean }> {
+      return { deleted: true };
+    },
+    async listChatMessages<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async createChatMessage<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async updateChatMessage<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async deleteChatMessage(): Promise<{ deleted: boolean }> {
+      return { deleted: true };
+    },
+    async patchChatMessageExtra<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async addChatMessageSwipe<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async patchChatMetadata<T = unknown>(chatId: string, patch: Record<string, unknown>): Promise<T> {
+      const chat = (store.chats ?? {})[chatId] ?? {};
+      store.chats = { ...(store.chats ?? {}), [chatId]: { ...chat, metadata: patch } };
+      return store.chats[chatId] as T;
+    },
+    async patchChatSummaries<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async listChatMemories<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async getWorldState<T = unknown>(): Promise<T | null> {
+      return null as T | null;
+    },
+    async saveTrackerSnapshot<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async listLorebookEntries<T = unknown>(lorebookId: string): Promise<T[]> {
+      return Object.values(store["lorebook-entries"] ?? {}).filter((entry) => entry.lorebookId === lorebookId) as T[];
+    },
+    async createLorebookEntries<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async promptFull<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+  };
+}
+
+function baseStore(overrides: Store = {}): Store {
+  return {
+    chats: {
+      "chat-1": {
+        id: "chat-1",
+        mode: "conversation",
+        connectionId: "conn-1",
+        characterIds: ["char-1"],
+        metadata: { activeLorebookIds: ["active-lorebook"] },
+      },
+    },
+    characters: {
+      "char-1": {
+        id: "char-1",
+        data: {
+          name: "Mira",
+          description: "A careful astronomer.",
+          personality: "Thoughtful and nocturnal.",
+          tags: ["astronomer"],
+        },
+      },
+    },
+    connections: {
+      "conn-1": { id: "conn-1", model: "test-model" },
+    },
+    lorebooks: {},
+    "lorebook-entries": {},
+    "lorebook-folders": {},
+    ...overrides,
+  };
+}
+
+async function runSchedule(store: Store): Promise<string> {
+  let systemPrompt = "";
+  await generateConversationSchedules(
+    {
+      storage: createStorage(store),
+      llm: {
+        async complete(request) {
+          systemPrompt = String(request.messages.find((message) => message.role === "system")?.content ?? "");
+          return scheduleResponse;
+        },
+        async *stream() {
+          yield { type: "done" as const };
+        },
+        async listModels() {
+          return [];
+        },
+      },
+    },
+    { chatId: "chat-1", forceRefresh: true },
+  );
+  return systemPrompt;
+}
+
+describe("generateConversationSchedules lorebook context", () => {
+  it("includes scoped enabled lorebook entries in the schedule prompt", async () => {
+    const prompt = await runSchedule(
+      baseStore({
+        lorebooks: {
+          "active-lorebook": { id: "active-lorebook", name: "City Lore", enabled: true },
+          "character-lorebook": {
+            id: "character-lorebook",
+            name: "Mira Lore",
+            enabled: true,
+            characterIds: ["char-1"],
+          },
+          "inactive-lorebook": { id: "inactive-lorebook", name: "Unused Lore", enabled: true },
+        },
+        "lorebook-entries": {
+          "entry-city": {
+            id: "entry-city",
+            lorebookId: "active-lorebook",
+            name: "Observatory District",
+            content: "The observatory district is busiest from midnight until dawn.",
+            enabled: true,
+          },
+          "entry-character": {
+            id: "entry-character",
+            lorebookId: "character-lorebook",
+            name: "Night Shift",
+            content: "Mira works the night shift at the observatory every weekday.",
+            enabled: true,
+          },
+          "entry-disabled": {
+            id: "entry-disabled",
+            lorebookId: "active-lorebook",
+            name: "Disabled",
+            content: "This disabled entry should not appear.",
+            enabled: false,
+          },
+          "entry-other": {
+            id: "entry-other",
+            lorebookId: "inactive-lorebook",
+            name: "Other",
+            content: "This inactive lorebook should not appear.",
+            enabled: true,
+          },
+          "entry-filtered": {
+            id: "entry-filtered",
+            lorebookId: "active-lorebook",
+            name: "Other Character",
+            content: "This entry is filtered to another character.",
+            enabled: true,
+            characterFilterMode: "include",
+            characterFilterIds: ["char-2"],
+          },
+        },
+      }),
+    );
+
+    expect(prompt).toContain("<schedule_lorebook_context>");
+    expect(prompt).toContain("The observatory district is busiest from midnight until dawn.");
+    expect(prompt).toContain("Mira works the night shift at the observatory every weekday.");
+    expect(prompt).not.toContain("This disabled entry should not appear.");
+    expect(prompt).not.toContain("This inactive lorebook should not appear.");
+    expect(prompt).not.toContain("This entry is filtered to another character.");
+  });
+
+  it("caps oversized lorebook entries before injecting schedule context", async () => {
+    const prompt = await runSchedule(
+      baseStore({
+        lorebooks: {
+          "active-lorebook": { id: "active-lorebook", name: "Huge Lore", enabled: true },
+        },
+        "lorebook-entries": {
+          "entry-huge": {
+            id: "entry-huge",
+            lorebookId: "active-lorebook",
+            name: "Huge Routine",
+            content: `${"Routine fact. ".repeat(700)}TAIL_MARKER`,
+            enabled: true,
+          },
+        },
+      }),
+    );
+
+    expect(prompt).toContain("Huge Routine");
+    expect(prompt).toContain("Routine fact.");
+    expect(prompt).not.toContain("TAIL_MARKER");
+  });
+});

--- a/src/engine/modes/chat/schedules/schedule.service.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.ts
@@ -1,8 +1,12 @@
 import type { LlmGateway, LlmMessage } from "../../../capabilities/llm";
 import type { StorageGateway } from "../../../capabilities/storage";
+import type { LorebookEntry } from "../../../contracts/types/lorebook";
 import { parseJsonArray, parseJsonObject } from "../../../core/json";
+import { loadLorebookEntriesForActivationBatch } from "../../../generation/active-lorebook-scanner";
 import { boolish } from "../../../generation/runtime-records";
 import type { BaseLLMProvider, ChatMessage } from "../../../generation-core/llm/base-provider.js";
+import { resolveActiveLorebookScopeReason } from "../../../generation-core/lorebooks/active-lorebook-scope";
+import { lorebookEntryPassesContextFilters } from "../../../generation-core/lorebooks/keyword-scanner";
 import { readString as stringValue } from "../../../shared/value-readers";
 
 // ── Types ──
@@ -59,6 +63,8 @@ export interface GenerateConversationSchedulesResult {
 
 const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 const SCHEDULE_CONTINUITY_MAX_CHARS = 6000;
+const SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS = 6000;
+const SCHEDULE_LOREBOOK_ENTRY_MAX_CHARS = 1200;
 
 const STATUS_KEYWORDS: Record<string, "online" | "idle" | "dnd" | "offline"> = {
   sleep: "offline",
@@ -157,6 +163,13 @@ export async function generateConversationSchedules(
       const recentContinuityContext = existing
         ? buildScheduleContinuityContext({ meta, characterData, existingSchedule: existing })
         : undefined;
+      const scheduleLorebookContext = await buildScheduleLorebookContext(
+        capabilities.storage,
+        chat,
+        meta,
+        character,
+        characterData,
+      );
       const { schedule } = await generateCharacterSchedule(
         provider,
         model,
@@ -165,6 +178,7 @@ export async function generateConversationSchedules(
         stringValue(characterData.personality),
         userSchedulePreferences,
         recentContinuityContext,
+        scheduleLorebookContext,
       );
       const fullSchedule = preserveTimingSettings({ ...schedule, weekStart: mondayStr }, existing);
       newSchedules[characterId] = fullSchedule;
@@ -220,6 +234,7 @@ async function generateCharacterSchedule(
   characterPersonality: string,
   userSchedulePreferences?: string,
   recentContinuityContext?: string,
+  scheduleLorebookContext?: string,
 ): Promise<{ schedule: Omit<WeekSchedule, "weekStart">; raw: string }> {
   const systemPrompt = [
     `You are a schedule generator. Create a realistic weekly schedule for a character based on their personality and description.`,
@@ -237,6 +252,18 @@ async function generateCharacterSchedule(
           `<recent_continuity>`,
           recentContinuityContext.trim(),
           `</recent_continuity>`,
+          ``,
+        ]
+      : []),
+    ...(scheduleLorebookContext?.trim()
+      ? [
+          `Schedule lorebook context:`,
+          `The following lorebook facts are already active for this chat or character.`,
+          `Use them only when they imply durable weekly routine details, such as work, school, location, commute, obligations, sleep patterns, culture, or recurring responsibilities.`,
+          `Do not copy irrelevant lore into the schedule just because it is listed here.`,
+          `<schedule_lorebook_context>`,
+          scheduleLorebookContext.trim(),
+          `</schedule_lorebook_context>`,
           ``,
         ]
       : []),
@@ -485,6 +512,109 @@ function getDaySchedule(
   if (Array.isArray(direct)) return direct;
   const match = Object.entries(days).find(([key]) => key.toLowerCase() === day.toLowerCase());
   return Array.isArray(match?.[1]) ? match[1] : [];
+}
+
+function stringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((item) => stringValue(item).trim()).filter(Boolean);
+  if (typeof value !== "string" || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed.map((item) => stringValue(item).trim()).filter(Boolean) : [];
+  } catch {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function lorebookContextCharacterTags(character: JsonRecord, characterData: JsonRecord): string[] {
+  return uniqueStrings([...stringArray(character.tags), ...stringArray(characterData.tags)]);
+}
+
+function formatScheduleLorebookEntry(entry: LorebookEntry): string {
+  const title = entry.name.trim() || "Entry";
+  return `### ${title}\n${limitText(entry.content, SCHEDULE_LOREBOOK_ENTRY_MAX_CHARS)}`;
+}
+
+function appendCappedScheduleLoreContext(parts: string[], text: string, usedChars: number): number {
+  const trimmed = text.trim();
+  if (!trimmed) return usedChars;
+  const separatorLength = parts.length > 0 ? 2 : 0;
+  const remaining = SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS - usedChars - separatorLength;
+  if (remaining <= 0) return usedChars;
+  if (trimmed.length <= remaining) {
+    parts.push(trimmed);
+    return usedChars + separatorLength + trimmed.length;
+  }
+  if (remaining >= 80) {
+    parts.push(`${trimmed.slice(0, remaining - 3).trim()}...`);
+    return SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS;
+  }
+  return usedChars;
+}
+
+async function buildScheduleLorebookContext(
+  storage: StorageGateway,
+  chat: JsonRecord,
+  meta: JsonRecord,
+  character: JsonRecord,
+  characterData: JsonRecord,
+): Promise<string> {
+  const characterId = stringValue(character.id).trim();
+  if (!characterId) return "";
+
+  const personaId = stringValue(chat.personaId ?? meta.personaId).trim();
+  const lorebooks = await storage.list<JsonRecord>("lorebooks");
+  const scopedLorebooks = lorebooks
+    .map((book) => ({
+      book,
+      reason: resolveActiveLorebookScopeReason(book, {
+        chat,
+        characters: [{ id: characterId }],
+        persona: personaId ? { id: personaId } : null,
+      }),
+    }))
+    .filter((item): item is { book: JsonRecord; reason: NonNullable<typeof item.reason> } => !!item.reason);
+  if (scopedLorebooks.length === 0) return "";
+
+  const entriesByLorebookId = await loadLorebookEntriesForActivationBatch(
+    storage,
+    scopedLorebooks.map((item) => item.book),
+  );
+  const characterTags = lorebookContextCharacterTags(character, characterData);
+  const generationTriggers = ["chat", "conversation", "schedule"];
+  const parts: string[] = [];
+  let usedChars = 0;
+
+  for (const { book, reason } of scopedLorebooks) {
+    const lorebookId = stringValue(book.id).trim();
+    const entries = (entriesByLorebookId.get(lorebookId) ?? [])
+      .filter((entry) =>
+        lorebookEntryPassesContextFilters(entry, {
+          activeCharacterIds: [characterId],
+          activeCharacterTags: characterTags,
+          generationTriggers,
+        }),
+      )
+      .sort((a, b) => a.order - b.order);
+    if (entries.length === 0) continue;
+
+    const lorebookName = stringValue(book.name).trim() || reason.lorebookName || lorebookId || "Lorebook";
+    usedChars = appendCappedScheduleLoreContext(parts, `## ${lorebookName}`, usedChars);
+    if (usedChars >= SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS) break;
+    for (const entry of entries) {
+      usedChars = appendCappedScheduleLoreContext(parts, formatScheduleLorebookEntry(entry), usedChars);
+      if (usedChars >= SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS) break;
+    }
+    if (usedChars >= SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS) break;
+  }
+
+  return parts.join("\n\n");
 }
 
 function hasSchedules(value: unknown): value is CharacterSchedules {

--- a/src/engine/modes/chat/schedules/schedule.service.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.ts
@@ -47,6 +47,11 @@ interface CharacterSchedules {
 
 type JsonRecord = Record<string, unknown>;
 
+interface ScheduleLorebookContextSource {
+  lorebooks: JsonRecord[];
+  entriesByLorebookId: Map<string, LorebookEntry[]>;
+}
+
 export interface GenerateConversationSchedulesInput {
   chatId: string;
   forceRefresh?: boolean;
@@ -129,6 +134,11 @@ export async function generateConversationSchedules(
     otherChatSchedules = await loadOtherConversationSchedules(capabilities.storage, input.chatId);
     return otherChatSchedules;
   };
+  let scheduleLorebookContextSource: Promise<ScheduleLorebookContextSource> | null = null;
+  const getScheduleLorebookContextSource = () => {
+    scheduleLorebookContextSource ??= loadScheduleLorebookContextSource(capabilities.storage);
+    return scheduleLorebookContextSource;
+  };
 
   for (const characterId of characterIds) {
     const existing = existingSchedules[characterId];
@@ -164,7 +174,7 @@ export async function generateConversationSchedules(
         ? buildScheduleContinuityContext({ meta, characterData, existingSchedule: existing })
         : undefined;
       const scheduleLorebookContext = await buildScheduleLorebookContext(
-        capabilities.storage,
+        await getScheduleLorebookContextSource(),
         chat,
         meta,
         character,
@@ -536,16 +546,25 @@ function lorebookContextCharacterTags(character: JsonRecord, characterData: Json
   return uniqueStrings([...stringArray(character.tags), ...stringArray(characterData.tags)]);
 }
 
+function limitPromptBlockText(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  return trimmed.length > maxChars ? `${trimmed.slice(0, maxChars - 3).trimEnd()}...` : trimmed;
+}
+
 function formatScheduleLorebookEntry(entry: LorebookEntry): string {
   const title = entry.name.trim() || "Entry";
-  return `### ${title}\n${limitText(entry.content, SCHEDULE_LOREBOOK_ENTRY_MAX_CHARS)}`;
+  return `### ${title}\n${limitPromptBlockText(entry.content, SCHEDULE_LOREBOOK_ENTRY_MAX_CHARS)}`;
+}
+
+function remainingScheduleLoreContextChars(parts: string[], usedChars: number): number {
+  return SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS - usedChars - (parts.length > 0 ? 2 : 0);
 }
 
 function appendCappedScheduleLoreContext(parts: string[], text: string, usedChars: number): number {
   const trimmed = text.trim();
   if (!trimmed) return usedChars;
   const separatorLength = parts.length > 0 ? 2 : 0;
-  const remaining = SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS - usedChars - separatorLength;
+  const remaining = remainingScheduleLoreContextChars(parts, usedChars);
   if (remaining <= 0) return usedChars;
   if (trimmed.length <= remaining) {
     parts.push(trimmed);
@@ -555,11 +574,19 @@ function appendCappedScheduleLoreContext(parts: string[], text: string, usedChar
     parts.push(`${trimmed.slice(0, remaining - 3).trim()}...`);
     return SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS;
   }
-  return usedChars;
+  return SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS;
+}
+
+async function loadScheduleLorebookContextSource(storage: StorageGateway): Promise<ScheduleLorebookContextSource> {
+  const lorebooks = await storage.list<JsonRecord>("lorebooks");
+  return {
+    lorebooks,
+    entriesByLorebookId: await loadLorebookEntriesForActivationBatch(storage, lorebooks),
+  };
 }
 
 async function buildScheduleLorebookContext(
-  storage: StorageGateway,
+  source: ScheduleLorebookContextSource,
   chat: JsonRecord,
   meta: JsonRecord,
   character: JsonRecord,
@@ -569,8 +596,7 @@ async function buildScheduleLorebookContext(
   if (!characterId) return "";
 
   const personaId = stringValue(chat.personaId ?? meta.personaId).trim();
-  const lorebooks = await storage.list<JsonRecord>("lorebooks");
-  const scopedLorebooks = lorebooks
+  const scopedLorebooks = source.lorebooks
     .map((book) => ({
       book,
       reason: resolveActiveLorebookScopeReason(book, {
@@ -582,10 +608,6 @@ async function buildScheduleLorebookContext(
     .filter((item): item is { book: JsonRecord; reason: NonNullable<typeof item.reason> } => !!item.reason);
   if (scopedLorebooks.length === 0) return "";
 
-  const entriesByLorebookId = await loadLorebookEntriesForActivationBatch(
-    storage,
-    scopedLorebooks.map((item) => item.book),
-  );
   const characterTags = lorebookContextCharacterTags(character, characterData);
   const generationTriggers = ["chat", "conversation", "schedule"];
   const parts: string[] = [];
@@ -593,7 +615,7 @@ async function buildScheduleLorebookContext(
 
   for (const { book, reason } of scopedLorebooks) {
     const lorebookId = stringValue(book.id).trim();
-    const entries = (entriesByLorebookId.get(lorebookId) ?? [])
+    const entries = (source.entriesByLorebookId.get(lorebookId) ?? [])
       .filter((entry) =>
         lorebookEntryPassesContextFilters(entry, {
           activeCharacterIds: [characterId],
@@ -604,11 +626,28 @@ async function buildScheduleLorebookContext(
       .sort((a, b) => a.order - b.order);
     if (entries.length === 0) continue;
 
+    const formattedEntries = entries.map(formatScheduleLorebookEntry);
     const lorebookName = stringValue(book.name).trim() || reason.lorebookName || lorebookId || "Lorebook";
-    usedChars = appendCappedScheduleLoreContext(parts, `## ${lorebookName}`, usedChars);
+    const header = `## ${lorebookName}`;
+    const remainingBeforeHeader = remainingScheduleLoreContextChars(parts, usedChars);
+    if (remainingBeforeHeader <= 0) break;
+    if (remainingBeforeHeader < 80) {
+      usedChars = SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS;
+      break;
+    }
+    const remainingAfterHeader = remainingBeforeHeader - header.length - 2;
+    if (
+      remainingAfterHeader < 80 &&
+      !formattedEntries.some((entry) => entry.trim().length <= Math.max(0, remainingAfterHeader))
+    ) {
+      usedChars = SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS;
+      break;
+    }
+
+    usedChars = appendCappedScheduleLoreContext(parts, header, usedChars);
     if (usedChars >= SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS) break;
-    for (const entry of entries) {
-      usedChars = appendCappedScheduleLoreContext(parts, formatScheduleLorebookEntry(entry), usedChars);
+    for (const entry of formattedEntries) {
+      usedChars = appendCappedScheduleLoreContext(parts, entry, usedChars);
       if (usedChars >= SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS) break;
     }
     if (usedChars >= SCHEDULE_LOREBOOK_CONTEXT_MAX_CHARS) break;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2097

## Why this change

- Conversation schedule generation could only use character card fields, continuity, and the global schedule preferences box. Lorebook-backed routine facts such as jobs, locations, commutes, culture, or recurring obligations had to be copied into the card/chat/preferences manually.

## What changed

- Adds a capped schedule-lorebook context block to the Conversation schedule-generation prompt.
- Reuses existing active lorebook scope resolution so chat-selected, character-linked, persona-linked, chat-scoped, and global lorebooks follow the same relevance rules as the rest of the engine.
- Reuses existing lorebook entry activation loading so disabled entries and disabled folders stay excluded.
- Applies character/generation-trigger lorebook entry filters and caps oversized entry text before injection.
- Adds focused tests for included scoped lore, excluded lore, character-filtered lore, and oversized-entry truncation.

## Refactor impact

Primary owner:

Chat mode / React-free engine schedule generation.

Impact areas reviewed:

- `src/engine/modes/chat/schedules`
- Existing active lorebook scope and entry-loading helpers
- Architecture/import guard

Boundary notes:

- Keeps the change in React-free engine code.
- Does not add a Schedule Planner settings panel, editable prompt, schema field, or new agent type.
- Does not change normal chat prompt assembly; this only affects Conversation schedule generation when an LLM schedule is generated.

Pressure points touched:

- None of the listed broad pressure points. This does not touch ModeSurface, GameSurface, shared mode UI, Tauri command registration, or import modules.

## Validation

- [ ] Focused proof or matching lane command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm test -- src/engine/modes/chat/schedules/schedule.service.test.ts` — 2 tests passed.
- Codex ran `pnpm typecheck` — passed.
- Codex ran `pnpm check:architecture` — passed.
- Codex ran `pnpm check` — passed.
- Bunny review pass: local diff passed before PR open.
- Manual app verification not run; this is a non-UI prompt assembly behavior change covered by focused tests.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:
- N/A: this improves existing Conversation schedule generation behavior without adding a new UI surface, setting, mode, panel, or user-discoverable entry point.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A — no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Character schedules now include scoped lorebook context, enriching generated routines with relevant durable details (work, school, location, commute, obligations, sleep patterns) while avoiding irrelevant lore.

* **Tests**
  * Added tests for schedule generation with lore context, verifying entry filtering and that oversized lore content is capped before inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->