### PR TITLE
Support legacy array profile imports

### DIFF
--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -8,7 +8,7 @@ mod zip_import;
 use self::assets::{
     profile_assets, profile_assets_manifest, restore_profile_assets, RestoredProfileAssets,
 };
-use self::legacy::import_legacy_profile_tables;
+use self::legacy::{import_legacy_profile_tables, legacy_array_profile_tables};
 use self::zip_import::import_profile_zip;
 use super::contracts;
 use super::shared::*;
@@ -20,6 +20,31 @@ use std::path::{Path, PathBuf};
 
 const PROFILE_EXPORT_JSON_LIMIT_BYTES: usize = 256 * 1024 * 1024;
 const PROFILE_EXPORT_JSON_TOO_LARGE_CODE: &str = "PROFILE_EXPORT_JSON_TOO_LARGE";
+
+#[derive(Clone, Copy)]
+pub(super) enum ProfileImportSourceFormat {
+    RefactorNative,
+    LegacyFileStorage,
+    LegacyArray,
+}
+
+impl ProfileImportSourceFormat {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::RefactorNative => "refactor-native",
+            Self::LegacyFileStorage => "legacy-modern-fileStorage",
+            Self::LegacyArray => "legacy-array",
+        }
+    }
+
+    fn converted_from(self) -> Option<&'static str> {
+        match self {
+            Self::RefactorNative => None,
+            Self::LegacyFileStorage => Some("legacy-modern-fileStorage"),
+            Self::LegacyArray => Some("legacy-array"),
+        }
+    }
+}
 
 pub(crate) struct ProfileExportDownload {
     pub(crate) bytes: Vec<u8>,
@@ -200,19 +225,38 @@ fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
         .and_then(Value::as_object)
         .filter(|_| body.get("type").and_then(Value::as_str) == Some("marinara_profile"))
         .ok_or_else(|| AppError::invalid_input("Invalid Marinara profile export"))?;
-    if let Some(collections) = data.get("collections").and_then(Value::as_object) {
-        return import_profile_collections(state, data, collections);
-    }
-    let tables = data
-        .get("fileStorage")
-        .and_then(|value| value.get("tables"))
-        .and_then(Value::as_object)
-        .ok_or_else(|| {
-            AppError::invalid_input(
-                "Profile export must contain data.collections or data.fileStorage.tables",
+    if let Some(collections_value) = data.get("collections") {
+        let collections = collections_value.as_object().ok_or_else(|| {
+            profile_format_error(
+                "Profile export data.collections must be an object",
+                "invalid-refactor-native",
             )
         })?;
-    import_legacy_profile_tables(state, data, tables)
+        return import_profile_collections(state, data, collections);
+    }
+    if let Some(tables_value) = data
+        .get("fileStorage")
+        .and_then(|file_storage| file_storage.get("tables"))
+    {
+        let tables = tables_value.as_object().ok_or_else(|| {
+            profile_format_error(
+                "Profile export data.fileStorage.tables must be an object",
+                "invalid-legacy-modern-fileStorage",
+            )
+        })?;
+        return import_legacy_profile_tables(state, data, tables).map(|value| {
+            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyFileStorage)
+        });
+    }
+    if let Some(tables) = legacy_array_profile_tables(data)? {
+        return import_legacy_profile_tables(state, data, &tables).map(|value| {
+            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyArray)
+        });
+    }
+    Err(profile_format_error(
+        "Profile export must contain data.collections, data.fileStorage.tables, or legacy profile arrays",
+        "unknown",
+    ))
 }
 
 fn import_profile_collections(
@@ -228,6 +272,49 @@ fn import_profile_collections(
             restored_assets.install()
         });
     finish_profile_import_assets(restored_assets, result)
+        .map(|value| with_profile_import_metadata(value, ProfileImportSourceFormat::RefactorNative))
+}
+
+pub(super) fn with_profile_import_metadata(
+    mut value: Value,
+    source_format: ProfileImportSourceFormat,
+) -> Value {
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "sourceFormat".to_string(),
+            Value::String(source_format.as_str().to_string()),
+        );
+        let converted = match source_format.converted_from() {
+            Some(from) => json!({
+                "applied": true,
+                "from": from,
+                "to": "refactor-collections",
+            }),
+            None => json!({
+                "applied": false,
+            }),
+        };
+        object.insert("converted".to_string(), converted);
+    }
+    value
+}
+
+pub(super) fn profile_format_error(
+    message: impl Into<String>,
+    source_format: &'static str,
+) -> AppError {
+    AppError::with_details(
+        "invalid_input",
+        message,
+        json!({
+            "sourceFormat": source_format,
+            "expectedFormats": [
+                "refactor-native",
+                "legacy-modern-fileStorage",
+                "legacy-array",
+            ],
+        }),
+    )
 }
 
 pub(super) fn validate_native_profile_import(
@@ -880,6 +967,262 @@ mod tests {
             std::fs::read(avatar_dir.join("keep.png")).expect("avatar should remain"),
             b"keep"
         );
+    }
+
+    #[test]
+    fn profile_import_native_reports_source_format_metadata() {
+        let state = test_state("native-source-format");
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": complete_empty_profile_collections(),
+                    "assets": []
+                }
+            }),
+        )
+        .expect("native profile import should succeed");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["sourceFormat"], "refactor-native");
+        assert_eq!(result["converted"]["applied"], false);
+    }
+
+    #[test]
+    fn profile_import_legacy_file_storage_reports_source_format_metadata() {
+        let state = test_state("legacy-file-storage-source-format");
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "fileStorage": {
+                        "tables": {
+                            "chats": []
+                        }
+                    }
+                }
+            }),
+        )
+        .expect("legacy fileStorage profile import should succeed");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["sourceFormat"], "legacy-modern-fileStorage");
+        assert_eq!(result["converted"]["applied"], true);
+        assert_eq!(result["converted"]["from"], "legacy-modern-fileStorage");
+        assert_eq!(result["converted"]["to"], "refactor-collections");
+    }
+
+    #[test]
+    fn profile_import_legacy_array_imports_direct_arrays() {
+        let state = test_state("legacy-array-direct");
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "characters": [{
+                        "id": "char-1",
+                        "name": "Hero",
+                        "data": "{\"name\":\"Hero\"}",
+                        "avatarBase64": "aGVybw=="
+                    }],
+                    "personas": [{
+                        "id": "persona-1",
+                        "name": "Player",
+                        "avatarBase64": "cGxheWVy"
+                    }],
+                    "lorebooks": [{
+                        "id": "lorebook-1",
+                        "name": "Book",
+                        "entries": [{
+                            "id": "entry-1",
+                            "keys": "[\"key\"]",
+                            "enabled": "true"
+                        }],
+                        "folders": [{
+                            "id": "folder-1",
+                            "name": "Folder"
+                        }]
+                    }],
+                    "presets": [{
+                        "id": "preset-1",
+                        "name": "Preset",
+                        "groups": [{
+                            "id": "group-1",
+                            "name": "Group"
+                        }],
+                        "sections": [{
+                            "id": "section-1",
+                            "name": "Section"
+                        }],
+                        "choices": [{
+                            "id": "choice-1",
+                            "name": "Choice"
+                        }]
+                    }],
+                    "agents": [{
+                        "id": "agent-1",
+                        "name": "Agent",
+                        "type": "custom-agent",
+                        "settings": {}
+                    }],
+                    "themes": [{
+                        "id": "theme-1",
+                        "name": "Theme"
+                    }]
+                }
+            }),
+        )
+        .expect("legacy array profile import should succeed");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["sourceFormat"], "legacy-array");
+        assert_eq!(result["converted"]["applied"], true);
+        assert_eq!(result["converted"]["from"], "legacy-array");
+        assert_eq!(result["imported"]["characters"], 1);
+        assert_eq!(result["imported"]["personas"], 1);
+        assert_eq!(result["imported"]["lorebooks"], 1);
+        assert_eq!(result["imported"]["lorebook-entries"], 1);
+        assert_eq!(result["imported"]["lorebook-folders"], 1);
+        assert_eq!(result["imported"]["presets"], 1);
+        assert_eq!(result["imported"]["prompt-groups"], 1);
+        assert_eq!(result["imported"]["prompt-sections"], 1);
+        assert_eq!(result["imported"]["prompt-variables"], 1);
+        assert_eq!(result["imported"]["agents"], 1);
+        assert_eq!(result["imported"]["themes"], 1);
+
+        let character = state
+            .storage
+            .get("characters", "char-1")
+            .expect("character lookup should not fail")
+            .expect("character should import");
+        assert_eq!(character["data"]["name"], "Hero");
+        assert!(character["avatarPath"]
+            .as_str()
+            .expect("avatar path should be a string")
+            .starts_with("data:image/png;base64,"));
+        let entry = state
+            .storage
+            .get("lorebook-entries", "entry-1")
+            .expect("entry lookup should not fail")
+            .expect("entry should import");
+        assert_eq!(entry["lorebookId"], "lorebook-1");
+        assert_eq!(entry["keys"][0], "key");
+        let section = state
+            .storage
+            .get("prompt-sections", "section-1")
+            .expect("section lookup should not fail")
+            .expect("section should import");
+        assert_eq!(section["presetId"], "preset-1");
+    }
+
+    #[test]
+    fn profile_import_legacy_array_rejects_non_array_without_wiping() {
+        let state = test_state("legacy-array-reject-no-wipe");
+        state
+            .storage
+            .replace_all("characters", vec![json!({ "id": "existing-character" })])
+            .expect("existing character should seed");
+
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "characters": {}
+                }
+            }),
+        )
+        .expect_err("non-array legacy field should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        let details = error
+            .details
+            .expect("legacy array error should include details");
+        assert_eq!(details["sourceFormat"], "invalid-legacy-array");
+        assert_eq!(details["field"], "characters");
+        assert!(state
+            .storage
+            .get("characters", "existing-character")
+            .expect("character lookup should not fail")
+            .is_some());
+    }
+
+    #[test]
+    fn profile_import_legacy_array_empty_parents_clear_nested_tables() {
+        let state = test_state("legacy-array-clear-nested");
+        state
+            .storage
+            .replace_all(
+                "lorebook-entries",
+                vec![json!({ "id": "stale-entry", "lorebookId": "old-book" })],
+            )
+            .expect("stale lorebook entry should seed");
+        state
+            .storage
+            .replace_all(
+                "prompt-sections",
+                vec![json!({ "id": "stale-section", "presetId": "old-preset" })],
+            )
+            .expect("stale prompt section should seed");
+
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "lorebooks": [],
+                    "presets": []
+                }
+            }),
+        )
+        .expect("empty legacy parent arrays should import");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["imported"]["lorebooks"], 0);
+        assert_eq!(result["imported"]["lorebook-entries"], 0);
+        assert_eq!(result["imported"]["presets"], 0);
+        assert_eq!(result["imported"]["prompt-sections"], 0);
+        assert!(state
+            .storage
+            .list("lorebook-entries")
+            .expect("lorebook entries should list")
+            .is_empty());
+        assert!(state
+            .storage
+            .list("prompt-sections")
+            .expect("prompt sections should list")
+            .is_empty());
+    }
+
+    #[test]
+    fn profile_import_unknown_reports_expected_formats() {
+        let state = test_state("unknown-source-format");
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {}
+            }),
+        )
+        .expect_err("unknown profile shape should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        let details = error
+            .details
+            .expect("unknown profile error should include details");
+        assert_eq!(details["sourceFormat"], "unknown");
+        assert_eq!(details["expectedFormats"][0], "refactor-native");
+        assert_eq!(details["expectedFormats"][1], "legacy-modern-fileStorage");
+        assert_eq!(details["expectedFormats"][2], "legacy-array");
     }
 
     fn complete_empty_profile_collections() -> Map<String, Value> {

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -1155,6 +1155,102 @@ mod tests {
     }
 
     #[test]
+    fn profile_import_legacy_array_generates_parent_ids_for_nested_children() {
+        let state = test_state("legacy-array-generated-parent-ids");
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "lorebooks": [{
+                        "id": "",
+                        "name": "Generated Book",
+                        "entries": [{
+                            "id": "entry-generated",
+                            "keys": "[\"generated\"]",
+                            "enabled": "true"
+                        }],
+                        "folders": [{
+                            "id": "folder-generated",
+                            "name": "Generated Folder"
+                        }]
+                    }],
+                    "presets": [{
+                        "name": "Generated Preset",
+                        "groups": [{
+                            "id": "group-generated",
+                            "name": "Generated Group"
+                        }],
+                        "sections": [{
+                            "id": "section-generated",
+                            "name": "Generated Section"
+                        }],
+                        "choices": [{
+                            "id": "choice-generated",
+                            "name": "Generated Choice"
+                        }]
+                    }]
+                }
+            }),
+        )
+        .expect("legacy array profile import should generate parent ids");
+
+        assert_eq!(result["success"], true);
+        let lorebook = state
+            .storage
+            .list("lorebooks")
+            .expect("lorebooks should list")
+            .pop()
+            .expect("lorebook should import");
+        let lorebook_id = lorebook["id"]
+            .as_str()
+            .filter(|id| !id.trim().is_empty())
+            .expect("lorebook should receive an id");
+        let entry = state
+            .storage
+            .get("lorebook-entries", "entry-generated")
+            .expect("entry lookup should not fail")
+            .expect("entry should import");
+        assert_eq!(entry["lorebookId"], lorebook_id);
+        let folder = state
+            .storage
+            .get("lorebook-folders", "folder-generated")
+            .expect("folder lookup should not fail")
+            .expect("folder should import");
+        assert_eq!(folder["lorebookId"], lorebook_id);
+
+        let preset = state
+            .storage
+            .list("prompts")
+            .expect("prompts should list")
+            .pop()
+            .expect("preset should import");
+        let preset_id = preset["id"]
+            .as_str()
+            .filter(|id| !id.trim().is_empty())
+            .expect("preset should receive an id");
+        let group = state
+            .storage
+            .get("prompt-groups", "group-generated")
+            .expect("group lookup should not fail")
+            .expect("group should import");
+        assert_eq!(group["presetId"], preset_id);
+        let section = state
+            .storage
+            .get("prompt-sections", "section-generated")
+            .expect("section lookup should not fail")
+            .expect("section should import");
+        assert_eq!(section["presetId"], preset_id);
+        let choice = state
+            .storage
+            .get("prompt-variables", "choice-generated")
+            .expect("choice lookup should not fail")
+            .expect("choice should import");
+        assert_eq!(choice["presetId"], preset_id);
+    }
+
+    #[test]
     fn profile_import_legacy_array_empty_parents_clear_nested_tables() {
         let state = test_state("legacy-array-clear-nested");
         state

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -166,11 +166,7 @@ fn legacy_array_lorebook_tables(rows: Vec<Value>) -> AppResult<LegacyArrayLorebo
     let mut folders = Vec::new();
 
     for mut row in rows {
-        let parent_id = row
-            .get("id")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .map(str::to_string);
+        let parent_id = legacy_array_parent_id(&mut row);
         let object = row
             .as_object_mut()
             .expect("legacy_array_rows ensures rows are objects");
@@ -179,7 +175,7 @@ fn legacy_array_lorebook_tables(rows: Vec<Value>) -> AppResult<LegacyArrayLorebo
                 &mut entries,
                 "lorebooks.entries",
                 value,
-                parent_id.as_deref(),
+                &parent_id,
                 "lorebookId",
             )?;
         }
@@ -188,7 +184,7 @@ fn legacy_array_lorebook_tables(rows: Vec<Value>) -> AppResult<LegacyArrayLorebo
                 &mut folders,
                 "lorebooks.folders",
                 value,
-                parent_id.as_deref(),
+                &parent_id,
                 "lorebookId",
             )?;
         }
@@ -216,11 +212,7 @@ fn legacy_array_preset_tables(rows: Vec<Value>) -> AppResult<LegacyArrayPresetTa
     let mut choices = Vec::new();
 
     for mut row in rows {
-        let parent_id = row
-            .get("id")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .map(str::to_string);
+        let parent_id = legacy_array_parent_id(&mut row);
         let object = row
             .as_object_mut()
             .expect("legacy_array_rows ensures rows are objects");
@@ -229,7 +221,7 @@ fn legacy_array_preset_tables(rows: Vec<Value>) -> AppResult<LegacyArrayPresetTa
                 &mut groups,
                 "presets.groups",
                 value,
-                parent_id.as_deref(),
+                &parent_id,
                 "presetId",
             )?;
         }
@@ -238,7 +230,7 @@ fn legacy_array_preset_tables(rows: Vec<Value>) -> AppResult<LegacyArrayPresetTa
                 &mut sections,
                 "presets.sections",
                 value,
-                parent_id.as_deref(),
+                &parent_id,
                 "presetId",
             )?;
         }
@@ -247,7 +239,7 @@ fn legacy_array_preset_tables(rows: Vec<Value>) -> AppResult<LegacyArrayPresetTa
                 &mut choices,
                 "presets.choices",
                 value,
-                parent_id.as_deref(),
+                &parent_id,
                 "presetId",
             )?;
         }
@@ -262,11 +254,27 @@ fn legacy_array_preset_tables(rows: Vec<Value>) -> AppResult<LegacyArrayPresetTa
     })
 }
 
+fn legacy_array_parent_id(row: &mut Value) -> String {
+    let object = row
+        .as_object_mut()
+        .expect("legacy_array_rows ensures rows are objects");
+    if let Some(id) = object
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        return id.to_string();
+    }
+    let id = new_id();
+    object.insert("id".to_string(), Value::String(id.clone()));
+    id
+}
+
 fn append_legacy_array_child_rows(
     output: &mut Vec<Value>,
     field: &'static str,
     value: Value,
-    parent_id: Option<&str>,
+    parent_id: &str,
     parent_field: &'static str,
 ) -> AppResult<()> {
     let rows = value.as_array().ok_or_else(|| {
@@ -285,7 +293,7 @@ fn append_legacy_array_child_rows(
             ));
         }
         let mut child = child;
-        if let (Some(parent_id), Some(object)) = (parent_id, child.as_object_mut()) {
+        if let Some(object) = child.as_object_mut() {
             let needs_parent = object
                 .get(parent_field)
                 .and_then(Value::as_str)

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -67,6 +67,291 @@ const LEGACY_GAME_STATE_ALIASES: &[(&str, &str)] = &[
     ("createdAt", "created_at"),
 ];
 
+pub(super) fn legacy_array_profile_tables(
+    data: &Map<String, Value>,
+) -> AppResult<Option<Map<String, Value>>> {
+    let mut tables = Map::new();
+    let mut found = false;
+
+    if let Some(rows) = legacy_array_rows(data, "characters")? {
+        found = true;
+        tables.insert(
+            "characters".to_string(),
+            Value::Array(normalize_legacy_array_avatar_rows(rows)),
+        );
+    }
+    if let Some(rows) = legacy_array_rows(data, "personas")? {
+        found = true;
+        tables.insert(
+            "personas".to_string(),
+            Value::Array(normalize_legacy_array_avatar_rows(rows)),
+        );
+    }
+    if let Some(rows) = legacy_array_rows(data, "agents")? {
+        found = true;
+        tables.insert("agent_configs".to_string(), Value::Array(rows));
+    }
+    if let Some(rows) = legacy_array_rows(data, "themes")? {
+        found = true;
+        tables.insert("custom_themes".to_string(), Value::Array(rows));
+    }
+    if let Some(rows) = legacy_array_rows(data, "lorebooks")? {
+        found = true;
+        let extracted = legacy_array_lorebook_tables(rows)?;
+        tables.insert("lorebooks".to_string(), Value::Array(extracted.parents));
+        tables.insert(
+            "lorebook_entries".to_string(),
+            Value::Array(extracted.entries),
+        );
+        tables.insert(
+            "lorebook_folders".to_string(),
+            Value::Array(extracted.folders),
+        );
+    }
+    if let Some(rows) = legacy_array_rows(data, "presets")? {
+        found = true;
+        let extracted = legacy_array_preset_tables(rows)?;
+        tables.insert(
+            "prompt_presets".to_string(),
+            Value::Array(extracted.parents),
+        );
+        tables.insert("prompt_groups".to_string(), Value::Array(extracted.groups));
+        tables.insert(
+            "prompt_sections".to_string(),
+            Value::Array(extracted.sections),
+        );
+        tables.insert("choice_blocks".to_string(), Value::Array(extracted.choices));
+    }
+
+    Ok(found.then_some(tables))
+}
+
+fn legacy_array_rows(
+    data: &Map<String, Value>,
+    field: &'static str,
+) -> AppResult<Option<Vec<Value>>> {
+    let Some(value) = data.get(field) else {
+        return Ok(None);
+    };
+    let rows = value.as_array().ok_or_else(|| {
+        legacy_array_format_error(
+            format!("Legacy profile field `{field}` must be a JSON array"),
+            field,
+            None,
+        )
+    })?;
+    let mut normalized = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().cloned().enumerate() {
+        if !row.is_object() {
+            return Err(legacy_array_format_error(
+                format!("Legacy profile field `{field}` row {index} must be a JSON object"),
+                field,
+                Some(index),
+            ));
+        }
+        normalized.push(row);
+    }
+    Ok(Some(normalized))
+}
+
+struct LegacyArrayLorebookTables {
+    parents: Vec<Value>,
+    entries: Vec<Value>,
+    folders: Vec<Value>,
+}
+
+fn legacy_array_lorebook_tables(rows: Vec<Value>) -> AppResult<LegacyArrayLorebookTables> {
+    let mut parents = Vec::with_capacity(rows.len());
+    let mut entries = Vec::new();
+    let mut folders = Vec::new();
+
+    for mut row in rows {
+        let parent_id = row
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string);
+        let object = row
+            .as_object_mut()
+            .expect("legacy_array_rows ensures rows are objects");
+        if let Some(value) = object.remove("entries") {
+            append_legacy_array_child_rows(
+                &mut entries,
+                "lorebooks.entries",
+                value,
+                parent_id.as_deref(),
+                "lorebookId",
+            )?;
+        }
+        if let Some(value) = object.remove("folders") {
+            append_legacy_array_child_rows(
+                &mut folders,
+                "lorebooks.folders",
+                value,
+                parent_id.as_deref(),
+                "lorebookId",
+            )?;
+        }
+        parents.push(row);
+    }
+
+    Ok(LegacyArrayLorebookTables {
+        parents,
+        entries,
+        folders,
+    })
+}
+
+struct LegacyArrayPresetTables {
+    parents: Vec<Value>,
+    groups: Vec<Value>,
+    sections: Vec<Value>,
+    choices: Vec<Value>,
+}
+
+fn legacy_array_preset_tables(rows: Vec<Value>) -> AppResult<LegacyArrayPresetTables> {
+    let mut parents = Vec::with_capacity(rows.len());
+    let mut groups = Vec::new();
+    let mut sections = Vec::new();
+    let mut choices = Vec::new();
+
+    for mut row in rows {
+        let parent_id = row
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string);
+        let object = row
+            .as_object_mut()
+            .expect("legacy_array_rows ensures rows are objects");
+        if let Some(value) = object.remove("groups") {
+            append_legacy_array_child_rows(
+                &mut groups,
+                "presets.groups",
+                value,
+                parent_id.as_deref(),
+                "presetId",
+            )?;
+        }
+        if let Some(value) = object.remove("sections") {
+            append_legacy_array_child_rows(
+                &mut sections,
+                "presets.sections",
+                value,
+                parent_id.as_deref(),
+                "presetId",
+            )?;
+        }
+        if let Some(value) = object.remove("choices") {
+            append_legacy_array_child_rows(
+                &mut choices,
+                "presets.choices",
+                value,
+                parent_id.as_deref(),
+                "presetId",
+            )?;
+        }
+        parents.push(row);
+    }
+
+    Ok(LegacyArrayPresetTables {
+        parents,
+        groups,
+        sections,
+        choices,
+    })
+}
+
+fn append_legacy_array_child_rows(
+    output: &mut Vec<Value>,
+    field: &'static str,
+    value: Value,
+    parent_id: Option<&str>,
+    parent_field: &'static str,
+) -> AppResult<()> {
+    let rows = value.as_array().ok_or_else(|| {
+        legacy_array_format_error(
+            format!("Legacy profile field `{field}` must be a JSON array"),
+            field,
+            None,
+        )
+    })?;
+    for (index, child) in rows.iter().cloned().enumerate() {
+        if !child.is_object() {
+            return Err(legacy_array_format_error(
+                format!("Legacy profile field `{field}` row {index} must be a JSON object"),
+                field,
+                Some(index),
+            ));
+        }
+        let mut child = child;
+        if let (Some(parent_id), Some(object)) = (parent_id, child.as_object_mut()) {
+            let needs_parent = object
+                .get(parent_field)
+                .and_then(Value::as_str)
+                .is_none_or(|value| value.trim().is_empty());
+            if needs_parent {
+                object.insert(
+                    parent_field.to_string(),
+                    Value::String(parent_id.to_string()),
+                );
+            }
+        }
+        output.push(child);
+    }
+    Ok(())
+}
+
+fn normalize_legacy_array_avatar_rows(rows: Vec<Value>) -> Vec<Value> {
+    rows.into_iter()
+        .map(|mut row| {
+            normalize_legacy_array_avatar_base64(&mut row);
+            row
+        })
+        .collect()
+}
+
+fn normalize_legacy_array_avatar_base64(row: &mut Value) {
+    let Some(object) = row.as_object_mut() else {
+        return;
+    };
+    let Some(raw) = object.remove("avatarBase64") else {
+        return;
+    };
+    let Some(raw) = raw
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    let avatar_url = if raw.starts_with("data:") {
+        raw.to_string()
+    } else {
+        format!("data:image/png;base64,{raw}")
+    };
+    object.insert("avatar".to_string(), Value::String(avatar_url.clone()));
+    object.insert("avatarPath".to_string(), Value::String(avatar_url.clone()));
+    object.insert("avatarUrl".to_string(), Value::String(avatar_url));
+}
+
+fn legacy_array_format_error(
+    message: impl Into<String>,
+    field: &'static str,
+    index: Option<usize>,
+) -> AppError {
+    let mut details = Map::new();
+    details.insert(
+        "sourceFormat".to_string(),
+        Value::String("invalid-legacy-array".to_string()),
+    );
+    details.insert("field".to_string(), Value::String(field.to_string()));
+    if let Some(index) = index {
+        details.insert("index".to_string(), json!(index));
+    }
+    AppError::with_details("invalid_input", message, Value::Object(details))
+}
+
 pub(super) fn import_legacy_profile_tables(
     state: &AppState,
     data: &Map<String, Value>,

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -1,7 +1,9 @@
 use super::assets::{normalize_zip_entry_name, restore_profile_zip_assets};
 use super::{
     finish_profile_import_assets, import_profile_collections_with_restored_assets,
-    legacy::import_legacy_profile_tables_with_restored_assets, validate_native_profile_import,
+    legacy::{import_legacy_profile_tables_with_restored_assets, legacy_array_profile_tables},
+    profile_format_error, validate_native_profile_import, with_profile_import_metadata,
+    ProfileImportSourceFormat,
 };
 use crate::state::AppState;
 use marinara_core::{AppError, AppResult};
@@ -34,7 +36,13 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
         .get("fileStorage")
         .and_then(|value| value.get("files"))
         .or_else(|| data.get("assets"));
-    if let Some(collections) = data.get("collections").and_then(Value::as_object) {
+    if let Some(collections_value) = data.get("collections") {
+        let collections = collections_value.as_object().ok_or_else(|| {
+            profile_format_error(
+                "Profile ZIP data.collections must be an object",
+                "invalid-refactor-native",
+            )
+        })?;
         validate_native_profile_import(data, collections)?;
         let mut restored_assets =
             restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
@@ -45,17 +53,20 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
             restored_count,
             || restored_assets.install(),
         );
-        finish_profile_import_assets(restored_assets, result)
-    } else {
-        let tables = data
-            .get("fileStorage")
-            .and_then(|value| value.get("tables"))
-            .and_then(Value::as_object)
-            .ok_or_else(|| {
-                AppError::invalid_input(
-                    "Profile ZIP must contain data.collections or data.fileStorage.tables",
-                )
-            })?;
+        return finish_profile_import_assets(restored_assets, result).map(|value| {
+            with_profile_import_metadata(value, ProfileImportSourceFormat::RefactorNative)
+        });
+    }
+    if let Some(tables_value) = data
+        .get("fileStorage")
+        .and_then(|file_storage| file_storage.get("tables"))
+    {
+        let tables = tables_value.as_object().ok_or_else(|| {
+            profile_format_error(
+                "Profile ZIP data.fileStorage.tables must be an object",
+                "invalid-legacy-modern-fileStorage",
+            )
+        })?;
         let mut restored_assets =
             restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
         let restored_count = restored_assets.restored();
@@ -67,8 +78,30 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
             staging_root.as_deref(),
             || restored_assets.install(),
         );
-        finish_profile_import_assets(restored_assets, result)
+        return finish_profile_import_assets(restored_assets, result).map(|value| {
+            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyFileStorage)
+        });
     }
+    if let Some(tables) = legacy_array_profile_tables(data)? {
+        let mut restored_assets =
+            restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
+        let restored_count = restored_assets.restored();
+        let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
+        let result = import_legacy_profile_tables_with_restored_assets(
+            state,
+            &tables,
+            restored_count,
+            staging_root.as_deref(),
+            || restored_assets.install(),
+        );
+        return finish_profile_import_assets(restored_assets, result).map(|value| {
+            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyArray)
+        });
+    }
+    Err(profile_format_error(
+        "Profile ZIP must contain data.collections, data.fileStorage.tables, or legacy profile arrays",
+        "unknown",
+    ))
 }
 
 fn zip_entry_names<R: Read + std::io::Seek>(
@@ -195,6 +228,7 @@ mod tests {
 
         let result = import_profile_zip(&state, &zip_path).expect("zip import should succeed");
         assert_eq!(result["success"], true);
+        assert_eq!(result["sourceFormat"], "legacy-modern-fileStorage");
 
         let chat = state
             .storage
@@ -202,6 +236,45 @@ mod tests {
             .expect("chat lookup should not fail")
             .expect("imported chat should be present");
         assert_eq!(chat["name"], "Imported Chat");
+
+        let _ = std::fs::remove_file(&zip_path);
+    }
+
+    #[test]
+    fn import_profile_zip_imports_legacy_array_profile() {
+        let state = test_state("legacy-array");
+        let profile_json = json!({
+            "type": "marinara_profile",
+            "data": {
+                "characters": [
+                    {
+                        "id": "char-zip",
+                        "name": "Zip Hero",
+                        "data": "{\"name\":\"Zip Hero\"}",
+                        "avatarBase64": "emlw"
+                    }
+                ]
+            }
+        })
+        .to_string();
+        let zip_path = write_profile_zip("legacy-array", &profile_json);
+
+        let result = import_profile_zip(&state, &zip_path).expect("zip import should succeed");
+        assert_eq!(result["success"], true);
+        assert_eq!(result["sourceFormat"], "legacy-array");
+        assert_eq!(result["converted"]["applied"], true);
+        assert_eq!(result["imported"]["characters"], 1);
+
+        let character = state
+            .storage
+            .get("characters", "char-zip")
+            .expect("character lookup should not fail")
+            .expect("legacy array character should import");
+        assert_eq!(character["data"]["name"], "Zip Hero");
+        assert!(character["avatarPath"]
+            .as_str()
+            .expect("avatar path should be a string")
+            .starts_with("data:image/png;base64,"));
 
         let _ = std::fs::remove_file(&zip_path);
     }

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -47,6 +47,12 @@ type ProfileImportResult = {
   message?: string;
   imported?: ProfileImportStats;
   warnings?: ProfileImportWarning[];
+  sourceFormat?: string;
+  converted?: {
+    applied?: boolean;
+    from?: string;
+    to?: string;
+  };
 };
 
 function formatProfileImportDuration(seconds: number) {

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -33,6 +33,8 @@ type ProfileImportProgressState = {
   imported?: ProfileImportStats;
   warnings?: ProfileImportWarning[];
   error?: string;
+  sourceFormat?: string;
+  converted?: ProfileImportConversion;
 };
 
 type ProfileImportWarning = {
@@ -48,11 +50,13 @@ type ProfileImportResult = {
   imported?: ProfileImportStats;
   warnings?: ProfileImportWarning[];
   sourceFormat?: string;
-  converted?: {
-    applied?: boolean;
-    from?: string;
-    to?: string;
-  };
+  converted?: ProfileImportConversion;
+};
+
+type ProfileImportConversion = {
+  applied?: boolean;
+  from?: string;
+  to?: string;
 };
 
 function formatProfileImportDuration(seconds: number) {
@@ -110,6 +114,30 @@ function formatProfileImportWarnings(warnings?: ProfileImportWarning[]) {
   return `${count} warning${count === 1 ? "" : "s"}`;
 }
 
+function formatProfileImportSourceFormat(sourceFormat?: string) {
+  if (!sourceFormat) return "";
+  const labels: Record<string, string> = {
+    "refactor-native": "refactor native",
+    "legacy-modern-fileStorage": "legacy fileStorage",
+    "legacy-array": "legacy array",
+    "refactor-collections": "refactor collections",
+  };
+  return labels[sourceFormat] ?? sourceFormat;
+}
+
+function formatProfileImportMetadata(progress: ProfileImportProgressState) {
+  const source = formatProfileImportSourceFormat(progress.sourceFormat);
+  const parts = source ? [`Source: ${source}`] : [];
+  if (progress.converted?.applied) {
+    const from = formatProfileImportSourceFormat(progress.converted.from);
+    const to = formatProfileImportSourceFormat(progress.converted.to);
+    parts.push(from && to ? `Conversion: ${from} -> ${to}` : "Conversion: applied");
+  } else if (progress.converted?.applied === false) {
+    parts.push("Conversion: none");
+  }
+  return parts.join(". ");
+}
+
 export function ProfileImportSection() {
   const qc = useQueryClient();
   const remoteProfileInputRef = useRef<HTMLInputElement>(null);
@@ -138,6 +166,8 @@ export function ProfileImportSection() {
     qc.invalidateQueries();
     const imported = data?.imported;
     const warnings = Array.isArray(data?.warnings) ? data.warnings : [];
+    const sourceFormat = typeof data?.sourceFormat === "string" ? data.sourceFormat : undefined;
+    const converted = data?.converted && typeof data.converted === "object" ? data.converted : undefined;
     const summary = formatProfileImportStats(imported);
     const skippedSummary = formatProfileImportSkippedStats(imported);
     const warningSummary = formatProfileImportWarnings(warnings);
@@ -152,6 +182,8 @@ export function ProfileImportSection() {
         elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
         imported,
         warnings,
+        sourceFormat,
+        converted,
       };
     });
     toast.success(
@@ -297,9 +329,7 @@ export function ProfileImportSection() {
         )}
       >
         {profileImportBusy ? <Loader2 size="1rem" className="animate-spin" /> : <Download size="1rem" />}
-        {profileImportBusy
-          ? "Importing Profile..."
-          : "Import Profile (JSON/ZIP)"}
+        {profileImportBusy ? "Importing Profile..." : "Import Profile (JSON/ZIP)"}
       </button>
 
       {profileImportProgress && (
@@ -355,6 +385,11 @@ export function ProfileImportSection() {
               {formatProfileImportStats(profileImportProgress.imported) && (
                 <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
                   Imported so far: {formatProfileImportStats(profileImportProgress.imported)}
+                </div>
+              )}
+              {formatProfileImportMetadata(profileImportProgress) && (
+                <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
+                  {formatProfileImportMetadata(profileImportProgress)}
                 </div>
               )}
               {formatProfileImportSkippedStats(profileImportProgress.imported) && (


### PR DESCRIPTION
## Linked issue

Related to https://github.com/Pasta-Devs/Marinara-Engine/issues/2108

## Why this change

- Profile imports should accept legacy v1.6.1-compatible profile exports that carry direct top-level arrays instead of only refactor `data.collections` or legacy `data.fileStorage.tables`.
- Import failures should report the expected source formats clearly and avoid silent collection wipes when malformed legacy-array fields are present.

## What changed

- Added import source format metadata for native refactor profiles, legacy fileStorage profiles, and legacy direct-array profiles.
- Added a legacy-array translator for characters, personas, lorebooks, presets, agents, and themes, including nested lorebook/preset child rows and legacy avatar base64 normalization.
- Extended ZIP profile import to use the same legacy-array path and metadata.
- Updated the settings import result type to accept the new metadata fields.

## Refactor impact

Primary owner:

Rust storage profile import, with a small shell settings type update.

Impact areas reviewed:

- JSON profile import dispatch
- ZIP profile import dispatch
- Legacy table import normalization and replacement behavior
- Settings import result typing
- Legacy v1.6.1 profile export shape from `origin/main`

Boundary notes:

- Behavior stays in `src-tauri` storage/profile import modules.
- React change is type-only and does not add raw Tauri or remote-runtime calls.
- No engine, shared API, or remote runtime routing changes.

Pressure points touched:

- Import modules under `src-tauri/src/commands/storage/profile*`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `git diff --check` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml profile_import -- --nocapture` passed, 21 tests.
- `cargo test --manifest-path src-tauri/Cargo.toml import_profile_zip -- --nocapture` passed, 3 tests.
- `pnpm check` passed.
- Native Tauri app manual import was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility fix for an existing profile import workflow; no new discoverable UI surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed. This changes import compatibility and response metadata, not contributor guidance, architecture docs, or release claims.

## UI evidence

N/A. Backend import behavior plus a TypeScript response type update only; no visible UI layout change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile imports now include metadata showing the source format and any format conversions applied during the import process.
  * Added support for importing legacy array-based profile formats.

* **Bug Fixes**
  * Enhanced error messages for invalid profile imports with clearer details about expected profile formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
