### PR TITLE
Prefer expression sprites in runtime overlay

### DIFF
--- a/src/features/runtime/visuals/components/SpriteOverlay.tsx
+++ b/src/features/runtime/visuals/components/SpriteOverlay.tsx
@@ -401,7 +401,7 @@ function CharacterSprite({
     const fullBodySprites = allowFullBody
       ? allSprites.filter((sprite) => isFullBodySpriteExpression(sprite.expression))
       : [];
-    const spritePools = [fullBodySprites, expressionSprites];
+    const spritePools = fullBodyOnly ? [fullBodySprites] : [expressionSprites, fullBodySprites];
 
     const fullBodyBaseExpression = (value: string) => (value.startsWith("full_") ? value.slice(5) : value);
     const findMatchingSprite = (predicate: (spriteExpression: string) => boolean) => {

--- a/src/features/runtime/visuals/components/SpriteOverlay.tsx
+++ b/src/features/runtime/visuals/components/SpriteOverlay.tsx
@@ -434,7 +434,7 @@ function CharacterSprite({
     });
     if (neutral) return neutral;
 
-    return fullBodySprites[0]?.url ?? expressionSprites[0]?.url ?? null;
+    return spritePools.find((spriteList) => spriteList.length > 0)?.[0]?.url ?? null;
   }, [sprites, expression, fullBodyOnly, spriteDisplayModes]);
 
   const standardSizeClass =


### PR DESCRIPTION
## Linked issue

Closes #2110

## Why this change

- Runtime sprite overlays could prefer a matching `full_*` sprite before a facial expression sprite when both sprite display modes were enabled, which could hide roleplay expression sprite parity behind full-body assets.

## What changed

- Updated `SpriteOverlay` sprite resolution so normal runtime overlays prefer facial expression sprites first.
- Preserved game/full-body behavior by keeping `fullBodyOnly` overlays restricted to the full-body sprite pool.

## Refactor impact

Primary owner:

Runtime visuals.

Impact areas reviewed:

- Roleplay `SpriteOverlay` usage with expression and full-body display modes.
- Game `SpriteOverlay` usage with `fullBodyOnly`.
- Tracker sprite helper behavior, which already resolves expression sprites independently.

Boundary notes:

- Runtime visual behavior remains in `src/features/runtime/visuals`.
- No engine, shared API, Rust, or remote-runtime boundary changes.

Pressure points touched:

- Runtime `SpriteOverlay`.
- Reviewed roleplay and game `SpriteOverlay` call sites.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check` passed.
- Rendered app/browser sprite visibility proof was not run locally in this pass.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This fixes existing runtime sprite selection behavior and adds no new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured; no visible layout change. The user-facing change is corrected sprite selection priority in runtime overlays.
