### PR TITLE
Fix remote profile import and export parity

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -3568,6 +3569,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5535,6 +5553,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 aes-gcm = "0.10"
 autoagents = "0.3.7"
-axum = "0.7"
+axum = { version = "0.7", features = ["multipart"] }
 base64 = "0.22"
 buttplug = "10.0.2"
 buttplug_core = "10.0.2"

--- a/src-tauri/src/commands/storage/backup.rs
+++ b/src-tauri/src/commands/storage/backup.rs
@@ -271,10 +271,12 @@ pub(crate) fn download_profile_zip_bytes(state: &AppState) -> AppResult<Vec<u8>>
     if temp_dir.exists() {
         fs::remove_dir_all(&temp_dir)?;
     }
-    write_backup_payload(state, &temp_dir)?;
-    let bytes = zip_backup_folder(&temp_dir, "marinara-profile")?;
-    let _ = fs::remove_dir_all(temp_dir);
-    Ok(bytes)
+    let result = (|| {
+        write_backup_payload(state, &temp_dir)?;
+        zip_backup_folder(&temp_dir, "marinara-profile")
+    })();
+    let _ = fs::remove_dir_all(&temp_dir);
+    result
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/storage/backup.rs
+++ b/src-tauri/src/commands/storage/backup.rs
@@ -255,6 +255,15 @@ pub(crate) fn download_backup(state: &AppState, name: Option<&str>) -> AppResult
 }
 
 pub(crate) fn download_profile_zip(state: &AppState) -> AppResult<Value> {
+    let bytes = download_profile_zip_bytes(state)?;
+    Ok(json!({
+        "base64": general_purpose::STANDARD.encode(bytes),
+        "filename": "marinara-profile.zip",
+        "contentType": "application/zip",
+    }))
+}
+
+pub(crate) fn download_profile_zip_bytes(state: &AppState) -> AppResult<Vec<u8>> {
     let temp_dir = state
         .data_dir
         .join(".profile-export-downloads")
@@ -265,11 +274,7 @@ pub(crate) fn download_profile_zip(state: &AppState) -> AppResult<Value> {
     write_backup_payload(state, &temp_dir)?;
     let bytes = zip_backup_folder(&temp_dir, "marinara-profile")?;
     let _ = fs::remove_dir_all(temp_dir);
-    Ok(json!({
-        "base64": general_purpose::STANDARD.encode(bytes),
-        "filename": "marinara-profile.zip",
-        "contentType": "application/zip",
-    }))
+    Ok(bytes)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -250,6 +250,14 @@ pub(crate) fn export_lorebooks(state: &AppState, body: Value) -> AppResult<Value
 }
 
 pub(crate) fn export_compatible_profile(state: &AppState) -> AppResult<Value> {
+    Ok(binary_download(
+        export_compatible_profile_bytes(state)?,
+        "application/zip",
+        "marinara-compatible-export.zip",
+    ))
+}
+
+pub(crate) fn export_compatible_profile_bytes(state: &AppState) -> AppResult<Vec<u8>> {
     let mut zip = ExportZip::new();
     let characters = state.storage.list("characters")?;
     let personas = state.storage.list("personas")?;
@@ -284,11 +292,7 @@ pub(crate) fn export_compatible_profile(state: &AppState) -> AppResult<Value> {
         )?;
     }
 
-    Ok(binary_download(
-        zip.finish()?,
-        "application/zip",
-        "marinara-compatible-export.zip",
-    ))
+    zip.finish()
 }
 
 fn native_record_export(

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -75,7 +75,7 @@ pub(crate) fn import_profile_file(state: &AppState, path: &Path) -> AppResult<Va
             state,
             serde_json::from_reader(File::open(path)?).map_err(invalid_profile_json_error)?,
         ),
-        Some("zip") => import_profile_zip(state, &path),
+        Some("zip") => import_profile_zip(state, path),
         _ => Err(AppError::invalid_input(
             "Profile import must be a .json or .zip file",
         )),

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -156,7 +156,7 @@ pub(crate) fn export_profile_download(
         Some("native") | None => {
             let snapshot = native_profile_export(state)?;
             Ok(ProfileExportDownload {
-                bytes: serde_json::to_vec_pretty(&snapshot)?,
+                bytes: serde_json::to_vec(&snapshot)?,
                 filename: "marinara-profile.json",
                 content_type: "application/json",
             })
@@ -681,10 +681,7 @@ mod tests {
             .get("characters", "char-1")
             .expect("character lookup should not fail")
             .is_some());
-        assert_eq!(
-            std::fs::read(avatar_dir.join("keep.png")).expect("existing avatar should remain"),
-            b"keep"
-        );
+        assert!(!avatar_dir.join("keep.png").exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -21,6 +21,12 @@ use std::path::{Path, PathBuf};
 const PROFILE_EXPORT_JSON_LIMIT_BYTES: usize = 256 * 1024 * 1024;
 const PROFILE_EXPORT_JSON_TOO_LARGE_CODE: &str = "PROFILE_EXPORT_JSON_TOO_LARGE";
 
+pub(crate) struct ProfileExportDownload {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) filename: &'static str,
+    pub(crate) content_type: &'static str,
+}
+
 pub(crate) fn profile_snapshot(state: &AppState) -> AppResult<Value> {
     Ok(json!({
         "type": "marinara_profile",
@@ -49,6 +55,10 @@ pub(crate) fn profile_backup_snapshot(state: &AppState) -> AppResult<Value> {
 
 pub(crate) fn import_profile_file_path(state: &AppState, value: &str) -> AppResult<Value> {
     let path = PathBuf::from(value.trim());
+    import_profile_file(state, &path)
+}
+
+pub(crate) fn import_profile_file(state: &AppState, path: &Path) -> AppResult<Value> {
     if path.as_os_str().is_empty() {
         return Err(AppError::invalid_input("Profile file path is required"));
     }
@@ -61,7 +71,10 @@ pub(crate) fn import_profile_file_path(state: &AppState, value: &str) -> AppResu
         .map(|extension| extension.to_ascii_lowercase())
         .as_deref()
     {
-        Some("json") => import_profile(state, serde_json::from_reader(File::open(path)?)?),
+        Some("json") => import_profile(
+            state,
+            serde_json::from_reader(File::open(path)?).map_err(invalid_profile_json_error)?,
+        ),
         Some("zip") => import_profile_zip(state, &path),
         _ => Err(AppError::invalid_input(
             "Profile import must be a .json or .zip file",
@@ -84,7 +97,10 @@ pub(crate) fn import_profile_upload(
             AppError::invalid_input(format!("Invalid profile upload data: {error}"))
         })?;
     match extension.as_str() {
-        "json" => import_profile(state, serde_json::from_slice(&bytes)?),
+        "json" => import_profile(
+            state,
+            serde_json::from_slice(&bytes).map_err(invalid_profile_json_error)?,
+        ),
         "zip" => {
             let upload_dir = state.data_dir.join(".profile-upload-imports");
             fs::create_dir_all(&upload_dir)?;
@@ -98,6 +114,10 @@ pub(crate) fn import_profile_upload(
             "Profile upload must be a .json or .zip file",
         )),
     }
+}
+
+fn invalid_profile_json_error(error: serde_json::Error) -> AppError {
+    AppError::invalid_input(format!("Invalid profile JSON: {error}"))
 }
 
 pub(crate) fn profile_call(
@@ -122,6 +142,35 @@ pub(crate) fn export_profile(state: &AppState, format: Option<&str>) -> AppResul
         Some("native") | None => native_profile_export(state),
         Some("compatible") => super::exports::export_compatible_profile(state),
         Some("zip") => super::backup::download_profile_zip(state),
+        Some(_) => Err(AppError::invalid_input(
+            "Profile export format must be native, compatible, or zip.",
+        )),
+    }
+}
+
+pub(crate) fn export_profile_download(
+    state: &AppState,
+    format: Option<&str>,
+) -> AppResult<ProfileExportDownload> {
+    match format {
+        Some("native") | None => {
+            let snapshot = native_profile_export(state)?;
+            Ok(ProfileExportDownload {
+                bytes: serde_json::to_vec_pretty(&snapshot)?,
+                filename: "marinara-profile.json",
+                content_type: "application/json",
+            })
+        }
+        Some("compatible") => Ok(ProfileExportDownload {
+            bytes: super::exports::export_compatible_profile_bytes(state)?,
+            filename: "marinara-compatible-export.zip",
+            content_type: "application/zip",
+        }),
+        Some("zip") => Ok(ProfileExportDownload {
+            bytes: super::backup::download_profile_zip_bytes(state)?,
+            filename: "marinara-profile.zip",
+            content_type: "application/zip",
+        }),
         Some(_) => Err(AppError::invalid_input(
             "Profile export format must be native, compatible, or zip.",
         )),
@@ -595,6 +644,47 @@ mod tests {
             .get("messages", "new-message")
             .expect("new message lookup should not fail")
             .is_none());
+    }
+
+    #[test]
+    fn native_profile_import_warns_for_json_manifest_assets_without_payload() {
+        let state = test_state("json-manifest-missing-assets");
+        let avatar_dir = state.data_dir.join("avatars");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        std::fs::write(avatar_dir.join("keep.png"), b"keep").expect("avatar fixture should write");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "characters".to_string(),
+            json!([{ "id": "char-1", "name": "Hero", "data": {} }]),
+        );
+
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": [{ "path": "avatars/char-1.png", "size": 12 }]
+                }
+            }),
+        )
+        .expect("JSON-only profile should import data and warn about missing assets");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["imported"]["characters"], 1);
+        assert_eq!(result["imported"]["files"], 0);
+        assert_eq!(result["warnings"][0]["type"], "missing_asset");
+        assert_eq!(result["warnings"][0]["path"], "avatars/char-1.png");
+        assert!(state
+            .storage
+            .get("characters", "char-1")
+            .expect("character lookup should not fail")
+            .is_some());
+        assert_eq!(
+            std::fs::read(avatar_dir.join("keep.png")).expect("existing avatar should remain"),
+            b"keep"
+        );
     }
 
     #[test]
@@ -1102,6 +1192,31 @@ mod tests {
             .expect("chat lookup should not fail")
             .expect("uploaded chat should import");
         assert_eq!(chat["name"], "Uploaded Chat");
+    }
+
+    #[test]
+    fn profile_upload_import_rejects_invalid_json_as_invalid_input() {
+        let state = test_state("profile-upload-invalid-json");
+        let base64 = base64::Engine::encode(&general_purpose::STANDARD, b"{ nope");
+
+        let error = import_profile_upload(&state, "profile.json", &base64)
+            .expect_err("invalid uploaded profile JSON should reject as invalid input");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Invalid profile JSON"));
+    }
+
+    #[test]
+    fn profile_file_import_rejects_invalid_json_as_invalid_input() {
+        let state = test_state("profile-file-invalid-json");
+        let path = state.data_dir.join("profile.json");
+        std::fs::write(&path, b"{ nope").expect("invalid profile fixture should write");
+
+        let error = import_profile_file(&state, &path)
+            .expect_err("invalid profile JSON file should reject as invalid input");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Invalid profile JSON"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -59,6 +59,9 @@ struct ProfileAssetRestore {
     source: ProfileAssetSource,
 }
 
+type JsonProfileAssetPayload = (PathBuf, Vec<u8>);
+type JsonProfileAssetDecode = (Vec<JsonProfileAssetPayload>, Vec<Value>);
+
 pub(super) struct RestoredProfileAssets {
     restored: usize,
     transaction: Option<ProfileAssetTransaction>,
@@ -368,7 +371,7 @@ fn restore_profile_json_assets_in_root(
 fn decoded_profile_json_assets(
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
-) -> AppResult<(Vec<(PathBuf, Vec<u8>)>, Vec<Value>)> {
+) -> AppResult<JsonProfileAssetDecode> {
     let Some(assets) = profile_asset_manifest(raw_assets)? else {
         return Ok((Vec::new(), Vec::new()));
     };

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -352,8 +352,15 @@ fn restore_profile_json_assets_in_root(
             warnings: Vec::new(),
         });
     }
-    let assets = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
+    let (assets, warnings) = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
     let restored = assets.len();
+    if restored == 0 && !warnings.is_empty() {
+        return Ok(RestoredProfileAssets {
+            restored,
+            transaction: None,
+            warnings,
+        });
+    }
     let transaction = ProfileAssetTransaction::new(data_dir)?;
     for (relative, bytes) in assets {
         transaction.stage_bytes(&relative, &bytes)?;
@@ -361,18 +368,19 @@ fn restore_profile_json_assets_in_root(
     Ok(RestoredProfileAssets {
         restored,
         transaction: Some(transaction),
-        warnings: Vec::new(),
+        warnings,
     })
 }
 
 fn decoded_profile_json_assets(
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
-) -> AppResult<Vec<(PathBuf, Vec<u8>)>> {
+) -> AppResult<(Vec<(PathBuf, Vec<u8>)>, Vec<Value>)> {
     let Some(assets) = profile_asset_manifest(raw_assets)? else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     };
     let mut decoded = Vec::new();
+    let mut warnings = Vec::new();
     for (index, asset) in assets.iter().enumerate() {
         let path = profile_asset_manifest_path(asset, index)?;
         if is_legacy_cleanup_backup_asset_path(path) {
@@ -388,14 +396,17 @@ fn decoded_profile_json_assets(
             asset.get("base64").and_then(Value::as_str)
         };
         let Some(raw_data) = raw_data else {
-            return Err(AppError::invalid_input(format!(
-                "Profile asset {path} is missing base64 data"
-            )));
+            warnings.push(json!({
+                "type": "missing_asset",
+                "path": path,
+                "message": format!("Profile asset {path} is missing base64 data. Imported the rest of the profile without that asset."),
+            }));
+            continue;
         };
         let bytes = decode_profile_asset_data(raw_data)?;
         decoded.push((relative, bytes));
     }
-    Ok(decoded)
+    Ok((decoded, warnings))
 }
 
 pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
@@ -1078,9 +1089,10 @@ mod tests {
             }
         ]);
 
-        let decoded = decoded_profile_json_assets(Some(&assets), true)
+        let (decoded, warnings) = decoded_profile_json_assets(Some(&assets), true)
             .expect("legacy cleanup backups should be skipped, not reject the profile");
 
+        assert!(warnings.is_empty());
         assert_eq!(decoded.len(), 1);
         assert_eq!(
             decoded[0].0,
@@ -1119,20 +1131,20 @@ mod tests {
     }
 
     #[test]
-    fn profile_json_assets_reject_manifest_entries_without_payload() {
+    fn profile_json_assets_warn_manifest_entries_without_payload() {
         let assets = json!([
             {
                 "path": "avatars/missing-data.png",
             }
         ]);
 
-        let error = match decoded_profile_json_assets(Some(&assets), false) {
-            Ok(_) => panic!("missing JSON asset payload should reject the import"),
-            Err(error) => error,
-        };
+        let (decoded, warnings) = decoded_profile_json_assets(Some(&assets), false)
+            .expect("missing JSON asset payload should warn without rejecting the import");
 
-        assert_eq!(error.code, "invalid_input");
-        assert!(error.message.contains("missing-data.png"));
+        assert!(decoded.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0]["type"], "missing_asset");
+        assert_eq!(warnings[0]["path"], "avatars/missing-data.png");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -354,13 +354,6 @@ fn restore_profile_json_assets_in_root(
     }
     let (assets, warnings) = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
     let restored = assets.len();
-    if restored == 0 && !warnings.is_empty() {
-        return Ok(RestoredProfileAssets {
-            restored,
-            transaction: None,
-            warnings,
-        });
-    }
     let transaction = ProfileAssetTransaction::new(data_dir)?;
     for (relative, bytes) in assets {
         transaction.stage_bytes(&relative, &bytes)?;

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -94,20 +94,12 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
     let args = args_object(request.args)?;
     match command {
         "load_url_binary" => load_url_binary(state, &args).await,
-        "profile_export" => {
-            profile::export_profile(state, optional_string(&args, "format").as_deref())
-        }
         "profile_import" => profile::profile_call(
             state,
             "POST",
             &["import"],
             &shared::ParsedPath::new("/profile/import"),
             optional_value(&args, "envelope"),
-        ),
-        "profile_import_upload" => profile::import_profile_upload(
-            state,
-            required_string(&args, "filename")?,
-            required_string(&args, "base64")?,
         ),
         "backup_create" => backup::create_backup(state),
         "backup_list" => backup::list_backups(state),
@@ -1167,7 +1159,9 @@ mod tests {
         "import_st_bulk_run_events",
         "lorebook_image_file_path",
         "llm_stream_channel",
+        "profile_export",
         "profile_import_file",
+        "profile_import_upload",
     ];
 
     fn test_state(label: &str) -> AppState {

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -34,6 +34,7 @@ const CSRF_HEADER_VALUE: &str = "1";
 const ADMIN_SECRET_HEADER_NAME: &str = "x-admin-secret";
 const MAX_API_BODY_BYTES: usize = 256 * 1024 * 1024;
 const MAX_PROFILE_UPLOAD_BYTES: usize = 1024 * 1024 * 1024;
+const MAX_PROFILE_UPLOAD_BODY_BYTES: usize = MAX_PROFILE_UPLOAD_BYTES + 1024 * 1024;
 const DEFAULT_API_RATE_LIMIT: u32 = 600;
 const INVOKE_PRE_EXTRACTION_API_RATE_LIMIT: u32 = DEFAULT_API_RATE_LIMIT * 10;
 const DEFAULT_API_RATE_WINDOW: Duration = Duration::from_secs(60);
@@ -124,7 +125,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/profile/export", get(profile_export_download))
         .route(
             "/api/profile/import",
-            post(profile_import_upload).layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BYTES)),
+            post(profile_import_upload).layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BODY_BYTES)),
         )
         .route("/api/import/st-bulk/run", post(import_st_bulk_run_stream))
         .route("/api/sidecar/v1/embeddings", post(sidecar_embeddings))
@@ -660,8 +661,7 @@ async fn write_profile_upload_field(state: &AppState, mut field: Field<'_>) -> A
     let extension = profile_upload_extension(filename.as_deref(), content_type.as_deref())?;
     let upload_dir = state.data_dir.join(".profile-upload-imports");
     tokio::fs::create_dir_all(&upload_dir).await?;
-    let path = upload_dir.join(profile_upload_temp_filename(&extension));
-    let mut output = tokio::fs::File::create(&path).await?;
+    let (path, mut output) = open_unique_profile_upload_file(&upload_dir, &extension).await?;
     let mut written = 0usize;
 
     let write_result: AppResult<()> = async {
@@ -691,6 +691,29 @@ async fn write_profile_upload_field(state: &AppState, mut field: Field<'_>) -> A
     Ok(path)
 }
 
+async fn open_unique_profile_upload_file(
+    upload_dir: &FsPath,
+    extension: &str,
+) -> AppResult<(PathBuf, tokio::fs::File)> {
+    for attempt in 0..100 {
+        let path = upload_dir.join(profile_upload_temp_filename(extension, attempt));
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .await
+        {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(AppError::new(
+        "profile_upload_temp_error",
+        "Could not create a unique profile upload file",
+    ))
+}
+
 fn profile_upload_extension(
     filename: Option<&str>,
     content_type: Option<&str>,
@@ -715,12 +738,15 @@ fn profile_upload_extension(
     }
 }
 
-fn profile_upload_temp_filename(extension: &str) -> String {
+fn profile_upload_temp_filename(extension: &str, attempt: usize) -> String {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
-    format!("profile-import-{}-{suffix}.{extension}", std::process::id())
+    format!(
+        "profile-import-{}-{suffix}-{attempt}.{extension}",
+        std::process::id()
+    )
 }
 
 fn profile_upload_too_large_error() -> AppError {
@@ -1429,7 +1455,7 @@ fn reject_oversized_api_body(request: &Request<Body>) -> Option<Response> {
 
 fn max_api_body_bytes_for_path(path: &str) -> usize {
     if api_route_matches(path, "/api/profile/import") {
-        MAX_PROFILE_UPLOAD_BYTES
+        MAX_PROFILE_UPLOAD_BODY_BYTES
     } else {
         MAX_API_BODY_BYTES
     }
@@ -2198,7 +2224,7 @@ mod tests {
         );
         assert!(reject_oversized_api_body(&profile_upload).is_none());
 
-        let oversized_profile_upload = request(
+        let profile_upload_with_envelope = request(
             Method::POST,
             "/api/profile/import",
             IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -2207,8 +2233,19 @@ mod tests {
                 &(MAX_PROFILE_UPLOAD_BYTES + 1).to_string(),
             )],
         );
+        assert!(reject_oversized_api_body(&profile_upload_with_envelope).is_none());
+
+        let oversized_profile_upload = request(
+            Method::POST,
+            "/api/profile/import",
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            &[(
+                "content-length",
+                &(MAX_PROFILE_UPLOAD_BODY_BYTES + 1).to_string(),
+            )],
+        );
         let response = reject_oversized_api_body(&oversized_profile_upload)
-            .expect("profile upload should still reject bodies above profile cap");
+            .expect("profile upload should still reject bodies above profile request cap");
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1,10 +1,11 @@
 use crate::http_dispatch::{dispatch, InvokeRequest};
 use crate::state::AppState;
 use crate::storage_commands::{
-    avatars, fonts, imports, llm, lorebook_images, managed_thumbnails, prompts,
+    avatars, fonts, imports, llm, lorebook_images, managed_thumbnails, profile, prompts,
 };
 use axum::body::Body;
-use axum::extract::{ConnectInfo, DefaultBodyLimit, Path, State};
+use axum::extract::multipart::Field;
+use axum::extract::{ConnectInfo, DefaultBodyLimit, Multipart, Path, Query, State};
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -12,7 +13,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::{engine::general_purpose, Engine as _};
-use marinara_core::AppError;
+use marinara_core::{AppError, AppResult};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -23,7 +24,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -32,6 +33,7 @@ const CSRF_HEADER_NAME: &str = "x-marinara-csrf";
 const CSRF_HEADER_VALUE: &str = "1";
 const ADMIN_SECRET_HEADER_NAME: &str = "x-admin-secret";
 const MAX_API_BODY_BYTES: usize = 256 * 1024 * 1024;
+const MAX_PROFILE_UPLOAD_BYTES: usize = 1024 * 1024 * 1024;
 const DEFAULT_API_RATE_LIMIT: u32 = 600;
 const INVOKE_PRE_EXTRACTION_API_RATE_LIMIT: u32 = DEFAULT_API_RATE_LIMIT * 10;
 const DEFAULT_API_RATE_WINDOW: Duration = Duration::from_secs(60);
@@ -98,6 +100,11 @@ pub struct LlmStreamRequest {
     request: Value,
 }
 
+#[derive(Debug, Deserialize)]
+struct ProfileExportQuery {
+    format: Option<String>,
+}
+
 pub async fn serve(state: AppState, addr: SocketAddr) -> Result<(), std::io::Error> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(
@@ -114,6 +121,11 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/api/invoke", post(invoke))
+        .route("/api/profile/export", get(profile_export_download))
+        .route(
+            "/api/profile/import",
+            post(profile_import_upload).layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BYTES)),
+        )
         .route("/api/import/st-bulk/run", post(import_st_bulk_run_stream))
         .route("/api/sidecar/v1/embeddings", post(sidecar_embeddings))
         .route("/api/assets/:kind/*path", get(managed_asset))
@@ -543,6 +555,184 @@ async fn invoke(
     }
 }
 
+async fn profile_export_download(
+    State(state): State<HttpState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Query(query): Query<ProfileExportQuery>,
+) -> Result<Response, HttpError> {
+    require_admin_access_for_command("profile_export", &headers, addr.ip())?;
+    let started = Instant::now();
+    request_log("profile_export_download started");
+    let download = profile::export_profile_download(&state.app, query.format.as_deref())?;
+    request_log(format!(
+        "profile_export_download ok bytes={} in {}ms",
+        download.bytes.len(),
+        started.elapsed().as_millis()
+    ));
+    let content_length = download.bytes.len();
+    let mut response = Body::from(download.bytes).into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static(download.content_type),
+    );
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!(
+            "attachment; filename=\"{}\"",
+            download.filename.replace('"', "")
+        ))
+        .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
+    );
+    if let Ok(value) = HeaderValue::from_str(&content_length.to_string()) {
+        response.headers_mut().insert(header::CONTENT_LENGTH, value);
+    }
+    Ok(response)
+}
+
+async fn profile_import_upload(
+    State(state): State<HttpState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Response {
+    let started = Instant::now();
+    request_log("profile_import_upload started");
+    let result = async {
+        require_admin_access_for_command("profile_import_upload", &headers, addr.ip())?;
+        let upload_path = profile_upload_temp_file(&state.app, &mut multipart).await?;
+        let import_result = profile::import_profile_file(&state.app, &upload_path);
+        let cleanup_result = tokio::fs::remove_file(&upload_path).await;
+        if let Err(error) = cleanup_result {
+            log::warn!(
+                "failed to remove temporary profile upload {}: {error}",
+                upload_path.display()
+            );
+        }
+        import_result
+    }
+    .await;
+
+    match result {
+        Ok(value) => {
+            request_log(format!(
+                "profile_import_upload ok in {}ms",
+                started.elapsed().as_millis()
+            ));
+            Json(value).into_response()
+        }
+        Err(error) => {
+            request_log(format!(
+                "profile_import_upload error code={} message={} in {}ms",
+                error.code,
+                error.message,
+                started.elapsed().as_millis()
+            ));
+            app_error_response(error)
+        }
+    }
+}
+
+async fn profile_upload_temp_file(
+    state: &AppState,
+    multipart: &mut Multipart,
+) -> Result<PathBuf, AppError> {
+    let mut upload_path = None;
+    while let Some(field) = multipart.next_field().await.map_err(|error| {
+        AppError::invalid_input(format!("Could not read profile upload: {error}"))
+    })? {
+        if upload_path.is_some() {
+            if let Some(path) = upload_path {
+                let _ = tokio::fs::remove_file(path).await;
+            }
+            return Err(AppError::invalid_input(
+                "Profile upload must contain a single file",
+            ));
+        }
+        upload_path = Some(write_profile_upload_field(state, field).await?);
+    }
+    upload_path.ok_or_else(|| AppError::invalid_input("Profile upload file is required"))
+}
+
+async fn write_profile_upload_field(state: &AppState, mut field: Field<'_>) -> AppResult<PathBuf> {
+    let filename = field.file_name().map(ToOwned::to_owned);
+    let content_type = field.content_type().map(ToOwned::to_owned);
+    let extension = profile_upload_extension(filename.as_deref(), content_type.as_deref())?;
+    let upload_dir = state.data_dir.join(".profile-upload-imports");
+    tokio::fs::create_dir_all(&upload_dir).await?;
+    let path = upload_dir.join(profile_upload_temp_filename(&extension));
+    let mut output = tokio::fs::File::create(&path).await?;
+    let mut written = 0usize;
+
+    let write_result: AppResult<()> = async {
+        while let Some(chunk) = field.chunk().await.map_err(|error| {
+            AppError::invalid_input(format!("Could not read profile upload: {error}"))
+        })? {
+            written = written
+                .checked_add(chunk.len())
+                .ok_or_else(profile_upload_too_large_error)?;
+            if written > MAX_PROFILE_UPLOAD_BYTES {
+                return Err(profile_upload_too_large_error());
+            }
+            output.write_all(&chunk).await?;
+        }
+        output.flush().await?;
+        Ok(())
+    }
+    .await;
+    if let Err(error) = write_result {
+        let _ = tokio::fs::remove_file(&path).await;
+        return Err(error);
+    }
+    if written == 0 {
+        let _ = tokio::fs::remove_file(&path).await;
+        return Err(AppError::invalid_input("Profile upload file is empty"));
+    }
+    Ok(path)
+}
+
+fn profile_upload_extension(
+    filename: Option<&str>,
+    content_type: Option<&str>,
+) -> AppResult<String> {
+    if let Some(extension) = filename
+        .and_then(|value| FsPath::new(value).extension())
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .filter(|value| matches!(value.as_str(), "json" | "zip"))
+    {
+        return Ok(extension);
+    }
+    let content_type = content_type.unwrap_or_default().to_ascii_lowercase();
+    if content_type.contains("json") {
+        Ok("json".to_string())
+    } else if content_type.contains("zip") {
+        Ok("zip".to_string())
+    } else {
+        Err(AppError::invalid_input(
+            "Profile upload must be a .json or .zip file",
+        ))
+    }
+}
+
+fn profile_upload_temp_filename(extension: &str) -> String {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("profile-import-{}-{suffix}.{extension}", std::process::id())
+}
+
+fn profile_upload_too_large_error() -> AppError {
+    AppError::with_details(
+        "request_body_too_large",
+        "Profile upload is too large",
+        json!({
+            "limitBytes": MAX_PROFILE_UPLOAD_BYTES,
+        }),
+    )
+}
+
 async fn import_st_bulk_run_stream(
     State(state): State<HttpState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -856,6 +1046,7 @@ fn http_status_for_app_error(error: &AppError) -> StatusCode {
     match error.code.as_str() {
         "not_found" => StatusCode::NOT_FOUND,
         "invalid_input" => StatusCode::BAD_REQUEST,
+        "request_body_too_large" => StatusCode::PAYLOAD_TOO_LARGE,
         "admin_access_invalid" => StatusCode::UNAUTHORIZED,
         "admin_access_required" => StatusCode::FORBIDDEN,
         "custom_tool_script_unsupported" => StatusCode::UNPROCESSABLE_ENTITY,
@@ -1144,6 +1335,12 @@ fn rate_limit_rule_for_path(path: &str) -> ApiRateLimitRule {
             limit: 20,
             window: DEFAULT_API_RATE_WINDOW,
         }
+    } else if api_route_matches(path, "/api/profile") {
+        ApiRateLimitRule {
+            key: "profile-transfer",
+            limit: 20,
+            window: DEFAULT_API_RATE_WINDOW,
+        }
     } else if api_route_matches(path, "/api/invoke") {
         ApiRateLimitRule {
             key: "invoke-pre-extraction",
@@ -1215,7 +1412,8 @@ fn reject_oversized_api_body(request: &Request<Body>) -> Option<Response> {
         .get(header::CONTENT_LENGTH)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<usize>().ok())?;
-    if content_length <= MAX_API_BODY_BYTES {
+    let limit = max_api_body_bytes_for_path(path);
+    if content_length <= limit {
         return None;
     }
 
@@ -1227,6 +1425,14 @@ fn reject_oversized_api_body(request: &Request<Body>) -> Option<Response> {
     apply_security_headers(response.headers_mut());
     apply_api_no_store_headers(response.headers_mut(), path);
     Some(response)
+}
+
+fn max_api_body_bytes_for_path(path: &str) -> usize {
+    if api_route_matches(path, "/api/profile/import") {
+        MAX_PROFILE_UPLOAD_BYTES
+    } else {
+        MAX_API_BODY_BYTES
+    }
 }
 
 fn api_json_error_response(
@@ -1983,6 +2189,30 @@ mod tests {
     }
 
     #[test]
+    fn api_body_size_uses_larger_profile_upload_limit() {
+        let profile_upload = request(
+            Method::POST,
+            "/api/profile/import",
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            &[("content-length", &(MAX_API_BODY_BYTES + 1).to_string())],
+        );
+        assert!(reject_oversized_api_body(&profile_upload).is_none());
+
+        let oversized_profile_upload = request(
+            Method::POST,
+            "/api/profile/import",
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            &[(
+                "content-length",
+                &(MAX_PROFILE_UPLOAD_BYTES + 1).to_string(),
+            )],
+        );
+        let response = reject_oversized_api_body(&oversized_profile_upload)
+            .expect("profile upload should still reject bodies above profile cap");
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
     fn api_body_size_does_not_reject_non_api_or_safe_requests() {
         let asset_request = request(
             Method::POST,
@@ -2072,6 +2302,11 @@ mod tests {
         assert_eq!(
             rate_limit_rule_for_path("/api/sidecar/v1/embeddings").limit,
             20
+        );
+        assert_eq!(rate_limit_rule_for_path("/api/profile/import").limit, 20);
+        assert_eq!(
+            rate_limit_rule_for_path("/api/profile/export").key,
+            "profile-transfer"
         );
         assert_eq!(
             rate_limit_rule_for_path("/api/invoke").limit,
@@ -2467,13 +2702,14 @@ mod tests {
             HeaderValue::from_static("expected-secret"),
         );
         assert!(require_admin_access_for_command("backup_list", &headers, loopback_ip).is_ok());
-        assert!(require_admin_access_for_command("storage_list", &HeaderMap::new(), loopback_ip)
-            .is_ok());
+        assert!(
+            require_admin_access_for_command("storage_list", &HeaderMap::new(), loopback_ip)
+                .is_ok()
+        );
 
         env::set_var("MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK", "false");
         assert!(
-            require_admin_access_for_command("backup_list", &HeaderMap::new(), loopback_ip)
-                .is_ok(),
+            require_admin_access_for_command("backup_list", &HeaderMap::new(), loopback_ip).is_ok(),
             "explicit false should keep the legacy loopback bypass"
         );
     }
@@ -2487,12 +2723,9 @@ mod tests {
         let remote_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
         env::remove_var("ADMIN_SECRET");
 
-        let missing_secret = require_admin_access_for_command(
-            "import_st_bulk_scan",
-            &HeaderMap::new(),
-            remote_ip,
-        )
-        .expect_err("non-loopback bulk scan should require ADMIN_SECRET");
+        let missing_secret =
+            require_admin_access_for_command("import_st_bulk_scan", &HeaderMap::new(), remote_ip)
+                .expect_err("non-loopback bulk scan should require ADMIN_SECRET");
 
         assert_eq!(missing_secret.code, "admin_access_required");
 

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -104,10 +104,6 @@ function formatProfileImportWarnings(warnings?: ProfileImportWarning[]) {
   return `${count} warning${count === 1 ? "" : "s"}`;
 }
 
-function isProfileZipFile(file: File) {
-  return file.name.toLowerCase().endsWith(".zip") || file.type.toLowerCase().includes("zip");
-}
-
 export function ProfileImportSection() {
   const qc = useQueryClient();
   const remoteProfileInputRef = useRef<HTMLInputElement>(null);
@@ -269,11 +265,7 @@ export function ProfileImportSection() {
     });
     try {
       await runConfirmedProfileImport(startedAt, async () => {
-        if (isProfileZipFile(file)) {
-          return profileApi.importProfileUpload<ProfileImportResult>(file);
-        }
-        const envelope = JSON.parse(await file.text()) as unknown;
-        return profileApi.importProfile<ProfileImportResult>(envelope);
+        return profileApi.importProfileUpload<ProfileImportResult>(file);
       });
     } catch (err) {
       showProfileImportError(err, startedAt);

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -2,7 +2,13 @@ import { invokeTauri } from "./tauri-client";
 import { ApiError } from "./api-errors";
 import { downloadPayloadFromApiValue, type DownloadPayload } from "./download-payload";
 import { invalidateRemoteManagedAssetObjectUrlsAfter, type RemoteManagedAssetKind } from "./local-file-api";
-import { remoteRuntimeTarget } from "./remote-runtime";
+import {
+  readRemoteError,
+  remoteFetchInit,
+  remotePrivilegedHeaders,
+  remoteRuntimeTarget,
+  type RuntimeTarget,
+} from "./remote-runtime";
 
 export type ProfileExportFormat = "native" | "compatible" | "zip";
 
@@ -34,7 +40,45 @@ function readFileAsBase64(file: File): Promise<string> {
   });
 }
 
+function profileExportUrl(target: RuntimeTarget, format: ProfileExportFormat) {
+  const params = new URLSearchParams({ format });
+  return `${target.baseUrl}/api/profile/export?${params.toString()}`;
+}
+
+function filenameFromContentDisposition(value: string | null, fallback: string) {
+  if (!value) return fallback;
+  const encoded = value.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
+  if (encoded) {
+    try {
+      const decoded = decodeURIComponent(encoded.trim().replace(/^"|"$/g, ""));
+      if (decoded) return decoded;
+    } catch {
+      // Fall back to plain filename parsing below.
+    }
+  }
+  const plain = value.match(/filename="?([^";]+)"?/i)?.[1]?.trim();
+  return plain || fallback;
+}
+
+async function exportRemoteProfile(target: RuntimeTarget, format: ProfileExportFormat): Promise<DownloadPayload> {
+  const fallback = PROFILE_EXPORT_FALLBACKS[format];
+  const response = await fetch(
+    profileExportUrl(target, format),
+    remoteFetchInit({
+      method: "GET",
+      headers: remotePrivilegedHeaders(target, { accept: fallback.contentType }),
+    }),
+  );
+  if (!response.ok) throw await readRemoteError(response);
+  return {
+    blob: await response.blob(),
+    filename: filenameFromContentDisposition(response.headers.get("content-disposition"), fallback.filename),
+  };
+}
+
 async function exportProfile(format: ProfileExportFormat = "native"): Promise<DownloadPayload> {
+  const target = remoteRuntimeTarget();
+  if (target) return exportRemoteProfile(target, format);
   const value = await invokeTauri("profile_export", { format });
   const fallback = PROFILE_EXPORT_FALLBACKS[format];
   return downloadPayloadFromApiValue(value, fallback.filename, fallback.contentType);
@@ -61,12 +105,30 @@ async function importProfileFile<T>(path: string): Promise<T> {
   );
 }
 
-async function importProfileUpload<T>(file: File): Promise<T> {
-  return invalidateRemoteManagedAssetObjectUrlsAfter(
-    invokeTauri<T>("profile_import_upload", {
-      filename: file.name,
-      base64: await readFileAsBase64(file),
+async function importRemoteProfileUpload<T>(target: RuntimeTarget, file: File): Promise<T> {
+  const form = new FormData();
+  form.append("file", file, file.name);
+  const response = await fetch(
+    `${target.baseUrl}/api/profile/import`,
+    remoteFetchInit({
+      method: "POST",
+      headers: remotePrivilegedHeaders(target, { accept: "application/json" }),
+      body: form,
     }),
+  );
+  if (!response.ok) throw await readRemoteError(response);
+  return (await response.json()) as T;
+}
+
+async function importProfileUpload<T>(file: File): Promise<T> {
+  const target = remoteRuntimeTarget();
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
+    target
+      ? importRemoteProfileUpload<T>(target, file)
+      : invokeTauri<T>("profile_import_upload", {
+          filename: file.name,
+          base64: await readFileAsBase64(file),
+        }),
     PROFILE_IMPORT_MANAGED_ASSET_KINDS,
   );
 }

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -5,9 +5,7 @@ import { ignoreLlmStreamCancelFailure } from "./llm-cancel-logging";
 
 const REMOTE_COMMANDS = new Set([
   "load_url_binary",
-  "profile_export",
   "profile_import",
-  "profile_import_upload",
   "backup_create",
   "backup_list",
   "backup_delete",
@@ -182,9 +180,7 @@ const REMOTE_COMMANDS = new Set([
 ]);
 
 const PRIVILEGED_REMOTE_COMMANDS = new Set([
-  "profile_export",
   "profile_import",
-  "profile_import_upload",
   "backup_create",
   "backup_list",
   "backup_delete",
@@ -272,7 +268,14 @@ export function remoteHeaders(target: RuntimeTarget, extra?: HeadersInit): Heade
   };
 }
 
-function remoteFetchInit(init: RequestInit): RequestInit {
+export function remotePrivilegedHeaders(target: RuntimeTarget, extra?: HeadersInit): HeadersInit {
+  return remoteHeaders(target, {
+    ...extra,
+    ...adminSecretHeader(),
+  });
+}
+
+export function remoteFetchInit(init: RequestInit): RequestInit {
   return {
     ...init,
     cache: "no-store",
@@ -419,7 +422,7 @@ export async function checkRemoteRuntimeHealth(
   }
 }
 
-async function readRemoteError(response: Response): Promise<ApiError> {
+export async function readRemoteError(response: Response): Promise<ApiError> {
   const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
   try {
     const body = await response.json();


### PR DESCRIPTION
## Linked issue

Related to https://github.com/Pasta-Devs/Marinara-Engine/issues/2108

## Why this change

- Remote runtime profile import/export needed parity with the embedded Tauri path for profile JSON and ZIP transfers. Large profile files should not be forced through `/api/invoke` JSON/base64 payload limits.
- JSON profile imports with manifest-only asset entries should warn without clearing existing managed asset directories.
- Invalid profile JSON uploads should report an input error instead of surfacing as an internal server error.

## What changed

- Added dedicated `/api/profile/export` download and `/api/profile/import` multipart upload routes for the hostable runtime, including admin access, upload size limits, rate-limit coverage, and content-disposition metadata.
- Routed the shared profile API to the dedicated remote endpoints while keeping embedded Tauri profile import/export behavior intact.
- Reused byte-oriented profile ZIP and compatible export helpers for binary remote downloads.
- Changed JSON profile asset restore so missing inline asset payloads become warnings without creating an empty asset replacement transaction.
- Mapped invalid JSON file/upload imports to `invalid_input` and added focused Rust coverage for the changed profile paths.

## Refactor impact

Primary owner:

Rust storage/profile import-export and shared API remote runtime profile wrapper.

Impact areas reviewed:

- Profile import/export storage contracts.
- Managed asset restore transaction behavior.
- Hostable HTTP middleware for body limits, rate limits, admin access, and error status mapping.
- Shared profile API and settings import caller.
- Remote managed asset invalidation after profile imports.

Boundary notes:

- React settings UI continues to call the typed `src/shared/api/profile-api.ts` wrapper.
- Shared API wrapper owns the embedded-versus-remote dispatch choice.
- Privileged profile file transfer, storage mutation, and asset restore behavior remain in Rust.
- No engine-layer changes.

Pressure points touched:

- Import modules under `src-tauri/src/commands/storage/profile*`.
- Hostable HTTP routing in `src-tauri/src/http_server.rs`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm check` passed locally.
- `cargo test --manifest-path src-tauri/Cargo.toml profile -- --nocapture` passed locally.
- `cargo test --manifest-path src-tauri/Cargo.toml http_server -- --nocapture` passed locally.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed locally.
- `pnpm typecheck` and `pnpm check:architecture` passed locally during review.
- Native Tauri manual profile import/export QA was not run.
- Hands-on remote runtime browser upload/download QA was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Updates existing profile import/export behavior for remote runtime parity; no new discoverable surface was added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes were made because this preserves an existing settings workflow and remote-runtime compatibility path without adding a new user-facing surface. No staging/package-workspace/release claims were touched.

## UI evidence

No screenshots or recordings; this change does not alter visible layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP API endpoints for profile export and import operations with improved file handling and admin access control.

* **Bug Fixes**
  * Enhanced profile import robustness by converting hard-failure behaviors to warning-based handling for missing asset data.
  * Improved error messages for invalid JSON profile validation during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->