### PR TITLE
Fix empty new chat setup cleanup

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,92 +1,84 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2070,
-    "title": "[Issue]: remote runtime JSON API calls lack legacy no-store cache policy",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2070"
+    "number": 2101,
+    "title": "[Issue]: New Conversation and New Chat can create completely empty conversations",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2101"
   },
-  "pr": {
-    "number": 2090,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2090"
-  },
-  "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
+  "coreClaim": "New Conversation and New Chat setup does not keep a persisted chat when setup finishes with no messages and no selected characters.",
   "assignment": {
     "assignee": "cha1latte",
     "assignedBeforeWork": true
   },
   "preflight": {
     "noAssociatedPr": true,
-    "details": "workflow-health did not flag a duplicate for #2070; gh PR search for direct #2070 links returned no matches."
+    "details": "gh issue view showed no comments or linked fix. gh PR search for 2101 found only unrelated closed PR #1238."
   },
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "method": "Static source repro plus regression test coverage",
-    "evidence": "Baseline HEAD src/shared/api/remote-runtime.ts did not contain cache: \"no-store\" fetch options; current tests assert the restored policy on every remote JSON/SSE fetch path."
+    "method": "Static source repro from upstream/refactor.",
+    "evidence": "On upstream/refactor, useStartNewChat and ModeHomeSurface create a chat with characterIds: [], ChatSetupWizard keeps Start Chatting disabled until characters exist, and the Skip buttons call onFinish. ConversationModeRoute and RoleplayModeRoute passed overlays.finishWizard as onWizardFinish, which only closed the wizard/opened settings and did not delete the placeholder."
   },
   "verification": {
     "originalReproPassed": true,
-    "baselinePassed": true,
-    "baselineCommand": "pnpm check",
-    "baselineEvidence": "pnpm check passed after the final diff.",
     "focusedProof": [
-      "pnpm test -- src/shared/api/remote-runtime.test.ts: passed 5 tests.",
-      "cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses: passed 1 test."
+      "pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts: passed 4 tests.",
+      "pnpm typecheck: passed.",
+      "pnpm check: passed."
     ],
     "edgeCases": [
-      "Health and invoke readiness probes set cache: \"no-store\".",
-      "Normal /api/invoke command calls set cache: \"no-store\".",
-      "Generic JSON event streams, including /api/import/st-bulk/run, set cache: \"no-store\".",
-      "LLM stream and cancel calls set cache: \"no-store\".",
-      "Rust hostable response helper preserves explicit managed asset cache headers while applying no-store to JSON API responses."
+      "Empty persisted setup placeholder with no characters and zero messages is classified for cleanup.",
+      "Setup with at least one selected character is kept.",
+      "Setup with at least one message is kept.",
+      "Unloaded chat state is not treated as an empty placeholder."
     ],
-    "visualProof": "Backend/logic proof captured as focused terminal command output in Codex transcript; no UI state exists for this cache-policy regression."
+    "baselinePassed": true,
+    "baselineCommand": "pnpm check",
+    "baselineEvidence": "pnpm check passed after fixing the public chat-ui export boundary.",
+    "visualProof": "Static/terminal proof only; no local Tauri shell UI was available for a screenshot of the affected persisted-state flow."
   },
+  "manualBlockers": [
+    {
+      "description": "True Tauri-shell click-through of New Conversation/New Chat persistence requires the desktop shell/runtime state; local proof uses static source reproduction plus focused regression tests.",
+      "blockingCoreClaim": false
+    }
+  ],
   "riskClaimMatrix": {
-    "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
-    "riskType": "remote runtime cache-policy compatibility",
+    "coreClaim": "New chat setup cleanup deletes only empty setup placeholders and keeps configured or messaged chats.",
+    "riskType": "persisted chat cleanup",
     "entrypoints": [
-      "src/shared/api/remote-runtime.ts health probe",
-      "src/shared/api/remote-runtime.ts /api/invoke calls",
-      "src/shared/api/remote-runtime.ts generic JSON/SSE stream calls",
-      "src/shared/api/remote-runtime.ts LLM stream and cancel calls",
-      "src-tauri/src/http_server.rs hostable HTTP response middleware"
+      "src/app/shell/useStartNewChat.ts new chat action",
+      "src/features/modes/router/components/ModeHomeSurface.tsx quick start",
+      "src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx gated setup",
+      "src/features/modes/conversation/components/ConversationModeRoute.tsx setup finish",
+      "src/features/modes/roleplay/components/RoleplayModeRoute.tsx setup finish"
     ],
     "currentPathsOrFormats": [
-      "/health",
-      "/api/invoke",
-      "/api/import/st-bulk/run",
-      "/api/llm/stream",
-      "/api/llm/stream/:stream_id/cancel",
-      "/api/assets/:kind/*path"
+      "conversation chat records with no messages and no characterIds",
+      "roleplay chat records with no messages and no characterIds"
     ],
     "legacyPathsOrFormats": [
-      "legacy client shared API fetch cache: \"no-store\"",
-      "legacy server /api/* Cache-Control: no-store hook"
+      "existing persisted chats that already have messages",
+      "existing persisted chats that already have selected characters"
     ],
     "positiveRowsTested": [
-      "client health fetch",
-      "client invoke readiness fetch",
-      "client invoke fetch",
-      "client generic JSON event stream fetch",
-      "client LLM stream fetch",
-      "client LLM stream cancel fetch",
-      "server /api/invoke response helper"
+      "empty chat setup placeholder is classified for cleanup"
     ],
     "negativeRowsTested": [
-      "server managed asset route preserves explicit public/no-cache headers",
-      "server non-api asset path does not receive API no-store header"
+      "chat with characterIds is not classified for cleanup",
+      "chat with messages is not classified for cleanup",
+      "null/unloaded chat is not classified for cleanup"
     ],
     "groundTruthFacts": [
-      "Harness-proven by cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses: http_server.rs applies no-store to API headers and preserves explicit managed asset cache headers.",
-      "Derived from git show HEAD:src/shared/api/remote-runtime.ts plus Select-String: baseline remote-runtime.ts lacked cache: \"no-store\" fetch options before this patch."
+      "Derived from artifact: upstream/refactor source inspection recorded in reproduction.evidence shows Skip called onFinish while Start Chatting was disabled without characters.",
+      "Harness-proven: pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts passed and covers empty, configured, messaged, and unloaded chat rows."
     ],
     "userActionCopy": "No user action required."
   },
-  "manualBlockers": [],
   "finalDoneGate": {
     "didFixBug": true,
-    "hasProfessionalVisualProof": true,
+    "hasProfessionalVisualProof": false,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true
   }

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -36,7 +36,8 @@
       "Known setup placeholder is still classified for cleanup before message rows finish loading.",
       "Setup with at least one selected character is kept.",
       "Setup with at least one message is kept.",
-      "Unrelated empty chats are not treated as setup placeholders."
+      "Unrelated empty chats are not treated as setup placeholders.",
+      "Legacy wizard open retains setup identity after clearing legacy store flags; cancellation and active chat changes still clear it."
     ],
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
@@ -79,7 +80,8 @@
     ],
     "groundTruthFacts": [
       "Derived from artifact: upstream/refactor source inspection recorded in reproduction.evidence shows Skip called onFinish while Start Chatting was disabled without characters.",
-      "Harness-proven: pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts passed and covers empty setup, unloaded setup, configured, messaged, and unrelated empty chat rows."
+      "Harness-proven: pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts passed and covers empty setup, unloaded setup, configured, messaged, and unrelated empty chat rows.",
+      "Derived from artifact: diff inspection shows legacy setup flag cleanup no longer clears newChatSetupChatId after a successful wizard open; scheduled cancellation, explicit clearNewChatSetup, finishWizard, and active chat changes still clear it."
     ],
     "userActionCopy": "No user action required."
   },

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -27,15 +27,16 @@
   "verification": {
     "originalReproPassed": true,
     "focusedProof": [
-      "pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts: passed 4 tests.",
+      "pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts: passed 5 tests.",
       "pnpm typecheck: passed.",
       "pnpm check: passed."
     ],
     "edgeCases": [
-      "Empty persisted setup placeholder with no characters and zero messages is classified for cleanup.",
+      "Empty persisted setup placeholder with no characters and zero messages is classified for cleanup only when it matches the retained setup chat id.",
+      "Known setup placeholder is still classified for cleanup before message rows finish loading.",
       "Setup with at least one selected character is kept.",
       "Setup with at least one message is kept.",
-      "Unloaded chat state is not treated as an empty placeholder."
+      "Unrelated empty chats are not treated as setup placeholders."
     ],
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
@@ -55,6 +56,7 @@
       "src/app/shell/useStartNewChat.ts new chat action",
       "src/features/modes/router/components/ModeHomeSurface.tsx quick start",
       "src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx gated setup",
+      "src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts retained setup identity",
       "src/features/modes/conversation/components/ConversationModeRoute.tsx setup finish",
       "src/features/modes/roleplay/components/RoleplayModeRoute.tsx setup finish"
     ],
@@ -67,16 +69,17 @@
       "existing persisted chats that already have selected characters"
     ],
     "positiveRowsTested": [
-      "empty chat setup placeholder is classified for cleanup"
+      "empty chat setup placeholder is classified for cleanup",
+      "known setup placeholder with unloaded message rows is classified for cleanup"
     ],
     "negativeRowsTested": [
       "chat with characterIds is not classified for cleanup",
       "chat with messages is not classified for cleanup",
-      "null/unloaded chat is not classified for cleanup"
+      "unrelated empty chat id is not classified for cleanup"
     ],
     "groundTruthFacts": [
       "Derived from artifact: upstream/refactor source inspection recorded in reproduction.evidence shows Skip called onFinish while Start Chatting was disabled without characters.",
-      "Harness-proven: pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts passed and covers empty, configured, messaged, and unloaded chat rows."
+      "Harness-proven: pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts passed and covers empty setup, unloaded setup, configured, messaged, and unrelated empty chat rows."
     ],
     "userActionCopy": "No user action required."
   },

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -5,6 +5,10 @@
     "title": "[Issue]: New Conversation and New Chat can create completely empty conversations",
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2101"
   },
+  "pr": {
+    "number": 2103,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2103"
+  },
   "coreClaim": "New Conversation and New Chat setup does not keep a persisted chat when setup finishes with no messages and no selected characters.",
   "assignment": {
     "assignee": "cha1latte",

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -112,6 +112,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
     void deleteChat
       .mutateAsync(cancellingChatId)
       .then(() => {
+        overlays.clearNewChatSetup();
         if (useChatStore.getState().activeChatId === cancellingChatId) setActiveChatId(null);
       })
       .catch(() => {
@@ -122,16 +123,25 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
   const handleFinishNewConversationSetup = useCallback(() => {
     if (
       isEmptyNewChatSetup({
-        chat: data.chat,
+        activeChatId,
+        setupChatId: overlays.newChatSetupChatId,
         chatCharIds: data.chatCharIds,
         totalMessageCount: data.totalMessageCount,
+        messagesLoaded: data.messages !== undefined,
       })
     ) {
       handleCancelNewConversationSetup();
       return;
     }
     overlays.finishWizard();
-  }, [data.chat, data.chatCharIds, data.totalMessageCount, handleCancelNewConversationSetup, overlays]);
+  }, [
+    activeChatId,
+    data.chatCharIds,
+    data.messages,
+    data.totalMessageCount,
+    handleCancelNewConversationSetup,
+    overlays,
+  ]);
 
   const cardCssMode = (() => {
     const mode = data.chatMeta.cardCssMode;

--- a/src/features/modes/conversation/components/ConversationModeRoute.tsx
+++ b/src/features/modes/conversation/components/ConversationModeRoute.tsx
@@ -11,6 +11,7 @@ import {
   useChatTranscriptShortcuts,
   useChatTtsAutoplay,
   useSpriteMetadataState,
+  isEmptyNewChatSetup,
 } from "../../shared/chat-ui/index";
 import { useDeleteChat } from "../../../catalog/chats/index";
 import { ChatConversationSurface } from "./ChatConversationSurface";
@@ -118,6 +119,20 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
       });
   }, [activeChatId, deleteChat, overlays, setActiveChatId]);
 
+  const handleFinishNewConversationSetup = useCallback(() => {
+    if (
+      isEmptyNewChatSetup({
+        chat: data.chat,
+        chatCharIds: data.chatCharIds,
+        totalMessageCount: data.totalMessageCount,
+      })
+    ) {
+      handleCancelNewConversationSetup();
+      return;
+    }
+    overlays.finishWizard();
+  }, [data.chat, data.chatCharIds, data.totalMessageCount, handleCancelNewConversationSetup, overlays]);
+
   const cardCssMode = (() => {
     const mode = data.chatMeta.cardCssMode;
     if (mode === "disabled" || mode === "exclusive") return mode;
@@ -178,7 +193,7 @@ export function ConversationModeRoute({ activeChatId }: ConversationModeRoutePro
         onCloseFiles={overlays.closeFiles}
         onCloseGallery={overlays.closeGallery}
         onIllustrate={timeline.handleIllustrate}
-        onWizardFinish={overlays.finishWizard}
+        onWizardFinish={handleFinishNewConversationSetup}
         onWizardCancel={handleCancelNewConversationSetup}
         onClosePeekPrompt={timeline.closePeekPrompt}
         onResetSpritePlacements={spriteState.handleResetSpritePlacements}

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -5,6 +5,7 @@ import { useEncounterStore } from "../../../../shared/stores/encounter.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 import { spriteApi } from "../../../../shared/api/image-generation-api";
 import { agentConfigEnabled, useAgentConfigs, type AgentConfigRow } from "../../../catalog/agents/index";
+import { useDeleteChat } from "../../../catalog/chats/index";
 import { spriteKeys, type SpriteInfo } from "../../../catalog/sprites/index";
 import {
   type ExpressionAvatarResolver,
@@ -17,6 +18,7 @@ import {
   useChatTranscriptShortcuts,
   useChatTtsAutoplay,
   useSpriteMetadataState,
+  isEmptyNewChatSetup,
 } from "../../shared/chat-ui/index";
 import { useEncounter } from "../encounter/hooks/use-encounter";
 import { useAgentInjectionReview } from "../hooks/use-agent-injection-review";
@@ -74,6 +76,8 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
   const centerCompact = useUIStore((state) => state.centerCompact);
   const weatherEffects = useUIStore((state) => state.weatherEffects);
   const pendingNewChatMode = useChatStore((state) => state.pendingNewChatMode);
+  const setActiveChatId = useChatStore((state) => state.setActiveChatId);
+  const deleteChat = useDeleteChat();
   const overlays = useChatOverlays(activeChatId);
   const data = useChatSurfaceData({
     activeChatId,
@@ -279,6 +283,29 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
     [activeChatId, forkScene, isForking, timeline.isStreaming],
   );
 
+  const handleFinishNewRoleplaySetup = useCallback(() => {
+    if (
+      isEmptyNewChatSetup({
+        chat: data.chat,
+        chatCharIds: data.chatCharIds,
+        totalMessageCount: data.totalMessageCount,
+      })
+    ) {
+      const cancellingChatId = activeChatId;
+      overlays.setWizardOpen(false);
+      void deleteChat
+        .mutateAsync(cancellingChatId)
+        .then(() => {
+          if (useChatStore.getState().activeChatId === cancellingChatId) setActiveChatId(null);
+        })
+        .catch(() => {
+          if (useChatStore.getState().activeChatId === cancellingChatId) overlays.setWizardOpen(true);
+        });
+      return;
+    }
+    overlays.finishWizard();
+  }, [activeChatId, data.chat, data.chatCharIds, data.totalMessageCount, deleteChat, overlays, setActiveChatId]);
+
   const cardCssMode = (() => {
     const mode = data.chatMeta.cardCssMode;
     if (mode === "disabled" || mode === "exclusive") return mode;
@@ -376,7 +403,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
         onCloseFiles={overlays.closeFiles}
         onCloseGallery={overlays.closeGallery}
         onIllustrate={timeline.handleIllustrate}
-        onWizardFinish={overlays.finishWizard}
+        onWizardFinish={handleFinishNewRoleplaySetup}
         onClosePeekPrompt={timeline.closePeekPrompt}
         onResetSpritePlacements={spriteState.handleResetSpritePlacements}
         onSpriteSideChange={spriteState.handleSetSpritePosition}

--- a/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
+++ b/src/features/modes/roleplay/components/RoleplayModeRoute.tsx
@@ -286,9 +286,11 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
   const handleFinishNewRoleplaySetup = useCallback(() => {
     if (
       isEmptyNewChatSetup({
-        chat: data.chat,
+        activeChatId,
+        setupChatId: overlays.newChatSetupChatId,
         chatCharIds: data.chatCharIds,
         totalMessageCount: data.totalMessageCount,
+        messagesLoaded: data.messages !== undefined,
       })
     ) {
       const cancellingChatId = activeChatId;
@@ -296,6 +298,7 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
       void deleteChat
         .mutateAsync(cancellingChatId)
         .then(() => {
+          overlays.clearNewChatSetup();
           if (useChatStore.getState().activeChatId === cancellingChatId) setActiveChatId(null);
         })
         .catch(() => {
@@ -304,7 +307,15 @@ export function RoleplayModeRoute({ activeChatId, fallbackChatMode = "roleplay" 
       return;
     }
     overlays.finishWizard();
-  }, [activeChatId, data.chat, data.chatCharIds, data.totalMessageCount, deleteChat, overlays, setActiveChatId]);
+  }, [
+    activeChatId,
+    data.chatCharIds,
+    data.messages,
+    data.totalMessageCount,
+    deleteChat,
+    overlays,
+    setActiveChatId,
+  ]);
 
   const cardCssMode = (() => {
     const mode = data.chatMeta.cardCssMode;

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -116,17 +116,20 @@ export function useChatOverlays(activeChatId: string) {
       const clearLegacyFlags = () => {
         useChatStore.getState().setShouldOpenWizard(false);
         useChatStore.getState().setShouldOpenSettings(false);
+      };
+      const cancelLegacyOpen = () => {
+        clearLegacyFlags();
         setNewChatSetupChatId(null);
       };
       queueSetupOverlayOpen(
         `legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`,
         () => {
-          setNewChatSetupChatId(activeChatId);
+          if (shouldOpenWizard) setNewChatSetupChatId(activeChatId);
           if (shouldOpenWizard) setWizardOpen(true);
           else setSettingsOpen(true);
           clearLegacyFlags();
         },
-        clearLegacyFlags,
+        cancelLegacyOpen,
       );
     }
   }, [newChatSetupIntent, queueSetupOverlayOpen, shouldOpenSettings, shouldOpenWizard, activeChatId]);

--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -52,6 +52,7 @@ export function useChatOverlays(activeChatId: string) {
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [spriteArrangeMode, setSpriteArrangeMode] = useState(false);
+  const [newChatSetupChatId, setNewChatSetupChatId] = useState<string | null>(null);
   const pendingSetupOverlayOpenRef = useRef<PendingSetupOverlayOpen | null>(null);
 
   const newChatSetupIntent = useChatStore((state) => state.newChatSetupIntent);
@@ -83,6 +84,7 @@ export function useChatOverlays(activeChatId: string) {
 
   useEffect(() => {
     setSpriteArrangeMode(false);
+    setNewChatSetupChatId(null);
   }, [activeChatId]);
 
   useEffect(
@@ -98,6 +100,7 @@ export function useChatOverlays(activeChatId: string) {
 
     const intent = useChatStore.getState().consumeNewChatSetupIntent(activeChatId);
     if (intent) {
+      setNewChatSetupChatId(intent.chatId);
       queueSetupOverlayOpen(`intent:${intent.chatId}`, () => {
         if (intent.openWizard) {
           if (intent.shortcutMode) useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
@@ -113,10 +116,12 @@ export function useChatOverlays(activeChatId: string) {
       const clearLegacyFlags = () => {
         useChatStore.getState().setShouldOpenWizard(false);
         useChatStore.getState().setShouldOpenSettings(false);
+        setNewChatSetupChatId(null);
       };
       queueSetupOverlayOpen(
         `legacy:${activeChatId}:${shouldOpenWizard ? "wizard" : "settings"}`,
         () => {
+          setNewChatSetupChatId(activeChatId);
           if (shouldOpenWizard) setWizardOpen(true);
           else setSettingsOpen(true);
           clearLegacyFlags();
@@ -132,11 +137,13 @@ export function useChatOverlays(activeChatId: string) {
     galleryOpen,
     wizardOpen,
     spriteArrangeMode,
+    newChatSetupChatId,
     setSettingsOpen,
     setFilesOpen,
     setGalleryOpen,
     setWizardOpen,
     setSpriteArrangeMode,
+    clearNewChatSetup: () => setNewChatSetupChatId(null),
     openSettings: () => setSettingsOpen(true),
     openFiles: () => setFilesOpen(true),
     openGallery: () => setGalleryOpen(true),
@@ -146,6 +153,7 @@ export function useChatOverlays(activeChatId: string) {
     finishWizard: () => {
       setWizardOpen(false);
       setSettingsOpen(true);
+      setNewChatSetupChatId(null);
     },
     toggleSpriteArrange: () => setSpriteArrangeMode((current) => !current),
   };

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -29,6 +29,7 @@ export * from "./hooks/use-streaming-tts";
 export * from "./hooks/use-sprite-metadata-state";
 export * from "./lib/message-thinking";
 export * from "./lib/message-attachments";
+export * from "./lib/empty-new-chat";
 export * from "./lib/prompt-snapshot";
 export * from "./lib/transcript-render-window";
 export * from "./lib/transcript-scroll-geometry";

--- a/src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts
+++ b/src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts
@@ -6,9 +6,23 @@ describe("isEmptyNewChatSetup", () => {
   it("detects a persisted setup placeholder with no characters or messages", () => {
     expect(
       isEmptyNewChatSetup({
-        chat: { id: "chat-1" },
+        activeChatId: "chat-1",
+        setupChatId: "chat-1",
         chatCharIds: [],
         totalMessageCount: 0,
+        messagesLoaded: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a known setup placeholder before message rows finish loading", () => {
+    expect(
+      isEmptyNewChatSetup({
+        activeChatId: "chat-1",
+        setupChatId: "chat-1",
+        chatCharIds: [],
+        totalMessageCount: 0,
+        messagesLoaded: false,
       }),
     ).toBe(true);
   });
@@ -16,9 +30,11 @@ describe("isEmptyNewChatSetup", () => {
   it("keeps chats that already have selected characters", () => {
     expect(
       isEmptyNewChatSetup({
-        chat: { id: "chat-1" },
+        activeChatId: "chat-1",
+        setupChatId: "chat-1",
         chatCharIds: ["char-1"],
         totalMessageCount: 0,
+        messagesLoaded: true,
       }),
     ).toBe(false);
   });
@@ -26,19 +42,23 @@ describe("isEmptyNewChatSetup", () => {
   it("keeps chats that already have messages", () => {
     expect(
       isEmptyNewChatSetup({
-        chat: { id: "chat-1" },
+        activeChatId: "chat-1",
+        setupChatId: "chat-1",
         chatCharIds: [],
         totalMessageCount: 1,
+        messagesLoaded: true,
       }),
     ).toBe(false);
   });
 
-  it("does not treat unloaded chat state as a placeholder", () => {
+  it("does not treat unrelated empty chats as setup placeholders", () => {
     expect(
       isEmptyNewChatSetup({
-        chat: null,
+        activeChatId: "chat-1",
+        setupChatId: "chat-2",
         chatCharIds: [],
         totalMessageCount: 0,
+        messagesLoaded: true,
       }),
     ).toBe(false);
   });

--- a/src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts
+++ b/src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { isEmptyNewChatSetup } from "./empty-new-chat";
+
+describe("isEmptyNewChatSetup", () => {
+  it("detects a persisted setup placeholder with no characters or messages", () => {
+    expect(
+      isEmptyNewChatSetup({
+        chat: { id: "chat-1" },
+        chatCharIds: [],
+        totalMessageCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps chats that already have selected characters", () => {
+    expect(
+      isEmptyNewChatSetup({
+        chat: { id: "chat-1" },
+        chatCharIds: ["char-1"],
+        totalMessageCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps chats that already have messages", () => {
+    expect(
+      isEmptyNewChatSetup({
+        chat: { id: "chat-1" },
+        chatCharIds: [],
+        totalMessageCount: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat unloaded chat state as a placeholder", () => {
+    expect(
+      isEmptyNewChatSetup({
+        chat: null,
+        chatCharIds: [],
+        totalMessageCount: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/modes/shared/chat-ui/lib/empty-new-chat.ts
+++ b/src/features/modes/shared/chat-ui/lib/empty-new-chat.ts
@@ -1,0 +1,9 @@
+type EmptyNewChatCandidate = {
+  chat: { id?: string | null } | null | undefined;
+  chatCharIds: string[];
+  totalMessageCount: number;
+};
+
+export function isEmptyNewChatSetup({ chat, chatCharIds, totalMessageCount }: EmptyNewChatCandidate): boolean {
+  return Boolean(chat?.id) && chatCharIds.length === 0 && totalMessageCount === 0;
+}

--- a/src/features/modes/shared/chat-ui/lib/empty-new-chat.ts
+++ b/src/features/modes/shared/chat-ui/lib/empty-new-chat.ts
@@ -1,9 +1,22 @@
 type EmptyNewChatCandidate = {
-  chat: { id?: string | null } | null | undefined;
+  activeChatId: string | null;
+  setupChatId: string | null;
   chatCharIds: string[];
   totalMessageCount: number;
+  messagesLoaded: boolean;
 };
 
-export function isEmptyNewChatSetup({ chat, chatCharIds, totalMessageCount }: EmptyNewChatCandidate): boolean {
-  return Boolean(chat?.id) && chatCharIds.length === 0 && totalMessageCount === 0;
+export function isEmptyNewChatSetup({
+  activeChatId,
+  setupChatId,
+  chatCharIds,
+  totalMessageCount,
+  messagesLoaded,
+}: EmptyNewChatCandidate): boolean {
+  return (
+    Boolean(activeChatId) &&
+    setupChatId === activeChatId &&
+    chatCharIds.length === 0 &&
+    (!messagesLoaded || totalMessageCount === 0)
+  );
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2101

## Why this change

- New Conversation/New Chat setup created a persisted placeholder chat before the user had supplied meaningful setup data. If the user used `Skip`, the wizard finished normally and kept a completely empty chat in history.

## What changed

- Added a shared `isEmptyNewChatSetup` helper for detecting setup placeholders with no selected characters and zero messages.
- Conversation setup now deletes the placeholder instead of finishing setup when `Skip` is used on an empty setup.
- Roleplay setup now applies the same cleanup for the shell New Chat path.
- Added focused regression coverage for the empty/configured/messaged/unloaded rows.

## Refactor impact

Primary owner:

chat mode / roleplay mode

Impact areas reviewed:

- New chat creation from `src/app/shell/useStartNewChat.ts`
- Quick start creation from `src/features/modes/router/components/ModeHomeSurface.tsx`
- Gated setup creation from `src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx`
- Conversation and roleplay setup finish handlers

Boundary notes:

- Kept the fix in React feature/shared mode UI. No engine, shared API, Rust storage, schema, dependency, or prompt-pipeline changes.

Pressure points touched:

- `ConversationModeRoute`
- `RoleplayModeRoute`
- shared mode chat-ui public export surface

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex ran `pnpm test -- src/features/modes/shared/chat-ui/lib/empty-new-chat.test.ts` (4 tests passed).
- Codex ran `pnpm typecheck` (passed).
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` (passed).
- Codex ran `pnpm check` (passed).
- Manual Tauri-shell click-through is still recommended before ready: create a New Conversation/New Chat, choose `Skip` without characters/messages, and confirm no empty chat remains in the list.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; it does not add a discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshot attached yet. The core persisted-state flow needs the Tauri shell/runtime to manually verify the chat list after skipping setup, so this should remain draft until that click-through is done.
