### PR TITLE
Handle character sprite download failures

### DIFF
--- a/src/features/catalog/characters/components/CharacterSpritesTab.tsx
+++ b/src/features/catalog/characters/components/CharacterSpritesTab.tsx
@@ -145,6 +145,17 @@ export function CharacterSpritesTab({
     downloadBlob(blob, sprite.filename || `${sprite.expression}.png`);
   }, []);
 
+  const handleDownloadSprite = useCallback(
+    async (sprite: SpriteInfo) => {
+      try {
+        await downloadSpriteFile(sprite);
+      } catch (error) {
+        toast.error(getErrorMessage(error, "Failed to download sprite."));
+      }
+    },
+    [downloadSpriteFile],
+  );
+
   const handleExportSprites = useCallback(
     async (spritesToExport: SpriteInfo[], modeLabel: string) => {
       if (spritesToExport.length === 0) return;
@@ -347,7 +358,7 @@ export function CharacterSpritesTab({
         displayExpression={displayExpression}
         onOpenWandCleanup={setWandCleanupSprite}
         onFrame={setFramingSprite}
-        onDownload={(sprite) => void downloadSpriteFile(sprite)}
+        onDownload={(sprite) => void handleDownloadSprite(sprite)}
         onReplace={startUpload}
         onDelete={setDeleteSpriteRequest}
       />


### PR DESCRIPTION
## Linked issue

Closes #2109

## Why this change

- Character sprite single-download failures could reject silently from the rendered editor path, leaving the user without visible recovery feedback.

## What changed

- Added a character sprite download handler that catches failed managed URL/blob loads and shows the same visible error toast used by the persona sprite editor.
- Routed the character sprite grid download action through the guarded handler.

## Refactor impact

Primary owner:

Catalog resources.

Impact areas reviewed:

- Character sprite editor download/export paths.
- Persona sprite editor download path for parity.
- Shared `loadUrlBlob` / `downloadBlob` behavior.

Boundary notes:

- Feature UI remains in `src/features/catalog`.
- No engine, shared API, Rust, or remote-runtime boundary changes.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check` passed.
- Rendered app/browser download proof was not run locally in this pass.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This only adds missing failure feedback to an existing sprite editor action.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured; no visible layout change. The user-facing change is an error toast when character sprite download fails.
