### PR TITLE
Restore Google Fonts download safety parity

### DIFF
--- a/src-tauri/src/commands/storage/fonts.rs
+++ b/src-tauri/src/commands/storage/fonts.rs
@@ -288,6 +288,14 @@ async fn fetch_google_font_faces(family: &str) -> AppResult<Vec<FontFace>> {
         .map_err(|error| AppError::new("font_client_error", error.to_string()))?;
     let css2 = fetch_google_css(&client, &css2_url).await?;
     let legacy = fetch_google_css(&client, &legacy_url).await?;
+    google_font_faces_from_css_results(family, css2, legacy)
+}
+
+fn google_font_faces_from_css_results(
+    family: &str,
+    css2: GoogleCssResult,
+    legacy: GoogleCssResult,
+) -> AppResult<Vec<FontFace>> {
     let css2_faces = css2
         .css
         .as_deref()
@@ -307,6 +315,19 @@ async fn fetch_google_font_faces(family: &str) -> AppResult<Vec<FontFace>> {
     };
     if !faces.is_empty() {
         return Ok(faces);
+    }
+    if let Some(error) = [
+        css2.request_error.as_deref(),
+        legacy.request_error.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .next()
+    {
+        return Err(AppError::new(
+            "font_lookup_failed",
+            format!("Could not reach Google Fonts. Check your internet connection. {error}"),
+        ));
     }
     if !css2.reached_google && !legacy.reached_google {
         return Err(AppError::new(
@@ -333,6 +354,7 @@ struct GoogleCssResult {
     css: Option<String>,
     reached_google: bool,
     non_success_status: Option<reqwest::StatusCode>,
+    request_error: Option<String>,
 }
 
 async fn fetch_google_css(client: &reqwest::Client, url: &str) -> AppResult<GoogleCssResult> {
@@ -341,29 +363,41 @@ async fn fetch_google_css(client: &reqwest::Client, url: &str) -> AppResult<Goog
         .header(reqwest::header::USER_AGENT, GOOGLE_FONTS_USER_AGENT)
         .send()
         .await;
-    let Ok(response) = response else {
-        return Ok(GoogleCssResult {
-            css: None,
-            reached_google: false,
-            non_success_status: None,
-        });
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            return Ok(GoogleCssResult {
+                css: None,
+                reached_google: false,
+                non_success_status: None,
+                request_error: Some(error.to_string()),
+            });
+        }
     };
     if !response.status().is_success() {
         return Ok(GoogleCssResult {
             css: None,
             reached_google: true,
             non_success_status: Some(response.status()),
+            request_error: None,
         });
     }
+    let text = match response.text().await {
+        Ok(text) => text,
+        Err(error) => {
+            return Ok(GoogleCssResult {
+                css: None,
+                reached_google: true,
+                non_success_status: None,
+                request_error: Some(error.to_string()),
+            });
+        }
+    };
     Ok(GoogleCssResult {
-        css: Some(
-            response
-                .text()
-                .await
-                .map_err(|error| AppError::new("font_lookup_failed", error.to_string()))?,
-        ),
+        css: Some(text),
         reached_google: true,
         non_success_status: None,
+        request_error: None,
     })
 }
 
@@ -715,6 +749,64 @@ mod tests {
             face: regular_face(),
             bytes: bytes.to_vec(),
         }
+    }
+
+    fn google_css_result(
+        css: Option<&str>,
+        reached_google: bool,
+        non_success_status: Option<reqwest::StatusCode>,
+        request_error: Option<&str>,
+    ) -> GoogleCssResult {
+        GoogleCssResult {
+            css: css.map(ToOwned::to_owned),
+            reached_google,
+            non_success_status,
+            request_error: request_error.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn google_font_lookup_keeps_partial_request_error_when_other_endpoint_is_empty() {
+        let result = google_font_faces_from_css_results(
+            "Missing Font",
+            google_css_result(Some("/* no faces */"), true, None, None),
+            google_css_result(None, false, None, Some("connection reset")),
+        );
+        let error = match result {
+            Ok(_) => panic!("partial request failure must not become not found"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.code, "font_lookup_failed");
+        assert!(
+            error.message.contains("connection reset"),
+            "transport detail should stay visible"
+        );
+    }
+
+    #[test]
+    fn google_font_lookup_accepts_successful_endpoint_despite_other_request_error() {
+        let css = r#"
+            @font-face {
+                font-family: 'Example';
+                font-style: normal;
+                font-weight: 400;
+                src: url(https://fonts.gstatic.com/s/example/v1/example.woff2) format('woff2');
+            }
+        "#;
+
+        let faces = google_font_faces_from_css_results(
+            "Example",
+            google_css_result(Some(css), true, None, None),
+            google_css_result(None, false, None, Some("connection reset")),
+        )
+        .expect("successful endpoint should produce faces");
+
+        assert_eq!(faces.len(), 1);
+        assert_eq!(
+            faces[0].url,
+            "https://fonts.gstatic.com/s/example/v1/example.woff2"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/fonts.rs
+++ b/src-tauri/src/commands/storage/fonts.rs
@@ -1,8 +1,18 @@
 use super::images::percent_encode_component;
 use super::*;
+use std::collections::HashSet;
 use std::path::Path;
+use std::sync::{LazyLock, Mutex};
 
 const FONT_EXTS: &[&str] = &["ttf", "otf", "woff", "woff2"];
+const MAX_FONT_BYTES: usize = 10 * 1024 * 1024;
+const GOOGLE_FONTS_USER_AGENT: &str =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120 Safari/537.36";
+static DOWNLOADING_GOOGLE_FONTS: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+static GOOGLE_FONT_METADATA_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+#[cfg(test)]
+static FAIL_NEXT_FONT_METADATA_WRITE: Mutex<bool> = Mutex::new(false);
 
 pub(crate) async fn fonts_call(
     state: &AppState,
@@ -144,15 +154,54 @@ async fn download_google_font(state: &AppState, body: Value) -> AppResult<Value>
         ));
     }
 
+    let safe_name = family.replace(' ', "");
+    let _download_guard = GoogleFontDownloadGuard::acquire(&safe_name, family)?;
+
+    download_google_font_inner(state, family, &safe_name).await
+}
+
+#[derive(Debug)]
+struct GoogleFontDownloadGuard {
+    safe_name: String,
+}
+
+impl GoogleFontDownloadGuard {
+    fn acquire(safe_name: &str, family: &str) -> AppResult<Self> {
+        let mut downloading = DOWNLOADING_GOOGLE_FONTS.lock().map_err(|_| {
+            AppError::new("font_download_failed", "Font download lock was poisoned")
+        })?;
+        if !downloading.insert(safe_name.to_string()) {
+            return Err(AppError::new(
+                "font_download_conflict",
+                format!("\"{family}\" is already being downloaded"),
+            ));
+        }
+        Ok(Self {
+            safe_name: safe_name.to_string(),
+        })
+    }
+}
+
+impl Drop for GoogleFontDownloadGuard {
+    fn drop(&mut self) {
+        if let Ok(mut downloading) = DOWNLOADING_GOOGLE_FONTS.lock() {
+            downloading.remove(&self.safe_name);
+        }
+    }
+}
+
+async fn download_google_font_inner(
+    state: &AppState,
+    family: &str,
+    safe_name: &str,
+) -> AppResult<Value> {
     let root = fonts_root(state)?;
     let faces = fetch_google_font_faces(family).await?;
-    let mut metadata = read_font_metadata(&root);
-    let safe_name = family.replace(' ', "");
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .build()
         .map_err(|error| AppError::new("font_client_error", error.to_string()))?;
-    let mut files = Vec::new();
+    let mut downloaded = Vec::new();
     for (index, face) in faces.iter().enumerate() {
         let suffix = if faces.len() == 1 {
             String::new()
@@ -175,33 +224,32 @@ async fn download_google_font(state: &AppState, body: Value) -> AppResult<Value>
             .bytes()
             .await
             .map_err(|error| AppError::new("font_download_failed", error.to_string()))?;
-        if bytes.len() > 10 * 1024 * 1024 || bytes.get(0..4) != Some(b"wOF2") {
+        if bytes.len() > MAX_FONT_BYTES || bytes.get(0..4) != Some(b"wOF2") {
             return Err(AppError::new(
                 "font_download_failed",
                 "Downloaded file was not a valid woff2 font",
             ));
         }
-        fs::write(root.join(&filename), &bytes)?;
-        metadata.insert(
-            filename.clone(),
-            json!({
-                "family": family,
-                "weight": face.weight,
-                "style": face.style,
-                "unicodeRange": face.unicode_range,
-                "source": "google"
-            }),
-        );
-        files.push(json!({
-            "filename": filename,
-            "family": family,
-            "url": format!("tauri-api:/fonts/file/{}", percent_encode_component(&filename)),
-            "weight": face.weight,
-            "style": face.style,
-            "unicodeRange": face.unicode_range
-        }));
+        downloaded.push(DownloadedFontFile {
+            filename,
+            face: face.clone(),
+            bytes: bytes.to_vec(),
+        });
     }
-    write_font_metadata(&root, &metadata)?;
+    replace_managed_google_font_files(&root, safe_name, family, &downloaded)?;
+    let files = downloaded
+        .iter()
+        .map(|download| {
+            json!({
+                "filename": download.filename,
+                "family": family,
+                "url": format!("tauri-api:/fonts/file/{}", percent_encode_component(&download.filename)),
+                "weight": download.face.weight,
+                "style": download.face.style,
+                "unicodeRange": download.face.unicode_range
+            })
+        })
+        .collect::<Vec<_>>();
     Ok(json!({
         "filename": files.first().and_then(|file| file.get("filename")).cloned().unwrap_or_else(|| json!(format!("{safe_name}-Regular.woff2"))),
         "family": family,
@@ -218,38 +266,116 @@ struct FontFace {
     unicode_range: Value,
 }
 
+struct DownloadedFontFile {
+    filename: String,
+    face: FontFace,
+    bytes: Vec<u8>,
+}
+
 async fn fetch_google_font_faces(family: &str) -> AppResult<Vec<FontFace>> {
-    let url = format!(
+    let encoded_family = percent_encode_component(family);
+    let css2_url = format!(
         "https://fonts.googleapis.com/css2?family={}:wght@400&display=swap",
-        percent_encode_component(family)
+        encoded_family
     );
-    let css = reqwest::Client::builder()
+    let legacy_url = format!(
+        "https://fonts.googleapis.com/css?family={}:400&display=swap",
+        encoded_family
+    );
+    let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()
-        .map_err(|error| AppError::new("font_client_error", error.to_string()))?
-        .get(url)
-        .header(
-            reqwest::header::USER_AGENT,
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120 Safari/537.36",
-        )
-        .send()
-        .await
-        .map_err(|error| AppError::new("font_lookup_failed", error.to_string()))?;
-    if !css.status().is_success() {
+        .map_err(|error| AppError::new("font_client_error", error.to_string()))?;
+    let css2 = fetch_google_css(&client, &css2_url).await?;
+    let legacy = fetch_google_css(&client, &legacy_url).await?;
+    let css2_faces = css2
+        .css
+        .as_deref()
+        .map(parse_google_font_faces)
+        .transpose()?
+        .unwrap_or_default();
+    let legacy_faces = legacy
+        .css
+        .as_deref()
+        .map(parse_google_font_faces)
+        .transpose()?
+        .unwrap_or_default();
+    let faces = if legacy_faces.len() > css2_faces.len() {
+        legacy_faces
+    } else {
+        css2_faces
+    };
+    if !faces.is_empty() {
+        return Ok(faces);
+    }
+    if !css2.reached_google && !legacy.reached_google {
         return Err(AppError::new(
             "font_lookup_failed",
-            format!("Google Fonts returned {}", css.status()),
+            "Could not reach Google Fonts. Check your internet connection.",
         ));
     }
-    parse_google_font_faces(
-        &css.text()
-            .await
-            .map_err(|error| AppError::new("font_lookup_failed", error.to_string()))?,
-    )
+    if let Some(status) = [css2.non_success_status, legacy.non_success_status]
+        .into_iter()
+        .flatten()
+        .find(|status| is_retryable_google_status(*status))
+    {
+        return Err(AppError::new(
+            "font_lookup_failed",
+            format!("Google Fonts returned {status}"),
+        ));
+    }
+    Err(AppError::not_found(format!(
+        "Font \"{family}\" not found on Google Fonts, or has no regular (400) weight available"
+    )))
+}
+
+struct GoogleCssResult {
+    css: Option<String>,
+    reached_google: bool,
+    non_success_status: Option<reqwest::StatusCode>,
+}
+
+async fn fetch_google_css(client: &reqwest::Client, url: &str) -> AppResult<GoogleCssResult> {
+    let response = client
+        .get(url)
+        .header(reqwest::header::USER_AGENT, GOOGLE_FONTS_USER_AGENT)
+        .send()
+        .await;
+    let Ok(response) = response else {
+        return Ok(GoogleCssResult {
+            css: None,
+            reached_google: false,
+            non_success_status: None,
+        });
+    };
+    if !response.status().is_success() {
+        return Ok(GoogleCssResult {
+            css: None,
+            reached_google: true,
+            non_success_status: Some(response.status()),
+        });
+    }
+    Ok(GoogleCssResult {
+        css: Some(
+            response
+                .text()
+                .await
+                .map_err(|error| AppError::new("font_lookup_failed", error.to_string()))?,
+        ),
+        reached_google: true,
+        non_success_status: None,
+    })
+}
+
+fn is_retryable_google_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error()
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
 }
 
 fn parse_google_font_faces(css: &str) -> AppResult<Vec<FontFace>> {
     let mut faces = Vec::new();
+    let mut seen = HashSet::new();
     for block in css.split("@font-face").skip(1) {
         let Some(start) = block.find('{') else {
             continue;
@@ -266,19 +392,159 @@ fn parse_google_font_faces(css: &str) -> AppResult<Vec<FontFace>> {
             .find(|ch: char| ch == ')' || ch == '"' || ch == '\'' || ch.is_whitespace())
             .unwrap_or(url_tail.len());
         let url = url_tail[..url_end].to_string();
-        faces.push(FontFace {
-            url,
-            weight: css_descriptor(body, "font-weight").unwrap_or_else(|| "400".to_string()),
-            style: css_descriptor(body, "font-style").unwrap_or_else(|| "normal".to_string()),
-            unicode_range: css_descriptor(body, "unicode-range")
-                .map(Value::String)
-                .unwrap_or(Value::Null),
-        });
-    }
-    if faces.is_empty() {
-        return Err(AppError::not_found("Font not found on Google Fonts"));
+        let weight = css_descriptor(body, "font-weight").unwrap_or_else(|| "400".to_string());
+        let style = css_descriptor(body, "font-style").unwrap_or_else(|| "normal".to_string());
+        let unicode_range = css_descriptor(body, "unicode-range")
+            .map(Value::String)
+            .unwrap_or(Value::Null);
+        let key = format!("{url}|{weight}|{style}|{unicode_range}");
+        if seen.insert(key) {
+            faces.push(FontFace {
+                url,
+                weight,
+                style,
+                unicode_range,
+            });
+        }
     }
     Ok(faces)
+}
+
+fn replace_managed_google_font_files(
+    root: &Path,
+    safe_name: &str,
+    family: &str,
+    downloaded: &[DownloadedFontFile],
+) -> AppResult<()> {
+    let _metadata_guard = GOOGLE_FONT_METADATA_LOCK
+        .lock()
+        .map_err(|_| AppError::new("font_download_failed", "Font metadata lock was poisoned"))?;
+    let metadata = read_font_metadata(root);
+    for target in downloaded {
+        if root.join(&target.filename).exists()
+            && metadata
+                .get(&target.filename)
+                .and_then(|meta| meta.get("source"))
+                .and_then(Value::as_str)
+                != Some("google")
+        {
+            return Err(AppError::new(
+                "font_download_conflict",
+                format!("\"{family}\" is already installed"),
+            ));
+        }
+    }
+    let operation_id = format!("{}-{}", now_millis(), std::process::id(),);
+    let mut temp_files = Vec::new();
+    let mut backups = Vec::new();
+    let mut installed_targets = Vec::new();
+    let result = (|| -> AppResult<()> {
+        for target in downloaded {
+            let temp_filename = format!("{}.{}.tmp", target.filename, operation_id);
+            fs::write(root.join(&temp_filename), &target.bytes)?;
+            temp_files.push(temp_filename);
+        }
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            if !entry.path().is_file() {
+                continue;
+            }
+            let filename = entry.file_name().to_string_lossy().to_string();
+            if !is_managed_google_family_file(&filename, safe_name, &metadata) {
+                continue;
+            }
+            let backup_filename = format!("{filename}.{operation_id}.bak");
+            fs::rename(root.join(&filename), root.join(&backup_filename))?;
+            backups.push((filename, backup_filename));
+        }
+        for target in downloaded {
+            let temp_filename = format!("{}.{}.tmp", target.filename, operation_id);
+            fs::rename(root.join(&temp_filename), root.join(&target.filename))?;
+            temp_files.retain(|filename| filename != &temp_filename);
+            installed_targets.push(target.filename.clone());
+        }
+        let mut next_metadata = metadata;
+        for (filename, _) in &backups {
+            next_metadata.remove(filename);
+        }
+        for target in downloaded {
+            next_metadata.insert(
+                target.filename.clone(),
+                json!({
+                    "family": family,
+                    "weight": target.face.weight,
+                    "style": target.face.style,
+                    "unicodeRange": target.face.unicode_range,
+                    "source": "google"
+                }),
+            );
+        }
+        write_font_metadata(root, &next_metadata)?;
+        for (_, backup_filename) in &backups {
+            let _ = fs::remove_file(root.join(backup_filename));
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        for filename in installed_targets {
+            let _ = fs::remove_file(root.join(filename));
+        }
+        for (filename, backup_filename) in backups {
+            let _ = fs::rename(root.join(backup_filename), root.join(filename));
+        }
+        for temp_filename in temp_files {
+            let _ = fs::remove_file(root.join(temp_filename));
+        }
+    }
+    result
+}
+
+fn is_managed_google_family_file(
+    filename: &str,
+    safe_name: &str,
+    metadata: &Map<String, Value>,
+) -> bool {
+    let extension = Path::new(filename)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if !FONT_EXTS.contains(&extension.as_str())
+        || !is_legacy_managed_google_filename(filename, safe_name)
+    {
+        return false;
+    }
+    metadata
+        .get(filename)
+        .and_then(|meta| meta.get("source"))
+        .and_then(Value::as_str)
+        == Some("google")
+}
+
+fn is_legacy_managed_google_filename(filename: &str, safe_name: &str) -> bool {
+    let Some(stem) = Path::new(filename)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+    else {
+        return false;
+    };
+    let extension = Path::new(filename)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if extension != "woff2" {
+        return false;
+    }
+    let stem = stem.to_ascii_lowercase();
+    let legacy_stem = format!("{safe_name}-Regular").to_ascii_lowercase();
+    if stem == legacy_stem {
+        return true;
+    }
+    let Some(suffix) = stem.strip_prefix(&format!("{legacy_stem}-")) else {
+        return false;
+    };
+    suffix.len() == 3 && suffix.chars().all(|ch| ch.is_ascii_digit())
 }
 
 fn css_descriptor(body: &str, key: &str) -> Option<String> {
@@ -306,11 +572,61 @@ fn read_font_metadata(root: &Path) -> Map<String, Value> {
 }
 
 fn write_font_metadata(root: &Path, metadata: &Map<String, Value>) -> AppResult<()> {
-    fs::write(
-        root.join("font-metadata.json"),
-        serde_json::to_vec_pretty(metadata)?,
-    )?;
-    Ok(())
+    #[cfg(test)]
+    if let Ok(mut fail_next) = FAIL_NEXT_FONT_METADATA_WRITE.lock() {
+        if *fail_next {
+            *fail_next = false;
+            return Err(AppError::new(
+                "font_metadata_write_failed",
+                "Injected font metadata write failure",
+            ));
+        }
+    }
+
+    let metadata_path = root.join("font-metadata.json");
+    let temp_path = root.join(format!(
+        "font-metadata.json.{}-{}.tmp",
+        now_millis(),
+        std::process::id()
+    ));
+    let result = (|| -> AppResult<()> {
+        fs::write(&temp_path, serde_json::to_vec_pretty(metadata)?)?;
+        replace_existing_file(&temp_path, &metadata_path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temp_path);
+    }
+    result
+}
+
+fn replace_existing_file(temp: &Path, target: &Path) -> std::io::Result<()> {
+    match fs::rename(temp, target) {
+        Ok(()) => Ok(()),
+        Err(_) if target.exists() => {
+            let backup = target.with_file_name(format!(
+                "{}.{}-{}.bak",
+                target
+                    .file_name()
+                    .map(|value| value.to_string_lossy())
+                    .unwrap_or_else(|| "font-metadata.json".into()),
+                now_millis(),
+                std::process::id()
+            ));
+            fs::rename(target, &backup)?;
+            match fs::rename(temp, target) {
+                Ok(()) => {
+                    let _ = fs::remove_file(backup);
+                    Ok(())
+                }
+                Err(error) => {
+                    let _ = fs::rename(&backup, target);
+                    Err(error)
+                }
+            }
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn font_display_name(filename: &str) -> String {
@@ -354,5 +670,144 @@ fn infer_font_style(filename: &str) -> &'static str {
         "italic"
     } else {
         "normal"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    struct TempFontRoot {
+        path: PathBuf,
+    }
+
+    impl TempFontRoot {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "marinara-fonts-{label}-{}-{}",
+                now_millis(),
+                new_id()
+            ));
+            fs::create_dir_all(&path).expect("temp font root should be created");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempFontRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn regular_face() -> FontFace {
+        FontFace {
+            url: "https://fonts.gstatic.com/s/example/v1/example.woff2".to_string(),
+            weight: "400".to_string(),
+            style: "normal".to_string(),
+            unicode_range: Value::Null,
+        }
+    }
+
+    fn downloaded_font(filename: &str, bytes: &[u8]) -> DownloadedFontFile {
+        DownloadedFontFile {
+            filename: filename.to_string(),
+            face: regular_face(),
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn google_font_download_guard_drop_releases_family() {
+        let safe_name = format!("GuardedFont{}", new_id().replace('-', ""));
+        let first =
+            GoogleFontDownloadGuard::acquire(&safe_name, "Guarded Font").expect("first guard");
+        let conflict = GoogleFontDownloadGuard::acquire(&safe_name, "Guarded Font")
+            .expect_err("second guard should conflict");
+        assert_eq!(conflict.code, "font_download_conflict");
+
+        drop(first);
+
+        let second =
+            GoogleFontDownloadGuard::acquire(&safe_name, "Guarded Font").expect("guard released");
+        drop(second);
+    }
+
+    #[test]
+    fn replace_managed_google_font_files_rejects_non_google_filename_conflict() {
+        let root = TempFontRoot::new("non-google-conflict");
+        let filename = "OpenSans-Regular.woff2";
+        fs::write(root.path.join(filename), b"custom font").expect("custom font should be written");
+
+        let error = replace_managed_google_font_files(
+            &root.path,
+            "OpenSans",
+            "Open Sans",
+            &[downloaded_font(filename, b"new google font")],
+        )
+        .expect_err("custom filename conflict should be rejected");
+
+        assert_eq!(error.code, "font_download_conflict");
+        assert_eq!(
+            fs::read(root.path.join(filename)).expect("custom font should remain"),
+            b"custom font"
+        );
+        assert!(
+            !root.path.join("font-metadata.json").exists(),
+            "metadata should not be created for rejected custom conflict"
+        );
+    }
+
+    #[test]
+    fn replace_managed_google_font_files_restores_prior_file_after_metadata_failure() {
+        let root = TempFontRoot::new("metadata-rollback");
+        let filename = "Roboto-Regular.woff2";
+        fs::write(root.path.join(filename), b"old managed font")
+            .expect("old managed font should be written");
+        fs::write(
+            root.path.join("font-metadata.json"),
+            serde_json::to_vec_pretty(&json!({
+                filename: {
+                    "family": "Roboto",
+                    "weight": "400",
+                    "style": "normal",
+                    "source": "google"
+                }
+            }))
+            .expect("metadata should serialize"),
+        )
+        .expect("old metadata should be written");
+
+        *FAIL_NEXT_FONT_METADATA_WRITE
+            .lock()
+            .expect("failure hook lock") = true;
+        let error = replace_managed_google_font_files(
+            &root.path,
+            "Roboto",
+            "Roboto",
+            &[downloaded_font(filename, b"new managed font")],
+        )
+        .expect_err("metadata failure should roll back installed font files");
+
+        assert_eq!(error.code, "font_metadata_write_failed");
+        assert_eq!(
+            fs::read(root.path.join(filename)).expect("old managed font should be restored"),
+            b"old managed font"
+        );
+        let metadata = read_font_metadata(&root.path);
+        assert_eq!(
+            metadata
+                .get(filename)
+                .and_then(|entry| entry.get("source"))
+                .and_then(Value::as_str),
+            Some("google")
+        );
+        let leftovers = fs::read_dir(&root.path)
+            .expect("font root should be readable")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .filter(|name| name.ends_with(".tmp") || name.ends_with(".bak"))
+            .collect::<Vec<_>>();
+        assert!(leftovers.is_empty(), "rollback should clean temp files");
     }
 }


### PR DESCRIPTION
## Linked issue

Closes #2112

## Why this change

- Restores legacy Google Fonts download safeguards that were missing on the refactor Rust storage path: duplicate in-flight download protection, CSS endpoint fallback/richer shard selection, and atomic managed shard replacement.

## What changed

- Added a per-family in-memory Google Fonts download guard in the Rust fonts command.
- Fetches both the CSS2 and legacy Google Fonts CSS endpoints, then uses whichever returns the richer face/shard list.
- Downloads and validates all target `.woff2` shards before replacing existing managed Google font files.
- Replaces managed Google font shards through temp files and backups, with rollback on install or metadata failures.
- Writes font metadata through a temp file replacement path instead of direct writes.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Catalog media/settings asset font download path
- Embedded Tauri command path
- Remote runtime command allowlist and HTTP dispatch path

Boundary notes:

- Behavior remains inside `src-tauri/src/commands/storage/fonts.rs`.
- `src/shared/api/settings-assets-api.ts`, `src/shared/api/remote-runtime.ts`, and `src-tauri/src/http_dispatch.rs` already route `fonts_google_download` explicitly; no feature-layer raw runtime calls were added.
- No React, engine, or shared API contract shape changes.

Pressure points touched:

- None. No `ModeSurface`, `GameSurface`, shared mode UI, command registration, or import modules changed.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm check`
- Static parity comparison against `upstream/main:packages/server/src/routes/fonts.routes.ts` for `downloadingFonts`, `loadGoogleFontFaces`, and `replaceManagedGoogleFontFiles`.
- No manual app download against live Google Fonts was performed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; it restores existing Google Fonts download safety behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; no visible UI changes.
