### PR TITLE
Unify profile import progress API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 COPY src-tauri/Cargo.toml src-tauri/Cargo.lock ./src-tauri/
+COPY src ./src
 COPY src-tauri/crates ./src-tauri/crates
 COPY src-tauri/src ./src-tauri/src
 COPY src-tauri/build.rs ./src-tauri/build.rs

--- a/src/features/shell/settings/components/ProfileImportSection.tsx
+++ b/src/features/shell/settings/components/ProfileImportSection.tsx
@@ -510,13 +510,10 @@ export function ProfileImportSection() {
         startedAt,
         () => profileApi.previewProfileFile<ProfileImportResult>(selected),
         (preview, onProgress) =>
-          profileApi.importProfileFileWithProgress<ProfileImportResult>(
-            selected,
-            {
-              previewFingerprint: preview.fileFingerprint,
-            },
+          profileApi.importProfileFile<ProfileImportResult>(selected, {
+            previewFingerprint: preview.fileFingerprint,
             onProgress,
-          ),
+          }),
       );
     } catch (err) {
       showProfileImportError(err, startedAt);
@@ -540,7 +537,7 @@ export function ProfileImportSection() {
       await runPreviewedProfileImport(
         startedAt,
         () => profileApi.previewProfileUpload<ProfileImportResult>(file),
-        (_preview, onProgress) => profileApi.importProfileUploadWithProgress<ProfileImportResult>(file, onProgress),
+        (_preview, onProgress) => profileApi.importProfileUpload<ProfileImportResult>(file, { onProgress }),
       );
     } catch (err) {
       showProfileImportError(err, startedAt);

--- a/src/shared/api/profile-api.ts
+++ b/src/shared/api/profile-api.ts
@@ -31,8 +31,15 @@ const PROFILE_IMPORT_MANAGED_ASSET_KINDS: RemoteManagedAssetKind[] = [
 ];
 
 export type ProfileImportProgressEvent = { type: string; data: unknown };
-type RawProfileImportEvent = { type?: unknown; data?: unknown; text?: unknown; [key: string]: unknown };
 type ProfileImportProgressHandler = (event: ProfileImportProgressEvent) => void;
+type ProfileImportFileOptions = {
+  previewFingerprint?: string | null;
+  onProgress?: ProfileImportProgressHandler;
+};
+type ProfileImportUploadOptions = {
+  onProgress?: ProfileImportProgressHandler;
+};
+type RawProfileImportEvent = { type?: unknown; data?: unknown; text?: unknown; [key: string]: unknown };
 
 function readFileAsBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -97,21 +104,8 @@ async function importProfile<T>(envelope: unknown): Promise<T> {
   );
 }
 
-async function importProfileFile<T>(path: string, options?: { previewFingerprint?: string | null }): Promise<T> {
-  if (remoteRuntimeTarget()) {
-    throw new ApiError(
-      "Profile import from a local file path is not available while Remote Runtime is configured.",
-      400,
-      { code: "remote_local_path_unsupported" },
-    );
-  }
-  return invalidateRemoteManagedAssetObjectUrlsAfter(
-    invokeTauri<T>("profile_import_file", {
-      path,
-      previewFingerprint: options?.previewFingerprint ?? null,
-    }),
-    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
-  );
+async function importProfileFile<T>(path: string, options?: ProfileImportFileOptions): Promise<T> {
+  return importProfileFileWithProgress<T>(path, options, options?.onProgress);
 }
 
 function normalizeProfileImportEvent(event: RawProfileImportEvent): ProfileImportProgressEvent {
@@ -149,7 +143,7 @@ function profileImportEventError(event: ProfileImportProgressEvent): ApiError {
 
 async function runTauriProfileFileImportWithProgress<T>(
   path: string,
-  options: { previewFingerprint?: string | null } | undefined,
+  options: ProfileImportFileOptions | undefined,
   onProgress?: ProfileImportProgressHandler,
 ): Promise<T> {
   const queue: RawProfileImportEvent[] = [];
@@ -221,9 +215,10 @@ async function runTauriProfileFileImportWithProgress<T>(
 
 async function importProfileFileWithProgress<T>(
   path: string,
-  options?: { previewFingerprint?: string | null },
+  options?: ProfileImportFileOptions,
   onProgress?: ProfileImportProgressHandler,
 ): Promise<T> {
+  const progressHandler = onProgress ?? options?.onProgress;
   if (remoteRuntimeTarget()) {
     throw new ApiError(
       "Profile import from a local file path is not available while Remote Runtime is configured.",
@@ -232,7 +227,7 @@ async function importProfileFileWithProgress<T>(
     );
   }
   return invalidateRemoteManagedAssetObjectUrlsAfter(
-    runTauriProfileFileImportWithProgress<T>(path, options, onProgress),
+    runTauriProfileFileImportWithProgress<T>(path, options, progressHandler),
     PROFILE_IMPORT_MANAGED_ASSET_KINDS,
   );
 }
@@ -273,21 +268,6 @@ async function previewProfileUpload<T>(file: File): Promise<T> {
       });
 }
 
-async function importRemoteProfileUpload<T>(target: RuntimeTarget, file: File): Promise<T> {
-  const form = new FormData();
-  form.append("file", file, file.name);
-  const response = await fetch(
-    `${target.baseUrl}/api/profile/import`,
-    remoteFetchInit({
-      method: "POST",
-      headers: remotePrivilegedHeaders(target, { accept: "application/json" }),
-      body: form,
-    }),
-  );
-  if (!response.ok) throw await readRemoteError(response);
-  return (await response.json()) as T;
-}
-
 async function importRemoteProfileUploadWithProgress<T>(
   file: File,
   onProgress?: ProfileImportProgressHandler,
@@ -310,28 +290,26 @@ async function importRemoteProfileUploadWithProgress<T>(
   return doneData as T;
 }
 
-async function importProfileUpload<T>(file: File): Promise<T> {
-  const target = remoteRuntimeTarget();
-  return invalidateRemoteManagedAssetObjectUrlsAfter(
-    target
-      ? importRemoteProfileUpload<T>(target, file)
-      : invokeTauri<T>("profile_import_upload", {
-          filename: file.name,
-          base64: await readFileAsBase64(file),
-        }),
-    PROFILE_IMPORT_MANAGED_ASSET_KINDS,
-  );
+async function importProfileUpload<T>(file: File, options?: ProfileImportUploadOptions): Promise<T> {
+  return importProfileUploadWithProgress<T>(file, options?.onProgress);
 }
 
 async function importProfileUploadWithProgress<T>(file: File, onProgress?: ProfileImportProgressHandler): Promise<T> {
   const target = remoteRuntimeTarget();
+  if (!target) {
+    // Embedded upload buffers through FileReader before Rust receives the file,
+    // so this compatibility path cannot emit real import progress. The local
+    // UI uses file-path import for progress.
+    return invalidateRemoteManagedAssetObjectUrlsAfter(
+      invokeTauri<T>("profile_import_upload", {
+        filename: file.name,
+        base64: await readFileAsBase64(file),
+      }),
+      PROFILE_IMPORT_MANAGED_ASSET_KINDS,
+    );
+  }
   return invalidateRemoteManagedAssetObjectUrlsAfter(
-    target
-      ? importRemoteProfileUploadWithProgress<T>(file, onProgress)
-      : invokeTauri<T>("profile_import_upload", {
-          filename: file.name,
-          base64: await readFileAsBase64(file),
-        }),
+    importRemoteProfileUploadWithProgress<T>(file, onProgress),
     PROFILE_IMPORT_MANAGED_ASSET_KINDS,
   );
 }


### PR DESCRIPTION
## Linked issue

Closes https://github.com/Pasta-Devs/Marinara-Engine/issues/2108

## Why this change

- Follow-up to profile import progress reporting: the settings UI can call the normal profile import API methods while still passing progress handlers, and the Docker server build includes frontend sources needed by Rust compile-time checks.

## What changed

- Added progress options to `profileApi.importProfileFile` and `profileApi.importProfileUpload`, delegating to the existing streaming import paths.
- Updated the profile import settings section to use the unified import methods instead of the explicit `WithProgress` methods.
- Copied `src/` into the Docker builder stage so Rust compile-time references to shared frontend sources are available.

## Refactor impact

Primary owner:

- Shared API / shell settings / hostable runtime Docker build.

Impact areas reviewed:

- Profile import file-path import, remote upload import, remote import SSE route, managed asset URL invalidation, and Docker build context.

Boundary notes:

- Feature code continues to call the focused `src/shared/api/profile-api.ts` wrapper.
- The shared API wrapper remains the transport boundary between embedded Tauri and remote runtime profile import.
- Docker change only adds build-context input needed by existing Rust `include_str!` checks.

Pressure points touched:

- None of the listed pressure points were expanded. Profile import command registration was reviewed but not changed.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Ran `git diff --check`: clean.
- Ran `pnpm typecheck`: passed.
- Ran `pnpm check:architecture`: passed.
- Ran `pnpm check`: passed, including line endings, architecture, frontend typecheck, Rust workspace `cargo check`, docs, discovery metadata, launcher safety, and unused-code checks.
- Not run: full Docker image build.
- Not run: manual native Tauri or remote-runtime profile import QA.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A: this unifies existing profile import API calls and fixes Docker build context; it does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

- Docs changes not needed; the existing Docker instructions stay accurate.
- No release notes file exists in the repo.

## UI evidence

Not included; this is API wiring/build-context cleanup with no visible UI layout change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized profile import and upload functionality to use structured option objects for consistent progress callback handling.
  * Updated build configuration for the Rust compilation stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->