### PR TITLE
Fix managed message attachment handling

### DIFF
--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -55,14 +55,14 @@ export interface AddChatMessageSwipeOptions {
 }
 
 export interface StorageImageAttachmentReference {
-  type?: unknown;
-  url?: unknown;
-  data?: unknown;
-  imageUrl?: unknown;
-  filename?: unknown;
-  name?: unknown;
-  filePath?: unknown;
-  galleryId?: unknown;
+  type?: string | null;
+  url?: string | null;
+  data?: string | null;
+  imageUrl?: string | null;
+  filename?: string | null;
+  name?: string | null;
+  filePath?: string | null;
+  galleryId?: string | null;
 }
 
 export interface StorageGateway {

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -54,6 +54,17 @@ export interface AddChatMessageSwipeOptions {
   characterId?: string | null;
 }
 
+export interface StorageImageAttachmentReference {
+  type?: unknown;
+  url?: unknown;
+  data?: unknown;
+  imageUrl?: unknown;
+  filename?: unknown;
+  name?: unknown;
+  filePath?: unknown;
+  galleryId?: unknown;
+}
+
 export interface StorageGateway {
   list<T = unknown>(entity: StorageEntity, options?: StorageListOptions): Promise<T[]>;
   get<T = unknown>(
@@ -75,6 +86,7 @@ export interface StorageGateway {
   ): Promise<{ updated: boolean; message?: T }>;
   deleteChatMessage(messageId: string): Promise<{ deleted: boolean }>;
   patchChatMessageExtra<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T>;
+  resolveImageAttachmentDataUrl?(attachment: StorageImageAttachmentReference): Promise<string | null>;
   /**
    * Evict saved generation prompt snapshots from older assistant messages,
    * keeping only the most recent `keepLast` (default 2, matching v1.6.1). Bounds

--- a/src/engine/contracts/schemas/chat.schema.ts
+++ b/src/engine/contracts/schemas/chat.schema.ts
@@ -65,9 +65,14 @@ export const generateRequestSchema = z.object({
     .array(
       z.object({
         type: z.string(),
-        data: z.string(),
-        filename: z.string().optional(),
-        name: z.string().optional(),
+        url: z.string().nullable().optional(),
+        data: z.string().nullable().optional(),
+        imageUrl: z.string().nullable().optional(),
+        filePath: z.string().nullable().optional(),
+        filename: z.string().nullable().optional(),
+        name: z.string().nullable().optional(),
+        prompt: z.string().nullable().optional(),
+        galleryId: z.string().nullable().optional(),
       }),
     )
     .optional()

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -387,6 +387,8 @@ export interface MessageAttachment {
   type?: string | null;
   url?: string | null;
   data?: string | null;
+  imageUrl?: string | null;
+  filePath?: string | null;
   filename?: string | null;
   name?: string | null;
   prompt?: string | null;

--- a/src/engine/generation/generate-route-utils.ts
+++ b/src/engine/generation/generate-route-utils.ts
@@ -7,6 +7,8 @@ export type PromptAttachment = {
   type?: string | null;
   url?: string | null;
   data?: string | null;
+  imageUrl?: string | null;
+  filePath?: string | null;
   filename?: string | null;
   name?: string | null;
   prompt?: string | null;

--- a/src/engine/generation/generate-route-utils.ts
+++ b/src/engine/generation/generate-route-utils.ts
@@ -1,19 +1,11 @@
 import { generationParametersSchema } from "../contracts/schemas/prompt.schema";
 import type { GenerationParameters } from "../contracts/types/prompt";
+import { getAttachmentFilename, type PromptAttachment } from "../shared/attachments/image-attachments";
 import { parseRecord, readNonNegativeInteger, readString } from "./runtime-records";
 
 export type StoredGenerationParameters = Partial<GenerationParameters>;
-export type PromptAttachment = {
-  type?: string | null;
-  url?: string | null;
-  data?: string | null;
-  imageUrl?: string | null;
-  filePath?: string | null;
-  filename?: string | null;
-  name?: string | null;
-  prompt?: string | null;
-  galleryId?: string | null;
-};
+export type { PromptAttachment };
+export { getAttachmentFilename };
 
 const TEXT_ATTACHMENT_CHAR_LIMIT = 60_000;
 const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
@@ -109,11 +101,6 @@ export function resolveRegenerationGameStateFallbackMessageIds(
     }
   }
   return Array.from(targets.values());
-}
-
-export function getAttachmentFilename(attachment: PromptAttachment): string {
-  const rawName = attachment.filename ?? attachment.name;
-  return typeof rawName === "string" && rawName.trim() ? rawName.trim() : "attachment";
 }
 
 export function extractImageAttachmentDataUrls(attachments: PromptAttachment[] | undefined): string[] {

--- a/src/engine/generation/managed-attachments.ts
+++ b/src/engine/generation/managed-attachments.ts
@@ -1,0 +1,141 @@
+import type { StorageGateway } from "../capabilities/storage";
+import { getAttachmentFilename, type PromptAttachment } from "./generate-route-utils";
+import { readString } from "./runtime-records";
+
+const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
+
+function isImageAttachment(attachment: PromptAttachment): boolean {
+  const type = readString(attachment.type).toLowerCase();
+  return type === "image" || type.startsWith("image/");
+}
+
+function inlineImageDataUrl(value: unknown): string {
+  const text = readString(value).trim();
+  return text.toLowerCase().startsWith("data:image/") ? text : "";
+}
+
+function attachmentInlineImageDataUrl(attachment: PromptAttachment): string {
+  return (
+    inlineImageDataUrl(attachment.data) ||
+    inlineImageDataUrl(attachment.url) ||
+    inlineImageDataUrl(attachment.imageUrl)
+  );
+}
+
+function estimateDataUrlBytes(dataUrl: string): number {
+  const commaIndex = dataUrl.indexOf(",");
+  if (!dataUrl.startsWith("data:") || commaIndex < 0) return utf8ByteLength(dataUrl);
+
+  const meta = dataUrl.slice(0, commaIndex).toLowerCase();
+  const payload = dataUrl.slice(commaIndex + 1);
+  if (!meta.includes(";base64")) {
+    try {
+      return utf8ByteLength(decodeURIComponent(payload));
+    } catch {
+      return utf8ByteLength(payload);
+    }
+  }
+
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((payload.length * 3) / 4) - padding);
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function isProviderSizedImageDataUrl(dataUrl: string): boolean {
+  return estimateDataUrlBytes(dataUrl) <= IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT;
+}
+
+function galleryStringField(row: unknown, field: string): string {
+  return row && typeof row === "object" && !Array.isArray(row)
+    ? readString((row as Record<string, unknown>)[field]).trim()
+    : "";
+}
+
+function attachmentFilename(attachment: PromptAttachment, index: number): string {
+  const filename = getAttachmentFilename(attachment).trim();
+  return filename && filename !== "attachment" ? filename : `attachment-${index + 1}`;
+}
+
+function managedAttachmentFromGallery(
+  attachment: PromptAttachment,
+  gallery: unknown,
+  fallbackFilename: string,
+): PromptAttachment {
+  const url = galleryStringField(gallery, "url") || readString(attachment.url).trim();
+  const galleryId = galleryStringField(gallery, "id") || readString(attachment.galleryId).trim();
+  const filePath = galleryStringField(gallery, "filePath") || readString(attachment.filePath).trim();
+  const filename = galleryStringField(gallery, "filename") || readString(attachment.filename).trim() || fallbackFilename;
+  const name = readString(attachment.name).trim() || filename;
+  const next: PromptAttachment = {
+    ...attachment,
+    data: null,
+    filename,
+    name,
+  };
+  if (url) next.url = url;
+  if (galleryId) next.galleryId = galleryId;
+  if (filePath) next.filePath = filePath;
+  if (inlineImageDataUrl(attachment.imageUrl) && url) next.imageUrl = url;
+  return next;
+}
+
+export async function prepareManagedImageAttachments(
+  storage: StorageGateway,
+  chatId: string,
+  attachments: PromptAttachment[] | undefined,
+): Promise<PromptAttachment[]> {
+  const normalizedAttachments = attachments ?? [];
+  if (normalizedAttachments.length === 0) return [];
+
+  const normalizedChatId = readString(chatId).trim();
+  if (!normalizedChatId) return normalizedAttachments;
+
+  const managed: PromptAttachment[] = [];
+  for (let index = 0; index < normalizedAttachments.length; index += 1) {
+    const attachment = normalizedAttachments[index]!;
+    if (!isImageAttachment(attachment)) {
+      managed.push(attachment);
+      continue;
+    }
+
+    const dataUrl = attachmentInlineImageDataUrl(attachment);
+    if (!dataUrl) {
+      managed.push(attachment);
+      continue;
+    }
+
+    const filename = attachmentFilename(attachment, index);
+    const gallery = await storage.create<Record<string, unknown>>("gallery", {
+      chatId: normalizedChatId,
+      filePath: filename,
+      filename,
+      kind: "attachment",
+      prompt: attachment.prompt ?? null,
+      url: dataUrl,
+    });
+    managed.push(managedAttachmentFromGallery(attachment, gallery, filename));
+  }
+  return managed;
+}
+
+export async function resolveImageAttachmentDataUrls(
+  storage: StorageGateway,
+  attachments: PromptAttachment[] | undefined,
+): Promise<string[]> {
+  const images: string[] = [];
+  for (const attachment of attachments ?? []) {
+    if (!isImageAttachment(attachment)) continue;
+    const inline = attachmentInlineImageDataUrl(attachment);
+    if (inline) {
+      if (isProviderSizedImageDataUrl(inline)) images.push(inline);
+      continue;
+    }
+
+    const resolved = await storage.resolveImageAttachmentDataUrl?.(attachment);
+    if (resolved && isProviderSizedImageDataUrl(resolved)) images.push(resolved);
+  }
+  return images;
+}

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -52,7 +52,10 @@ import {
   shouldPreferLatestVisibleGameState,
   type PromptAttachment,
 } from "./generate-route-utils";
-import { prepareManagedImageAttachments, resolveImageAttachmentDataUrls } from "./managed-attachments";
+import {
+  prepareManagedImageAttachments,
+  resolveImageAttachmentDataUrls,
+} from "../shared/attachments/image-attachments";
 import type { GenerationEvent } from "./generation-events";
 import {
   applyGenerationReplayToRegenerateInput,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -53,8 +53,10 @@ import {
   type PromptAttachment,
 } from "./generate-route-utils";
 import {
-  prepareManagedImageAttachments,
+  deletePreparedManagedImageAttachments,
+  prepareManagedImageAttachmentBatch,
   resolveImageAttachmentDataUrls,
+  type PreparedManagedImageAttachments,
 } from "../shared/attachments/image-attachments";
 import type { GenerationEvent } from "./generation-events";
 import {
@@ -150,6 +152,7 @@ export interface RetryAgentsInput extends JsonRecord {
 interface PreparedUserInput {
   content: string;
   attachments: PromptAttachment[];
+  preparedAttachments: PreparedManagedImageAttachments;
   images: string[];
   mentionedCharacterNames: string[];
 }
@@ -285,7 +288,8 @@ async function prepareUserInput(storage: StorageGateway, input: StartGenerationI
   const raw = inputUserMessage(input).trim();
   const attachments = inputAttachments(input);
   const images = await resolveImageAttachmentDataUrls(storage, attachments);
-  const managedAttachments = await prepareManagedImageAttachments(storage, input.chatId, attachments);
+  const preparedAttachments = await prepareManagedImageAttachmentBatch(storage, input.chatId, attachments);
+  const managedAttachments = preparedAttachments.attachments;
   const mentionedCharacterNames = stringArray(input.mentionedCharacterNames).filter((name) => name.trim().length > 0);
   const regexed = raw ? await applyRuntimeRegexScripts(storage, "user_input", raw) : "";
   const withReadableAttachments = appendReadableAttachmentsToContent(regexed, managedAttachments);
@@ -295,9 +299,23 @@ async function prepareUserInput(storage: StorageGateway, input: StartGenerationI
       [withReadableAttachments, imageNotes].filter((part) => part.trim().length > 0).join("\n\n"),
     ),
     attachments: managedAttachments,
+    preparedAttachments,
     images,
     mentionedCharacterNames,
   };
+}
+
+async function deletePreparedUserInputAttachmentsSafely(
+  storage: StorageGateway,
+  prepared: PreparedUserInput,
+  reason: string,
+): Promise<void> {
+  if (prepared.preparedAttachments.createdGalleryIds.length === 0) return;
+  try {
+    await deletePreparedManagedImageAttachments(storage, prepared.preparedAttachments);
+  } catch (error) {
+    console.warn(`[generation] Failed to roll back prepared image attachments after ${reason}`, error);
+  }
 }
 
 function shouldSaveUserMessage(
@@ -2656,17 +2674,27 @@ export async function* startGeneration(
 
   yield { type: "phase", data: "Saving message..." };
   const preparedUserInput = await prepareUserInput(deps.storage, input);
-  throwIfAborted(signal);
-  const savesUserMessage = shouldSaveUserMessage(input, preparedUserInput, internalOptions);
-  const messageLoadOptions = generationMessageLoadOptions(chat, input);
+  let savesUserMessage = false;
+  let savedUserMessage: unknown | null = null;
   let storedMessages: JsonRecord[] | null = null;
-  if (savesUserMessage) {
-    storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
+  const messageLoadOptions = generationMessageLoadOptions(chat, input);
+  try {
     throwIfAborted(signal);
-    await commitVisibleTrackerSnapshotSafely(deps.storage, chatId, storedMessages);
-    throwIfAborted(signal);
+    savesUserMessage = shouldSaveUserMessage(input, preparedUserInput, internalOptions);
+    if (!savesUserMessage) {
+      await deletePreparedUserInputAttachmentsSafely(deps.storage, preparedUserInput, "non-persisted generation setup");
+    }
+    if (savesUserMessage) {
+      storedMessages = await loadChatMessages(deps.storage, chatId, messageLoadOptions);
+      throwIfAborted(signal);
+      await commitVisibleTrackerSnapshotSafely(deps.storage, chatId, storedMessages);
+      throwIfAborted(signal);
+    }
+    savedUserMessage = await saveUserMessage(deps.storage, chat, input, preparedUserInput, internalOptions);
+  } catch (error) {
+    await deletePreparedUserInputAttachmentsSafely(deps.storage, preparedUserInput, "failed user message save");
+    throw error;
   }
-  const savedUserMessage = await saveUserMessage(deps.storage, chat, input, preparedUserInput, internalOptions);
   throwIfAborted(signal);
   if (savedUserMessage) yield { type: "user_message", data: savedGenerationEventData(savedUserMessage) };
   const connection = await resolveGenerationConnection(deps.storage, chat, input);

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -45,7 +45,6 @@ import {
 } from "./context";
 import {
   appendReadableAttachmentsToContent,
-  extractImageAttachmentDataUrls,
   getAttachmentFilename,
   resolveRegenerationGameStateAnchor,
   resolveRegenerationGameStateFallbackMessageIds,
@@ -53,6 +52,7 @@ import {
   shouldPreferLatestVisibleGameState,
   type PromptAttachment,
 } from "./generate-route-utils";
+import { prepareManagedImageAttachments, resolveImageAttachmentDataUrls } from "./managed-attachments";
 import type { GenerationEvent } from "./generation-events";
 import {
   applyGenerationReplayToRegenerateInput,
@@ -281,16 +281,17 @@ function imageAttachmentNotes(attachments: PromptAttachment[]): string {
 async function prepareUserInput(storage: StorageGateway, input: StartGenerationInput): Promise<PreparedUserInput> {
   const raw = inputUserMessage(input).trim();
   const attachments = inputAttachments(input);
-  const images = extractImageAttachmentDataUrls(attachments);
+  const images = await resolveImageAttachmentDataUrls(storage, attachments);
+  const managedAttachments = await prepareManagedImageAttachments(storage, input.chatId, attachments);
   const mentionedCharacterNames = stringArray(input.mentionedCharacterNames).filter((name) => name.trim().length > 0);
   const regexed = raw ? await applyRuntimeRegexScripts(storage, "user_input", raw) : "";
-  const withReadableAttachments = appendReadableAttachmentsToContent(regexed, attachments);
-  const imageNotes = imageAttachmentNotes(attachments);
+  const withReadableAttachments = appendReadableAttachmentsToContent(regexed, managedAttachments);
+  const imageNotes = imageAttachmentNotes(managedAttachments);
   return {
     content: collapseExcessBlankLines(
       [withReadableAttachments, imageNotes].filter((part) => part.trim().length > 0).join("\n\n"),
     ),
-    attachments,
+    attachments: managedAttachments,
     images,
     mentionedCharacterNames,
   };
@@ -302,7 +303,11 @@ function shouldSaveUserMessage(
   internalOptions: InternalStartGenerationOptions = {},
 ): boolean {
   if (internalOptions.skipUserMessageSave === true) return false;
-  return !!prepared.content.trim() && input.impersonate !== true && !readString(input.regenerateMessageId).trim();
+  return (
+    (!!prepared.content.trim() || prepared.attachments.length > 0) &&
+    input.impersonate !== true &&
+    !readString(input.regenerateMessageId).trim()
+  );
 }
 
 async function saveUserMessage(

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -54,6 +54,7 @@ import {
 } from "./generate-route-utils";
 import {
   deletePreparedManagedImageAttachments,
+  isImageAttachment,
   prepareManagedImageAttachmentBatch,
   resolveImageAttachmentDataUrls,
   type PreparedManagedImageAttachments,
@@ -277,9 +278,7 @@ function assertChatCanGenerate(chat: JsonRecord, input?: { forCharacterId?: unkn
 }
 
 function imageAttachmentNotes(attachments: PromptAttachment[]): string {
-  const names = attachments
-    .filter((attachment) => readString(attachment.type).toLowerCase().startsWith("image/"))
-    .map(getAttachmentFilename);
+  const names = attachments.filter(isImageAttachment).map(getAttachmentFilename);
   if (names.length === 0) return "";
   return names.map((name) => `[Attached image: ${name}]`).join("\n");
 }
@@ -289,20 +288,29 @@ async function prepareUserInput(storage: StorageGateway, input: StartGenerationI
   const attachments = inputAttachments(input);
   const images = await resolveImageAttachmentDataUrls(storage, attachments);
   const preparedAttachments = await prepareManagedImageAttachmentBatch(storage, input.chatId, attachments);
-  const managedAttachments = preparedAttachments.attachments;
-  const mentionedCharacterNames = stringArray(input.mentionedCharacterNames).filter((name) => name.trim().length > 0);
-  const regexed = raw ? await applyRuntimeRegexScripts(storage, "user_input", raw) : "";
-  const withReadableAttachments = appendReadableAttachmentsToContent(regexed, managedAttachments);
-  const imageNotes = imageAttachmentNotes(managedAttachments);
-  return {
-    content: collapseExcessBlankLines(
-      [withReadableAttachments, imageNotes].filter((part) => part.trim().length > 0).join("\n\n"),
-    ),
-    attachments: managedAttachments,
-    preparedAttachments,
-    images,
-    mentionedCharacterNames,
-  };
+  try {
+    const managedAttachments = preparedAttachments.attachments;
+    const mentionedCharacterNames = stringArray(input.mentionedCharacterNames).filter((name) => name.trim().length > 0);
+    const regexed = raw ? await applyRuntimeRegexScripts(storage, "user_input", raw) : "";
+    const withReadableAttachments = appendReadableAttachmentsToContent(regexed, managedAttachments);
+    const imageNotes = imageAttachmentNotes(managedAttachments);
+    return {
+      content: collapseExcessBlankLines(
+        [withReadableAttachments, imageNotes].filter((part) => part.trim().length > 0).join("\n\n"),
+      ),
+      attachments: managedAttachments,
+      preparedAttachments,
+      images,
+      mentionedCharacterNames,
+    };
+  } catch (error) {
+    if (preparedAttachments.createdGalleryIds.length > 0) {
+      await deletePreparedManagedImageAttachments(storage, preparedAttachments).catch((rollbackError) => {
+        console.warn("[generation] Failed to roll back prepared image attachments after input preparation failure", rollbackError);
+      });
+    }
+    throw error;
+  }
 }
 
 async function deletePreparedUserInputAttachmentsSafely(

--- a/src/engine/shared/attachments/image-attachments.ts
+++ b/src/engine/shared/attachments/image-attachments.ts
@@ -38,6 +38,10 @@ function attachmentInlineImageDataUrl(attachment: PromptAttachment): string {
   );
 }
 
+function hasManagedGalleryReference(attachment: PromptAttachment): boolean {
+  return !!readString(attachment.galleryId).trim() || !!readString(attachment.filePath).trim();
+}
+
 function estimateDataUrlBytes(dataUrl: string): number {
   const commaIndex = dataUrl.indexOf(",");
   if (!dataUrl.startsWith("data:") || commaIndex < 0) return utf8ByteLength(dataUrl);
@@ -103,6 +107,16 @@ function managedAttachmentFromGallery(
   return next;
 }
 
+function managedAttachmentFromReference(attachment: PromptAttachment, fallbackFilename: string): PromptAttachment {
+  const filename = readString(attachment.filename).trim() || readString(attachment.name).trim() || fallbackFilename;
+  return {
+    ...attachment,
+    data: null,
+    filename,
+    name: readString(attachment.name).trim() || filename,
+  };
+}
+
 async function deleteGalleryIds(storage: StorageGateway, galleryIds: string[]): Promise<void> {
   const uniqueIds = Array.from(new Set(galleryIds.map((id) => id.trim()).filter(Boolean)));
   await Promise.all(uniqueIds.map((id) => storage.delete("gallery", id)));
@@ -129,6 +143,11 @@ export async function prepareManagedImageAttachmentBatch(
         continue;
       }
 
+      if (hasManagedGalleryReference(attachment)) {
+        managed.push(managedAttachmentFromReference(attachment, attachmentFilename(attachment, index)));
+        continue;
+      }
+
       const dataUrl = attachmentInlineImageDataUrl(attachment);
       if (!dataUrl) {
         managed.push(attachment);
@@ -145,7 +164,8 @@ export async function prepareManagedImageAttachmentBatch(
         url: dataUrl,
       });
       const galleryId = galleryStringField(gallery, "id");
-      if (galleryId) createdGalleryIds.push(galleryId);
+      if (!galleryId) throw new Error("Managed image attachment was saved without a gallery id.");
+      createdGalleryIds.push(galleryId);
       managed.push(managedAttachmentFromGallery(attachment, gallery, filename));
     }
   } catch (error) {
@@ -154,14 +174,6 @@ export async function prepareManagedImageAttachmentBatch(
   }
 
   return { attachments: managed, createdGalleryIds };
-}
-
-export async function prepareManagedImageAttachments(
-  storage: StorageGateway,
-  chatId: string,
-  attachments: PromptAttachment[] | undefined,
-): Promise<PromptAttachment[]> {
-  return (await prepareManagedImageAttachmentBatch(storage, chatId, attachments)).attachments;
 }
 
 export async function deletePreparedManagedImageAttachments(

--- a/src/engine/shared/attachments/image-attachments.ts
+++ b/src/engine/shared/attachments/image-attachments.ts
@@ -1,6 +1,22 @@
-import type { StorageGateway } from "../capabilities/storage";
-import { getAttachmentFilename, type PromptAttachment } from "./generate-route-utils";
-import { readString } from "./runtime-records";
+import type { StorageGateway } from "../../capabilities/storage";
+import { readString } from "../value-readers";
+
+export type PromptAttachment = {
+  type?: string | null;
+  url?: string | null;
+  data?: string | null;
+  imageUrl?: string | null;
+  filePath?: string | null;
+  filename?: string | null;
+  name?: string | null;
+  prompt?: string | null;
+  galleryId?: string | null;
+};
+
+export interface PreparedManagedImageAttachments {
+  attachments: PromptAttachment[];
+  createdGalleryIds: string[];
+}
 
 const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
 
@@ -54,6 +70,11 @@ function galleryStringField(row: unknown, field: string): string {
     : "";
 }
 
+export function getAttachmentFilename(attachment: PromptAttachment): string {
+  const rawName = attachment.filename ?? attachment.name;
+  return typeof rawName === "string" && rawName.trim() ? rawName.trim() : "attachment";
+}
+
 function attachmentFilename(attachment: PromptAttachment, index: number): string {
   const filename = getAttachmentFilename(attachment).trim();
   return filename && filename !== "attachment" ? filename : `attachment-${index + 1}`;
@@ -82,43 +103,72 @@ function managedAttachmentFromGallery(
   return next;
 }
 
+async function deleteGalleryIds(storage: StorageGateway, galleryIds: string[]): Promise<void> {
+  const uniqueIds = Array.from(new Set(galleryIds.map((id) => id.trim()).filter(Boolean)));
+  await Promise.all(uniqueIds.map((id) => storage.delete("gallery", id)));
+}
+
+export async function prepareManagedImageAttachmentBatch(
+  storage: StorageGateway,
+  chatId: string,
+  attachments: PromptAttachment[] | undefined,
+): Promise<PreparedManagedImageAttachments> {
+  const normalizedAttachments = attachments ?? [];
+  if (normalizedAttachments.length === 0) return { attachments: [], createdGalleryIds: [] };
+
+  const normalizedChatId = readString(chatId).trim();
+  if (!normalizedChatId) return { attachments: normalizedAttachments, createdGalleryIds: [] };
+
+  const managed: PromptAttachment[] = [];
+  const createdGalleryIds: string[] = [];
+  try {
+    for (let index = 0; index < normalizedAttachments.length; index += 1) {
+      const attachment = normalizedAttachments[index]!;
+      if (!isImageAttachment(attachment)) {
+        managed.push(attachment);
+        continue;
+      }
+
+      const dataUrl = attachmentInlineImageDataUrl(attachment);
+      if (!dataUrl) {
+        managed.push(attachment);
+        continue;
+      }
+
+      const filename = attachmentFilename(attachment, index);
+      const gallery = await storage.create<Record<string, unknown>>("gallery", {
+        chatId: normalizedChatId,
+        filePath: filename,
+        filename,
+        kind: "attachment",
+        prompt: attachment.prompt ?? null,
+        url: dataUrl,
+      });
+      const galleryId = galleryStringField(gallery, "id");
+      if (galleryId) createdGalleryIds.push(galleryId);
+      managed.push(managedAttachmentFromGallery(attachment, gallery, filename));
+    }
+  } catch (error) {
+    await deleteGalleryIds(storage, createdGalleryIds).catch(() => undefined);
+    throw error;
+  }
+
+  return { attachments: managed, createdGalleryIds };
+}
+
 export async function prepareManagedImageAttachments(
   storage: StorageGateway,
   chatId: string,
   attachments: PromptAttachment[] | undefined,
 ): Promise<PromptAttachment[]> {
-  const normalizedAttachments = attachments ?? [];
-  if (normalizedAttachments.length === 0) return [];
+  return (await prepareManagedImageAttachmentBatch(storage, chatId, attachments)).attachments;
+}
 
-  const normalizedChatId = readString(chatId).trim();
-  if (!normalizedChatId) return normalizedAttachments;
-
-  const managed: PromptAttachment[] = [];
-  for (let index = 0; index < normalizedAttachments.length; index += 1) {
-    const attachment = normalizedAttachments[index]!;
-    if (!isImageAttachment(attachment)) {
-      managed.push(attachment);
-      continue;
-    }
-
-    const dataUrl = attachmentInlineImageDataUrl(attachment);
-    if (!dataUrl) {
-      managed.push(attachment);
-      continue;
-    }
-
-    const filename = attachmentFilename(attachment, index);
-    const gallery = await storage.create<Record<string, unknown>>("gallery", {
-      chatId: normalizedChatId,
-      filePath: filename,
-      filename,
-      kind: "attachment",
-      prompt: attachment.prompt ?? null,
-      url: dataUrl,
-    });
-    managed.push(managedAttachmentFromGallery(attachment, gallery, filename));
-  }
-  return managed;
+export async function deletePreparedManagedImageAttachments(
+  storage: StorageGateway,
+  prepared: PreparedManagedImageAttachments,
+): Promise<void> {
+  await deleteGalleryIds(storage, prepared.createdGalleryIds);
 }
 
 export async function resolveImageAttachmentDataUrls(

--- a/src/engine/shared/attachments/image-attachments.ts
+++ b/src/engine/shared/attachments/image-attachments.ts
@@ -20,7 +20,7 @@ export interface PreparedManagedImageAttachments {
 
 const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
 
-function isImageAttachment(attachment: PromptAttachment): boolean {
+export function isImageAttachment(attachment: PromptAttachment): boolean {
   const type = readString(attachment.type).toLowerCase();
   return type === "image" || type.startsWith("image/");
 }

--- a/src/features/catalog/gallery/cache.ts
+++ b/src/features/catalog/gallery/cache.ts
@@ -10,12 +10,17 @@ function hasManagedGalleryReference(attachment: ManagedAttachmentGalleryReferenc
   return !!attachment.galleryId?.trim() || !!attachment.filePath?.trim();
 }
 
+export function invalidateGalleryImagesForChat(queryClient: QueryClient, chatId: string | null | undefined): void {
+  const normalizedChatId = chatId?.trim();
+  if (!normalizedChatId) return;
+  void queryClient.invalidateQueries({ queryKey: galleryKeys.images(normalizedChatId) });
+}
+
 export function invalidateGalleryImagesForManagedAttachments(
   queryClient: QueryClient,
   chatId: string | null | undefined,
   attachments: readonly ManagedAttachmentGalleryReference[],
 ): void {
-  const normalizedChatId = chatId?.trim();
-  if (!normalizedChatId || !attachments.some(hasManagedGalleryReference)) return;
-  void queryClient.invalidateQueries({ queryKey: galleryKeys.images(normalizedChatId) });
+  if (!attachments.some(hasManagedGalleryReference)) return;
+  invalidateGalleryImagesForChat(queryClient, chatId);
 }

--- a/src/features/catalog/gallery/cache.ts
+++ b/src/features/catalog/gallery/cache.ts
@@ -1,0 +1,21 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { galleryKeys } from "./query-keys";
+
+type ManagedAttachmentGalleryReference = {
+  galleryId?: string | null;
+  filePath?: string | null;
+};
+
+function hasManagedGalleryReference(attachment: ManagedAttachmentGalleryReference): boolean {
+  return !!attachment.galleryId?.trim() || !!attachment.filePath?.trim();
+}
+
+export function invalidateGalleryImagesForManagedAttachments(
+  queryClient: QueryClient,
+  chatId: string | null | undefined,
+  attachments: readonly ManagedAttachmentGalleryReference[],
+): void {
+  const normalizedChatId = chatId?.trim();
+  if (!normalizedChatId || !attachments.some(hasManagedGalleryReference)) return;
+  void queryClient.invalidateQueries({ queryKey: galleryKeys.images(normalizedChatId) });
+}

--- a/src/features/catalog/gallery/index.ts
+++ b/src/features/catalog/gallery/index.ts
@@ -1,2 +1,3 @@
 export * from "./query-keys";
+export * from "./cache";
 export * from "./hooks/use-gallery";

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -25,7 +25,12 @@ import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
-import { storageApi } from "../../../../shared/api/storage-api";
+import {
+  deletePreparedManagedImageAttachments,
+  prepareManagedImageAttachmentBatch,
+  prepareManagedImageAttachments,
+  type PreparedManagedImageAttachments,
+} from "../../../../shared/api/message-attachment-api";
 import { useGenerate } from "../../../runtime/generation/index";
 import { readScopedRegexMode, useApplyRegex } from "../../../catalog/agents/regex-application";
 import {
@@ -74,7 +79,6 @@ import { EmojiPicker } from "../../../../shared/components/ui/EmojiPicker";
 import { GifPicker } from "../../../../shared/components/ui/GifPicker";
 import { SpeechToTextButton } from "../../../../shared/components/ui/SpeechToTextButton";
 import type { Message } from "../../../../engine/contracts/types/chat";
-import { prepareManagedImageAttachments } from "../../../../engine/generation/managed-attachments";
 import { buildGuidedGenerationInstructionMessage } from "../../../../engine/shared/text/generation-guide";
 
 interface Attachment {
@@ -611,7 +615,7 @@ export function ConversationInput({
       let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
       try {
         managedAttachments = currentAttachments.length
-          ? await prepareManagedImageAttachments(storageApi, activeChatId, currentAttachments)
+          ? await prepareManagedImageAttachments(activeChatId, currentAttachments)
           : [];
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
@@ -729,7 +733,7 @@ export function ConversationInput({
     let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
     try {
       managedAttachments = pendingAttachments.length
-        ? await prepareManagedImageAttachments(storageApi, activeChatId, pendingAttachments)
+        ? await prepareManagedImageAttachments(activeChatId, pendingAttachments)
         : [];
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
@@ -962,25 +966,35 @@ export function ConversationInput({
     setMentionCompletions([]);
 
     let createdMessageId: string | null = null;
+    let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
     try {
-      const managedAttachments = pendingAttachments.length
-        ? await prepareManagedImageAttachments(storageApi, submittingChatId, pendingAttachments)
-        : [];
-      invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
       const created = await createMessage.mutateAsync({
         role: "user",
         content: message,
         characterId: null,
       });
       createdMessageId = created.id;
+      preparedManagedAttachments = pendingAttachments.length
+        ? await prepareManagedImageAttachmentBatch(submittingChatId, pendingAttachments)
+        : null;
+      const managedAttachments = preparedManagedAttachments?.attachments ?? [];
       if (managedAttachments.length) {
         await updateMessageExtra.mutateAsync({
           messageId: created.id,
           extra: { attachments: managedAttachments },
         });
+        invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
       }
     } catch (error) {
       let rollbackFailed = false;
+      if (preparedManagedAttachments?.createdGalleryIds.length) {
+        try {
+          await deletePreparedManagedImageAttachments(preparedManagedAttachments);
+        } catch {
+          rollbackFailed = true;
+        }
+        invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, preparedManagedAttachments.attachments);
+      }
       if (createdMessageId) {
         try {
           await deleteMessage.mutateAsync(createdMessageId);
@@ -1010,7 +1024,7 @@ export function ConversationInput({
         setInputDraft(submittingChatId, submittedDraft);
       }
       const msg = error instanceof Error ? error.message : "Failed to post message";
-      toast.error(rollbackFailed ? `${msg}; the partial message may need to be removed before retrying.` : msg);
+      toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
     }
   }, [
     activeChatId,
@@ -1300,21 +1314,50 @@ export function ConversationInput({
         // If fetch fails (CORS etc.), send without attachment — still shows as image in chat
       }
 
+      const saveGifMessage = async () => {
+        let createdMessageId: string | null = null;
+        let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
+        try {
+          const created = await createMessage.mutateAsync({ role: "user", content: gifUrl, characterId: null });
+          createdMessageId = created.id;
+          preparedManagedAttachments = gifAttachments
+            ? await prepareManagedImageAttachmentBatch(activeChatId, gifAttachments)
+            : null;
+          const managedGifAttachments = preparedManagedAttachments?.attachments ?? [];
+          if (managedGifAttachments.length) {
+            await updateMessageExtra.mutateAsync({
+              messageId: created.id,
+              extra: { attachments: managedGifAttachments },
+            });
+            invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedGifAttachments);
+          }
+        } catch (error) {
+          if (preparedManagedAttachments?.createdGalleryIds.length) {
+            await deletePreparedManagedImageAttachments(preparedManagedAttachments).catch(() => undefined);
+            invalidateGalleryImagesForManagedAttachments(qc, activeChatId, preparedManagedAttachments.attachments);
+          }
+          if (createdMessageId) {
+            await deleteMessage.mutateAsync(createdMessageId).catch(() => undefined);
+          }
+          toast.error(error instanceof Error ? error.message : "Failed to send GIF.");
+        }
+      };
+
       // If already streaming for this chat, just save the message
       if (isStreaming) {
-        createMessage.mutate({ role: "user", content: gifUrl, characterId: null });
+        await saveGifMessage();
         return;
       }
 
       if (groupResponseOrder === "manual" && characterNames.length > 1) {
-        createMessage.mutate({ role: "user", content: gifUrl, characterId: null });
+        await saveGifMessage();
         return;
       }
 
       let managedGifAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> | undefined;
       try {
         managedGifAttachments = gifAttachments
-          ? await prepareManagedImageAttachments(storageApi, activeChatId, gifAttachments)
+          ? await prepareManagedImageAttachments(activeChatId, gifAttachments)
           : undefined;
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Failed to prepare GIF attachment.");
@@ -1331,7 +1374,17 @@ export function ConversationInput({
         ...(managedGifAttachments?.length ? { attachments: managedGifAttachments } : {}),
       });
     },
-    [activeChatId, isStreaming, groupResponseOrder, characterNames.length, generate, createMessage, qc],
+    [
+      activeChatId,
+      isStreaming,
+      groupResponseOrder,
+      characterNames.length,
+      generate,
+      createMessage,
+      deleteMessage,
+      updateMessageExtra,
+      qc,
+    ],
   );
 
   const handleCharacterResponse = useCallback(

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -28,7 +28,6 @@ import { useUIStore } from "../../../../shared/stores/ui.store";
 import {
   deletePreparedManagedImageAttachments,
   prepareManagedImageAttachmentBatch,
-  prepareManagedImageAttachments,
   type PreparedManagedImageAttachments,
 } from "../../../../shared/api/message-attachment-api";
 import { useGenerate } from "../../../runtime/generation/index";
@@ -41,7 +40,7 @@ import {
   chatKeys,
 } from "../../../catalog/chats/index";
 import { characterKeys } from "../../../catalog/characters/index";
-import { invalidateGalleryImagesForManagedAttachments } from "../../../catalog/gallery/index";
+import { invalidateGalleryImagesForChat, invalidateGalleryImagesForManagedAttachments } from "../../../catalog/gallery/index";
 import {
   personaKeys,
   useActivePersonaSummary,
@@ -750,16 +749,6 @@ export function ConversationInput({
     message = resolveInputMacros(message);
 
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
-    let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
-    try {
-      managedAttachments = pendingAttachments.length
-        ? await prepareManagedImageAttachments(activeChatId, pendingAttachments)
-        : [];
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
-      return;
-    }
-    invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
 
     if (textareaRef.current) {
       textareaRef.current.value = "";
@@ -774,16 +763,45 @@ export function ConversationInput({
     const mentioned = extractMentions(raw);
 
     if (groupResponseOrder === "manual" && mentioned.length === 0) {
-      const created = await createMessage.mutateAsync({
-        role: "user",
-        content: message,
-        characterId: null,
-      });
-      if (managedAttachments.length) {
-        await updateMessageExtra.mutateAsync({
-          messageId: created.id,
-          extra: { attachments: managedAttachments },
+      let createdMessageId: string | null = null;
+      let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
+      try {
+        preparedManagedAttachments = pendingAttachments.length
+          ? await prepareManagedImageAttachmentBatch(activeChatId, pendingAttachments)
+          : null;
+        const managedAttachments = preparedManagedAttachments?.attachments ?? [];
+        const created = await createMessage.mutateAsync({
+          role: "user",
+          content: message,
+          characterId: null,
         });
+        createdMessageId = created.id;
+        if (managedAttachments.length) {
+          await updateMessageExtra.mutateAsync({
+            messageId: created.id,
+            extra: { attachments: managedAttachments },
+          });
+          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
+        }
+      } catch (error) {
+        let rollbackFailed = false;
+        if (preparedManagedAttachments?.createdGalleryIds.length) {
+          try {
+            await deletePreparedManagedImageAttachments(preparedManagedAttachments);
+          } catch {
+            rollbackFailed = true;
+          }
+          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, preparedManagedAttachments.attachments);
+        }
+        if (createdMessageId) {
+          try {
+            await deleteMessage.mutateAsync(createdMessageId);
+          } catch {
+            rollbackFailed = true;
+          }
+        }
+        const msg = error instanceof Error ? error.message : "Failed to send message";
+        toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
       }
       return;
     }
@@ -793,11 +811,13 @@ export function ConversationInput({
         chatId: activeChatId,
         connectionId: null,
         userMessage: message,
-        ...(managedAttachments.length ? { attachments: managedAttachments } : {}),
+        ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
         ...(mentioned.length ? { mentionedCharacterNames: mentioned } : {}),
       });
     } catch {
       // useGenerate owns provider-failure UI feedback; aborts are an expected Stop generating path.
+    } finally {
+      if (pendingAttachments.length) invalidateGalleryImagesForChat(qc, activeChatId);
     }
   }, [
     activeChatId,
@@ -1375,25 +1395,18 @@ export function ConversationInput({
         return;
       }
 
-      let managedGifAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> | undefined;
       try {
-        managedGifAttachments = gifAttachments
-          ? await prepareManagedImageAttachments(activeChatId, gifAttachments)
-          : undefined;
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to prepare GIF attachment.");
-        return;
+        await generate({
+          chatId: activeChatId,
+          connectionId: null,
+          userMessage: gifUrl,
+          ...(gifAttachments?.length ? { attachments: gifAttachments } : {}),
+        });
+      } catch {
+        // useGenerate owns provider-failure UI feedback; aborts are an expected Stop generating path.
+      } finally {
+        if (gifAttachments?.length) invalidateGalleryImagesForChat(qc, activeChatId);
       }
-      if (managedGifAttachments) {
-        invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedGifAttachments);
-      }
-
-      await generate({
-        chatId: activeChatId,
-        connectionId: null,
-        userMessage: gifUrl,
-        ...(managedGifAttachments?.length ? { attachments: managedGifAttachments } : {}),
-      });
     },
     [
       activeChatId,

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -25,6 +25,7 @@ import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
+import { storageApi } from "../../../../shared/api/storage-api";
 import { useGenerate } from "../../../runtime/generation/index";
 import { readScopedRegexMode, useApplyRegex } from "../../../catalog/agents/regex-application";
 import {
@@ -35,6 +36,7 @@ import {
   chatKeys,
 } from "../../../catalog/chats/index";
 import { characterKeys } from "../../../catalog/characters/index";
+import { invalidateGalleryImagesForManagedAttachments } from "../../../catalog/gallery/index";
 import {
   personaKeys,
   useActivePersonaSummary,
@@ -72,6 +74,7 @@ import { EmojiPicker } from "../../../../shared/components/ui/EmojiPicker";
 import { GifPicker } from "../../../../shared/components/ui/GifPicker";
 import { SpeechToTextButton } from "../../../../shared/components/ui/SpeechToTextButton";
 import type { Message } from "../../../../engine/contracts/types/chat";
+import { prepareManagedImageAttachments } from "../../../../engine/generation/managed-attachments";
 import { buildGuidedGenerationInstructionMessage } from "../../../../engine/shared/text/generation-guide";
 
 interface Attachment {
@@ -599,28 +602,38 @@ export function ConversationInput({
       }
       // Final pass: resolve macros introduced by translation while {{input}} still points to raw.
       message = resolveInputMacros(message);
-      if (textareaRef.current) {
-        textareaRef.current.value = "";
-        textareaRef.current.style.height = "auto";
-      }
-      clearInputDraft(activeChatId);
-      syncInputState("");
       const currentAttachments = attachments.map((a) => ({
         type: a.type,
         data: a.data,
         filename: a.name,
         name: a.name,
       }));
+      let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
+      try {
+        managedAttachments = currentAttachments.length
+          ? await prepareManagedImageAttachments(storageApi, activeChatId, currentAttachments)
+          : [];
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
+        return;
+      }
+      invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
+      if (textareaRef.current) {
+        textareaRef.current.value = "";
+        textareaRef.current.style.height = "auto";
+      }
+      clearInputDraft(activeChatId);
+      syncInputState("");
       replaceAttachments([]);
       const created = await createMessage.mutateAsync({
         role: "user",
         content: message,
         characterId: null,
       });
-      if (currentAttachments.length) {
+      if (managedAttachments.length) {
         await updateMessageExtra.mutateAsync({
           messageId: created.id,
-          extra: { attachments: currentAttachments },
+          extra: { attachments: managedAttachments },
         });
       }
       return;
@@ -712,6 +725,18 @@ export function ConversationInput({
     // Final pass: resolve macros introduced by translation while {{input}} still points to raw.
     message = resolveInputMacros(message);
 
+    const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
+    let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
+    try {
+      managedAttachments = pendingAttachments.length
+        ? await prepareManagedImageAttachments(storageApi, activeChatId, pendingAttachments)
+        : [];
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
+      return;
+    }
+    invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
+
     if (textareaRef.current) {
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
@@ -719,7 +744,6 @@ export function ConversationInput({
     clearInputDraft(activeChatId);
     syncInputState("");
 
-    const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
     replaceAttachments([]);
 
     // Extract @mentions from the raw message (before regex transforms)
@@ -731,10 +755,10 @@ export function ConversationInput({
         content: message,
         characterId: null,
       });
-      if (pendingAttachments.length) {
+      if (managedAttachments.length) {
         await updateMessageExtra.mutateAsync({
           messageId: created.id,
-          extra: { attachments: pendingAttachments },
+          extra: { attachments: managedAttachments },
         });
       }
       return;
@@ -745,7 +769,7 @@ export function ConversationInput({
         chatId: activeChatId,
         connectionId: null,
         userMessage: message,
-        ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
+        ...(managedAttachments.length ? { attachments: managedAttachments } : {}),
         ...(mentioned.length ? { mentionedCharacterNames: mentioned } : {}),
       });
     } catch {
@@ -939,16 +963,20 @@ export function ConversationInput({
 
     let createdMessageId: string | null = null;
     try {
+      const managedAttachments = pendingAttachments.length
+        ? await prepareManagedImageAttachments(storageApi, submittingChatId, pendingAttachments)
+        : [];
+      invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
       const created = await createMessage.mutateAsync({
         role: "user",
         content: message,
         characterId: null,
       });
       createdMessageId = created.id;
-      if (pendingAttachments.length) {
+      if (managedAttachments.length) {
         await updateMessageExtra.mutateAsync({
           messageId: created.id,
-          extra: { attachments: pendingAttachments },
+          extra: { attachments: managedAttachments },
         });
       }
     } catch (error) {
@@ -1261,11 +1289,13 @@ export function ConversationInput({
       if (!activeChatId) return;
 
       // Fetch the GIF and convert to PNG so all providers can handle it
-      let gifAttachments: Array<{ type: string; data: string }> | undefined;
+      let gifAttachments: Array<{ type: string; data: string; filename: string; name: string }> | undefined;
       try {
         const blob = await loadUrlBlob(gifUrl);
         const attachment = await prepareImageAttachment(blob, "gif");
-        gifAttachments = [{ type: attachment.type, data: attachment.data }];
+        gifAttachments = [
+          { type: attachment.type, data: attachment.data, filename: attachment.name, name: attachment.name },
+        ];
       } catch {
         // If fetch fails (CORS etc.), send without attachment — still shows as image in chat
       }
@@ -1281,14 +1311,27 @@ export function ConversationInput({
         return;
       }
 
+      let managedGifAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> | undefined;
+      try {
+        managedGifAttachments = gifAttachments
+          ? await prepareManagedImageAttachments(storageApi, activeChatId, gifAttachments)
+          : undefined;
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to prepare GIF attachment.");
+        return;
+      }
+      if (managedGifAttachments) {
+        invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedGifAttachments);
+      }
+
       await generate({
         chatId: activeChatId,
         connectionId: null,
         userMessage: gifUrl,
-        ...(gifAttachments ? { attachments: gifAttachments } : {}),
+        ...(managedGifAttachments?.length ? { attachments: managedGifAttachments } : {}),
       });
     },
-    [activeChatId, isStreaming, groupResponseOrder, characterNames.length, generate, createMessage],
+    [activeChatId, isStreaming, groupResponseOrder, characterNames.length, generate, createMessage, qc],
   );
 
   const handleCharacterResponse = useCallback(

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -748,13 +748,48 @@ export function ConversationInput({
     // Final pass: resolve macros introduced by translation while {{input}} still points to raw.
     message = resolveInputMacros(message);
 
-    const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
+    const submittingChatId = activeChatId;
+    const submittedDraft = raw;
+    const submittedHeight = textareaRef.current?.style.height ?? "auto";
+    const submittedAttachments = attachments;
+    const submittedCompletions = completions;
+    const submittedMentionQuery = _mentionQuery;
+    const submittedMentionCompletions = mentionCompletions;
+    const pendingAttachments = submittedAttachments.map((a) => ({
+      type: a.type,
+      data: a.data,
+      filename: a.name,
+      name: a.name,
+    }));
+    const restoreSubmittedDraft = () => {
+      const activeChatIdAfterFailure = useChatStore.getState().activeChatId;
+      const currentValue = textareaRef.current?.value ?? "";
+      const canRestoreVisibleDraft = activeChatIdAfterFailure === submittingChatId && currentValue.length === 0;
+      if (canRestoreVisibleDraft && textareaRef.current) {
+        textareaRef.current.value = submittedDraft;
+        textareaRef.current.style.height = submittedHeight;
+        syncInputState(submittedDraft);
+        setCompletions(submittedCompletions);
+        setMentionQuery(submittedMentionQuery);
+        setMentionCompletions(submittedMentionCompletions);
+      }
+      if (submittedAttachments.length > 0) {
+        if (activeChatIdAfterFailure === submittingChatId) {
+          updateAttachments((current) => (current.length === 0 ? submittedAttachments : current));
+        } else {
+          pendingAttachmentDraftsRef.current.set(submittingChatId, submittedAttachments);
+        }
+      }
+      if (submittedDraft && (canRestoreVisibleDraft || activeChatIdAfterFailure !== submittingChatId)) {
+        setInputDraft(submittingChatId, submittedDraft);
+      }
+    };
 
     if (textareaRef.current) {
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
     }
-    clearInputDraft(activeChatId);
+    clearInputDraft(submittingChatId);
     syncInputState("");
 
     replaceAttachments([]);
@@ -767,7 +802,7 @@ export function ConversationInput({
       let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
       try {
         preparedManagedAttachments = pendingAttachments.length
-          ? await prepareManagedImageAttachmentBatch(activeChatId, pendingAttachments)
+          ? await prepareManagedImageAttachmentBatch(submittingChatId, pendingAttachments)
           : null;
         const managedAttachments = preparedManagedAttachments?.attachments ?? [];
         const created = await createMessage.mutateAsync({
@@ -781,7 +816,7 @@ export function ConversationInput({
             messageId: created.id,
             extra: { attachments: managedAttachments },
           });
-          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
+          invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
         }
       } catch (error) {
         let rollbackFailed = false;
@@ -791,7 +826,7 @@ export function ConversationInput({
           } catch {
             rollbackFailed = true;
           }
-          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, preparedManagedAttachments.attachments);
+          invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, preparedManagedAttachments.attachments);
         }
         if (createdMessageId) {
           try {
@@ -800,6 +835,7 @@ export function ConversationInput({
             rollbackFailed = true;
           }
         }
+        if (!rollbackFailed) restoreSubmittedDraft();
         const msg = error instanceof Error ? error.message : "Failed to send message";
         toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
       }
@@ -808,7 +844,7 @@ export function ConversationInput({
 
     try {
       await generate({
-        chatId: activeChatId,
+        chatId: submittingChatId,
         connectionId: null,
         userMessage: message,
         ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
@@ -817,7 +853,7 @@ export function ConversationInput({
     } catch {
       // useGenerate owns provider-failure UI feedback; aborts are an expected Stop generating path.
     } finally {
-      if (pendingAttachments.length) invalidateGalleryImagesForChat(qc, activeChatId);
+      if (pendingAttachments.length) invalidateGalleryImagesForChat(qc, submittingChatId);
     }
   }, [
     activeChatId,

--- a/src/features/modes/conversation/components/ConversationInput.tsx
+++ b/src/features/modes/conversation/components/ConversationInput.tsx
@@ -612,16 +612,47 @@ export function ConversationInput({
         filename: a.name,
         name: a.name,
       }));
-      let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
+      let createdMessageId: string | null = null;
+      let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
       try {
-        managedAttachments = currentAttachments.length
-          ? await prepareManagedImageAttachments(activeChatId, currentAttachments)
-          : [];
+        const created = await createMessage.mutateAsync({
+          role: "user",
+          content: message,
+          characterId: null,
+        });
+        createdMessageId = created.id;
+        preparedManagedAttachments = currentAttachments.length
+          ? await prepareManagedImageAttachmentBatch(activeChatId, currentAttachments)
+          : null;
+        const managedAttachments = preparedManagedAttachments?.attachments ?? [];
+        if (managedAttachments.length) {
+          await updateMessageExtra.mutateAsync({
+            messageId: created.id,
+            extra: { attachments: managedAttachments },
+          });
+          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
+        }
       } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
+        let rollbackFailed = false;
+        if (preparedManagedAttachments?.createdGalleryIds.length) {
+          try {
+            await deletePreparedManagedImageAttachments(preparedManagedAttachments);
+          } catch {
+            rollbackFailed = true;
+          }
+          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, preparedManagedAttachments.attachments);
+        }
+        if (createdMessageId) {
+          try {
+            await deleteMessage.mutateAsync(createdMessageId);
+          } catch {
+            rollbackFailed = true;
+          }
+        }
+        const msg = error instanceof Error ? error.message : "Failed to send message";
+        toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
         return;
       }
-      invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
       if (textareaRef.current) {
         textareaRef.current.value = "";
         textareaRef.current.style.height = "auto";
@@ -629,17 +660,6 @@ export function ConversationInput({
       clearInputDraft(activeChatId);
       syncInputState("");
       replaceAttachments([]);
-      const created = await createMessage.mutateAsync({
-        role: "user",
-        content: message,
-        characterId: null,
-      });
-      if (managedAttachments.length) {
-        await updateMessageExtra.mutateAsync({
-          messageId: created.id,
-          extra: { attachments: managedAttachments },
-        });
-      }
       return;
     }
 
@@ -790,6 +810,7 @@ export function ConversationInput({
     extractMentions,
     clearInputDraft,
     createMessage,
+    deleteMessage,
     updateMessageExtra,
     characterNames,
     latestAssistantMessage,

--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -34,8 +34,7 @@ import {
   GenerationReplayDetailsModal,
   hasGenerationReplayDetails,
   isImageMessageAttachment,
-  messageAttachmentImageAlt,
-  messageAttachmentImageSource,
+  MessageAttachmentImagePreview,
   messageAttachmentsFromExtra,
   readStoredThinking,
   ResolvedAvatarImage,
@@ -953,25 +952,18 @@ export const ConversationMessage = memo(function ConversationMessage({
         {!isHiddenCollapsed && attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
           <div className="ml-14 mt-1.5 flex flex-col items-start gap-2">
             {attachments.map((att, i) => {
-              const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
-              return imageSource ? (
-                <div key={i} className="group/att relative inline-block">
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setImageLightbox({ url: imageSource, prompt: att.prompt });
-                    }}
-                    className="block cursor-zoom-in rounded-lg text-left"
-                    title="Open image"
-                  >
-                    <img
-                      src={imageSource}
-                      alt={messageAttachmentImageAlt(att)}
-                      className="max-h-80 max-w-full rounded-lg"
-                      loading="lazy"
-                    />
-                  </button>
+              return isImageMessageAttachment(att) ? (
+                <MessageAttachmentImagePreview
+                  key={i}
+                  attachment={att}
+                  className="group/att relative inline-block"
+                  buttonClassName="block cursor-zoom-in rounded-lg text-left"
+                  imageClassName="max-h-80 max-w-full rounded-lg"
+                  onOpen={(imageSource, event) => {
+                    event.stopPropagation();
+                    setImageLightbox({ url: imageSource, prompt: att.prompt });
+                  }}
+                >
                   <button
                     onClick={() => handleRemoveAttachment(i)}
                     title="Remove from message"
@@ -979,7 +971,7 @@ export const ConversationMessage = memo(function ConversationMessage({
                   >
                     <X size="0.875rem" />
                   </button>
-                </div>
+                </MessageAttachmentImagePreview>
               ) : null;
             })}
           </div>
@@ -1310,25 +1302,18 @@ export const ConversationMessage = memo(function ConversationMessage({
         {!isHiddenCollapsed && attachments.length > 0 && !IMAGE_URL_RE.test(renderedContent.trim()) && (
           <div className="mt-1.5 flex flex-col items-center gap-2">
             {attachments.map((att, i) => {
-              const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
-              return imageSource ? (
-                <div key={i} className="group/att relative inline-block">
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setImageLightbox({ url: imageSource, prompt: att.prompt });
-                    }}
-                    className="block cursor-zoom-in rounded-lg text-left"
-                    title="Open image"
-                  >
-                    <img
-                      src={imageSource}
-                      alt={messageAttachmentImageAlt(att)}
-                      className="max-h-80 max-w-full rounded-lg"
-                      loading="lazy"
-                    />
-                  </button>
+              return isImageMessageAttachment(att) ? (
+                <MessageAttachmentImagePreview
+                  key={i}
+                  attachment={att}
+                  className="group/att relative inline-block"
+                  buttonClassName="block cursor-zoom-in rounded-lg text-left"
+                  imageClassName="max-h-80 max-w-full rounded-lg"
+                  onOpen={(imageSource, event) => {
+                    event.stopPropagation();
+                    setImageLightbox({ url: imageSource, prompt: att.prompt });
+                  }}
+                >
                   <button
                     onClick={() => handleRemoveAttachment(i)}
                     title="Remove from message"
@@ -1336,7 +1321,7 @@ export const ConversationMessage = memo(function ConversationMessage({
                   >
                     <X size="0.875rem" />
                   </button>
-                </div>
+                </MessageAttachmentImagePreview>
               ) : null;
             })}
           </div>

--- a/src/features/modes/game/components/GameInput.tsx
+++ b/src/features/modes/game/components/GameInput.tsx
@@ -12,6 +12,7 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { translateDraftText } from "../../../../shared/lib/draft-translation";
 import { MAX_FILE_SIZES } from "../../../../engine/contracts/constants/defaults";
 import type { DiceRollResult } from "../../../../engine/contracts/types/game";
+import type { PromptAttachment } from "../../../../engine/generation/generate-route-utils";
 import {
   CHAT_INPUT_ICON_BUTTON_ACTIVE_CLASS,
   CHAT_INPUT_ICON_BUTTON_CLASS,
@@ -31,9 +32,9 @@ type AddressMode = "scene" | "party" | "gm";
 interface GameInputProps {
   onSend: (
     message: string,
-    attachments?: Array<{ type: string; data: string }>,
+    attachments?: PromptAttachment[],
     options?: { commitPendingMove?: boolean },
-  ) => void;
+  ) => boolean | Promise<boolean>;
   onRollDice: (notation: string) => Promise<DiceRollResult | null>;
   /** When true, allow "Talk to Party" in the address selector. */
   hasPartyMembers?: boolean;
@@ -211,8 +212,11 @@ export function GameInput({
     }
 
     const pendingAttachments =
-      attachments.length > 0 ? attachments.map((a) => ({ type: a.type, data: a.data })) : undefined;
+      attachments.length > 0
+        ? attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }))
+        : undefined;
 
+    let clearQueuedDiceOnSend = false;
     if (queuedDice) {
       setRollingQueuedDice(true);
       let diceResult: DiceRollResult | null = null;
@@ -224,7 +228,7 @@ export function GameInput({
       if (!diceResult) return;
       const diceTag = formatDiceResultTag(diceResult);
       body = body ? `${body}\n${diceTag}` : diceTag;
-      setQueuedDice(null);
+      clearQueuedDiceOnSend = true;
     }
 
     if (addressMode === "party") {
@@ -233,11 +237,13 @@ export function GameInput({
       body = body ? `[To the GM] ${body}` : "[To the GM]";
     }
 
-    onSend(body, pendingAttachments, { commitPendingMove });
+    const sent = await onSend(body, pendingAttachments, { commitPendingMove });
+    if (!sent) return;
 
     setText("");
     clearDraft();
     setAttachments([]);
+    if (clearQueuedDiceOnSend) setQueuedDice(null);
     if (inputRef.current) inputRef.current.style.height = "auto";
     inputRef.current?.focus();
   };

--- a/src/features/modes/game/components/GameInput.tsx
+++ b/src/features/modes/game/components/GameInput.tsx
@@ -12,7 +12,7 @@ import { useChatStore } from "../../../../shared/stores/chat.store";
 import { translateDraftText } from "../../../../shared/lib/draft-translation";
 import { MAX_FILE_SIZES } from "../../../../engine/contracts/constants/defaults";
 import type { DiceRollResult } from "../../../../engine/contracts/types/game";
-import type { PromptAttachment } from "../../../../engine/generation/generate-route-utils";
+import type { PromptAttachment } from "../../../../shared/api/message-attachment-api";
 import {
   CHAT_INPUT_ICON_BUTTON_ACTIVE_CLASS,
   CHAT_INPUT_ICON_BUTTON_CLASS,

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -36,8 +36,12 @@ import { useAgentStore } from "../../../../shared/stores/agent.store";
 import { useGameStateStore } from "../../../runtime/world-state/index";
 import { useGameStatePatcher } from "../../../runtime/world-state/index";
 import type { GameStatePatchField, GameStatePatchValue } from "../../../runtime/world-state/types";
-import type { PromptAttachment } from "../../../../engine/generation/generate-route-utils";
-import { prepareManagedImageAttachments } from "../../../../engine/generation/managed-attachments";
+import {
+  deletePreparedManagedImageAttachments,
+  prepareManagedImageAttachmentBatch,
+  type PreparedManagedImageAttachments,
+  type PromptAttachment,
+} from "../../../../shared/api/message-attachment-api";
 import { makeManualTrackerRowId } from "../../../../engine/shared/game-state/tracker-row-ids";
 import {
   useSyncGameState,
@@ -84,7 +88,6 @@ import { npcAvatarApi } from "../../../../shared/api/avatar-api";
 import { spriteApi } from "../../../../shared/api/image-generation-api";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { gameAssetFileUrlFromPath, userBackgroundUrl } from "../../../../shared/api/local-file-api";
-import { storageApi } from "../../../../shared/api/storage-api";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, type AvatarCropValue } from "../../../../shared/lib/utils";
@@ -4852,34 +4855,55 @@ export function GameSurface({
     useSpotifyGameMusic,
   ]);
 
-  const sendMessage = useCallback(
-    async (message: string, attachments?: PromptAttachment[]): Promise<boolean> => {
-      if ((chatMeta.gameSessionStatus as string) === "concluded") return false;
+  const prepareGameTurnSubmission = useCallback(
+    async (
+      message: string,
+      attachments?: PromptAttachment[],
+    ): Promise<{ message: string; preparedAttachments: PreparedManagedImageAttachments | null } | null> => {
+      if (!activeChatId || (chatMeta.gameSessionStatus as string) === "concluded") return null;
       const trimmedMessage = message.trim();
       const hasAttachments = !!attachments?.length;
-      if (!trimmedMessage && !hasAttachments) return false;
-      let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
+      if (!trimmedMessage && !hasAttachments) return null;
       try {
-        managedAttachments = hasAttachments
-          ? await prepareManagedImageAttachments(storageApi, activeChatId, attachments ?? [])
-          : [];
+        return {
+          message: trimmedMessage,
+          preparedAttachments: hasAttachments
+            ? await prepareManagedImageAttachmentBatch(activeChatId, attachments ?? [])
+            : null,
+        };
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
-        return false;
+        return null;
       }
+    },
+    [activeChatId, chatMeta.gameSessionStatus],
+  );
+
+  const queuePreparedGameTurn = useCallback(
+    (submission: { message: string; preparedAttachments: PreparedManagedImageAttachments | null }): boolean => {
+      const managedAttachments = submission.preparedAttachments?.attachments ?? [];
       invalidateGalleryImagesForManagedAttachments(queryClient, activeChatId, managedAttachments);
       void generateGameTurn({
         chatId: activeChatId,
         connectionId: null,
         kind: "turn",
-        userMessage: formatTextQuotes(trimmedMessage, quoteFormat),
+        userMessage: formatTextQuotes(submission.message, quoteFormat),
         ...(managedAttachments.length ? { attachments: managedAttachments } : {}),
       }).catch(() => {
         // Generation UI already shows the recoverable error state.
       });
       return true;
     },
-    [activeChatId, chatMeta.gameSessionStatus, generateGameTurn, queryClient, quoteFormat],
+    [activeChatId, generateGameTurn, queryClient, quoteFormat],
+  );
+
+  const sendMessage = useCallback(
+    async (message: string, attachments?: PromptAttachment[]): Promise<boolean> => {
+      const submission = await prepareGameTurnSubmission(message, attachments);
+      if (!submission) return false;
+      return queuePreparedGameTurn(submission);
+    },
+    [prepareGameTurnSubmission, queuePreparedGameTurn],
   );
 
   // Game mutations
@@ -7204,10 +7228,29 @@ export function GameSurface({
     ) => {
       if (!sessionInteractive) return false;
       audioManager.unlock();
-      // Commit a pending interrupt: persist the truncated GM message before generating
-      // so the server-side prompt build doesn't see segments the player never read. We
-      // await so the PATCH (and the optional risky-mode system message) land before
-      // /generate reads from the DB.
+      const shouldCommitPendingMove = !!(options?.commitPendingMove && pendingMapMove);
+      const clearCommittedPendingMapMove = () => {
+        if (shouldCommitPendingMove) setPendingMapMove(null);
+      };
+      const isPartyDirectTurn = getGameDirectAddressMode(message) === "party" && !attachments?.length;
+      if (isPartyDirectTurn && (partyTurnInFlightRef.current || partyTurn.isPending)) {
+        return false;
+      }
+      const preparedTurn = isPartyDirectTurn ? null : await prepareGameTurnSubmission(message, attachments);
+      if (!isPartyDirectTurn && !preparedTurn) return false;
+      const cleanupPreparedTurn = async () => {
+        if (!preparedTurn?.preparedAttachments?.createdGalleryIds.length) return;
+        await deletePreparedManagedImageAttachments(preparedTurn.preparedAttachments).catch(() => undefined);
+        invalidateGalleryImagesForManagedAttachments(
+          queryClient,
+          activeChatId,
+          preparedTurn.preparedAttachments.attachments,
+        );
+      };
+
+      // Commit a pending interrupt after the turn is known queueable: persist the
+      // truncated GM message before generation so the server-side prompt build
+      // does not see segments the player never read.
       const activeInterrupt = pendingInterrupt && pendingInterrupt.chatId === activeChatId ? pendingInterrupt : null;
       const interruptedCommandKey = activeInterrupt?.messageId
         ? interactiveCommandKey(activeChatId, activeInterrupt.messageId)
@@ -7222,6 +7265,7 @@ export function GameSurface({
             content: activeInterrupt.truncatedContent,
           });
         } catch {
+          await cleanupPreparedTurn();
           if (interruptedCommandKey) interruptedInteractiveCommandKeysRef.current.delete(interruptedCommandKey);
           toast.error("Failed to commit the interrupt. Please try again.");
           return false;
@@ -7238,6 +7282,7 @@ export function GameSurface({
               "[Interrupt] The player attempts to interrupt the Game Master mid-action. Their following turn cuts in before the GM's planned events could occur. Treat their interjection as an in-fiction interruption — the situation may resist them, and the attempt can fail depending on context. If the player includes a dice roll, let the result determine whether the interruption succeeds or how it lands.",
           });
         } catch {
+          await cleanupPreparedTurn();
           if (interruptedCommandKey) interruptedInteractiveCommandKeysRef.current.delete(interruptedCommandKey);
           toast.error("Failed to mark the risky interrupt. Please try again.");
           return false;
@@ -7247,19 +7292,11 @@ export function GameSurface({
         clearPendingInteractiveCommands();
       }
       setPendingInterrupt(null);
-      const shouldCommitPendingMove = !!(options?.commitPendingMove && pendingMapMove);
-      const clearCommittedPendingMapMove = () => {
-        if (shouldCommitPendingMove) setPendingMapMove(null);
-      };
       if (shouldCommitPendingMove && pendingMapMove) {
         moveOnMap.mutate({ chatId: activeChatId, position: pendingMapMove.position, mapId: activeMapId });
       }
       setActiveChoices(null);
-      if (getGameDirectAddressMode(message) === "party" && !attachments?.length) {
-        if (partyTurnInFlightRef.current || partyTurn.isPending) {
-          clearCommittedPendingMapMove();
-          return false;
-        }
+      if (isPartyDirectTurn) {
         const formattedMessage = formatTextQuotes(message, quoteFormat);
         const playerAction = stripGameDirectAddressPrefix(formattedMessage);
         const requestId = partyTurnRequestIdRef.current + 1;
@@ -7296,7 +7333,8 @@ export function GameSurface({
         }
         return true;
       }
-      const sent = await sendMessage(message, attachments);
+      if (!preparedTurn) return false;
+      const sent = queuePreparedGameTurn(preparedTurn);
       if (sent) clearCommittedPendingMapMove();
       return sent;
     },
@@ -7312,7 +7350,9 @@ export function GameSurface({
       partyTurn,
       quoteFormat,
       latestNarrationText,
-      sendMessage,
+      prepareGameTurnSubmission,
+      queryClient,
+      queuePreparedGameTurn,
       sessionInteractive,
       updateMessage,
     ],

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -36,6 +36,8 @@ import { useAgentStore } from "../../../../shared/stores/agent.store";
 import { useGameStateStore } from "../../../runtime/world-state/index";
 import { useGameStatePatcher } from "../../../runtime/world-state/index";
 import type { GameStatePatchField, GameStatePatchValue } from "../../../runtime/world-state/types";
+import type { PromptAttachment } from "../../../../engine/generation/generate-route-utils";
+import { prepareManagedImageAttachments } from "../../../../engine/generation/managed-attachments";
 import { makeManualTrackerRowId } from "../../../../engine/shared/game-state/tracker-row-ids";
 import {
   useSyncGameState,
@@ -72,7 +74,7 @@ import {
   useUpdateChatMetadata,
   useUpdateMessage,
 } from "../../../catalog/chats/index";
-import { galleryKeys } from "../../../catalog/gallery/query-keys";
+import { galleryKeys, invalidateGalleryImagesForManagedAttachments } from "../../../catalog/gallery/index";
 import { useConnections } from "../../../catalog/connections/index";
 import { useGameGeneration } from "../hooks/use-game-generation";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -82,6 +84,7 @@ import { npcAvatarApi } from "../../../../shared/api/avatar-api";
 import { spriteApi } from "../../../../shared/api/image-generation-api";
 import { spotifyApi } from "../../../../shared/api/integration-utility-api";
 import { gameAssetFileUrlFromPath, userBackgroundUrl } from "../../../../shared/api/local-file-api";
+import { storageApi } from "../../../../shared/api/storage-api";
 import { showConfirmDialog } from "../../../../shared/lib/app-dialogs";
 import { formatTextQuotes } from "../../../../shared/lib/dialogue-quotes";
 import { cn, type AvatarCropValue } from "../../../../shared/lib/utils";
@@ -4850,22 +4853,33 @@ export function GameSurface({
   ]);
 
   const sendMessage = useCallback(
-    (message: string, attachments?: Array<{ type: string; data: string }>) => {
-      if ((chatMeta.gameSessionStatus as string) === "concluded") return;
+    async (message: string, attachments?: PromptAttachment[]): Promise<boolean> => {
+      if ((chatMeta.gameSessionStatus as string) === "concluded") return false;
       const trimmedMessage = message.trim();
       const hasAttachments = !!attachments?.length;
-      if (!trimmedMessage && !hasAttachments) return;
+      if (!trimmedMessage && !hasAttachments) return false;
+      let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
+      try {
+        managedAttachments = hasAttachments
+          ? await prepareManagedImageAttachments(storageApi, activeChatId, attachments ?? [])
+          : [];
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
+        return false;
+      }
+      invalidateGalleryImagesForManagedAttachments(queryClient, activeChatId, managedAttachments);
       void generateGameTurn({
         chatId: activeChatId,
         connectionId: null,
         kind: "turn",
         userMessage: formatTextQuotes(trimmedMessage, quoteFormat),
-        ...(hasAttachments ? { attachments } : {}),
+        ...(managedAttachments.length ? { attachments: managedAttachments } : {}),
       }).catch(() => {
         // Generation UI already shows the recoverable error state.
       });
+      return true;
     },
-    [activeChatId, chatMeta.gameSessionStatus, generateGameTurn, quoteFormat],
+    [activeChatId, chatMeta.gameSessionStatus, generateGameTurn, queryClient, quoteFormat],
   );
 
   // Game mutations
@@ -7185,7 +7199,7 @@ export function GameSurface({
   const handleSendGameTurn = useCallback(
     async (
       message: string,
-      attachments?: Array<{ type: string; data: string }>,
+      attachments?: PromptAttachment[],
       options?: { commitPendingMove?: boolean },
     ) => {
       if (!sessionInteractive) return false;
@@ -7282,9 +7296,9 @@ export function GameSurface({
         }
         return true;
       }
-      sendMessage(message, attachments);
-      clearCommittedPendingMapMove();
-      return true;
+      const sent = await sendMessage(message, attachments);
+      if (sent) clearCommittedPendingMapMove();
+      return sent;
     },
     [
       activeChatId,

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -699,7 +699,7 @@ export const ChatInput = memo(function ChatInput({
             rollbackFailed = true;
           }
         }
-        restoreSubmittedInput();
+        if (!rollbackFailed) restoreSubmittedInput();
         const msg = error instanceof Error ? error.message : "Failed to send message";
         toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
       }
@@ -708,7 +708,7 @@ export const ChatInput = memo(function ChatInput({
 
     let userMessageAccepted = false;
     try {
-      await generate({
+      const generated = await generate({
         chatId: submittingChatId,
         connectionId: null,
         userMessage: message,
@@ -717,6 +717,7 @@ export const ChatInput = memo(function ChatInput({
           userMessageAccepted = true;
         },
       });
+      if (generated === false && !userMessageAccepted) restoreSubmittedInput();
     } catch (error) {
       if (isAbortError(error)) return;
       if (!userMessageAccepted) restoreSubmittedInput();

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -20,7 +20,12 @@ import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
-import { storageApi } from "../../../../../shared/api/storage-api";
+import {
+  deletePreparedManagedImageAttachments,
+  prepareManagedImageAttachmentBatch,
+  prepareManagedImageAttachments,
+  type PreparedManagedImageAttachments,
+} from "../../../../../shared/api/message-attachment-api";
 import { useGenerate } from "../../../../runtime/generation/index";
 import { readScopedRegexMode, useApplyRegex } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
@@ -28,7 +33,6 @@ import { characterKeys } from "../../../../catalog/characters/index";
 import { invalidateGalleryImagesForManagedAttachments } from "../../../../catalog/gallery/index";
 import { personaKeys } from "../../../../catalog/personas/index";
 import type { Message } from "../../../../../engine/contracts/types/chat";
-import { prepareManagedImageAttachments } from "../../../../../engine/generation/managed-attachments";
 import { buildGuidedGenerationInstructionMessage } from "../../../../../engine/shared/text/generation-guide";
 import {
   matchSlashCommand,
@@ -619,7 +623,7 @@ export const ChatInput = memo(function ChatInput({
     let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
     try {
       managedAttachments = pendingAttachments.length
-        ? await prepareManagedImageAttachments(storageApi, activeChatId, pendingAttachments)
+        ? await prepareManagedImageAttachments(activeChatId, pendingAttachments)
         : [];
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
@@ -826,25 +830,35 @@ export const ChatInput = memo(function ChatInput({
     clearInputDraft(submittingChatId);
 
     let createdMessageId: string | null = null;
+    let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
     try {
-      const managedAttachments = pendingAttachments.length
-        ? await prepareManagedImageAttachments(storageApi, submittingChatId, pendingAttachments)
-        : [];
-      invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
       const created = await createMessage.mutateAsync({
         role: "user",
         content: message,
         characterId: null,
       });
       createdMessageId = created.id;
+      preparedManagedAttachments = pendingAttachments.length
+        ? await prepareManagedImageAttachmentBatch(submittingChatId, pendingAttachments)
+        : null;
+      const managedAttachments = preparedManagedAttachments?.attachments ?? [];
       if (managedAttachments.length) {
         await updateMessageExtra.mutateAsync({
           messageId: created.id,
           extra: { attachments: managedAttachments },
         });
+        invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
       }
     } catch (error) {
       let rollbackFailed = false;
+      if (preparedManagedAttachments?.createdGalleryIds.length) {
+        try {
+          await deletePreparedManagedImageAttachments(preparedManagedAttachments);
+        } catch {
+          rollbackFailed = true;
+        }
+        invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, preparedManagedAttachments.attachments);
+      }
       if (createdMessageId) {
         try {
           await deleteMessage.mutateAsync(createdMessageId);
@@ -872,7 +886,7 @@ export const ChatInput = memo(function ChatInput({
         setInputDraft(submittingChatId, submittedDraft);
       }
       const msg = error instanceof Error ? error.message : "Failed to post message";
-      toast.error(rollbackFailed ? `${msg}; the partial message may need to be removed before retrying.` : msg);
+      toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
     }
   }, [
     activeChatId,

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -23,14 +23,13 @@ import { useUIStore } from "../../../../../shared/stores/ui.store";
 import {
   deletePreparedManagedImageAttachments,
   prepareManagedImageAttachmentBatch,
-  prepareManagedImageAttachments,
   type PreparedManagedImageAttachments,
 } from "../../../../../shared/api/message-attachment-api";
 import { useGenerate } from "../../../../runtime/generation/index";
 import { readScopedRegexMode, useApplyRegex } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
 import { characterKeys } from "../../../../catalog/characters/index";
-import { invalidateGalleryImagesForManagedAttachments } from "../../../../catalog/gallery/index";
+import { invalidateGalleryImagesForChat, invalidateGalleryImagesForManagedAttachments } from "../../../../catalog/gallery/index";
 import { personaKeys } from "../../../../catalog/personas/index";
 import type { Message } from "../../../../../engine/contracts/types/chat";
 import { buildGuidedGenerationInstructionMessage } from "../../../../../engine/shared/text/generation-guide";
@@ -620,16 +619,6 @@ export const ChatInput = memo(function ChatInput({
     message = resolveInputMacros(message);
 
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
-    let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
-    try {
-      managedAttachments = pendingAttachments.length
-        ? await prepareManagedImageAttachments(activeChatId, pendingAttachments)
-        : [];
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
-      return;
-    }
-    invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
 
     if (textareaRef.current) {
       textareaRef.current.value = "";
@@ -642,21 +631,45 @@ export const ChatInput = memo(function ChatInput({
 
     // Manual mode: only create the user message, no auto-generation
     if (groupResponseOrder === "manual") {
+      let createdMessageId: string | null = null;
+      let preparedManagedAttachments: PreparedManagedImageAttachments | null = null;
       try {
+        preparedManagedAttachments = pendingAttachments.length
+          ? await prepareManagedImageAttachmentBatch(activeChatId, pendingAttachments)
+          : null;
+        const managedAttachments = preparedManagedAttachments?.attachments ?? [];
         const created = await createMessage.mutateAsync({
           role: "user",
           content: message,
           characterId: null,
         });
+        createdMessageId = created.id;
         if (managedAttachments.length) {
           await updateMessageExtra.mutateAsync({
             messageId: created.id,
             extra: { attachments: managedAttachments },
           });
+          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
         }
       } catch (error) {
+        let rollbackFailed = false;
+        if (preparedManagedAttachments?.createdGalleryIds.length) {
+          try {
+            await deletePreparedManagedImageAttachments(preparedManagedAttachments);
+          } catch {
+            rollbackFailed = true;
+          }
+          invalidateGalleryImagesForManagedAttachments(qc, activeChatId, preparedManagedAttachments.attachments);
+        }
+        if (createdMessageId) {
+          try {
+            await deleteMessage.mutateAsync(createdMessageId);
+          } catch {
+            rollbackFailed = true;
+          }
+        }
         const msg = error instanceof Error ? error.message : "Failed to send message";
-        toast.error(msg);
+        toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
       }
       return;
     }
@@ -666,11 +679,13 @@ export const ChatInput = memo(function ChatInput({
         chatId: activeChatId,
         connectionId: null,
         userMessage: message,
-        ...(managedAttachments.length ? { attachments: managedAttachments } : {}),
+        ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
       });
     } catch (error) {
       if (isAbortError(error)) return;
       console.error("Send failed:", error);
+    } finally {
+      if (pendingAttachments.length) invalidateGalleryImagesForChat(qc, activeChatId);
     }
   }, [
     activeChatId,
@@ -685,6 +700,7 @@ export const ChatInput = memo(function ChatInput({
     mode,
     groupResponseOrder,
     createMessage,
+    deleteMessage,
     updateMessageExtra,
     syncInputState,
     replaceAttachments,

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -20,12 +20,15 @@ import { toast } from "sonner";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../../shared/stores/ui.store";
+import { storageApi } from "../../../../../shared/api/storage-api";
 import { useGenerate } from "../../../../runtime/generation/index";
 import { readScopedRegexMode, useApplyRegex } from "../../../../catalog/agents/regex-application";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, chatKeys } from "../../../../catalog/chats/index";
 import { characterKeys } from "../../../../catalog/characters/index";
+import { invalidateGalleryImagesForManagedAttachments } from "../../../../catalog/gallery/index";
 import { personaKeys } from "../../../../catalog/personas/index";
 import type { Message } from "../../../../../engine/contracts/types/chat";
+import { prepareManagedImageAttachments } from "../../../../../engine/generation/managed-attachments";
 import { buildGuidedGenerationInstructionMessage } from "../../../../../engine/shared/text/generation-guide";
 import {
   matchSlashCommand,
@@ -612,13 +615,24 @@ export const ChatInput = memo(function ChatInput({
 
     message = resolveInputMacros(message);
 
+    const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
+    let managedAttachments: Awaited<ReturnType<typeof prepareManagedImageAttachments>> = [];
+    try {
+      managedAttachments = pendingAttachments.length
+        ? await prepareManagedImageAttachments(storageApi, activeChatId, pendingAttachments)
+        : [];
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to prepare image attachments.");
+      return;
+    }
+    invalidateGalleryImagesForManagedAttachments(qc, activeChatId, managedAttachments);
+
     if (textareaRef.current) {
       textareaRef.current.value = "";
       textareaRef.current.style.height = "auto";
     }
     syncInputState("");
     setCompletions([]);
-    const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
     replaceAttachments([]);
     clearInputDraft(activeChatId);
 
@@ -630,10 +644,10 @@ export const ChatInput = memo(function ChatInput({
           content: message,
           characterId: null,
         });
-        if (pendingAttachments.length) {
+        if (managedAttachments.length) {
           await updateMessageExtra.mutateAsync({
             messageId: created.id,
-            extra: { attachments: pendingAttachments },
+            extra: { attachments: managedAttachments },
           });
         }
       } catch (error) {
@@ -648,7 +662,7 @@ export const ChatInput = memo(function ChatInput({
         chatId: activeChatId,
         connectionId: null,
         userMessage: message,
-        ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
+        ...(managedAttachments.length ? { attachments: managedAttachments } : {}),
       });
     } catch (error) {
       if (isAbortError(error)) return;
@@ -813,16 +827,20 @@ export const ChatInput = memo(function ChatInput({
 
     let createdMessageId: string | null = null;
     try {
+      const managedAttachments = pendingAttachments.length
+        ? await prepareManagedImageAttachments(storageApi, submittingChatId, pendingAttachments)
+        : [];
+      invalidateGalleryImagesForManagedAttachments(qc, submittingChatId, managedAttachments);
       const created = await createMessage.mutateAsync({
         role: "user",
         content: message,
         characterId: null,
       });
       createdMessageId = created.id;
-      if (pendingAttachments.length) {
+      if (managedAttachments.length) {
         await updateMessageExtra.mutateAsync({
           messageId: created.id,
-          extra: { attachments: pendingAttachments },
+          extra: { attachments: managedAttachments },
         });
       }
     } catch (error) {

--- a/src/features/modes/shared/chat-ui/components/ChatInput.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatInput.tsx
@@ -618,7 +618,38 @@ export const ChatInput = memo(function ChatInput({
 
     message = resolveInputMacros(message);
 
-    const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
+    const submittingChatId = activeChatId;
+    const submittedDraft = raw;
+    const submittedHeight = textareaRef.current?.style.height ?? "auto";
+    const submittedAttachments = attachments;
+    const submittedCompletions = completions;
+    const pendingAttachments = submittedAttachments.map((a) => ({
+      type: a.type,
+      data: a.data,
+      filename: a.name,
+      name: a.name,
+    }));
+    const restoreSubmittedInput = () => {
+      const activeChatIdAfterFailure = useChatStore.getState().activeChatId;
+      const currentValue = textareaRef.current?.value ?? "";
+      const canRestoreVisibleDraft = activeChatIdAfterFailure === submittingChatId && currentValue.length === 0;
+      if (canRestoreVisibleDraft && textareaRef.current) {
+        textareaRef.current.value = submittedDraft;
+        textareaRef.current.style.height = submittedHeight;
+        syncInputState(submittedDraft);
+        setCompletions(submittedCompletions);
+      }
+      if (submittedAttachments.length > 0) {
+        if (activeChatIdAfterFailure === submittingChatId) {
+          updateAttachments((current) => (current.length === 0 ? submittedAttachments : current));
+        } else {
+          pendingAttachmentDraftsRef.current.set(submittingChatId, submittedAttachments);
+        }
+      }
+      if (submittedDraft && (canRestoreVisibleDraft || activeChatIdAfterFailure !== submittingChatId)) {
+        setInputDraft(submittingChatId, submittedDraft);
+      }
+    };
 
     if (textareaRef.current) {
       textareaRef.current.value = "";
@@ -668,24 +699,30 @@ export const ChatInput = memo(function ChatInput({
             rollbackFailed = true;
           }
         }
+        restoreSubmittedInput();
         const msg = error instanceof Error ? error.message : "Failed to send message";
         toast.error(rollbackFailed ? `${msg}; partial saved data may need to be removed before retrying.` : msg);
       }
       return;
     }
 
+    let userMessageAccepted = false;
     try {
       await generate({
-        chatId: activeChatId,
+        chatId: submittingChatId,
         connectionId: null,
         userMessage: message,
         ...(pendingAttachments.length ? { attachments: pendingAttachments } : {}),
+        onUserMessageAccepted: () => {
+          userMessageAccepted = true;
+        },
       });
     } catch (error) {
       if (isAbortError(error)) return;
+      if (!userMessageAccepted) restoreSubmittedInput();
       console.error("Send failed:", error);
     } finally {
-      if (pendingAttachments.length) invalidateGalleryImagesForChat(qc, activeChatId);
+      if (pendingAttachments.length) invalidateGalleryImagesForChat(qc, submittingChatId);
     }
   }, [
     activeChatId,

--- a/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatMessage.tsx
@@ -82,12 +82,11 @@ import { SwipeJumpControl } from "./SwipeJumpControl";
 import { readStoredThinking } from "../lib/message-thinking";
 import {
   isImageMessageAttachment,
-  messageAttachmentImageAlt,
-  messageAttachmentImageSource,
   messageAttachmentsFromExtra,
 } from "../lib/message-attachments";
 import { resolvePromptSnapshotFromExtra } from "../lib/prompt-snapshot";
 import { ResolvedAvatarImage } from "./ResolvedAvatarImage";
+import { MessageAttachmentImagePreview } from "./MessageAttachmentImagePreview";
 import { resolveAvatarFileUrl } from "../../../../../shared/api/local-file-api";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
@@ -2239,24 +2238,15 @@ export const ChatMessage = memo(function ChatMessage({
             {!editing && attachments.length > 0 && !IMAGE_URL_RE.test(message.content.trim()) && (
               <div className="mt-1.5 flex flex-col items-center gap-2 px-3 pb-2">
                 {attachments.map((att, i) => {
-                  const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
-                  return imageSource ? (
-                    <div key={i} className="group/att relative inline-block">
-                      <button
-                        type="button"
-                        onClick={() => openImageLightbox(imageSource, att.prompt)}
-                        className="block"
-                        title="Open image"
-                        aria-label={`Open ${messageAttachmentImageAlt(att)}`}
-                      >
-                        <img
-                          src={imageSource}
-                          alt={messageAttachmentImageAlt(att)}
-                          className="max-h-80 max-w-full rounded-lg"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </button>
+                  return isImageMessageAttachment(att) ? (
+                    <MessageAttachmentImagePreview
+                      key={i}
+                      attachment={att}
+                      className="group/att relative inline-block"
+                      buttonClassName="block"
+                      imageClassName="max-h-80 max-w-full rounded-lg"
+                      onOpen={(imageSource) => openImageLightbox(imageSource, att.prompt)}
+                    >
                       <button
                         type="button"
                         onClick={() => handleRemoveAttachment(i)}
@@ -2266,7 +2256,7 @@ export const ChatMessage = memo(function ChatMessage({
                       >
                         <X size="0.875rem" />
                       </button>
-                    </div>
+                    </MessageAttachmentImagePreview>
                   ) : null;
                 })}
               </div>
@@ -2699,24 +2689,15 @@ export const ChatMessage = memo(function ChatMessage({
           {!editing && attachments.length > 0 && !IMAGE_URL_RE.test(message.content.trim()) && (
             <div className="mt-1.5 flex flex-col items-center gap-2 px-3 pb-2">
               {attachments.map((att, i) => {
-                const imageSource = isImageMessageAttachment(att) ? messageAttachmentImageSource(att) : null;
-                return imageSource ? (
-                  <div key={i} className="group/att relative inline-block">
-                    <button
-                      type="button"
-                      onClick={() => openImageLightbox(imageSource, att.prompt)}
-                      className="block"
-                      title="Open image"
-                      aria-label={`Open ${messageAttachmentImageAlt(att)}`}
-                    >
-                      <img
-                        src={imageSource}
-                        alt={messageAttachmentImageAlt(att)}
-                        className="max-h-80 max-w-full rounded-lg"
-                        loading="lazy"
-                        decoding="async"
-                      />
-                    </button>
+                return isImageMessageAttachment(att) ? (
+                  <MessageAttachmentImagePreview
+                    key={i}
+                    attachment={att}
+                    className="group/att relative inline-block"
+                    buttonClassName="block"
+                    imageClassName="max-h-80 max-w-full rounded-lg"
+                    onOpen={(imageSource) => openImageLightbox(imageSource, att.prompt)}
+                  >
                     <button
                       type="button"
                       onClick={() => handleRemoveAttachment(i)}
@@ -2726,7 +2707,7 @@ export const ChatMessage = memo(function ChatMessage({
                     >
                       <X size="0.875rem" />
                     </button>
-                  </div>
+                  </MessageAttachmentImagePreview>
                 ) : null;
               })}
             </div>

--- a/src/features/modes/shared/chat-ui/components/MessageAttachmentImagePreview.tsx
+++ b/src/features/modes/shared/chat-ui/components/MessageAttachmentImagePreview.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState, type MouseEvent, type ReactNode } from "react";
+import type { MessageAttachment } from "../../../../../engine/contracts/types/chat";
+import { resolveGalleryFileUrl } from "../../../../../shared/api/local-file-api";
+import { messageAttachmentImageAlt, messageAttachmentImageSource } from "../lib/message-attachments";
+
+const RESOLVED_ATTACHMENT_SRC_CACHE_LIMIT = 128;
+const resolvedAttachmentSrcCache = new Map<string, string>();
+
+function readCachedResolvedAttachmentSrc(key: string): string | null {
+  return resolvedAttachmentSrcCache.get(key) ?? null;
+}
+
+function rememberResolvedAttachmentSrc(key: string, src: string | null): void {
+  resolvedAttachmentSrcCache.delete(key);
+  if (!src) return;
+  resolvedAttachmentSrcCache.set(key, src);
+  while (resolvedAttachmentSrcCache.size > RESOLVED_ATTACHMENT_SRC_CACHE_LIMIT) {
+    const oldestKey = resolvedAttachmentSrcCache.keys().next().value;
+    if (!oldestKey) break;
+    resolvedAttachmentSrcCache.delete(oldestKey);
+  }
+}
+
+function hasText(value: string | null | undefined): boolean {
+  return !!value?.trim();
+}
+
+function isLikelyFilesystemPath(value: string): boolean {
+  const normalized = value.replace(/\\/g, "/");
+  return (
+    /^[a-z]:\//i.test(normalized) ||
+    normalized.startsWith("//") ||
+    /^\/(Users|home|var|data|tmp|opt|private)\//i.test(normalized)
+  );
+}
+
+function useResolvedMessageAttachmentImageSource(attachment: MessageAttachment): string | null {
+  const directSrc = messageAttachmentImageSource(attachment);
+  const filename = attachment.filename ?? attachment.name ?? null;
+  const filePath = attachment.filePath ?? null;
+  const hasManagedGallery = hasText(filename) || hasText(filePath);
+  const fallbackSrc = useMemo(() => {
+    if (!directSrc) return null;
+    return hasManagedGallery && isLikelyFilesystemPath(directSrc) ? null : directSrc;
+  }, [directSrc, hasManagedGallery]);
+  const resolutionKey = JSON.stringify([directSrc ?? "", filename ?? "", filePath ?? ""]);
+  const cachedResolvedSrc = hasManagedGallery ? readCachedResolvedAttachmentSrc(resolutionKey) : null;
+  const [resolvedState, setResolvedState] = useState<{ key: string; src: string | null }>({
+    key: resolutionKey,
+    src: cachedResolvedSrc ?? fallbackSrc,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasManagedGallery) {
+      setResolvedState({ key: resolutionKey, src: fallbackSrc });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const cachedSrc = readCachedResolvedAttachmentSrc(resolutionKey);
+    const nextInitialSrc = cachedSrc ?? fallbackSrc;
+    setResolvedState({ key: resolutionKey, src: nextInitialSrc });
+    if (cachedSrc) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    resolveGalleryFileUrl(filename, filePath)
+      .then((url) => {
+        if (cancelled) return;
+        const next = url ?? fallbackSrc;
+        rememberResolvedAttachmentSrc(resolutionKey, next);
+        setResolvedState({ key: resolutionKey, src: next });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        rememberResolvedAttachmentSrc(resolutionKey, null);
+        setResolvedState({ key: resolutionKey, src: fallbackSrc });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fallbackSrc, filePath, filename, hasManagedGallery, resolutionKey]);
+
+  return resolvedState.key === resolutionKey ? (resolvedState.src ?? cachedResolvedSrc ?? fallbackSrc) : cachedResolvedSrc;
+}
+
+export function MessageAttachmentImagePreview({
+  attachment,
+  className,
+  buttonClassName,
+  imageClassName,
+  title = "Open image",
+  ariaLabel,
+  loading = "lazy",
+  decoding = "async",
+  onOpen,
+  children,
+}: {
+  attachment: MessageAttachment;
+  className?: string;
+  buttonClassName?: string;
+  imageClassName?: string;
+  title?: string;
+  ariaLabel?: string;
+  loading?: "eager" | "lazy";
+  decoding?: "sync" | "async" | "auto";
+  onOpen: (src: string, event: MouseEvent<HTMLButtonElement>) => void;
+  children?: ReactNode;
+}) {
+  const imageSrc = useResolvedMessageAttachmentImageSource(attachment);
+  if (!imageSrc) return null;
+  const alt = messageAttachmentImageAlt(attachment);
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={(event) => onOpen(imageSrc, event)}
+        className={buttonClassName}
+        title={title}
+        aria-label={ariaLabel ?? `Open ${alt}`}
+      >
+        <img src={imageSrc} alt={alt} className={imageClassName} loading={loading} decoding={decoding} />
+      </button>
+      {children}
+    </div>
+  );
+}

--- a/src/features/modes/shared/chat-ui/index.ts
+++ b/src/features/modes/shared/chat-ui/index.ts
@@ -9,6 +9,7 @@ export * from "./components/EchoChamberPanel";
 export * from "./components/GenerationReplayDetailsModal";
 export * from "./components/ImagePromptPanel";
 export * from "./components/input-button-styles";
+export * from "./components/MessageAttachmentImagePreview";
 export * from "./components/NewChatConnectionGate";
 export * from "./components/QuickConnectionSwitcher";
 export * from "./components/QuickPersonaSwitcher";

--- a/src/features/modes/shared/chat-ui/lib/message-attachments.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-attachments.ts
@@ -1,6 +1,16 @@
 import type { MessageAttachment, MessageAttachmentExtraValue } from "../../../../../engine/contracts/types/chat";
 
-const MESSAGE_ATTACHMENT_KEYS = ["type", "url", "data", "filename", "name", "prompt", "galleryId"] as const;
+const MESSAGE_ATTACHMENT_KEYS = [
+  "type",
+  "url",
+  "data",
+  "imageUrl",
+  "filePath",
+  "filename",
+  "name",
+  "prompt",
+  "galleryId",
+] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);

--- a/src/features/modes/shared/chat-ui/lib/message-attachments.ts
+++ b/src/features/modes/shared/chat-ui/lib/message-attachments.ts
@@ -66,8 +66,10 @@ export function isImageMessageAttachment(attachment: MessageAttachment): boolean
 }
 
 export function messageAttachmentImageSource(attachment: MessageAttachment): string | null {
-  const source = attachment.url ?? attachment.data;
-  return typeof source === "string" && source.length > 0 ? source : null;
+  const source = [attachment.url, attachment.imageUrl, attachment.data].find(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  return source ?? null;
 }
 
 export function messageAttachmentImageAlt(attachment: MessageAttachment): string {

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -73,6 +73,7 @@ export type GenerateArgs = GenerationReplayInput & {
   chatId: string;
   connectionId?: string | null;
   message?: string;
+  onUserMessageAccepted?: () => void;
   [key: string]: unknown;
 };
 
@@ -1165,6 +1166,7 @@ export async function runGenerationWithUi(
   options: { beforeStart?: (args: GenerateArgs, signal: AbortSignal) => Promise<void> } = {},
 ): Promise<boolean> {
   const chatId = args.chatId;
+  const { onUserMessageAccepted, ...streamArgs } = args;
   const regenerateMessageId = readString(args.regenerateMessageId).trim() || null;
   const requestedCharacterId = readString(args.forCharacterId).trim() || null;
   await assertChatCanGenerate(queryClient, chatId);
@@ -1445,9 +1447,9 @@ export async function runGenerationWithUi(
 
   try {
     insertOptimisticUserMessage(queryClient, args);
-    await options.beforeStart?.(args, controller.signal);
+    await options.beforeStart?.(streamArgs, controller.signal);
     if (controller.signal.aborted) throw new DOMException("The operation was aborted.", "AbortError");
-    for await (const event of streamFactory(args, controller.signal)) {
+    for await (const event of streamFactory(streamArgs, controller.signal)) {
       if (!foregroundGenerationReleased && !ownsChatController()) break;
       switch (event.type) {
         case "phase":
@@ -1486,6 +1488,7 @@ export async function runGenerationWithUi(
             if (event.type === "user_message") await flushLiveGenerationBuffers();
             upsertCachedMessage(queryClient, chatId, event.data);
             scheduleChatQueryRefresh(queryClient, chatId);
+            if (event.type === "user_message") onUserMessageAccepted?.();
             if (event.type !== "user_message") releaseForegroundGenerationUi();
             drainAgentResultEffects();
           }

--- a/src/shared/api/message-attachment-api.ts
+++ b/src/shared/api/message-attachment-api.ts
@@ -1,20 +1,12 @@
 import {
   deletePreparedManagedImageAttachments as deletePreparedManagedImageAttachmentsWithStorage,
   prepareManagedImageAttachmentBatch as prepareManagedImageAttachmentBatchWithStorage,
-  prepareManagedImageAttachments as prepareManagedImageAttachmentsWithStorage,
   type PreparedManagedImageAttachments,
   type PromptAttachment,
 } from "../../engine/shared/attachments/image-attachments";
 import { storageApi } from "./storage-api";
 
 export type { PreparedManagedImageAttachments, PromptAttachment };
-
-export function prepareManagedImageAttachments(
-  chatId: string,
-  attachments: PromptAttachment[] | undefined,
-): Promise<PromptAttachment[]> {
-  return prepareManagedImageAttachmentsWithStorage(storageApi, chatId, attachments);
-}
 
 export function prepareManagedImageAttachmentBatch(
   chatId: string,

--- a/src/shared/api/message-attachment-api.ts
+++ b/src/shared/api/message-attachment-api.ts
@@ -1,0 +1,28 @@
+import {
+  deletePreparedManagedImageAttachments as deletePreparedManagedImageAttachmentsWithStorage,
+  prepareManagedImageAttachmentBatch as prepareManagedImageAttachmentBatchWithStorage,
+  prepareManagedImageAttachments as prepareManagedImageAttachmentsWithStorage,
+  type PreparedManagedImageAttachments,
+  type PromptAttachment,
+} from "../../engine/shared/attachments/image-attachments";
+import { storageApi } from "./storage-api";
+
+export type { PreparedManagedImageAttachments, PromptAttachment };
+
+export function prepareManagedImageAttachments(
+  chatId: string,
+  attachments: PromptAttachment[] | undefined,
+): Promise<PromptAttachment[]> {
+  return prepareManagedImageAttachmentsWithStorage(storageApi, chatId, attachments);
+}
+
+export function prepareManagedImageAttachmentBatch(
+  chatId: string,
+  attachments: PromptAttachment[] | undefined,
+): Promise<PreparedManagedImageAttachments> {
+  return prepareManagedImageAttachmentBatchWithStorage(storageApi, chatId, attachments);
+}
+
+export function deletePreparedManagedImageAttachments(prepared: PreparedManagedImageAttachments): Promise<void> {
+  return deletePreparedManagedImageAttachmentsWithStorage(storageApi, prepared);
+}

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -1,14 +1,20 @@
 import type {
   AddChatMessageSwipeOptions,
+  StorageImageAttachmentReference,
   StorageEntity,
   StorageGateway,
   StorageListOptions,
 } from "../../engine/capabilities/storage";
 import { collapseExcessBlankLines } from "../../engine/shared/text/newlines";
 import { ApiError } from "./api-errors";
-import { invalidateRemoteManagedAssetObjectUrlsAfter, type RemoteManagedAssetKind } from "./local-file-api";
+import {
+  invalidateRemoteManagedAssetObjectUrlsAfter,
+  resolveGalleryFileUrl,
+  type RemoteManagedAssetKind,
+} from "./local-file-api";
 import { invokeTauri } from "./tauri-client";
 import { trackerSnapshotApi, type TrackerSnapshotInput } from "./tracker-snapshot-api";
+import { urlBinaryApi } from "./url-binary-api";
 
 function asRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
@@ -214,6 +220,76 @@ async function patchChatSummariesField<T>(chatId: string, patch: Record<string, 
   return storageApi.update<T>("chats", chatId, { metadata });
 }
 
+function textField(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function inlineImageDataUrl(value: unknown): string {
+  const text = textField(value);
+  return text.toLowerCase().startsWith("data:image/") ? text : "";
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Image attachment resolver returned an invalid file payload."));
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Image attachment resolver failed to read the file."));
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function loadImageUrlAsDataUrl(url: string, fallbackMimeType = "image/png"): Promise<string | null> {
+  if (!url) return null;
+  const inline = inlineImageDataUrl(url);
+  if (inline) return inline;
+  try {
+    const blob = await urlBinaryApi.load(url, fallbackMimeType);
+    const mimeType = textField(blob.type).toLowerCase();
+    if (mimeType && !mimeType.startsWith("image/")) return null;
+    return blobToDataUrl(blob);
+  } catch {
+    return null;
+  }
+}
+
+async function galleryImageDataUrl(gallery: unknown): Promise<string | null> {
+  if (!gallery || typeof gallery !== "object" || Array.isArray(gallery)) return null;
+  const record = gallery as Record<string, unknown>;
+  const urlData = await loadImageUrlAsDataUrl(textField(record.url));
+  if (urlData) return urlData;
+  const resolvedUrl = await resolveGalleryFileUrl(textField(record.filename), textField(record.filePath));
+  return resolvedUrl ? loadImageUrlAsDataUrl(resolvedUrl) : null;
+}
+
+async function resolveImageAttachmentDataUrl(
+  attachment: StorageImageAttachmentReference,
+): Promise<string | null> {
+  const inline =
+    inlineImageDataUrl(attachment.data) ||
+    inlineImageDataUrl(attachment.url) ||
+    inlineImageDataUrl(attachment.imageUrl);
+  if (inline) return inline;
+
+  const galleryId = textField(attachment.galleryId);
+  if (galleryId) {
+    const gallery = await storageApi.get<Record<string, unknown>>("gallery", galleryId).catch(() => null);
+    const galleryData = await galleryImageDataUrl(gallery);
+    if (galleryData) return galleryData;
+  }
+
+  const urlData = await loadImageUrlAsDataUrl(textField(attachment.url) || textField(attachment.imageUrl));
+  if (urlData) return urlData;
+
+  const resolvedUrl = await resolveGalleryFileUrl(textField(attachment.filename), textField(attachment.filePath));
+  return resolvedUrl ? loadImageUrlAsDataUrl(resolvedUrl) : null;
+}
+
 export const storageApi: StorageGateway = {
   list: async (entity: StorageEntity, options?: StorageListOptions) =>
     normalizeStorageReadResult(
@@ -289,6 +365,7 @@ export const storageApi: StorageGateway = {
       extra: { ...asRecord(message.extra), ...patch },
     });
   },
+  resolveImageAttachmentDataUrl,
   addChatMessageSwipe: (chatId, messageId, content, options) =>
     invokeTauri("chat_message_add_swipe", {
       chatId,

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -14,7 +14,7 @@ import {
 } from "./local-file-api";
 import { invokeTauri } from "./tauri-client";
 import { trackerSnapshotApi, type TrackerSnapshotInput } from "./tracker-snapshot-api";
-import { urlBinaryApi } from "./url-binary-api";
+import { blobToDataUrl, urlBinaryApi } from "./url-binary-api";
 
 function asRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
@@ -229,21 +229,6 @@ function inlineImageDataUrl(value: unknown): string {
   return text.toLowerCase().startsWith("data:image/") ? text : "";
 }
 
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result === "string") {
-        resolve(reader.result);
-      } else {
-        reject(new Error("Image attachment resolver returned an invalid file payload."));
-      }
-    };
-    reader.onerror = () => reject(reader.error ?? new Error("Image attachment resolver failed to read the file."));
-    reader.readAsDataURL(blob);
-  });
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -342,12 +327,18 @@ async function resolveImageAttachmentDataUrl(
   }
 
   const directUrl = textField(attachment.url) || textField(attachment.imageUrl);
-  const urlData = await loadImageUrlAsDataUrl(directUrl, "image/png", "image attachment url");
-  if (urlData) return urlData;
+  const errors: string[] = [];
+  if (directUrl) {
+    try {
+      const urlData = await loadImageUrlAsDataUrl(directUrl, "image/png", "image attachment url");
+      if (urlData) return urlData;
+    } catch (error) {
+      errors.push(errorMessage(error));
+    }
+  }
 
   const filename = textField(attachment.filename);
   const filePath = textField(attachment.filePath);
-  const errors: string[] = [];
   const fileData = await loadResolvedGalleryFileDataUrl(filename, filePath, "image attachment file", errors);
   if (fileData) return fileData;
   if (errors.length) throw new Error(errors.join("; "));

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -244,27 +244,78 @@ function blobToDataUrl(blob: Blob): Promise<string> {
   });
 }
 
-async function loadImageUrlAsDataUrl(url: string, fallbackMimeType = "image/png"): Promise<string | null> {
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function loadImageUrlAsDataUrl(
+  url: string,
+  fallbackMimeType = "image/png",
+  sourceLabel = "image attachment",
+): Promise<string | null> {
   if (!url) return null;
   const inline = inlineImageDataUrl(url);
   if (inline) return inline;
   try {
     const blob = await urlBinaryApi.load(url, fallbackMimeType);
     const mimeType = textField(blob.type).toLowerCase();
-    if (mimeType && !mimeType.startsWith("image/")) return null;
+    if (mimeType && !mimeType.startsWith("image/")) {
+      throw new Error(`${sourceLabel} resolved to ${mimeType}, not an image.`);
+    }
     return blobToDataUrl(blob);
-  } catch {
+  } catch (error) {
+    throw new Error(`Failed to load ${sourceLabel}: ${errorMessage(error)}`);
+  }
+}
+
+async function loadResolvedGalleryFileDataUrl(
+  filename: string,
+  filePath: string,
+  sourceLabel: string,
+  errors: string[],
+): Promise<string | null> {
+  if (!filename && !filePath) return null;
+  let resolvedUrl: string | null = null;
+  try {
+    resolvedUrl = await resolveGalleryFileUrl(filename, filePath);
+  } catch (error) {
+    errors.push(`failed to resolve ${sourceLabel}: ${errorMessage(error)}`);
+    return null;
+  }
+  if (!resolvedUrl) {
+    errors.push(`could not resolve ${sourceLabel}`);
+    return null;
+  }
+  try {
+    return await loadImageUrlAsDataUrl(resolvedUrl, "image/png", sourceLabel);
+  } catch (error) {
+    errors.push(errorMessage(error));
     return null;
   }
 }
 
-async function galleryImageDataUrl(gallery: unknown): Promise<string | null> {
+async function galleryImageDataUrl(gallery: unknown, galleryId: string): Promise<string | null> {
   if (!gallery || typeof gallery !== "object" || Array.isArray(gallery)) return null;
   const record = gallery as Record<string, unknown>;
-  const urlData = await loadImageUrlAsDataUrl(textField(record.url));
-  if (urlData) return urlData;
-  const resolvedUrl = await resolveGalleryFileUrl(textField(record.filename), textField(record.filePath));
-  return resolvedUrl ? loadImageUrlAsDataUrl(resolvedUrl) : null;
+  const errors: string[] = [];
+  const url = textField(record.url);
+  if (url) {
+    try {
+      const urlData = await loadImageUrlAsDataUrl(url, "image/png", `gallery image ${galleryId} url`);
+      if (urlData) return urlData;
+    } catch (error) {
+      errors.push(errorMessage(error));
+    }
+  }
+  const fileData = await loadResolvedGalleryFileDataUrl(
+    textField(record.filename),
+    textField(record.filePath),
+    `gallery image ${galleryId} file`,
+    errors,
+  );
+  if (fileData) return fileData;
+  if (errors.length) throw new Error(errors.join("; "));
+  return null;
 }
 
 async function resolveImageAttachmentDataUrl(
@@ -278,16 +329,29 @@ async function resolveImageAttachmentDataUrl(
 
   const galleryId = textField(attachment.galleryId);
   if (galleryId) {
-    const gallery = await storageApi.get<Record<string, unknown>>("gallery", galleryId).catch(() => null);
-    const galleryData = await galleryImageDataUrl(gallery);
+    let gallery: Record<string, unknown> | null = null;
+    try {
+      gallery = await storageApi.get<Record<string, unknown>>("gallery", galleryId);
+    } catch (error) {
+      throw new Error(`Failed to load image attachment gallery ${galleryId}: ${errorMessage(error)}`);
+    }
+    if (!gallery) throw new Error(`Image attachment gallery ${galleryId} was not found.`);
+    const galleryData = await galleryImageDataUrl(gallery, galleryId);
     if (galleryData) return galleryData;
+    throw new Error(`Image attachment gallery ${galleryId} does not contain a readable image.`);
   }
 
-  const urlData = await loadImageUrlAsDataUrl(textField(attachment.url) || textField(attachment.imageUrl));
+  const directUrl = textField(attachment.url) || textField(attachment.imageUrl);
+  const urlData = await loadImageUrlAsDataUrl(directUrl, "image/png", "image attachment url");
   if (urlData) return urlData;
 
-  const resolvedUrl = await resolveGalleryFileUrl(textField(attachment.filename), textField(attachment.filePath));
-  return resolvedUrl ? loadImageUrlAsDataUrl(resolvedUrl) : null;
+  const filename = textField(attachment.filename);
+  const filePath = textField(attachment.filePath);
+  const errors: string[] = [];
+  const fileData = await loadResolvedGalleryFileDataUrl(filename, filePath, "image attachment file", errors);
+  if (fileData) return fileData;
+  if (errors.length) throw new Error(errors.join("; "));
+  return null;
 }
 
 export const storageApi: StorageGateway = {

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -12,9 +12,10 @@ import {
   resolveGalleryFileUrl,
   type RemoteManagedAssetKind,
 } from "./local-file-api";
+import { blobToDataUrl } from "../lib/url-blob";
 import { invokeTauri } from "./tauri-client";
 import { trackerSnapshotApi, type TrackerSnapshotInput } from "./tracker-snapshot-api";
-import { blobToDataUrl, urlBinaryApi } from "./url-binary-api";
+import { urlBinaryApi } from "./url-binary-api";
 
 function asRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {
@@ -247,7 +248,7 @@ async function loadImageUrlAsDataUrl(
     if (mimeType && !mimeType.startsWith("image/")) {
       throw new Error(`${sourceLabel} resolved to ${mimeType}, not an image.`);
     }
-    return blobToDataUrl(blob);
+    return blobToDataUrl(blob, "URL binary request failed to read the file.");
   } catch (error) {
     throw new Error(`Failed to load ${sourceLabel}: ${errorMessage(error)}`);
   }

--- a/src/shared/api/url-binary-api.ts
+++ b/src/shared/api/url-binary-api.ts
@@ -50,21 +50,6 @@ function base64ToBlob(base64: string, mimeType: string): Blob {
   return new Blob([bytesToArrayBuffer(base64ToBytes(base64))], { type: mimeType });
 }
 
-export function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result === "string") {
-        resolve(reader.result);
-      } else {
-        reject(new Error("URL binary request returned an invalid file payload."));
-      }
-    };
-    reader.onerror = () => reject(reader.error ?? new Error("URL binary request failed to read the file."));
-    reader.readAsDataURL(blob);
-  });
-}
-
 export const urlBinaryApi = {
   load: async (url: string, fallbackMimeType = "application/octet-stream"): Promise<Blob> => {
     const response = await invokeTauri<unknown>("load_url_binary", {

--- a/src/shared/api/url-binary-api.ts
+++ b/src/shared/api/url-binary-api.ts
@@ -50,6 +50,21 @@ function base64ToBlob(base64: string, mimeType: string): Blob {
   return new Blob([bytesToArrayBuffer(base64ToBytes(base64))], { type: mimeType });
 }
 
+export function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("URL binary request returned an invalid file payload."));
+      }
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("URL binary request failed to read the file."));
+    reader.readAsDataURL(blob);
+  });
+}
+
 export const urlBinaryApi = {
   load: async (url: string, fallbackMimeType = "application/octet-stream"): Promise<Blob> => {
     const response = await invokeTauri<unknown>("load_url_binary", {


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Image attachments on user messages need to be stored as managed gallery assets instead of keeping inline data in message extras.
- Attachment preparation failures should not silently clear the user's draft or pending files.
- Gallery drawers should refresh when message attachments create new gallery rows.

## What changed

- Added managed image attachment preparation and provider data-url resolution through the storage gateway.
- Saved attachment-only user messages and preserved managed attachment references on generated/manual message paths.
- Updated conversation, shared chat, and game input flows so failed attachment preparation leaves drafts and files in place.
- Invalidated gallery image queries after managed attachment rows are created.
- Expanded the generation attachment schema to accept managed reference fields such as `url`, `filePath`, and `galleryId`.

## Refactor impact

Primary owner:

Engine generation, shared API storage, and mode input surfaces.

Impact areas reviewed:

- Conversation and shared chat input send/post-only paths.
- Game turn input and GameSurface send path.
- Gallery image query cache invalidation.
- Message attachment rendering and generation attachment contract.

Boundary notes:

- Engine code uses the `StorageGateway` port for storage-backed attachment behavior.
- Shared API owns managed gallery URL/data resolution through existing storage, local-file, and URL-binary wrappers.
- Feature UI calls typed shared API/runtime helpers and does not add raw Tauri or remote-runtime calls.
- Rust command boundaries are unchanged; existing generic gallery storage create continues to persist inline data URLs as managed files.

Pressure points touched:

- `GameSurface` send orchestration.
- Shared mode `ChatInput`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Commands run locally:

- `git diff --check`
- `git diff --cached --check`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check`

Manual native Tauri image-send QA was not run. The remaining manual check is sending an image attachment in conversation/roleplay and game, then confirming the message renders, provider image input still works, and the gallery updates.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

N/A proposed: this is a bugfix/internal storage and send-flow correction, not a new discoverable feature. Left unchecked for human confirmation.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: no docs changes were needed for this bugfix. No root changelog/release note file is present in this checkout.

## UI evidence

No screenshots or recordings captured. Native/manual UI QA remains the main proof gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced image attachment support with improved handling of URLs, file paths, and gallery-backed references.
  * Added automatic data URL resolution for image attachments across conversations and games.

* **Bug Fixes**
  * Improved attachment validation and caching behavior for image attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->