### PR TITLE
Fix managed character gallery export

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2130"
   },
   "pr": {
-    "number": null,
-    "url": null
+    "number": 2203,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2203"
   },
   "coreClaim": "Native character .marinara export embeds managed character-gallery assets so import/export round trips preserve gallery images.",
   "assignment": {

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,60 +1,105 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2128,
-    "title": "Character editor quote formatting misses advanced card fields",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2128"
+    "number": 2130,
+    "title": "Native character export omits managed gallery images",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2130"
   },
   "pr": {
-    "number": 2201,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2201"
+    "number": null,
+    "url": null
   },
-  "coreClaim": "Character editor save formatting normalizes configured quote style for creator notes, system prompt, post-history instructions, and depth prompt text.",
+  "coreClaim": "Native character .marinara export embeds managed character-gallery assets so import/export round trips preserve gallery images.",
   "assignment": {
-    "assignee": "cha1latte",
+    "assignee": "@me",
     "assignedBeforeWork": true,
-    "evidence": "gh issue edit 2128 --repo Pasta-Devs/Marinara-Engine --add-assignee \"@me\" returned the issue URL before reproduction or edits."
+    "assignedToSelf": true
   },
   "preflight": {
     "noAssociatedPr": true,
-    "details": "gh PR search for #2128 and the issue title returned no matches; no local branch or worktree for issue 2128 existed before this run."
+    "details": "No PRs or local issue branches/worktrees were found for #2130 or the issue title before work started.",
+    "base": "upstream/refactor",
+    "worktree": "C:/tmp/Marinara-Engine-issue-2130"
+  },
+  "riskClaimMatrix": {
+    "coreClaim": "Native character .marinara export embeds managed character-gallery assets so import/export round trips preserve gallery images.",
+    "riskType": "import-export compatibility and managed user assets",
+    "entrypoints": [
+      "src-tauri native character export",
+      "src-tauri native character import",
+      "character-gallery managed upload rows",
+      "character gallery delete cleanup"
+    ],
+    "currentPathsOrFormats": [
+      "character-gallery rows with filePath, filename, and asset URL",
+      "native marinara_character envelope data.gallery entries with embedded data URLs"
+    ],
+    "legacyPathsOrFormats": [
+      "character-gallery rows whose url is already an inline data:image value",
+      "native marinara_character envelope data.gallery entries with inline data"
+    ],
+    "positiveRowsTested": [
+      "Managed character-gallery row exports as one embedded data:image gallery entry.",
+      "Native marinara_character import materializes embedded gallery data as a managed gallery asset URL and file.",
+      "Inline legacy gallery row still exports unchanged."
+    ],
+    "negativeRowsTested": [
+      "Missing managed gallery file is skipped instead of exporting a broken asset reference."
+    ],
+    "groundTruthFacts": [
+      "harness-proven: native_character_export_embeds_managed_gallery_assets creates the managed gallery file under AppState.data_dir/gallery and verifies gallery_for_character returns embedded data:image data.",
+      "harness-proven: native_marinara_character_import_materializes_embedded_gallery_assets reads the created character-gallery row and verifies the stored file exists on disk."
+    ],
+    "userActionCopy": [
+      {
+        "action": "copy the exported native .marinara file, and optionally back up the app-owned gallery data before import/export testing",
+        "items": [
+          "*.marinara",
+          "DATA_DIR/gallery",
+          "DATA_DIR/collections/character-gallery.json",
+          "DATA_DIR/collections/characters.json"
+        ],
+        "destination": "a separate folder outside the active Marinara profile data directory",
+        "currentLayouts": [
+          "current managed gallery layout: character-gallery row has filePath, filename, and asset URL; bytes live under DATA_DIR/gallery"
+        ],
+        "legacyLayouts": [
+          "legacy inline gallery layout: character-gallery row url is an inline data:image value"
+        ]
+      }
+    ],
+    "manualBlockers": []
   },
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "method": "Focused Vitest regression test against the formatter model before the production patch.",
-    "evidence": [
-      "pnpm exec vitest run src\\features\\catalog\\characters\\lib\\character-editor-model.test.ts failed before the fix.",
-      "creator_notes returned `Creator says \"draft\".` instead of typographic quotes.",
-      "depth_prompt.prompt returned `Remember \"the signal\".` instead of typographic quotes."
-    ]
+    "command": "cargo test --manifest-path src-tauri\\Cargo.toml gallery_assets -- --nocapture",
+    "evidence": "Before the export fix, storage_commands::exports::tests::native_character_export_embeds_managed_gallery_assets failed because gallery_for_character returned 0 exported gallery items instead of 1 for a managed character-gallery row."
   },
   "verification": {
     "originalReproPassed": true,
+    "command": "cargo test --manifest-path src-tauri\\Cargo.toml gallery -- --nocapture",
+    "evidence": "17 gallery-focused Rust tests passed, including managed native export, inline gallery compatibility, missing-file negative control, native import materialization, and existing gallery delete cleanup tests.",
+    "edgeCases": [
+      "Managed character-gallery asset exports as embedded data:image data.",
+      "Inline legacy gallery data remains exportable.",
+      "Missing managed gallery file is skipped.",
+      "Native marinara_character import materializes embedded gallery data back into managed asset rows.",
+      "Existing gallery row delete and character/chat delete cleanup tests still pass."
+    ],
+    "visualProof": "Backend/storage bug with no meaningful UI state; the actual command proof is recorded in reproduction.evidence and verification.evidence.",
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
-    "baselineEvidence": "pnpm check passed after the final production diff and again after merging upstream/refactor to resolve PR conflicts.",
-    "focusedProof": [
-      "pnpm exec vitest run src\\features\\catalog\\characters\\lib\\character-editor-model.test.ts passed after the fix and Bunny repair.",
-      "pnpm typecheck passed.",
-      "git diff --check passed."
-    ],
-    "edgeCases": [
-      "creator_notes, system_prompt, and post_history_instructions now use typographic quote formatting.",
-      "creator_notes preserves complete <style>...</style> blocks while formatting surrounding prose.",
-      "depth_prompt.prompt now uses typographic quote formatting.",
-      "depth_prompt.depth, depth_prompt.role, and unrelated extension properties are preserved unchanged."
-    ],
-    "visualProof": "scratch/issue-2128-vitest-after.png",
-    "visualProofNotes": "Local screenshot rendered from the raw passing Vitest output in scratch/issue-2128-vitest-after.txt. There is no meaningful app UI state for this formatter-model proof."
+    "baselineEvidence": "pnpm check passed after pnpm install --frozen-lockfile in the isolated worktree.",
+    "laneCheckCommand": "cargo check --manifest-path src-tauri\\Cargo.toml",
+    "laneCheckEvidence": "cargo check passed for the Tauri storage lane."
   },
   "manualBlockers": [],
-  "riskClaimMatrix": null,
+  "notes": [],
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": true,
-    "claimBoundariesProven": true,
-    "notes": "Local proof, pnpm check, proof gate, and Bunny pass are complete. A later Bunny finding about creator-notes CSS was repaired with a focused regression row; the branch was merged with upstream/refactor to clear PR conflicts."
+    "claimBoundariesProven": true
   }
 }

--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -810,18 +810,10 @@ fn gallery_for_character(state: &AppState, character_id: &str) -> AppResult<Vec<
     )?;
     let mut gallery = Vec::new();
     for record in records.as_array().into_iter().flatten() {
-        let Some(data) = record
-            .get("url")
-            .and_then(Value::as_str)
-            .filter(|value| value.starts_with("data:image/"))
-        else {
+        let Some((data, image_path)) = gallery_record_data_url(state, record)? else {
             continue;
         };
-        let filename = record
-            .get("filename")
-            .or_else(|| record.get("filePath"))
-            .and_then(Value::as_str)
-            .unwrap_or("image.png");
+        let filename = gallery_record_filename(record, image_path.as_deref());
         gallery.push(json!({
             "filename": filename,
             "data": data,
@@ -833,6 +825,49 @@ fn gallery_for_character(state: &AppState, character_id: &str) -> AppResult<Vec<
         }));
     }
     Ok(gallery)
+}
+
+fn gallery_record_data_url(
+    state: &AppState,
+    record: &Value,
+) -> AppResult<Option<(String, Option<PathBuf>)>> {
+    if let Some(data) = record
+        .get("url")
+        .and_then(Value::as_str)
+        .filter(|value| media_uploads::is_inline_image_data_url(value))
+    {
+        return Ok(Some((data.to_string(), None)));
+    }
+    let Some(path) =
+        media_uploads::managed_record_file_path(state, "gallery", record, "filePath", "filename")?
+    else {
+        return Ok(None);
+    };
+    if !is_export_image_file(&path) {
+        return Ok(None);
+    }
+    Ok(data_url_from_file(&path).map(|data| (data, Some(path))))
+}
+
+fn gallery_record_filename(record: &Value, image_path: Option<&Path>) -> String {
+    record
+        .get("filename")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            record
+                .get("filePath")
+                .and_then(Value::as_str)
+                .and_then(|value| Path::new(value).file_name())
+                .map(|value| value.to_string_lossy().to_string())
+        })
+        .or_else(|| {
+            image_path
+                .and_then(Path::file_name)
+                .map(|value| value.to_string_lossy().to_string())
+        })
+        .unwrap_or_else(|| "image.png".to_string())
 }
 
 fn data_url_from_file(path: &Path) -> Option<String> {
@@ -1086,6 +1121,7 @@ fn safe_export_name(name: &str, fallback: &str) -> String {
 mod tests {
     use super::*;
     use crate::state::AppState;
+    use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn test_state(label: &str) -> AppState {
@@ -1106,6 +1142,124 @@ mod tests {
             .as_array()
             .cloned()
             .unwrap_or_default()
+    }
+
+    fn tiny_png_bytes() -> Vec<u8> {
+        general_purpose::STANDARD
+            .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==")
+            .expect("embedded test PNG should decode")
+    }
+
+    #[test]
+    fn native_character_export_embeds_managed_gallery_assets() {
+        let state = test_state("managed-character-gallery-export");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "character-1",
+                    "data": { "name": "Gallery Character" }
+                }),
+            )
+            .expect("character should be created");
+        let gallery_dir = state.data_dir.join("gallery");
+        fs::create_dir_all(&gallery_dir).expect("gallery directory should be created");
+        let image_path = gallery_dir.join("managed-gallery.png");
+        fs::write(&image_path, tiny_png_bytes()).expect("managed gallery image should be written");
+        let asset_url = media_uploads::file_path_asset_url(&image_path);
+        state
+            .storage
+            .create(
+                "character-gallery",
+                json!({
+                    "id": "gallery-1",
+                    "characterId": "character-1",
+                    "filePath": image_path.to_string_lossy(),
+                    "filename": "managed-gallery.png",
+                    "url": asset_url,
+                    "prompt": "pose reference",
+                    "provider": "local",
+                    "model": "test",
+                    "width": 1,
+                    "height": 1
+                }),
+            )
+            .expect("managed gallery row should be created");
+
+        let gallery =
+            gallery_for_character(&state, "character-1").expect("character gallery should export");
+
+        assert_eq!(gallery.len(), 1);
+        assert_eq!(
+            gallery[0].get("filename").and_then(Value::as_str),
+            Some("managed-gallery.png")
+        );
+        assert!(
+            gallery[0]
+                .get("data")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.starts_with("data:image/png;base64,")),
+            "managed gallery export should embed image data"
+        );
+        assert_eq!(
+            gallery[0].get("prompt").and_then(Value::as_str),
+            Some("pose reference")
+        );
+    }
+
+    #[test]
+    fn native_character_export_keeps_inline_gallery_and_skips_missing_files() {
+        let state = test_state("inline-character-gallery-export");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "character-1",
+                    "data": { "name": "Inline Gallery Character" }
+                }),
+            )
+            .expect("character should be created");
+        let inline_data =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+        state
+            .storage
+            .create(
+                "character-gallery",
+                json!({
+                    "id": "gallery-inline",
+                    "characterId": "character-1",
+                    "filename": "inline.png",
+                    "url": inline_data
+                }),
+            )
+            .expect("inline gallery row should be created");
+        state
+            .storage
+            .create(
+                "character-gallery",
+                json!({
+                    "id": "gallery-missing",
+                    "characterId": "character-1",
+                    "filename": "missing.png",
+                    "url": media_uploads::file_path_asset_url(&state.data_dir.join("gallery").join("missing.png"))
+                }),
+            )
+            .expect("missing gallery row should be created");
+
+        let gallery =
+            gallery_for_character(&state, "character-1").expect("character gallery should export");
+
+        assert_eq!(gallery.len(), 1);
+        assert_eq!(
+            gallery[0].get("filename").and_then(Value::as_str),
+            Some("inline.png")
+        );
+        assert_eq!(
+            gallery[0].get("data").and_then(Value::as_str),
+            Some(inline_data)
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -129,6 +129,59 @@ fn native_marinara_character_import_materializes_embedded_avatar() {
 }
 
 #[test]
+fn native_marinara_character_import_materializes_embedded_gallery_assets() {
+    let state = test_state("native-character-gallery");
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_character",
+            "version": 1,
+            "data": {
+                "spec": "chara_card_v2",
+                "data": {
+                    "name": "Native Gallery Character"
+                },
+                "gallery": [
+                    {
+                        "filename": "pose.png",
+                        "data": embedded_avatar(),
+                        "prompt": "pose reference",
+                        "provider": "local",
+                        "model": "test",
+                        "width": 1,
+                        "height": 1
+                    }
+                ]
+            }
+        }),
+    )
+    .expect("native character gallery import should succeed");
+
+    let character_id = test_string(&imported, "characterId");
+    let rows = state
+        .storage
+        .list("character-gallery")
+        .expect("character gallery rows should be readable");
+    let gallery = record_with_field(&rows, "characterId", character_id);
+    let url = test_string(gallery, "url");
+    assert!(
+        url.starts_with("asset://localhost/") || url.starts_with("http://asset.localhost/"),
+        "imported gallery rows should use managed asset URLs"
+    );
+    assert!(
+        !url.starts_with("data:image/"),
+        "imported gallery rows should not keep inline image data"
+    );
+    assert!(
+        Path::new(test_string(gallery, "filePath")).exists(),
+        "imported gallery image should be written as a managed file"
+    );
+    assert_eq!(test_string(gallery, "filename"), "pose.png");
+    assert_eq!(test_string(gallery, "prompt"), "pose reference");
+    assert_eq!(imported["galleryImported"], json!(1));
+}
+
+#[test]
 fn native_marinara_character_import_rolls_back_avatar_when_record_write_fails() {
     let state = test_state("native-character-avatar-rollback");
     block_collection_writes(&state, "characters");


### PR DESCRIPTION
## Linked issue

Closes #2130

## Why this change

- Native `.marinara` character export skipped gallery images uploaded through the managed-gallery flow because those rows store an asset URL instead of an inline `data:image/...` URL.
- The export/import round trip should preserve managed character gallery images, including legacy inline gallery rows.

## What changed

- Native character export now resolves managed `character-gallery` files from the app-owned gallery directory and embeds them into the `.marinara` envelope as data URLs.
- Gallery export still preserves inline legacy gallery data and skips rows whose managed files are missing instead of exporting broken references.
- Added Rust regression coverage for managed gallery export, inline/missing-file boundaries, and native import materializing embedded gallery images as managed assets.

## Refactor impact

Primary owner:

Rust storage / native character import-export

Impact areas reviewed:

- `src-tauri/src/commands/storage/exports.rs`
- `src-tauri/src/commands/storage/imports/marinara_tests.rs`
- Existing gallery upload, import materialization, and delete cleanup behavior through the focused gallery test filter

Boundary notes:

- Change stays in `src-tauri`; no React, engine, shared API, remote-runtime, schema, dependency, or version files changed.
- Export reads only files resolved by the existing managed-record file resolver under the app-owned gallery directory.

Pressure points touched:

- Native `.marinara` character export gallery assembly
- Native `.marinara` character import regression coverage

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the bug before the fix with `cargo test --manifest-path src-tauri\Cargo.toml gallery_assets -- --nocapture`: the new managed-export regression failed because `gallery_for_character` returned 0 items for a managed gallery row.
- Codex verified the fix with `cargo test --manifest-path src-tauri\Cargo.toml gallery -- --nocapture`: 17 gallery-focused Rust tests passed.
- Codex ran `cargo check --manifest-path src-tauri\Cargo.toml`: passed.
- Codex ran `pnpm install --frozen-lockfile` in the isolated worktree because `node_modules` was absent, with no dependency declaration changes.
- Codex ran `pnpm check`: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Bunny review ran before opening the PR and passed for the rebased diff.
- Manual UI verification is not required for the core claim; this is a backend storage/import-export path with command-level proof.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for an existing native character export/import behavior; no new discoverable product surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a Rust storage/native import-export bug with no meaningful visible UI state; command proof is recorded above and in `scratch/bugfix-verification.json`.
