### PR TITLE
Add profile import preview confirmation

### DIFF
--- a/src-tauri/src/commands/storage/commands/profile.rs
+++ b/src-tauri/src/commands/storage/commands/profile.rs
@@ -218,8 +218,29 @@ pub fn profile_import(state: State<'_, AppState>, envelope: Value) -> Result<Val
 }
 
 #[tauri::command]
-pub fn profile_import_file(state: State<'_, AppState>, path: String) -> Result<Value, AppError> {
-    profile::import_profile_file_path(&state, &path)
+pub fn profile_import_preview_file(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<Value, AppError> {
+    profile::preview_profile_file_path(&state, &path)
+}
+
+#[tauri::command]
+pub fn profile_import_file(
+    state: State<'_, AppState>,
+    path: String,
+    preview_fingerprint: Option<String>,
+) -> Result<Value, AppError> {
+    profile::import_profile_file_path(&state, &path, preview_fingerprint.as_deref())
+}
+
+#[tauri::command]
+pub fn profile_import_preview_upload(
+    state: State<'_, AppState>,
+    filename: String,
+    base64: String,
+) -> Result<Value, AppError> {
+    profile::preview_profile_upload(&state, &filename, &base64)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -6,20 +6,33 @@ mod legacy;
 mod zip_import;
 
 use self::assets::{
-    profile_assets, profile_assets_manifest, restore_profile_assets, RestoredProfileAssets,
+    preview_legacy_profile_json_assets, preview_profile_assets, profile_assets,
+    profile_assets_manifest, restore_profile_assets, RestoredProfileAssets,
 };
-use self::legacy::{import_legacy_profile_tables, legacy_array_profile_tables};
-use self::zip_import::import_profile_zip;
+use self::legacy::{
+    import_legacy_profile_tables, legacy_array_profile_tables, preview_legacy_profile_tables,
+};
+use self::zip_import::{
+    import_profile_zip, import_profile_zip_file, preview_profile_zip, preview_profile_zip_file,
+};
 use super::contracts;
 use super::shared::*;
 use super::*;
 use base64::engine::general_purpose;
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 const PROFILE_EXPORT_JSON_LIMIT_BYTES: usize = 256 * 1024 * 1024;
 const PROFILE_EXPORT_JSON_TOO_LARGE_CODE: &str = "PROFILE_EXPORT_JSON_TOO_LARGE";
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProfileImportMode {
+    Preview,
+    Commit,
+}
 
 #[derive(Clone, Copy)]
 pub(super) enum ProfileImportSourceFormat {
@@ -44,6 +57,11 @@ impl ProfileImportSourceFormat {
             Self::LegacyArray => Some("legacy-array"),
         }
     }
+}
+
+struct ProfileCollectionsImportPlan {
+    imported: Map<String, Value>,
+    replacements: Vec<(&'static str, Vec<Value>)>,
 }
 
 pub(crate) struct ProfileExportDownload {
@@ -78,17 +96,51 @@ pub(crate) fn profile_backup_snapshot(state: &AppState) -> AppResult<Value> {
     }))
 }
 
-pub(crate) fn import_profile_file_path(state: &AppState, value: &str) -> AppResult<Value> {
+pub(crate) fn import_profile_file_path(
+    state: &AppState,
+    value: &str,
+    preview_fingerprint: Option<&str>,
+) -> AppResult<Value> {
     let path = PathBuf::from(value.trim());
-    import_profile_file(state, &path)
+    import_profile_file_with_preview_fingerprint(state, &path, preview_fingerprint)
+}
+
+pub(crate) fn preview_profile_file_path(state: &AppState, value: &str) -> AppResult<Value> {
+    let path = PathBuf::from(value.trim());
+    preview_profile_file(state, &path)
 }
 
 pub(crate) fn import_profile_file(state: &AppState, path: &Path) -> AppResult<Value> {
+    import_profile_file_with_preview_fingerprint(state, path, None)
+}
+
+pub(crate) fn import_profile_file_with_preview_fingerprint(
+    state: &AppState,
+    path: &Path,
+    preview_fingerprint: Option<&str>,
+) -> AppResult<Value> {
     if path.as_os_str().is_empty() {
         return Err(AppError::invalid_input("Profile file path is required"));
     }
     if !path.is_file() {
         return Err(AppError::invalid_input("Profile import path is not a file"));
+    }
+    let mut file = File::open(path)?;
+    if let Some(expected) = preview_fingerprint
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let actual = profile_file_fingerprint(&mut file)?;
+        if actual != expected {
+            return Err(AppError::with_details(
+                "profile_file_changed",
+                "Profile file changed after preview. Select the file again before importing.",
+                json!({
+                    "expectedFingerprint": expected,
+                    "actualFingerprint": actual,
+                }),
+            ));
+        }
     }
     match path
         .extension()
@@ -98,13 +150,40 @@ pub(crate) fn import_profile_file(state: &AppState, path: &Path) -> AppResult<Va
     {
         Some("json") => import_profile(
             state,
-            serde_json::from_reader(File::open(path)?).map_err(invalid_profile_json_error)?,
+            serde_json::from_reader(file).map_err(invalid_profile_json_error)?,
         ),
-        Some("zip") => import_profile_zip(state, path),
+        Some("zip") => import_profile_zip_file(state, file),
         _ => Err(AppError::invalid_input(
             "Profile import must be a .json or .zip file",
         )),
     }
+}
+
+pub(crate) fn preview_profile_file(state: &AppState, path: &Path) -> AppResult<Value> {
+    if path.as_os_str().is_empty() {
+        return Err(AppError::invalid_input("Profile file path is required"));
+    }
+    if !path.is_file() {
+        return Err(AppError::invalid_input("Profile import path is not a file"));
+    }
+    let mut file = File::open(path)?;
+    let fingerprint = profile_file_fingerprint(&mut file)?;
+    let result = match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("json") => preview_profile(
+            state,
+            serde_json::from_reader(file).map_err(invalid_profile_json_error)?,
+        ),
+        Some("zip") => preview_profile_zip_file(state, file),
+        _ => Err(AppError::invalid_input(
+            "Profile import must be a .json or .zip file",
+        )),
+    }?;
+    Ok(with_profile_import_file_fingerprint(result, fingerprint))
 }
 
 pub(crate) fn import_profile_upload(
@@ -112,15 +191,7 @@ pub(crate) fn import_profile_upload(
     filename: &str,
     base64: &str,
 ) -> AppResult<Value> {
-    let extension = Path::new(filename)
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(|extension| extension.to_ascii_lowercase())
-        .ok_or_else(|| AppError::invalid_input("Profile upload must be a .json or .zip file"))?;
-    let bytes =
-        base64::Engine::decode(&general_purpose::STANDARD, base64.trim()).map_err(|error| {
-            AppError::invalid_input(format!("Invalid profile upload data: {error}"))
-        })?;
+    let (extension, bytes) = profile_upload_bytes(filename, base64)?;
     match extension.as_str() {
         "json" => import_profile(
             state,
@@ -141,6 +212,70 @@ pub(crate) fn import_profile_upload(
     }
 }
 
+pub(crate) fn preview_profile_upload(
+    state: &AppState,
+    filename: &str,
+    base64: &str,
+) -> AppResult<Value> {
+    let (extension, bytes) = profile_upload_bytes(filename, base64)?;
+    match extension.as_str() {
+        "json" => preview_profile(
+            state,
+            serde_json::from_slice(&bytes).map_err(invalid_profile_json_error)?,
+        ),
+        "zip" => {
+            let upload_dir = state.data_dir.join(".profile-upload-imports");
+            fs::create_dir_all(&upload_dir)?;
+            let path = upload_dir.join(format!("profile-preview-{}.zip", now_millis()));
+            fs::write(&path, bytes)?;
+            let result = preview_profile_zip(state, &path);
+            let _ = fs::remove_file(path);
+            result
+        }
+        _ => Err(AppError::invalid_input(
+            "Profile upload must be a .json or .zip file",
+        )),
+    }
+}
+
+fn profile_upload_bytes(filename: &str, base64: &str) -> AppResult<(String, Vec<u8>)> {
+    let extension = Path::new(filename)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .ok_or_else(|| AppError::invalid_input("Profile upload must be a .json or .zip file"))?;
+    let bytes =
+        base64::Engine::decode(&general_purpose::STANDARD, base64.trim()).map_err(|error| {
+            AppError::invalid_input(format!("Invalid profile upload data: {error}"))
+        })?;
+    Ok((extension, bytes))
+}
+
+fn profile_file_fingerprint(file: &mut File) -> AppResult<String> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    file.seek(SeekFrom::Start(0))?;
+    Ok(format!("sha256:{}", hex_bytes(&hasher.finalize())))
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
 fn invalid_profile_json_error(error: serde_json::Error) -> AppError {
     AppError::invalid_input(format!("Invalid profile JSON: {error}"))
 }
@@ -154,6 +289,7 @@ pub(crate) fn profile_call(
 ) -> AppResult<Value> {
     match (method, rest) {
         ("GET", ["export"]) => export_profile(state, route.query.get("format").map(String::as_str)),
+        ("POST", ["import", "preview"]) => preview_profile(state, body),
         ("POST", ["import"]) => import_profile(state, body),
         _ => Err(AppError::new(
             "route_not_found",
@@ -220,6 +356,14 @@ fn native_profile_export(state: &AppState) -> AppResult<Value> {
 }
 
 fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
+    run_profile_import(state, body, ProfileImportMode::Commit)
+}
+
+fn preview_profile(state: &AppState, body: Value) -> AppResult<Value> {
+    run_profile_import(state, body, ProfileImportMode::Preview)
+}
+
+fn run_profile_import(state: &AppState, body: Value, mode: ProfileImportMode) -> AppResult<Value> {
     let data = body
         .get("data")
         .and_then(Value::as_object)
@@ -232,7 +376,7 @@ fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
                 "invalid-refactor-native",
             )
         })?;
-        return import_profile_collections(state, data, collections);
+        return run_profile_collections(state, data, collections, mode);
     }
     if let Some(tables_value) = data
         .get("fileStorage")
@@ -244,14 +388,27 @@ fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
                 "invalid-legacy-modern-fileStorage",
             )
         })?;
-        return import_legacy_profile_tables(state, data, tables).map(|value| {
-            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyFileStorage)
-        });
+        let files = data.get("fileStorage").and_then(|value| value.get("files"));
+        return run_profile_legacy_tables(
+            state,
+            tables,
+            files,
+            ProfileImportSourceFormat::LegacyFileStorage,
+            mode,
+        );
     }
     if let Some(tables) = legacy_array_profile_tables(data)? {
-        return import_legacy_profile_tables(state, data, &tables).map(|value| {
-            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyArray)
-        });
+        let files = data
+            .get("fileStorage")
+            .and_then(|value| value.get("files"))
+            .or_else(|| data.get("assets"));
+        return run_profile_legacy_tables(
+            state,
+            &tables,
+            files,
+            ProfileImportSourceFormat::LegacyArray,
+            mode,
+        );
     }
     Err(profile_format_error(
         "Profile export must contain data.collections, data.fileStorage.tables, or legacy profile arrays",
@@ -259,20 +416,75 @@ fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
     ))
 }
 
-fn import_profile_collections(
+fn run_profile_collections(
     state: &AppState,
     data: &Map<String, Value>,
     collections: &Map<String, Value>,
+    mode: ProfileImportMode,
 ) -> AppResult<Value> {
     validate_native_profile_import(data, collections)?;
-    let mut restored_assets = restore_profile_assets(state, data.get("assets"))?;
-    let restored_count = restored_assets.restored();
-    let result =
-        import_profile_collections_with_restored_assets(state, collections, restored_count, || {
-            restored_assets.install()
-        });
-    finish_profile_import_assets(restored_assets, result)
-        .map(|value| with_profile_import_metadata(value, ProfileImportSourceFormat::RefactorNative))
+    match mode {
+        ProfileImportMode::Preview => {
+            let (restored_assets, warnings) = preview_profile_assets(data.get("assets"))?;
+            let result = preview_profile_collections_with_restored_assets(
+                state,
+                collections,
+                restored_assets,
+            )?;
+            Ok(with_profile_import_warnings(
+                with_profile_import_metadata(result, ProfileImportSourceFormat::RefactorNative),
+                warnings,
+            ))
+        }
+        ProfileImportMode::Commit => {
+            let mut restored_assets = restore_profile_assets(state, data.get("assets"))?;
+            let restored_count = restored_assets.restored();
+            let result = import_profile_collections_with_restored_assets(
+                state,
+                collections,
+                restored_count,
+                || restored_assets.install(),
+            );
+            finish_profile_import_assets(restored_assets, result).map(|value| {
+                with_profile_import_metadata(value, ProfileImportSourceFormat::RefactorNative)
+            })
+        }
+    }
+}
+
+fn run_profile_legacy_tables(
+    state: &AppState,
+    tables: &Map<String, Value>,
+    raw_assets: Option<&Value>,
+    source_format: ProfileImportSourceFormat,
+    mode: ProfileImportMode,
+) -> AppResult<Value> {
+    match mode {
+        ProfileImportMode::Preview => {
+            let (restored_assets, warnings) = preview_legacy_profile_json_assets(raw_assets)?;
+            let result = preview_legacy_profile_tables(state, tables, restored_assets)?;
+            Ok(with_profile_import_warnings(
+                with_profile_import_metadata(result, source_format),
+                warnings,
+            ))
+        }
+        ProfileImportMode::Commit => import_legacy_profile_tables(state, tables, raw_assets)
+            .map(|value| with_profile_import_metadata(value, source_format)),
+    }
+}
+
+pub(super) fn preview_profile_collections_with_restored_assets(
+    state: &AppState,
+    collections: &Map<String, Value>,
+    restored_assets: usize,
+) -> AppResult<Value> {
+    let plan = profile_collections_import_plan(
+        state,
+        collections,
+        restored_assets,
+        ProfileImportMode::Preview,
+    )?;
+    Ok(json!({ "success": true, "preview": true, "imported": plan.imported }))
 }
 
 pub(super) fn with_profile_import_metadata(
@@ -295,6 +507,22 @@ pub(super) fn with_profile_import_metadata(
             }),
         };
         object.insert("converted".to_string(), converted);
+    }
+    value
+}
+
+pub(super) fn with_profile_import_warnings(mut value: Value, warnings: Vec<Value>) -> Value {
+    if !warnings.is_empty() {
+        if let Some(object) = value.as_object_mut() {
+            object.insert("warnings".to_string(), Value::Array(warnings));
+        }
+    }
+    value
+}
+
+fn with_profile_import_file_fingerprint(mut value: Value, fingerprint: String) -> Value {
+    if let Some(object) = value.as_object_mut() {
+        object.insert("fileFingerprint".to_string(), Value::String(fingerprint));
     }
     value
 }
@@ -364,6 +592,24 @@ pub(super) fn import_profile_collections_with_restored_assets<F>(
 where
     F: FnOnce() -> AppResult<()>,
 {
+    let plan = profile_collections_import_plan(
+        state,
+        collections,
+        restored_assets,
+        ProfileImportMode::Commit,
+    )?;
+    state
+        .storage
+        .replace_all_many_and_then(plan.replacements, install_assets)?;
+    Ok(json!({ "success": true, "imported": plan.imported }))
+}
+
+fn profile_collections_import_plan(
+    state: &AppState,
+    collections: &Map<String, Value>,
+    restored_assets: usize,
+    mode: ProfileImportMode,
+) -> AppResult<ProfileCollectionsImportPlan> {
     let mut imported = Map::new();
     let mut replacements = Vec::new();
     let mut unsupported_prompt_overrides = 0usize;
@@ -392,10 +638,7 @@ where
         }
         normalize_profile_json_fields(collection, &mut rows)?;
         if collection == "connections" {
-            rows = rows
-                .into_iter()
-                .map(|row| connection_secrets::prepare_connection_for_create(state, row))
-                .collect::<AppResult<Vec<_>>>()?;
+            rows = normalize_profile_connection_rows(state, rows, mode)?;
         }
         imported.insert(collection.to_string(), json!(rows.len()));
         replacements.push((collection, rows));
@@ -407,9 +650,6 @@ where
         replacements.push((message_swipes::COLLECTION, Vec::new()));
     }
     normalize_message_swipe_replacements(&mut replacements, &mut imported)?;
-    state
-        .storage
-        .replace_all_many_and_then(replacements, install_assets)?;
     imported.insert("files".to_string(), json!(restored_assets));
     if unsupported_prompt_overrides > 0 {
         imported.insert(
@@ -418,7 +658,33 @@ where
         );
     }
     insert_profile_import_aliases(&mut imported);
-    Ok(json!({ "success": true, "imported": imported }))
+    Ok(ProfileCollectionsImportPlan {
+        imported,
+        replacements,
+    })
+}
+
+fn normalize_profile_connection_rows(
+    state: &AppState,
+    rows: Vec<Value>,
+    mode: ProfileImportMode,
+) -> AppResult<Vec<Value>> {
+    match mode {
+        ProfileImportMode::Commit => rows
+            .into_iter()
+            .map(|row| connection_secrets::prepare_connection_for_create(state, row))
+            .collect(),
+        ProfileImportMode::Preview => {
+            for row in &rows {
+                if !row.is_object() {
+                    return Err(AppError::invalid_input(
+                        "Profile collection `connections` rows must be JSON objects",
+                    ));
+                }
+            }
+            Ok(rows)
+        }
+    }
 }
 
 pub(super) fn normalize_message_swipe_replacements(
@@ -1122,6 +1388,40 @@ mod tests {
     }
 
     #[test]
+    fn profile_import_legacy_array_restores_top_level_assets_manifest() {
+        let state = test_state("legacy-array-top-level-assets");
+        let result = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "characters": [],
+                    "assets": [{
+                        "path": "avatars/legacy-array-asset.png",
+                        "base64": "aGVybw=="
+                    }]
+                }
+            }),
+        )
+        .expect("legacy array import should restore data.assets payloads");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["sourceFormat"], "legacy-array");
+        assert_eq!(result["imported"]["files"], 1);
+        assert_eq!(
+            std::fs::read(
+                state
+                    .data_dir
+                    .join("avatars")
+                    .join("legacy-array-asset.png")
+            )
+            .expect("restored legacy array asset should exist"),
+            b"hero"
+        );
+    }
+
+    #[test]
     fn profile_import_legacy_array_rejects_non_array_without_wiping() {
         let state = test_state("legacy-array-reject-no-wipe");
         state
@@ -1628,6 +1928,254 @@ mod tests {
             .expect("chat lookup should not fail")
             .expect("uploaded chat should import");
         assert_eq!(chat["name"], "Uploaded Chat");
+    }
+
+    #[test]
+    fn profile_import_preview_reports_counts_without_writing() {
+        let state = test_state("profile-preview-no-write");
+        let preview = preview_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "characters": [{
+                        "id": "preview-char",
+                        "name": "Preview Character",
+                        "data": "{\"name\":\"Preview Character\"}"
+                    }],
+                    "presets": [{
+                        "id": "preview-preset",
+                        "name": "Preview Preset",
+                        "sections": [{
+                            "id": "preview-section",
+                            "name": "Section"
+                        }]
+                    }]
+                }
+            }),
+        )
+        .expect("legacy array preview should succeed");
+
+        assert_eq!(preview["success"], true);
+        assert_eq!(preview["preview"], true);
+        assert_eq!(preview["sourceFormat"], "legacy-array");
+        assert_eq!(preview["converted"]["applied"], true);
+        assert_eq!(preview["imported"]["characters"], 1);
+        assert_eq!(preview["imported"]["presets"], 1);
+        assert_eq!(preview["imported"]["prompt-sections"], 1);
+        assert!(state
+            .storage
+            .get("characters", "preview-char")
+            .expect("character lookup should not fail")
+            .is_none());
+    }
+
+    #[test]
+    fn profile_import_preview_warns_for_json_manifest_assets_without_payload() {
+        let state = test_state("profile-preview-missing-json-asset");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "characters".to_string(),
+            json!([{ "id": "char-1", "name": "Hero", "data": {} }]),
+        );
+
+        let preview = preview_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": [{ "path": "avatars/char-1.png", "size": 12 }]
+                }
+            }),
+        )
+        .expect("preview should preserve profile data and warn about missing asset data");
+
+        assert_eq!(preview["success"], true);
+        assert_eq!(preview["preview"], true);
+        assert_eq!(preview["sourceFormat"], "refactor-native");
+        assert_eq!(preview["imported"]["characters"], 1);
+        assert_eq!(preview["imported"]["files"], 0);
+        assert_eq!(preview["warnings"][0]["type"], "missing_asset");
+        assert_eq!(preview["warnings"][0]["path"], "avatars/char-1.png");
+        assert!(state
+            .storage
+            .get("characters", "char-1")
+            .expect("character lookup should not fail")
+            .is_none());
+    }
+
+    #[test]
+    fn profile_import_preview_rejects_invalid_inline_asset_data_without_writing() {
+        let state = test_state("profile-preview-invalid-asset-data");
+        let collections = complete_empty_profile_collections();
+
+        let error = preview_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": [{
+                        "path": "avatars/bad-inline.png",
+                        "base64": "not valid base64"
+                    }]
+                }
+            }),
+        )
+        .expect_err("preview should reject invalid inline profile asset data");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Invalid profile asset data"));
+        assert!(!state
+            .data_dir
+            .join("avatars")
+            .join("bad-inline.png")
+            .exists());
+    }
+
+    #[test]
+    fn profile_import_preview_counts_connections_without_creating_secret_key() {
+        let state = test_state("profile-preview-connection-no-secret-write");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "connections".to_string(),
+            json!([{
+                "id": "preview-connection",
+                "name": "Preview Connection",
+                "provider": "openai",
+                "apiKey": "preview-secret"
+            }]),
+        );
+
+        let preview = preview_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }),
+        )
+        .expect("preview should count connection rows without committing secrets");
+
+        assert_eq!(preview["success"], true);
+        assert_eq!(preview["preview"], true);
+        assert_eq!(preview["imported"]["connections"], 1);
+        assert!(state
+            .storage
+            .get("connections", "preview-connection")
+            .expect("connection lookup should not fail")
+            .is_none());
+        assert!(!state
+            .data_dir
+            .join("secrets")
+            .join("connection-master.key")
+            .exists());
+    }
+
+    #[test]
+    fn profile_upload_preview_accepts_json_payloads_without_writing() {
+        let state = test_state("profile-upload-preview-json");
+        let envelope = json!({
+            "type": "marinara_profile",
+            "version": 1,
+            "data": {
+                "fileStorage": {
+                    "tables": {
+                        "chats": [
+                            {
+                                "id": "chat-preview",
+                                "name": "Preview Chat",
+                                "mode": "conversation",
+                                "metadata": {},
+                                "characterIds": []
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+        let base64 = base64::Engine::encode(
+            &general_purpose::STANDARD,
+            serde_json::to_vec(&envelope).unwrap(),
+        );
+
+        let preview = preview_profile_upload(&state, "profile.json", &base64)
+            .expect("uploaded profile JSON preview should succeed");
+
+        assert_eq!(preview["success"], true);
+        assert_eq!(preview["preview"], true);
+        assert_eq!(preview["sourceFormat"], "legacy-modern-fileStorage");
+        assert_eq!(preview["imported"]["chats"], 1);
+        assert!(state
+            .storage
+            .get("chats", "chat-preview")
+            .expect("chat lookup should not fail")
+            .is_none());
+    }
+
+    #[test]
+    fn profile_file_import_rejects_file_changed_after_preview() {
+        let state = test_state("profile-file-preview-changed");
+        let path = state.data_dir.join("profile.json");
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "characters": [{
+                        "id": "preview-character",
+                        "name": "Preview Character"
+                    }]
+                }
+            }))
+            .expect("profile fixture should serialize"),
+        )
+        .expect("profile fixture should write");
+
+        let preview = preview_profile_file(&state, &path).expect("preview should succeed");
+        let fingerprint = preview["fileFingerprint"]
+            .as_str()
+            .expect("preview should include a file fingerprint")
+            .to_string();
+
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "characters": [{
+                        "id": "changed-character",
+                        "name": "Changed Character"
+                    }]
+                }
+            }))
+            .expect("changed profile fixture should serialize"),
+        )
+        .expect("changed profile fixture should write");
+
+        let error = import_profile_file_with_preview_fingerprint(&state, &path, Some(&fingerprint))
+            .expect_err("changed file should be rejected before import");
+
+        assert_eq!(error.code, "profile_file_changed");
+        assert!(state
+            .storage
+            .get("characters", "changed-character")
+            .expect("character lookup should not fail")
+            .is_none());
+        assert!(state
+            .storage
+            .get("characters", "preview-character")
+            .expect("character lookup should not fail")
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -12,17 +12,15 @@ use self::assets::{
 use self::legacy::{
     import_legacy_profile_tables, legacy_array_profile_tables, preview_legacy_profile_tables,
 };
-use self::zip_import::{
-    import_profile_zip, import_profile_zip_file, preview_profile_zip, preview_profile_zip_file,
-};
+use self::zip_import::{import_profile_zip, preview_profile_zip};
 use super::contracts;
 use super::shared::*;
 use super::*;
 use base64::engine::general_purpose;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
-use std::fs::{self, File};
-use std::io::{Read, Seek, SeekFrom};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 const PROFILE_EXPORT_JSON_LIMIT_BYTES: usize = 256 * 1024 * 1024;
@@ -62,6 +60,11 @@ impl ProfileImportSourceFormat {
 struct ProfileCollectionsImportPlan {
     imported: Map<String, Value>,
     replacements: Vec<(&'static str, Vec<Value>)>,
+}
+
+struct ProfileFileSnapshot {
+    path: PathBuf,
+    fingerprint: String,
 }
 
 pub(crate) struct ProfileExportDownload {
@@ -119,71 +122,50 @@ pub(crate) fn import_profile_file_with_preview_fingerprint(
     path: &Path,
     preview_fingerprint: Option<&str>,
 ) -> AppResult<Value> {
-    if path.as_os_str().is_empty() {
-        return Err(AppError::invalid_input("Profile file path is required"));
-    }
-    if !path.is_file() {
-        return Err(AppError::invalid_input("Profile import path is not a file"));
-    }
-    let mut file = File::open(path)?;
-    if let Some(expected) = preview_fingerprint
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let actual = profile_file_fingerprint(&mut file)?;
-        if actual != expected {
-            return Err(AppError::with_details(
-                "profile_file_changed",
-                "Profile file changed after preview. Select the file again before importing.",
-                json!({
-                    "expectedFingerprint": expected,
-                    "actualFingerprint": actual,
-                }),
-            ));
+    with_profile_file_snapshot(state, path, |snapshot_path, extension, fingerprint| {
+        if let Some(expected) = preview_fingerprint
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if fingerprint != expected {
+                return Err(AppError::with_details(
+                    "profile_file_changed",
+                    "Profile file changed after preview. Select the file again before importing.",
+                    json!({
+                        "expectedFingerprint": expected,
+                        "actualFingerprint": fingerprint,
+                    }),
+                ));
+            }
         }
-    }
-    match path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(|extension| extension.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("json") => import_profile(
-            state,
-            serde_json::from_reader(file).map_err(invalid_profile_json_error)?,
-        ),
-        Some("zip") => import_profile_zip_file(state, file),
-        _ => Err(AppError::invalid_input(
-            "Profile import must be a .json or .zip file",
-        )),
-    }
+        match extension {
+            "json" => import_profile(
+                state,
+                serde_json::from_reader(File::open(snapshot_path)?)
+                    .map_err(invalid_profile_json_error)?,
+            ),
+            "zip" => import_profile_zip(state, snapshot_path),
+            _ => unreachable!("profile_file_extension only returns json or zip"),
+        }
+    })
 }
 
 pub(crate) fn preview_profile_file(state: &AppState, path: &Path) -> AppResult<Value> {
-    if path.as_os_str().is_empty() {
-        return Err(AppError::invalid_input("Profile file path is required"));
-    }
-    if !path.is_file() {
-        return Err(AppError::invalid_input("Profile import path is not a file"));
-    }
-    let mut file = File::open(path)?;
-    let fingerprint = profile_file_fingerprint(&mut file)?;
-    let result = match path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(|extension| extension.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("json") => preview_profile(
-            state,
-            serde_json::from_reader(file).map_err(invalid_profile_json_error)?,
-        ),
-        Some("zip") => preview_profile_zip_file(state, file),
-        _ => Err(AppError::invalid_input(
-            "Profile import must be a .json or .zip file",
-        )),
-    }?;
-    Ok(with_profile_import_file_fingerprint(result, fingerprint))
+    with_profile_file_snapshot(state, path, |snapshot_path, extension, fingerprint| {
+        let result = match extension {
+            "json" => preview_profile(
+                state,
+                serde_json::from_reader(File::open(snapshot_path)?)
+                    .map_err(invalid_profile_json_error)?,
+            ),
+            "zip" => preview_profile_zip(state, snapshot_path),
+            _ => unreachable!("profile_file_extension only returns json or zip"),
+        }?;
+        Ok(with_profile_import_file_fingerprint(
+            result,
+            fingerprint.to_string(),
+        ))
+    })
 }
 
 pub(crate) fn import_profile_upload(
@@ -200,8 +182,7 @@ pub(crate) fn import_profile_upload(
         "zip" => {
             let upload_dir = state.data_dir.join(".profile-upload-imports");
             fs::create_dir_all(&upload_dir)?;
-            let path = upload_dir.join(format!("profile-import-{}.zip", now_millis()));
-            fs::write(&path, bytes)?;
+            let path = write_profile_temp_file(&upload_dir, "profile-import", "zip", &bytes)?;
             let result = import_profile_zip(state, &path);
             let _ = fs::remove_file(path);
             result
@@ -226,8 +207,7 @@ pub(crate) fn preview_profile_upload(
         "zip" => {
             let upload_dir = state.data_dir.join(".profile-upload-imports");
             fs::create_dir_all(&upload_dir)?;
-            let path = upload_dir.join(format!("profile-preview-{}.zip", now_millis()));
-            fs::write(&path, bytes)?;
+            let path = write_profile_temp_file(&upload_dir, "profile-preview", "zip", &bytes)?;
             let result = preview_profile_zip(state, &path);
             let _ = fs::remove_file(path);
             result
@@ -251,19 +231,120 @@ fn profile_upload_bytes(filename: &str, base64: &str) -> AppResult<(String, Vec<
     Ok((extension, bytes))
 }
 
-fn profile_file_fingerprint(file: &mut File) -> AppResult<String> {
-    file.seek(SeekFrom::Start(0))?;
+fn with_profile_file_snapshot<T>(
+    state: &AppState,
+    path: &Path,
+    operation: impl FnOnce(&Path, &str, &str) -> AppResult<T>,
+) -> AppResult<T> {
+    validate_profile_file_path(path)?;
+    let extension = profile_file_extension(path)?;
+    let upload_dir = state.data_dir.join(".profile-upload-imports");
+    fs::create_dir_all(&upload_dir)?;
+    let snapshot = copy_profile_file_snapshot(path, &upload_dir, &extension)?;
+    let result = operation(&snapshot.path, &extension, &snapshot.fingerprint);
+    let _ = fs::remove_file(snapshot.path);
+    result
+}
+
+fn validate_profile_file_path(path: &Path) -> AppResult<()> {
+    if path.as_os_str().is_empty() {
+        return Err(AppError::invalid_input("Profile file path is required"));
+    }
+    if !path.is_file() {
+        return Err(AppError::invalid_input("Profile import path is not a file"));
+    }
+    Ok(())
+}
+
+fn profile_file_extension(path: &Path) -> AppResult<String> {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("json") => Ok("json".to_string()),
+        Some("zip") => Ok("zip".to_string()),
+        _ => Err(AppError::invalid_input(
+            "Profile import must be a .json or .zip file",
+        )),
+    }
+}
+
+fn copy_profile_file_snapshot(
+    source_path: &Path,
+    upload_dir: &Path,
+    extension: &str,
+) -> AppResult<ProfileFileSnapshot> {
+    let mut source = File::open(source_path)?;
+    let (path, mut output) =
+        create_profile_temp_file(upload_dir, "profile-file-snapshot", extension)?;
     let mut hasher = Sha256::new();
     let mut buffer = [0_u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
+    let copy_result: AppResult<()> = (|| {
+        loop {
+            let read = source.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+            output.write_all(&buffer[..read])?;
         }
-        hasher.update(&buffer[..read]);
+        output.flush()?;
+        Ok(())
+    })();
+    drop(output);
+    if let Err(error) = copy_result {
+        let _ = fs::remove_file(&path);
+        return Err(error);
     }
-    file.seek(SeekFrom::Start(0))?;
-    Ok(format!("sha256:{}", hex_bytes(&hasher.finalize())))
+    Ok(ProfileFileSnapshot {
+        path,
+        fingerprint: format!("sha256:{}", hex_bytes(&hasher.finalize())),
+    })
+}
+
+fn write_profile_temp_file(
+    upload_dir: &Path,
+    prefix: &str,
+    extension: &str,
+    bytes: &[u8],
+) -> AppResult<PathBuf> {
+    let (path, mut file) = create_profile_temp_file(upload_dir, prefix, extension)?;
+    let write_result: AppResult<()> = (|| {
+        file.write_all(bytes)?;
+        file.flush()?;
+        Ok(())
+    })();
+    drop(file);
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&path);
+        return Err(error);
+    }
+    Ok(path)
+}
+
+fn create_profile_temp_file(
+    upload_dir: &Path,
+    prefix: &str,
+    extension: &str,
+) -> AppResult<(PathBuf, File)> {
+    for attempt in 0..1000 {
+        let path = upload_dir.join(format!(
+            "{prefix}-{}-{}-{attempt}.{extension}",
+            now_millis(),
+            std::process::id()
+        ));
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Err(AppError::new(
+        "profile_temp_file_unavailable",
+        "Could not create a unique temporary profile import file",
+    ))
 }
 
 fn hex_bytes(bytes: &[u8]) -> String {

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -18,6 +18,7 @@ const PROFILE_ASSET_DIRS: &[&str] = &[
     "knowledge-sources",
     "lorebooks/images",
 ];
+const MAX_PROFILE_ASSET_BYTES: u64 = 256 * 1024 * 1024;
 
 const OLD_ASSET_MARKERS: &[&str] = &[
     "/api/avatars/file/",
@@ -455,12 +456,9 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
                         "Could not read profile asset {entry_name}: {error}"
                     ))
                 })?;
+                validate_profile_zip_asset_declared_size(&entry_name, entry.size())?;
                 let mut output = File::create(target)?;
-                std::io::copy(&mut entry, &mut output).map_err(|error| {
-                    AppError::invalid_input(format!(
-                        "Could not read profile asset {entry_name}: {error}"
-                    ))
-                })?;
+                copy_limited_profile_zip_asset(&entry_name, &mut entry, &mut output)?;
                 output.flush()?;
             }
         }
@@ -488,11 +486,8 @@ pub(super) fn preview_profile_zip_assets<R: Read + Seek>(
                 "Could not read profile asset {entry_name}: {error}"
             ))
         })?;
-        std::io::copy(&mut entry, &mut std::io::sink()).map_err(|error| {
-            AppError::invalid_input(format!(
-                "Could not read profile asset {entry_name}: {error}"
-            ))
-        })?;
+        validate_profile_zip_asset_declared_size(entry_name, entry.size())?;
+        copy_limited_profile_zip_asset(entry_name, &mut entry, std::io::sink())?;
     }
     Ok((assets.len(), warnings))
 }
@@ -552,6 +547,53 @@ fn profile_asset_manifest_path(asset: &Value, index: usize) -> AppResult<&str> {
         .ok_or_else(|| {
             AppError::invalid_input(format!("Profile asset entry {index} is missing path"))
         })
+}
+
+fn validate_profile_zip_asset_declared_size(entry_name: &str, size: u64) -> AppResult<()> {
+    validate_profile_zip_asset_declared_size_with_limit(entry_name, size, MAX_PROFILE_ASSET_BYTES)
+}
+
+fn validate_profile_zip_asset_declared_size_with_limit(
+    entry_name: &str,
+    size: u64,
+    limit: u64,
+) -> AppResult<()> {
+    if size > limit {
+        return Err(profile_zip_asset_too_large_error(entry_name, size, limit));
+    }
+    Ok(())
+}
+
+fn copy_limited_profile_zip_asset<R: Read, W: Write>(
+    entry_name: &str,
+    reader: R,
+    writer: W,
+) -> AppResult<u64> {
+    copy_limited_profile_zip_asset_with_limit(entry_name, reader, writer, MAX_PROFILE_ASSET_BYTES)
+}
+
+fn copy_limited_profile_zip_asset_with_limit<R: Read, W: Write>(
+    entry_name: &str,
+    reader: R,
+    mut writer: W,
+    limit: u64,
+) -> AppResult<u64> {
+    let mut limited = reader.take(limit.saturating_add(1));
+    let copied = std::io::copy(&mut limited, &mut writer).map_err(|error| {
+        AppError::invalid_input(format!(
+            "Could not read profile asset {entry_name}: {error}"
+        ))
+    })?;
+    if copied > limit {
+        return Err(profile_zip_asset_too_large_error(entry_name, copied, limit));
+    }
+    Ok(copied)
+}
+
+fn profile_zip_asset_too_large_error(entry_name: &str, size: u64, limit: u64) -> AppError {
+    AppError::invalid_input(format!(
+        "Profile asset {entry_name} is too large ({size} bytes; limit is {limit} bytes)"
+    ))
 }
 
 pub(super) fn normalize_legacy_profile_asset_paths(
@@ -1206,5 +1248,31 @@ mod tests {
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0]["type"], "missing_asset");
         assert_eq!(warnings[0]["path"], "avatars/missing-from-zip.png");
+    }
+
+    #[test]
+    fn profile_zip_asset_declared_size_over_limit_is_rejected() {
+        let error = validate_profile_zip_asset_declared_size_with_limit("avatars/huge.png", 6, 5)
+            .expect_err("declared oversized ZIP asset should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("avatars/huge.png"));
+        assert!(error.message.contains("too large"));
+    }
+
+    #[test]
+    fn profile_zip_asset_stream_over_limit_is_rejected() {
+        let reader = std::io::repeat(0).take(6);
+        let error = copy_limited_profile_zip_asset_with_limit(
+            "avatars/huge.png",
+            reader,
+            std::io::sink(),
+            5,
+        )
+        .expect_err("streamed oversized ZIP asset should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("avatars/huge.png"));
+        assert!(error.message.contains("too large"));
     }
 }

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -419,37 +419,8 @@ fn preview_profile_json_assets(
     raw_assets: Option<&Value>,
     allow_legacy_data_field: bool,
 ) -> AppResult<(usize, Vec<Value>)> {
-    let Some(assets) = profile_asset_manifest(raw_assets)? else {
-        return Ok((0, Vec::new()));
-    };
-    let mut restored = 0usize;
-    let mut warnings = Vec::new();
-    for (index, asset) in assets.iter().enumerate() {
-        let path = profile_asset_manifest_path(asset, index)?;
-        if is_legacy_cleanup_backup_asset_path(path) {
-            continue;
-        }
-        safe_profile_asset_path(path)?;
-        let raw_data = if allow_legacy_data_field {
-            asset
-                .get("base64")
-                .or_else(|| asset.get("data"))
-                .and_then(Value::as_str)
-        } else {
-            asset.get("base64").and_then(Value::as_str)
-        };
-        if let Some(raw_data) = raw_data {
-            let _ = decode_profile_asset_data(raw_data)?;
-            restored += 1;
-        } else {
-            warnings.push(json!({
-                "type": "missing_asset",
-                "path": path,
-                "message": format!("Profile asset {path} is missing base64 data. Imported the rest of the profile without that asset."),
-            }));
-        }
-    }
-    Ok((restored, warnings))
+    let (assets, warnings) = decoded_profile_json_assets(raw_assets, allow_legacy_data_field)?;
+    Ok((assets.len(), warnings))
 }
 
 pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
@@ -485,7 +456,11 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
                     ))
                 })?;
                 let mut output = File::create(target)?;
-                std::io::copy(&mut entry, &mut output)?;
+                std::io::copy(&mut entry, &mut output).map_err(|error| {
+                    AppError::invalid_input(format!(
+                        "Could not read profile asset {entry_name}: {error}"
+                    ))
+                })?;
                 output.flush()?;
             }
         }
@@ -497,40 +472,29 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
     })
 }
 
-pub(super) fn preview_profile_zip_assets(
+pub(super) fn preview_profile_zip_assets<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
     raw_assets: Option<&Value>,
     names: &[String],
     profile_prefix: &str,
 ) -> AppResult<(usize, Vec<Value>)> {
-    let Some(assets) = profile_asset_manifest(raw_assets)? else {
-        return Ok((0, Vec::new()));
-    };
-    let mut restored = 0usize;
-    let mut warnings = Vec::new();
-    for (index, asset) in assets.iter().enumerate() {
-        let path = profile_asset_manifest_path(asset, index)?;
-        if is_legacy_cleanup_backup_asset_path(path) {
+    let (assets, warnings) = decoded_profile_zip_assets(raw_assets, names, profile_prefix)?;
+    for asset in &assets {
+        let ProfileAssetSource::ZipEntry(entry_name) = &asset.source else {
             continue;
-        }
-        safe_profile_asset_path(path)?;
-        if let Some(raw_data) = asset
-            .get("base64")
-            .or_else(|| asset.get("data"))
-            .and_then(Value::as_str)
-        {
-            let _ = decode_profile_asset_data(raw_data)?;
-            restored += 1;
-        } else if zip_asset_entry_name(names, profile_prefix, path).is_some() {
-            restored += 1;
-        } else {
-            warnings.push(json!({
-                "type": "missing_asset",
-                "path": path,
-                "message": format!("Profile ZIP is missing {path}. Imported the rest of the profile without that asset."),
-            }));
-        }
+        };
+        let mut entry = archive.by_name(entry_name).map_err(|error| {
+            AppError::invalid_input(format!(
+                "Could not read profile asset {entry_name}: {error}"
+            ))
+        })?;
+        std::io::copy(&mut entry, &mut std::io::sink()).map_err(|error| {
+            AppError::invalid_input(format!(
+                "Could not read profile asset {entry_name}: {error}"
+            ))
+        })?;
     }
-    Ok((restored, warnings))
+    Ok((assets.len(), warnings))
 }
 
 fn decoded_profile_zip_assets(

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -328,6 +328,16 @@ pub(super) fn restore_profile_assets(
     restore_profile_json_assets(state, raw_assets, false)
 }
 
+pub(super) fn preview_profile_assets(raw_assets: Option<&Value>) -> AppResult<(usize, Vec<Value>)> {
+    preview_profile_json_assets(raw_assets, false)
+}
+
+pub(super) fn preview_legacy_profile_json_assets(
+    raw_assets: Option<&Value>,
+) -> AppResult<(usize, Vec<Value>)> {
+    preview_profile_json_assets(raw_assets, true)
+}
+
 pub(super) fn restore_legacy_profile_json_assets(
     state: &AppState,
     raw_assets: Option<&Value>,
@@ -405,6 +415,43 @@ fn decoded_profile_json_assets(
     Ok((decoded, warnings))
 }
 
+fn preview_profile_json_assets(
+    raw_assets: Option<&Value>,
+    allow_legacy_data_field: bool,
+) -> AppResult<(usize, Vec<Value>)> {
+    let Some(assets) = profile_asset_manifest(raw_assets)? else {
+        return Ok((0, Vec::new()));
+    };
+    let mut restored = 0usize;
+    let mut warnings = Vec::new();
+    for (index, asset) in assets.iter().enumerate() {
+        let path = profile_asset_manifest_path(asset, index)?;
+        if is_legacy_cleanup_backup_asset_path(path) {
+            continue;
+        }
+        safe_profile_asset_path(path)?;
+        let raw_data = if allow_legacy_data_field {
+            asset
+                .get("base64")
+                .or_else(|| asset.get("data"))
+                .and_then(Value::as_str)
+        } else {
+            asset.get("base64").and_then(Value::as_str)
+        };
+        if let Some(raw_data) = raw_data {
+            let _ = decode_profile_asset_data(raw_data)?;
+            restored += 1;
+        } else {
+            warnings.push(json!({
+                "type": "missing_asset",
+                "path": path,
+                "message": format!("Profile asset {path} is missing base64 data. Imported the rest of the profile without that asset."),
+            }));
+        }
+    }
+    Ok((restored, warnings))
+}
+
 pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
     state: &AppState,
     archive: &mut zip::ZipArchive<R>,
@@ -448,6 +495,42 @@ pub(super) fn restore_profile_zip_assets<R: Read + Seek>(
         transaction: Some(transaction),
         warnings,
     })
+}
+
+pub(super) fn preview_profile_zip_assets(
+    raw_assets: Option<&Value>,
+    names: &[String],
+    profile_prefix: &str,
+) -> AppResult<(usize, Vec<Value>)> {
+    let Some(assets) = profile_asset_manifest(raw_assets)? else {
+        return Ok((0, Vec::new()));
+    };
+    let mut restored = 0usize;
+    let mut warnings = Vec::new();
+    for (index, asset) in assets.iter().enumerate() {
+        let path = profile_asset_manifest_path(asset, index)?;
+        if is_legacy_cleanup_backup_asset_path(path) {
+            continue;
+        }
+        safe_profile_asset_path(path)?;
+        if let Some(raw_data) = asset
+            .get("base64")
+            .or_else(|| asset.get("data"))
+            .and_then(Value::as_str)
+        {
+            let _ = decode_profile_asset_data(raw_data)?;
+            restored += 1;
+        } else if zip_asset_entry_name(names, profile_prefix, path).is_some() {
+            restored += 1;
+        } else {
+            warnings.push(json!({
+                "type": "missing_asset",
+                "path": path,
+                "message": format!("Profile ZIP is missing {path}. Imported the rest of the profile without that asset."),
+            }));
+        }
+    }
+    Ok((restored, warnings))
 }
 
 fn decoded_profile_zip_assets(

--- a/src-tauri/src/commands/storage/profile/assets.rs
+++ b/src-tauri/src/commands/storage/profile/assets.rs
@@ -410,7 +410,7 @@ fn decoded_profile_json_assets(
             }));
             continue;
         };
-        let bytes = decode_profile_asset_data(raw_data)?;
+        let bytes = decode_profile_asset_data(path, raw_data)?;
         decoded.push((relative, bytes));
     }
     Ok((decoded, warnings))
@@ -513,7 +513,7 @@ fn decoded_profile_zip_assets(
             .or_else(|| asset.get("data"))
             .and_then(Value::as_str)
         {
-            ProfileAssetSource::Bytes(decode_profile_asset_data(raw_data)?)
+            ProfileAssetSource::Bytes(decode_profile_asset_data(path, raw_data)?)
         } else if let Some(entry_name) = zip_asset_entry_name(names, profile_prefix, path) {
             ProfileAssetSource::ZipEntry(entry_name)
         } else {
@@ -559,7 +559,7 @@ fn validate_profile_zip_asset_declared_size_with_limit(
     limit: u64,
 ) -> AppResult<()> {
     if size > limit {
-        return Err(profile_zip_asset_too_large_error(entry_name, size, limit));
+        return Err(profile_asset_too_large_error(entry_name, size, limit));
     }
     Ok(())
 }
@@ -585,12 +585,12 @@ fn copy_limited_profile_zip_asset_with_limit<R: Read, W: Write>(
         ))
     })?;
     if copied > limit {
-        return Err(profile_zip_asset_too_large_error(entry_name, copied, limit));
+        return Err(profile_asset_too_large_error(entry_name, copied, limit));
     }
     Ok(copied)
 }
 
-fn profile_zip_asset_too_large_error(entry_name: &str, size: u64, limit: u64) -> AppError {
+fn profile_asset_too_large_error(entry_name: &str, size: u64, limit: u64) -> AppError {
     AppError::invalid_input(format!(
         "Profile asset {entry_name} is too large ({size} bytes; limit is {limit} bytes)"
     ))
@@ -824,16 +824,61 @@ fn image_mime_from_path(path: &Path) -> &'static str {
     }
 }
 
-fn decode_profile_asset_data(value: &str) -> AppResult<Vec<u8>> {
-    let payload = value
+fn decode_profile_asset_data(asset_name: &str, value: &str) -> AppResult<Vec<u8>> {
+    decode_profile_asset_data_with_limit(asset_name, value, MAX_PROFILE_ASSET_BYTES)
+}
+
+fn decode_profile_asset_data_with_limit(
+    asset_name: &str,
+    value: &str,
+    limit: u64,
+) -> AppResult<Vec<u8>> {
+    let payload = profile_asset_data_payload(value);
+    validate_profile_inline_asset_encoded_size(asset_name, payload, limit)?;
+    let bytes = general_purpose::STANDARD
+        .decode(payload)
+        .map_err(|error| AppError::invalid_input(format!("Invalid profile asset data: {error}")))?;
+    let decoded_size = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    if decoded_size > limit {
+        return Err(profile_asset_too_large_error(
+            asset_name,
+            decoded_size,
+            limit,
+        ));
+    }
+    Ok(bytes)
+}
+
+fn profile_asset_data_payload(value: &str) -> &str {
+    value
         .split_once(',')
         .filter(|(header, _)| header.starts_with("data:"))
         .map(|(_, payload)| payload)
         .unwrap_or(value)
-        .trim();
-    general_purpose::STANDARD
-        .decode(payload)
-        .map_err(|error| AppError::invalid_input(format!("Invalid profile asset data: {error}")))
+        .trim()
+}
+
+fn validate_profile_inline_asset_encoded_size(
+    asset_name: &str,
+    payload: &str,
+    limit: u64,
+) -> AppResult<()> {
+    let encoded_len = u64::try_from(payload.len()).unwrap_or(u64::MAX);
+    let max_encoded_len = max_base64_encoded_len_for_decoded_limit(limit);
+    if encoded_len > max_encoded_len {
+        return Err(AppError::invalid_input(format!(
+            "Profile asset {asset_name} is too large (encoded payload is {encoded_len} bytes; decoded limit is {limit} bytes)"
+        )));
+    }
+    Ok(())
+}
+
+fn max_base64_encoded_len_for_decoded_limit(limit: u64) -> u64 {
+    let full_groups = limit / 3;
+    let remainder = limit % 3;
+    full_groups
+        .saturating_mul(4)
+        .saturating_add(if remainder == 0 { 0 } else { 4 })
 }
 
 fn write_profile_asset_in_root(data_dir: &Path, relative: &Path, bytes: &[u8]) -> AppResult<()> {
@@ -1270,6 +1315,31 @@ mod tests {
             5,
         )
         .expect_err("streamed oversized ZIP asset should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("avatars/huge.png"));
+        assert!(error.message.contains("too large"));
+    }
+
+    #[test]
+    fn profile_inline_asset_encoded_size_over_limit_is_rejected_before_decode() {
+        let error = decode_profile_asset_data_with_limit("avatars/huge.png", "!!!!!!!!!!!!", 5)
+            .expect_err("encoded oversized inline asset should reject before base64 decode");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("avatars/huge.png"));
+        assert!(error.message.contains("too large"));
+        assert!(!error.message.contains("Invalid profile asset data"));
+    }
+
+    #[test]
+    fn profile_inline_asset_decoded_size_over_limit_is_rejected() {
+        let payload = format!(
+            "data:image/png;base64,{}",
+            general_purpose::STANDARD.encode(vec![0_u8; 6])
+        );
+        let error = decode_profile_asset_data_with_limit("avatars/huge.png", &payload, 5)
+            .expect_err("decoded oversized inline asset should reject");
 
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("avatars/huge.png"));

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -362,11 +362,10 @@ fn legacy_array_format_error(
 
 pub(super) fn import_legacy_profile_tables(
     state: &AppState,
-    data: &Map<String, Value>,
     tables: &Map<String, Value>,
+    raw_assets: Option<&Value>,
 ) -> AppResult<Value> {
-    let files = data.get("fileStorage").and_then(|value| value.get("files"));
-    let mut restored_assets = restore_legacy_profile_json_assets(state, files)?;
+    let mut restored_assets = restore_legacy_profile_json_assets(state, raw_assets)?;
     let restored_count = restored_assets.restored();
     let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
     let result = import_legacy_profile_tables_with_restored_assets(
@@ -389,6 +388,33 @@ pub(super) fn import_legacy_profile_tables_with_restored_assets<F>(
 where
     F: FnOnce() -> AppResult<()>,
 {
+    let plan = legacy_profile_import_plan(state, tables, restored_assets, staging_root)?;
+    state
+        .storage
+        .replace_all_many_and_then(plan.replacements, install_assets)?;
+    Ok(json!({ "success": true, "imported": plan.imported }))
+}
+
+pub(super) fn preview_legacy_profile_tables(
+    state: &AppState,
+    tables: &Map<String, Value>,
+    restored_assets: usize,
+) -> AppResult<Value> {
+    let plan = legacy_profile_import_plan(state, tables, restored_assets, None)?;
+    Ok(json!({ "success": true, "preview": true, "imported": plan.imported }))
+}
+
+struct LegacyProfileImportPlan {
+    imported: Map<String, Value>,
+    replacements: Vec<(&'static str, Vec<Value>)>,
+}
+
+fn legacy_profile_import_plan(
+    state: &AppState,
+    tables: &Map<String, Value>,
+    restored_assets: usize,
+    staging_root: Option<&Path>,
+) -> AppResult<LegacyProfileImportPlan> {
     let mut imported = Map::new();
     let mut replacements = Vec::new();
     let mut unsupported_prompt_overrides = 0usize;
@@ -447,9 +473,6 @@ where
         replacements.push((message_swipes::COLLECTION, Vec::new()));
     }
     super::normalize_message_swipe_replacements(&mut replacements, &mut imported)?;
-    state
-        .storage
-        .replace_all_many_and_then(replacements, install_assets)?;
     imported.insert("files".to_string(), json!(restored_assets));
     if unsupported_prompt_overrides > 0 {
         imported.insert(
@@ -467,7 +490,10 @@ where
         imported.insert("ooc-influences".to_string(), json!(imported_ooc_influences));
     }
     insert_profile_import_aliases(&mut imported);
-    Ok(json!({ "success": true, "imported": imported }))
+    Ok(LegacyProfileImportPlan {
+        imported,
+        replacements,
+    })
 }
 
 fn table_rows(tables: &Map<String, Value>, table: &str) -> Vec<Value> {

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -55,6 +55,15 @@ const LEGACY_PROFILE_TABLES: &[(&str, &str)] = &[
     ("game_checkpoints", "game-checkpoints"),
 ];
 
+const LEGACY_PROFILE_AUXILIARY_TABLES: &[&str] = &[
+    "lorebook_character_links",
+    "lorebook_persona_links",
+    "memory_chunks",
+    "conversation_notes",
+    "ooc_influences",
+    "message_swipes",
+];
+
 const LEGACY_GAME_STATE_ALIASES: &[(&str, &str)] = &[
     ("chatId", "chat_id"),
     ("messageId", "message_id"),
@@ -420,24 +429,21 @@ fn legacy_profile_import_plan(
     let mut unsupported_prompt_overrides = 0usize;
     let mut imported_conversation_notes = 0usize;
     let mut imported_ooc_influences = 0usize;
+    validate_legacy_profile_auxiliary_tables(tables)?;
     for (table, collection) in LEGACY_PROFILE_TABLES {
         // A partial profile (an older backup, a hand-built export, or a file
         // missing a table) must not wipe collections it does not carry.
         // Skipping the replacement leaves the user's existing collection
         // untouched; a table that is present but empty is still an explicit
         // clear and falls through to a normal empty replacement.
-        let Some(table_value) = tables.get(*table) else {
+        let Some(_) = tables.get(*table) else {
             continue;
         };
         // A present-but-non-array table is malformed (e.g. `"characters": {}`).
         // `table_rows` would coerce it to an empty array, which silently clears
         // the collection - the same data loss the absent-key skip above guards
         // against. Reject the import instead so nothing is replaced.
-        if !table_value.is_array() {
-            return Err(AppError::invalid_input(format!(
-                "Legacy profile table `{table}` must be a JSON array"
-            )));
-        }
+        validate_legacy_profile_table_array(tables, table)?;
         let mut rows = table_rows(tables, table);
         match *collection {
             "app-settings" => normalize_legacy_app_settings(&mut rows),
@@ -494,6 +500,24 @@ fn legacy_profile_import_plan(
         imported,
         replacements,
     })
+}
+
+fn validate_legacy_profile_auxiliary_tables(tables: &Map<String, Value>) -> AppResult<()> {
+    for table in LEGACY_PROFILE_AUXILIARY_TABLES {
+        validate_legacy_profile_table_array(tables, table)?;
+    }
+    Ok(())
+}
+
+fn validate_legacy_profile_table_array(tables: &Map<String, Value>, table: &str) -> AppResult<()> {
+    if let Some(table_value) = tables.get(table) {
+        if !table_value.is_array() {
+            return Err(AppError::invalid_input(format!(
+                "Legacy profile table `{table}` must be a JSON array"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn table_rows(tables: &Map<String, Value>, table: &str) -> Vec<Value> {
@@ -1717,6 +1741,35 @@ mod tests {
             .storage
             .get("characters", "char-1")
             .expect("character lookup should not fail")
+            .is_some());
+    }
+
+    #[test]
+    fn legacy_malformed_auxiliary_table_is_rejected_without_wiping() {
+        let state = test_state("malformed-aux-table-no-wipe");
+        state
+            .storage
+            .upsert_with_id(
+                "messages",
+                "message-1",
+                json!({ "id": "message-1", "chatId": "chat-1", "content": "Keep Me" }),
+            )
+            .expect("seeded message should write");
+
+        let mut tables = Map::new();
+        tables.insert("messages".to_string(), json!([]));
+        tables.insert("message_swipes".to_string(), json!({}));
+
+        let error =
+            import_legacy_profile_tables_with_restored_assets(&state, &tables, 0, None, || Ok(()))
+                .expect_err("a present-but-non-array auxiliary table should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("message_swipes"));
+        assert!(state
+            .storage
+            .get("messages", "message-1")
+            .expect("message lookup should not fail")
             .is_some());
     }
 }

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -134,7 +134,7 @@ fn run_profile_zip_collections<R: Read + std::io::Seek>(
     match mode {
         ProfileImportMode::Preview => {
             let (restored_assets, warnings) =
-                preview_profile_zip_assets(raw_assets, names, profile_prefix)?;
+                preview_profile_zip_assets(archive, raw_assets, names, profile_prefix)?;
             let result = preview_profile_collections_with_restored_assets(
                 state,
                 collections,
@@ -175,7 +175,7 @@ fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
     match mode {
         ProfileImportMode::Preview => {
             let (restored_assets, warnings) =
-                preview_profile_zip_assets(raw_assets, names, profile_prefix)?;
+                preview_profile_zip_assets(archive, raw_assets, names, profile_prefix)?;
             let result = preview_legacy_profile_tables(state, tables, restored_assets)?;
             Ok(with_profile_import_warnings(
                 with_profile_import_metadata(result, source_format),
@@ -294,6 +294,34 @@ mod tests {
         writer
             .write_all(profile_json.as_bytes())
             .expect("zip entry should write");
+        writer.finish().expect("zip should finalize");
+        zip_path
+    }
+
+    fn write_profile_zip_with_asset(
+        label: &str,
+        profile_json: &str,
+        asset_path: &str,
+        asset_bytes: &[u8],
+    ) -> PathBuf {
+        let zip_path =
+            std::env::temp_dir().join(format!("marinara-zip-import-{label}-{}.zip", nonce()));
+        let file = File::create(&zip_path).expect("zip file should be creatable");
+        let mut writer = zip::ZipWriter::new(file);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        writer
+            .start_file(PROFILE_JSON_ENTRY, options)
+            .expect("profile zip entry should start");
+        writer
+            .write_all(profile_json.as_bytes())
+            .expect("profile zip entry should write");
+        writer
+            .start_file(asset_path, options)
+            .expect("asset zip entry should start");
+        writer
+            .write_all(asset_bytes)
+            .expect("asset zip entry should write");
         writer.finish().expect("zip should finalize");
         zip_path
     }
@@ -468,6 +496,63 @@ mod tests {
             preview["warnings"][0]["path"],
             "avatars/missing-from-zip.png"
         );
+        assert!(state
+            .storage
+            .get("chats", "chat-preview")
+            .expect("chat lookup should not fail")
+            .is_none());
+
+        let _ = std::fs::remove_file(&zip_path);
+    }
+
+    #[test]
+    fn preview_profile_zip_rejects_corrupt_asset_entry_without_importing() {
+        let state = test_state("preview-corrupt-asset");
+        let asset_bytes = b"valid-asset-bytes";
+        let profile_json = json!({
+            "type": "marinara_profile",
+            "data": {
+                "fileStorage": {
+                    "tables": {
+                        "chats": [
+                            {
+                                "id": "chat-preview",
+                                "name": "Preview Chat",
+                                "mode": "conversation",
+                                "metadata": {},
+                                "characterIds": []
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "path": "avatars/avatar.png",
+                            "size": asset_bytes.len()
+                        }
+                    ]
+                }
+            }
+        })
+        .to_string();
+        let zip_path = write_profile_zip_with_asset(
+            "preview-corrupt-asset",
+            &profile_json,
+            "avatars/avatar.png",
+            asset_bytes,
+        );
+        let mut zip_bytes = std::fs::read(&zip_path).expect("zip should be readable");
+        let offset = zip_bytes
+            .windows(asset_bytes.len())
+            .position(|window| window == asset_bytes)
+            .expect("asset bytes should be present in stored zip entry");
+        zip_bytes[offset] ^= 0xff;
+        std::fs::write(&zip_path, zip_bytes).expect("corrupted zip should write");
+
+        let error = preview_profile_zip(&state, &zip_path)
+            .expect_err("zip preview should reject corrupt asset entries");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Could not read profile asset"));
         assert!(state
             .storage
             .get("chats", "chat-preview")

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -1,15 +1,19 @@
-use super::assets::{normalize_zip_entry_name, restore_profile_zip_assets};
+use super::assets::{
+    normalize_zip_entry_name, preview_profile_zip_assets, restore_profile_zip_assets,
+};
+use super::legacy::preview_legacy_profile_tables;
 use super::{
     finish_profile_import_assets, import_profile_collections_with_restored_assets,
     legacy::{import_legacy_profile_tables_with_restored_assets, legacy_array_profile_tables},
-    profile_format_error, validate_native_profile_import, with_profile_import_metadata,
-    ProfileImportSourceFormat,
+    preview_profile_collections_with_restored_assets, profile_format_error,
+    validate_native_profile_import, with_profile_import_metadata, with_profile_import_warnings,
+    ProfileImportMode, ProfileImportSourceFormat,
 };
 use crate::state::AppState;
 use marinara_core::{AppError, AppResult};
 use serde_json::Value;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Seek};
 use std::path::Path;
 
 const PROFILE_JSON_ENTRY: &str = "marinara-profile.json";
@@ -21,8 +25,33 @@ const PROFILE_JSON_ENTRY: &str = "marinara-profile.json";
 const MAX_PROFILE_JSON_BYTES: u64 = 1024 * 1024 * 1024;
 
 pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Value> {
-    let file = File::open(path)?;
-    let mut archive = zip::ZipArchive::new(file)
+    import_profile_zip_file(state, File::open(path)?)
+}
+
+pub(super) fn preview_profile_zip(state: &AppState, path: &Path) -> AppResult<Value> {
+    preview_profile_zip_file(state, File::open(path)?)
+}
+
+pub(super) fn import_profile_zip_file<R: Read + Seek>(
+    state: &AppState,
+    reader: R,
+) -> AppResult<Value> {
+    run_profile_zip_reader(state, reader, ProfileImportMode::Commit)
+}
+
+pub(super) fn preview_profile_zip_file<R: Read + Seek>(
+    state: &AppState,
+    reader: R,
+) -> AppResult<Value> {
+    run_profile_zip_reader(state, reader, ProfileImportMode::Preview)
+}
+
+fn run_profile_zip_reader<R: Read + Seek>(
+    state: &AppState,
+    reader: R,
+    mode: ProfileImportMode,
+) -> AppResult<Value> {
+    let mut archive = zip::ZipArchive::new(reader)
         .map_err(|error| AppError::invalid_input(format!("Could not read profile ZIP: {error}")))?;
     let names = zip_entry_names(&mut archive)?;
     let (profile_entry, profile_prefix) = profile_json_entry(&names)?;
@@ -44,18 +73,15 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
             )
         })?;
         validate_native_profile_import(data, collections)?;
-        let mut restored_assets =
-            restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
-        let restored_count = restored_assets.restored();
-        let result = import_profile_collections_with_restored_assets(
+        return run_profile_zip_collections(
             state,
+            &mut archive,
+            &names,
+            &profile_prefix,
+            files,
             collections,
-            restored_count,
-            || restored_assets.install(),
+            mode,
         );
-        return finish_profile_import_assets(restored_assets, result).map(|value| {
-            with_profile_import_metadata(value, ProfileImportSourceFormat::RefactorNative)
-        });
     }
     if let Some(tables_value) = data
         .get("fileStorage")
@@ -67,41 +93,111 @@ pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Val
                 "invalid-legacy-modern-fileStorage",
             )
         })?;
-        let mut restored_assets =
-            restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
-        let restored_count = restored_assets.restored();
-        let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
-        let result = import_legacy_profile_tables_with_restored_assets(
+        return run_profile_zip_legacy_tables(
             state,
+            &mut archive,
+            &names,
+            &profile_prefix,
+            files,
             tables,
-            restored_count,
-            staging_root.as_deref(),
-            || restored_assets.install(),
+            ProfileImportSourceFormat::LegacyFileStorage,
+            mode,
         );
-        return finish_profile_import_assets(restored_assets, result).map(|value| {
-            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyFileStorage)
-        });
     }
     if let Some(tables) = legacy_array_profile_tables(data)? {
-        let mut restored_assets =
-            restore_profile_zip_assets(state, &mut archive, &names, &profile_prefix, files)?;
-        let restored_count = restored_assets.restored();
-        let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
-        let result = import_legacy_profile_tables_with_restored_assets(
+        return run_profile_zip_legacy_tables(
             state,
+            &mut archive,
+            &names,
+            &profile_prefix,
+            files,
             &tables,
-            restored_count,
-            staging_root.as_deref(),
-            || restored_assets.install(),
+            ProfileImportSourceFormat::LegacyArray,
+            mode,
         );
-        return finish_profile_import_assets(restored_assets, result).map(|value| {
-            with_profile_import_metadata(value, ProfileImportSourceFormat::LegacyArray)
-        });
     }
     Err(profile_format_error(
         "Profile ZIP must contain data.collections, data.fileStorage.tables, or legacy profile arrays",
         "unknown",
     ))
+}
+
+fn run_profile_zip_collections<R: Read + std::io::Seek>(
+    state: &AppState,
+    archive: &mut zip::ZipArchive<R>,
+    names: &[String],
+    profile_prefix: &str,
+    raw_assets: Option<&Value>,
+    collections: &serde_json::Map<String, Value>,
+    mode: ProfileImportMode,
+) -> AppResult<Value> {
+    match mode {
+        ProfileImportMode::Preview => {
+            let (restored_assets, warnings) =
+                preview_profile_zip_assets(raw_assets, names, profile_prefix)?;
+            let result = preview_profile_collections_with_restored_assets(
+                state,
+                collections,
+                restored_assets,
+            )?;
+            Ok(with_profile_import_warnings(
+                with_profile_import_metadata(result, ProfileImportSourceFormat::RefactorNative),
+                warnings,
+            ))
+        }
+        ProfileImportMode::Commit => {
+            let mut restored_assets =
+                restore_profile_zip_assets(state, archive, names, profile_prefix, raw_assets)?;
+            let restored_count = restored_assets.restored();
+            let result = import_profile_collections_with_restored_assets(
+                state,
+                collections,
+                restored_count,
+                || restored_assets.install(),
+            );
+            finish_profile_import_assets(restored_assets, result).map(|value| {
+                with_profile_import_metadata(value, ProfileImportSourceFormat::RefactorNative)
+            })
+        }
+    }
+}
+
+fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
+    state: &AppState,
+    archive: &mut zip::ZipArchive<R>,
+    names: &[String],
+    profile_prefix: &str,
+    raw_assets: Option<&Value>,
+    tables: &serde_json::Map<String, Value>,
+    source_format: ProfileImportSourceFormat,
+    mode: ProfileImportMode,
+) -> AppResult<Value> {
+    match mode {
+        ProfileImportMode::Preview => {
+            let (restored_assets, warnings) =
+                preview_profile_zip_assets(raw_assets, names, profile_prefix)?;
+            let result = preview_legacy_profile_tables(state, tables, restored_assets)?;
+            Ok(with_profile_import_warnings(
+                with_profile_import_metadata(result, source_format),
+                warnings,
+            ))
+        }
+        ProfileImportMode::Commit => {
+            let mut restored_assets =
+                restore_profile_zip_assets(state, archive, names, profile_prefix, raw_assets)?;
+            let restored_count = restored_assets.restored();
+            let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
+            let result = import_legacy_profile_tables_with_restored_assets(
+                state,
+                tables,
+                restored_count,
+                staging_root.as_deref(),
+                || restored_assets.install(),
+            );
+            finish_profile_import_assets(restored_assets, result)
+                .map(|value| with_profile_import_metadata(value, source_format))
+        }
+    }
 }
 
 fn zip_entry_names<R: Read + std::io::Seek>(
@@ -325,6 +421,58 @@ mod tests {
             .expect("chat lookup should not fail")
             .expect("recoverable profile data should import");
         assert_eq!(chat["name"], "Recovered Chat");
+
+        let _ = std::fs::remove_file(&zip_path);
+    }
+
+    #[test]
+    fn preview_profile_zip_reports_counts_and_warnings_without_importing() {
+        let state = test_state("preview-missing-asset");
+        let profile_json = json!({
+            "type": "marinara_profile",
+            "data": {
+                "fileStorage": {
+                    "tables": {
+                        "chats": [
+                            {
+                                "id": "chat-preview",
+                                "name": "Preview Chat",
+                                "mode": "conversation",
+                                "metadata": {},
+                                "characterIds": []
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "path": "avatars/missing-from-zip.png",
+                            "size": 12
+                        }
+                    ]
+                }
+            }
+        })
+        .to_string();
+        let zip_path = write_profile_zip("preview-missing-asset", &profile_json);
+
+        let preview = preview_profile_zip(&state, &zip_path)
+            .expect("zip preview should preserve counts and warn about missing assets");
+
+        assert_eq!(preview["success"], true);
+        assert_eq!(preview["preview"], true);
+        assert_eq!(preview["sourceFormat"], "legacy-modern-fileStorage");
+        assert_eq!(preview["imported"]["chats"], 1);
+        assert_eq!(preview["imported"]["files"], 0);
+        assert_eq!(preview["warnings"][0]["type"], "missing_asset");
+        assert_eq!(
+            preview["warnings"][0]["path"],
+            "avatars/missing-from-zip.png"
+        );
+        assert!(state
+            .storage
+            .get("chats", "chat-preview")
+            .expect("chat lookup should not fail")
+            .is_none());
 
         let _ = std::fs::remove_file(&zip_path);
     }

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -24,6 +24,12 @@ const PROFILE_JSON_ENTRY: &str = "marinara-profile.json";
 // migrations through.
 const MAX_PROFILE_JSON_BYTES: u64 = 1024 * 1024 * 1024;
 
+struct ProfileZipAssetContext<'a> {
+    names: &'a [String],
+    profile_prefix: &'a str,
+    raw_assets: Option<&'a Value>,
+}
+
 pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Value> {
     import_profile_zip_file(state, File::open(path)?)
 }
@@ -73,15 +79,12 @@ fn run_profile_zip_reader<R: Read + Seek>(
             )
         })?;
         validate_native_profile_import(data, collections)?;
-        return run_profile_zip_collections(
-            state,
-            &mut archive,
-            &names,
-            &profile_prefix,
-            files,
-            collections,
-            mode,
-        );
+        let assets = ProfileZipAssetContext {
+            names: &names,
+            profile_prefix: &profile_prefix,
+            raw_assets: files,
+        };
+        return run_profile_zip_collections(state, &mut archive, assets, collections, mode);
     }
     if let Some(tables_value) = data
         .get("fileStorage")
@@ -93,24 +96,30 @@ fn run_profile_zip_reader<R: Read + Seek>(
                 "invalid-legacy-modern-fileStorage",
             )
         })?;
+        let assets = ProfileZipAssetContext {
+            names: &names,
+            profile_prefix: &profile_prefix,
+            raw_assets: files,
+        };
         return run_profile_zip_legacy_tables(
             state,
             &mut archive,
-            &names,
-            &profile_prefix,
-            files,
+            assets,
             tables,
             ProfileImportSourceFormat::LegacyFileStorage,
             mode,
         );
     }
     if let Some(tables) = legacy_array_profile_tables(data)? {
+        let assets = ProfileZipAssetContext {
+            names: &names,
+            profile_prefix: &profile_prefix,
+            raw_assets: files,
+        };
         return run_profile_zip_legacy_tables(
             state,
             &mut archive,
-            &names,
-            &profile_prefix,
-            files,
+            assets,
             &tables,
             ProfileImportSourceFormat::LegacyArray,
             mode,
@@ -125,16 +134,18 @@ fn run_profile_zip_reader<R: Read + Seek>(
 fn run_profile_zip_collections<R: Read + std::io::Seek>(
     state: &AppState,
     archive: &mut zip::ZipArchive<R>,
-    names: &[String],
-    profile_prefix: &str,
-    raw_assets: Option<&Value>,
+    assets: ProfileZipAssetContext<'_>,
     collections: &serde_json::Map<String, Value>,
     mode: ProfileImportMode,
 ) -> AppResult<Value> {
     match mode {
         ProfileImportMode::Preview => {
-            let (restored_assets, warnings) =
-                preview_profile_zip_assets(archive, raw_assets, names, profile_prefix)?;
+            let (restored_assets, warnings) = preview_profile_zip_assets(
+                archive,
+                assets.raw_assets,
+                assets.names,
+                assets.profile_prefix,
+            )?;
             let result = preview_profile_collections_with_restored_assets(
                 state,
                 collections,
@@ -146,8 +157,13 @@ fn run_profile_zip_collections<R: Read + std::io::Seek>(
             ))
         }
         ProfileImportMode::Commit => {
-            let mut restored_assets =
-                restore_profile_zip_assets(state, archive, names, profile_prefix, raw_assets)?;
+            let mut restored_assets = restore_profile_zip_assets(
+                state,
+                archive,
+                assets.names,
+                assets.profile_prefix,
+                assets.raw_assets,
+            )?;
             let restored_count = restored_assets.restored();
             let result = import_profile_collections_with_restored_assets(
                 state,
@@ -165,17 +181,19 @@ fn run_profile_zip_collections<R: Read + std::io::Seek>(
 fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
     state: &AppState,
     archive: &mut zip::ZipArchive<R>,
-    names: &[String],
-    profile_prefix: &str,
-    raw_assets: Option<&Value>,
+    assets: ProfileZipAssetContext<'_>,
     tables: &serde_json::Map<String, Value>,
     source_format: ProfileImportSourceFormat,
     mode: ProfileImportMode,
 ) -> AppResult<Value> {
     match mode {
         ProfileImportMode::Preview => {
-            let (restored_assets, warnings) =
-                preview_profile_zip_assets(archive, raw_assets, names, profile_prefix)?;
+            let (restored_assets, warnings) = preview_profile_zip_assets(
+                archive,
+                assets.raw_assets,
+                assets.names,
+                assets.profile_prefix,
+            )?;
             let result = preview_legacy_profile_tables(state, tables, restored_assets)?;
             Ok(with_profile_import_warnings(
                 with_profile_import_metadata(result, source_format),
@@ -183,8 +201,13 @@ fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
             ))
         }
         ProfileImportMode::Commit => {
-            let mut restored_assets =
-                restore_profile_zip_assets(state, archive, names, profile_prefix, raw_assets)?;
+            let mut restored_assets = restore_profile_zip_assets(
+                state,
+                archive,
+                assets.names,
+                assets.profile_prefix,
+                assets.raw_assets,
+            )?;
             let restored_count = restored_assets.restored();
             let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
             let result = import_legacy_profile_tables_with_restored_assets(

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1160,6 +1160,8 @@ mod tests {
         "lorebook_image_file_path",
         "llm_stream_channel",
         "profile_export",
+        "profile_import_preview_file",
+        "profile_import_preview_upload",
         "profile_import_file",
         "profile_import_upload",
     ];

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -124,6 +124,11 @@ pub fn router(state: AppState) -> Router {
         .route("/api/invoke", post(invoke))
         .route("/api/profile/export", get(profile_export_download))
         .route(
+            "/api/profile/import/preview",
+            post(profile_import_preview_upload)
+                .layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BODY_BYTES)),
+        )
+        .route(
             "/api/profile/import",
             post(profile_import_upload).layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BODY_BYTES)),
         )
@@ -634,6 +639,49 @@ async fn profile_import_upload(
     }
 }
 
+async fn profile_import_preview_upload(
+    State(state): State<HttpState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Response {
+    let started = Instant::now();
+    request_log("profile_import_preview_upload started");
+    let result = async {
+        require_admin_access_for_command("profile_import_preview_upload", &headers, addr.ip())?;
+        let upload_path = profile_upload_temp_file(&state.app, &mut multipart).await?;
+        let preview_result = profile::preview_profile_file(&state.app, &upload_path);
+        let cleanup_result = tokio::fs::remove_file(&upload_path).await;
+        if let Err(error) = cleanup_result {
+            log::warn!(
+                "failed to remove temporary profile preview upload {}: {error}",
+                upload_path.display()
+            );
+        }
+        preview_result
+    }
+    .await;
+
+    match result {
+        Ok(value) => {
+            request_log(format!(
+                "profile_import_preview_upload ok in {}ms",
+                started.elapsed().as_millis()
+            ));
+            Json(value).into_response()
+        }
+        Err(error) => {
+            request_log(format!(
+                "profile_import_preview_upload error code={} message={} in {}ms",
+                error.code,
+                error.message,
+                started.elapsed().as_millis()
+            ));
+            app_error_response(error)
+        }
+    }
+}
+
 async fn profile_upload_temp_file(
     state: &AppState,
     multipart: &mut Multipart,
@@ -811,6 +859,7 @@ fn is_privileged_remote_command(command: &str) -> bool {
         command,
         "profile_export"
             | "profile_import"
+            | "profile_import_preview_upload"
             | "profile_import_upload"
             | "backup_create"
             | "backup_list"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,8 @@ pub fn run() {
             storage_commands::profile_commands::load_url_binary,
             storage_commands::profile_commands::profile_export,
             storage_commands::profile_commands::profile_import,
+            storage_commands::profile_commands::profile_import_preview_file,
+            storage_commands::profile_commands::profile_import_preview_upload,
             storage_commands::profile_commands::profile_import_file,
             storage_commands::profile_commands::profile_import_upload,
             storage_commands::backup_commands::backup_create,

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -91,7 +91,7 @@ type ProfileImportConversion = {
   to?: string;
 };
 
-const PROFILE_IMPORT_STAT_LABELS: Array<{ key: string; singular: string; plural: string }> = [
+const PROFILE_IMPORT_STAT_LABELS: Array<{ key: string; aliases?: string[]; singular: string; plural: string }> = [
   { key: "characters", singular: "character", plural: "characters" },
   { key: "character-groups", singular: "character group", plural: "character groups" },
   { key: "character-versions", singular: "character version", plural: "character versions" },
@@ -100,7 +100,7 @@ const PROFILE_IMPORT_STAT_LABELS: Array<{ key: string; singular: string; plural:
   { key: "lorebooks", singular: "lorebook", plural: "lorebooks" },
   { key: "lorebook-entries", singular: "lorebook entry", plural: "lorebook entries" },
   { key: "lorebook-folders", singular: "lorebook folder", plural: "lorebook folders" },
-  { key: "presets", singular: "preset", plural: "presets" },
+  { key: "presets", aliases: ["prompts"], singular: "preset", plural: "presets" },
   { key: "prompt-groups", singular: "prompt group", plural: "prompt groups" },
   { key: "prompt-sections", singular: "prompt section", plural: "prompt sections" },
   { key: "prompt-variables", singular: "prompt variable", plural: "prompt variables" },
@@ -174,10 +174,14 @@ function profileImportStatEntries(stats: ProfileImportStats) {
   const used = new Set<string>();
   const entries: Array<{ key: string; count: number; singular: string; plural: string }> = [];
   for (const label of PROFILE_IMPORT_STAT_LABELS) {
-    const count = stats[label.key];
-    used.add(label.key);
+    const keys = [label.key, ...(label.aliases ?? [])];
+    for (const key of keys) used.add(key);
+    const count =
+      typeof stats[label.key] === "number"
+        ? stats[label.key]
+        : label.aliases?.map((key) => stats[key]).find((value) => typeof value === "number");
     if (typeof count === "number" && count > 0) {
-      entries.push({ ...label, count });
+      entries.push({ key: label.key, singular: label.singular, plural: label.plural, count });
     }
   }
   for (const [key, count] of Object.entries(stats)) {
@@ -210,6 +214,10 @@ function formatProfileImportWarnings(warnings?: ProfileImportWarning[]) {
   const count = warnings?.length ?? 0;
   if (count <= 0) return "";
   return `${count} warning${count === 1 ? "" : "s"}`;
+}
+
+function hasProfileImportWarningType(warnings: ProfileImportWarning[] | undefined, type: string) {
+  return warnings?.some((warning) => warning.type === type) ?? false;
 }
 
 function formatProfileImportSourceFormat(sourceFormat?: string) {
@@ -259,12 +267,17 @@ function formatProfileImportConfirmationMessage(preview: ProfileImportResult) {
         : "";
   const skipped = formatProfileImportSkippedStats(imported);
   const warningSummary = formatProfileImportWarnings(warnings);
+  const warningDetail = warningSummary
+    ? hasProfileImportWarningType(warnings, "missing_asset")
+      ? `${warningSummary} detected. Missing assets will be skipped.`
+      : `${warningSummary} detected. Review warnings before continuing.`
+    : "";
   return [
     `Found: ${found}.`,
     source ? `Source: ${source}.` : "",
     conversion,
     skipped ? `Skipped during conversion: ${skipped}.` : "",
-    warningSummary ? `${warningSummary} detected. Missing assets will be skipped.` : "",
+    warningDetail,
     "Importing replaces the matching profile data areas from this file. This cannot be undone. Continue?",
   ]
     .filter(Boolean)

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -1,6 +1,6 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Check, Download, Loader2 } from "lucide-react";
+import { AlertTriangle, Check, Download, FileSearch, Loader2 } from "lucide-react";
 import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { profileApi } from "../../../../shared/api/profile-api";
@@ -10,21 +10,51 @@ import { cn } from "../../../../shared/lib/utils";
 import { useUIStore } from "../../../../shared/stores/ui.store";
 
 type ProfileImportStats = {
+  [key: string]: number | undefined;
   characters?: number;
+  "character-groups"?: number;
+  "character-versions"?: number;
   personas?: number;
+  "persona-groups"?: number;
   lorebooks?: number;
+  "lorebook-entries"?: number;
+  "lorebook-folders"?: number;
+  prompts?: number;
+  "prompt-groups"?: number;
+  "prompt-sections"?: number;
+  "prompt-variables"?: number;
+  "prompt-overrides"?: number;
   presets?: number;
+  "chat-presets"?: number;
   agents?: number;
+  "agent-runs"?: number;
+  "agent-memory"?: number;
   themes?: number;
+  extensions?: number;
   chats?: number;
+  "chat-folders"?: number;
   messages?: number;
+  "message-swipes"?: number;
   connections?: number;
+  "connection-folders"?: number;
+  "custom-tools"?: number;
+  "regex-scripts"?: number;
+  "app-settings"?: number;
+  gallery?: number;
+  "character-gallery"?: number;
+  "background-metadata"?: number;
+  sprites?: number;
+  "knowledge-sources"?: number;
+  "game-state-snapshots"?: number;
+  "game-checkpoints"?: number;
+  "conversation-notes"?: number;
+  "ooc-influences"?: number;
   files?: number;
   unsupportedPromptOverrides?: number;
 };
 
 type ProfileImportProgressState = {
-  status: "reading" | "starting" | "running" | "success" | "error";
+  status: "reading" | "preview" | "starting" | "running" | "success" | "error";
   label: string;
   completedItems: number;
   totalItems: number;
@@ -45,12 +75,14 @@ type ProfileImportWarning = {
 
 type ProfileImportResult = {
   success?: boolean;
+  preview?: boolean;
   error?: string;
   message?: string;
   imported?: ProfileImportStats;
   warnings?: ProfileImportWarning[];
   sourceFormat?: string;
   converted?: ProfileImportConversion;
+  fileFingerprint?: string;
 };
 
 type ProfileImportConversion = {
@@ -58,6 +90,49 @@ type ProfileImportConversion = {
   from?: string;
   to?: string;
 };
+
+const PROFILE_IMPORT_STAT_LABELS: Array<{ key: string; singular: string; plural: string }> = [
+  { key: "characters", singular: "character", plural: "characters" },
+  { key: "character-groups", singular: "character group", plural: "character groups" },
+  { key: "character-versions", singular: "character version", plural: "character versions" },
+  { key: "personas", singular: "persona", plural: "personas" },
+  { key: "persona-groups", singular: "persona group", plural: "persona groups" },
+  { key: "lorebooks", singular: "lorebook", plural: "lorebooks" },
+  { key: "lorebook-entries", singular: "lorebook entry", plural: "lorebook entries" },
+  { key: "lorebook-folders", singular: "lorebook folder", plural: "lorebook folders" },
+  { key: "presets", singular: "preset", plural: "presets" },
+  { key: "prompt-groups", singular: "prompt group", plural: "prompt groups" },
+  { key: "prompt-sections", singular: "prompt section", plural: "prompt sections" },
+  { key: "prompt-variables", singular: "prompt variable", plural: "prompt variables" },
+  { key: "prompt-overrides", singular: "prompt override", plural: "prompt overrides" },
+  { key: "chat-presets", singular: "chat preset", plural: "chat presets" },
+  { key: "agents", singular: "agent", plural: "agents" },
+  { key: "agent-runs", singular: "agent run", plural: "agent runs" },
+  { key: "agent-memory", singular: "agent memory row", plural: "agent memory rows" },
+  { key: "themes", singular: "theme", plural: "themes" },
+  { key: "extensions", singular: "extension", plural: "extensions" },
+  { key: "connections", singular: "connection", plural: "connections" },
+  { key: "connection-folders", singular: "connection folder", plural: "connection folders" },
+  { key: "chats", singular: "chat", plural: "chats" },
+  { key: "chat-folders", singular: "chat folder", plural: "chat folders" },
+  { key: "messages", singular: "message", plural: "messages" },
+  { key: "message-swipes", singular: "message swipe", plural: "message swipes" },
+  { key: "custom-tools", singular: "custom tool", plural: "custom tools" },
+  { key: "regex-scripts", singular: "regex script", plural: "regex scripts" },
+  { key: "app-settings", singular: "app setting", plural: "app settings" },
+  { key: "gallery", singular: "gallery item", plural: "gallery items" },
+  { key: "character-gallery", singular: "character gallery item", plural: "character gallery items" },
+  { key: "background-metadata", singular: "background", plural: "backgrounds" },
+  { key: "sprites", singular: "sprite", plural: "sprites" },
+  { key: "knowledge-sources", singular: "knowledge source", plural: "knowledge sources" },
+  { key: "game-state-snapshots", singular: "game state snapshot", plural: "game state snapshots" },
+  { key: "game-checkpoints", singular: "game checkpoint", plural: "game checkpoints" },
+  { key: "conversation-notes", singular: "conversation note", plural: "conversation notes" },
+  { key: "ooc-influences", singular: "OOC influence", plural: "OOC influences" },
+  { key: "files", singular: "file", plural: "files" },
+];
+const PROFILE_IMPORT_STAT_META_KEYS = new Set(["unsupportedPromptOverrides"]);
+const PROFILE_IMPORT_STAT_ALIAS_KEYS = new Set(["prompts"]);
 
 function formatProfileImportDuration(seconds: number) {
   const safeSeconds = Math.max(0, Math.round(seconds));
@@ -77,6 +152,7 @@ function estimateProfileImportRemainingSeconds(progress: ProfileImportProgressSt
 
 function getProfileImportPercent(progress: ProfileImportProgressState) {
   if (progress.status === "success") return 100;
+  if (progress.status === "preview") return 0;
   if (progress.totalItems <= 0) return progress.status === "running" ? 8 : 0;
   const percent = Math.round((progress.completedItems / progress.totalItems) * 100);
   return Math.min(99, Math.max(progress.status === "running" ? 8 : 0, percent));
@@ -84,22 +160,44 @@ function getProfileImportPercent(progress: ProfileImportProgressState) {
 
 function formatProfileImportStats(stats?: ProfileImportStats) {
   if (!stats) return "";
-  const entries: Array<[number | undefined, string]> = [
-    [stats.characters, "characters"],
-    [stats.personas, "personas"],
-    [stats.lorebooks, "lorebooks"],
-    [stats.presets, "presets"],
-    [stats.agents, "agents"],
-    [stats.themes, "themes"],
-    [stats.chats, "chats"],
-    [stats.messages, "messages"],
-    [stats.connections, "connections"],
-    [stats.files, "files"],
-  ];
-  return entries
-    .filter(([count]) => typeof count === "number" && count > 0)
-    .map(([count, label]) => `${count} ${label}`)
+  return profileImportStatEntries(stats)
+    .map(({ count, singular, plural }) => `${count} ${count === 1 ? singular : plural}`)
     .join(", ");
+}
+
+function getProfileImportItemCount(stats?: ProfileImportStats) {
+  if (!stats) return 0;
+  return profileImportStatEntries(stats).reduce((total, { count }) => total + count, 0);
+}
+
+function profileImportStatEntries(stats: ProfileImportStats) {
+  const used = new Set<string>();
+  const entries: Array<{ key: string; count: number; singular: string; plural: string }> = [];
+  for (const label of PROFILE_IMPORT_STAT_LABELS) {
+    const count = stats[label.key];
+    used.add(label.key);
+    if (typeof count === "number" && count > 0) {
+      entries.push({ ...label, count });
+    }
+  }
+  for (const [key, count] of Object.entries(stats)) {
+    if (
+      used.has(key) ||
+      PROFILE_IMPORT_STAT_META_KEYS.has(key) ||
+      PROFILE_IMPORT_STAT_ALIAS_KEYS.has(key) ||
+      typeof count !== "number" ||
+      count <= 0
+    ) {
+      continue;
+    }
+    const label = formatUnknownProfileImportStatKey(key);
+    entries.push({ key, count, singular: label, plural: label });
+  }
+  return entries;
+}
+
+function formatUnknownProfileImportStatKey(key: string) {
+  return key.replace(/[-_]+/g, " ");
 }
 
 function formatProfileImportSkippedStats(stats?: ProfileImportStats) {
@@ -138,6 +236,41 @@ function formatProfileImportMetadata(progress: ProfileImportProgressState) {
   return parts.join(". ");
 }
 
+function profileImportMetadataFromResult(data?: ProfileImportResult) {
+  return {
+    imported: data?.imported,
+    warnings: Array.isArray(data?.warnings) ? data.warnings : [],
+    sourceFormat: typeof data?.sourceFormat === "string" ? data.sourceFormat : undefined,
+    converted: data?.converted && typeof data.converted === "object" ? data.converted : undefined,
+  };
+}
+
+function formatProfileImportConfirmationMessage(preview: ProfileImportResult) {
+  const { imported, warnings, sourceFormat, converted } = profileImportMetadataFromResult(preview);
+  const found = formatProfileImportStats(imported) || "no counted records";
+  const source = formatProfileImportSourceFormat(sourceFormat);
+  const conversion =
+    converted?.applied
+      ? `Conversion: ${formatProfileImportSourceFormat(converted.from) || "legacy"} -> ${
+          formatProfileImportSourceFormat(converted.to) || "refactor"
+        }.`
+      : converted?.applied === false
+        ? "Conversion: none."
+        : "";
+  const skipped = formatProfileImportSkippedStats(imported);
+  const warningSummary = formatProfileImportWarnings(warnings);
+  return [
+    `Found: ${found}.`,
+    source ? `Source: ${source}.` : "",
+    conversion,
+    skipped ? `Skipped during conversion: ${skipped}.` : "",
+    warningSummary ? `${warningSummary} detected. Missing assets will be skipped.` : "",
+    "Importing replaces the matching profile data areas from this file. This cannot be undone. Continue?",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
 export function ProfileImportSection() {
   const qc = useQueryClient();
   const remoteProfileInputRef = useRef<HTMLInputElement>(null);
@@ -145,6 +278,7 @@ export function ProfileImportSection() {
   const [profileImportProgress, setProfileImportProgress] = useState<ProfileImportProgressState | null>(null);
   const profileImportBusy =
     profileImportProgress?.status === "reading" ||
+    profileImportProgress?.status === "preview" ||
     profileImportProgress?.status === "starting" ||
     profileImportProgress?.status === "running";
   const isRemoteRuntime = remoteRuntimeUrl.trim().length > 0;
@@ -153,7 +287,11 @@ export function ProfileImportSection() {
     if (!profileImportBusy) return;
     const timer = window.setInterval(() => {
       setProfileImportProgress((current) =>
-        current && (current.status === "reading" || current.status === "starting" || current.status === "running")
+        current &&
+        (current.status === "reading" ||
+          current.status === "preview" ||
+          current.status === "starting" ||
+          current.status === "running")
           ? { ...current, elapsedSeconds: Math.floor((Date.now() - current.startedAt) / 1000) }
           : current,
       );
@@ -164,10 +302,7 @@ export function ProfileImportSection() {
   const finishProfileImport = (data: ProfileImportResult, startedAt: number) => {
     if (data?.success === false) throw new Error(data.error ?? data.message ?? "Unknown error");
     qc.invalidateQueries();
-    const imported = data?.imported;
-    const warnings = Array.isArray(data?.warnings) ? data.warnings : [];
-    const sourceFormat = typeof data?.sourceFormat === "string" ? data.sourceFormat : undefined;
-    const converted = data?.converted && typeof data.converted === "object" ? data.converted : undefined;
+    const { imported, warnings, sourceFormat, converted } = profileImportMetadataFromResult(data);
     const summary = formatProfileImportStats(imported);
     const skippedSummary = formatProfileImportSkippedStats(imported);
     const warningSummary = formatProfileImportWarnings(warnings);
@@ -197,11 +332,40 @@ export function ProfileImportSection() {
     );
   };
 
-  const runConfirmedProfileImport = async (startedAt: number, importProfile: () => Promise<ProfileImportResult>) => {
+  const runPreviewedProfileImport = async (
+    startedAt: number,
+    previewProfile: () => Promise<ProfileImportResult>,
+    importProfile: (preview: ProfileImportResult) => Promise<ProfileImportResult>,
+  ) => {
+    setProfileImportProgress((current) =>
+      current
+        ? {
+            ...current,
+            status: "reading",
+            label: "Scanning profile file",
+            elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+          }
+        : current,
+    );
+    const preview = await previewProfile();
+    if (preview?.success === false) throw new Error(preview.error ?? preview.message ?? "Unknown error");
+    const { imported, warnings, sourceFormat, converted } = profileImportMetadataFromResult(preview);
+    const totalItems = Math.max(1, getProfileImportItemCount(imported));
+    setProfileImportProgress({
+      status: "preview",
+      label: "Review profile import",
+      completedItems: 0,
+      totalItems,
+      startedAt,
+      elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+      imported,
+      warnings,
+      sourceFormat,
+      converted,
+    });
     const confirmed = await showConfirmDialog({
       title: "Import Profile",
-      message:
-        "Importing a profile replaces data from the selected file and may remove existing collections, depending on the export format. This cannot be undone. Continue?",
+      message: formatProfileImportConfirmationMessage(preview),
       confirmLabel: "Import",
       cancelLabel: "Cancel",
       tone: "destructive",
@@ -215,7 +379,7 @@ export function ProfileImportSection() {
         ? {
             ...current,
             status: "starting",
-            label: "Reading profile file",
+            label: "Preparing profile import",
             elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
           }
         : current,
@@ -231,7 +395,7 @@ export function ProfileImportSection() {
           }
         : current,
     );
-    finishProfileImport(await importProfile(), startedAt);
+    finishProfileImport(await importProfile(preview), startedAt);
   };
 
   const showProfileImportError = (err: unknown, startedAt: number) => {
@@ -282,7 +446,14 @@ export function ProfileImportSection() {
         setProfileImportProgress(null);
         return;
       }
-      await runConfirmedProfileImport(startedAt, () => profileApi.importProfileFile<ProfileImportResult>(selected));
+      await runPreviewedProfileImport(
+        startedAt,
+        () => profileApi.previewProfileFile<ProfileImportResult>(selected),
+        (preview) =>
+          profileApi.importProfileFile<ProfileImportResult>(selected, {
+            previewFingerprint: preview.fileFingerprint,
+          }),
+      );
     } catch (err) {
       showProfileImportError(err, startedAt);
     }
@@ -302,9 +473,11 @@ export function ProfileImportSection() {
       elapsedSeconds: 0,
     });
     try {
-      await runConfirmedProfileImport(startedAt, async () => {
-        return profileApi.importProfileUpload<ProfileImportResult>(file);
-      });
+      await runPreviewedProfileImport(
+        startedAt,
+        () => profileApi.previewProfileUpload<ProfileImportResult>(file),
+        () => profileApi.importProfileUpload<ProfileImportResult>(file),
+      );
     } catch (err) {
       showProfileImportError(err, startedAt);
     }
@@ -329,7 +502,11 @@ export function ProfileImportSection() {
         )}
       >
         {profileImportBusy ? <Loader2 size="1rem" className="animate-spin" /> : <Download size="1rem" />}
-        {profileImportBusy ? "Importing Profile..." : "Import Profile (JSON/ZIP)"}
+        {profileImportBusy
+          ? profileImportProgress?.status === "reading" || profileImportProgress?.status === "preview"
+            ? "Scanning Profile..."
+            : "Importing Profile..."
+          : "Import Profile (JSON/ZIP)"}
       </button>
 
       {profileImportProgress && (
@@ -351,6 +528,8 @@ export function ProfileImportSection() {
                 <Check size="0.875rem" className="shrink-0" />
               ) : profileImportProgress.status === "error" ? (
                 <AlertTriangle size="0.875rem" className="shrink-0" />
+              ) : profileImportProgress.status === "preview" ? (
+                <FileSearch size="0.875rem" className="shrink-0 text-emerald-500" />
               ) : (
                 <Loader2 size="0.875rem" className="shrink-0 animate-spin text-emerald-500" />
               )}
@@ -363,28 +542,33 @@ export function ProfileImportSection() {
 
           {profileImportProgress.status !== "error" && (
             <>
-              <div className="h-1.5 overflow-hidden rounded-full bg-[var(--border)]">
-                <div
-                  className={cn(
-                    "h-full rounded-full transition-all duration-300",
-                    profileImportProgress.status === "success" ? "bg-emerald-500" : "bg-emerald-400",
-                  )}
-                  style={{ width: `${getProfileImportPercent(profileImportProgress)}%` }}
-                />
-              </div>
-              <div className="flex flex-wrap items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                <span>
-                  {profileImportProgress.completedItems}/{profileImportProgress.totalItems} items
-                </span>
-                {estimateProfileImportRemainingSeconds(profileImportProgress) !== null && (
-                  <span>
-                    ETA {formatProfileImportDuration(estimateProfileImportRemainingSeconds(profileImportProgress) ?? 0)}
-                  </span>
-                )}
-              </div>
+              {profileImportProgress.status !== "preview" && (
+                <>
+                  <div className="h-1.5 overflow-hidden rounded-full bg-[var(--border)]">
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all duration-300",
+                        profileImportProgress.status === "success" ? "bg-emerald-500" : "bg-emerald-400",
+                      )}
+                      style={{ width: `${getProfileImportPercent(profileImportProgress)}%` }}
+                    />
+                  </div>
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                    <span>
+                      {profileImportProgress.completedItems}/{profileImportProgress.totalItems} items
+                    </span>
+                    {estimateProfileImportRemainingSeconds(profileImportProgress) !== null && (
+                      <span>
+                        ETA {formatProfileImportDuration(estimateProfileImportRemainingSeconds(profileImportProgress) ?? 0)}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
               {formatProfileImportStats(profileImportProgress.imported) && (
                 <div className="text-[0.6875rem] text-[var(--muted-foreground)]">
-                  Imported so far: {formatProfileImportStats(profileImportProgress.imported)}
+                  {profileImportProgress.status === "success" ? "Imported" : "Found"}:{" "}
+                  {formatProfileImportStats(profileImportProgress.imported)}
                 </div>
               )}
               {formatProfileImportMetadata(profileImportProgress) && (

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -91,7 +91,10 @@ async function importProfile<T>(envelope: unknown): Promise<T> {
   );
 }
 
-async function importProfileFile<T>(path: string): Promise<T> {
+async function importProfileFile<T>(
+  path: string,
+  options?: { previewFingerprint?: string | null },
+): Promise<T> {
   if (remoteRuntimeTarget()) {
     throw new ApiError(
       "Profile import from a local file path is not available while Remote Runtime is configured.",
@@ -100,9 +103,48 @@ async function importProfileFile<T>(path: string): Promise<T> {
     );
   }
   return invalidateRemoteManagedAssetObjectUrlsAfter(
-    invokeTauri<T>("profile_import_file", { path }),
+    invokeTauri<T>("profile_import_file", {
+      path,
+      previewFingerprint: options?.previewFingerprint ?? null,
+    }),
     PROFILE_IMPORT_MANAGED_ASSET_KINDS,
   );
+}
+
+async function previewProfileFile<T>(path: string): Promise<T> {
+  if (remoteRuntimeTarget()) {
+    throw new ApiError(
+      "Profile preview from a local file path is not available while Remote Runtime is configured.",
+      400,
+      { code: "remote_local_path_unsupported" },
+    );
+  }
+  return invokeTauri<T>("profile_import_preview_file", { path });
+}
+
+async function previewRemoteProfileUpload<T>(target: RuntimeTarget, file: File): Promise<T> {
+  const form = new FormData();
+  form.append("file", file, file.name);
+  const response = await fetch(
+    `${target.baseUrl}/api/profile/import/preview`,
+    remoteFetchInit({
+      method: "POST",
+      headers: remotePrivilegedHeaders(target, { accept: "application/json" }),
+      body: form,
+    }),
+  );
+  if (!response.ok) throw await readRemoteError(response);
+  return (await response.json()) as T;
+}
+
+async function previewProfileUpload<T>(file: File): Promise<T> {
+  const target = remoteRuntimeTarget();
+  return target
+    ? previewRemoteProfileUpload<T>(target, file)
+    : invokeTauri<T>("profile_import_preview_upload", {
+        filename: file.name,
+        base64: await readFileAsBase64(file),
+      });
 }
 
 async function importRemoteProfileUpload<T>(target: RuntimeTarget, file: File): Promise<T> {
@@ -158,6 +200,8 @@ async function downloadBackup(name?: string): Promise<DownloadPayload> {
 export const profileApi = {
   exportProfile,
   importProfile,
+  previewProfileFile,
+  previewProfileUpload,
   importProfileFile,
   importProfileUpload,
 };


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Profile import preview needed to line up with the real import path so users can review what will be replaced before committing a profile restore.
- Legacy profile compatibility needed safer preview coverage for JSON/ZIP assets, legacy array assets, and connection rows without writing secrets during preview.

## What changed

- Added profile import preview commands for local files and uploads, plus a remote `/api/profile/import/preview` route.
- Refactored profile import and ZIP import through shared preview/commit mode paths so format detection and import planning stay aligned.
- Added preview validation/counting for profile assets and legacy tables without writing collections, assets, or connection secret keys.
- Updated the Settings profile import flow to scan first, show source/conversion/count/warning details, then confirm before import.
- Guarded local file imports with a preview fingerprint so changed files are rejected before commit.

## Refactor impact

Primary owner:

- Rust storage profile imports, shared profile API wrapper, and Settings profile import UI.

Impact areas reviewed:

- Embedded Tauri profile import commands.
- Hostable remote profile upload/preview route.
- Profile JSON and ZIP import paths.
- Native refactor profile exports, legacy fileStorage profiles, and legacy array profiles.
- Asset restore/preview validation and connection secret handling.

Boundary notes:

- Feature UI continues to call the focused `profileApi` wrapper.
- Runtime wrapper owns embedded-vs-remote preview/import routing.
- Rust storage modules own privileged parsing, asset handling, collection replacement, and preview validation.
- No engine imports or mode-owner boundaries changed.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration.
- Profile import modules under `src-tauri/src/commands/storage/profile*`.
- Dedicated HTTP route wiring in `src-tauri/src/http_server.rs`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml profile_import_preview -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml profile_import_legacy_array -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml preview_profile_zip -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml profile_file_import_rejects_file_changed_after_preview -- --nocapture` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml storage_commands::profile:: -- --nocapture` passed on the rebased branch.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed on the rebased branch.
- `git diff --check` passed.
- Native Tauri UI/manual import flow verification was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing Settings profile import workflow improved; no new discoverable feature entry was added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Notes:

- No root changelog file exists in this checkout.
- No docs changes were needed for this compatibility and safety improvement.

## UI evidence

- Not captured. Remaining gap: native Tauri manual confirmation-flow QA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile imports now include a preview phase before confirming the import
  * Import statistics display detailed counts of records and any warnings
  * File fingerprinting validates that imported files remain unchanged between preview and import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->