### PR TITLE
Sync linked embedded lorebook edits

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -443,6 +443,9 @@ pub(crate) fn storage_create_inner(
         connection_secrets::mask_connection_for_read(&mut masked);
         return Ok(masked);
     }
+    if entity == "lorebook-entries" {
+        sync_linked_character_books_for_entry_rows(state, &[&created])?;
+    }
     Ok(created)
 }
 
@@ -479,6 +482,11 @@ pub(crate) fn storage_update_inner(
         return patch_chat_preset(state, &id, patch);
     }
     validate_connection_folder_for_patch(state, &entity, &patch)?;
+    let previous_lorebook_entry = if entity == "lorebook-entries" {
+        state.storage.get(&entity, &id)?
+    } else {
+        None
+    };
     let updated = if entity == "connections" {
         connection_secrets::patch_connection(
             state,
@@ -494,6 +502,15 @@ pub(crate) fn storage_update_inner(
     };
     if entity == "connections" {
         clear_other_default_agent_connections(state, &updated)?;
+    }
+    if entity == "lorebook-entries" {
+        sync_linked_character_books_for_entry_rows(
+            state,
+            &[previous_lorebook_entry.as_ref(), Some(&updated)]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+        )?;
     }
     Ok(updated)
 }
@@ -733,7 +750,11 @@ pub(crate) fn delete_entity(
             "Default chat presets cannot be deleted",
         ));
     }
-    let existing = owned_record_for_delete(state, entity, id)?;
+    let existing = if entity == "lorebook-entries" {
+        state.storage.get(entity, id)?
+    } else {
+        owned_record_for_delete(state, entity, id)?
+    };
     let message_chat_id = if entity == "messages" {
         existing
             .as_ref()
@@ -756,6 +777,11 @@ pub(crate) fn delete_entity(
             existing.as_ref(),
             message_chat_id.as_deref(),
         )?;
+        if entity == "lorebook-entries" {
+            if let Some(existing) = existing.as_ref() {
+                sync_linked_character_books_for_entry_rows(state, &[existing])?;
+            }
+        }
     }
     Ok(json!({ "deleted": deleted }))
 }
@@ -926,6 +952,119 @@ fn delete_lorebook_children(state: &AppState, lorebook_id: &str) -> Result<(), A
     state.storage.delete_where("lorebook-entries", &filters)?;
     state.storage.delete_where("lorebook-folders", &filters)?;
     Ok(())
+}
+
+fn lorebook_entry_lorebook_id(entry: &Value) -> Option<&str> {
+    entry
+        .get("lorebookId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn sync_linked_character_books_for_entry_rows(
+    state: &AppState,
+    entries: &[&Value],
+) -> Result<(), AppError> {
+    let lorebook_ids = entries
+        .iter()
+        .filter_map(|entry| lorebook_entry_lorebook_id(entry))
+        .collect::<HashSet<_>>();
+    for lorebook_id in lorebook_ids {
+        sync_linked_character_books_for_lorebook(state, lorebook_id)?;
+    }
+    Ok(())
+}
+
+fn sync_linked_character_books_for_lorebook(
+    state: &AppState,
+    lorebook_id: &str,
+) -> Result<(), AppError> {
+    let mut filters = Map::new();
+    filters.insert(
+        "lorebookId".to_string(),
+        Value::String(lorebook_id.to_string()),
+    );
+    let mut entries = state.storage.list_where("lorebook-entries", &filters)?;
+    entries.sort_by(|left, right| {
+        compare_json_values(
+            left.get("sortOrder").or_else(|| left.get("order")),
+            right.get("sortOrder").or_else(|| right.get("order")),
+        )
+        .then_with(|| compare_json_values(left.get("createdAt"), right.get("createdAt")))
+    });
+
+    for character in state.storage.list("characters")? {
+        let Some(character_id) = character.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let mut data = character.get("data").cloned().unwrap_or_else(|| json!({}));
+        if embedded_lorebook_id(&data) != Some(lorebook_id) {
+            continue;
+        }
+        let Some(data_object) = data.as_object_mut() else {
+            continue;
+        };
+        let mut book = data_object
+            .get("character_book")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        book.insert(
+            "entries".to_string(),
+            Value::Array(
+                entries
+                    .iter()
+                    .enumerate()
+                    .map(|(index, entry)| linked_character_book_entry(entry, index))
+                    .collect(),
+            ),
+        );
+        data_object.insert("character_book".to_string(), Value::Object(book));
+
+        if let Some(import_metadata) = data
+            .pointer_mut("/extensions/importMetadata/embeddedLorebook")
+            .and_then(Value::as_object_mut)
+        {
+            import_metadata.insert("entriesImported".to_string(), json!(entries.len()));
+            import_metadata.insert("hasEmbeddedLorebook".to_string(), Value::Bool(true));
+        }
+        state
+            .storage
+            .patch("characters", character_id, json!({ "data": data }))?;
+    }
+    Ok(())
+}
+
+fn linked_character_book_entry(entry: &Value, index: usize) -> Value {
+    let name = entry
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("Entry");
+    json!({
+        "keys": shared::string_array_from_value(entry.get("keys")),
+        "content": entry.get("content").and_then(Value::as_str).unwrap_or(""),
+        "extensions": entry.get("extensions").cloned().unwrap_or_else(|| json!({})),
+        "enabled": entry.get("enabled").and_then(Value::as_bool).unwrap_or(true),
+        "insertion_order": entry.get("order").or_else(|| entry.get("sortOrder")).and_then(Value::as_i64).unwrap_or(index as i64),
+        "case_sensitive": entry.get("caseSensitive").and_then(Value::as_bool).unwrap_or(false),
+        "name": name,
+        "priority": entry.get("priority").and_then(Value::as_i64).unwrap_or(100),
+        "id": index as i64,
+        "comment": entry.get("comment").and_then(Value::as_str).unwrap_or(name),
+        "selective": entry.get("selective").and_then(Value::as_bool).unwrap_or(false),
+        "secondary_keys": shared::string_array_from_value(entry.get("secondaryKeys")),
+        "constant": entry.get("constant").and_then(Value::as_bool).unwrap_or(false),
+        "position": linked_character_book_position(entry.get("position")),
+    })
+}
+
+fn linked_character_book_position(value: Option<&Value>) -> &'static str {
+    match value {
+        Some(Value::String(raw)) if raw == "after_char" => "after_char",
+        _ => "before_char",
+    }
 }
 
 fn remove_string_from_json_array(value: Option<&Value>, removed_id: &str) -> Option<Value> {
@@ -1341,11 +1480,213 @@ mod tests {
             .unwrap_or(false)
     }
 
+    fn seed_linked_character_book(state: &AppState) {
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "character-1",
+                    "name": "Mira",
+                    "data": {
+                        "name": "Mira",
+                        "character_book": {
+                            "entries": [
+                                {
+                                    "name": "Old",
+                                    "comment": "Old",
+                                    "content": "old text",
+                                    "keys": ["old"],
+                                    "secondary_keys": []
+                                }
+                            ]
+                        },
+                        "extensions": {
+                            "importMetadata": {
+                                "embeddedLorebook": {
+                                    "hasEmbeddedLorebook": true,
+                                    "lorebookId": "linked-book",
+                                    "entriesImported": 1
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("character should seed");
+        state
+            .storage
+            .create(
+                "lorebooks",
+                json!({
+                    "id": "linked-book",
+                    "name": "Mira Lorebook",
+                    "category": "character",
+                    "sourceCharacterId": "character-1"
+                }),
+            )
+            .expect("lorebook should seed");
+    }
+
+    fn character_book_entries(state: &AppState) -> Vec<Value> {
+        state
+            .storage
+            .get("characters", "character-1")
+            .expect("character should read")
+            .and_then(|character| {
+                character
+                    .pointer("/data/character_book/entries")
+                    .and_then(Value::as_array)
+                    .cloned()
+            })
+            .unwrap_or_default()
+    }
+
+    fn first_character_book_entry(state: &AppState) -> Value {
+        character_book_entries(state)
+            .into_iter()
+            .next()
+            .expect("character book should have an entry")
+    }
+
     fn cleanup_registered(collection: &str, cleanup: contracts::DeleteCleanup) -> bool {
         contracts::collection_contract(collection)
             .expect("collection should be registered")
             .delete_cleanup
             .contains(&cleanup)
+    }
+
+    #[test]
+    fn creating_linked_lorebook_entry_syncs_character_book() {
+        let state = test_state("linked-character-book-entry-create");
+        seed_linked_character_book(&state);
+
+        storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "lorebookId": "linked-book",
+                "name": "Moon",
+                "content": "moon text",
+                "keys": ["moon"],
+                "secondaryKeys": ["silver"],
+                "order": 4,
+                "position": "after_char"
+            }),
+        )
+        .expect("entry create should sync");
+
+        let entry = first_character_book_entry(&state);
+        assert_eq!(entry.get("name").and_then(Value::as_str), Some("Moon"));
+        assert_eq!(
+            entry.get("content").and_then(Value::as_str),
+            Some("moon text")
+        );
+        assert_eq!(entry["keys"], json!(["moon"]));
+        assert_eq!(entry["secondary_keys"], json!(["silver"]));
+        assert_eq!(
+            entry.get("insertion_order").and_then(Value::as_i64),
+            Some(4)
+        );
+        assert_eq!(
+            entry.get("position").and_then(Value::as_str),
+            Some("after_char")
+        );
+    }
+
+    #[test]
+    fn updating_linked_lorebook_entry_syncs_character_book() {
+        let state = test_state("linked-character-book-entry-update");
+        seed_linked_character_book(&state);
+        storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "id": "entry-1",
+                "lorebookId": "linked-book",
+                "name": "Moon",
+                "content": "moon text",
+                "keys": ["moon"]
+            }),
+        )
+        .expect("entry should seed through create");
+
+        storage_update_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            "entry-1".to_string(),
+            json!({
+                "name": "Sun",
+                "content": "sun text",
+                "keys": ["sun"],
+                "enabled": false
+            }),
+        )
+        .expect("entry update should sync");
+
+        let entry = first_character_book_entry(&state);
+        assert_eq!(entry.get("name").and_then(Value::as_str), Some("Sun"));
+        assert_eq!(
+            entry.get("content").and_then(Value::as_str),
+            Some("sun text")
+        );
+        assert_eq!(entry["keys"], json!(["sun"]));
+        assert_eq!(entry.get("enabled").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    fn moving_entry_out_of_linked_lorebook_removes_it_from_character_book() {
+        let state = test_state("linked-character-book-entry-move");
+        seed_linked_character_book(&state);
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "other-book", "name": "Other" }))
+            .expect("target lorebook should seed");
+        storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "id": "entry-1",
+                "lorebookId": "linked-book",
+                "name": "Moon",
+                "content": "moon text",
+                "keys": ["moon"]
+            }),
+        )
+        .expect("entry should seed through create");
+
+        storage_update_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            "entry-1".to_string(),
+            json!({ "lorebookId": "other-book" }),
+        )
+        .expect("moving entry should sync source lorebook");
+
+        assert!(character_book_entries(&state).is_empty());
+    }
+
+    #[test]
+    fn deleting_linked_lorebook_entry_syncs_character_book() {
+        let state = test_state("linked-character-book-entry-delete");
+        seed_linked_character_book(&state);
+        storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "id": "entry-1",
+                "lorebookId": "linked-book",
+                "name": "Moon",
+                "content": "moon text",
+                "keys": ["moon"]
+            }),
+        )
+        .expect("entry should seed through create");
+
+        delete_entity(&state, "lorebook-entries", "entry-1", false)
+            .expect("entry delete should sync");
+
+        assert!(character_book_entries(&state).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::builtins::is_protected_record;
 use crate::state::AppState;
-use marinara_core::{ensure_object, AppError};
+use marinara_core::{ensure_object, new_id, now_iso, AppError};
 use serde_json::{json, Map, Value};
 use std::collections::HashSet;
 use tauri::State;
@@ -428,6 +428,9 @@ pub(crate) fn storage_create_inner(
     }
     let should_remove_prepared_gallery_file = gallery_create_persists_inline_image(&entity, &value);
     let prepared = prepare_entity_for_create(state, &entity, value)?;
+    if entity == "lorebook-entries" {
+        return create_lorebook_entry_with_character_book_sync(state, prepared);
+    }
     let created = match state.storage.create(&entity, prepared.clone()) {
         Ok(created) => created,
         Err(error) => {
@@ -442,9 +445,6 @@ pub(crate) fn storage_create_inner(
         let mut masked = created;
         connection_secrets::mask_connection_for_read(&mut masked);
         return Ok(masked);
-    }
-    if entity == "lorebook-entries" {
-        sync_linked_character_books_for_entry_rows(state, &[&created])?;
     }
     Ok(created)
 }
@@ -482,35 +482,17 @@ pub(crate) fn storage_update_inner(
         return patch_chat_preset(state, &id, patch);
     }
     validate_connection_folder_for_patch(state, &entity, &patch)?;
-    let previous_lorebook_entry = if entity == "lorebook-entries" {
-        state.storage.get(&entity, &id)?
-    } else {
-        None
-    };
+    let normalized_patch = shared::normalize_update_patch(&entity, patch)?;
+    if entity == "lorebook-entries" {
+        return update_lorebook_entry_with_character_book_sync(state, &id, normalized_patch);
+    }
     let updated = if entity == "connections" {
-        connection_secrets::patch_connection(
-            state,
-            &id,
-            shared::normalize_update_patch(&entity, patch)?,
-        )?
+        connection_secrets::patch_connection(state, &id, normalized_patch)?
     } else {
-        state.storage.patch(
-            &entity,
-            &id,
-            shared::normalize_update_patch(&entity, patch)?,
-        )?
+        state.storage.patch(&entity, &id, normalized_patch)?
     };
     if entity == "connections" {
         clear_other_default_agent_connections(state, &updated)?;
-    }
-    if entity == "lorebook-entries" {
-        sync_linked_character_books_for_entry_rows(
-            state,
-            &[previous_lorebook_entry.as_ref(), Some(&updated)]
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>(),
-        )?;
     }
     Ok(updated)
 }
@@ -750,11 +732,11 @@ pub(crate) fn delete_entity(
             "Default chat presets cannot be deleted",
         ));
     }
-    let existing = if entity == "lorebook-entries" {
-        state.storage.get(entity, id)?
-    } else {
-        owned_record_for_delete(state, entity, id)?
-    };
+    if entity == "lorebook-entries" {
+        let deleted = delete_lorebook_entry_with_character_book_sync(state, id)?;
+        return Ok(json!({ "deleted": deleted }));
+    }
+    let existing = owned_record_for_delete(state, entity, id)?;
     let message_chat_id = if entity == "messages" {
         existing
             .as_ref()
@@ -777,11 +759,6 @@ pub(crate) fn delete_entity(
             existing.as_ref(),
             message_chat_id.as_deref(),
         )?;
-        if entity == "lorebook-entries" {
-            if let Some(existing) = existing.as_ref() {
-                sync_linked_character_books_for_entry_rows(state, &[existing])?;
-            }
-        }
     }
     Ok(json!({ "deleted": deleted }))
 }
@@ -962,8 +939,145 @@ fn lorebook_entry_lorebook_id(entry: &Value) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
-fn sync_linked_character_books_for_entry_rows(
+fn create_lorebook_entry_with_character_book_sync(
     state: &AppState,
+    value: Value,
+) -> Result<Value, AppError> {
+    let mut object = ensure_object(value)?;
+    let had_id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.trim().is_empty());
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(new_id);
+    let now = now_iso();
+    object.insert("id".to_string(), Value::String(id.clone()));
+    object
+        .entry("createdAt".to_string())
+        .or_insert_with(|| Value::String(now.clone()));
+    object
+        .entry("updatedAt".to_string())
+        .or_insert_with(|| Value::String(now));
+    let record = Value::Object(object);
+    let created = record.clone();
+    state.storage.update_collections_atomically(
+        vec!["lorebook-entries", "characters"],
+        move |collections| {
+            let (entry_rows, character_rows) = lorebook_entry_atomic_rows(collections)?;
+            if had_id
+                && entry_rows
+                    .iter()
+                    .any(|row| row.get("id").and_then(Value::as_str) == Some(id.as_str()))
+            {
+                return Err(AppError::invalid_input(format!(
+                    "lorebook-entries/{id} already exists"
+                )));
+            }
+            entry_rows.retain(|row| row.get("id").and_then(Value::as_str) != Some(id.as_str()));
+            entry_rows.push(record);
+            sync_linked_character_books_for_entry_rows_in_place(
+                character_rows,
+                entry_rows,
+                &[&created],
+            )?;
+            Ok(created)
+        },
+    )
+}
+
+fn update_lorebook_entry_with_character_book_sync(
+    state: &AppState,
+    id: &str,
+    patch: Value,
+) -> Result<Value, AppError> {
+    let patch = ensure_object(patch)?;
+    state.storage.update_collections_atomically(
+        vec!["lorebook-entries", "characters"],
+        move |collections| {
+            let (entry_rows, character_rows) = lorebook_entry_atomic_rows(collections)?;
+            let previous = entry_rows
+                .iter()
+                .find(|row| row.get("id").and_then(Value::as_str) == Some(id))
+                .cloned()
+                .ok_or_else(|| {
+                    AppError::not_found(format!("lorebook-entries/{id} was not found"))
+                })?;
+            let row = entry_rows
+                .iter_mut()
+                .find(|row| row.get("id").and_then(Value::as_str) == Some(id))
+                .ok_or_else(|| {
+                    AppError::not_found(format!("lorebook-entries/{id} was not found"))
+                })?;
+            let Some(object) = row.as_object_mut() else {
+                return Err(AppError::invalid_input("Stored record is not an object"));
+            };
+            for (key, value) in patch {
+                object.insert(key, value);
+            }
+            object.insert("updatedAt".to_string(), Value::String(now_iso()));
+            let updated = Value::Object(object.clone());
+            sync_linked_character_books_for_entry_rows_in_place(
+                character_rows,
+                entry_rows,
+                &[&previous, &updated],
+            )?;
+            Ok(updated)
+        },
+    )
+}
+
+fn delete_lorebook_entry_with_character_book_sync(
+    state: &AppState,
+    id: &str,
+) -> Result<bool, AppError> {
+    state.storage.update_collections_atomically(
+        vec!["lorebook-entries", "characters"],
+        move |collections| {
+            let (entry_rows, character_rows) = lorebook_entry_atomic_rows(collections)?;
+            let previous = entry_rows
+                .iter()
+                .find(|row| row.get("id").and_then(Value::as_str) == Some(id))
+                .cloned();
+            let before = entry_rows.len();
+            entry_rows.retain(|row| row.get("id").and_then(Value::as_str) != Some(id));
+            let deleted = entry_rows.len() != before;
+            if let Some(previous) = previous.as_ref().filter(|_| deleted) {
+                sync_linked_character_books_for_entry_rows_in_place(
+                    character_rows,
+                    entry_rows,
+                    &[previous],
+                )?;
+            }
+            Ok(deleted)
+        },
+    )
+}
+
+fn lorebook_entry_atomic_rows<'a>(
+    collections: &'a mut [marinara_storage::AtomicCollectionRows],
+) -> Result<(&'a mut Vec<Value>, &'a mut Vec<Value>), AppError> {
+    let [left, right] = collections else {
+        return Err(AppError::new(
+            "storage_error",
+            "Lorebook entry sync expected lorebook and character collections",
+        ));
+    };
+    match (left.collection(), right.collection()) {
+        ("lorebook-entries", "characters") => Ok((left.rows_mut(), right.rows_mut())),
+        _ => Err(AppError::new(
+            "storage_error",
+            "Lorebook entry sync received unexpected collections",
+        )),
+    }
+}
+
+fn sync_linked_character_books_for_entry_rows_in_place(
+    character_rows: &mut [Value],
+    all_entry_rows: &[Value],
     entries: &[&Value],
 ) -> Result<(), AppError> {
     let lorebook_ids = entries
@@ -971,21 +1085,25 @@ fn sync_linked_character_books_for_entry_rows(
         .filter_map(|entry| lorebook_entry_lorebook_id(entry))
         .collect::<HashSet<_>>();
     for lorebook_id in lorebook_ids {
-        sync_linked_character_books_for_lorebook(state, lorebook_id)?;
+        sync_linked_character_books_for_lorebook_in_place(
+            character_rows,
+            all_entry_rows,
+            lorebook_id,
+        )?;
     }
     Ok(())
 }
 
-fn sync_linked_character_books_for_lorebook(
-    state: &AppState,
+fn sync_linked_character_books_for_lorebook_in_place(
+    character_rows: &mut [Value],
+    all_entry_rows: &[Value],
     lorebook_id: &str,
 ) -> Result<(), AppError> {
-    let mut filters = Map::new();
-    filters.insert(
-        "lorebookId".to_string(),
-        Value::String(lorebook_id.to_string()),
-    );
-    let mut entries = state.storage.list_where("lorebook-entries", &filters)?;
+    let mut entries = all_entry_rows
+        .iter()
+        .filter(|entry| lorebook_entry_lorebook_id(entry) == Some(lorebook_id))
+        .cloned()
+        .collect::<Vec<_>>();
     entries.sort_by(|left, right| {
         compare_json_values(
             left.get("sortOrder").or_else(|| left.get("order")),
@@ -994,7 +1112,7 @@ fn sync_linked_character_books_for_lorebook(
         .then_with(|| compare_json_values(left.get("createdAt"), right.get("createdAt")))
     });
 
-    for character in state.storage.list("characters")? {
+    for character in character_rows {
         let Some(character_id) = character.get("id").and_then(Value::as_str) else {
             continue;
         };
@@ -1005,11 +1123,15 @@ fn sync_linked_character_books_for_lorebook(
         let Some(data_object) = data.as_object_mut() else {
             continue;
         };
-        let mut book = data_object
-            .get("character_book")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
+        let mut book = match data_object.get("character_book") {
+            Some(Value::Null) | None => Map::new(),
+            Some(Value::Object(book)) => book.clone(),
+            Some(_) => {
+                return Err(AppError::invalid_input(format!(
+                    "Character {character_id} has a malformed embedded lorebook"
+                )));
+            }
+        };
         book.insert(
             "entries".to_string(),
             Value::Array(
@@ -1029,9 +1151,13 @@ fn sync_linked_character_books_for_lorebook(
             import_metadata.insert("entriesImported".to_string(), json!(entries.len()));
             import_metadata.insert("hasEmbeddedLorebook".to_string(), Value::Bool(true));
         }
-        state
-            .storage
-            .patch("characters", character_id, json!({ "data": data }))?;
+        let Some(character_object) = character.as_object_mut() else {
+            return Err(AppError::invalid_input(
+                "Stored character record is not an object",
+            ));
+        };
+        character_object.insert("data".to_string(), data);
+        character_object.insert("updatedAt".to_string(), Value::String(now_iso()));
     }
     Ok(())
 }
@@ -1063,6 +1189,7 @@ fn linked_character_book_entry(entry: &Value, index: usize) -> Value {
 fn linked_character_book_position(value: Option<&Value>) -> &'static str {
     match value {
         Some(Value::String(raw)) if raw == "after_char" => "after_char",
+        Some(Value::Number(raw)) if raw.as_i64() == Some(1) => "after_char",
         _ => "before_char",
     }
 }
@@ -1549,6 +1676,14 @@ mod tests {
             .expect("character book should have an entry")
     }
 
+    fn entry_exists(state: &AppState, id: &str) -> bool {
+        state
+            .storage
+            .get("lorebook-entries", id)
+            .expect("entry lookup should not fail")
+            .is_some()
+    }
+
     fn cleanup_registered(collection: &str, cleanup: contracts::DeleteCleanup) -> bool {
         contracts::collection_contract(collection)
             .expect("collection should be registered")
@@ -1592,6 +1727,75 @@ mod tests {
             entry.get("position").and_then(Value::as_str),
             Some("after_char")
         );
+    }
+
+    #[test]
+    fn numeric_after_char_position_syncs_to_character_book() {
+        let state = test_state("linked-character-book-numeric-position");
+        seed_linked_character_book(&state);
+
+        storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "lorebookId": "linked-book",
+                "name": "Depth",
+                "content": "numeric position",
+                "keys": ["depth"],
+                "position": 1
+            }),
+        )
+        .expect("entry create should sync numeric position");
+
+        let entry = first_character_book_entry(&state);
+        assert_eq!(
+            entry.get("position").and_then(Value::as_str),
+            Some("after_char")
+        );
+    }
+
+    #[test]
+    fn linked_lorebook_entry_create_is_atomic_when_character_book_sync_fails() {
+        let state = test_state("linked-character-book-entry-create-atomic");
+        seed_linked_character_book(&state);
+        state
+            .storage
+            .patch(
+                "characters",
+                "character-1",
+                json!({
+                    "data": {
+                        "name": "Mira",
+                        "character_book": "malformed",
+                        "extensions": {
+                            "importMetadata": {
+                                "embeddedLorebook": {
+                                    "hasEmbeddedLorebook": true,
+                                    "lorebookId": "linked-book",
+                                    "entriesImported": 1
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("malformed linked character book should seed");
+
+        let error = storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "id": "entry-atomic",
+                "lorebookId": "linked-book",
+                "name": "Atomic",
+                "content": "should not persist",
+                "keys": ["atomic"]
+            }),
+        )
+        .expect_err("malformed linked character book should reject the entry create");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(!entry_exists(&state, "entry-atomic"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1057,9 +1057,9 @@ fn delete_lorebook_entry_with_character_book_sync(
     )
 }
 
-fn lorebook_entry_atomic_rows<'a>(
-    collections: &'a mut [marinara_storage::AtomicCollectionRows],
-) -> Result<(&'a mut Vec<Value>, &'a mut Vec<Value>), AppError> {
+fn lorebook_entry_atomic_rows(
+    collections: &mut [marinara_storage::AtomicCollectionRows],
+) -> Result<(&mut Vec<Value>, &mut Vec<Value>), AppError> {
     let [left, right] = collections else {
         return Err(AppError::new(
             "storage_error",


### PR DESCRIPTION
## Linked issue

Closes #2158

## Why this change

- Linked lorebooks imported from embedded character books were edited as standalone lorebooks, but the character's `data.character_book` was not mirrored after entry create/update/delete. The character editor could reopen stale embedded entries and exports could carry stale data.

## What changed

- Synced linked embedded `character_book.entries` after `lorebook-entries` create, update, move, and delete mutations.
- Translated standalone lorebook entry fields back to the embedded character-book shape, including `secondary_keys` and `insertion_order`.
- Added Rust coverage for create, update, move-away, and delete sync behavior.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Generic storage create/update/delete command paths
- Character embedded lorebook metadata
- Lorebook entry field mapping used by the character editor

Boundary notes:

- Fix lives in privileged storage because persisted character data must stay in sync for every caller, not only the React lorebook editor. No React, shared API, or remote-runtime command shape changes.

Pressure points touched:

- none

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml linked_lorebook_entry`
- `cargo test --manifest-path src-tauri/Cargo.toml moving_entry_out_of_linked_lorebook`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing linked embedded lorebook behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A, storage sync behavior covered by Rust command tests.
