### PR TITLE
Fix conversation mention schedule delays

### DIFF
--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -189,6 +189,7 @@ describe("startGeneration conversation availability delays", () => {
     try {
       expect(delayedMs(await collectEvents("idle", {}))).toBe(120_000);
       expect(delayedMs(await collectEvents("dnd", {}))).toBe(180_000);
+      expect(delayedMs(await collectEvents("idle", {}, { secondStatus: "dnd" }))).toBe(120_000);
     } finally {
       random.mockRestore();
     }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -23,19 +23,29 @@ function scheduleFor(status: "idle" | "dnd" | "offline"): WeekSchedule {
   };
 }
 
-function createStore(status: "idle" | "dnd" | "offline"): Store {
+function createStore(
+  status: "idle" | "dnd" | "offline",
+  options: { secondStatus?: "idle" | "dnd" | "offline" } = {},
+): Store {
+  const characterIds = options.secondStatus ? ["char-1", "char-2"] : ["char-1"];
   return {
     chats: {
       "chat-1": {
         id: "chat-1",
         mode: "conversation",
         connectionId: "conn-1",
-        characterIds: ["char-1"],
-        metadata: { characterSchedules: { "char-1": scheduleFor(status) } },
+        characterIds,
+        metadata: {
+          characterSchedules: {
+            "char-1": scheduleFor(status),
+            ...(options.secondStatus ? { "char-2": scheduleFor(options.secondStatus) } : {}),
+          },
+        },
       },
     },
     characters: {
       "char-1": { id: "char-1", data: { name: "Mira" } },
+      ...(options.secondStatus ? { "char-2": { id: "char-2", data: { name: "Sol" } } } : {}),
     },
     connections: {
       "conn-1": { id: "conn-1", provider: "test", model: "test-model" },
@@ -118,7 +128,7 @@ function createStorage(store: Store): StorageGateway {
   };
 }
 
-function createDeps(status: "idle" | "dnd" | "offline") {
+function createDeps(status: "idle" | "dnd" | "offline", options: { secondStatus?: "idle" | "dnd" | "offline" } = {}) {
   const llm: LlmGateway = {
     async complete() {
       return "";
@@ -131,15 +141,19 @@ function createDeps(status: "idle" | "dnd" | "offline") {
     },
   };
   return {
-    storage: createStorage(createStore(status)),
+    storage: createStorage(createStore(status, options)),
     integrations: {} as IntegrationGateway,
     llm,
   };
 }
 
-async function collectEvents(status: "idle" | "dnd" | "offline", input: Partial<StartGenerationInput>) {
+async function collectEvents(
+  status: "idle" | "dnd" | "offline",
+  input: Partial<StartGenerationInput>,
+  options: { secondStatus?: "idle" | "dnd" | "offline" } = {},
+) {
   const events = [];
-  for await (const event of startGeneration(createDeps(status), {
+  for await (const event of startGeneration(createDeps(status, options), {
     chatId: "chat-1",
     message: "Hi @Mira",
     ...input,
@@ -162,6 +176,9 @@ describe("startGeneration conversation availability delays", () => {
       expect(delayedMs(await collectEvents("idle", { mentionedCharacterNames: ["Mira"] }))).toBe(5_000);
       expect(delayedMs(await collectEvents("dnd", { mentionedCharacterNames: ["Mira"] }))).toBe(30_000);
       expect(delayedMs(await collectEvents("idle", { forCharacterId: "char-1" }))).toBe(5_000);
+      expect(
+        delayedMs(await collectEvents("idle", { mentionedCharacterNames: ["Mira"] }, { secondStatus: "dnd" })),
+      ).toBe(5_000);
     } finally {
       random.mockRestore();
     }
@@ -183,6 +200,14 @@ describe("startGeneration conversation availability delays", () => {
       const offlineEvents = await collectEvents("offline", { mentionedCharacterNames: ["Mira"] });
       expect(offlineEvents.some((event) => event.type === "offline")).toBe(true);
       expect(delayedMs(offlineEvents)).toBeNull();
+
+      const offlineMentionEvents = await collectEvents(
+        "offline",
+        { mentionedCharacterNames: ["Mira"] },
+        { secondStatus: "idle" },
+      );
+      expect(offlineMentionEvents.some((event) => event.type === "offline")).toBe(true);
+      expect(delayedMs(offlineMentionEvents)).toBeNull();
 
       const regenerateEvents = await collectEvents("idle", {
         regenerateMessageId: "assistant-1",

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmGateway } from "../capabilities/llm";
+import type { StorageEntity, StorageGateway } from "../capabilities/storage";
+import type { WeekSchedule } from "../modes/chat/schedules/schedule.service";
+import { startGeneration, type StartGenerationInput } from "./start-generation";
+
+type Store = Partial<Record<StorageEntity, Record<string, Record<string, unknown>>>>;
+
+const WEEK_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"] as const;
+
+function scheduleFor(status: "idle" | "dnd" | "offline"): WeekSchedule {
+  return {
+    weekStart: "2026-06-01T00:00:00.000Z",
+    days: Object.fromEntries(
+      WEEK_DAYS.map((day) => [day, [{ time: "00:00-23:59", activity: "busy", status }]]),
+    ) as WeekSchedule["days"],
+    inactivityThresholdMinutes: 120,
+    idleResponseDelayMinutes: 2,
+    dndResponseDelayMinutes: 3,
+    talkativeness: 50,
+  };
+}
+
+function createStore(status: "idle" | "dnd" | "offline"): Store {
+  return {
+    chats: {
+      "chat-1": {
+        id: "chat-1",
+        mode: "conversation",
+        connectionId: "conn-1",
+        characterIds: ["char-1"],
+        metadata: { characterSchedules: { "char-1": scheduleFor(status) } },
+      },
+    },
+    characters: {
+      "char-1": { id: "char-1", data: { name: "Mira" } },
+    },
+    connections: {
+      "conn-1": { id: "conn-1", provider: "test", model: "test-model" },
+    },
+  };
+}
+
+function createStorage(store: Store): StorageGateway {
+  return {
+    async list<T = unknown>(entity: StorageEntity): Promise<T[]> {
+      return Object.values(store[entity] ?? {}) as T[];
+    },
+    async get<T = unknown>(entity: StorageEntity, id: string): Promise<T | null> {
+      return ((store[entity] ?? {})[id] as T | undefined) ?? null;
+    },
+    async create<T = unknown>(entity: StorageEntity, value: Record<string, unknown>): Promise<T> {
+      const id = String(value.id ?? `${entity}-${Object.keys(store[entity] ?? {}).length + 1}`);
+      store[entity] = { ...(store[entity] ?? {}), [id]: { ...value, id } };
+      return store[entity]![id] as T;
+    },
+    async update<T = unknown>(entity: StorageEntity, id: string, patch: Record<string, unknown>): Promise<T> {
+      store[entity] = {
+        ...(store[entity] ?? {}),
+        [id]: { ...((store[entity] ?? {})[id] ?? {}), ...patch },
+      };
+      return store[entity]![id] as T;
+    },
+    async delete(): Promise<{ deleted: boolean }> {
+      return { deleted: true };
+    },
+    async listChatMessages<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async createChatMessage<T = unknown>(chatId: string, value: Record<string, unknown>): Promise<T> {
+      return {
+        id: `message-${Object.keys(store.messages ?? {}).length + 1}`,
+        chatId,
+        createdAt: new Date().toISOString(),
+        ...value,
+      } as T;
+    },
+    async updateChatMessage<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T> {
+      return { id: messageId, ...patch } as T;
+    },
+    async deleteChatMessage(): Promise<{ deleted: boolean }> {
+      return { deleted: true };
+    },
+    async patchChatMessageExtra<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T> {
+      return { id: messageId, extra: patch } as T;
+    },
+    async addChatMessageSwipe<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async patchChatMetadata<T = unknown>(chatId: string, patch: Record<string, unknown>): Promise<T> {
+      const chat = (store.chats ?? {})[chatId] ?? {};
+      store.chats = { ...(store.chats ?? {}), [chatId]: { ...chat, metadata: patch } };
+      return store.chats[chatId] as T;
+    },
+    async patchChatSummaries<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async listChatMemories<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async getWorldState<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+    async saveTrackerSnapshot<T = unknown>(): Promise<T> {
+      return {} as T;
+    },
+    async listLorebookEntries<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async createLorebookEntries<T = unknown>(): Promise<T[]> {
+      return [] as T[];
+    },
+    async promptFull<T = unknown>(): Promise<T | null> {
+      return null;
+    },
+  };
+}
+
+function createDeps(status: "idle" | "dnd" | "offline") {
+  const llm: LlmGateway = {
+    async complete() {
+      return "";
+    },
+    async *stream() {
+      yield { type: "token" as const, text: "Hello." };
+    },
+    async listModels() {
+      return [];
+    },
+  };
+  return {
+    storage: createStorage(createStore(status)),
+    integrations: {} as IntegrationGateway,
+    llm,
+  };
+}
+
+async function collectEvents(status: "idle" | "dnd" | "offline", input: Partial<StartGenerationInput>) {
+  const events = [];
+  for await (const event of startGeneration(createDeps(status), {
+    chatId: "chat-1",
+    message: "Hi @Mira",
+    ...input,
+  })) {
+    events.push(event);
+    if (event.type === "delayed" || event.type === "offline" || event.type === "done") break;
+  }
+  return events;
+}
+
+function delayedMs(events: Awaited<ReturnType<typeof collectEvents>>): number | null {
+  const delayed = events.find((event) => event.type === "delayed");
+  return delayed?.type === "delayed" ? Number(delayed.data.delayMs) : null;
+}
+
+describe("startGeneration conversation availability delays", () => {
+  it("uses short legacy mention delays for explicit conversation mentions and manual targets", async () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      expect(delayedMs(await collectEvents("idle", { mentionedCharacterNames: ["Mira"] }))).toBe(5_000);
+      expect(delayedMs(await collectEvents("dnd", { mentionedCharacterNames: ["Mira"] }))).toBe(30_000);
+      expect(delayedMs(await collectEvents("idle", { forCharacterId: "char-1" }))).toBe(5_000);
+    } finally {
+      random.mockRestore();
+    }
+  });
+
+  it("keeps generic busy delays for normal conversation replies", async () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      expect(delayedMs(await collectEvents("idle", {}))).toBe(120_000);
+      expect(delayedMs(await collectEvents("dnd", {}))).toBe(180_000);
+    } finally {
+      random.mockRestore();
+    }
+  });
+
+  it("does not turn offline or regenerate conversation turns into mention delays", async () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const offlineEvents = await collectEvents("offline", { mentionedCharacterNames: ["Mira"] });
+      expect(offlineEvents.some((event) => event.type === "offline")).toBe(true);
+      expect(delayedMs(offlineEvents)).toBeNull();
+
+      const regenerateEvents = await collectEvents("idle", {
+        regenerateMessageId: "assistant-1",
+        mentionedCharacterNames: ["Mira"],
+      });
+      expect(delayedMs(regenerateEvents)).toBeNull();
+    } finally {
+      random.mockRestore();
+    }
+  });
+});

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1428,10 +1428,14 @@ async function resolveConversationAvailability(args: {
       schedule: isRecord(row?.schedule) ? (row.schedule as unknown as WeekSchedule) : null,
     });
   }
-  const allOffline = characters.length > 0 && characters.every((character) => character.status === "offline");
+  const mentionedCharacters =
+    mentionedNames.size > 0 ? characters.filter((character) => mentionedNames.has(character.name.toLowerCase())) : [];
+  const availableCharacters = mentionedCharacters.length > 0 ? mentionedCharacters : characters;
+  const allOffline =
+    availableCharacters.length > 0 && availableCharacters.every((character) => character.status === "offline");
   let delayMs = 0;
   let delayStatus: ConversationAvailabilityStatus = "online";
-  for (const character of characters) {
+  for (const character of availableCharacters) {
     const isMentionedOrManualTarget =
       (manualTarget.length > 0 && character.id === manualTarget) || mentionedNames.has(character.name.toLowerCase());
     const characterDelay = isMentionedOrManualTarget
@@ -1442,7 +1446,7 @@ async function resolveConversationAvailability(args: {
       delayStatus = character.status;
     }
   }
-  return { characters, allOffline, delayMs, delayStatus };
+  return { characters: availableCharacters, allOffline, delayMs, delayStatus };
 }
 
 function abortableDelay(delayMs: number, signal?: AbortSignal): Promise<void> {

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -11,7 +11,7 @@ import { chatSummaryFingerprintMatches, fingerprintChatSummary } from "../shared
 import { collapseExcessBlankLines } from "../shared/text/newlines";
 import { buildImpersonateInstruction } from "../modes/chat/commands/impersonate-prompt";
 import { getConversationStatus } from "../modes/chat/autonomous/autonomous.service";
-import { getBusyDelay, type WeekSchedule } from "../modes/chat/schedules/schedule.service";
+import { getBusyDelay, getMentionDelay, type WeekSchedule } from "../modes/chat/schedules/schedule.service";
 import {
   activeCharacterIds,
   assertChatHasActiveCharacters,
@@ -1393,10 +1393,16 @@ function conversationStatus(value: unknown): ConversationAvailabilityStatus {
   return value === "idle" || value === "dnd" || value === "offline" ? value : "online";
 }
 
+function normalizedMentionedCharacterNames(names: string[]): Set<string> {
+  return new Set(names.map((name) => name.trim().toLowerCase()).filter(Boolean));
+}
+
 async function resolveConversationAvailability(args: {
   storage: StorageGateway;
   chat: JsonRecord;
   targetCharacterId?: string | null;
+  manualTargetCharacterId?: string | null;
+  mentionedCharacterNames?: string[];
 }): Promise<{
   characters: ConversationAvailabilityCharacter[];
   allOffline: boolean;
@@ -1408,6 +1414,8 @@ async function resolveConversationAvailability(args: {
   if (activeIds.length === 0) return null;
   const activeSet = new Set(activeIds);
   const requested = readString(args.targetCharacterId).trim();
+  const manualTarget = readString(args.manualTargetCharacterId).trim();
+  const mentionedNames = normalizedMentionedCharacterNames(args.mentionedCharacterNames ?? []);
   const respondingIds = requested && activeSet.has(requested) ? [requested] : activeIds;
   const statusResult = await getConversationStatus(args.storage, readString(args.chat.id).trim());
   const characters: ConversationAvailabilityCharacter[] = [];
@@ -1424,7 +1432,11 @@ async function resolveConversationAvailability(args: {
   let delayMs = 0;
   let delayStatus: ConversationAvailabilityStatus = "online";
   for (const character of characters) {
-    const characterDelay = getBusyDelay(character.status, character.schedule ?? undefined);
+    const isMentionedOrManualTarget =
+      (manualTarget.length > 0 && character.id === manualTarget) || mentionedNames.has(character.name.toLowerCase());
+    const characterDelay = isMentionedOrManualTarget
+      ? getMentionDelay(character.status)
+      : getBusyDelay(character.status, character.schedule ?? undefined);
     if (characterDelay > delayMs) {
       delayMs = characterDelay;
       delayStatus = character.status;
@@ -2600,10 +2612,13 @@ export async function* startGeneration(
   }
   const directMessages = requestMessages(input);
   if (!directMessages && input.impersonate !== true) {
+    const manualTargetCharacterId = readString(input.forCharacterId).trim();
     const availability = await resolveConversationAvailability({
       storage: deps.storage,
       chat,
-      targetCharacterId: readString(input.forCharacterId).trim() || resolvedGroupTarget,
+      targetCharacterId: manualTargetCharacterId || resolvedGroupTarget,
+      manualTargetCharacterId,
+      mentionedCharacterNames: preparedUserInput.mentionedCharacterNames,
     });
     throwIfAborted(signal);
     const characterNames = availability?.characters.map((character) => character.name) ?? [];

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2588,6 +2588,7 @@ export async function* startGeneration(
       return;
     }
   }
+  const explicitManualTargetCharacterId = readString(input.forCharacterId).trim();
   const sequentialGroupTargetId = sequentialGroupTargetCharacterId(chat, input, storedMessages);
   if (sequentialGroupTargetId) {
     input = { ...input, forCharacterId: sequentialGroupTargetId };
@@ -2616,12 +2617,12 @@ export async function* startGeneration(
   }
   const directMessages = requestMessages(input);
   if (!directMessages && input.impersonate !== true) {
-    const manualTargetCharacterId = readString(input.forCharacterId).trim();
+    const targetCharacterId = readString(input.forCharacterId).trim() || resolvedGroupTarget;
     const availability = await resolveConversationAvailability({
       storage: deps.storage,
       chat,
-      targetCharacterId: manualTargetCharacterId || resolvedGroupTarget,
-      manualTargetCharacterId,
+      targetCharacterId,
+      manualTargetCharacterId: explicitManualTargetCharacterId,
       mentionedCharacterNames: preparedUserInput.mentionedCharacterNames,
     });
     throwIfAborted(signal);

--- a/src/engine/modes/chat/schedules/schedule.service.ts
+++ b/src/engine/modes/chat/schedules/schedule.service.ts
@@ -1000,3 +1000,15 @@ export function getBusyDelay(
 ): number {
   return getConfiguredResponseDelay(status, schedule);
 }
+
+export function getMentionDelay(status: "online" | "idle" | "dnd" | "offline"): number {
+  switch (status) {
+    case "online":
+    case "offline":
+      return 0;
+    case "idle":
+      return (5 + Math.random() * 10) * 1000;
+    case "dnd":
+      return (30 + Math.random() * 60) * 1000;
+  }
+}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2131

## Why this change

- Conversation @mentions and manual character targets should preserve the legacy short schedule delay path instead of waiting on the normal configured busy delay.

## What changed

- Added a legacy-compatible mention delay helper for idle and DND schedule statuses.
- Passed explicit mention/manual-target context into conversation availability resolution.
- Added regression coverage for mentioned idle/DND, manual idle, multi-character mention aggregation, normal auto-selected group targets, normal idle/DND, offline, and regenerate paths.

## Refactor impact

Primary owner:

- Engine generation

Impact areas reviewed:

- Conversation-mode schedule availability
- Mention/manual target generation input
- Normal non-mentioned busy delay behavior
- Normal auto-selected group target delay behavior
- Multi-character conversation mention delay aggregation
- Offline and regenerate exclusions

Boundary notes:

- Engine-only change. No React, shared API, Tauri/Rust, storage schema, prompt assembly, or remote-runtime boundary changes.

Pressure points touched:

- `src/engine/generation/start-generation.ts`
- `src/engine/modes/chat/schedules/schedule.service.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex proof: pre-fix focused Vitest repro failed with mentioned idle delay `120000` ms instead of `5000` ms.
- Codex proof after fix: `pnpm test -- src/engine/generation/start-generation.test.ts` passed.
- Codex proof after Bunny repair: `pnpm check` passed.
- Codex proof gate: local proof ledger passed Marinara proof-gate validation.
- Bunny review: initial medium finding on multi-character mention aggregation was repaired; local Bunny/proof checks passed after repair.
- CodeRabbit review: initial finding on auto-selected group targets being treated as manual was repaired; focused Vitest and `pnpm check` passed after repair.
- Manual verification needed: none for the core engine timing contract.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix only; no new user-discoverable surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence (if applicable)

- Not applicable: this is a non-UI engine timing contract fix. The affected behavior is proven with the focused generation harness and full repo checks above.
