### PR TITLE
Fix lorebook entry transfer folder ownership

### DIFF
--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -43,7 +43,7 @@ async function transferLorebookEntries(
         await storageApi.update<LorebookEntry>(
           "lorebook-entries",
           entryId,
-          updateLorebookEntrySchema.parse({ lorebookId: targetLorebookId }),
+          updateLorebookEntrySchema.parse({ lorebookId: targetLorebookId, folderId: null }),
         ),
       );
     } else {
@@ -55,6 +55,7 @@ async function transferLorebookEntries(
           createLorebookEntrySchema.parse({
             ...copy,
             lorebookId: targetLorebookId,
+            folderId: null,
           }),
         ),
       );


### PR DESCRIPTION
## Linked issue

Closes #2186

## Why this change

- Copying or moving lorebook entries between lorebooks preserved the source entry `folderId`, which could leave the target lorebook with entries pointing at folders it does not own.

## What changed

- Clears `folderId` to `null` when moving selected entries to another lorebook.
- Clears `folderId` to `null` when copying selected entries to another lorebook.

## Refactor impact

Primary owner:

- Catalog lorebook entry transfer hook

Impact areas reviewed:

- Lorebook entry transfer UI hook
- Lorebook entry create/update schemas
- Storage API call shape used by embedded and remote runtime adapters

Boundary notes:

- No new engine, shared API, Tauri, or remote-runtime boundary added. Existing catalog hook continues to call the typed storage API wrapper.

Pressure points touched:

- None.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passes locally.
- `pnpm check` was attempted locally but stopped at `check:line-endings` because the working tree reports pre-existing CRLF line endings across many unrelated files before reaching architecture/frontend/Rust/docs checks.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No visible UI change; persistence payload only.