### PR TITLE
Fix Docker runtime data bind mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 # Local environment and app/runtime data
 .env
 .marinara-legacy-profile-import.json
+.docker-marinara-data/
 packages/
 
 # Rust / Tauri

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ docker compose up --build
 - `docker compose up --build` builds and starts the remote Rust runtime container. Its `/data`
   directory uses the Compose-managed `marinara-server-data` volume by default; set
   `MARINARA_HOST_DATA_DIR` to a copied app data directory when validating Docker migration parity.
+  Because the runtime stores records under `/data/data`, legacy Node data from
+  `packages/server/data/` should be copied into the host folder as a `data/` child, not mounted as
+  `/data` itself.
   Binding live app data directly can leave root-owned files on the host, so use the named volume
   or a throwaway copied directory for Docker tests.
   If you already tested with a host folder such as `.docker-marinara-data/`, set

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ docker compose up --build
 - `docker compose up --build` builds and starts the remote Rust runtime container. Its `/data`
   directory uses the Compose-managed `marinara-server-data` volume by default; set
   `MARINARA_HOST_DATA_DIR` to a copied app data directory when validating Docker migration parity.
+  Binding live app data directly can leave root-owned files on the host, so use the named volume
+  or a throwaway copied directory for Docker tests.
   If you already tested with a host folder such as `.docker-marinara-data/`, set
   `MARINARA_HOST_DATA_DIR=./.docker-marinara-data` to keep using that folder.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ docker compose up --build
 - `pnpm dev` runs the web shell only. Tauri-only capabilities will not all work there.
 - `marinara-server` runs the hostable Rust HTTP runtime. It hosts the Rust API only, not the React UI.
 - `docker compose up --build` builds and starts the remote Rust runtime container. Its `/data`
-  directory bind-mounts to `.docker-marinara-data/` by default; set `MARINARA_HOST_DATA_DIR`
-  to an existing app data directory when validating Docker migration parity.
+  directory uses the existing `marinara-server-data` named volume by default; set
+  `MARINARA_HOST_DATA_DIR` to a copied app data directory when validating Docker migration parity.
 
 ## Current Source Shape
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,9 @@ docker compose up --build
 - `pnpm tauri dev` is the normal desktop development command.
 - `pnpm dev` runs the web shell only. Tauri-only capabilities will not all work there.
 - `marinara-server` runs the hostable Rust HTTP runtime. It hosts the Rust API only, not the React UI.
-- `docker compose up --build` builds and starts the remote Rust runtime container.
+- `docker compose up --build` builds and starts the remote Rust runtime container. Its `/data`
+  directory bind-mounts to `.docker-marinara-data/` by default; set `MARINARA_HOST_DATA_DIR`
+  to an existing app data directory when validating Docker migration parity.
 
 ## Current Source Shape
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,10 @@ docker compose up --build
 - `pnpm dev` runs the web shell only. Tauri-only capabilities will not all work there.
 - `marinara-server` runs the hostable Rust HTTP runtime. It hosts the Rust API only, not the React UI.
 - `docker compose up --build` builds and starts the remote Rust runtime container. Its `/data`
-  directory uses the existing `marinara-server-data` named volume by default; set
+  directory uses the Compose-managed `marinara-server-data` volume by default; set
   `MARINARA_HOST_DATA_DIR` to a copied app data directory when validating Docker migration parity.
+  If you already tested with a host folder such as `.docker-marinara-data/`, set
+  `MARINARA_HOST_DATA_DIR=./.docker-marinara-data` to keep using that folder.
 
 ## Current Source Shape
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,13 @@ Docker Compose stores remote-runtime data in its Compose-managed
 `marinara-server-data` volume by default. To test migration against app data,
 copy that app data into a throwaway host folder and point
 `MARINARA_HOST_DATA_DIR` at the copy before starting Compose so the container and
-host read the same `/data` tree without rewriting live desktop data. If you
-already tested with a host folder such as `.docker-marinara-data/`, keep using
-that folder by setting `MARINARA_HOST_DATA_DIR=./.docker-marinara-data`.
+host read the same `/data` tree without rewriting live desktop data. The runtime
+stores records under `/data/data`, so legacy Node data from `packages/server/data/`
+should be copied into the host folder as a `data/` child, for example
+`.docker-marinara-data/data/`; do not point `MARINARA_HOST_DATA_DIR` directly at
+the `packages/server/data/` folder. If you already tested with a host folder such
+as `.docker-marinara-data/`, keep using that folder by setting
+`MARINARA_HOST_DATA_DIR=./.docker-marinara-data`.
 
 The Compose file is intended for same-machine browser access by default. It binds
 the host port to `127.0.0.1:8787` and enables the Docker bridge auth bypass so a

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ With Docker Compose:
 docker compose up --build
 ```
 
-Docker Compose stores remote-runtime data in the host-visible
-`.docker-marinara-data/` folder by default. To test migration against an
-existing app data directory, point `MARINARA_HOST_DATA_DIR` at that directory
-before starting Compose so the container and host read the same `/data` tree.
+Docker Compose stores remote-runtime data in the existing
+`marinara-server-data` named volume by default. To test migration against app
+data, copy that app data into a throwaway host folder and point
+`MARINARA_HOST_DATA_DIR` at the copy before starting Compose so the container and
+host read the same `/data` tree without rewriting live desktop data.
 
 The Compose file is intended for same-machine browser access by default. It binds
 the host port to `127.0.0.1:8787` and enables the Docker bridge auth bypass so a

--- a/README.md
+++ b/README.md
@@ -112,11 +112,13 @@ With Docker Compose:
 docker compose up --build
 ```
 
-Docker Compose stores remote-runtime data in the existing
-`marinara-server-data` named volume by default. To test migration against app
-data, copy that app data into a throwaway host folder and point
+Docker Compose stores remote-runtime data in its Compose-managed
+`marinara-server-data` volume by default. To test migration against app data,
+copy that app data into a throwaway host folder and point
 `MARINARA_HOST_DATA_DIR` at the copy before starting Compose so the container and
-host read the same `/data` tree without rewriting live desktop data.
+host read the same `/data` tree without rewriting live desktop data. If you
+already tested with a host folder such as `.docker-marinara-data/`, keep using
+that folder by setting `MARINARA_HOST_DATA_DIR=./.docker-marinara-data`.
 
 The Compose file is intended for same-machine browser access by default. It binds
 the host port to `127.0.0.1:8787` and enables the Docker bridge auth bypass so a

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ With Docker Compose:
 docker compose up --build
 ```
 
+Docker Compose stores remote-runtime data in the host-visible
+`.docker-marinara-data/` folder by default. To test migration against an
+existing app data directory, point `MARINARA_HOST_DATA_DIR` at that directory
+before starting Compose so the container and host read the same `/data` tree.
+
 The Compose file is intended for same-machine browser access by default. It binds
 the host port to `127.0.0.1:8787` and enables the Docker bridge auth bypass so a
 host browser can reach the container through the mapped local port. For LAN or

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     ports:
       - "127.0.0.1:8787:8787"
     volumes:
-      - marinara-server-data:/data
-
-volumes:
-  marinara-server-data:
+      - type: bind
+        source: ${MARINARA_HOST_DATA_DIR:-./.docker-marinara-data}
+        target: /data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     ports:
       - "127.0.0.1:8787:8787"
     volumes:
-      - type: bind
-        source: ${MARINARA_HOST_DATA_DIR:-./.docker-marinara-data}
-        target: /data
+      - ${MARINARA_HOST_DATA_DIR:-marinara-server-data}:/data
+
+volumes:
+  marinara-server-data:

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -293,8 +293,10 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
           To verify migration against app data, copy that data into a throwaway
           host folder and set <code>MARINARA_HOST_DATA_DIR</code> to the copy
           before starting Compose so the container and host share the same data
-          tree without rewriting live desktop data. If you already tested with a
-          host folder such as <code>.docker-marinara-data/</code>, set
+          tree without rewriting live desktop data. Binding live app data
+          directly can leave root-owned files on the host, so use the named
+          volume or a throwaway copied directory for Docker tests. If you
+          already tested with a host folder such as <code>.docker-marinara-data/</code>, set
           <code>MARINARA_HOST_DATA_DIR=./.docker-marinara-data</code> to keep
           using that folder.
         </p>

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -288,8 +288,8 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         <p>The compose service is intended for same-machine browser access by default and exposes:</p>
         <pre><code>http://127.0.0.1:8787</code></pre>
         <p>
-          Compose stores <code>/data</code> in the existing
-          Compose-managed <code>marinara-server-data</code> volume by default.
+          Compose stores <code>/data</code> in the Compose-managed
+          <code>marinara-server-data</code> volume by default.
           To verify migration against app data, copy that data into a throwaway
           host folder and set <code>MARINARA_HOST_DATA_DIR</code> to the copy
           before starting Compose so the container and host share the same data

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -289,11 +289,14 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         <pre><code>http://127.0.0.1:8787</code></pre>
         <p>
           Compose stores <code>/data</code> in the existing
-          <code>marinara-server-data</code> named volume by default. To verify
-          migration against app data, copy that data into a throwaway host
-          folder and set <code>MARINARA_HOST_DATA_DIR</code> to the copy before
-          starting Compose so the container and host share the same data tree
-          without rewriting live desktop data.
+          Compose-managed <code>marinara-server-data</code> volume by default.
+          To verify migration against app data, copy that data into a throwaway
+          host folder and set <code>MARINARA_HOST_DATA_DIR</code> to the copy
+          before starting Compose so the container and host share the same data
+          tree without rewriting live desktop data. If you already tested with a
+          host folder such as <code>.docker-marinara-data/</code>, set
+          <code>MARINARA_HOST_DATA_DIR=./.docker-marinara-data</code> to keep
+          using that folder.
         </p>
         <p>
           The default Compose port binding is limited to <code>127.0.0.1</code>. For LAN or

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -288,6 +288,13 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         <p>The compose service is intended for same-machine browser access by default and exposes:</p>
         <pre><code>http://127.0.0.1:8787</code></pre>
         <p>
+          Compose bind-mounts <code>/data</code> from the host-visible
+          <code>.docker-marinara-data/</code> folder by default. To verify
+          migration against an existing app data directory, set
+          <code>MARINARA_HOST_DATA_DIR</code> to that directory before starting
+          Compose so the container and host share the same data tree.
+        </p>
+        <p>
           The default Compose port binding is limited to <code>127.0.0.1</code>. For LAN or
           reverse-proxy access, intentionally change the bind address and configure
           <code>BASIC_AUTH_USER</code>/<code>BASIC_AUTH_PASS</code>, <code>IP_ALLOWLIST</code>, or another
@@ -295,7 +302,7 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         </p>
         <p>To build directly from GitHub, use Docker's remote git context:</p>
         <pre><code>docker build -t marinara-engine-server https://github.com/Pasta-Devs/Marinara-Engine.git#refactor
-docker run --rm -p 8787:8787 -v marinara-server-data:/data marinara-engine-server</code></pre>
+docker run --rm -p 127.0.0.1:8787:8787 -v "$(pwd)/.docker-marinara-data:/data" marinara-engine-server</code></pre>
 
         <h2>Checks</h2>
         <table>

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -293,10 +293,14 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
           To verify migration against app data, copy that data into a throwaway
           host folder and set <code>MARINARA_HOST_DATA_DIR</code> to the copy
           before starting Compose so the container and host share the same data
-          tree without rewriting live desktop data. Binding live app data
-          directly can leave root-owned files on the host, so use the named
-          volume or a throwaway copied directory for Docker tests. If you
-          already tested with a host folder such as <code>.docker-marinara-data/</code>, set
+          tree without rewriting live desktop data. The runtime stores records
+          under <code>/data/data</code>, so legacy Node data from
+          <code>packages/server/data/</code> should be copied into the host
+          folder as a <code>data/</code> child, not mounted as <code>/data</code>
+          itself. Binding live app data directly can leave root-owned files on
+          the host, so use the named volume or a throwaway copied directory for
+          Docker tests. If you already tested with a host folder such as
+          <code>.docker-marinara-data/</code>, set
           <code>MARINARA_HOST_DATA_DIR=./.docker-marinara-data</code> to keep
           using that folder.
         </p>

--- a/docs/developer/run-build.html
+++ b/docs/developer/run-build.html
@@ -288,11 +288,12 @@ MARINARA_DATA_DIR=/path/to/data</code></pre>
         <p>The compose service is intended for same-machine browser access by default and exposes:</p>
         <pre><code>http://127.0.0.1:8787</code></pre>
         <p>
-          Compose bind-mounts <code>/data</code> from the host-visible
-          <code>.docker-marinara-data/</code> folder by default. To verify
-          migration against an existing app data directory, set
-          <code>MARINARA_HOST_DATA_DIR</code> to that directory before starting
-          Compose so the container and host share the same data tree.
+          Compose stores <code>/data</code> in the existing
+          <code>marinara-server-data</code> named volume by default. To verify
+          migration against app data, copy that data into a throwaway host
+          folder and set <code>MARINARA_HOST_DATA_DIR</code> to the copy before
+          starting Compose so the container and host share the same data tree
+          without rewriting live desktop data.
         </p>
         <p>
           The default Compose port binding is limited to <code>127.0.0.1</code>. For LAN or


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

No linked GitHub issue yet. This is from a reported refactor Docker migration parity bug where the remote runtime container could not see the expected app data folder.

## Why this change

- Docker Compose persists `/data` in a named Docker volume by default. That is safe for existing Docker users, but testers also need an intentional way to bind copied app data into the runtime for migration parity checks.

## What changed

- Kept the Compose-managed `marinara-server-data` volume as the default Compose `/data` mount.
- Added `MARINARA_HOST_DATA_DIR` as an override for binding a copied app data directory into the container.
- Documented how earlier `.docker-marinara-data/` test users can keep using that folder explicitly with `MARINARA_HOST_DATA_DIR`.
- Updated README, contributing docs, and developer docs to explain the Docker data path and migration-parity workflow.
- Ignored `.docker-marinara-data/` in git.

## Refactor impact

Primary owner:

Remote runtime / Docker runtime configuration.

Impact areas reviewed:

- Docker Compose runtime data mount
- Remote runtime `MARINARA_DATA_DIR=/data` contract
- README, CONTRIBUTING, and developer run/build docs

Boundary notes:

- No engine, feature UI, shared API, Tauri command, or Rust storage migration code changed.
- The fix is a runtime configuration contract change: Compose preserves the existing Docker data volume by default while allowing an explicit host bind mount for migration parity testing.

Pressure points touched:

- Docker remote runtime data persistence and migration parity.
- No ModeSurface, GameSurface, command registration, or import modules touched.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->

- [ ] Focused proof or matching lane command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex focused proof: `node scratch\docker-data-volume-repro.mjs` passed after confirming Compose preserves the Compose-managed `marinara-server-data` default and supports `MARINARA_HOST_DATA_DIR`.
- Codex default config proof: `docker compose config` resolved `/data` to the Compose-managed `marinara-server-data` volume.
- Codex override proof: `MARINARA_HOST_DATA_DIR=C:\tmp\marinara-docker-data docker compose config` resolved `/data` to the host bind mount `C:\tmp\marinara-docker-data`.
- Codex docs check: `pnpm check:docs` passed.
- Codex pre-PR gate: `pnpm check` passed.
- Bunny review: passed before PR open; later Bunny comments about volume compatibility, project-scoped volume wording, and live-data/root-write risk were addressed by keeping the Compose-managed volume default, documenting migration parity against copied app data, warning about root-owned host files, and documenting the `.docker-marinara-data/` compatibility override.
- Manual gap: actual migration with the reporter's copied app data folder was not run in this environment. Keep the PR draft until someone points `MARINARA_HOST_DATA_DIR` at a throwaway copy of real app data and confirms the migration path behaves as expected.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:
- This is a Docker runtime compatibility/configuration fix and documentation update, not an in-app discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs updated: README, CONTRIBUTING, and developer run/build docs now describe the default Compose-managed Docker data volume, `.docker-marinara-data/` compatibility override, root-owned-file risk, and migration-parity override.

## UI evidence

N/A. No visible UI changed.
