### PR TITLE
Fix lorebook overview tag splitting

### DIFF
--- a/src/features/catalog/lorebooks/components/editor/LorebookOverviewTab.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookOverviewTab.tsx
@@ -17,6 +17,21 @@ const CATEGORY_OPTIONS: Array<{ value: LorebookCategory; label: string; icon: ty
 
 type ScopeSummaryLine = { label: string; names: string };
 
+function appendLorebookOverviewTags(tags: readonly string[], rawInput: string): string[] {
+  const nextTags = [...tags];
+  const tagSet = new Set(nextTags);
+  for (const tag of rawInput
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)) {
+    if (!tagSet.has(tag)) {
+      nextTags.push(tag);
+      tagSet.add(tag);
+    }
+  }
+  return nextTags;
+}
+
 export type LorebookOverviewScopeSummary =
   | null
   | { text: string }
@@ -121,9 +136,9 @@ export function LorebookOverviewTab({
   onDirty: () => void;
 }) {
   const addTag = () => {
-    const tag = newTag.trim();
-    if (tag && !tags.includes(tag)) {
-      onTagsChange([...tags, tag]);
+    const nextTags = appendLorebookOverviewTags(tags, newTag);
+    if (nextTags.length !== tags.length) {
+      onTagsChange(nextTags);
       onDirty();
     }
     onNewTagChange("");


### PR DESCRIPTION
## Linked issue

Closes #2190

## Why this change

- The refactor lorebook overview editor treated a comma-separated tag entry such as `npc, city, politics` as one literal tag, regressing legacy behavior that split the input into separate tags.

## What changed

- Added a lorebook overview tag append helper that splits comma-separated input, trims each part, skips blank values, and avoids duplicate tags.
- Routed the existing Enter key and add button path through the same helper so both interactions restore the legacy behavior.

## Refactor impact

Primary owner:

- Catalog lorebook overview editor

Impact areas reviewed:

- Lorebook overview tag input behavior
- Existing add button and Enter key tag submission path

Boundary notes:

- Feature UI-only change in `src/features/catalog/lorebooks/components/editor/LorebookOverviewTab.tsx`; no engine, shared API, Rust, storage, or remote-runtime boundary touched.

Pressure points touched:

- None

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed locally.
- `pnpm exec eslint src/features/catalog/lorebooks/components/editor/LorebookOverviewTab.tsx` passed locally.
- `pnpm check` was attempted but stopped in `pnpm check:line-endings` because existing repo files are currently reported with CRLF line endings in an LF-normalized working tree. This PR did not touch those listed files.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores existing lorebook tag input behavior; does not add a new discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not captured; this is a small input parsing fix verified through the shared add-tag path and local TypeScript/ESLint checks.
