### PR TITLE
Scope game media runtime by game id

### DIFF
--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -2321,7 +2321,9 @@ export function GameSurface({
   const weatherMsgRef = useRef<string | null>(null);
   const sceneAnalysisTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoAssetGenerationKeyRef = useRef<string | null>(null);
-  const introPresentationStorageKey = `game-intro-presented:${activeChatId}`;
+  const activeGameMetaId = typeof chatMeta.gameId === "string" && chatMeta.gameId.trim() ? chatMeta.gameId : null;
+  const sceneRuntimeScopeKey = `${activeChatId}:${activeGameMetaId ?? ""}`;
+  const introPresentationStorageKey = `game-intro-presented:${sceneRuntimeScopeKey}`;
   const assistantTurnCount = useMemo(
     () => messages.filter((m) => (m.role === "assistant" || m.role === "narrator") && !!m.content.trim()).length,
     [messages],
@@ -2372,14 +2374,14 @@ export function GameSurface({
   }, [persistedGameAudioSettings]);
 
   // Clear stale party dialogue when switching chats (M7)
-  const prevActiveChatRef = useRef(activeChatId);
+  const prevSceneRuntimeScopeRef = useRef(sceneRuntimeScopeKey);
   useEffect(() => {
     inventoryItemsRef.current = inventoryItems;
   }, [inventoryItems]);
 
   useEffect(() => {
-    if (prevActiveChatRef.current === activeChatId) return; // skip initial mount
-    prevActiveChatRef.current = activeChatId;
+    if (prevSceneRuntimeScopeRef.current === sceneRuntimeScopeKey) return; // skip initial mount
+    prevSceneRuntimeScopeRef.current = sceneRuntimeScopeKey;
     recentMusicHistoryRef.current = normalizeRecentMusicHistory(chatMeta.gameRecentMusic);
     recentSpotifyTrackHistoryRef.current = normalizeRecentSpotifyTrackHistory(chatMeta.gameRecentSpotifyTracks);
     partyDialogueRestoredRef.current = false;
@@ -2419,7 +2421,7 @@ export function GameSurface({
     // Allow the auto-tutorial to re-evaluate for the new chat (guard still gates on disabled flag)
     tutorialAutoTriggeredRef.current = false;
   }, [
-    activeChatId,
+    sceneRuntimeScopeKey,
     chatMeta.gameInventory,
     chatMeta.gameRecentMusic,
     chatMeta.gameRecentSpotifyTracks,
@@ -2639,17 +2641,21 @@ export function GameSurface({
   // On unmount, only dispose audio (stop sounds) but keep store state intact so that
   // same-chat remount (e.g. returning from persona editor) can read it immediately
   // without waiting for the scene restore effect.
-  const prevChatIdRef = useRef(activeChatId);
+  const prevSceneRuntimeMediaScopeRef = useRef(sceneRuntimeScopeKey);
   useEffect(() => {
-    if (prevChatIdRef.current !== activeChatId) {
+    if (prevSceneRuntimeMediaScopeRef.current !== sceneRuntimeScopeKey) {
       audioManager.dispose();
       useGameAssetStore.getState().resetPlaybackState();
-      prevChatIdRef.current = activeChatId;
+      sceneReadyMsgIdRef.current = undefined;
+      weatherMsgRef.current = null;
+      isRestoredRef.current = false;
+      sceneRestoredRef.current = false;
+      prevSceneRuntimeMediaScopeRef.current = sceneRuntimeScopeKey;
     }
     return () => {
       audioManager.dispose();
     };
-  }, [activeChatId]);
+  }, [sceneRuntimeScopeKey]);
 
   // Reconnect audio and background on mount if the store was disposed
   // (e.g. user left to home and returned to the same game).
@@ -3299,6 +3305,7 @@ export function GameSurface({
     }
   }, [
     activeChatId,
+    sceneRuntimeScopeKey,
     isMessagesLoading,
     latestAssistantMsg?.content,
     latestAssistantMsg?.id,
@@ -4866,7 +4873,7 @@ export function GameSurface({
   const updateSessionHistoryMetadata = useUpdateChatMetadata();
   const updateMessage = useUpdateMessage(activeChatId);
   const startSessionLocked = startSession.isPending || startSessionRequested;
-  const gameId = (chatMeta.gameId as string) || null;
+  const gameId = activeGameMetaId;
   const createGameResetRef = useRef(createGame.reset);
   const gameSetupResetRef = useRef(gameSetup.reset);
   const startGameResetRef = useRef(startGame.reset);
@@ -7899,23 +7906,23 @@ export function GameSurface({
     return undefined;
   }, [sceneAnalysisEnabled, chatBackground, currentBackground, scopedAssetMap]);
 
-  const lastResolvedBackgroundRef = useRef<{ chatId: string; url?: string }>({ chatId: activeChatId });
+  const lastResolvedBackgroundRef = useRef<{ scopeKey: string; url?: string }>({ scopeKey: sceneRuntimeScopeKey });
   useEffect(() => {
-    if (lastResolvedBackgroundRef.current.chatId !== activeChatId) {
-      lastResolvedBackgroundRef.current = { chatId: activeChatId };
+    if (lastResolvedBackgroundRef.current.scopeKey !== sceneRuntimeScopeKey) {
+      lastResolvedBackgroundRef.current = { scopeKey: sceneRuntimeScopeKey };
     }
-  }, [activeChatId]);
+  }, [sceneRuntimeScopeKey]);
   useEffect(() => {
     if (resolvedBackground !== undefined) {
-      lastResolvedBackgroundRef.current = { chatId: activeChatId, url: resolvedBackground };
-    } else if (!scenePreparing && lastResolvedBackgroundRef.current.chatId === activeChatId) {
-      lastResolvedBackgroundRef.current = { chatId: activeChatId };
+      lastResolvedBackgroundRef.current = { scopeKey: sceneRuntimeScopeKey, url: resolvedBackground };
+    } else if (!scenePreparing && lastResolvedBackgroundRef.current.scopeKey === sceneRuntimeScopeKey) {
+      lastResolvedBackgroundRef.current = { scopeKey: sceneRuntimeScopeKey };
     }
-  }, [activeChatId, resolvedBackground, scenePreparing]);
+  }, [sceneRuntimeScopeKey, resolvedBackground, scenePreparing]);
 
   const displayedBackground =
     resolvedBackground ??
-    (scenePreparing && lastResolvedBackgroundRef.current.chatId === activeChatId
+    (scenePreparing && lastResolvedBackgroundRef.current.scopeKey === sceneRuntimeScopeKey
       ? lastResolvedBackgroundRef.current.url
       : undefined);
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2107

## Why this change

- Same-chat game replacement could keep scene media/background runtime state scoped only to the chat id, allowing stale backgrounds, playback state, restore flags, and scene readiness to leak across game identities.

## What changed

- Added a scene runtime scope key based on `activeChatId` and `chatMeta.gameId`.
- Used that scope key for game runtime reset, media playback reset, intro presentation storage, scene restore effect dependencies, and the last resolved background cache.
- Reused the same scoped game id for existing session operations instead of re-reading raw metadata later.

## Refactor impact

Primary owner:

Game mode runtime visuals/media.

Impact areas reviewed:

- `GameSurface` scene media/background reset behavior.
- Scene restore refs and pending readiness refs.
- Last resolved background cache during scene preparation.

Boundary notes:

- Stays inside React game-mode feature code.
- No engine, shared API, Rust, storage, or remote-runtime boundary changes.

Pressure points touched:

- `GameSurface` only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `git diff --check` passed.
- Static review confirmed the reset/cache paths now depend on `sceneRuntimeScopeKey` rather than `activeChatId` alone.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible layout change. Runtime behavior change is scoped to same-chat game identity replacement.
