### PR TITLE
Fix group delete responsiveness

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,89 +1,94 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2070,
-    "title": "[Issue]: remote runtime JSON API calls lack legacy no-store cache policy",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2070"
+    "number": 2100,
+    "title": "[Issue]: Deleting conversation groups with branched conversations can make the app appear frozen",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2100"
   },
-  "pr": {
-    "number": 2090,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2090"
+  "pr": {},
+  "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous Tauri command, and the user sees a pending delete state until the command settles.",
+  "reproduction": {
+    "attempted": true,
+    "reproducedBeforeFix": true,
+    "method": "Source-level command-path repro against upstream/refactor plus affected UI inspection.",
+    "evidence": [
+      "upstream/refactor exported `pub fn chat_group_delete` and directly called `chats::delete_chat_group(&state, &group_id)` with no `spawn_blocking` handoff.",
+      "The two group-delete UI consumers closed their modal/drawer immediately after starting the mutation, so the pending state was not kept visible for large deletes."
+    ],
+    "duplicatePrPreflight": "No matching PRs found for #2100 or conversation group delete wording; no local issue-2100 branch/worktree existed before this run."
   },
-  "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
+  "verification": {
+    "originalReproPassed": true,
+    "baselinePassed": true,
+    "baselineCommand": "pnpm check",
+    "baselineEvidence": "`pnpm check` passed after the final diff.",
+    "focusedProof": [
+      "`pnpm typecheck` passed.",
+      "`cargo check --manifest-path src-tauri/Cargo.toml` passed.",
+      "`cargo test --manifest-path src-tauri/Cargo.toml delete_chat_group_reports_exact_deleted_chat_ids_including_scene_children` passed 1 targeted test.",
+      "`git diff --check` passed."
+    ],
+    "edgeCases": [
+      "Existing group delete still reports origin, sibling, and owned scene child chat ids.",
+      "Delete confirmation controls disable repeat clicks while a group delete is pending.",
+      "Delete surfaces keep the destructive dialog/drawer visible until the group delete succeeds."
+    ],
+    "visualProof": "scratch/issue-2100-shell-proof.png",
+    "visualProofNotes": "Playwright loaded the local Vite shell at http://localhost:1420/ and captured the rendered app. The plain browser shell cannot exercise real Tauri storage deletes, so command behavior is proven by Rust/source checks."
+  },
+  "manualBlockers": [
+    {
+      "description": "Hosted visual evidence is not attached yet because `gh gist create` rejected the binary PNG screenshot. Local Playwright shell proof exists at scratch/issue-2100-shell-proof.png; exact large-profile Tauri app-shell delete verification remains a human/manual draft-PR check.",
+      "blockingCoreClaim": false
+    }
+  ],
   "assignment": {
     "assignee": "cha1latte",
     "assignedBeforeWork": true
   },
   "preflight": {
     "noAssociatedPr": true,
-    "details": "workflow-health did not flag a duplicate for #2070; gh PR search for direct #2070 links returned no matches."
-  },
-  "reproduction": {
-    "attempted": true,
-    "reproducedBeforeFix": true,
-    "method": "Static source repro plus regression test coverage",
-    "evidence": "Baseline HEAD src/shared/api/remote-runtime.ts did not contain cache: \"no-store\" fetch options; current tests assert the restored policy on every remote JSON/SSE fetch path."
-  },
-  "verification": {
-    "originalReproPassed": true,
-    "baselinePassed": true,
-    "baselineCommand": "pnpm check",
-    "baselineEvidence": "pnpm check passed after the final diff.",
-    "focusedProof": [
-      "pnpm test -- src/shared/api/remote-runtime.test.ts: passed 5 tests.",
-      "cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses: passed 1 test."
-    ],
-    "edgeCases": [
-      "Health and invoke readiness probes set cache: \"no-store\".",
-      "Normal /api/invoke command calls set cache: \"no-store\".",
-      "Generic JSON event streams, including /api/import/st-bulk/run, set cache: \"no-store\".",
-      "LLM stream and cancel calls set cache: \"no-store\".",
-      "Rust hostable response helper preserves explicit managed asset cache headers while applying no-store to JSON API responses."
-    ],
-    "visualProof": "Backend/logic proof captured as focused terminal command output in Codex transcript; no UI state exists for this cache-policy regression."
+    "details": "workflow-health did not flag a duplicate for #2100; gh PR search for direct #2100 and conversation group delete wording returned no matches."
   },
   "riskClaimMatrix": {
-    "coreClaim": "Remote runtime JSON API responses and remote client fetches use no-store without changing managed asset cache policy.",
-    "riskType": "remote runtime cache-policy compatibility",
+    "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous Tauri command, and the user sees a pending delete state until the command settles.",
+    "riskType": "cross-boundary Tauri command responsiveness and delete UI feedback",
     "entrypoints": [
-      "src/shared/api/remote-runtime.ts health probe",
-      "src/shared/api/remote-runtime.ts /api/invoke calls",
-      "src/shared/api/remote-runtime.ts generic JSON/SSE stream calls",
-      "src/shared/api/remote-runtime.ts LLM stream and cancel calls",
-      "src-tauri/src/http_server.rs hostable HTTP response middleware"
+      "src-tauri chat_group_delete command",
+      "src/app/shell/ChatSidebar.tsx delete group modal",
+      "src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx delete group footer"
     ],
     "currentPathsOrFormats": [
-      "/health",
-      "/api/invoke",
-      "/api/import/st-bulk/run",
-      "/api/llm/stream",
-      "/api/llm/stream/:stream_id/cancel",
-      "/api/assets/:kind/*path"
+      "chat_group_delete(groupId)",
+      "sidebar branched-chat delete modal",
+      "Manage Chat Files drawer delete group action"
     ],
     "legacyPathsOrFormats": [
-      "legacy client shared API fetch cache: \"no-store\"",
-      "legacy server /api/* Cache-Control: no-store hook"
+      "pre-fix synchronous `pub fn chat_group_delete` command",
+      "pre-fix UI closes modal/drawer immediately after firing the group delete mutation"
     ],
     "positiveRowsTested": [
-      "client health fetch",
-      "client invoke readiness fetch",
-      "client invoke fetch",
-      "client generic JSON event stream fetch",
-      "client LLM stream fetch",
-      "client LLM stream cancel fetch",
-      "server /api/invoke response helper"
+      "Rust command compiles after async spawn_blocking handoff.",
+      "TypeScript compiles after pending-state UI changes.",
+      "Existing cascade regression test still deletes grouped chats and owned scene children."
     ],
     "negativeRowsTested": [
-      "server managed asset route preserves explicit public/no-cache headers",
-      "server non-api asset path does not receive API no-store header"
+      "Existing single-chat delete mutation path was not changed.",
+      "Storage deletion semantics and schemas were not changed."
     ],
     "groundTruthFacts": [
-      "Harness-proven by cargo test --manifest-path src-tauri/Cargo.toml api_no_store_headers_apply_only_to_api_responses: http_server.rs applies no-store to API headers and preserves explicit managed asset cache headers.",
-      "Derived from git show HEAD:src/shared/api/remote-runtime.ts plus Select-String: baseline remote-runtime.ts lacked cache: \"no-store\" fetch options before this patch."
+      "Derived from `git show upstream/refactor:src-tauri/src/commands/storage/commands/chats.rs`: baseline `chat_group_delete` was synchronous.",
+      "Derived from current source and `cargo check`: fixed `chat_group_delete` is async and uses `tauri::async_runtime::spawn_blocking`.",
+      "Derived from current source and `pnpm typecheck`: both UI consumers compile with the pending delete state."
     ],
-    "userActionCopy": "No user action required."
+    "manualBlockers": [
+      {
+        "description": "No new copy/backup instruction was added because this PR does not change destructive delete scope, storage layouts, or recovery behavior; the existing Delete Entire Group confirmation remains the user-facing destructive-action copy.",
+        "blockingCoreClaim": false
+      }
+    ],
+    "userActionCopy": []
   },
-  "manualBlockers": [],
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -9,13 +9,14 @@
     "number": 2104,
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2104"
   },
-  "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous Tauri command, and the user sees a pending delete state until the command settles.",
+  "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous embedded or hostable command, and the user sees a pending delete state until the command settles.",
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
     "method": "Source-level command-path repro against upstream/refactor plus affected UI inspection.",
     "evidence": [
       "upstream/refactor exported `pub fn chat_group_delete` and directly called `chats::delete_chat_group(&state, &group_id)` with no `spawn_blocking` handoff.",
+      "upstream/refactor HTTP dispatch also called `chats::delete_chat_group(state, required_string(&args, \"groupId\")?)` directly.",
       "The two group-delete UI consumers closed their modal/drawer immediately after starting the mutation, so the pending state was not kept visible for large deletes."
     ],
     "duplicatePrPreflight": "No matching PRs found for #2100 or conversation group delete wording; no local issue-2100 branch/worktree existed before this run."
@@ -54,24 +55,28 @@
     "details": "workflow-health did not flag a duplicate for #2100; gh PR search for direct #2100 and conversation group delete wording returned no matches."
   },
   "riskClaimMatrix": {
-    "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous Tauri command, and the user sees a pending delete state until the command settles.",
+    "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous embedded or hostable command, and the user sees a pending delete state until the command settles.",
     "riskType": "cross-boundary Tauri command responsiveness and delete UI feedback",
     "entrypoints": [
       "src-tauri chat_group_delete command",
+      "src-tauri HTTP dispatch chat_group_delete command",
       "src/app/shell/ChatSidebar.tsx delete group modal",
       "src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx delete group footer"
     ],
     "currentPathsOrFormats": [
       "chat_group_delete(groupId)",
+      "remote /api/invoke chat_group_delete(groupId)",
       "sidebar branched-chat delete modal",
       "Manage Chat Files drawer delete group action"
     ],
     "legacyPathsOrFormats": [
       "pre-fix synchronous `pub fn chat_group_delete` command",
+      "pre-fix hostable HTTP dispatch direct `chats::delete_chat_group` call",
       "pre-fix UI closes modal/drawer immediately after firing the group delete mutation"
     ],
     "positiveRowsTested": [
-      "Rust command compiles after async spawn_blocking handoff.",
+      "Rust embedded command compiles after async spawn_blocking handoff.",
+      "Rust hostable HTTP dispatch compiles after async spawn_blocking handoff.",
       "TypeScript compiles after pending-state UI changes.",
       "Existing cascade regression test still deletes grouped chats and owned scene children."
     ],
@@ -82,6 +87,7 @@
     "groundTruthFacts": [
       "Derived from `git show upstream/refactor:src-tauri/src/commands/storage/commands/chats.rs`: baseline `chat_group_delete` was synchronous.",
       "Derived from current source and `cargo check`: fixed `chat_group_delete` is async and uses `tauri::async_runtime::spawn_blocking`.",
+      "Derived from current source and `cargo check`: fixed HTTP dispatch `chat_group_delete` uses `tauri::async_runtime::spawn_blocking`.",
       "Derived from current source and `pnpm typecheck`: both UI consumers compile with the pending delete state."
     ],
     "manualBlockers": [

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -100,7 +100,7 @@
   },
   "finalDoneGate": {
     "didFixBug": true,
-    "hasProfessionalVisualProof": true,
+    "hasProfessionalVisualProof": false,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true
   }

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -5,7 +5,10 @@
     "title": "[Issue]: Deleting conversation groups with branched conversations can make the app appear frozen",
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2100"
   },
-  "pr": {},
+  "pr": {
+    "number": 2104,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2104"
+  },
   "coreClaim": "Deleting a conversation group no longer runs the long storage cascade as a synchronous Tauri command, and the user sees a pending delete state until the command settles.",
   "reproduction": {
     "attempted": true,

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -85,10 +85,26 @@
       "Storage deletion semantics and schemas were not changed."
     ],
     "groundTruthFacts": [
-      "Derived from `git show upstream/refactor:src-tauri/src/commands/storage/commands/chats.rs`: baseline `chat_group_delete` was synchronous.",
-      "Derived from current source and `cargo check`: fixed `chat_group_delete` is async and uses `tauri::async_runtime::spawn_blocking`.",
-      "Derived from current source and `cargo check`: fixed HTTP dispatch `chat_group_delete` uses `tauri::async_runtime::spawn_blocking`.",
-      "Derived from current source and `pnpm typecheck`: both UI consumers compile with the pending delete state."
+      {
+        "sourceType": "derived",
+        "description": "Baseline embedded chat_group_delete was synchronous.",
+        "evidence": "`git show upstream/refactor:src-tauri/src/commands/storage/commands/chats.rs` showed `pub fn chat_group_delete` directly calling `chats::delete_chat_group(&state, &group_id)`."
+      },
+      {
+        "sourceType": "derived",
+        "description": "Fixed embedded chat_group_delete uses the blocking task pool.",
+        "evidence": "Current `src-tauri/src/commands/storage/commands/chats.rs` compiles with `pub async fn chat_group_delete` and `tauri::async_runtime::spawn_blocking`."
+      },
+      {
+        "sourceType": "derived",
+        "description": "Fixed hostable HTTP chat_group_delete dispatch uses the blocking task pool.",
+        "evidence": "Current `src-tauri/src/http_dispatch.rs` compiles with `tauri::async_runtime::spawn_blocking` around `chats::delete_chat_group`."
+      },
+      {
+        "sourceType": "derived",
+        "description": "Both group-delete UI consumers compile with visible pending-state guards.",
+        "evidence": "`pnpm typecheck` and `pnpm check` passed after the sidebar and drawer pending-state changes."
+      }
     ],
     "manualBlockers": [
       {
@@ -98,6 +114,79 @@
     ],
     "userActionCopy": []
   },
+  "contractLaneGate": {
+    "brokenContract": "Conversation-group deletion could run a long storage cascade synchronously through embedded Tauri or hostable HTTP command dispatch while UI consumers hid the pending delete state.",
+    "producer": "src-tauri chat_group_delete command and HTTP dispatch",
+    "consumer": "src/features chat group delete UI through the existing chat API hooks",
+    "impliedContract": "Remote-capable group deletion should not monopolize the app command runtime, and destructive delete UI should remain visibly pending until the command settles.",
+    "actualEnforcement": "Both embedded and hostable chat_group_delete paths call chats::delete_chat_group inside tauri::async_runtime::spawn_blocking, and both UI delete surfaces guard close/switch/action paths while deleteChatGroup.isPending.",
+    "primaryOwnerLane": "src-tauri",
+    "primaryOwnerDetail": "Storage command responsiveness for chat_group_delete.",
+    "consumerOnlyLanes": ["src/features"],
+    "wrongLaneFixToAvoid": "A UI-only spinner or close guard that leaves the storage cascade running synchronously in either embedded or hostable command dispatch.",
+    "regressionProof": [
+      "cargo test --manifest-path src-tauri/Cargo.toml delete_chat_group_reports_exact_deleted_chat_ids_including_scene_children",
+      "pnpm check after merging upstream/refactor"
+    ]
+  },
+  "proofRows": {
+    "positiveRows": [
+      "Rust embedded command compiles after async spawn_blocking handoff.",
+      "Rust hostable HTTP dispatch compiles after async spawn_blocking handoff.",
+      "TypeScript compiles after pending-state UI changes.",
+      "Existing cascade regression test still deletes grouped chats and owned scene children."
+    ],
+    "contradictionRows": [
+      "Existing single-chat delete mutation path was not changed.",
+      "Storage deletion semantics and schemas were not changed."
+    ],
+    "legacyDefaultRows": [
+      "Baseline embedded chat_group_delete was synchronous before this PR.",
+      "Baseline hostable HTTP chat_group_delete dispatch was synchronous before this PR.",
+      "Baseline sidebar and drawer group-delete UI closed immediately after starting the delete mutation.",
+      "Final drawer import, export, branch switch, rename, branch delete, backdrop close, and header close controls are locked while group deletion is pending."
+    ],
+    "untestedRows": [
+      "Exact large-profile Tauri app-shell delete verification remains a draft manual check because the plain Vite shell cannot execute the real Tauri storage command."
+    ]
+  },
+  "ownedFacts": [
+    {
+      "sourceType": "derived",
+      "description": "Baseline embedded chat_group_delete was synchronous.",
+      "evidence": "`git show upstream/refactor:src-tauri/src/commands/storage/commands/chats.rs` showed `pub fn chat_group_delete` directly calling `chats::delete_chat_group(&state, &group_id)`."
+    },
+    {
+      "sourceType": "derived",
+      "description": "Fixed embedded chat_group_delete uses the blocking task pool.",
+      "evidence": "Current `src-tauri/src/commands/storage/commands/chats.rs` compiles with `pub async fn chat_group_delete` and `tauri::async_runtime::spawn_blocking`."
+    },
+    {
+      "sourceType": "derived",
+      "description": "Fixed hostable HTTP chat_group_delete dispatch uses the blocking task pool.",
+      "evidence": "Current `src-tauri/src/http_dispatch.rs` compiles with `tauri::async_runtime::spawn_blocking` around `chats::delete_chat_group`."
+    },
+    {
+      "sourceType": "derived",
+      "description": "Both group-delete UI consumers compile with visible pending-state guards.",
+      "evidence": "`pnpm typecheck` and `pnpm check` passed after the sidebar and drawer pending-state changes."
+    }
+  ],
+  "userActionCopy": [
+    {
+      "surface": "ChatSidebar and ChatFilesDrawer delete group confirmation",
+      "source": "Current selected conversation group in app storage",
+      "destination": "Permanent delete operation for that selected conversation group",
+      "action": "User confirms the Delete Entire Group destructive action",
+      "folders": "Conversation group and associated chat records owned by the selected group",
+      "copy": "Delete all {count} chats in this group? This cannot be undone.",
+      "detectedLayouts": [
+        "Current layout: sidebar and Manage Chat Files drawer show the same Delete Entire Group confirmation copy before deletion starts.",
+        "Legacy layout: delete scope and confirmation copy are unchanged from before this PR."
+      ],
+      "note": "Existing destructive copy remains in place; this PR changes responsiveness and pending-state behavior, not delete scope or recovery semantics."
+    }
+  ],
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": false,

--- a/src-tauri/src/commands/storage/commands/chats.rs
+++ b/src-tauri/src/commands/storage/commands/chats.rs
@@ -68,8 +68,14 @@ pub fn chat_notes_clear(state: State<'_, AppState>, chat_id: String) -> Result<V
 }
 
 #[tauri::command]
-pub fn chat_group_delete(state: State<'_, AppState>, group_id: String) -> Result<Value, AppError> {
-    chats::delete_chat_group(&state, &group_id)
+pub async fn chat_group_delete(
+    state: State<'_, AppState>,
+    group_id: String,
+) -> Result<Value, AppError> {
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || chats::delete_chat_group(&state, &group_id))
+        .await
+        .map_err(|error| AppError::new("task_join_error", error.to_string()))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -592,7 +592,15 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
             "notes",
             Vec::new(),
         ),
-        "chat_group_delete" => chats::delete_chat_group(state, required_string(&args, "groupId")?),
+        "chat_group_delete" => {
+            let state = state.clone();
+            let group_id = required_string(&args, "groupId")?.to_string();
+            tauri::async_runtime::spawn_blocking(move || {
+                chats::delete_chat_group(&state, &group_id)
+            })
+            .await
+            .map_err(|error| AppError::new("task_join_error", error.to_string()))?
+        }
         "chat_messages_bulk_delete" => chats::bulk_delete_messages(
             state,
             required_string(&args, "chatId")?,

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -27,6 +27,7 @@ import {
   Download,
   X,
   Star,
+  Loader2,
 } from "lucide-react";
 import {
   useBulkExportChats,
@@ -627,6 +628,17 @@ export function ChatSidebar({
     },
     [selectedChatIds, moveChatMut, exitMultiSelect],
   );
+
+  const handleDeleteEntireGroup = useCallback(() => {
+    if (!deleteTarget?.groupId || deleteChatGroup.isPending) return;
+    const deletingGroupId = deleteTarget.groupId;
+    deleteChatGroup.mutate(deletingGroupId, {
+      onSuccess: () => {
+        if (activeGroupId === deletingGroupId) setActiveChatId(null);
+        setDeleteTarget(null);
+      },
+    });
+  }, [activeGroupId, deleteChatGroup, deleteTarget, setActiveChatId]);
 
   // ── Chat row renderer (shared between unfiled + folder sections) ──
   const renderChatRow = ({ chat, branchCount }: ChatSidebarRow) => {
@@ -1258,7 +1270,14 @@ export function ChatSidebar({
       <UserStatusFooter />
 
       {/* ── Delete Branch Modal ── */}
-      <Modal open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} title="Delete Chat" width="max-w-sm">
+      <Modal
+        open={deleteTarget !== null}
+        onClose={() => {
+          if (!deleteChatGroup.isPending) setDeleteTarget(null);
+        }}
+        title="Delete Chat"
+        width="max-w-sm"
+      >
         {deleteTarget && (
           <div className="flex flex-col gap-4">
             <div className="flex items-start gap-3">
@@ -1278,23 +1297,23 @@ export function ChatSidebar({
                   if (activeChatId === deleteTarget.chatId) setActiveChatId(null);
                   setDeleteTarget(null);
                 }}
+                disabled={deleteChatGroup.isPending}
                 className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
               >
                 <Trash2 size="0.8125rem" />
                 Delete This Chat Only
               </button>
               <button
-                onClick={() => {
-                  if (deleteTarget.groupId) {
-                    deleteChatGroup.mutate(deleteTarget.groupId);
-                    if (activeGroupId === deleteTarget.groupId) setActiveChatId(null);
-                  }
-                  setDeleteTarget(null);
-                }}
-                className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2.5 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98]"
+                onClick={() => void handleDeleteEntireGroup()}
+                disabled={deleteChatGroup.isPending}
+                className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2.5 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98] disabled:cursor-wait disabled:opacity-70"
               >
-                <Trash2 size="0.8125rem" />
-                Delete Entire Group
+                {deleteChatGroup.isPending ? (
+                  <Loader2 size="0.8125rem" className="animate-spin" />
+                ) : (
+                  <Trash2 size="0.8125rem" />
+                )}
+                {deleteChatGroup.isPending ? "Deleting group..." : "Delete Entire Group"}
               </button>
             </div>
           </div>

--- a/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
@@ -40,9 +40,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   const [isImporting, setIsImporting] = useState(false);
 
   const chatFiles = (groupChats ?? []) as Chat[];
+  const isGroupDeletePending = deleteChatGroup.isPending;
 
   const handleClose = () => {
-    if (deleteChatGroup.isPending) return;
+    if (isGroupDeletePending) return;
     onClose();
   };
 
@@ -50,6 +51,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     const file = e.target.files?.[0];
     if (!file) return;
     e.target.value = "";
+    if (isGroupDeletePending) return;
 
     setIsImporting(true);
     try {
@@ -83,11 +85,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   };
 
   const handleSwitch = (chatId: string) => {
-    if (deleteChatGroup.isPending) return;
+    if (isGroupDeletePending) return;
     setActiveChatId(chatId);
     onClose();
   };
-  const isGroupDeletePending = deleteChatGroup.isPending;
 
   const updateMetadata = useUpdateChatMetadata();
 
@@ -227,16 +228,16 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           <div className="flex gap-2">
             <button
               onClick={() => exportChat.mutate({ chatId: activeChatId ?? chat.id, format: "jsonl" })}
-              disabled={exportChat.isPending}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
+              disabled={exportChat.isPending || isGroupDeletePending}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:cursor-wait disabled:opacity-50 disabled:hover:bg-[var(--secondary)]"
             >
               <Download size="0.8125rem" />
               JSONL
             </button>
             <button
               onClick={() => exportChat.mutate({ chatId: activeChatId ?? chat.id, format: "text" })}
-              disabled={exportChat.isPending}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
+              disabled={exportChat.isPending || isGroupDeletePending}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:cursor-wait disabled:opacity-50 disabled:hover:bg-[var(--secondary)]"
             >
               <FileText size="0.8125rem" />
               Text
@@ -254,9 +255,12 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           </p>
           <button
             type="button"
-            onClick={() => importInputRef.current?.click()}
-            disabled={isImporting}
-            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:opacity-50"
+            onClick={() => {
+              if (isGroupDeletePending) return;
+              importInputRef.current?.click();
+            }}
+            disabled={isImporting || isGroupDeletePending}
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98] disabled:cursor-wait disabled:opacity-50 disabled:hover:bg-[var(--secondary)]"
           >
             <Upload size="0.8125rem" />
             {isImporting ? "Importing…" : "JSONL"}

--- a/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
@@ -41,6 +41,11 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
 
   const chatFiles = (groupChats ?? []) as Chat[];
 
+  const handleClose = () => {
+    if (deleteChatGroup.isPending) return;
+    onClose();
+  };
+
   const handleImportChat = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -78,6 +83,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   };
 
   const handleSwitch = (chatId: string) => {
+    if (deleteChatGroup.isPending) return;
     setActiveChatId(chatId);
     onClose();
   };
@@ -125,13 +131,13 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   if (!groupId) {
     return (
       <>
-        <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
+        <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={handleClose} />
         <div className="absolute right-0 top-0 z-50 flex h-full w-80 max-md:w-full flex-col border-l border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:pt-[env(safe-area-inset-top)]">
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <h3 className="text-sm font-bold">Manage Chat Files</h3>
             <button
               type="button"
-              onClick={onClose}
+              onClick={handleClose}
               aria-label="Close chat files drawer"
               className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
             >
@@ -194,7 +200,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
   return (
     <>
       {/* Backdrop */}
-      <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={handleClose} />
 
       {/* Drawer */}
       <div className="absolute right-0 top-0 z-50 flex h-full w-80 max-md:w-full flex-col border-l border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:pt-[env(safe-area-inset-top)]">
@@ -203,9 +209,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
           <h3 className="text-sm font-bold">Manage Chat Files</h3>
           <button
             type="button"
-            onClick={onClose}
+            onClick={handleClose}
+            disabled={deleteChatGroup.isPending}
             aria-label="Close chat files drawer"
-            className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+            className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] disabled:cursor-wait disabled:opacity-50"
           >
             <X size="1rem" />
           </button>

--- a/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
@@ -87,6 +87,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     setActiveChatId(chatId);
     onClose();
   };
+  const isGroupDeletePending = deleteChatGroup.isPending;
 
   const updateMetadata = useUpdateChatMetadata();
 
@@ -279,9 +280,13 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                 <div
                   key={cf.id}
                   onClick={() => handleSwitch(cf.id)}
+                  aria-disabled={isGroupDeletePending}
                   className={cn(
-                    "group flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all",
-                    isActive ? "bg-sky-400/10 ring-1 ring-sky-400/30" : "hover:bg-[var(--accent)]",
+                    "group flex items-center gap-3 rounded-xl p-2.5 transition-all",
+                    isGroupDeletePending ? "cursor-wait opacity-70" : "cursor-pointer",
+                    isActive
+                      ? "bg-sky-400/10 ring-1 ring-sky-400/30"
+                      : !isGroupDeletePending && "hover:bg-[var(--accent)]",
                   )}
                 >
                   <div
@@ -310,9 +315,11 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
+                          if (isGroupDeletePending) return;
                           void handleRename(cf);
                         }}
-                        className="rounded-lg p-1.5 transition-all hover:bg-[var(--accent)]/80 active:scale-[0.95] ring-1 ring-transparent hover:ring-[var(--border)]"
+                        disabled={isGroupDeletePending}
+                        className="rounded-lg p-1.5 ring-1 ring-transparent transition-all hover:bg-[var(--accent)]/80 hover:ring-[var(--border)] active:scale-[0.95] disabled:cursor-wait disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:ring-transparent"
                         title="Rename branch"
                       >
                         <Pencil size="0.75rem" className="text-[var(--muted-foreground)]" />
@@ -320,9 +327,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
+                          if (isGroupDeletePending) return;
                           void handleDelete(cf.id);
                         }}
-                        disabled={deleteChat.isPending}
+                        disabled={deleteChat.isPending || isGroupDeletePending}
                         className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15"
                         title="Delete branch"
                       >

--- a/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx
@@ -3,7 +3,7 @@
 // Like SillyTavern's "Manage chat files" feature
 // ──────────────────────────────────────────────
 import { useRef, useState } from "react";
-import { X, Trash2, FileText, MessageSquare, Download, Pencil, Upload } from "lucide-react";
+import { X, Trash2, FileText, MessageSquare, Download, Pencil, Upload, Loader2 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
@@ -343,15 +343,22 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
               ) {
                 return;
               }
-              deleteChatGroup.mutate(groupId);
-              setActiveChatId(null);
-              onClose();
+              deleteChatGroup.mutate(groupId, {
+                onSuccess: () => {
+                  setActiveChatId(null);
+                  onClose();
+                },
+              });
             }}
             disabled={deleteChatGroup.isPending}
-            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98] disabled:opacity-50"
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98] disabled:cursor-wait disabled:opacity-70"
           >
-            <Trash2 size="0.8125rem" />
-            Delete Entire Group
+            {deleteChatGroup.isPending ? (
+              <Loader2 size="0.8125rem" className="animate-spin" />
+            ) : (
+              <Trash2 size="0.8125rem" />
+            )}
+            {deleteChatGroup.isPending ? "Deleting group..." : "Delete Entire Group"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
﻿<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2100

## Why this change

- Large branched conversation-group deletes can take long enough that the Tauri app appears frozen or unresponsive.
- The group delete command was doing the full storage cascade synchronously, and the UI surfaces that start the delete closed immediately instead of keeping a visible pending state.

## What changed

- Moved `chat_group_delete` onto Tauri's blocking task pool with `spawn_blocking`, matching the heavier storage-delete command pattern.
- Moved the hostable HTTP `chat_group_delete` dispatch path onto the same blocking task pool so embedded and remote-capable invocations share the responsiveness contract.
- Kept the sidebar branched-chat delete modal open while group deletion is pending, disabled repeat clicks, and showed `Deleting group...`.
- Kept the Manage Chat Files drawer open while group deletion is pending, disabled repeat clicks, and showed `Deleting group...`.
- Updated `scratch/bugfix-verification.json` with the issue-2100 proof record.

## Refactor impact

Primary owner:

Rust storage command wrapper, with app-shell/shared chat UI consumers.

Impact areas reviewed:

- `src-tauri/src/commands/storage/commands/chats.rs`
- `src-tauri/src/http_dispatch.rs`
- `src/app/shell/ChatSidebar.tsx`
- `src/features/modes/shared/chat-ui/components/ChatFilesDrawer.tsx`
- Existing group-delete cascade behavior through the targeted Rust regression test

Boundary notes:

- Storage deletion semantics, schemas, and single-chat delete behavior are unchanged.
- Engine code was not touched.
- Feature code continues to call the existing focused chat API wrapper through `useDeleteChatGroup`.

Pressure points touched:

- Tauri `chat_group_delete` command wrapper.
- Hostable HTTP dispatch for `chat_group_delete`.
- App shell chat sidebar branch-delete modal.
- Shared mode UI Manage Chat Files drawer.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex proof:
  - `pnpm typecheck` passed.
  - `cargo check --manifest-path src-tauri/Cargo.toml` passed.
  - `cargo test --manifest-path src-tauri/Cargo.toml delete_chat_group_reports_exact_deleted_chat_ids_including_scene_children` passed.
  - `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
  - `pnpm check` passed.
  - Playwright loaded the local Vite shell and captured local visual proof at `scratch/issue-2100-shell-proof.png`.
- Draft limitation: exact large-profile group deletion still needs Tauri app-shell verification because the plain Vite browser cannot execute the real Tauri storage command, and the local PNG could not be uploaded as a GitHub-renderable gist from this environment.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing delete workflow; no new feature discovery entry needed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence (if applicable)

- Local-only Playwright shell screenshot: `scratch/issue-2100-shell-proof.png`.
- No hosted screenshot is embedded yet; `gh gist create` rejected the binary PNG upload in this environment. Keeping this PR draft until hosted evidence or human app-shell verification is added.

