### PR TITLE
Materialize native persona import avatars

### DIFF
--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -242,6 +242,24 @@ fn apply_imported_character_avatar_metadata(
     absolute_path
 }
 
+fn apply_imported_avatar_metadata(record: &mut Value, avatar: ImportedAvatarReference) -> String {
+    let absolute_path = avatar.absolute_path.clone();
+    let object = record
+        .as_object_mut()
+        .expect("import record should be an object");
+    object.insert(
+        "avatar".to_string(),
+        Value::String(avatar.asset_url.clone()),
+    );
+    object.insert("avatarPath".to_string(), Value::String(avatar.asset_url));
+    object.insert(
+        "avatarFilePath".to_string(),
+        Value::String(absolute_path.clone()),
+    );
+    object.insert("avatarFilename".to_string(), Value::String(avatar.filename));
+    absolute_path
+}
+
 fn import_marinara_character(state: &AppState, data: Value) -> AppResult<Value> {
     if data.get("spec").is_some() && data.get("data").is_some_and(Value::is_object) {
         let mut character_data = data.get("data").cloned().unwrap_or_else(|| json!({}));
@@ -401,10 +419,23 @@ fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
     let mut source = data.clone();
     remove_fields(&mut source, &["id", "metadata", "avatar", "sprites"]);
     let mut record_value = with_entity_defaults("personas", source)?;
-    if let Some(avatar) = data.get("avatar").and_then(Value::as_str) {
-        if let Some(record) = record_value.as_object_mut() {
-            record.insert("avatarPath".to_string(), Value::String(avatar.to_string()));
-            record.insert("avatar".to_string(), Value::String(avatar.to_string()));
+    let avatar_absolute_path = data_image_string(data.get("avatar"))
+        .map(|avatar| {
+            let mut payload = data.clone();
+            if let Some(object) = payload.as_object_mut() {
+                object.insert("_avatarDataUrl".to_string(), Value::String(avatar));
+            }
+            imported_avatar_reference_in_folder(state, &payload, None, None, "avatars/personas")
+        })
+        .transpose()?
+        .flatten()
+        .map(|avatar| apply_imported_avatar_metadata(&mut record_value, avatar));
+    if avatar_absolute_path.is_none() {
+        if let Some(avatar) = data.get("avatar").and_then(Value::as_str) {
+            if let Some(record) = record_value.as_object_mut() {
+                record.insert("avatarPath".to_string(), Value::String(avatar.to_string()));
+                record.insert("avatar".to_string(), Value::String(avatar.to_string()));
+            }
         }
     }
     apply_import_timestamps(&mut record_value, &data);
@@ -420,6 +451,7 @@ fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
             "type": "marinara_persona",
             "id": record.get("id").cloned().unwrap_or(Value::Null),
             "name": record.get("name").cloned().unwrap_or(Value::Null),
+            "persona": record,
             "spritesImported": sprites_imported
         }))
     })();
@@ -433,6 +465,9 @@ fn import_marinara_persona(state: &AppState, data: Value) -> AppResult<Value> {
                 &[persona_id.to_string()],
                 &mut rollback_errors,
             );
+        }
+        if let Some(path) = avatar_absolute_path.as_deref() {
+            rollback_managed_file_path(state, "avatars/personas", path, &mut rollback_errors);
         }
         append_marinara_rollback_errors(error, "persona import", rollback_errors)
     })

--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -2,10 +2,13 @@ use super::*;
 
 #[path = "marinara_assets.rs"]
 mod marinara_assets;
+#[path = "marinara_helpers.rs"]
+mod marinara_helpers;
 #[path = "marinara_rollback.rs"]
 mod marinara_rollback;
 
 use marinara_assets::*;
+use marinara_helpers::*;
 use marinara_rollback::*;
 
 const PROFILE_IMPORT_GUIDANCE: &str =
@@ -99,121 +102,6 @@ pub(super) fn import_marinara_file(state: &AppState, body: Value) -> AppResult<V
     import_marinara_envelope(state, envelope)
 }
 
-fn data_string_name(record: &Value) -> Option<String> {
-    record
-        .get("data")
-        .and_then(|data| data.get("name"))
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned)
-}
-
-fn data_image_string(value: Option<&Value>) -> Option<String> {
-    value
-        .and_then(Value::as_str)
-        .filter(|value| value.starts_with("data:image/"))
-        .map(ToOwned::to_owned)
-}
-
-fn remove_fields(value: &mut Value, fields: &[&str]) {
-    if let Some(object) = value.as_object_mut() {
-        for field in fields {
-            object.remove(*field);
-        }
-    }
-}
-
-fn hydrate_metadata_timestamps(value: &mut Value) {
-    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
-        return;
-    };
-    if metadata.contains_key("timestamps") {
-        return;
-    }
-    let created_at = metadata.get("createdAt").cloned();
-    let updated_at = metadata.get("updatedAt").cloned();
-    if created_at.is_none() && updated_at.is_none() {
-        return;
-    }
-    metadata.insert(
-        "timestamps".to_string(),
-        json!({
-            "createdAt": created_at.unwrap_or(Value::Null),
-            "updatedAt": updated_at.unwrap_or(Value::Null)
-        }),
-    );
-}
-
-fn inherit_wrapper_timestamps(record: &mut Value, wrapper: &Value) {
-    let Some(timestamps) = wrapper
-        .get("metadata")
-        .and_then(|metadata| metadata.get("timestamps"))
-        .cloned()
-    else {
-        return;
-    };
-    let Some(object) = record.as_object_mut() else {
-        return;
-    };
-    let metadata = object
-        .entry("metadata".to_string())
-        .or_insert_with(|| json!({}));
-    if let Some(metadata) = metadata.as_object_mut() {
-        metadata
-            .entry("timestamps".to_string())
-            .or_insert(timestamps);
-    }
-}
-
-fn apply_import_timestamps(record: &mut Value, payload: &Value) {
-    let mut timestamp_payload = payload.clone();
-    hydrate_metadata_timestamps(&mut timestamp_payload);
-    apply_timestamp_overrides(record, &Value::Null, &timestamp_payload);
-}
-
-fn created_record_id(record: &Value, label: &str) -> AppResult<String> {
-    record
-        .get("id")
-        .and_then(Value::as_str)
-        .filter(|id| !id.trim().is_empty())
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| AppError::new("storage_error", format!("Created {label} is missing an id")))
-}
-
-fn array_from_envelope(data: &Value, envelope: &Map<String, Value>, key: &str) -> Vec<Value> {
-    data.get(key)
-        .or_else(|| envelope.get(key))
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-}
-
-fn remap_imported_child_order(
-    value: Option<&Value>,
-    id_map: &HashMap<String, String>,
-    fallback: &[String],
-) -> Vec<String> {
-    let mut ordered = Vec::new();
-    if let Some(items) = value.and_then(Value::as_array) {
-        for item in items {
-            let Some(old_id) = item.as_str() else {
-                continue;
-            };
-            let Some(new_id) = id_map.get(old_id) else {
-                continue;
-            };
-            if !ordered.iter().any(|id| id == new_id) {
-                ordered.push(new_id.clone());
-            }
-        }
-    }
-    for new_id in fallback {
-        if !ordered.iter().any(|id| id == new_id) {
-            ordered.push(new_id.clone());
-        }
-    }
-    ordered
-}
-
 fn native_character_avatar_payload(data: &Value) -> Value {
     let mut payload = data.clone();
     let Some(avatar) = data_image_string(data.get("avatar")) else {
@@ -223,6 +111,15 @@ fn native_character_avatar_payload(data: &Value) -> Value {
         object.insert("_avatarDataUrl".to_string(), Value::String(avatar));
     }
     payload
+}
+
+fn created_record_id(record: &Value, label: &str) -> AppResult<String> {
+    record
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| AppError::new("storage_error", format!("Created {label} is missing an id")))
 }
 
 fn apply_imported_character_avatar_metadata(

--- a/src-tauri/src/commands/storage/imports/marinara_helpers.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_helpers.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+pub(super) fn data_string_name(record: &Value) -> Option<String> {
+    record
+        .get("data")
+        .and_then(|data| data.get("name"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+pub(super) fn data_image_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .filter(|value| value.starts_with("data:image/"))
+        .map(ToOwned::to_owned)
+}
+
+pub(super) fn remove_fields(value: &mut Value, fields: &[&str]) {
+    if let Some(object) = value.as_object_mut() {
+        for field in fields {
+            object.remove(*field);
+        }
+    }
+}
+
+pub(super) fn hydrate_metadata_timestamps(value: &mut Value) {
+    let Some(metadata) = value.get_mut("metadata").and_then(Value::as_object_mut) else {
+        return;
+    };
+    if metadata.contains_key("timestamps") {
+        return;
+    }
+    let created_at = metadata.get("createdAt").cloned();
+    let updated_at = metadata.get("updatedAt").cloned();
+    if created_at.is_none() && updated_at.is_none() {
+        return;
+    }
+    metadata.insert(
+        "timestamps".to_string(),
+        json!({
+            "createdAt": created_at.unwrap_or(Value::Null),
+            "updatedAt": updated_at.unwrap_or(Value::Null)
+        }),
+    );
+}
+
+pub(super) fn inherit_wrapper_timestamps(record: &mut Value, wrapper: &Value) {
+    let Some(timestamps) = wrapper
+        .get("metadata")
+        .and_then(|metadata| metadata.get("timestamps"))
+        .cloned()
+    else {
+        return;
+    };
+    let Some(object) = record.as_object_mut() else {
+        return;
+    };
+    let metadata = object
+        .entry("metadata".to_string())
+        .or_insert_with(|| json!({}));
+    if let Some(metadata) = metadata.as_object_mut() {
+        metadata
+            .entry("timestamps".to_string())
+            .or_insert(timestamps);
+    }
+}
+
+pub(super) fn apply_import_timestamps(record: &mut Value, payload: &Value) {
+    let mut timestamp_payload = payload.clone();
+    hydrate_metadata_timestamps(&mut timestamp_payload);
+    apply_timestamp_overrides(record, &Value::Null, &timestamp_payload);
+}
+
+pub(super) fn array_from_envelope(
+    data: &Value,
+    envelope: &Map<String, Value>,
+    key: &str,
+) -> Vec<Value> {
+    data.get(key)
+        .or_else(|| envelope.get(key))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+pub(super) fn remap_imported_child_order(
+    value: Option<&Value>,
+    id_map: &HashMap<String, String>,
+    fallback: &[String],
+) -> Vec<String> {
+    let mut ordered = Vec::new();
+    if let Some(items) = value.and_then(Value::as_array) {
+        for item in items {
+            let Some(old_id) = item.as_str() else {
+                continue;
+            };
+            let Some(new_id) = id_map.get(old_id) else {
+                continue;
+            };
+            if !ordered.iter().any(|id| id == new_id) {
+                ordered.push(new_id.clone());
+            }
+        }
+    }
+    for new_id in fallback {
+        if !ordered.iter().any(|id| id == new_id) {
+            ordered.push(new_id.clone());
+        }
+    }
+    ordered
+}

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -129,8 +129,9 @@ fn native_marinara_character_import_materializes_embedded_avatar() {
 }
 
 #[test]
-fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
+fn native_marinara_character_import_rolls_back_avatar_when_record_write_fails() {
     let state = test_state("native-character-avatar-rollback");
+    block_collection_writes(&state, "characters");
 
     let error = import_marinara_envelope(
         &state,
@@ -143,16 +144,13 @@ fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
                     "name": "Rollback Native Character Avatar",
                     "description": "Should be removed"
                 },
-                "avatar": embedded_avatar(),
-                "sprites": [
-                    { "data": "data:image/png;base64,not-valid-base64!" }
-                ]
+                "avatar": embedded_avatar()
             }
         }),
     )
-    .expect_err("sprite decode failure should reject character import");
+    .expect_err("character write failure should reject character import");
 
-    assert_eq!(error.code, "invalid_input");
+    assert_eq!(error.code, "io_error");
     assert!(
         state.storage.list("characters").unwrap().is_empty(),
         "failed native character import must remove the created character"
@@ -288,8 +286,9 @@ fn native_marinara_persona_import_materializes_embedded_avatar() {
 }
 
 #[test]
-fn native_marinara_persona_import_rolls_back_avatar_when_sprite_fails() {
+fn native_marinara_persona_import_rolls_back_avatar_when_record_write_fails() {
     let state = test_state("native-persona-avatar-rollback");
+    block_collection_writes(&state, "personas");
 
     let error = import_marinara_envelope(
         &state,
@@ -298,16 +297,13 @@ fn native_marinara_persona_import_rolls_back_avatar_when_sprite_fails() {
             "version": 1,
             "data": {
                 "name": "Rollback Native Persona Avatar",
-                "avatar": embedded_avatar(),
-                "sprites": [
-                    { "data": "data:image/png;base64,not-valid-base64!" }
-                ]
+                "avatar": embedded_avatar()
             }
         }),
     )
-    .expect_err("sprite decode failure should reject persona import");
+    .expect_err("persona write failure should reject persona import");
 
-    assert_eq!(error.code, "invalid_input");
+    assert_eq!(error.code, "io_error");
     assert!(
         state.storage.list("personas").unwrap().is_empty(),
         "failed native persona import must remove the created persona"

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -129,6 +129,41 @@ fn native_marinara_character_import_materializes_embedded_avatar() {
 }
 
 #[test]
+fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
+    let state = test_state("native-character-avatar-rollback");
+
+    let error = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_character",
+            "version": 1,
+            "data": {
+                "spec": "chara_card_v2",
+                "data": {
+                    "name": "Rollback Native Character Avatar",
+                    "description": "Should be removed"
+                },
+                "avatar": embedded_avatar(),
+                "sprites": [
+                    { "data": "data:image/png;base64,not-valid-base64!" }
+                ]
+            }
+        }),
+    )
+    .expect_err("sprite decode failure should reject character import");
+
+    assert_eq!(error.code, "invalid_input");
+    assert!(
+        state.storage.list("characters").unwrap().is_empty(),
+        "failed native character import must remove the created character"
+    );
+    assert!(
+        !state.data_dir.join("avatars").join("characters").exists(),
+        "failed native character import must remove the managed avatar file"
+    );
+}
+
+#[test]
 fn native_marinara_storage_record_import_materializes_embedded_avatar() {
     let state = test_state("native-storage-avatar");
     let imported = import_marinara_envelope(

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -210,6 +210,80 @@ fn native_marinara_character_import_skips_malformed_optional_sprite() {
 }
 
 #[test]
+fn native_marinara_persona_import_materializes_embedded_avatar() {
+    let state = test_state("native-persona-avatar");
+
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_persona",
+            "version": 1,
+            "data": {
+                "name": "Native Persona Avatar",
+                "avatar": embedded_avatar()
+            }
+        }),
+    )
+    .expect("native persona import should succeed");
+
+    let persona = &imported["persona"];
+    assert!(
+        test_string(persona, "avatarPath").starts_with("asset://localhost/")
+            || test_string(persona, "avatarPath").starts_with("http://asset.localhost/"),
+        "persona avatar should be stored as a managed asset URL"
+    );
+    assert!(
+        test_string(persona, "avatarFilePath").contains("avatars")
+            && test_string(persona, "avatarFilePath").contains("personas"),
+        "persona avatar should stay under persona avatar storage"
+    );
+    assert!(
+        Path::new(test_string(persona, "avatarFilePath")).exists(),
+        "managed persona avatar file should exist"
+    );
+    assert_eq!(
+        persona.get("avatar").and_then(Value::as_str),
+        persona.get("avatarPath").and_then(Value::as_str),
+        "persona avatar aliases should both point at the managed asset URL"
+    );
+    assert!(
+        !test_string(persona, "avatar").starts_with("data:image/"),
+        "native persona imports should not keep embedded avatar bytes inline"
+    );
+}
+
+#[test]
+fn native_marinara_persona_import_rolls_back_avatar_when_sprite_fails() {
+    let state = test_state("native-persona-avatar-rollback");
+
+    let error = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_persona",
+            "version": 1,
+            "data": {
+                "name": "Rollback Native Persona Avatar",
+                "avatar": embedded_avatar(),
+                "sprites": [
+                    { "data": "data:image/png;base64,not-valid-base64!" }
+                ]
+            }
+        }),
+    )
+    .expect_err("sprite decode failure should reject persona import");
+
+    assert_eq!(error.code, "invalid_input");
+    assert!(
+        state.storage.list("personas").unwrap().is_empty(),
+        "failed native persona import must remove the created persona"
+    );
+    assert!(
+        !state.data_dir.join("avatars").join("personas").exists(),
+        "failed native persona import must remove the managed avatar file"
+    );
+}
+
+#[test]
 fn parented_record_import_rolls_back_created_records_on_failure() {
     let state = test_state("parented-rollback");
     let owner_id = "preset-rollback";

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -269,13 +269,29 @@ fn imported_avatar_reference(
     filename: Option<&str>,
     trusted_avatar_source: Option<&Path>,
 ) -> AppResult<Option<ImportedAvatarReference>> {
+    imported_avatar_reference_in_folder(
+        state,
+        payload,
+        filename,
+        trusted_avatar_source,
+        "avatars/characters",
+    )
+}
+
+fn imported_avatar_reference_in_folder(
+    state: &AppState,
+    payload: &Value,
+    filename: Option<&str>,
+    trusted_avatar_source: Option<&Path>,
+    folder: &str,
+) -> AppResult<Option<ImportedAvatarReference>> {
     if let Some(source) = trusted_avatar_source {
         let filename_hint = source
             .file_name()
             .and_then(|value| value.to_str())
             .or(filename)
             .unwrap_or("avatar.png");
-        let stored = persist_image_file_copy(state, "avatars/characters", filename_hint, source)?;
+        let stored = persist_image_file_copy(state, folder, filename_hint, source)?;
         return Ok(Some(ImportedAvatarReference {
             asset_url: stored.asset_url,
             absolute_path: stored.absolute_path,
@@ -296,13 +312,7 @@ fn imported_avatar_reference(
         .and_then(Value::as_str)
         .or(filename)
         .unwrap_or("avatar");
-    let stored = persist_image_bytes(
-        state,
-        "avatars/characters",
-        &safe_filename(fallback),
-        &bytes,
-        &mime,
-    )?;
+    let stored = persist_image_bytes(state, folder, &safe_filename(fallback), &bytes, &mime)?;
     Ok(Some(ImportedAvatarReference {
         asset_url: stored.asset_url,
         absolute_path: stored.absolute_path,


### PR DESCRIPTION
## Linked issue

Closes #2174

## Why this change

- Native Marinara persona imports with embedded avatar data kept the data URL inline instead of materializing a managed persona avatar file.

## What changed

- Made the native import avatar materialization helper folder-aware.
- Materialized native persona embedded avatars under `avatars/personas`.
- Stored managed avatar URL and metadata on imported persona rows.
- Rolled back the managed persona avatar file if later persona import work fails.
- Returned the imported persona record in the native persona import response for parity with character imports and test visibility.

## Refactor impact

Primary owner:

Tauri/Rust storage imports.

Impact areas reviewed:

- Native Marinara persona import
- Native character import avatar helper call path
- Persona sprite failure rollback path

Boundary notes:

Rust storage/import boundary only. No React UI, engine, shared API wrapper, or remote runtime routing changes.

Pressure points touched:

Import modules only; no `src-tauri/src/lib.rs` command registration changes.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml native_marinara_persona_import_materializes_embedded_avatar`
- `cargo test --manifest-path src-tauri/Cargo.toml native_marinara_persona_import_rolls_back_avatar_when_sprite_fails`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for existing native persona import behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - Rust storage/import behavior only.
