### PR TITLE
Fix game party recruit card generation

### DIFF
--- a/scratch/issue-2134-party-card-proof.mjs
+++ b/scratch/issue-2134-party-card-proof.mjs
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const apiPath = resolve(root, "src/features/modes/game/api/game-api.ts");
+const promptsPath = resolve(root, "src/engine/modes/game/prompts/gm-prompts.ts");
+
+const api = readFileSync(apiPath, "utf8");
+const prompts = readFileSync(promptsPath, "utf8");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const upsertStart = api.indexOf("async upsertPartyCard(data:");
+const upsertEnd = api.indexOf("async removePartyMember", upsertStart);
+assert(upsertStart >= 0 && upsertEnd > upsertStart, "Could not locate upsertPartyCard body.");
+
+const upsertBody = api.slice(upsertStart, upsertEnd);
+
+assert(
+  prompts.includes("export function buildPartyRecruitCardPrompt"),
+  "Game GM prompts do not export buildPartyRecruitCardPrompt.",
+);
+assert(
+  upsertBody.includes("buildPartyRecruitCardPrompt") && upsertBody.includes("llmJson"),
+  "upsertPartyCard does not route through the LLM party-card prompt.",
+);
+assert(
+  upsertBody.includes("purpose:") && upsertBody.includes('"regenerate"') && upsertBody.includes('"recruit"'),
+  "upsertPartyCard does not distinguish recruit and regenerate prompt purposes.",
+);
+
+console.log("Issue #2134 proof passed: party card upsert uses the LLM recruit/regenerate prompt path.");

--- a/src/engine/modes/game/prompts/gm-prompts.ts
+++ b/src/engine/modes/game/prompts/gm-prompts.ts
@@ -1104,3 +1104,83 @@ export function buildSessionConclusionPrompt(args: {
     `Output valid JSON only.`,
   ].join("\n");
 }
+
+export function buildPartyRecruitCardPrompt(ctx: {
+  targetCharacterName: string;
+  targetCharacterCard: string;
+  currentPartyNames: string[];
+  currentPartyCards?: string | null;
+  existingTargetCard?: string | null;
+  worldOverview?: string | null;
+  storyArc?: string | null;
+  plotTwists?: string[] | null;
+  currentState?: string | null;
+  recentTranscript?: string | null;
+  language?: string | null;
+  purpose?: "recruit" | "regenerate";
+}): string {
+  const normalizedLanguage = normalizePromptLanguage(ctx.language);
+  const isRegeneration = ctx.purpose === "regenerate";
+  const sections: string[] = [
+    `You are the Game Master updating an ongoing RPG campaign.`,
+    isRegeneration
+      ? `A companion's party sheet is malformed, generic, or outdated. Regenerate one clean JSON character card for them that matches the existing game card schema.`
+      : `A new companion is joining the party. Create one JSON character card for them that matches the existing game card schema.`,
+    ``,
+    ...(normalizedLanguage
+      ? [
+          `<language>`,
+          `Write every natural-language string value in ${normalizedLanguage}. Keep JSON keys and structural syntax in English.`,
+          `</language>`,
+          ``,
+        ]
+      : []),
+    `Rules:`,
+    `- Return exactly one JSON object with these keys: name, shortDescription, class, abilities, strengths, weaknesses, extra, rpgStats.`,
+    `- Keep name exactly "${ctx.targetCharacterName}".`,
+    `- Ground the card in the existing campaign state, world, story arc, plot twists, and recent transcript.`,
+    `- Respect the supplied character card or NPC context as canon. Do not contradict it.`,
+    `- Avoid generic boilerplate such as Adventurer, Attack, Assist, empty description, or all six attributes being 10 unless the fiction truly demands it.`,
+    `- abilities, strengths, and weaknesses must be arrays of short strings.`,
+    `- extra must be an object of string values. Include compact fields such as voice, personalStake, affiliation, title, flaw, or motif when they fit.`,
+    `- rpgStats.attributes must contain STR, DEX, CON, INT, WIS, and CHA numeric values. rpgStats.hp must contain value and max.`,
+    ...(isRegeneration
+      ? [
+          `- Treat the existing target party sheet as a damaged draft: preserve useful facts, but fix malformed fields, missing structure, and off-tone values.`,
+        ]
+      : []),
+    `- Do not output markdown, explanations, or wrapper text.`,
+    ``,
+    `<current_party>`,
+    `Current party members: ${ctx.currentPartyNames.length > 0 ? ctx.currentPartyNames.join(", ") : "None"}`,
+    `</current_party>`,
+    ``,
+    `<target_character>`,
+    ctx.targetCharacterCard,
+    `</target_character>`,
+  ];
+
+  if (ctx.worldOverview?.trim()) {
+    sections.push(``, `<world_overview>`, ctx.worldOverview.trim(), `</world_overview>`);
+  }
+  if (ctx.storyArc?.trim()) {
+    sections.push(``, `<story_arc>`, ctx.storyArc.trim(), `</story_arc>`);
+  }
+  if (ctx.plotTwists && ctx.plotTwists.length > 0) {
+    sections.push(``, `<plot_twists>`, ...ctx.plotTwists.filter((twist) => twist.trim()), `</plot_twists>`);
+  }
+  if (ctx.currentPartyCards?.trim()) {
+    sections.push(``, `<existing_party_cards>`, ctx.currentPartyCards.trim(), `</existing_party_cards>`);
+  }
+  if (ctx.existingTargetCard?.trim()) {
+    sections.push(``, `<existing_target_party_sheet>`, ctx.existingTargetCard.trim(), `</existing_target_party_sheet>`);
+  }
+  if (ctx.currentState?.trim()) {
+    sections.push(``, `<current_state>`, ctx.currentState.trim(), `</current_state>`);
+  }
+  if (ctx.recentTranscript?.trim()) {
+    sections.push(``, `<recent_transcript>`, ctx.recentTranscript.trim(), `</recent_transcript>`);
+  }
+
+  return sections.join("\n");
+}

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -31,10 +31,7 @@ import { chatCommandApi } from "../../../../shared/api/chat-command-api";
 import { resolveGalleryFileUrl } from "../../../../shared/api/local-file-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { urlBinaryApi } from "../../../../shared/api/url-binary-api";
-import {
-  createLorebookEntrySchema,
-  createLorebookSchema,
-} from "../../../../engine/contracts/schemas/lorebook.schema";
+import { createLorebookEntrySchema, createLorebookSchema } from "../../../../engine/contracts/schemas/lorebook.schema";
 import { resolveCombatRound } from "../../../../engine/modes/game/mechanics/combat.service";
 import { rollDice as rollGameDice } from "../../../../engine/modes/game/mechanics/dice.service";
 import {
@@ -63,7 +60,11 @@ import {
   listElementPresets,
 } from "../../../../engine/modes/game/mechanics/element-reactions.service";
 import { buildPartySystemPrompt } from "../../../../engine/modes/game/prompts/party-prompts";
-import { buildSessionConclusionPrompt, buildSetupPrompt } from "../../../../engine/modes/game/prompts/gm-prompts";
+import {
+  buildPartyRecruitCardPrompt,
+  buildSessionConclusionPrompt,
+  buildSetupPrompt,
+} from "../../../../engine/modes/game/prompts/gm-prompts";
 import {
   GAME_BACKGROUND_PROMPT_OVERRIDE,
   GAME_ILLUSTRATION_PROMPT_OVERRIDE,
@@ -95,7 +96,12 @@ import {
   advanceTime as advanceGameTime,
   type GameTime,
 } from "../../../../engine/modes/game/world/time.service";
-import { generateWeather, inferBiome, type Season, type WeatherState } from "../../../../engine/modes/game/world/weather.service";
+import {
+  generateWeather,
+  inferBiome,
+  type Season,
+  type WeatherState,
+} from "../../../../engine/modes/game/world/weather.service";
 import { parsePartyDialogue } from "../lib/party-dialogue-parser";
 
 export interface CreateGameResponse {
@@ -238,7 +244,8 @@ type GameJsonRepairKind =
   | "game_map"
   | "session_conclusion"
   | "session_lorebook"
-  | "campaign_progression";
+  | "campaign_progression"
+  | "party_card";
 
 type GameJsonRepairContext = {
   kind: GameJsonRepairKind;
@@ -1175,6 +1182,8 @@ function applyJournalEntry(journal: Journal, type: string, data: Record<string, 
   return addEventEntry(journal, title, content);
 }
 
+const PARTY_CARD_ATTRIBUTE_NAMES = ["STR", "DEX", "CON", "INT", "WIS", "CHA"] as const;
+
 function buildGameCard(characterName: string): Record<string, unknown> {
   return {
     name: characterName,
@@ -1196,6 +1205,177 @@ function buildGameCard(characterName: string): Record<string, unknown> {
       hp: { value: 20, max: 20 },
     },
   };
+}
+
+function normalizedName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function gameCardTextListWithFallback(value: unknown, fallback: string[]): string[] {
+  const entries = Array.isArray(value)
+    ? value
+        .map((entry) => (typeof entry === "string" || typeof entry === "number" ? String(entry).trim() : ""))
+        .filter(Boolean)
+    : [];
+  return entries.length ? entries : fallback;
+}
+
+function gameCardExtra(value: unknown, fallback: Record<string, unknown>): Record<string, string> {
+  const raw = asRecord(value);
+  const fallbackRecord = asRecord(fallback);
+  const entries = Object.entries(Object.keys(raw).length ? raw : fallbackRecord)
+    .map(([key, entry]) => {
+      const cleanKey = key.trim();
+      const cleanValue =
+        typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean"
+          ? String(entry).trim()
+          : "";
+      return cleanKey && cleanValue ? ([cleanKey, cleanValue] as const) : null;
+    })
+    .filter((entry): entry is readonly [string, string] => entry !== null);
+  return Object.fromEntries(entries);
+}
+
+function normalizePartyCardAttributes(value: unknown, fallback: unknown): Array<{ name: string; value: number }> {
+  const fallbackAttributes = sheetAttributes(fallback) ?? [];
+  const fallbackByName = new Map(fallbackAttributes.map((attr) => [normalizedName(attr.name), attr.value]));
+  const generatedByName = new Map(
+    (sheetAttributes(value) ?? []).map((attr) => [normalizedName(attr.name), attr.value]),
+  );
+
+  return PARTY_CARD_ATTRIBUTE_NAMES.map((name) => {
+    const key = normalizedName(name);
+    const rawValue = generatedByName.get(key) ?? fallbackByName.get(key) ?? 10;
+    return { name, value: Math.max(1, Math.min(30, Math.round(rawValue))) };
+  });
+}
+
+function normalizePartyCardHp(value: unknown, fallback: unknown): { value: number; max: number } {
+  const record = asRecord(value);
+  const fallbackRecord = asRecord(fallback);
+  const max = Math.max(1, Math.min(999, Math.round(readNumber(record.max, readNumber(fallbackRecord.max, 20)))));
+  const current = Math.max(
+    0,
+    Math.min(max, Math.round(readNumber(record.value, readNumber(fallbackRecord.value, max)))),
+  );
+  return { value: current, max };
+}
+
+function normalizeGeneratedPartyCard(
+  raw: Record<string, unknown>,
+  fallback: Record<string, unknown>,
+  characterName: string,
+): Record<string, unknown> {
+  const rawStats = asRecord(raw.rpgStats);
+  const fallbackStats = asRecord(fallback.rpgStats);
+  return {
+    name: characterName,
+    shortDescription: readTrimmed(raw.shortDescription) || readTrimmed(fallback.shortDescription),
+    class: readTrimmed(raw.class) || readTrimmed(fallback.class) || "Companion",
+    abilities: gameCardTextListWithFallback(raw.abilities, gameCardTextListWithFallback(fallback.abilities, [])),
+    strengths: gameCardTextListWithFallback(raw.strengths, gameCardTextListWithFallback(fallback.strengths, [])),
+    weaknesses: gameCardTextListWithFallback(raw.weaknesses, gameCardTextListWithFallback(fallback.weaknesses, [])),
+    extra: gameCardExtra(raw.extra, asRecord(fallback.extra)),
+    rpgStats: {
+      attributes: normalizePartyCardAttributes(rawStats.attributes, fallbackStats.attributes),
+      hp: normalizePartyCardHp(rawStats.hp, fallbackStats.hp),
+    },
+  };
+}
+
+function gameCardByName(cards: unknown[], characterName: string): Record<string, unknown> | null {
+  const targetName = normalizedName(characterName);
+  for (const item of cards) {
+    const record = asRecord(item);
+    if (normalizedName(readTrimmed(record.name)) === targetName) return record;
+  }
+  return null;
+}
+
+function compactCharacterPromptRecord(record: Record<string, unknown>, fallbackName: string): string {
+  const data = asRecord(record.data);
+  const extensions = asRecord(data.extensions);
+  const promptRecord = {
+    name: recordName(record) || fallbackName,
+    description: readTrimmed(data.description),
+    personality: readTrimmed(data.personality),
+    scenario: readTrimmed(data.scenario),
+    systemPrompt: readTrimmed(data.system_prompt),
+    backstory: readTrimmed(extensions.backstory),
+    appearance: readTrimmed(extensions.appearance),
+    tags: stringArray(data.tags),
+  };
+  return JSON.stringify(promptRecord, null, 2);
+}
+
+function compactNpcPromptRecord(record: Record<string, unknown>, fallbackName: string): string {
+  return JSON.stringify(
+    {
+      name: readTrimmed(record.name) || fallbackName,
+      description: readTrimmed(record.description),
+      location: readTrimmed(record.location),
+      notes: Array.isArray(record.notes) ? record.notes.map(String).filter(Boolean).slice(0, 8) : [],
+      reputation: Number.isFinite(Number(record.reputation)) ? Number(record.reputation) : null,
+    },
+    null,
+    2,
+  );
+}
+
+async function targetPartyCardPromptContext(
+  chat: Chat,
+  meta: Record<string, unknown>,
+  characterName: string,
+  characterId?: string,
+): Promise<string> {
+  const candidateIds = [
+    ...(characterId ? [characterId] : []),
+    ...(Array.isArray(chat.characterIds) ? chat.characterIds : []),
+  ].filter((id): id is string => typeof id === "string" && id.trim().length > 0 && !id.startsWith("npc:"));
+  const uniqueIds = [...new Set(candidateIds)];
+  const characterRows = await Promise.all(
+    uniqueIds.map((id) => storageApi.get<Record<string, unknown>>("characters", id).catch(() => null)),
+  );
+  const targetName = normalizedName(characterName);
+  const characterRecord =
+    characterRows.find(
+      (row): row is Record<string, unknown> => !!row && normalizedName(recordName(row)) === targetName,
+    ) ?? null;
+  if (characterRecord) return compactCharacterPromptRecord(characterRecord, characterName);
+
+  const npcs = Array.isArray(meta.gameNpcs) ? meta.gameNpcs.map(asRecord) : [];
+  const npc = npcs.find((row) => normalizedName(readTrimmed(row.name)) === targetName);
+  if (npc) return compactNpcPromptRecord(npc, characterName);
+
+  return JSON.stringify(
+    {
+      name: characterName,
+      note: "No library character or tracked NPC record was found. Infer the new companion from campaign context and recent transcript.",
+    },
+    null,
+    2,
+  );
+}
+
+function currentPartyNames(cards: unknown[]): string[] {
+  return cards.map((item) => readTrimmed(asRecord(item).name)).filter(Boolean);
+}
+
+function partyCardCurrentState(chat: Chat, meta: Record<string, unknown>): string {
+  const gameState = asRecord((chat as { gameState?: unknown }).gameState);
+  const activeMap = asRecord(meta.gameMap);
+  return JSON.stringify(
+    {
+      sessionNumber: Number(meta.gameSessionNumber ?? 1),
+      activeState: readTrimmed(meta.gameActiveState),
+      location: readTrimmed(gameState.location) || readTrimmed(activeMap.name),
+      time: readTrimmed(gameState.time) || readTrimmed(meta.gameTimeFormatted),
+      weather: gameState.weather ?? meta.gameWeather ?? null,
+      playerNotes: readTrimmed(meta.gamePlayerNotes),
+    },
+    null,
+    2,
+  );
 }
 
 function playerAttributes(meta: Record<string, unknown>): Partial<RPGAttributes> {
@@ -1875,7 +2055,12 @@ export const gameApi = {
       label: "Session started",
       triggerType: "session_start",
     });
-    return { status: "active", alreadyStarted: false, sessionChat, ...(checkpointWarning ? { checkpointWarning } : {}) };
+    return {
+      status: "active",
+      alreadyStarted: false,
+      sessionChat,
+      ...(checkpointWarning ? { checkpointWarning } : {}),
+    };
   },
 
   async startSession(data: { gameId: string; connectionId?: string }): Promise<StartSessionResponse> {
@@ -2154,17 +2339,62 @@ export const gameApi = {
     characterId?: string;
     connectionId?: string;
     added?: boolean;
+    generated?: Record<string, unknown>;
   }): Promise<PartyCardResponse> {
+    const characterName = data.characterName.trim();
+    if (!characterName) {
+      throw new Error("Party card generation requires a character name.");
+    }
     const chat = await getChat(data.chatId);
     const meta = chatMeta(chat);
     const cards = Array.isArray(meta.gameCharacterCards) ? [...meta.gameCharacterCards] : [];
-    const card = buildGameCard(data.characterName);
-    const nextCards = cards.filter((item) => asRecord(item).name !== data.characterName).concat(card);
+    const existingTargetCard = gameCardByName(cards, characterName);
+    const fallback = existingTargetCard ?? buildGameCard(characterName);
+    const generated =
+      data.generated ??
+      (await llmJson({
+        connectionId: data.connectionId,
+        fallback,
+        system: "Create one Marinara Engine Game mode party character card. Return valid JSON only.",
+        user: buildPartyRecruitCardPrompt({
+          targetCharacterName: characterName,
+          targetCharacterCard: await targetPartyCardPromptContext(chat, meta, characterName, data.characterId),
+          currentPartyNames: currentPartyNames(cards).filter(
+            (name) => normalizedName(name) !== normalizedName(characterName),
+          ),
+          currentPartyCards: cards.length ? JSON.stringify(cards, null, 2) : null,
+          existingTargetCard: existingTargetCard ? JSON.stringify(existingTargetCard, null, 2) : null,
+          worldOverview: readTrimmed(meta.gameWorldOverview),
+          storyArc: readTrimmed(meta.gameStoryArc),
+          plotTwists: Array.isArray(meta.gamePlotTwists) ? meta.gamePlotTwists.map(String).filter(Boolean) : null,
+          currentState: partyCardCurrentState(chat, meta),
+          recentTranscript: await sessionTranscript(data.chatId, 40),
+          language: readTrimmed(meta.gameLanguage),
+          purpose: existingTargetCard && !data.added ? "regenerate" : "recruit",
+        }),
+        parameters: { temperature: 0.45, maxTokens: 1400 },
+        repair: {
+          kind: "party_card",
+          title: `Repair ${characterName} Party Card JSON`,
+          applyBody: {
+            chatId: data.chatId,
+            characterName,
+            characterId: data.characterId,
+            connectionId: data.connectionId,
+            added: data.added,
+          },
+        },
+      }));
+    const card = normalizeGeneratedPartyCard(generated, fallback, characterName);
+    const targetName = normalizedName(characterName);
+    const nextCards = cards
+      .filter((item) => normalizedName(readTrimmed(asRecord(item).name)) !== targetName)
+      .concat(card);
     const sessionChat = await patchChatMetadata(data.chatId, { gameCharacterCards: nextCards });
     return {
       sessionChat,
       added: data.added,
-      characterName: data.characterName,
+      characterName,
       cardCreated: true,
       gameCard: card,
     };
@@ -2737,7 +2967,8 @@ export const gameApi = {
     const illustration = asRecord(record.illustration);
     const hasIllustrationRequest = Object.keys(illustration).length > 0;
     const illustrationAllowed =
-      hasIllustrationRequest && canGenerateSceneIllustration(meta, await gameIllustrationTurnNumber(String(record.chatId)));
+      hasIllustrationRequest &&
+      canGenerateSceneIllustration(meta, await gameIllustrationTurnNumber(String(record.chatId)));
     if (illustrationAllowed) {
       const label =
         (typeof illustration.reason === "string" && illustration.reason) ||
@@ -3011,6 +3242,15 @@ export async function applyGameJsonRepair(request: JsonRepairRequest, rawJson: s
         chatId,
         connectionId,
         sessionNumber: Number(body.sessionNumber ?? 1),
+        generated: repaired,
+      });
+    case "party_card":
+      return gameApi.upsertPartyCard({
+        chatId,
+        connectionId,
+        characterName: typeof body.characterName === "string" ? body.characterName : "",
+        characterId: typeof body.characterId === "string" ? body.characterId : undefined,
+        added: body.added === true,
         generated: repaired,
       });
     default:

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -57,6 +57,7 @@ import {
   useJournalEntry,
   useTransitionGameState,
   useRecruitPartyMember,
+  useRegeneratePartyCard,
   useRemovePartyMember,
   gameKeys,
   patchChatMetadata,
@@ -2171,6 +2172,7 @@ export function GameSurface({
     pendingInventoryUseRef.current = pendingInventoryUse;
   }, [pendingInventoryUse]);
   const recruitPartyMember = useRecruitPartyMember();
+  const regeneratePartyCard = useRegeneratePartyCard();
   const removePartyMember = useRemovePartyMember();
   const availableMaps = useMemo(() => (maps.length > 0 ? maps : currentMap ? [currentMap] : []), [currentMap, maps]);
   const viewedMap = useMemo(() => {
@@ -2221,18 +2223,28 @@ export function GameSurface({
         const commandKey = `${messageId}:${partyChange.change}:${characterName.toLowerCase()}`;
         if (processedPartyChangeCommandsRef.current.has(commandKey)) continue;
         processedPartyChangeCommandsRef.current.add(commandKey);
-        const mutation = partyChange.change === "add" ? recruitPartyMember : removePartyMember;
-        mutation.mutate(
-          { chatId: activeChatId, characterName },
-          {
-            onError: () => {
-              processedPartyChangeCommandsRef.current.delete(commandKey);
+        if (partyChange.change === "add") {
+          recruitPartyMember.mutate(
+            { chatId: activeChatId, characterName, connectionId: chat.connectionId ?? undefined },
+            {
+              onError: () => {
+                processedPartyChangeCommandsRef.current.delete(commandKey);
+              },
             },
-          },
-        );
+          );
+        } else {
+          removePartyMember.mutate(
+            { chatId: activeChatId, characterName },
+            {
+              onError: () => {
+                processedPartyChangeCommandsRef.current.delete(commandKey);
+              },
+            },
+          );
+        }
       }
     },
-    [activeChatId, recruitPartyMember, removePartyMember],
+    [activeChatId, chat.connectionId, recruitPartyMember, removePartyMember],
   );
 
   const upsertReadableJournalEntry = useCallback(
@@ -6960,6 +6972,23 @@ export function GameSurface({
     [activeChatId, activeMapId, updateChatMetadata],
   );
 
+  const handleRegeneratePartyCard = useCallback(
+    async (characterName: string) => {
+      if (!activeChatId) return;
+      try {
+        await regeneratePartyCard.mutateAsync({
+          chatId: activeChatId,
+          characterName,
+          connectionId: chat.connectionId ?? undefined,
+        });
+      } catch (error) {
+        if (handleJsonRepairError(error)) return;
+        throw error;
+      }
+    },
+    [activeChatId, chat.connectionId, handleJsonRepairError, regeneratePartyCard],
+  );
+
   const handleRegenerateSessionConclusion = useCallback(
     async (sessionNumber: number) => {
       if (!activeChatId) return;
@@ -9353,6 +9382,8 @@ export function GameSurface({
           onSave={(gameCard: GameCharacterSheetGameCard | undefined) =>
             handleSaveCharacterSheet(partyCards[characterSheetCharId].title, gameCard)
           }
+          onRegenerate={() => handleRegeneratePartyCard(partyCards[characterSheetCharId].title)}
+          isRegenerating={regeneratePartyCard.isPending}
         />
       )}
 

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -351,6 +351,29 @@ export function useRecruitPartyMember() {
   });
 }
 
+export function useRegeneratePartyCard() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { chatId: string; characterName: string; connectionId?: string }) =>
+      gameApi.upsertPartyCard({ ...data, added: false }),
+    onSuccess: (res, variables) => {
+      publishSessionChat(qc, res.sessionChat);
+      qc.invalidateQueries({ queryKey: chatKeys.detail(variables.chatId) });
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      toast.success(`${res.characterName}'s party card was regenerated.`);
+    },
+    onError: (err) => {
+      console.error("[regeneratePartyCard] Error:", err);
+      if (isJsonRepairApiError(err)) {
+        toast.info("Review the generated party card JSON before applying it.", { duration: 8000 });
+        return;
+      }
+      toast.error(err.message || "Failed to regenerate party card.");
+    },
+  });
+}
+
 export function useRemovePartyMember() {
   const qc = useQueryClient();
 


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2134

## Why this change

- Game mode recruits created from `[party_change: change="add"]` were stored as static boilerplate `Adventurer` sheets instead of context-grounded companion cards.
- The sheet modal's existing regenerate path was not wired, so malformed or outdated companion cards could not be refreshed from game context.

## What changed

- Added a React-free GM prompt builder for recruit/regenerate party cards.
- Routed `gameApi.upsertPartyCard` through the existing LLM JSON path with world, story arc, plot twist, current-state, party-card, and recent-transcript context.
- Normalized generated party-card JSON before storing it, including RPG attributes and HP.
- Passed the chat LLM connection into automatic party recruit mutations and wired the character sheet regenerate button.
- Added `party_card` handling to the game JSON repair apply flow.

## Refactor impact

Primary owner:

game mode, engine generation

Impact areas reviewed:

- Game mode party card metadata, GM prompt assembly, JSON repair apply flow, GameSurface party-change handling, and character sheet regenerate wiring.

Boundary notes:

- Engine prompt logic stays React-free in `src/engine`.
- Feature code continues to use `gameApi` and focused hooks.
- No raw Tauri calls, raw remote-runtime fetches, Rust changes, schema changes, or dependency changes.

Pressure points touched:

- GameSurface
- `gameApi`
- GM prompt module
- Game JSON repair apply switch

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `node scratch\issue-2134-party-card-proof.mjs` passes.
- `pnpm typecheck` passes.
- `pnpm check:architecture` passes.
- `pnpm check` passes.
- Manual Tauri desktop gameplay verification not run: I did not start a game and recruit a companion against a live LLM connection in the desktop app.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this restores existing game companion card generation/regeneration behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. No visible layout change; the sheet regenerate control already existed and is now wired to the repaired generation path.
