### PR TITLE
Preserve managed image references

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -522,7 +522,7 @@ fn gallery_defaults_for_create(state: &AppState, value: Value) -> Result<Value, 
         .get("url")
         .and_then(Value::as_str)
         .map(str::trim)
-        .filter(|value| value.starts_with("data:image/"))
+        .filter(|value| media_uploads::is_inline_image_data_url(value))
         .map(str::to_string)
     else {
         return Ok(Value::Object(object));
@@ -550,7 +550,7 @@ fn gallery_create_persists_inline_image(entity: &str, value: &Value) -> bool {
             .get("url")
             .and_then(Value::as_str)
             .map(str::trim)
-            .is_some_and(|value| value.starts_with("data:image/"))
+            .is_some_and(media_uploads::is_inline_image_data_url)
 }
 
 fn connection_folder_defaults_for_create(
@@ -1989,7 +1989,7 @@ mod tests {
     fn gallery_create_persists_data_url_as_managed_file() {
         let state = test_state("gallery-create-managed-file");
         let image =
-            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lTmZsgAAAABJRU5ErkJggg==";
+            "DaTa:Image/PNG;BaSe64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lTmZsgAAAABJRU5ErkJggg==";
 
         let created = storage_create_inner(
             &state,
@@ -2009,7 +2009,7 @@ mod tests {
             .and_then(Value::as_str)
             .expect("gallery url should be present");
         assert!(
-            !url.starts_with("data:image/"),
+            !url.to_ascii_lowercase().starts_with("data:image/"),
             "gallery rows should not store inline image data"
         );
         let filename = created

--- a/src-tauri/src/commands/storage/imports/marinara_assets.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_assets.rs
@@ -79,7 +79,7 @@ fn restore_sprites_for_owner(
             .get("data")
             .or_else(|| sprite.get("url"))
             .and_then(Value::as_str)
-            .filter(|value| value.starts_with("data:image/"))
+            .filter(|value| is_inline_image_data_url(value))
         else {
             continue;
         };
@@ -126,7 +126,7 @@ pub(super) fn restore_character_gallery(
             .get("data")
             .or_else(|| item.get("url"))
             .and_then(Value::as_str)
-            .filter(|value| value.starts_with("data:image/"))
+            .filter(|value| is_inline_image_data_url(value))
         else {
             continue;
         };

--- a/src-tauri/src/commands/storage/imports/marinara_helpers.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_helpers.rs
@@ -11,7 +11,7 @@ pub(super) fn data_string_name(record: &Value) -> Option<String> {
 pub(super) fn data_image_string(value: Option<&Value>) -> Option<String> {
     value
         .and_then(Value::as_str)
-        .filter(|value| value.starts_with("data:image/"))
+        .filter(|value| is_inline_image_data_url(value))
         .map(ToOwned::to_owned)
 }
 

--- a/src-tauri/src/commands/storage/imports/payloads.rs
+++ b/src-tauri/src/commands/storage/imports/payloads.rs
@@ -140,7 +140,7 @@ pub(super) fn image_mime_from_path(path: &str) -> &'static str {
 }
 
 fn resolve_charx_asset(bytes: &[u8], uri: &str, ext: Option<&str>) -> AppResult<Option<String>> {
-    if uri.starts_with("data:image/") {
+    if is_inline_image_data_url(uri) {
         return Ok(Some(uri.to_string()));
     }
     let zip_path = if let Some(path) = uri.strip_prefix("embeded://") {

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -1,6 +1,6 @@
 use super::super::media_uploads::{
-    decode_image_payload, extension_for_image_mime, persist_image_bytes, persist_image_file_copy,
-    safe_filename, unique_file_path,
+    decode_image_payload, extension_for_image_mime, is_inline_image_data_url, persist_image_bytes,
+    persist_image_file_copy, safe_filename, unique_file_path,
 };
 use super::super::shared::*;
 use super::super::*;
@@ -301,7 +301,7 @@ fn imported_avatar_reference_in_folder(
     let Some(value) = payload.get("_avatarDataUrl").and_then(Value::as_str) else {
         return Ok(None);
     };
-    if !value.starts_with("data:image/") {
+    if !is_inline_image_data_url(value) {
         return Ok(None);
     }
     let (mime, bytes) = decode_image_payload(value, "avatar")?;

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -246,6 +246,49 @@ fn import_st_character_rolls_back_character_and_avatar_when_embedded_lorebook_fa
 }
 
 #[test]
+fn import_st_character_materializes_mixed_case_inline_avatar() {
+    let app_root = temp_path("mixed-case-avatar");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+
+    let result = import_st_character(
+        &state,
+        json!({
+            "spec": "chara_card_v2",
+            "data": {
+                "name": "Mixed Case Avatar",
+                "description": "Uses a mixed-case data URL prefix"
+            },
+            "_avatarDataUrl": format!("DaTa:Image/PNG;BaSe64,{TINY_PNG}")
+        }),
+    )
+    .expect("mixed-case inline avatar should import");
+
+    let character = result
+        .get("character")
+        .and_then(Value::as_object)
+        .expect("import should return a character record");
+    let avatar_path = character
+        .get("avatarPath")
+        .and_then(Value::as_str)
+        .expect("managed avatar URL should be stored");
+    assert!(
+        !avatar_path.to_ascii_lowercase().starts_with("data:image/"),
+        "mixed-case inline avatars should be stored as managed files"
+    );
+    let avatar_file_path = character
+        .get("avatarFilePath")
+        .and_then(Value::as_str)
+        .expect("managed avatar file path should be stored");
+    assert!(
+        Path::new(avatar_file_path).exists(),
+        "managed avatar file should exist"
+    );
+
+    let _ = fs::remove_dir_all(app_root);
+}
+
+#[test]
 fn import_st_preset_rolls_back_prompt_tree_when_section_flush_fails() {
     let app_root = temp_path("st-preset-rollback");
     let state =

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -109,6 +109,13 @@ pub(crate) fn file_path_asset_url(path: &Path) -> String {
     }
 }
 
+pub(crate) fn is_inline_image_data_url(value: &str) -> bool {
+    value
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("data:image/")
+}
+
 fn percent_encode_asset_path(value: &str) -> String {
     let mut encoded = String::new();
     for byte in value.as_bytes() {
@@ -217,9 +224,12 @@ fn is_path_inside_dir(path: &Path, dir: &Path) -> AppResult<bool> {
 
 pub(crate) fn decode_image_payload(value: &str, field_name: &str) -> AppResult<(String, Vec<u8>)> {
     if let Some((header, payload)) = value.split_once(',') {
-        if header.starts_with("data:") {
-            let mime = header
-                .trim_start_matches("data:")
+        let header = header.trim_start();
+        if header
+            .get(..5)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:"))
+        {
+            let mime = header[5..]
                 .split(';')
                 .next()
                 .filter(|value| !value.trim().is_empty())
@@ -415,6 +425,17 @@ mod tests {
 
         assert_eq!(mime, "image/png");
         assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn decode_image_payload_accepts_case_variant_data_header() {
+        let (mime, bytes) =
+            decode_image_payload(&format!("DaTa:Image/PNG;BaSe64,{TINY_PNG}"), "avatar")
+                .expect("case-variant data URL payload should decode");
+
+        assert_eq!(mime, "Image/PNG");
+        assert!(!bytes.is_empty());
+        assert!(is_inline_image_data_url("DaTa:Image/PNG;BaSe64,abc"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -110,10 +110,12 @@ pub(crate) fn file_path_asset_url(path: &Path) -> String {
 }
 
 pub(crate) fn is_inline_image_data_url(value: &str) -> bool {
+    const DATA_IMAGE_PREFIX: &[u8] = b"data:image/";
     value
         .trim_start()
-        .to_ascii_lowercase()
-        .starts_with("data:image/")
+        .as_bytes()
+        .get(..DATA_IMAGE_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(DATA_IMAGE_PREFIX))
 }
 
 fn percent_encode_asset_path(value: &str) -> String {

--- a/src-tauri/src/commands/storage/startup_migrations.rs
+++ b/src-tauri/src/commands/storage/startup_migrations.rs
@@ -1,7 +1,7 @@
 use super::{
     media_uploads::{
-        decode_image_payload, extension_for_image_mime, file_path_asset_url, safe_filename,
-        unique_file_path,
+        decode_image_payload, extension_for_image_mime, file_path_asset_url,
+        is_inline_image_data_url, safe_filename, unique_file_path,
     },
     message_swipes,
 };
@@ -622,13 +622,6 @@ fn inline_image_string(value: Option<&Value>) -> Option<String> {
     } else {
         None
     }
-}
-
-fn is_inline_image_data_url(value: &str) -> bool {
-    value
-        .trim_start()
-        .to_ascii_lowercase()
-        .starts_with("data:image/")
 }
 
 fn persist_inline_image_reference(

--- a/src/engine/contracts/types/game.ts
+++ b/src/engine/contracts/types/game.ts
@@ -125,6 +125,8 @@ export interface GameNpc {
   notes: string[];
   /** Optional avatar URL (generated or uploaded) */
   avatarUrl?: string | null;
+  /** Gallery row for a generated NPC portrait, used to rebuild provider reference images. */
+  avatarGalleryId?: string | null;
 }
 
 // ── Sessions ──

--- a/src/engine/contracts/types/scene.ts
+++ b/src/engine/contracts/types/scene.ts
@@ -235,7 +235,7 @@ export interface SceneAnalysis {
   /** Generated illustration background tag, populated when available. */
   generatedIllustration?: GeneratedSceneIllustration | null;
   /** NPC avatars generated during this scene wrap. */
-  generatedNpcAvatars?: Array<{ name: string; avatarUrl: string }>;
+  generatedNpcAvatars?: Array<{ name: string; avatarUrl: string; avatarGalleryId?: string | null }>;
 }
 
 /** A single widget update from scene analysis. */

--- a/src/engine/generation/connected-commands.ts
+++ b/src/engine/generation/connected-commands.ts
@@ -470,9 +470,10 @@ async function generateSelfie(args: {
       width: size.width,
       height: size.height,
     });
+    const storedImageUrl = readString(gallery.url).trim() || imageUrl;
     const attachment = {
       type: "image",
-      url: imageUrl,
+      url: storedImageUrl,
       filename: `selfie_${characterName.toLowerCase().replace(/\s+/g, "_")}.${imageExtension(mimeType)}`,
       prompt,
       galleryId: readString(gallery.id) || null,
@@ -483,7 +484,7 @@ async function generateSelfie(args: {
       data: {
         characterId,
         characterName,
-        imageUrl,
+        imageUrl: storedImageUrl,
         prompt,
         galleryId: readString(gallery.id) || null,
       },

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -768,9 +768,10 @@ async function generateIllustrationAttachments(args: {
           referenceData.referenceSubjectNames.length > 0 ? referenceData.referenceSubjectNames : item.characterNames,
         referenceImageCount: referenceData.referenceImages.length,
       });
+      const storedImageUrl = readString(gallery.url).trim() || imageUrl;
       const attachment = {
         type: "image",
-        url: imageUrl,
+        url: storedImageUrl,
         filename,
         prompt,
         galleryId: readString(gallery.id) || null,
@@ -779,7 +780,7 @@ async function generateIllustrationAttachments(args: {
       events.push({
         type: "illustration",
         data: {
-          imageUrl,
+          imageUrl: storedImageUrl,
           prompt,
           reason: item.reason,
           galleryId: readString(gallery.id) || null,

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -28,7 +28,9 @@ import { integrationGateway } from "../../../../shared/api/integration-gateway";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { llmApi } from "../../../../shared/api/llm-api";
 import { chatCommandApi } from "../../../../shared/api/chat-command-api";
+import { resolveGalleryFileUrl } from "../../../../shared/api/local-file-api";
 import { storageApi } from "../../../../shared/api/storage-api";
+import { urlBinaryApi } from "../../../../shared/api/url-binary-api";
 import {
   createLorebookEntrySchema,
   createLorebookSchema,
@@ -188,7 +190,7 @@ export interface GameAssetGenerationResult {
   generatedBackground: string | null;
   fallbackBackground: string | null;
   generatedIllustration: { tag: string; segment?: number; galleryId?: string | null } | null;
-  generatedNpcAvatars: Array<{ name: string; avatarUrl: string }>;
+  generatedNpcAvatars: Array<{ name: string; avatarUrl: string; avatarGalleryId?: string | null }>;
   sessionChat?: Chat;
 }
 
@@ -1402,6 +1404,53 @@ function usableReferenceImage(value: unknown): string {
   return "";
 }
 
+function isManagedLocalAssetUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("http://asset.localhost/") || normalized.startsWith("asset://localhost/");
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => reject(reader.error ?? new Error("Could not read image reference data."));
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function managedImageReferenceDataUrl(value: string): Promise<string> {
+  if (!isManagedLocalAssetUrl(value)) return "";
+  const blob = await urlBinaryApi.load(value, "image/png");
+  if (blob.type && !blob.type.toLowerCase().startsWith("image/")) return "";
+  return blobToDataUrl(blob);
+}
+
+async function providerReferenceImage(value: unknown): Promise<string> {
+  const direct = usableReferenceImage(value);
+  if (direct) return direct;
+  const text = readTrimmed(value);
+  if (!text) return "";
+  return managedImageReferenceDataUrl(text).catch(() => "");
+}
+
+async function galleryReferenceImage(galleryId: unknown): Promise<string> {
+  const id = readTrimmed(galleryId);
+  if (!id) return "";
+  const gallery = await storageApi.get<Record<string, unknown>>("gallery", id).catch(() => null);
+  if (!gallery) return "";
+  const direct = await providerReferenceImage(gallery.url);
+  if (direct) return direct;
+  const resolved = await resolveGalleryFileUrl(readTrimmed(gallery.filename), readTrimmed(gallery.filePath)).catch(
+    () => null,
+  );
+  return resolved ? providerReferenceImage(resolved) : "";
+}
+
+async function npcReferenceImage(npc: Record<string, unknown>): Promise<string> {
+  const direct = await providerReferenceImage(npc.avatarUrl ?? npc.avatar ?? npc.image);
+  return direct || galleryReferenceImage(npc.avatarGalleryId ?? npc.galleryId);
+}
+
 function recordName(record: Record<string, unknown>): string {
   const data = asRecord(record.data);
   return readTrimmed(data.name) || readTrimmed(record.name);
@@ -1495,7 +1544,7 @@ async function loadIllustrationReferenceSubjects(
 
   const npcs = Array.isArray(meta.gameNpcs) ? (meta.gameNpcs as Array<Record<string, unknown>>) : [];
   for (const npc of npcs) {
-    const avatar = usableReferenceImage(npc.avatarUrl ?? npc.avatar ?? npc.image);
+    const avatar = await npcReferenceImage(npc);
     if (!avatar) continue;
     subjects.push({
       id: readTrimmed(npc.id) || readTrimmed(npc.name),
@@ -2837,9 +2886,30 @@ export const gameApi = {
           gameLastIllustrationTag: tag,
         });
       } else if (item.kind === "portrait") {
+        const npcName = item.title.replace(/^Portrait:\s*/, "") || "NPC";
+        const mimeType = image.mimeType || "image/png";
+        const imageUrl = imageUrlFromGeneration(image);
+        if (!imageUrl) throw new Error("Image provider returned no image data.");
+        const filename = `${generatedAssetSlug(npcName)}.${imageExt(mimeType)}`;
+        const gallery = await storageApi.create<{ id?: string; url?: string }>("gallery", {
+          chatId,
+          filePath: filename,
+          filename,
+          url: imageUrl,
+          prompt: item.prompt,
+          provider: image.provider ?? "image_generation",
+          model: image.model ?? null,
+          width: item.width,
+          height: item.height,
+          kind: "portrait",
+          characters: [npcName],
+        });
+        const storedImageUrl = readTrimmed(gallery?.url) || imageUrl;
+        const avatarGalleryId = readTrimmed(gallery?.id) || null;
         generatedNpcAvatars.push({
-          name: item.title.replace(/^Portrait:\s*/, "") || "NPC",
-          avatarUrl: image.image ?? `data:${image.mimeType};base64,${image.base64}`,
+          name: npcName,
+          avatarUrl: storedImageUrl,
+          avatarGalleryId,
         });
       }
     }
@@ -2850,7 +2920,10 @@ export const gameApi = {
       for (const avatar of generatedNpcAvatars) {
         const existing = npcs.find((npc) => npc.name.toLowerCase() === avatar.name.toLowerCase());
         if (existing) {
-          (existing as GameNpc & { avatarUrl?: string }).avatarUrl = avatar.avatarUrl;
+          (existing as GameNpc & { avatarUrl?: string; avatarGalleryId?: string | null }).avatarUrl =
+            avatar.avatarUrl;
+          (existing as GameNpc & { avatarGalleryId?: string | null }).avatarGalleryId =
+            avatar.avatarGalleryId ?? null;
         } else {
           npcs.push({
             id: newId("npc"),
@@ -2862,6 +2935,7 @@ export const gameApi = {
             met: true,
             notes: [],
             avatarUrl: avatar.avatarUrl,
+            avatarGalleryId: avatar.avatarGalleryId ?? null,
           } as GameNpc);
         }
       }

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1409,6 +1409,16 @@ function isManagedLocalAssetUrl(value: string): boolean {
   return normalized.startsWith("http://asset.localhost/") || normalized.startsWith("asset://localhost/");
 }
 
+function isBrowserFetchableImageReferenceUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("blob:");
+}
+
+function isRemoteImageReferenceUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized.startsWith("http://") || normalized.startsWith("https://");
+}
+
 function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -1418,19 +1428,28 @@ function blobToDataUrl(blob: Blob): Promise<string> {
   });
 }
 
-async function managedImageReferenceDataUrl(value: string): Promise<string> {
-  if (!isManagedLocalAssetUrl(value)) return "";
+async function blobImageReferenceDataUrl(value: string): Promise<string> {
+  const response = await fetch(value);
+  if (!response.ok) return "";
+  const blob = await response.blob();
+  if (blob.type && !blob.type.toLowerCase().startsWith("image/")) return "";
+  return blobToDataUrl(blob);
+}
+
+async function managedImageReferenceDataUrl(value: string, allowResolvedUrl = false): Promise<string> {
+  if (allowResolvedUrl && isBrowserFetchableImageReferenceUrl(value)) return blobImageReferenceDataUrl(value);
+  if (!isManagedLocalAssetUrl(value) && !(allowResolvedUrl && isRemoteImageReferenceUrl(value))) return "";
   const blob = await urlBinaryApi.load(value, "image/png");
   if (blob.type && !blob.type.toLowerCase().startsWith("image/")) return "";
   return blobToDataUrl(blob);
 }
 
-async function providerReferenceImage(value: unknown): Promise<string> {
+async function providerReferenceImage(value: unknown, allowResolvedUrl = false): Promise<string> {
   const direct = usableReferenceImage(value);
   if (direct) return direct;
   const text = readTrimmed(value);
   if (!text) return "";
-  return managedImageReferenceDataUrl(text).catch(() => "");
+  return managedImageReferenceDataUrl(text, allowResolvedUrl).catch(() => "");
 }
 
 async function galleryReferenceImage(galleryId: unknown): Promise<string> {
@@ -1443,7 +1462,7 @@ async function galleryReferenceImage(galleryId: unknown): Promise<string> {
   const resolved = await resolveGalleryFileUrl(readTrimmed(gallery.filename), readTrimmed(gallery.filePath)).catch(
     () => null,
   );
-  return resolved ? providerReferenceImage(resolved) : "";
+  return resolved ? providerReferenceImage(resolved, true) : "";
 }
 
 async function npcReferenceImage(npc: Record<string, unknown>): Promise<string> {
@@ -2920,10 +2939,8 @@ export const gameApi = {
       for (const avatar of generatedNpcAvatars) {
         const existing = npcs.find((npc) => npc.name.toLowerCase() === avatar.name.toLowerCase());
         if (existing) {
-          (existing as GameNpc & { avatarUrl?: string; avatarGalleryId?: string | null }).avatarUrl =
-            avatar.avatarUrl;
-          (existing as GameNpc & { avatarGalleryId?: string | null }).avatarGalleryId =
-            avatar.avatarGalleryId ?? null;
+          existing.avatarUrl = avatar.avatarUrl;
+          existing.avatarGalleryId = avatar.avatarGalleryId ?? null;
         } else {
           npcs.push({
             id: newId("npc"),

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -213,7 +213,7 @@ type GameAssetGenerationResult = {
   generatedBackground: string | null;
   fallbackBackground?: string | null;
   generatedIllustration: { tag: string; segment?: number } | null;
-  generatedNpcAvatars: Array<{ name: string; avatarUrl: string }>;
+  generatedNpcAvatars: Array<{ name: string; avatarUrl: string; avatarGalleryId?: string | null }>;
   sessionChat?: Chat;
 };
 

--- a/src/features/modes/game/stores/game-mode.store.ts
+++ b/src/features/modes/game/stores/game-mode.store.ts
@@ -277,20 +277,34 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
     }),
   setNpcs: (npcs) =>
     set((s) => {
-      // Preserve existing avatarUrls: the incoming list may come from a stale
+      // Preserve existing avatar metadata: the incoming list may come from a stale
       // chat-metadata cache that predates a recent /generate-assets call. If
-      // we already have an avatarUrl for an NPC and the incoming record is
-      // missing one, keep ours rather than clobbering it to null.
-      const existingByName = new Map<string, string>();
+      // we already have an avatar for an NPC and the incoming record is
+      // missing it, keep ours rather than severing managed gallery linkage.
+      const existingByName = new Map<
+        string,
+        { avatarUrl: string | null; avatarGalleryId: string | null | undefined }
+      >();
       for (const existing of s.npcs) {
-        if (existing.avatarUrl && existing.name) {
-          existingByName.set(existing.name.toLowerCase(), existing.avatarUrl);
+        if (existing.name) {
+          existingByName.set(existing.name.toLowerCase(), {
+            avatarUrl: existing.avatarUrl ?? null,
+            avatarGalleryId: existing.avatarGalleryId,
+          });
         }
       }
       const merged = npcs.map((npc) => {
-        if (npc.avatarUrl) return npc;
         const preserved = existingByName.get((npc.name ?? "").toLowerCase());
-        return preserved ? { ...npc, avatarUrl: preserved } : npc;
+        if (!preserved) return npc;
+        return {
+          ...npc,
+          ...(npc.avatarUrl ? {} : preserved.avatarUrl ? { avatarUrl: preserved.avatarUrl } : {}),
+          ...(npc.avatarGalleryId !== undefined
+            ? {}
+            : preserved.avatarGalleryId !== undefined
+              ? { avatarGalleryId: preserved.avatarGalleryId ?? null }
+              : {}),
+        };
       });
       return { npcs: sanitizeGameNpcAvatarUrls(merged) };
     }),

--- a/src/features/modes/game/stores/game-mode.store.ts
+++ b/src/features/modes/game/stores/game-mode.store.ts
@@ -69,7 +69,7 @@ interface GameModeStore {
   applyWidgetUpdate: (update: WidgetUpdate) => HudWidget[];
   setBlueprint: (bp: GameBlueprint | null) => void;
   /** Patch avatarUrl on tracked NPCs after server-side image generation. */
-  patchNpcAvatars: (avatars: Array<{ name: string; avatarUrl: string }>) => void;
+  patchNpcAvatars: (avatars: Array<{ name: string; avatarUrl: string; avatarGalleryId?: string | null }>) => void;
   reset: () => void;
 }
 
@@ -142,7 +142,7 @@ function removeListWidgetItem(items: string[], target: string): string[] {
   return items.filter((_, index) => index !== partialMatches[0]!.index);
 }
 
-function buildTrackedNpcStub(name: string, avatarUrl: string): GameNpc {
+function buildTrackedNpcStub(name: string, avatarUrl: string, avatarGalleryId?: string | null): GameNpc {
   const slug = name
     .trim()
     .toLowerCase()
@@ -159,6 +159,7 @@ function buildTrackedNpcStub(name: string, avatarUrl: string): GameNpc {
     met: true,
     notes: [],
     avatarUrl,
+    avatarGalleryId: avatarGalleryId ?? null,
   };
 }
 
@@ -298,9 +299,17 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
       let modified = false;
       const nextNpcs = s.npcs.map((npc) => {
         const match = avatars.find((a) => a.name.toLowerCase() === npc.name.toLowerCase());
-        if (match && match.avatarUrl !== npc.avatarUrl) {
+        if (
+          match &&
+          (match.avatarUrl !== npc.avatarUrl ||
+            (match.avatarGalleryId !== undefined && match.avatarGalleryId !== (npc.avatarGalleryId ?? null)))
+        ) {
           modified = true;
-          return { ...npc, avatarUrl: match.avatarUrl };
+          return {
+            ...npc,
+            avatarUrl: match.avatarUrl,
+            ...(match.avatarGalleryId !== undefined ? { avatarGalleryId: match.avatarGalleryId } : {}),
+          };
         }
         return npc; // preserve reference — no churn
       });
@@ -308,7 +317,7 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
       for (const avatar of avatars) {
         const exists = nextNpcs.some((npc) => npc.name.toLowerCase() === avatar.name.toLowerCase());
         if (!exists) {
-          nextNpcs.push(buildTrackedNpcStub(avatar.name, avatar.avatarUrl));
+          nextNpcs.push(buildTrackedNpcStub(avatar.name, avatar.avatarUrl, avatar.avatarGalleryId));
           modified = true;
         }
       }

--- a/src/features/modes/game/stores/game-mode.store.ts
+++ b/src/features/modes/game/stores/game-mode.store.ts
@@ -163,6 +163,12 @@ function buildTrackedNpcStub(name: string, avatarUrl: string, avatarGalleryId?: 
   };
 }
 
+function sameAvatarUrl(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = left?.trim() ?? "";
+  const normalizedRight = right?.trim() ?? "";
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
 function slugifyMapId(value: string): string {
   return value
     .trim()
@@ -296,14 +302,15 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
       const merged = npcs.map((npc) => {
         const preserved = existingByName.get((npc.name ?? "").toLowerCase());
         if (!preserved) return npc;
+        const preserveAvatarUrl = !npc.avatarUrl && Boolean(preserved.avatarUrl);
+        const preserveAvatarGalleryId =
+          npc.avatarGalleryId === undefined &&
+          preserved.avatarGalleryId !== undefined &&
+          (preserveAvatarUrl || sameAvatarUrl(npc.avatarUrl, preserved.avatarUrl));
         return {
           ...npc,
-          ...(npc.avatarUrl ? {} : preserved.avatarUrl ? { avatarUrl: preserved.avatarUrl } : {}),
-          ...(npc.avatarGalleryId !== undefined
-            ? {}
-            : preserved.avatarGalleryId !== undefined
-              ? { avatarGalleryId: preserved.avatarGalleryId ?? null }
-              : {}),
+          ...(preserveAvatarUrl ? { avatarUrl: preserved.avatarUrl } : {}),
+          ...(preserveAvatarGalleryId ? { avatarGalleryId: preserved.avatarGalleryId ?? null } : {}),
         };
       });
       return { npcs: sanitizeGameNpcAvatarUrls(merged) };

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -1486,22 +1486,27 @@ export const ChatMessage = memo(function ChatMessage({
       : (charInfo?.avatarFilename ?? null);
   const [resolvedAvatarUrl, setResolvedAvatarUrl] = useState<string | null>(null);
   useEffect(() => {
-    let cancelled = false;
     setResolvedAvatarUrl(null);
-    if (!avatarFilePath && !avatarFilename) return undefined;
-    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
-      .then((url) => {
-        if (!cancelled) setResolvedAvatarUrl(url);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
   }, [avatarFilePath, avatarFilename, avatarUrl]);
-  const avatarLightboxUrl = resolvedAvatarUrl ?? avatarUrl;
   const handleResolvedAvatarSrc = useCallback((src: string | null) => {
     setResolvedAvatarUrl(src);
   }, []);
+  const openAvatarLightbox = useCallback(() => {
+    const fallback = resolvedAvatarUrl ?? avatarUrl;
+    if (!avatarFilePath && !avatarFilename) {
+      if (fallback) openImageLightbox(fallback);
+      return;
+    }
+    resolveAvatarFileUrl(avatarFilename, avatarFilePath)
+      .then((url) => {
+        const next = url ?? fallback;
+        if (url) setResolvedAvatarUrl(url);
+        if (next) openImageLightbox(next);
+      })
+      .catch(() => {
+        if (fallback) openImageLightbox(fallback);
+      });
+  }, [avatarFilePath, avatarFilename, avatarUrl, openImageLightbox, resolvedAvatarUrl]);
   const personaAvatarCrop = isUser
     ? msgPersona
       ? parseAvatarCropJson(msgPersona.avatarCrop)
@@ -1580,22 +1585,7 @@ export const ChatMessage = memo(function ChatMessage({
   const mergedAvatarTailRefs = useRef<(HTMLImageElement | null)[]>([]);
   const resolvedMergedAvatarUrlsRef = useRef(new Map<string, string>());
   useEffect(() => {
-    let cancelled = false;
     resolvedMergedAvatarUrlsRef.current.clear();
-    for (const avatar of mergedAvatars) {
-      if (!avatar.avatarFilePath && !avatar.avatarFilename) {
-        resolvedMergedAvatarUrlsRef.current.set(avatar.key, avatar.url);
-        continue;
-      }
-      resolveAvatarFileUrl(avatar.avatarFilename, avatar.avatarFilePath)
-        .then((url) => {
-          if (!cancelled && url) resolvedMergedAvatarUrlsRef.current.set(avatar.key, url);
-        })
-        .catch(() => {});
-    }
-    return () => {
-      cancelled = true;
-    };
   }, [mergedAvatars]);
   const rememberMergedAvatarSrc = useCallback((key: string, src: string | null) => {
     if (src) {
@@ -1605,9 +1595,24 @@ export const ChatMessage = memo(function ChatMessage({
     }
   }, []);
   const openMergedAvatarLightbox = useCallback(
-    (avatar?: { key: string; url: string }) => {
+    (avatar?: MergedAvatar) => {
       if (!avatar) return;
-      openImageLightbox(resolvedMergedAvatarUrlsRef.current.get(avatar.key) ?? avatar.url);
+      const cached = resolvedMergedAvatarUrlsRef.current.get(avatar.key);
+      if (cached) {
+        openImageLightbox(cached);
+        return;
+      }
+      if (!avatar.avatarFilePath && !avatar.avatarFilename) {
+        openImageLightbox(avatar.url);
+        return;
+      }
+      resolveAvatarFileUrl(avatar.avatarFilename, avatar.avatarFilePath)
+        .then((url) => {
+          const next = url ?? avatar.url;
+          if (url) resolvedMergedAvatarUrlsRef.current.set(avatar.key, url);
+          openImageLightbox(next);
+        })
+        .catch(() => openImageLightbox(avatar.url));
     },
     [openImageLightbox],
   );
@@ -2021,7 +2026,7 @@ export const ChatMessage = memo(function ChatMessage({
                       "relative cursor-pointer overflow-hidden ring-2 ring-white/10",
                       compactAvatarFrameClass,
                     )}
-                    onClick={() => avatarLightboxUrl && openImageLightbox(avatarLightboxUrl)}
+                    onClick={openAvatarLightbox}
                     aria-label={`Open ${displayName} avatar`}
                   >
                     <ResolvedAvatarImage
@@ -2170,7 +2175,7 @@ export const ChatMessage = memo(function ChatMessage({
                             "rpg-avatar-panel-media absolute inset-0 block h-full w-full cursor-zoom-in overflow-hidden",
                             !isUser && "rpg-avatar-panel",
                           )}
-                          onClick={() => avatarLightboxUrl && openImageLightbox(avatarLightboxUrl)}
+                          onClick={openAvatarLightbox}
                           aria-label={`Open ${displayName} avatar`}
                         >
                           <ResolvedAvatarImage
@@ -2568,7 +2573,7 @@ export const ChatMessage = memo(function ChatMessage({
               <button
                 type="button"
                 className="relative h-8 w-8 cursor-pointer overflow-hidden rounded-full"
-                onClick={() => avatarLightboxUrl && openImageLightbox(avatarLightboxUrl)}
+                onClick={openAvatarLightbox}
                 aria-label={`Open ${displayName} avatar`}
               >
                 <ResolvedAvatarImage

--- a/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ResolvedAvatarImage.tsx
@@ -112,6 +112,12 @@ export const ResolvedAvatarImage = forwardRef<
     const cachedSrc = readCachedResolvedAvatarSrc(resolutionKey);
     const nextInitialSrc = cachedSrc ?? immediateSrc;
     setResolvedState({ key: resolutionKey, src: nextInitialSrc });
+    if (cachedSrc) {
+      if (!effectiveThumbnailSize) onResolvedSrc?.(cachedSrc);
+      return () => {
+        cancelled = true;
+      };
+    }
     if (nextInitialSrc && !effectiveThumbnailSize) onResolvedSrc?.(nextInitialSrc);
     const resolveSrc = effectiveThumbnailSize
       ? resolveAvatarThumbnailFileUrl(avatarFilename, avatarFilePath, effectiveThumbnailSize, src)


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Inline image handling was still split across a few lowercase-only checks, so mixed-case data URL headers could be skipped or left inline instead of being materialized as managed image files.
- Generated images were persisted through gallery storage, but some downstream message and game paths still kept the original image data URL or could not reuse the managed gallery/local asset URL as a future provider reference.

## What changed

- Centralized inline image detection on the shared Rust storage helper across gallery create, startup migration, Marinara import, ST import, and charx asset paths.
- Made image payload decoding accept case-variant data URL headers and added Rust regression coverage for mixed-case ST avatar imports.
- Stored managed gallery URLs on generated selfie, illustration, and game NPC portrait outputs instead of keeping the transient generated data URL.
- Threaded optional `avatarGalleryId` through game NPC contracts, generation results, and the game mode store so generated NPC portraits remain linked to their gallery rows.
- Resolved managed gallery/local asset URLs back into data URLs when loading game illustration reference subjects.
- Updated shared chat avatar lightbox handling to resolve managed avatar file URLs lazily and reuse cached resolved sources.

## Refactor impact

Primary owner:

Rust storage/imports, engine generation, game mode assets, and shared chat UI.

Impact areas reviewed:

- Gallery create and startup inline-image migration paths.
- ST, Marinara, and charx character/persona avatar import paths.
- Generated image attachment metadata for selfie and illustration commands.
- Game NPC portrait generation, game NPC metadata, and future illustration reference loading.
- Shared transcript avatar rendering and lightbox source resolution.

Boundary notes:

- Feature code continues through focused shared API wrappers (`storageApi`, `urlBinaryApi`, and local file helpers); no raw Tauri invoke or raw remote-runtime fetch was added.
- Engine generation continues to use injected storage/generation ports and now records the managed gallery URL returned by that port.
- Rust changes stay inside storage, imports, media helpers, and tests; no command registry or HTTP dispatch changes.

Pressure points touched:

- `src/features/modes/game/api/game-api.ts` and the game mode store for NPC portrait metadata.
- Shared mode UI avatar components for lightbox source resolution.
- `src-tauri` storage/import modules for inline image detection and decoding.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml import_st_character_materializes_mixed_case_inline_avatar` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed.
- Native Tauri/provider image-generation flow was not run locally; this remains the main manual verification gap.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix and compatibility follow-up only; no new discoverable workflow, setting, mode, panel, or advanced tool was added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes were made because this preserves existing image/import behavior rather than adding a documented command, setting, workflow, or architecture rule.

## UI evidence

No screenshots or recordings captured. The UI-adjacent change is avatar lightbox source resolution, not layout or visual styling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of inline image data URLs with mixed-case prefixes.

* **New Features**
  * NPC avatars now tracked with gallery references for improved asset management.
  * Added support for resolving managed local avatar images.

* **Performance**
  * Avatar URLs now load lazily on-demand with improved caching instead of pre-loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
