### PR TITLE
feat: duplicate lorebook entries

### DIFF
--- a/src/features/catalog/lorebooks/components/entries/LorebookEntryRow.tsx
+++ b/src/features/catalog/lorebooks/components/entries/LorebookEntryRow.tsx
@@ -18,6 +18,7 @@ import {
   CheckCircle2,
   CheckSquare2,
   CircleDashed,
+  Copy,
   GripVertical,
   Hash,
   Lock,
@@ -31,7 +32,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../../../../shared/lib/utils";
 import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
-import { useUpdateLorebookEntry, useDeleteLorebookEntry } from "../../hooks/use-lorebooks";
+import { useUpdateLorebookEntry, useDeleteLorebookEntry, useDuplicateLorebookEntry } from "../../hooks/use-lorebooks";
 import type { LorebookEntry, LorebookFolder } from "../../../../../engine/contracts/types/lorebook";
 import { estimateTokens } from "../shared/LorebookFormFields";
 import { LorebookEntryDrawer } from "./LorebookEntryDrawer";
@@ -104,6 +105,7 @@ export function LorebookEntryRow({
 }: Props) {
   const updateEntry = useUpdateLorebookEntry();
   const deleteEntry = useDeleteLorebookEntry();
+  const duplicateEntry = useDuplicateLorebookEntry();
 
   // ── Inline-control optimistic state ──
   // We keep a local mirror of the entry's fields so the inputs feel snappy
@@ -242,6 +244,14 @@ export function LorebookEntryRow({
       deleteEntry.mutate({ lorebookId, entryId: entry.id });
     },
     [lorebookId, entry.id, deleteEntry],
+  );
+
+  const handleDuplicate = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      duplicateEntry.mutate({ entry });
+    },
+    [duplicateEntry, entry],
   );
 
   const showDepthInput = localPosition === 2;
@@ -621,6 +631,18 @@ export function LorebookEntryRow({
           <Hash size="0.5625rem" />
           {estimateTokens(entry.content).toLocaleString()}
         </span>
+
+        {/* Duplicate button (visible on hover, always on mobile) */}
+        <button
+          type="button"
+          aria-label="Duplicate entry"
+          title="Duplicate entry"
+          onClick={handleDuplicate}
+          disabled={duplicateEntry.isPending}
+          className="shrink-0 rounded p-1 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] group-hover:opacity-100 disabled:opacity-40 max-md:opacity-100"
+        >
+          <Copy size="0.75rem" />
+        </button>
 
         {/* Delete button (visible on hover, always on mobile) */}
         <button

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -284,6 +284,29 @@ export function useCreateLorebookEntry() {
   });
 }
 
+export function useDuplicateLorebookEntry() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ entry }: { entry: LorebookEntry }) => {
+      // Clone every field except the server-managed id/timestamps (the create
+      // schema strips unknown keys), appending " (Copy)" to the name. Spreading
+      // the source preserves its `order`, so the copy lands next to the original
+      // instead of at the schema's default order — and folderId, keys, filters,
+      // embedding, and all activation/injection settings carry over verbatim.
+      const clone = { ...(entry as unknown as Record<string, unknown>) };
+      delete clone.id;
+      return storageApi.create<LorebookEntry>(
+        "lorebook-entries",
+        createLorebookEntrySchema.parse({ ...clone, name: `${entry.name} (Copy)` }),
+      );
+    },
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.entry.lorebookId) });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+    },
+  });
+}
+
 export function useUpdateLorebookEntry() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Linked issue

Closes #2127 — Halfway, this PR is the entry-duplication part. Nested folders will follow as a separate PR.

## Why this change

- Re-creating a lorebook entry by hand — re-typing its keys, filters, injection/activation settings, and content — is tedious when you want a near-identical variant. A one-click duplicate is a pure QoL win, and it's fully additive (no existing behavior changes).

## What changed

- **`useDuplicateLorebookEntry` hook** (`hooks/use-lorebooks.ts`) — clones an entry through the existing generic `storageApi.create("lorebook-entries", …)` path: the create schema strips the server-managed `id`/`createdAt`/`updatedAt`, the name gets a `" (Copy)"` suffix, and **every other field carries over verbatim** — `folderId`, keys/secondaryKeys, all character/tag/trigger filters, position/depth/order, probability, timing, grouping, embedding, and activation conditions. Invalidates the same queries as `useCreateLorebookEntry`.
- **Duplicate button** (`components/entries/LorebookEntryRow.tsx`) — a `Copy`-icon button in the per-row actions, immediately left of the existing delete button. Mirrors delete's hover-reveal pattern (always visible on mobile) with neutral styling; disabled while the mutation is in flight.

**No backend/Rust changes.** Unlike `duplicate_character` (which needs Rust to deep-copy the managed avatar file on disk), lorebook entries have no managed on-disk asset — their entire CRUD already rides the generic storage gateway — so duplication is a pure client-side row clone. No new Tauri command, no `lib.rs` registration.

## Refactor impact

Primary owner: Catalog / Lorebooks editor (frontend)

Impact areas reviewed:

- `hooks/use-lorebooks.ts` (new `useDuplicateLorebookEntry` mutation) and `components/entries/LorebookEntryRow.tsx` (the row's duplicate button). No engine, storage-contract, or Rust changes.

Boundary notes:

- Confined to the lorebooks feature UI and its React Query layer. Reuses the existing generic `storageApi.create` and the established `createLorebookEntrySchema` rather than adding a parallel path; no new storage collection, command, or cross-boundary call.

Pressure points touched:

- None of the flagged ones — no `ModeSurface`/`GameSurface`/shared mode UI, no `src-tauri/src/lib.rs` command registration, no import modules. Lorebook entry row only.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` (`tsc -b`) clean; `check:architecture`, `check:frontend`, `check:discovery`, `check:docs`, and `check:unused` all pass locally.
- Verified by hand in the running Tauri build: clicking the duplicate icon creates a `"… (Copy)"` entry that preserves the source's content, keys, position (`↑Char`), order, and probability (confirmed token count and inline controls match the original); the copy lands in the same container; repeated duplication works. Confirmed in **light and dark mode**, and at the **mobile breakpoint** (≤768px — the inline controls collapse into the `⋯` menu and the copy/delete buttons go always-visible, no overflow, names truncate).

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A — adds a per-row action button alongside the existing delete action within the lorebook editor; a QoL action inside an existing panel, not a new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## Proof

Core claim:

- A one-click duplicate produces a faithful, independent copy of a lorebook entry in the same container, with all activation/injection settings preserved and only the name changed.

Verification run:

- `pnpm typecheck` plus `check:architecture` / `check:frontend` / `check:discovery` / `check:docs` / `check:unused` (all green), plus manual in-app testing in the Tauri build.

Evidence:

- The duplicated rows mirror the source's `↑Char` position, `ord: 1`, `p: 100%`, and `# 12` token count (identical content) — differing only by the `" (Copy)"` name — confirming the whole entry (not just the name) is cloned.
- The duplicate button renders consistently in light + dark mode and at the mobile breakpoint.

Known behavior (intended, not a bug):

- The copy inherits the source's exact `order`, so it sorts immediately after the original in the common case. When several entries share the **same** `order` value (e.g., all at the default), the copy lands at the end of that same-order group rather than directly beneath the source. This is deliberate: the only way to force flush placement is to renumber the whole container, which would overwrite every sibling's `order` — and `order` also drives prompt-injection priority. Non-invasive placement was chosen over exact adjacency.

Manual verification requested:

- None beyond the above; reviewers can confirm by duplicating any lorebook entry and checking the copy's drawer matches the source.

## UI evidence

<img width="1263" height="542" alt="image" src="https://github.com/user-attachments/assets/a1776202-39db-44d9-896e-e84088d34bff" />
(in larger view Duplicate and Trash buttons hidden by default until moused over)

<img width="1071" height="780" alt="image" src="https://github.com/user-attachments/assets/6edcb338-36c3-4c98-94de-c418e765619b" />

<img width="1072" height="780" alt="image" src="https://github.com/user-attachments/assets/6c58d490-8541-4908-b62d-aa848a26ccf3" />