### PR TITLE
Restore lorebook schedule missing-state compatibility

### DIFF
--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -78,11 +78,11 @@ export interface GameStateForScanning {
  */
 function evaluateConditions(conditions: ActivationCondition[], gameState: GameStateForScanning | null): boolean {
   if (conditions.length === 0) return true;
-  if (!gameState) return true;
+  if (!gameState) return false;
 
   for (const condition of conditions) {
     const fieldValue = getGameStateValue(gameState, condition.field);
-    if (fieldValue === null) continue;
+    if (fieldValue === null) return false;
 
     switch (condition.operator) {
       case "equals":

--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -78,11 +78,11 @@ export interface GameStateForScanning {
  */
 function evaluateConditions(conditions: ActivationCondition[], gameState: GameStateForScanning | null): boolean {
   if (conditions.length === 0) return true;
-  if (!gameState) return false;
+  if (!gameState) return true;
 
   for (const condition of conditions) {
-    if (!hasGameStateValue(gameState, condition.field)) return false;
-    const fieldValue = String(gameState[condition.field] ?? "");
+    const fieldValue = getGameStateValue(gameState, condition.field);
+    if (fieldValue === null) continue;
 
     switch (condition.operator) {
       case "equals":
@@ -109,9 +109,11 @@ function evaluateConditions(conditions: ActivationCondition[], gameState: GameSt
   return true;
 }
 
-function hasGameStateValue(gameState: GameStateForScanning, field: string): boolean {
+function getGameStateValue(gameState: GameStateForScanning, field: string): string | null {
   const value = gameState[field];
-  return value !== undefined && value !== null && String(value).trim().length > 0;
+  if (value === undefined || value === null) return null;
+  const fieldValue = String(value).trim();
+  return fieldValue.length > 0 ? fieldValue : null;
 }
 
 function scheduleValues(values: string[] | undefined): string[] {
@@ -132,33 +134,39 @@ function hasScheduleGate(schedule: LorebookSchedule): boolean {
 function evaluateSchedule(schedule: LorebookSchedule | null, gameState: GameStateForScanning | null): boolean {
   if (!schedule) return true;
   if (!hasScheduleGate(schedule)) return true;
-  if (!gameState) return false;
+  if (!gameState) return true;
 
   // Check active times
   const activeTimes = scheduleValues(schedule.activeTimes);
   if (activeTimes.length > 0) {
-    if (!hasGameStateValue(gameState, "time")) return false;
-    const currentTime = String(gameState.time).toLowerCase();
-    const matches = activeTimes.some((t) => currentTime.includes(t.toLowerCase()));
-    if (!matches) return false;
+    const currentTime = getGameStateValue(gameState, "time");
+    if (currentTime !== null) {
+      const normalizedTime = currentTime.toLowerCase();
+      const matches = activeTimes.some((t) => normalizedTime.includes(t.toLowerCase()));
+      if (!matches) return false;
+    }
   }
 
   // Check active dates
   const activeDates = scheduleValues(schedule.activeDates);
   if (activeDates.length > 0) {
-    if (!hasGameStateValue(gameState, "date")) return false;
-    const currentDate = String(gameState.date).toLowerCase();
-    const matches = activeDates.some((d) => currentDate.includes(d.toLowerCase()));
-    if (!matches) return false;
+    const currentDate = getGameStateValue(gameState, "date");
+    if (currentDate !== null) {
+      const normalizedDate = currentDate.toLowerCase();
+      const matches = activeDates.some((d) => normalizedDate.includes(d.toLowerCase()));
+      if (!matches) return false;
+    }
   }
 
   // Check active locations
   const activeLocations = scheduleValues(schedule.activeLocations);
   if (activeLocations.length > 0) {
-    if (!hasGameStateValue(gameState, "location")) return false;
-    const currentLoc = String(gameState.location).toLowerCase();
-    const matches = activeLocations.some((l) => currentLoc.includes(l.toLowerCase()));
-    if (!matches) return false;
+    const currentLoc = getGameStateValue(gameState, "location");
+    if (currentLoc !== null) {
+      const normalizedLocation = currentLoc.toLowerCase();
+      const matches = activeLocations.some((l) => normalizedLocation.includes(l.toLowerCase()));
+      if (!matches) return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
## Linked issue

Closes #2183

## Why this change

- Lorebook schedule gates drifted from the documented compatibility decision when game state or a relevant schedule field was absent.
- Review also caught a high-risk regression where missing game state satisfied activation conditions. Condition gates should remain fail-closed unless a future condition operator explicitly documents missing-tolerant behavior.

## What changed

- Schedule gates now skip absent or blank `time`, `date`, and `location` fields, while present mismatching schedule fields still block activation.
- Activation condition gates now preserve absence as failure when the game-state object is missing or the referenced field is absent/blank.
- Shared value normalization remains local to the React-free lorebook scanner.

## Refactor impact

Primary owner:

- Engine generation / lorebook keyword scanner.

Impact areas reviewed:

- Prompt assembly lorebook activation.
- Active World Info scan output.
- Scanner preview and debug scan behavior using the shared scanner.
- Agent and knowledge-router scanner callers.

Boundary notes:

- Change stays in React-free `src/engine/generation-core/lorebooks/keyword-scanner.ts`.
- No React, shared API, Tauri, Rust, or remote-runtime boundary changes.

Pressure points touched:

- None; no ModeSurface, GameSurface, shared mode UI, command registration, or import modules touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Fresh scratch Vitest proof on the current rebased branch passed locally, then the scratch test file was removed before handoff to keep the PR within the repo rule against submitting `*.test.ts` proof files:
  - command: `pnpm exec vitest run src/engine/generation-core/lorebooks/keyword-scanner.scratch.test.ts`
  - result: 1 test file passed, 3 tests passed
  - rows covered: null game state fails condition-gated entry; missing referenced field fails condition-gated entry; populated matching field activates the entry
- Earlier scratch proof also covered that missing schedule state remains permissive while present schedule mismatch still blocks.
- `pnpm typecheck` passed locally after rebasing onto upstream `refactor`.
- No browser proof run because the changed behavior is in the shared React-free engine scanner.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix in existing lorebook scanning behavior; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A; no visible UI change.
