### PR TITLE
Add profile import progress reporting

### DIFF
--- a/src-tauri/src/commands/storage/commands/profile.rs
+++ b/src-tauri/src/commands/storage/commands/profile.rs
@@ -235,6 +235,49 @@ pub fn profile_import_file(
 }
 
 #[tauri::command]
+pub fn profile_import_file_events(
+    state: State<'_, AppState>,
+    path: String,
+    preview_fingerprint: Option<String>,
+    on_event: tauri::ipc::Channel<Value>,
+) -> Result<Value, AppError> {
+    let result = profile::import_profile_file_path_with_progress(
+        &state,
+        &path,
+        preview_fingerprint.as_deref(),
+        |event| {
+            on_event
+                .send(event)
+                .map_err(|error| AppError::new("profile_import_event_error", error.to_string()))
+        },
+    );
+    match result {
+        Ok(value) => {
+            if let Err(error) = on_event.send(json!({ "type": "done", "data": value.clone() })) {
+                log::warn!("profile import completed but final event delivery failed: {error}");
+            }
+            Ok(value)
+        }
+        Err(error) => {
+            let payload = profile_import_error_event(&error);
+            let _ = on_event.send(payload);
+            Err(error)
+        }
+    }
+}
+
+fn profile_import_error_event(error: &AppError) -> Value {
+    json!({
+        "type": "error",
+        "data": {
+            "code": error.code.clone(),
+            "message": error.message.clone(),
+            "details": error.details.clone(),
+        },
+    })
+}
+
+#[tauri::command]
 pub fn profile_import_preview_upload(
     state: State<'_, AppState>,
     filename: String,

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -10,9 +10,10 @@ use self::assets::{
     profile_assets_manifest, restore_profile_assets, RestoredProfileAssets,
 };
 use self::legacy::{
-    import_legacy_profile_tables, legacy_array_profile_tables, preview_legacy_profile_tables,
+    import_legacy_profile_tables_with_progress, legacy_array_profile_tables,
+    preview_legacy_profile_tables,
 };
-use self::zip_import::{import_profile_zip, preview_profile_zip};
+use self::zip_import::{import_profile_zip, import_profile_zip_with_progress, preview_profile_zip};
 use super::contracts;
 use super::shared::*;
 use super::*;
@@ -67,6 +68,139 @@ struct ProfileFileSnapshot {
     fingerprint: String,
 }
 
+pub(super) struct ProfileImportProgress<'a> {
+    emit: Option<Box<dyn FnMut(Value) -> AppResult<()> + 'a>>,
+    current: usize,
+    total: usize,
+    imported: Map<String, Value>,
+}
+
+impl<'a> ProfileImportProgress<'a> {
+    pub(super) fn disabled() -> Self {
+        Self {
+            emit: None,
+            current: 0,
+            total: 1,
+            imported: Map::new(),
+        }
+    }
+
+    fn new(emit: impl FnMut(Value) -> AppResult<()> + 'a) -> Self {
+        Self {
+            emit: Some(Box::new(emit)),
+            current: 0,
+            total: 1,
+            imported: Map::new(),
+        }
+    }
+
+    pub(super) fn prepare(
+        &mut self,
+        phase: &'static str,
+        label: impl Into<String>,
+    ) -> AppResult<()> {
+        if self.emit.is_none() {
+            return Ok(());
+        }
+        self.total = self.total.max(1);
+        self.emit_event(phase, None, label.into())
+    }
+
+    pub(super) fn begin(
+        &mut self,
+        total: usize,
+        phase: &'static str,
+        label: impl Into<String>,
+    ) -> AppResult<()> {
+        if self.emit.is_none() {
+            return Ok(());
+        }
+        self.current = 0;
+        self.total = total.max(1);
+        self.imported.clear();
+        self.emit_event(phase, None, label.into())
+    }
+
+    pub(super) fn advance(
+        &mut self,
+        phase: &'static str,
+        item: impl Into<String>,
+        label: impl Into<String>,
+        count: usize,
+    ) -> AppResult<()> {
+        self.advance_counted(phase, item, label, count, Some(count))
+    }
+
+    pub(super) fn advance_untracked(
+        &mut self,
+        phase: &'static str,
+        item: impl Into<String>,
+        label: impl Into<String>,
+        count: usize,
+    ) -> AppResult<()> {
+        self.advance_counted(phase, item, label, count, None)
+    }
+
+    pub(super) fn advance_untracked_after_commit(
+        &mut self,
+        phase: &'static str,
+        item: impl Into<String>,
+        label: impl Into<String>,
+        count: usize,
+    ) {
+        if let Err(error) = self.advance_untracked(phase, item, label, count) {
+            log::warn!(
+                "profile import completed but progress delivery failed code={} message={}",
+                error.code,
+                error.message
+            );
+        }
+    }
+
+    pub(super) fn advance_counted(
+        &mut self,
+        phase: &'static str,
+        item: impl Into<String>,
+        label: impl Into<String>,
+        processed_count: usize,
+        imported_count: Option<usize>,
+    ) -> AppResult<()> {
+        if self.emit.is_none() {
+            return Ok(());
+        }
+        let item = item.into();
+        self.current = self.current.saturating_add(processed_count).min(self.total);
+        if let Some(imported_count) = imported_count {
+            self.imported.insert(item.clone(), json!(imported_count));
+        }
+        self.emit_event(phase, Some(item), label.into())
+    }
+
+    fn emit_event(
+        &mut self,
+        phase: &'static str,
+        item: Option<String>,
+        label: String,
+    ) -> AppResult<()> {
+        let Some(emit) = self.emit.as_mut() else {
+            return Ok(());
+        };
+        let mut data = Map::new();
+        data.insert("phase".to_string(), Value::String(phase.to_string()));
+        data.insert("label".to_string(), Value::String(label));
+        data.insert("current".to_string(), json!(self.current));
+        data.insert("total".to_string(), json!(self.total));
+        data.insert("imported".to_string(), Value::Object(self.imported.clone()));
+        if let Some(item) = item {
+            data.insert("item".to_string(), Value::String(item));
+        }
+        emit(json!({
+            "type": "progress",
+            "data": Value::Object(data),
+        }))
+    }
+}
+
 pub(crate) struct ProfileExportDownload {
     pub(crate) bytes: Vec<u8>,
     pub(crate) filename: &'static str,
@@ -108,6 +242,21 @@ pub(crate) fn import_profile_file_path(
     import_profile_file_with_preview_fingerprint(state, &path, preview_fingerprint)
 }
 
+pub(crate) fn import_profile_file_path_with_progress(
+    state: &AppState,
+    value: &str,
+    preview_fingerprint: Option<&str>,
+    emit: impl FnMut(Value) -> AppResult<()>,
+) -> AppResult<Value> {
+    let path = PathBuf::from(value.trim());
+    import_profile_file_with_preview_fingerprint_and_progress(
+        state,
+        &path,
+        preview_fingerprint,
+        emit,
+    )
+}
+
 pub(crate) fn preview_profile_file_path(state: &AppState, value: &str) -> AppResult<Value> {
     let path = PathBuf::from(value.trim());
     preview_profile_file(state, &path)
@@ -121,6 +270,36 @@ pub(crate) fn import_profile_file_with_preview_fingerprint(
     state: &AppState,
     path: &Path,
     preview_fingerprint: Option<&str>,
+) -> AppResult<Value> {
+    let mut progress = ProfileImportProgress::disabled();
+    import_profile_file_with_preview_fingerprint_inner(
+        state,
+        path,
+        preview_fingerprint,
+        &mut progress,
+    )
+}
+
+pub(crate) fn import_profile_file_with_preview_fingerprint_and_progress(
+    state: &AppState,
+    path: &Path,
+    preview_fingerprint: Option<&str>,
+    emit: impl FnMut(Value) -> AppResult<()>,
+) -> AppResult<Value> {
+    let mut progress = ProfileImportProgress::new(emit);
+    import_profile_file_with_preview_fingerprint_inner(
+        state,
+        path,
+        preview_fingerprint,
+        &mut progress,
+    )
+}
+
+fn import_profile_file_with_preview_fingerprint_inner(
+    state: &AppState,
+    path: &Path,
+    preview_fingerprint: Option<&str>,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     with_profile_file_snapshot(state, path, |snapshot_path, extension, fingerprint| {
         if let Some(expected) = preview_fingerprint
@@ -139,12 +318,13 @@ pub(crate) fn import_profile_file_with_preview_fingerprint(
             }
         }
         match extension {
-            "json" => import_profile(
+            "json" => import_profile_with_progress(
                 state,
                 serde_json::from_reader(File::open(snapshot_path)?)
                     .map_err(invalid_profile_json_error)?,
+                progress,
             ),
-            "zip" => import_profile_zip(state, snapshot_path),
+            "zip" => import_profile_zip_with_progress(state, snapshot_path, progress),
             _ => unreachable!("profile_file_extension only returns json or zip"),
         }
     })
@@ -437,14 +617,29 @@ fn native_profile_export(state: &AppState) -> AppResult<Value> {
 }
 
 fn import_profile(state: &AppState, body: Value) -> AppResult<Value> {
-    run_profile_import(state, body, ProfileImportMode::Commit)
+    let mut progress = ProfileImportProgress::disabled();
+    import_profile_with_progress(state, body, &mut progress)
+}
+
+fn import_profile_with_progress(
+    state: &AppState,
+    body: Value,
+    progress: &mut ProfileImportProgress<'_>,
+) -> AppResult<Value> {
+    run_profile_import(state, body, ProfileImportMode::Commit, progress)
 }
 
 fn preview_profile(state: &AppState, body: Value) -> AppResult<Value> {
-    run_profile_import(state, body, ProfileImportMode::Preview)
+    let mut progress = ProfileImportProgress::disabled();
+    run_profile_import(state, body, ProfileImportMode::Preview, &mut progress)
 }
 
-fn run_profile_import(state: &AppState, body: Value, mode: ProfileImportMode) -> AppResult<Value> {
+fn run_profile_import(
+    state: &AppState,
+    body: Value,
+    mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
+) -> AppResult<Value> {
     let data = body
         .get("data")
         .and_then(Value::as_object)
@@ -457,7 +652,7 @@ fn run_profile_import(state: &AppState, body: Value, mode: ProfileImportMode) ->
                 "invalid-refactor-native",
             )
         })?;
-        return run_profile_collections(state, data, collections, mode);
+        return run_profile_collections(state, data, collections, mode, progress);
     }
     if let Some(tables_value) = data
         .get("fileStorage")
@@ -476,6 +671,7 @@ fn run_profile_import(state: &AppState, body: Value, mode: ProfileImportMode) ->
             files,
             ProfileImportSourceFormat::LegacyFileStorage,
             mode,
+            progress,
         );
     }
     if let Some(tables) = legacy_array_profile_tables(data)? {
@@ -489,6 +685,7 @@ fn run_profile_import(state: &AppState, body: Value, mode: ProfileImportMode) ->
             files,
             ProfileImportSourceFormat::LegacyArray,
             mode,
+            progress,
         );
     }
     Err(profile_format_error(
@@ -502,6 +699,7 @@ fn run_profile_collections(
     data: &Map<String, Value>,
     collections: &Map<String, Value>,
     mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     validate_native_profile_import(data, collections)?;
     match mode {
@@ -518,12 +716,14 @@ fn run_profile_collections(
             ))
         }
         ProfileImportMode::Commit => {
+            progress.prepare("assets", "Preparing profile assets")?;
             let mut restored_assets = restore_profile_assets(state, data.get("assets"))?;
             let restored_count = restored_assets.restored();
-            let result = import_profile_collections_with_restored_assets(
+            let result = import_profile_collections_with_restored_assets_with_progress(
                 state,
                 collections,
                 restored_count,
+                progress,
                 || restored_assets.install(),
             );
             finish_profile_import_assets(restored_assets, result).map(|value| {
@@ -539,6 +739,7 @@ fn run_profile_legacy_tables(
     raw_assets: Option<&Value>,
     source_format: ProfileImportSourceFormat,
     mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     match mode {
         ProfileImportMode::Preview => {
@@ -549,8 +750,11 @@ fn run_profile_legacy_tables(
                 warnings,
             ))
         }
-        ProfileImportMode::Commit => import_legacy_profile_tables(state, tables, raw_assets)
-            .map(|value| with_profile_import_metadata(value, source_format)),
+        ProfileImportMode::Commit => {
+            progress.prepare("assets", "Preparing profile assets")?;
+            import_legacy_profile_tables_with_progress(state, tables, raw_assets, progress)
+                .map(|value| with_profile_import_metadata(value, source_format))
+        }
     }
 }
 
@@ -559,11 +763,13 @@ pub(super) fn preview_profile_collections_with_restored_assets(
     collections: &Map<String, Value>,
     restored_assets: usize,
 ) -> AppResult<Value> {
+    let mut progress = ProfileImportProgress::disabled();
     let plan = profile_collections_import_plan(
         state,
         collections,
         restored_assets,
         ProfileImportMode::Preview,
+        &mut progress,
     )?;
     Ok(json!({ "success": true, "preview": true, "imported": plan.imported }))
 }
@@ -664,10 +870,31 @@ pub(super) fn validate_native_profile_import(
     Ok(())
 }
 
+#[cfg(test)]
 pub(super) fn import_profile_collections_with_restored_assets<F>(
     state: &AppState,
     collections: &Map<String, Value>,
     restored_assets: usize,
+    install_assets: F,
+) -> AppResult<Value>
+where
+    F: FnOnce() -> AppResult<()>,
+{
+    let mut progress = ProfileImportProgress::disabled();
+    import_profile_collections_with_restored_assets_with_progress(
+        state,
+        collections,
+        restored_assets,
+        &mut progress,
+        install_assets,
+    )
+}
+
+pub(super) fn import_profile_collections_with_restored_assets_with_progress<F>(
+    state: &AppState,
+    collections: &Map<String, Value>,
+    restored_assets: usize,
+    progress: &mut ProfileImportProgress<'_>,
     install_assets: F,
 ) -> AppResult<Value>
 where
@@ -678,10 +905,13 @@ where
         collections,
         restored_assets,
         ProfileImportMode::Commit,
+        progress,
     )?;
+    progress.prepare("write", "Writing profile data")?;
     state
         .storage
         .replace_all_many_and_then(plan.replacements, install_assets)?;
+    progress.advance_untracked_after_commit("write", "write", "Profile data written", 1);
     Ok(json!({ "success": true, "imported": plan.imported }))
 }
 
@@ -690,10 +920,26 @@ fn profile_collections_import_plan(
     collections: &Map<String, Value>,
     restored_assets: usize,
     mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<ProfileCollectionsImportPlan> {
     let mut imported = Map::new();
     let mut replacements = Vec::new();
     let mut unsupported_prompt_overrides = 0usize;
+    if mode == ProfileImportMode::Commit {
+        progress.begin(
+            profile_collections_progress_total(collections, restored_assets),
+            "collections",
+            "Importing profile collections",
+        )?;
+        if restored_assets > 0 {
+            progress.advance(
+                "assets",
+                "files",
+                "Prepared profile assets",
+                restored_assets,
+            )?;
+        }
+    }
     for collection in contracts::profile_collections() {
         // A partial modern profile (a hand-built export, or a file missing a
         // collection) must not wipe collections it does not carry. Skipping the
@@ -714,6 +960,7 @@ fn profile_collections_import_plan(
             )));
         }
         let mut rows = collection_value.as_array().cloned().unwrap_or_default();
+        let processed_rows = rows.len();
         if collection == "prompt-overrides" {
             unsupported_prompt_overrides = normalize_profile_prompt_overrides(&mut rows);
         }
@@ -722,6 +969,15 @@ fn profile_collections_import_plan(
             rows = normalize_profile_connection_rows(state, rows, mode)?;
         }
         imported.insert(collection.to_string(), json!(rows.len()));
+        if mode == ProfileImportMode::Commit {
+            progress.advance_counted(
+                "collections",
+                collection,
+                profile_import_progress_label("Importing", collection),
+                processed_rows,
+                Some(rows.len()),
+            )?;
+        }
         replacements.push((collection, rows));
     }
     if collections.get("messages").is_some()
@@ -743,6 +999,21 @@ fn profile_collections_import_plan(
         imported,
         replacements,
     })
+}
+
+fn profile_collections_progress_total(
+    collections: &Map<String, Value>,
+    restored_assets: usize,
+) -> usize {
+    let row_count = contracts::profile_collections()
+        .filter_map(|collection| collections.get(collection).and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    restored_assets.saturating_add(row_count).saturating_add(1)
+}
+
+pub(super) fn profile_import_progress_label(prefix: &str, item: &str) -> String {
+    format!("{prefix} {}", item.replace('-', " "))
 }
 
 fn normalize_profile_connection_rows(
@@ -936,6 +1207,114 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp profile dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn profile_file_import_emits_progress_events() {
+        let state = test_state("progress-events");
+        let path = state.data_dir.join("progress-profile.json");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "characters".to_string(),
+            json!([
+                { "id": "progress-character-1", "name": "Progress 1" },
+                { "id": "progress-character-2", "name": "Progress 2" }
+            ]),
+        );
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }))
+            .expect("profile fixture should serialize"),
+        )
+        .expect("profile fixture should write");
+
+        let mut events = Vec::new();
+        let result = import_profile_file_with_preview_fingerprint_and_progress(
+            &state,
+            &path,
+            None,
+            |event| {
+                events.push(event);
+                Ok(())
+            },
+        )
+        .expect("profile import should succeed");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["imported"]["characters"], 2);
+        let progress_events = events
+            .iter()
+            .filter(|event| event["type"].as_str() == Some("progress"))
+            .collect::<Vec<_>>();
+        assert!(
+            progress_events.iter().any(|event| {
+                event["data"]["item"].as_str() == Some("characters")
+                    && event["data"]["imported"]["characters"].as_u64() == Some(2)
+            }),
+            "character progress event should include imported count"
+        );
+        let last = progress_events
+            .last()
+            .expect("profile import should emit progress events");
+        assert_eq!(last["data"]["phase"], "write");
+        assert_eq!(last["data"]["current"], last["data"]["total"]);
+    }
+
+    #[test]
+    fn native_profile_import_ignores_post_commit_progress_delivery_failure() {
+        let state = test_state("post-commit-progress-failure");
+        state
+            .storage
+            .replace_all("characters", vec![json!({ "id": "old-character" })])
+            .expect("old character fixture should write");
+
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "characters".to_string(),
+            json!([{ "id": "post-commit-character", "name": "Post Commit" }]),
+        );
+
+        let mut saw_post_commit_write = false;
+        let mut install_called = false;
+        let mut progress = ProfileImportProgress::new(|event| {
+            let data = &event["data"];
+            if data["phase"].as_str() == Some("write") && data["item"].as_str() == Some("write") {
+                saw_post_commit_write = true;
+                return Err(AppError::new(
+                    "profile_import_event_error",
+                    "progress receiver closed",
+                ));
+            }
+            Ok(())
+        });
+
+        let result = import_profile_collections_with_restored_assets_with_progress(
+            &state,
+            &collections,
+            0,
+            &mut progress,
+            || {
+                install_called = true;
+                Ok(())
+            },
+        )
+        .expect("post-commit progress failure should not fail import");
+        drop(progress);
+
+        assert!(install_called);
+        assert!(saw_post_commit_write);
+        assert_eq!(result["success"], true);
+        assert_eq!(
+            state.storage.list("characters").unwrap()[0]["id"],
+            "post-commit-character"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -11,7 +11,8 @@ use super::assets::{
     restore_legacy_profile_json_assets,
 };
 use super::{
-    finish_profile_import_assets, insert_profile_import_aliases, normalize_profile_prompt_overrides,
+    finish_profile_import_assets, insert_profile_import_aliases,
+    normalize_profile_prompt_overrides, profile_import_progress_label, ProfileImportProgress,
 };
 use crate::state::AppState;
 use marinara_core::{AppError, AppResult};
@@ -369,24 +370,27 @@ fn legacy_array_format_error(
     AppError::with_details("invalid_input", message, Value::Object(details))
 }
 
-pub(super) fn import_legacy_profile_tables(
+pub(super) fn import_legacy_profile_tables_with_progress(
     state: &AppState,
     tables: &Map<String, Value>,
     raw_assets: Option<&Value>,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     let mut restored_assets = restore_legacy_profile_json_assets(state, raw_assets)?;
     let restored_count = restored_assets.restored();
     let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
-    let result = import_legacy_profile_tables_with_restored_assets(
+    let result = import_legacy_profile_tables_with_restored_assets_with_progress(
         state,
         tables,
         restored_count,
         staging_root.as_deref(),
+        progress,
         || restored_assets.install(),
     );
     finish_profile_import_assets(restored_assets, result)
 }
 
+#[cfg(test)]
 pub(super) fn import_legacy_profile_tables_with_restored_assets<F>(
     state: &AppState,
     tables: &Map<String, Value>,
@@ -397,10 +401,34 @@ pub(super) fn import_legacy_profile_tables_with_restored_assets<F>(
 where
     F: FnOnce() -> AppResult<()>,
 {
-    let plan = legacy_profile_import_plan(state, tables, restored_assets, staging_root)?;
+    let mut progress = ProfileImportProgress::disabled();
+    import_legacy_profile_tables_with_restored_assets_with_progress(
+        state,
+        tables,
+        restored_assets,
+        staging_root,
+        &mut progress,
+        install_assets,
+    )
+}
+
+pub(super) fn import_legacy_profile_tables_with_restored_assets_with_progress<F>(
+    state: &AppState,
+    tables: &Map<String, Value>,
+    restored_assets: usize,
+    staging_root: Option<&Path>,
+    progress: &mut ProfileImportProgress<'_>,
+    install_assets: F,
+) -> AppResult<Value>
+where
+    F: FnOnce() -> AppResult<()>,
+{
+    let plan = legacy_profile_import_plan(state, tables, restored_assets, staging_root, progress)?;
+    progress.prepare("write", "Writing profile data")?;
     state
         .storage
         .replace_all_many_and_then(plan.replacements, install_assets)?;
+    progress.advance_untracked_after_commit("write", "write", "Profile data written", 1);
     Ok(json!({ "success": true, "imported": plan.imported }))
 }
 
@@ -409,7 +437,8 @@ pub(super) fn preview_legacy_profile_tables(
     tables: &Map<String, Value>,
     restored_assets: usize,
 ) -> AppResult<Value> {
-    let plan = legacy_profile_import_plan(state, tables, restored_assets, None)?;
+    let mut progress = ProfileImportProgress::disabled();
+    let plan = legacy_profile_import_plan(state, tables, restored_assets, None, &mut progress)?;
     Ok(json!({ "success": true, "preview": true, "imported": plan.imported }))
 }
 
@@ -423,6 +452,7 @@ fn legacy_profile_import_plan(
     tables: &Map<String, Value>,
     restored_assets: usize,
     staging_root: Option<&Path>,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<LegacyProfileImportPlan> {
     let mut imported = Map::new();
     let mut replacements = Vec::new();
@@ -430,6 +460,19 @@ fn legacy_profile_import_plan(
     let mut imported_conversation_notes = 0usize;
     let mut imported_ooc_influences = 0usize;
     validate_legacy_profile_auxiliary_tables(tables)?;
+    progress.begin(
+        legacy_profile_progress_total(tables, restored_assets),
+        "collections",
+        "Importing legacy profile tables",
+    )?;
+    if restored_assets > 0 {
+        progress.advance(
+            "assets",
+            "files",
+            "Prepared profile assets",
+            restored_assets,
+        )?;
+    }
     for (table, collection) in LEGACY_PROFILE_TABLES {
         // A partial profile (an older backup, a hand-built export, or a file
         // missing a table) must not wipe collections it does not carry.
@@ -445,6 +488,7 @@ fn legacy_profile_import_plan(
         // against. Reject the import instead so nothing is replaced.
         validate_legacy_profile_table_array(tables, table)?;
         let mut rows = table_rows(tables, table);
+        let processed_rows = rows.len();
         match *collection {
             "app-settings" => normalize_legacy_app_settings(&mut rows),
             "characters" => normalize_legacy_character_data(&mut rows),
@@ -472,6 +516,13 @@ fn legacy_profile_import_plan(
             normalize_legacy_profile_asset_paths(state, staging_root, row);
         }
         imported.insert((*collection).to_string(), json!(rows.len()));
+        progress.advance_counted(
+            "collections",
+            *collection,
+            profile_import_progress_label("Importing", collection),
+            processed_rows,
+            Some(rows.len()),
+        )?;
         replacements.push((*collection, rows));
     }
     if tables.get("messages").is_some() {
@@ -500,6 +551,15 @@ fn legacy_profile_import_plan(
         imported,
         replacements,
     })
+}
+
+fn legacy_profile_progress_total(tables: &Map<String, Value>, restored_assets: usize) -> usize {
+    let row_count = LEGACY_PROFILE_TABLES
+        .iter()
+        .filter_map(|(table, _)| tables.get(*table).and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+    restored_assets.saturating_add(row_count).saturating_add(1)
 }
 
 fn validate_legacy_profile_auxiliary_tables(tables: &Map<String, Value>) -> AppResult<()> {
@@ -1077,6 +1137,105 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp profile dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    #[test]
+    fn legacy_profile_import_emits_progress_events() {
+        let state = test_state("progress-events");
+        let mut tables = Map::new();
+        tables.insert(
+            "characters".to_string(),
+            json!([
+                { "id": "legacy-progress-1", "name": "Legacy Progress 1" },
+                { "id": "legacy-progress-2", "name": "Legacy Progress 2" }
+            ]),
+        );
+        let mut events = Vec::new();
+        let result = {
+            let mut progress = ProfileImportProgress::new(|event| {
+                events.push(event);
+                Ok(())
+            });
+            import_legacy_profile_tables_with_restored_assets_with_progress(
+                &state,
+                &tables,
+                0,
+                None,
+                &mut progress,
+                || Ok(()),
+            )
+        }
+        .expect("legacy profile import should succeed");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["imported"]["characters"], 2);
+        let progress_events = events
+            .iter()
+            .filter(|event| event["type"].as_str() == Some("progress"))
+            .collect::<Vec<_>>();
+        assert!(
+            progress_events.iter().any(|event| {
+                event["data"]["item"].as_str() == Some("characters")
+                    && event["data"]["imported"]["characters"].as_u64() == Some(2)
+            }),
+            "legacy character progress should include imported count"
+        );
+        let last = progress_events
+            .last()
+            .expect("legacy import should emit progress events");
+        assert_eq!(last["data"]["phase"], "write");
+        assert_eq!(last["data"]["current"], last["data"]["total"]);
+    }
+
+    #[test]
+    fn legacy_profile_import_ignores_post_commit_progress_delivery_failure() {
+        let state = test_state("post-commit-progress-failure");
+        state
+            .storage
+            .replace_all("characters", vec![json!({ "id": "old-character" })])
+            .expect("old character fixture should write");
+
+        let mut tables = Map::new();
+        tables.insert(
+            "characters".to_string(),
+            json!([{ "id": "legacy-post-commit-character", "name": "Legacy Post Commit" }]),
+        );
+
+        let mut saw_post_commit_write = false;
+        let mut install_called = false;
+        let mut progress = ProfileImportProgress::new(|event| {
+            let data = &event["data"];
+            if data["phase"].as_str() == Some("write") && data["item"].as_str() == Some("write") {
+                saw_post_commit_write = true;
+                return Err(AppError::new(
+                    "profile_import_event_error",
+                    "progress receiver closed",
+                ));
+            }
+            Ok(())
+        });
+
+        let result = import_legacy_profile_tables_with_restored_assets_with_progress(
+            &state,
+            &tables,
+            0,
+            None,
+            &mut progress,
+            || {
+                install_called = true;
+                Ok(())
+            },
+        )
+        .expect("post-commit progress failure should not fail legacy import");
+        drop(progress);
+
+        assert!(install_called);
+        assert!(saw_post_commit_write);
+        assert_eq!(result["success"], true);
+        assert_eq!(
+            state.storage.list("characters").unwrap()[0]["id"],
+            "legacy-post-commit-character"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/profile/zip_import.rs
+++ b/src-tauri/src/commands/storage/profile/zip_import.rs
@@ -3,11 +3,14 @@ use super::assets::{
 };
 use super::legacy::preview_legacy_profile_tables;
 use super::{
-    finish_profile_import_assets, import_profile_collections_with_restored_assets,
-    legacy::{import_legacy_profile_tables_with_restored_assets, legacy_array_profile_tables},
+    finish_profile_import_assets, import_profile_collections_with_restored_assets_with_progress,
+    legacy::{
+        import_legacy_profile_tables_with_restored_assets_with_progress,
+        legacy_array_profile_tables,
+    },
     preview_profile_collections_with_restored_assets, profile_format_error,
     validate_native_profile_import, with_profile_import_metadata, with_profile_import_warnings,
-    ProfileImportMode, ProfileImportSourceFormat,
+    ProfileImportMode, ProfileImportProgress, ProfileImportSourceFormat,
 };
 use crate::state::AppState;
 use marinara_core::{AppError, AppResult};
@@ -31,31 +34,43 @@ struct ProfileZipAssetContext<'a> {
 }
 
 pub(super) fn import_profile_zip(state: &AppState, path: &Path) -> AppResult<Value> {
-    import_profile_zip_file(state, File::open(path)?)
+    let mut progress = ProfileImportProgress::disabled();
+    import_profile_zip_with_progress(state, path, &mut progress)
+}
+
+pub(super) fn import_profile_zip_with_progress(
+    state: &AppState,
+    path: &Path,
+    progress: &mut ProfileImportProgress<'_>,
+) -> AppResult<Value> {
+    import_profile_zip_file_with_progress(state, File::open(path)?, progress)
 }
 
 pub(super) fn preview_profile_zip(state: &AppState, path: &Path) -> AppResult<Value> {
     preview_profile_zip_file(state, File::open(path)?)
 }
 
-pub(super) fn import_profile_zip_file<R: Read + Seek>(
+pub(super) fn import_profile_zip_file_with_progress<R: Read + Seek>(
     state: &AppState,
     reader: R,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
-    run_profile_zip_reader(state, reader, ProfileImportMode::Commit)
+    run_profile_zip_reader(state, reader, ProfileImportMode::Commit, progress)
 }
 
 pub(super) fn preview_profile_zip_file<R: Read + Seek>(
     state: &AppState,
     reader: R,
 ) -> AppResult<Value> {
-    run_profile_zip_reader(state, reader, ProfileImportMode::Preview)
+    let mut progress = ProfileImportProgress::disabled();
+    run_profile_zip_reader(state, reader, ProfileImportMode::Preview, &mut progress)
 }
 
 fn run_profile_zip_reader<R: Read + Seek>(
     state: &AppState,
     reader: R,
     mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     let mut archive = zip::ZipArchive::new(reader)
         .map_err(|error| AppError::invalid_input(format!("Could not read profile ZIP: {error}")))?;
@@ -84,7 +99,14 @@ fn run_profile_zip_reader<R: Read + Seek>(
             profile_prefix: &profile_prefix,
             raw_assets: files,
         };
-        return run_profile_zip_collections(state, &mut archive, assets, collections, mode);
+        return run_profile_zip_collections(
+            state,
+            &mut archive,
+            assets,
+            collections,
+            mode,
+            progress,
+        );
     }
     if let Some(tables_value) = data
         .get("fileStorage")
@@ -108,6 +130,7 @@ fn run_profile_zip_reader<R: Read + Seek>(
             tables,
             ProfileImportSourceFormat::LegacyFileStorage,
             mode,
+            progress,
         );
     }
     if let Some(tables) = legacy_array_profile_tables(data)? {
@@ -123,6 +146,7 @@ fn run_profile_zip_reader<R: Read + Seek>(
             &tables,
             ProfileImportSourceFormat::LegacyArray,
             mode,
+            progress,
         );
     }
     Err(profile_format_error(
@@ -137,6 +161,7 @@ fn run_profile_zip_collections<R: Read + std::io::Seek>(
     assets: ProfileZipAssetContext<'_>,
     collections: &serde_json::Map<String, Value>,
     mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     match mode {
         ProfileImportMode::Preview => {
@@ -157,6 +182,7 @@ fn run_profile_zip_collections<R: Read + std::io::Seek>(
             ))
         }
         ProfileImportMode::Commit => {
+            progress.prepare("assets", "Preparing profile ZIP assets")?;
             let mut restored_assets = restore_profile_zip_assets(
                 state,
                 archive,
@@ -165,10 +191,11 @@ fn run_profile_zip_collections<R: Read + std::io::Seek>(
                 assets.raw_assets,
             )?;
             let restored_count = restored_assets.restored();
-            let result = import_profile_collections_with_restored_assets(
+            let result = import_profile_collections_with_restored_assets_with_progress(
                 state,
                 collections,
                 restored_count,
+                progress,
                 || restored_assets.install(),
             );
             finish_profile_import_assets(restored_assets, result).map(|value| {
@@ -185,6 +212,7 @@ fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
     tables: &serde_json::Map<String, Value>,
     source_format: ProfileImportSourceFormat,
     mode: ProfileImportMode,
+    progress: &mut ProfileImportProgress<'_>,
 ) -> AppResult<Value> {
     match mode {
         ProfileImportMode::Preview => {
@@ -201,6 +229,7 @@ fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
             ))
         }
         ProfileImportMode::Commit => {
+            progress.prepare("assets", "Preparing profile ZIP assets")?;
             let mut restored_assets = restore_profile_zip_assets(
                 state,
                 archive,
@@ -210,11 +239,12 @@ fn run_profile_zip_legacy_tables<R: Read + std::io::Seek>(
             )?;
             let restored_count = restored_assets.restored();
             let staging_root = restored_assets.staging_root().map(Path::to_path_buf);
-            let result = import_legacy_profile_tables_with_restored_assets(
+            let result = import_legacy_profile_tables_with_restored_assets_with_progress(
                 state,
                 tables,
                 restored_count,
                 staging_root.as_deref(),
+                progress,
                 || restored_assets.install(),
             );
             finish_profile_import_assets(restored_assets, result)

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -1163,6 +1163,7 @@ mod tests {
         "profile_import_preview_file",
         "profile_import_preview_upload",
         "profile_import_file",
+        "profile_import_file_events",
         "profile_import_upload",
     ];
 

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -656,15 +656,29 @@ async fn profile_import_upload_stream(
     tokio::spawn(async move {
         let started = Instant::now();
         request_log("profile_import_upload_stream started");
-        let result = profile::import_profile_file_with_preview_fingerprint_and_progress(
-            &state.app,
-            &upload_path,
-            None,
-            |event| {
-                tx.send(Ok(Event::default().data(event.to_string())))
-                    .map_err(|error| AppError::new("sse_stream_error", error.to_string()))
-            },
-        );
+        let import_state = state.app.clone();
+        let import_path = upload_path.clone();
+        let progress_tx = tx.clone();
+        let result = match tokio::task::spawn_blocking(move || {
+            profile::import_profile_file_with_preview_fingerprint_and_progress(
+                &import_state,
+                &import_path,
+                None,
+                |event| {
+                    progress_tx
+                        .send(Ok(Event::default().data(event.to_string())))
+                        .map_err(|error| AppError::new("sse_stream_error", error.to_string()))
+                },
+            )
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => Err(AppError::new(
+                "profile_import_task_error",
+                error.to_string(),
+            )),
+        };
         let cleanup_result = tokio::fs::remove_file(&upload_path).await;
         if let Err(error) = cleanup_result {
             log::warn!(

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -132,6 +132,11 @@ pub fn router(state: AppState) -> Router {
             "/api/profile/import",
             post(profile_import_upload).layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BODY_BYTES)),
         )
+        .route(
+            "/api/profile/import/events",
+            post(profile_import_upload_stream)
+                .layer(DefaultBodyLimit::max(MAX_PROFILE_UPLOAD_BODY_BYTES)),
+        )
         .route("/api/import/st-bulk/run", post(import_st_bulk_run_stream))
         .route("/api/sidecar/v1/embeddings", post(sidecar_embeddings))
         .route("/api/assets/:kind/*path", get(managed_asset))
@@ -639,6 +644,70 @@ async fn profile_import_upload(
     }
 }
 
+async fn profile_import_upload_stream(
+    State(state): State<HttpState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Result<Sse<UnboundedReceiverStream<Result<Event, Infallible>>>, HttpError> {
+    require_admin_access_for_command("profile_import_upload_stream", &headers, addr.ip())?;
+    let upload_path = profile_upload_temp_file(&state.app, &mut multipart).await?;
+    let (tx, rx) = mpsc::unbounded_channel::<Result<Event, Infallible>>();
+    tokio::spawn(async move {
+        let started = Instant::now();
+        request_log("profile_import_upload_stream started");
+        let result = profile::import_profile_file_with_preview_fingerprint_and_progress(
+            &state.app,
+            &upload_path,
+            None,
+            |event| {
+                tx.send(Ok(Event::default().data(event.to_string())))
+                    .map_err(|error| AppError::new("sse_stream_error", error.to_string()))
+            },
+        );
+        let cleanup_result = tokio::fs::remove_file(&upload_path).await;
+        if let Err(error) = cleanup_result {
+            log::warn!(
+                "failed to remove temporary profile upload {}: {error}",
+                upload_path.display()
+            );
+        }
+        match result {
+            Ok(value) => {
+                request_log(format!(
+                    "profile_import_upload_stream ok in {}ms",
+                    started.elapsed().as_millis()
+                ));
+                let payload = json!({ "type": "done", "data": value });
+                let _ = tx.send(Ok(Event::default().data(payload.to_string())));
+            }
+            Err(error) => {
+                request_log(format!(
+                    "profile_import_upload_stream error code={} message={} in {}ms",
+                    error.code,
+                    error.message,
+                    started.elapsed().as_millis()
+                ));
+                let payload = profile_import_error_payload(&error);
+                let _ = tx.send(Ok(Event::default().data(payload.to_string())));
+            }
+        }
+    });
+
+    Ok(Sse::new(UnboundedReceiverStream::new(rx)).keep_alive(KeepAlive::default()))
+}
+
+fn profile_import_error_payload(error: &AppError) -> Value {
+    json!({
+        "type": "error",
+        "data": {
+            "code": error.code.clone(),
+            "message": error.message.clone(),
+            "details": error.details.clone(),
+        },
+    })
+}
+
 async fn profile_import_preview_upload(
     State(state): State<HttpState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -861,6 +930,7 @@ fn is_privileged_remote_command(command: &str) -> bool {
             | "profile_import"
             | "profile_import_preview_upload"
             | "profile_import_upload"
+            | "profile_import_upload_stream"
             | "backup_create"
             | "backup_list"
             | "backup_delete"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,7 @@ pub fn run() {
             storage_commands::profile_commands::profile_import_preview_file,
             storage_commands::profile_commands::profile_import_preview_upload,
             storage_commands::profile_commands::profile_import_file,
+            storage_commands::profile_commands::profile_import_file_events,
             storage_commands::profile_commands::profile_import_upload,
             storage_commands::backup_commands::backup_create,
             storage_commands::backup_commands::backup_list,

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Check, Download, FileSearch, Loader2 } from "lucide-react";
 import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { profileApi } from "../../../../shared/api/profile-api";
+import { profileApi, type ProfileImportProgressEvent } from "../../../../shared/api/profile-api";
 import { remoteRuntimeTarget } from "../../../../shared/api/remote-runtime";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { cn } from "../../../../shared/lib/utils";
@@ -253,18 +253,36 @@ function profileImportMetadataFromResult(data?: ProfileImportResult) {
   };
 }
 
+function isProfileImportRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function profileImportProgressNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : undefined;
+}
+
+function profileImportStatsFromUnknown(value: unknown): ProfileImportStats | undefined {
+  if (!isProfileImportRecord(value)) return undefined;
+  const stats: ProfileImportStats = {};
+  for (const [key, count] of Object.entries(value)) {
+    if (typeof count === "number" && Number.isFinite(count)) {
+      stats[key] = Math.max(0, Math.floor(count));
+    }
+  }
+  return Object.keys(stats).length > 0 ? stats : undefined;
+}
+
 function formatProfileImportConfirmationMessage(preview: ProfileImportResult) {
   const { imported, warnings, sourceFormat, converted } = profileImportMetadataFromResult(preview);
   const found = formatProfileImportStats(imported) || "no counted records";
   const source = formatProfileImportSourceFormat(sourceFormat);
-  const conversion =
-    converted?.applied
-      ? `Conversion: ${formatProfileImportSourceFormat(converted.from) || "legacy"} -> ${
-          formatProfileImportSourceFormat(converted.to) || "refactor"
-        }.`
-      : converted?.applied === false
-        ? "Conversion: none."
-        : "";
+  const conversion = converted?.applied
+    ? `Conversion: ${formatProfileImportSourceFormat(converted.from) || "legacy"} -> ${
+        formatProfileImportSourceFormat(converted.to) || "refactor"
+      }.`
+    : converted?.applied === false
+      ? "Conversion: none."
+      : "";
   const skipped = formatProfileImportSkippedStats(imported);
   const warningSummary = formatProfileImportWarnings(warnings);
   const warningDetail = warningSummary
@@ -345,10 +363,36 @@ export function ProfileImportSection() {
     );
   };
 
+  const applyProfileImportProgressEvent = (event: ProfileImportProgressEvent, startedAt: number) => {
+    if (event.type !== "progress") return;
+    const data = isProfileImportRecord(event.data) ? event.data : {};
+    const label = typeof data.label === "string" && data.label.trim() ? data.label : "Importing profile";
+    const current = profileImportProgressNumber(data.current);
+    const total = profileImportProgressNumber(data.total);
+    const imported = profileImportStatsFromUnknown(data.imported);
+    setProfileImportProgress((progress) => {
+      if (!progress) return progress;
+      const totalItems = Math.max(1, total ?? progress.totalItems);
+      const completedItems = Math.min(totalItems, current ?? progress.completedItems);
+      return {
+        ...progress,
+        status: "running",
+        label,
+        completedItems,
+        totalItems,
+        elapsedSeconds: Math.floor((Date.now() - startedAt) / 1000),
+        imported: imported ?? progress.imported,
+      };
+    });
+  };
+
   const runPreviewedProfileImport = async (
     startedAt: number,
     previewProfile: () => Promise<ProfileImportResult>,
-    importProfile: (preview: ProfileImportResult) => Promise<ProfileImportResult>,
+    importProfile: (
+      preview: ProfileImportResult,
+      onProgress: (event: ProfileImportProgressEvent) => void,
+    ) => Promise<ProfileImportResult>,
   ) => {
     setProfileImportProgress((current) =>
       current
@@ -408,7 +452,10 @@ export function ProfileImportSection() {
           }
         : current,
     );
-    finishProfileImport(await importProfile(preview), startedAt);
+    finishProfileImport(
+      await importProfile(preview, (event) => applyProfileImportProgressEvent(event, startedAt)),
+      startedAt,
+    );
   };
 
   const showProfileImportError = (err: unknown, startedAt: number) => {
@@ -462,10 +509,14 @@ export function ProfileImportSection() {
       await runPreviewedProfileImport(
         startedAt,
         () => profileApi.previewProfileFile<ProfileImportResult>(selected),
-        (preview) =>
-          profileApi.importProfileFile<ProfileImportResult>(selected, {
-            previewFingerprint: preview.fileFingerprint,
-          }),
+        (preview, onProgress) =>
+          profileApi.importProfileFileWithProgress<ProfileImportResult>(
+            selected,
+            {
+              previewFingerprint: preview.fileFingerprint,
+            },
+            onProgress,
+          ),
       );
     } catch (err) {
       showProfileImportError(err, startedAt);
@@ -489,7 +540,7 @@ export function ProfileImportSection() {
       await runPreviewedProfileImport(
         startedAt,
         () => profileApi.previewProfileUpload<ProfileImportResult>(file),
-        () => profileApi.importProfileUpload<ProfileImportResult>(file),
+        (_preview, onProgress) => profileApi.importProfileUploadWithProgress<ProfileImportResult>(file, onProgress),
       );
     } catch (err) {
       showProfileImportError(err, startedAt);
@@ -572,7 +623,8 @@ export function ProfileImportSection() {
                     </span>
                     {estimateProfileImportRemainingSeconds(profileImportProgress) !== null && (
                       <span>
-                        ETA {formatProfileImportDuration(estimateProfileImportRemainingSeconds(profileImportProgress) ?? 0)}
+                        ETA{" "}
+                        {formatProfileImportDuration(estimateProfileImportRemainingSeconds(profileImportProgress) ?? 0)}
                       </span>
                     )}
                   </div>

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -1,3 +1,4 @@
+import { Channel } from "@tauri-apps/api/core";
 import { invokeTauri } from "./tauri-client";
 import { ApiError } from "./api-errors";
 import { downloadPayloadFromApiValue, type DownloadPayload } from "./download-payload";
@@ -7,6 +8,7 @@ import {
   remoteFetchInit,
   remotePrivilegedHeaders,
   remoteRuntimeTarget,
+  streamRemoteFormEvents,
   type RuntimeTarget,
 } from "./remote-runtime";
 
@@ -27,6 +29,10 @@ const PROFILE_IMPORT_MANAGED_ASSET_KINDS: RemoteManagedAssetKind[] = [
   "lorebook",
   "sprite",
 ];
+
+export type ProfileImportProgressEvent = { type: string; data: unknown };
+type RawProfileImportEvent = { type?: unknown; data?: unknown; text?: unknown; [key: string]: unknown };
+type ProfileImportProgressHandler = (event: ProfileImportProgressEvent) => void;
 
 function readFileAsBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -91,10 +97,7 @@ async function importProfile<T>(envelope: unknown): Promise<T> {
   );
 }
 
-async function importProfileFile<T>(
-  path: string,
-  options?: { previewFingerprint?: string | null },
-): Promise<T> {
+async function importProfileFile<T>(path: string, options?: { previewFingerprint?: string | null }): Promise<T> {
   if (remoteRuntimeTarget()) {
     throw new ApiError(
       "Profile import from a local file path is not available while Remote Runtime is configured.",
@@ -107,6 +110,113 @@ async function importProfileFile<T>(
       path,
       previewFingerprint: options?.previewFingerprint ?? null,
     }),
+    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
+  );
+}
+
+function normalizeProfileImportEvent(event: RawProfileImportEvent): ProfileImportProgressEvent {
+  const type = typeof event.type === "string" ? event.type : "message";
+  return { type, data: "data" in event ? event.data : "text" in event ? event.text : event };
+}
+
+function profileImportEventError(event: ProfileImportProgressEvent): ApiError {
+  const data = event.data && typeof event.data === "object" && !Array.isArray(event.data) ? event.data : {};
+  const record = data as { message?: unknown; error?: unknown; code?: unknown };
+  return new ApiError(
+    typeof record.message === "string"
+      ? record.message
+      : typeof record.error === "string"
+        ? record.error
+        : "Profile import failed",
+    500,
+    { code: typeof record.code === "string" ? record.code : undefined, event },
+  );
+}
+
+async function runTauriProfileFileImportWithProgress<T>(
+  path: string,
+  options: { previewFingerprint?: string | null } | undefined,
+  onProgress?: ProfileImportProgressHandler,
+): Promise<T> {
+  const queue: RawProfileImportEvent[] = [];
+  let completed = false;
+  let failure: unknown = null;
+  let wake: (() => void) | null = null;
+  let doneData: T | null = null;
+  let hasDone = false;
+  const notify = () => {
+    wake?.();
+    wake = null;
+  };
+  const onEvent = new Channel<RawProfileImportEvent>((event) => {
+    queue.push(event);
+    if (event.type === "done" || event.type === "error") completed = true;
+    notify();
+  });
+  const command = invokeTauri<T>("profile_import_file_events", {
+    path,
+    previewFingerprint: options?.previewFingerprint ?? null,
+    onEvent,
+  }).then(
+    (value) => {
+      if (!hasDone && !failure) {
+        doneData = value;
+        hasDone = true;
+      }
+      completed = true;
+      notify();
+    },
+    (error) => {
+      if (!failure) failure = error;
+      completed = true;
+      notify();
+    },
+  );
+
+  while (!completed || queue.length > 0) {
+    if (queue.length === 0) {
+      if (failure) break;
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+      continue;
+    }
+    const event = normalizeProfileImportEvent(queue.shift()!);
+    if (event.type === "progress") {
+      onProgress?.(event);
+      continue;
+    }
+    if (event.type === "done") {
+      doneData = event.data as T;
+      hasDone = true;
+      completed = true;
+      continue;
+    }
+    if (event.type === "error") {
+      failure = profileImportEventError(event);
+      completed = true;
+    }
+  }
+  await command;
+  if (failure) throw failure;
+  if (!hasDone) throw new ApiError("Profile import stream ended before completion", 500);
+  return doneData as T;
+}
+
+async function importProfileFileWithProgress<T>(
+  path: string,
+  options?: { previewFingerprint?: string | null },
+  onProgress?: ProfileImportProgressHandler,
+): Promise<T> {
+  if (remoteRuntimeTarget()) {
+    throw new ApiError(
+      "Profile import from a local file path is not available while Remote Runtime is configured.",
+      400,
+      { code: "remote_local_path_unsupported" },
+    );
+  }
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
+    runTauriProfileFileImportWithProgress<T>(path, options, onProgress),
     PROFILE_IMPORT_MANAGED_ASSET_KINDS,
   );
 }
@@ -162,11 +272,46 @@ async function importRemoteProfileUpload<T>(target: RuntimeTarget, file: File): 
   return (await response.json()) as T;
 }
 
+async function importRemoteProfileUploadWithProgress<T>(
+  file: File,
+  onProgress?: ProfileImportProgressHandler,
+): Promise<T> {
+  const form = new FormData();
+  form.append("file", file, file.name);
+  let doneData: T | null = null;
+  let hasDone = false;
+  for await (const event of streamRemoteFormEvents("/api/profile/import/events", form, { privileged: true })) {
+    if (event.type === "progress") {
+      onProgress?.(event);
+      continue;
+    }
+    if (event.type === "done") {
+      doneData = event.data as T;
+      hasDone = true;
+    }
+  }
+  if (!hasDone) throw new ApiError("Profile import stream ended before completion", 500);
+  return doneData as T;
+}
+
 async function importProfileUpload<T>(file: File): Promise<T> {
   const target = remoteRuntimeTarget();
   return invalidateRemoteManagedAssetObjectUrlsAfter(
     target
       ? importRemoteProfileUpload<T>(target, file)
+      : invokeTauri<T>("profile_import_upload", {
+          filename: file.name,
+          base64: await readFileAsBase64(file),
+        }),
+    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
+  );
+}
+
+async function importProfileUploadWithProgress<T>(file: File, onProgress?: ProfileImportProgressHandler): Promise<T> {
+  const target = remoteRuntimeTarget();
+  return invalidateRemoteManagedAssetObjectUrlsAfter(
+    target
+      ? importRemoteProfileUploadWithProgress<T>(file, onProgress)
       : invokeTauri<T>("profile_import_upload", {
           filename: file.name,
           base64: await readFileAsBase64(file),
@@ -203,7 +348,9 @@ export const profileApi = {
   previewProfileFile,
   previewProfileUpload,
   importProfileFile,
+  importProfileFileWithProgress,
   importProfileUpload,
+  importProfileUploadWithProgress,
 };
 
 export const backupApi = {

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -119,18 +119,32 @@ function normalizeProfileImportEvent(event: RawProfileImportEvent): ProfileImpor
   return { type, data: "data" in event ? event.data : "text" in event ? event.text : event };
 }
 
+function isProfileImportEventRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function profileImportEventError(event: ProfileImportProgressEvent): ApiError {
-  const data = event.data && typeof event.data === "object" && !Array.isArray(event.data) ? event.data : {};
-  const record = data as { message?: unknown; error?: unknown; code?: unknown };
-  return new ApiError(
+  const record = isProfileImportEventRecord(event.data) ? event.data : {};
+  const originalError = isProfileImportEventRecord(record.error) ? record.error : undefined;
+  const code =
+    typeof record.code === "string"
+      ? record.code
+      : typeof originalError?.code === "string"
+        ? originalError.code
+        : undefined;
+  const message =
     typeof record.message === "string"
       ? record.message
       : typeof record.error === "string"
         ? record.error
-        : "Profile import failed",
-    500,
-    { code: typeof record.code === "string" ? record.code : undefined, event },
-  );
+        : typeof originalError?.message === "string"
+          ? originalError.message
+          : "Profile import failed";
+  return new ApiError(message, 500, {
+    ...(code ? { code } : {}),
+    event,
+    ...(originalError ? { originalError } : {}),
+  });
 }
 
 async function runTauriProfileFileImportWithProgress<T>(
@@ -141,6 +155,7 @@ async function runTauriProfileFileImportWithProgress<T>(
   const queue: RawProfileImportEvent[] = [];
   let completed = false;
   let failure: unknown = null;
+  let streamedFailure: ApiError | null = null;
   let wake: (() => void) | null = null;
   let doneData: T | null = null;
   let hasDone = false;
@@ -193,12 +208,13 @@ async function runTauriProfileFileImportWithProgress<T>(
       continue;
     }
     if (event.type === "error") {
-      failure = profileImportEventError(event);
+      streamedFailure = profileImportEventError(event);
       completed = true;
     }
   }
   await command;
   if (failure) throw failure;
+  if (streamedFailure) throw streamedFailure;
   if (!hasDone) throw new ApiError("Profile import stream ended before completion", 500);
   return doneData as T;
 }

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -504,36 +504,75 @@ export async function* streamRemoteJsonEvents(
       const parsed = parseSseData(buffer);
       buffer = parsed.rest;
       for (const data of parsed.events) {
-        const event = JSON.parse(data) as { type?: unknown; data?: unknown; text?: unknown };
-        const type = typeof event.type === "string" ? event.type : "message";
-        if (type === "error") {
-          const errorData = isRecord(event.data) ? event.data : {};
-          throw new ApiError(
-            readString(errorData.message) || readString(errorData.error) || "Remote event stream failed",
-            500,
-            event,
-          );
-        }
-        yield { type, data: "data" in event ? event.data : "text" in event ? event.text : event };
+        yield parseRemoteJsonEvent(data);
       }
     }
     const finalParsed = parseSseData(`${buffer}\n\n`);
     for (const data of finalParsed.events) {
-      const event = JSON.parse(data) as { type?: unknown; data?: unknown; text?: unknown };
-      const type = typeof event.type === "string" ? event.type : "message";
-      if (type === "error") {
-        const errorData = isRecord(event.data) ? event.data : {};
-        throw new ApiError(
-          readString(errorData.message) || readString(errorData.error) || "Remote event stream failed",
-          500,
-          event,
-        );
-      }
-      yield { type, data: "data" in event ? event.data : "text" in event ? event.text : event };
+      yield parseRemoteJsonEvent(data);
     }
   } finally {
     reader.releaseLock();
   }
+}
+
+export async function* streamRemoteFormEvents(
+  path: string,
+  body: FormData,
+  options: { signal?: AbortSignal; privileged?: boolean } = {},
+): AsyncGenerator<{ type: string; data: unknown }> {
+  const target = remoteRuntimeTarget();
+  if (!target) throw new ApiError("Remote runtime URL is not configured", 400);
+  const response = await fetch(
+    `${target.baseUrl}${path}`,
+    remoteFetchInit({
+      method: "POST",
+      headers: remoteHeaders(target, {
+        accept: "text/event-stream",
+        ...(options.privileged ? adminSecretHeader() : {}),
+      }),
+      body,
+      signal: options.signal,
+    }),
+  );
+  if (!response.ok) throw await readRemoteError(response);
+  if (!response.body) throw new ApiError("Remote runtime did not return an event stream", 500);
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parsed = parseSseData(buffer);
+      buffer = parsed.rest;
+      for (const data of parsed.events) {
+        yield parseRemoteJsonEvent(data);
+      }
+    }
+    const finalParsed = parseSseData(`${buffer}\n\n`);
+    for (const data of finalParsed.events) {
+      yield parseRemoteJsonEvent(data);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseRemoteJsonEvent(data: string): { type: string; data: unknown } {
+  const event = JSON.parse(data) as { type?: unknown; data?: unknown; text?: unknown };
+  const type = typeof event.type === "string" ? event.type : "message";
+  if (type === "error") {
+    const errorData = isRecord(event.data) ? event.data : {};
+    throw new ApiError(
+      readString(errorData.message) || readString(errorData.error) || "Remote event stream failed",
+      500,
+      event,
+    );
+  }
+  return { type, data: "data" in event ? event.data : "text" in event ? event.text : event };
 }
 
 function parseSseData(buffer: string): { events: string[]; rest: string } {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -493,26 +493,8 @@ export async function* streamRemoteJsonEvents(
   if (!response.ok) throw await readRemoteError(response);
   if (!response.body) throw new ApiError("Remote runtime did not return an event stream", 500);
 
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const parsed = parseSseData(buffer);
-      buffer = parsed.rest;
-      for (const data of parsed.events) {
-        yield parseRemoteJsonEvent(data);
-      }
-    }
-    const finalParsed = parseSseData(`${buffer}\n\n`);
-    for (const data of finalParsed.events) {
-      yield parseRemoteJsonEvent(data);
-    }
-  } finally {
-    reader.releaseLock();
+  for await (const data of readSseEventData(response.body)) {
+    yield parseRemoteJsonEvent(data);
   }
 }
 
@@ -538,7 +520,13 @@ export async function* streamRemoteFormEvents(
   if (!response.ok) throw await readRemoteError(response);
   if (!response.body) throw new ApiError("Remote runtime did not return an event stream", 500);
 
-  const reader = response.body.getReader();
+  for await (const data of readSseEventData(response.body)) {
+    yield parseRemoteJsonEvent(data);
+  }
+}
+
+async function* readSseEventData(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   try {
@@ -549,12 +537,12 @@ export async function* streamRemoteFormEvents(
       const parsed = parseSseData(buffer);
       buffer = parsed.rest;
       for (const data of parsed.events) {
-        yield parseRemoteJsonEvent(data);
+        yield data;
       }
     }
     const finalParsed = parseSseData(`${buffer}\n\n`);
     for (const data of finalParsed.events) {
-      yield parseRemoteJsonEvent(data);
+      yield data;
     }
   } finally {
     reader.releaseLock();


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Profile imports can take long enough that the Settings UI needs real progress feedback instead of a generic busy state.
- Progress transport failures must not be able to turn an already-committed import into a reported failure or asset rollback.

## What changed

- Added progress event plumbing for selected local profile file imports and remote profile upload imports.
- Updated the Settings profile import UI to show import phase, item counts, elapsed time, ETA, summaries, warnings, and completion state.
- Made post-commit progress delivery best-effort so dropped channels do not corrupt import outcome reporting.
- Added Rust regression coverage for native and legacy post-commit progress delivery failures.

## Refactor impact

Primary owner:

Rust storage/profile import, shared API runtime adapter, and shell Settings UI.

Impact areas reviewed:

- Native JSON and ZIP profile import.
- Legacy profile table import.
- Profile asset staging, install, commit, and rollback behavior.
- Tauri profile import command registration.
- Hostable runtime profile upload SSE route.
- Shared profile API wrapper and remote runtime event parsing.
- Settings profile import UI consumer.

Boundary notes:

- Feature UI continues to call the typed `profileApi` wrapper.
- Shared API owns the Tauri channel and remote runtime event-stream boundary.
- Rust command and HTTP route entrypoints delegate to the storage profile owner.
- Engine code is not touched.

Pressure points touched:

- `src-tauri/src/lib.rs` command registration.
- Profile import modules under `src-tauri/src/commands/storage/profile*`.
- `src-tauri/src/http_server.rs` dedicated profile import event route.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml post_commit_progress`
- `cargo test --manifest-path src-tauri/Cargo.toml progress_events`
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check`
- Live Tauri profile import QA not run.
- Live remote-runtime SSE import QA not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing Settings profile import entry point remains unchanged; this adds progress feedback and safer event handling to the same workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made because this does not change setup, architecture guidance, or a documented user procedure.

## UI evidence

Not captured. The UI change is covered by type/build checks only; live Tauri verification remains for reviewer/manual QA.