### PR TITLE
Fix persona duplicate active flags

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1,6 +1,6 @@
 use super::{
     avatars, characters, chats, connection_secrets, contracts, game_state_snapshots,
-    lorebook_images, media_uploads, message_swipes, prompts, shared,
+    lorebook_images, media_uploads, message_swipes, personas, prompts, shared,
 };
 use crate::builtins::is_protected_record;
 use crate::state::AppState;
@@ -1078,6 +1078,9 @@ pub(crate) fn duplicate_entity(
     if entity == "characters" {
         return characters::duplicate_character(state, id);
     }
+    if entity == "personas" {
+        return personas::duplicate_persona(state, id);
+    }
     if entity == "prompts" {
         return prompts::duplicate_prompt_preset(state, id);
     }
@@ -1622,6 +1625,61 @@ mod tests {
             .join("collections")
             .join("typo-collection.json")
             .exists());
+    }
+
+    #[test]
+    fn duplicating_active_persona_resets_active_flags() {
+        let state = test_state("persona-duplicate-active-flags");
+        storage_create_inner(
+            &state,
+            "personas".to_string(),
+            json!({
+                "id": "active-persona",
+                "name": "Active Persona",
+                "isActive": true,
+                "active": true
+            }),
+        )
+        .expect("persona should be created");
+
+        let duplicated = duplicate_entity(&state, "personas", "active-persona")
+            .expect("persona duplicate should succeed");
+
+        assert_ne!(duplicated["id"], "active-persona");
+        assert_eq!(duplicated["name"], "Active Persona Copy");
+        assert_eq!(duplicated["isActive"], false);
+        assert_eq!(duplicated["active"], false);
+
+        let original = state
+            .storage
+            .get("personas", "active-persona")
+            .expect("original persona should read")
+            .expect("original persona should still exist");
+        assert_eq!(original["isActive"], true);
+        assert_eq!(original["active"], true);
+    }
+
+    #[test]
+    fn duplicating_inactive_persona_keeps_duplicate_inactive() {
+        let state = test_state("persona-duplicate-inactive-flags");
+        storage_create_inner(
+            &state,
+            "personas".to_string(),
+            json!({
+                "id": "inactive-persona",
+                "name": "Inactive Persona",
+                "isActive": false,
+                "active": false
+            }),
+        )
+        .expect("persona should be created");
+
+        let duplicated = duplicate_entity(&state, "personas", "inactive-persona")
+            .expect("persona duplicate should succeed");
+
+        assert_eq!(duplicated["name"], "Inactive Persona Copy");
+        assert_eq!(duplicated["isActive"], false);
+        assert_eq!(duplicated["active"], false);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/personas.rs
+++ b/src-tauri/src/commands/storage/personas.rs
@@ -1,6 +1,24 @@
 use super::shared::*;
 use super::*;
 
+pub(crate) fn duplicate_persona(state: &AppState, id: &str) -> AppResult<Value> {
+    let mut record = get_required(state, "personas", id)?;
+    let object = record
+        .as_object_mut()
+        .ok_or_else(|| AppError::invalid_input("Persona is not an object"))?;
+    object.remove("id");
+    if let Some(name) = object
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    {
+        object.insert("name".to_string(), Value::String(format!("{name} Copy")));
+    }
+    object.insert("isActive".to_string(), Value::Bool(false));
+    object.insert("active".to_string(), Value::Bool(false));
+    state.storage.create("personas", record)
+}
+
 pub(crate) fn activate_persona(state: &AppState, id: &str) -> AppResult<Value> {
     get_required(state, "personas", id)?;
     let personas = state.storage.list("personas")?;


### PR DESCRIPTION
## Linked issue

Closes #2172

## Why this change

- Duplicating an active persona on `refactor` copied `isActive`/`active` truthy flags through the generic storage duplicate path, allowing multiple personas to appear active after duplicate.

## What changed

- Routed `storage_duplicate` for `personas` through a persona-owned duplicate helper.
- Persona duplicates now clear both `isActive` and `active` before the new row is created.
- Added focused Rust storage coverage for active and inactive persona duplicate behavior.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Catalog personas duplicate hook still calls the existing shared `storage_duplicate` wrapper.
- Remote runtime command allowlist already includes `storage_duplicate`; command shape did not change.
- Persona activation path still enforces one active row when explicitly activating.

Boundary notes:

- The invariant is enforced in `src-tauri` storage ownership, not in React UI or shared API call sites.
- No engine, mode, or shared API contract changes.

Pressure points touched:

- Generic storage duplicate router in `src-tauri/src/commands/storage/commands/entities.rs`.
- Persona storage helper in `src-tauri/src/commands/storage/personas.rs`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml duplicating_`
  - Passed 3 tests: the two new persona duplicate tests plus the existing connection duplicate test matched by the filter.
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing persona duplicate workflow is fixed; no new discoverable behavior or entrypoint was added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: storage behavior fix with no visible UI changes beyond duplicated persona active state.
