### PR TITLE
Fix character version history ordering

### DIFF
--- a/src/features/catalog/characters/hooks/use-characters.test.tsx
+++ b/src/features/catalog/characters/hooks/use-characters.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { storageApi } from "../../../../shared/api/storage-api";
+import { useCharacterVersions } from "./use-characters";
+
+vi.mock("../../../../shared/api/character-api", () => ({
+  characterApi: {
+    removeAvatar: vi.fn(),
+    restoreVersion: vi.fn(),
+    update: vi.fn(),
+    uploadAvatar: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/image-generation-api", () => ({
+  galleryApi: {
+    uploadCharacter: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/local-file-api", () => ({
+  resolveGalleryFileUrl: vi.fn(),
+}));
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: {
+    create: vi.fn(),
+    delete: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../../../../shared/api/storage-commands-api", () => ({
+  storageCommandsApi: {
+    duplicate: vi.fn(),
+  },
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function CharacterVersionsHarness({ characterId }: { characterId: string }) {
+  useCharacterVersions(characterId);
+  return null;
+}
+
+describe("useCharacterVersions", () => {
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.mocked(storageApi.list).mockResolvedValue([]);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("requests character versions newest first", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CharacterVersionsHarness characterId="character-1" />
+        </QueryClientProvider>,
+      );
+    });
+
+    await vi.waitFor(() => expect(storageApi.list).toHaveBeenCalled());
+
+    expect(storageApi.list).toHaveBeenCalledWith("character-versions", {
+      filters: { characterId: "character-1" },
+      orderBy: "createdAt",
+      descending: true,
+    });
+  });
+});

--- a/src/features/catalog/characters/hooks/use-characters.test.tsx
+++ b/src/features/catalog/characters/hooks/use-characters.test.tsx
@@ -44,7 +44,7 @@ vi.mock("../../../../shared/api/storage-commands-api", () => ({
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-function CharacterVersionsHarness({ characterId }: { characterId: string }) {
+function CharacterVersionsHarness({ characterId }: { characterId: string | null }) {
   useCharacterVersions(characterId);
   return null;
 }
@@ -93,5 +93,17 @@ describe("useCharacterVersions", () => {
       orderBy: "createdAt",
       descending: true,
     });
+  });
+
+  it("waits for a character id before requesting versions", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CharacterVersionsHarness characterId={null} />
+        </QueryClientProvider>,
+      );
+    });
+
+    expect(storageApi.list).not.toHaveBeenCalled();
   });
 });

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -310,7 +310,12 @@ export function useUpdateCharacter() {
 export function useCharacterVersions(id: string | null) {
   return useQuery({
     queryKey: characterKeys.versions(id ?? ""),
-    queryFn: () => storageApi.list<CharacterCardVersion>("character-versions", { filters: { characterId: id } }),
+    queryFn: () =>
+      storageApi.list<CharacterCardVersion>("character-versions", {
+        filters: { characterId: id },
+        orderBy: "createdAt",
+        descending: true,
+      }),
     enabled: !!id,
     staleTime: 60_000,
   });


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2129

## Why this change

- Character version history on refactor was requesting `character-versions` with only a `characterId` filter, so the generic storage list path kept its default ascending `createdAt` sort. That made older snapshots appear before newer snapshots, unlike legacy.

## What changed

- Updated `useCharacterVersions` to request `orderBy: "createdAt"` and `descending: true`.
- Added a focused hook regression test that verifies the version-history query preserves the character filter while requesting newest-first ordering.

## Refactor impact

Primary owner:

- Catalog characters

Impact areas reviewed:

- Catalog character editor version history hook
- Shared storage API list options contract
- Tauri generic storage list ordering behavior

Boundary notes:

- The fix stays in the feature consumer. It does not change generic storage defaults or Rust storage behavior for other entities.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the issue with `pnpm test src/features/catalog/characters/hooks/use-characters.test.tsx`; the test failed before the fix because the hook called `storageApi.list` without `orderBy` or `descending`.
- Codex reran `pnpm test src/features/catalog/characters/hooks/use-characters.test.tsx` after the fix; it passed.
- Codex ran `pnpm typecheck`; it passed.
- Codex ran `pnpm check`; it passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\issue-2129-bugfix-verification.json`; it passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] NA because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This is a non-UI ordering request fix in the character version-history hook; verification is the command output and full repo gate above.
