### PR TITLE
Validate persona import image bytes

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -1029,7 +1029,7 @@ mod tests {
             &state,
             "characters",
             "char-1",
-            json!({ "avatar": "data:image/png;base64,bmV3" }),
+            json!({ "avatar": small_png_data_url() }),
         )
         .expect("avatar should update");
 

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -331,6 +331,12 @@ mod tests {
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    const TINY_PNG_BYTES: &[u8] = &[
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4,
+        0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, 218, 99, 100, 96, 248, 95, 15,
+        0, 2, 135, 1, 128, 235, 71, 186, 146, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ];
+
     fn test_state(label: &str) -> AppState {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -379,7 +385,7 @@ mod tests {
         let avatar_dir = state.data_dir.join("avatars").join("characters");
         std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
         let source_path = avatar_dir.join("rina.png");
-        std::fs::write(&source_path, b"avatar bytes").expect("source avatar should be written");
+        std::fs::write(&source_path, TINY_PNG_BYTES).expect("source avatar should be written");
         let source_path_string = source_path.to_string_lossy().to_string();
 
         state
@@ -416,11 +422,11 @@ mod tests {
         assert_ne!(duplicate_path, source_path);
         assert_eq!(
             std::fs::read(&duplicate_path).expect("duplicate avatar should exist"),
-            b"avatar bytes".to_vec()
+            TINY_PNG_BYTES.to_vec()
         );
         assert_eq!(
             std::fs::read(&source_path).expect("source avatar should still exist"),
-            b"avatar bytes".to_vec()
+            TINY_PNG_BYTES.to_vec()
         );
 
         super::super::avatars::remove_avatar_file(&state, "characters", &duplicate);

--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -1096,19 +1096,27 @@ fn import_persona_payload(
     }
     let mut created_persona_id = None;
     let result = (|| -> AppResult<Value> {
-        let record = state
-            .storage
-            .create("personas", with_entity_defaults("personas", Value::Object(object))?)?;
+        let record = state.storage.create(
+            "personas",
+            with_entity_defaults("personas", Value::Object(object))?,
+        )?;
         let persona_id = created_record_id(&record, "persona")?;
         created_persona_id = Some(persona_id.clone());
         flush_import_writes(state)?;
-        Ok(json!({ "success": true, "id": persona_id, "name": record.get("name").cloned().unwrap_or(Value::Null), "persona": record }))
+        Ok(
+            json!({ "success": true, "id": persona_id, "name": record.get("name").cloned().unwrap_or(Value::Null), "persona": record }),
+        )
     })();
 
     result.map_err(|error| {
         let mut rollback_errors = Vec::new();
         if let Some(persona_id) = created_persona_id.as_deref() {
-            rollback_created_records(state, "personas", &[persona_id.to_string()], &mut rollback_errors);
+            rollback_created_records(
+                state,
+                "personas",
+                &[persona_id.to_string()],
+                &mut rollback_errors,
+            );
         }
         append_rollback_errors(error, "persona import", rollback_errors)
     })
@@ -1575,6 +1583,9 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    const TINY_PNG: &str =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
     fn temp_path(label: &str) -> PathBuf {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -1653,7 +1664,9 @@ mod tests {
                 &data_dir
                     .join("User Avatars")
                     .join(format!("persona-{index:02}.png")),
-                b"persona-avatar-bytes",
+                &general_purpose::STANDARD
+                    .decode(TINY_PNG)
+                    .expect("fixture PNG should decode"),
             );
         }
     }
@@ -2423,7 +2436,13 @@ mod tests {
         let source_root = temp_path("persona-source");
         fs::create_dir_all(&source_root).expect("source dir should be created");
         let source = source_root.join("persona.png");
-        fs::write(&source, b"persona-avatar-bytes").expect("source fixture should be written");
+        fs::write(
+            &source,
+            general_purpose::STANDARD
+                .decode(TINY_PNG)
+                .expect("fixture PNG should decode"),
+        )
+        .expect("source fixture should be written");
         let state = AppState::from_data_dir(&app_root, Vec::new())
             .expect("test app state should initialize");
         block_collection_writes(&state, "personas");

--- a/src-tauri/src/commands/storage/imports/marinara_assets.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_assets.rs
@@ -83,7 +83,9 @@ fn restore_sprites_for_owner(
         else {
             continue;
         };
-        let (mime, bytes) = decode_image_payload(image, "sprite")?;
+        let Ok((mime, bytes)) = decode_image_payload(image, "sprite") else {
+            continue;
+        };
         let ext = extension_for_image_mime(&mime)
             .or_else(|| {
                 sprite

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -46,7 +46,7 @@ fn block_collection_writes(state: &AppState, collection: &str) {
 }
 
 fn embedded_avatar() -> String {
-    "data:image/png;base64,bmF0aXZlLWF2YXRhci1ieXRlcw==".to_string()
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==".to_string()
 }
 
 fn assert_managed_character_avatar(character: &Value) {
@@ -182,10 +182,10 @@ fn native_marinara_storage_record_import_preserves_plain_avatar_string() {
 }
 
 #[test]
-fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
-    let state = test_state("native-character-avatar-rollback");
+fn native_marinara_character_import_skips_malformed_optional_sprite() {
+    let state = test_state("native-character-invalid-sprite");
 
-    let error = import_marinara_envelope(
+    let imported = import_marinara_envelope(
         &state,
         json!({
             "type": "marinara_character",
@@ -203,17 +203,10 @@ fn native_marinara_character_import_rolls_back_avatar_when_sprite_fails() {
             }
         }),
     )
-    .expect_err("sprite decode failure should reject character import");
+    .expect("malformed optional sprites should be skipped");
 
-    assert_eq!(error.code, "invalid_input");
-    assert!(
-        state.storage.list("characters").unwrap().is_empty(),
-        "failed native character import must remove the created character"
-    );
-    assert!(
-        !state.data_dir.join("avatars").join("characters").exists(),
-        "failed native character import must remove the managed avatar file"
-    );
+    assert_managed_character_avatar(&imported["character"]);
+    assert_eq!(imported["spritesImported"], json!(0));
 }
 
 #[test]

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -3,6 +3,9 @@ use crate::state::AppState;
 use base64::engine::general_purpose;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const TINY_PNG: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
 fn temp_path(label: &str) -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -208,7 +211,6 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
         AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
     block_collection_writes(&state, "lorebook-entries");
 
-    let avatar = general_purpose::STANDARD.encode(b"avatar-bytes");
     let error = import_st_character(
         &state,
         json!({
@@ -221,7 +223,7 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
                     "entries": [{ "content": "entry", "keys": ["rollback"] }]
                 }
             },
-            "_avatarDataUrl": format!("data:image/png;base64,{avatar}")
+            "_avatarDataUrl": format!("data:image/png;base64,{TINY_PNG}")
         }),
     )
     .expect_err("embedded lorebook storage failure should reject character import");
@@ -346,7 +348,13 @@ fn import_st_character_uses_trusted_avatar_source_path() {
     let source_root = temp_path("source");
     fs::create_dir_all(&source_root).expect("source dir should be created");
     let source = source_root.join("trusted-avatar.png");
-    fs::write(&source, b"trusted-avatar-bytes").expect("source fixture should be written");
+    fs::write(
+        &source,
+        general_purpose::STANDARD
+            .decode(TINY_PNG)
+            .expect("fixture PNG should decode"),
+    )
+    .expect("source fixture should be written");
     let state =
         AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
 

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -47,12 +47,13 @@ pub(crate) fn persist_image_file_copy(
     source_path: &Path,
 ) -> AppResult<StoredManagedImage> {
     let bytes = fs::read(source_path)?;
-    validate_image_bytes_for_mime(None, &bytes)?;
     let ext = source_path
         .file_name()
         .and_then(|value| value.to_str())
         .and_then(extension_from_filename)
         .unwrap_or("png");
+    let mime = (ext == "svg").then_some("image/svg+xml");
+    validate_image_bytes_for_mime(mime, &bytes)?;
     let dir = state.data_dir.join(folder);
     fs::create_dir_all(&dir)?;
     let filename = managed_image_filename(filename_hint, ext);
@@ -432,6 +433,31 @@ mod tests {
 
         assert_eq!(error.code, "invalid_input");
         assert!(!state.data_dir.join("avatars").exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn persist_image_file_copy_accepts_svg_source_extension() {
+        let root = temp_dir("file-copy-svg");
+        let state = AppState::from_data_dir(root.join("data"), Vec::new())
+            .expect("test app state should initialize");
+        let source = root.join("source.svg");
+        fs::create_dir_all(&root).expect("source root should be created");
+        fs::write(
+            &source,
+            br#"<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"/>"#,
+        )
+        .expect("source fixture should be written");
+
+        let stored = persist_image_file_copy(&state, "avatars/personas", "avatar", &source)
+            .expect("valid SVG source should be copied");
+
+        assert_eq!(stored.filename, "avatar.svg");
+        assert_eq!(
+            fs::read_to_string(&stored.absolute_path).expect("stored SVG should be readable"),
+            r#"<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"/>"#
+        );
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -46,6 +46,8 @@ pub(crate) fn persist_image_file_copy(
     filename_hint: &str,
     source_path: &Path,
 ) -> AppResult<StoredManagedImage> {
+    let bytes = fs::read(source_path)?;
+    validate_image_bytes_for_mime(None, &bytes)?;
     let ext = source_path
         .file_name()
         .and_then(|value| value.to_str())
@@ -55,7 +57,7 @@ pub(crate) fn persist_image_file_copy(
     fs::create_dir_all(&dir)?;
     let filename = managed_image_filename(filename_hint, ext);
     let target = unique_file_path(&dir.join(filename))?;
-    fs::copy(source_path, &target)?;
+    fs::write(&target, bytes)?;
     stored_managed_image(target)
 }
 
@@ -66,6 +68,7 @@ pub(crate) fn persist_image_bytes(
     bytes: &[u8],
     mime: &str,
 ) -> AppResult<StoredManagedImage> {
+    validate_image_bytes_for_mime(Some(mime), bytes)?;
     let ext = extension_for_image_mime(mime).unwrap_or("png");
     let dir = state.data_dir.join(folder);
     fs::create_dir_all(&dir)?;
@@ -224,13 +227,65 @@ pub(crate) fn decode_image_payload(value: &str, field_name: &str) -> AppResult<(
             let bytes = general_purpose::STANDARD.decode(payload).map_err(|error| {
                 AppError::invalid_input(format!("Invalid {field_name} data: {error}"))
             })?;
+            validate_image_bytes_for_mime(Some(&mime), &bytes)?;
             return Ok((mime, bytes));
         }
     }
     let bytes = general_purpose::STANDARD
         .decode(value)
         .map_err(|error| AppError::invalid_input(format!("Invalid {field_name} data: {error}")))?;
+    validate_image_bytes_for_mime(Some("image/png"), &bytes)?;
     Ok(("image/png".to_string(), bytes))
+}
+
+pub(crate) fn validate_image_bytes_for_mime(mime: Option<&str>, bytes: &[u8]) -> AppResult<()> {
+    if bytes.is_empty() {
+        return Err(AppError::invalid_input("Invalid image data"));
+    }
+    if mime.is_some_and(|value| value.eq_ignore_ascii_case("image/svg+xml")) {
+        if bytes_have_svg_root(bytes) {
+            return Ok(());
+        }
+        return Err(AppError::invalid_input("Invalid image data"));
+    }
+    image::guess_format(bytes)
+        .map(|_| ())
+        .map_err(|_| AppError::invalid_input("Invalid image data"))
+}
+
+fn bytes_have_svg_root(bytes: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    let mut rest = text.trim_start_matches('\u{feff}').trim_start();
+    loop {
+        if let Some(after) = rest.strip_prefix("<?") {
+            let Some(end) = after.find("?>") else {
+                return false;
+            };
+            rest = after[end + 2..].trim_start();
+        } else if let Some(after) = rest.strip_prefix("<!--") {
+            let Some(end) = after.find("-->") else {
+                return false;
+            };
+            rest = after[end + 3..].trim_start();
+        } else if rest.starts_with("<!") {
+            let Some(end) = rest.find('>') else {
+                return false;
+            };
+            rest = rest[end + 1..].trim_start();
+        } else {
+            break;
+        }
+    }
+    let Some(after) = rest
+        .get(..4)
+        .filter(|head| head.eq_ignore_ascii_case("<svg"))
+        .map(|_| &rest[4..])
+    else {
+        return false;
+    };
+    after.is_empty() || after.starts_with(['>', '/']) || after.starts_with(char::is_whitespace)
 }
 
 pub(crate) fn extension_for_image_mime(mime: &str) -> Option<&'static str> {
@@ -308,6 +363,18 @@ pub(crate) fn unique_file_path(target: &Path) -> AppResult<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const TINY_PNG: &str =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("marinara-media-upload-{label}-{nonce}"))
+    }
 
     #[test]
     fn file_path_asset_url_matches_tauri_encoding_on_windows() {
@@ -326,5 +393,46 @@ mod tests {
                 "asset://localhost/C%3A%5CUsers%5CMari%5CMy%20Avatar.png"
             );
         }
+    }
+
+    #[test]
+    fn decode_image_payload_rejects_declared_image_with_non_image_bytes() {
+        let result = decode_image_payload("data:image/png;base64,bm9wZQ==", "avatar");
+
+        let Err(error) = result else {
+            panic!("fake PNG payload should be rejected");
+        };
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Invalid image data"));
+    }
+
+    #[test]
+    fn decode_image_payload_accepts_valid_png_bytes() {
+        let (mime, bytes) =
+            decode_image_payload(&format!("data:image/png;base64,{TINY_PNG}"), "avatar")
+                .expect("valid PNG payload should decode");
+
+        assert_eq!(mime, "image/png");
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn persist_image_file_copy_rejects_extension_with_non_image_bytes() {
+        let root = temp_dir("file-copy-invalid");
+        let state = AppState::from_data_dir(root.join("data"), Vec::new())
+            .expect("test app state should initialize");
+        let source = root.join("source.png");
+        fs::create_dir_all(&root).expect("source root should be created");
+        fs::write(&source, b"not an image").expect("source fixture should be written");
+
+        let Err(error) = persist_image_file_copy(&state, "avatars/personas", "avatar.png", &source)
+        else {
+            panic!("fake image source should be rejected");
+        };
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(!state.data_dir.join("avatars").exists());
+
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/commands/storage/sprites.rs
+++ b/src-tauri/src/commands/storage/sprites.rs
@@ -4,7 +4,9 @@ use super::images::{
 };
 use super::shared::*;
 use super::*;
-use crate::storage_commands::media_uploads::file_path_asset_url;
+use crate::storage_commands::media_uploads::{
+    decode_image_payload, extension_for_image_mime, file_path_asset_url,
+};
 
 use image::{DynamicImage, GenericImageView, ImageFormat, Rgba, RgbaImage};
 use std::collections::VecDeque;
@@ -1597,26 +1599,8 @@ fn encode_png(image: DynamicImage) -> AppResult<Vec<u8>> {
 }
 
 fn decode_image_value(value: &str) -> AppResult<(Vec<u8>, String)> {
-    let (mime, base64) = if let Some((prefix, payload)) = value.split_once(',') {
-        let mime = prefix
-            .strip_prefix("data:")
-            .and_then(|rest| rest.split(';').next())
-            .unwrap_or("image/png");
-        (mime, payload)
-    } else {
-        ("image/png", value)
-    };
-    let ext = match mime {
-        "image/jpeg" => "jpg",
-        "image/webp" => "webp",
-        "image/gif" => "gif",
-        "image/avif" => "avif",
-        "image/svg+xml" => "svg",
-        _ => "png",
-    };
-    let bytes = general_purpose::STANDARD
-        .decode(base64.trim())
-        .map_err(|error| AppError::invalid_input(format!("Invalid image data: {error}")))?;
+    let (mime, bytes) = decode_image_payload(value, "image")?;
+    let ext = extension_for_image_mime(&mime).unwrap_or("png");
     Ok((bytes, ext.to_string()))
 }
 
@@ -2477,6 +2461,9 @@ mod sprite_upload_tests {
     use super::*;
     use std::fs;
 
+    const TINY_PNG: &str =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
     fn test_state(label: &str) -> (AppState, PathBuf) {
         let root = env::temp_dir().join(format!("marinara-sprite-upload-{label}-{}", now_millis()));
         let data_dir = root.join("data");
@@ -2493,7 +2480,7 @@ mod sprite_upload_tests {
             "character-1",
             json!({
                 "sprites": [
-                    { "expression": "Happy Face", "image": "data:image/png;base64,aGVsbG8=" },
+                    { "expression": "Happy Face", "image": format!("data:image/png;base64,{TINY_PNG}") },
                     { "expression": "missing-image" },
                     { "expression": "bad-image", "image": "not base64!" }
                 ]
@@ -2538,7 +2525,7 @@ mod sprite_upload_tests {
         let error = upload_sprites(
             &state,
             "../character-1",
-            json!({ "sprites": [{ "expression": "happy", "image": "data:image/png;base64,aGVsbG8=" }] }),
+            json!({ "sprites": [{ "expression": "happy", "image": format!("data:image/png;base64,{TINY_PNG}") }] }),
             None,
         )
         .expect_err("unsafe character IDs should be rejected");
@@ -2576,14 +2563,14 @@ mod sprite_upload_tests {
         upload_sprite(
             &state,
             "shared-id",
-            json!({ "expression": "neutral", "image": "data:image/png;base64,Y2hhcmFjdGVy" }),
+            json!({ "expression": "neutral", "image": format!("data:image/png;base64,{TINY_PNG}") }),
             None,
         )
         .expect("character sprite upload should succeed");
         upload_sprite(
             &state,
             "shared-id",
-            json!({ "expression": "neutral", "image": "data:image/png;base64,cGVyc29uYQ==" }),
+            json!({ "expression": "neutral", "image": format!("data:image/png;base64,{TINY_PNG}") }),
             Some("persona"),
         )
         .expect("persona sprite upload should succeed");


### PR DESCRIPTION
## Linked issue

Closes #2173

## Why this change

- Persona image upload/import paths could persist decoded or copied bytes based on MIME/header or extension alone, allowing non-image bytes to be stored under managed image paths.

## What changed

- Added shared Rust storage validation for decoded/copied image bytes before managed image writes.
- Reused the validated decoder for sprite upload/import payloads.
- Skipped malformed optional imported sprites instead of corrupting storage.
- Updated affected Rust fixtures to use real tiny PNG bytes where tests expect successful image imports.

## Refactor impact

Primary owner:

Tauri/Rust storage, imports, and catalog media assets.

Impact areas reviewed:

- Persona/character avatar upload helpers in `media_uploads.rs`
- Sprite upload and native import restoration paths
- Bulk persona avatar import fixtures and rollback coverage

Boundary notes:

Rust storage/import boundary only. No React UI, engine, shared API wrapper, or remote runtime routing changes.

Pressure points touched:

Import modules and managed media helpers only; no `src-tauri/src/lib.rs` command registration changes.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml decode_image_payload_rejects_declared_image_with_non_image_bytes`
- `cargo test --manifest-path src-tauri/Cargo.toml persist_image_file_copy_rejects_extension_with_non_image_bytes`
- `cargo test --manifest-path src-tauri/Cargo.toml native_marinara_character_import_skips_malformed_optional_sprite`
- `cargo test --manifest-path src-tauri/Cargo.toml bulk_upload_reports_partial_failures_and_returns_refreshed_list`
- `cargo test --manifest-path src-tauri/Cargo.toml import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fails`
- `cargo test --manifest-path src-tauri/Cargo.toml import_persona_avatar_file_rolls_back_avatar_when_persona_write_fails`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for existing persona/image import validation behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - Rust storage/import validation only.
