### PR TITLE
Fix game prompt sprite availability

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -33,7 +33,7 @@
     "baselineCommand": "pnpm check",
     "baselineEvidence": "passed after the reserved-only sprite edge-case patch and after merging upstream/refactor",
     "focusedProof": [
-      "pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/modes/game/prompts/sprite.service.test.ts passed before and after merging upstream/refactor.",
+      "pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/modes/game/prompts/sprite.service.test.ts passed before and after merging upstream/refactor; after Bunny repair it passed with 7 tests.",
       "pnpm typecheck passed before full baseline.",
       "pnpm check passed before and after merging upstream/refactor.",
       "git diff --check passed.",
@@ -43,7 +43,9 @@
       "GM prompt reminder includes party character expression sprite names from the visual asset gateway.",
       "GM prompt reminder includes custom full-body aliases with the full_ prefix removed.",
       "Engine-reserved automatic full-body poses such as full_idle are not exposed as model-visible full-body aliases.",
+      "Legacy/default full-body poses full_neutral, full_default, and full_walk are treated as automatic poses, not custom aliases.",
       "A character with only automatic full-body poses is omitted from model-visible sprite listings instead of producing an empty party prompt line.",
+      "Per-character visual asset lookup failures are treated as missing optional sprite enrichment and do not abort prompt assembly or party turns.",
       "Prompt preview receives the visual asset gateway so manual prompt inspection matches generation.",
       "Party turn passes the same characterSprites structure into buildPartySystemPrompt."
     ],
@@ -68,10 +70,12 @@
     "positiveRowsTested": [
       "expression sprites",
       "custom full-body alias sprites",
-      "multiple party characters"
+      "multiple party characters",
+      "visual asset gateway rejection on one party character"
     ],
     "negativeRowsTested": [
-      "automatic-only full-body pose is not shown as a custom alias"
+      "automatic-only full-body pose is not shown as a custom alias",
+      "legacy/default full-body poses neutral, default, and walk are not shown as custom aliases"
     ],
     "groundTruthFacts": [
       {

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -91,6 +91,6 @@
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true,
-    "notes": "Local proof, pnpm check, proof gate, Bunny pass, and upstream/refactor merge validation are complete."
+    "notes": "Local proof, pnpm check, proof gate, Bunny pass, and upstream/refactor merge validation are complete. PR body marks Feature Discoverability as N/A with a reason."
   }
 }

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -5,7 +5,10 @@
     "title": "Game mode GM and party system prompts no longer receive the per-character sprite list",
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2135"
   },
-  "pr": null,
+  "pr": {
+    "number": 2211,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2211"
+  },
   "coreClaim": "Game GM and party prompts receive saved party character sprite expressions and custom full-body aliases.",
   "reproduction": {
     "attempted": true,

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,60 +1,84 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2128,
-    "title": "Character editor quote formatting misses advanced card fields",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2128"
+    "number": 2135,
+    "title": "Game mode GM and party system prompts no longer receive the per-character sprite list",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2135"
   },
-  "pr": {
-    "number": 2201,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2201"
-  },
-  "coreClaim": "Character editor save formatting normalizes configured quote style for creator notes, system prompt, post-history instructions, and depth prompt text.",
-  "assignment": {
-    "assignee": "cha1latte",
-    "assignedBeforeWork": true,
-    "evidence": "gh issue edit 2128 --repo Pasta-Devs/Marinara-Engine --add-assignee \"@me\" returned the issue URL before reproduction or edits."
-  },
-  "preflight": {
-    "noAssociatedPr": true,
-    "details": "gh PR search for #2128 and the issue title returned no matches; no local branch or worktree for issue 2128 existed before this run."
-  },
+  "pr": null,
+  "coreClaim": "Game GM and party prompts receive saved party character sprite expressions and custom full-body aliases.",
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "method": "Focused Vitest regression test against the formatter model before the production patch.",
+    "method": "Copied the new prompt-assembly regression test into a pristine upstream/refactor worktree.",
     "evidence": [
-      "pnpm exec vitest run src\\features\\catalog\\characters\\lib\\character-editor-model.test.ts failed before the fix.",
-      "creator_notes returned `Creator says \"draft\".` instead of typographic quotes.",
-      "depth_prompt.prompt returned `Remember \"the signal\".` instead of typographic quotes."
+      "C:/tmp/Marinara-Engine-issue-2135-before: pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts failed before the fix.",
+      "The failing assertion showed the assembled game prompt did not contain Available custom sprites per character."
     ]
   },
   "verification": {
     "originalReproPassed": true,
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
-    "baselineEvidence": "pnpm check passed after the final production diff and again after merging upstream/refactor to resolve PR conflicts.",
+    "baselineEvidence": "passed after the reserved-only sprite edge-case patch",
     "focusedProof": [
-      "pnpm exec vitest run src\\features\\catalog\\characters\\lib\\character-editor-model.test.ts passed after the fix and Bunny repair.",
+      "pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/modes/game/prompts/sprite.service.test.ts passed.",
       "pnpm typecheck passed.",
-      "git diff --check passed."
+      "git diff --check passed.",
+      "node C:/Users/celia/.codex/tools/marinara-proof-gate.mjs scratch/bugfix-verification.json passed."
     ],
     "edgeCases": [
-      "creator_notes, system_prompt, and post_history_instructions now use typographic quote formatting.",
-      "creator_notes preserves complete <style>...</style> blocks while formatting surrounding prose.",
-      "depth_prompt.prompt now uses typographic quote formatting.",
-      "depth_prompt.depth, depth_prompt.role, and unrelated extension properties are preserved unchanged."
+      "GM prompt reminder includes party character expression sprite names from the visual asset gateway.",
+      "GM prompt reminder includes custom full-body aliases with the full_ prefix removed.",
+      "Engine-reserved automatic full-body poses such as full_idle are not exposed as model-visible full-body aliases.",
+      "A character with only automatic full-body poses is omitted from model-visible sprite listings instead of producing an empty party prompt line.",
+      "Prompt preview receives the visual asset gateway so manual prompt inspection matches generation."
     ],
-    "visualProof": "scratch/issue-2128-vitest-after.png",
-    "visualProofNotes": "Local screenshot rendered from the raw passing Vitest output in scratch/issue-2128-vitest-after.txt. There is no meaningful app UI state for this formatter-model proof."
+    "visualProof": "Backend prompt bug; before/after terminal proof from targeted Vitest runs is recorded in the PR body."
   },
   "manualBlockers": [],
-  "riskClaimMatrix": null,
+  "assignment": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2135",
+  "preflight": {
+    "noAssociatedPr": true,
+    "details": "Exact gh PR search for 2135 returned no matches; broader sprite-title search did not show an associated #2135 fix PR."
+  },
+  "riskClaimMatrix": {
+    "coreClaim": "Game GM and party prompts receive saved party character sprite expressions and custom full-body aliases.",
+    "riskType": "prompt assembly contract",
+    "entrypoints": [
+      "src/engine/generation/start-generation.ts",
+      "src/engine/generation/prompt-preview.ts",
+      "src/features/modes/game/api/game-api.ts partyTurn"
+    ],
+    "currentPathsOrFormats": [
+      "VisualAssetGateway.listSprites(ownerId, \"character\")",
+      "sprite expressions with full_ prefix for full-body poses"
+    ],
+    "legacyPathsOrFormats": [
+      "main listPartySprites buckets expression sprites, custom full-body aliases, and automatic poses"
+    ],
+    "positiveRowsTested": [
+      "expression sprites",
+      "custom full-body alias sprites",
+      "multiple party characters"
+    ],
+    "negativeRowsTested": [
+      "automatic-only full-body pose is not shown as a custom alias"
+    ],
+    "groundTruthFacts": [
+      {
+        "fact": "Saved sprites are exposed to engine code through VisualAssetGateway, not generic storage rows.",
+        "method": "derived from src/engine/capabilities/visual-assets.ts, src/shared/api/visual-assets-api.ts, and src-tauri/src/commands/storage/sprites.rs list_sprites."
+      }
+    ],
+    "userActionCopy": [],
+    "manualBlockers": []
+  },
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true,
-    "notes": "Local proof, pnpm check, proof gate, and Bunny pass are complete. A later Bunny finding about creator-notes CSS was repaired with a focused regression row; the branch was merged with upstream/refactor to clear PR conflicts."
+    "notes": "Local proof, pnpm check, proof gate, and Bunny pass are complete."
   }
 }

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { StorageGateway } from "../capabilities/storage";
+import type { VisualAssetGateway } from "../capabilities/visual-assets";
+import { buildPartySystemPrompt } from "../modes/game/prompts/party-prompts";
+import { loadCharacterSprites } from "../modes/game/prompts/sprite.service";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 
 type RowMap = Record<string, unknown[]>;
@@ -121,5 +124,84 @@ describe("assembleGenerationPrompt depth injection", () => {
       "post-history prompt",
       "depth lore entry",
     ]);
+  });
+});
+
+describe("assembleGenerationPrompt game sprites", () => {
+  const visuals: VisualAssetGateway = {
+    listSprites: async (ownerId) =>
+      ownerId === "char-1"
+        ? [
+            { expression: "neutral" },
+            { expression: "joy_01" },
+            { expression: "full_idle" },
+            { expression: "full_walk" },
+            { expression: "full_cape_flare" },
+          ]
+        : [{ expression: "worried" }],
+    listBackgrounds: async () => [],
+  };
+
+  it("passes party sprite availability into the GM prompt reminder", async () => {
+    const storage = storageWithRows({
+      prompts: [],
+      characters: [
+        { id: "char-1", name: "Marina", data: { name: "Marina", description: "A careful scout." } },
+        { id: "char-2", name: "Sol", data: { name: "Sol", description: "A bright mage." } },
+      ],
+      personas: [],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "game",
+        characterIds: ["char-1", "char-2"],
+        metadata: {
+          gamePartyCharacterIds: ["char-1", "char-2"],
+          gameSetupConfig: { genre: "fantasy", setting: "coast", tone: "warm", difficulty: "normal" },
+        },
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "Look around." }],
+      connection: {},
+      request: {},
+      latestUserInput: "Look around.",
+      visuals,
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Available custom sprites per character");
+    expect(prompt).toContain("Marina (expressions): neutral, joy_01");
+    expect(prompt).toContain("Marina (full-body): cape_flare");
+    expect(prompt).toContain("Sol (expressions): worried");
+    expect(prompt).not.toContain("Marina (full-body): idle");
+    expect(prompt).not.toContain("Marina (full-body): walk");
+  });
+
+  it("passes party sprite availability into the party-agent prompt", async () => {
+    const characterSprites = await loadCharacterSprites(visuals, [
+      { id: "char-1", name: "Marina" },
+      { id: "char-2", name: "Sol" },
+    ]);
+
+    const prompt = buildPartySystemPrompt({
+      partyCards: [
+        { name: "Marina", card: "Name: Marina\nDescription: A careful scout." },
+        { name: "Sol", card: "Name: Sol\nDescription: A bright mage." },
+      ],
+      playerName: "Player",
+      gameActiveState: "exploration",
+      characterSprites,
+    });
+
+    expect(prompt).toContain("Available sprites per character");
+    expect(prompt).toContain("Marina: neutral, joy_01 | custom full-body aliases: cape_flare");
+    expect(prompt).toContain("Sol: worried");
+    expect(prompt).not.toContain("custom full-body aliases: idle");
+    expect(prompt).not.toContain("custom full-body aliases: walk");
   });
 });

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -3,6 +3,7 @@ import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types
 import type { CharacterData } from "../contracts/types/character";
 import { BUILT_IN_AGENTS } from "../contracts/types/agent";
 import type { StorageGateway } from "../capabilities/storage";
+import type { VisualAssetGateway } from "../capabilities/visual-assets";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
 import { injectAtDepth } from "../generation-core/lorebooks/prompt-injector";
 import { wrapContent, wrapGroup } from "../generation-core/prompt/format-engine";
@@ -23,6 +24,7 @@ import type {
   SessionSummary,
 } from "../contracts/types/game";
 import { buildGmFormatReminder, buildGmSystemPrompt, type GmPromptContext } from "../modes/game/prompts/gm-prompts";
+import { loadCharacterSprites, type CharacterSpriteSubject } from "../modes/game/prompts/sprite.service";
 import { formatPerceptionHints, generatePerceptionHints } from "../modes/game/mechanics/perception.service";
 import { applyAllSegmentEdits } from "../modes/game/state/segment-edits";
 import { fingerprintChatSummary } from "../shared/text/chat-summary-fingerprint";
@@ -128,6 +130,7 @@ export interface PromptAssemblyInput {
       request?: { connectionId?: string | null; model?: string | null },
     ): Promise<number[][] | null>;
   } | null;
+  visuals?: VisualAssetGateway;
   persistPromptVariables?: boolean;
 }
 
@@ -637,6 +640,7 @@ async function buildGamePromptMessages(
   const partyIds = storedPartyIds.length ? storedPartyIds : stringArray(input.chat.characterIds);
   const partyNames: string[] = [];
   const partyCards: Array<{ name: string; card: string }> = [];
+  const spriteSubjects: CharacterSpriteSubject[] = [];
 
   for (const id of partyIds) {
     if (isPartyNpcId(id)) {
@@ -649,6 +653,7 @@ async function buildGamePromptMessages(
     const character = await loadCharacterById(storage, id, characterById);
     if (!character) continue;
     partyNames.push(character.name);
+    spriteSubjects.push({ id: character.id, name: character.name });
     partyCards.push({
       name: character.name,
       card: characterCardText(character, gameCardMap.get(character.name.toLowerCase())),
@@ -704,6 +709,7 @@ async function buildGamePromptMessages(
     perceptionHints: buildGamePerceptionHints(input.chat, meta, persona),
     moraleContext:
       meta.gameMorale == null ? undefined : `Current party morale: ${readNumber(meta.gameMorale, 50)} / 100.`,
+    characterSprites: await loadCharacterSprites(input.visuals, spriteSubjects),
     playerInventory: normalizeGameInventory(meta.gameInventory),
     language: readString(setup.language).trim() || undefined,
   };

--- a/src/engine/generation/prompt-preview.ts
+++ b/src/engine/generation/prompt-preview.ts
@@ -1,5 +1,6 @@
 import type { ChatMLMessage, GenerationParameters } from "../contracts/types/prompt";
 import type { StorageGateway } from "../capabilities/storage";
+import type { VisualAssetGateway } from "../capabilities/visual-assets";
 import { llmParameters, loadChatMessages, requireRecord, resolveGenerationConnection } from "./context";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 import { generationInfoFromVisibleParameters, providerVisibleLlmParameters } from "./provider-visible-parameters";
@@ -55,6 +56,7 @@ function promptPreviewMessageLoadOptions(
 export async function previewGenerationPrompt(
   storage: StorageGateway,
   input: PromptPreviewInput,
+  visuals?: VisualAssetGateway,
 ): Promise<PromptPreviewResult> {
   const chat = requireRecord(await storage.get("chats", input.chatId), "Chat");
   const connection = await resolveGenerationConnection(storage, chat, input);
@@ -89,6 +91,7 @@ export async function previewGenerationPrompt(
     connection,
     request,
     latestUserInput: "",
+    visuals,
   });
   const parameters = llmParameters(connection, request, previewChat, assembly.parameters);
   const visibleParameters = providerVisibleLlmParameters(connection, parameters, { stream: true });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2349,6 +2349,7 @@ async function runGenerationAgentsForTarget(args: {
     request: input,
     latestUserInput: "",
     embeddingSource: generationEmbeddingSource(deps.llm, connection),
+    visuals: deps.visuals,
     persistPromptVariables: true,
   });
   const results: AgentResult[] = [];
@@ -2651,6 +2652,7 @@ export async function* startGeneration(
     request: input,
     latestUserInput,
     embeddingSource: generationEmbeddingSource(deps.llm, connection),
+    visuals: deps.visuals,
     persistPromptVariables: true,
   });
   throwIfAborted(signal);
@@ -2713,6 +2715,7 @@ export async function* startGeneration(
       latestUserInput,
       agentData: runtime?.agentData,
       embeddingSource: generationEmbeddingSource(deps.llm, connection),
+      visuals: deps.visuals,
       persistPromptVariables: true,
     });
     throwIfAborted(signal);

--- a/src/engine/modes/game/prompts/sprite.service.test.ts
+++ b/src/engine/modes/game/prompts/sprite.service.test.ts
@@ -10,7 +10,10 @@ describe("game prompt sprite service", () => {
             { expression: "neutral" },
             { expression: "joy_01" },
             { expression: "joy_blush" },
+            { expression: "full_neutral" },
+            { expression: "full_default" },
             { expression: "full_idle" },
+            { expression: "full_walk" },
             { expression: "full_battle_stance" },
             { expression: "full_cape_flare" },
             { expression: "full_moonlit_pose" },
@@ -25,7 +28,7 @@ describe("game prompt sprite service", () => {
         expressions: ["neutral", "joy_01", "joy_blush"],
         expressionChoices: ["neutral", "joy"],
         fullBody: ["cape_flare", "moonlit_pose"],
-        automaticFullBody: ["idle", "battle_stance"],
+        automaticFullBody: ["neutral", "default", "idle", "walk", "battle_stance"],
       },
     ]);
   });
@@ -50,6 +53,32 @@ describe("game prompt sprite service", () => {
     ).resolves.toEqual([
       {
         name: "Marina",
+        expressions: ["smirk"],
+        expressionChoices: ["smirk"],
+        fullBody: [],
+        automaticFullBody: [],
+      },
+    ]);
+  });
+
+  it("treats per-character sprite lookup failures as missing optional enrichment", async () => {
+    await expect(
+      loadCharacterSprites(
+        {
+          listSprites: async (ownerId) => {
+            if (ownerId === "char-1") throw new Error("sprite folder unavailable");
+            return [{ expression: "smirk" }];
+          },
+          listBackgrounds: async () => [],
+        },
+        [
+          { id: "char-1", name: "Marina" },
+          { id: "char-2", name: "Sol" },
+        ],
+      ),
+    ).resolves.toEqual([
+      {
+        name: "Sol",
         expressions: ["smirk"],
         expressionChoices: ["smirk"],
         fullBody: [],

--- a/src/engine/modes/game/prompts/sprite.service.test.ts
+++ b/src/engine/modes/game/prompts/sprite.service.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { loadCharacterSprites } from "./sprite.service";
+
+describe("game prompt sprite service", () => {
+  it("separates expression sprites, custom full-body aliases, and automatic full-body poses", async () => {
+    await expect(
+      loadCharacterSprites(
+        {
+          listSprites: async () => [
+            { expression: "neutral" },
+            { expression: "joy_01" },
+            { expression: "joy_blush" },
+            { expression: "full_idle" },
+            { expression: "full_battle_stance" },
+            { expression: "full_cape_flare" },
+            { expression: "full_moonlit_pose" },
+          ],
+          listBackgrounds: async () => [],
+        },
+        [{ id: "char-1", name: "Marina" }],
+      ),
+    ).resolves.toEqual([
+      {
+        name: "Marina",
+        expressions: ["neutral", "joy_01", "joy_blush"],
+        expressionChoices: ["neutral", "joy"],
+        fullBody: ["cape_flare", "moonlit_pose"],
+        automaticFullBody: ["idle", "battle_stance"],
+      },
+    ]);
+  });
+
+  it("loads character sprite info through the visual asset gateway", async () => {
+    await expect(
+      loadCharacterSprites(
+        {
+          listSprites: async (ownerId) =>
+            ownerId === "char-1"
+              ? [{ expression: "smirk" }]
+              : ownerId === "char-2"
+                ? [{ expression: "full_idle" }]
+                : [],
+          listBackgrounds: async () => [],
+        },
+        [
+          { id: "char-1", name: "Marina" },
+          { id: "char-2", name: "Sol" },
+        ],
+      ),
+    ).resolves.toEqual([
+      {
+        name: "Marina",
+        expressions: ["smirk"],
+        expressionChoices: ["smirk"],
+        fullBody: [],
+        automaticFullBody: [],
+      },
+    ]);
+  });
+});

--- a/src/engine/modes/game/prompts/sprite.service.ts
+++ b/src/engine/modes/game/prompts/sprite.service.ts
@@ -16,6 +16,8 @@ export interface CharacterSpriteSubject {
 }
 
 const AUTOMATIC_FULL_BODY_POSES = new Set([
+  "neutral",
+  "default",
   "idle",
   "walk",
   "run",
@@ -103,7 +105,7 @@ export async function loadCharacterSprites(
 
   const rows = await Promise.all(
     subjects.map(async (subject) => {
-      const sprites = await visuals.listSprites(subject.id, "character");
+      const sprites = await visuals.listSprites(subject.id, "character").catch(() => []);
       return buildCharacterSpriteInfo(subject.name, sprites);
     }),
   );

--- a/src/engine/modes/game/prompts/sprite.service.ts
+++ b/src/engine/modes/game/prompts/sprite.service.ts
@@ -1,3 +1,5 @@
+import type { SpriteAssetInfo, VisualAssetGateway } from "../../../capabilities/visual-assets";
+
 export interface CharacterSpriteInfo {
   name: string;
   expressions: string[];
@@ -6,6 +8,107 @@ export interface CharacterSpriteInfo {
   fullBody: string[];
   /** Engine-assigned standard full-body poses; not exposed to the model. */
   automaticFullBody: string[];
+}
+
+export interface CharacterSpriteSubject {
+  id: string;
+  name: string;
+}
+
+const AUTOMATIC_FULL_BODY_POSES = new Set([
+  "idle",
+  "walk",
+  "run",
+  "battle_stance",
+  "attack",
+  "defend",
+  "casting",
+  "hurt",
+  "jump",
+  "thinking",
+  "cheer",
+  "victory",
+  "wave",
+  "sit",
+  "kneel",
+  "point",
+]);
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const text = value.trim();
+    if (!text) continue;
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(text);
+  }
+
+  return result;
+}
+
+function normalizeFullBodyAlias(expression: string): string | null {
+  const trimmed = expression.trim();
+  if (!trimmed.toLowerCase().startsWith("full_")) return null;
+  const alias = trimmed.slice(5).trim();
+  return alias || null;
+}
+
+function buildCharacterSpriteInfo(name: string, sprites: SpriteAssetInfo[]): CharacterSpriteInfo | null {
+  const expressions: string[] = [];
+  const fullBody: string[] = [];
+  const automaticFullBody: string[] = [];
+
+  for (const sprite of sprites) {
+    const expression = typeof sprite.expression === "string" ? sprite.expression.trim() : "";
+    if (!expression) continue;
+
+    const fullBodyAlias = normalizeFullBodyAlias(expression);
+    if (!fullBodyAlias) {
+      expressions.push(expression);
+      continue;
+    }
+
+    if (AUTOMATIC_FULL_BODY_POSES.has(fullBodyAlias.toLowerCase())) {
+      automaticFullBody.push(fullBodyAlias);
+    } else {
+      fullBody.push(fullBodyAlias);
+    }
+  }
+
+  const uniqueExpressions = uniqueStrings(expressions);
+  const uniqueFullBody = uniqueStrings(fullBody);
+  const uniqueAutomaticFullBody = uniqueStrings(automaticFullBody);
+  if (uniqueExpressions.length === 0 && uniqueFullBody.length === 0) {
+    return null;
+  }
+
+  return {
+    name,
+    expressions: uniqueExpressions,
+    expressionChoices: buildSpriteExpressionChoices(uniqueExpressions),
+    fullBody: uniqueFullBody,
+    automaticFullBody: uniqueAutomaticFullBody,
+  };
+}
+
+export async function loadCharacterSprites(
+  visuals: VisualAssetGateway | undefined,
+  subjects: CharacterSpriteSubject[],
+): Promise<CharacterSpriteInfo[]> {
+  if (!visuals || subjects.length === 0) return [];
+
+  const rows = await Promise.all(
+    subjects.map(async (subject) => {
+      const sprites = await visuals.listSprites(subject.id, "character");
+      return buildCharacterSpriteInfo(subject.name, sprites);
+    }),
+  );
+
+  return rows.filter((row): row is CharacterSpriteInfo => row !== null);
 }
 
 function getSpriteExpressionGroupKey(expression: string): string | null {

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -24,6 +24,7 @@ import { appendChatSummaryEntryToMetadata } from "../../../../engine/shared/text
 import { chatCommandApi } from "../../../../shared/api/chat-command-api";
 import { llmApi } from "../../../../shared/api/llm-api";
 import { storageApi } from "../../../../shared/api/storage-api";
+import { visualAssetsApi } from "../../../../shared/api/visual-assets-api";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { getExportErrorMessage } from "../../../shared/lib/export-feedback";
@@ -1050,7 +1051,7 @@ export function usePeekPrompt() {
   return useMutation({
     mutationFn: (input: string | PromptPreviewInput): Promise<PromptPreviewResult> => {
       const request: PromptPreviewInput = typeof input === "string" ? { chatId: input } : input;
-      return previewGenerationPrompt(storageApi, request);
+      return previewGenerationPrompt(storageApi, request, visualAssetsApi);
     },
   });
 }

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -31,6 +31,7 @@ import { chatCommandApi } from "../../../../shared/api/chat-command-api";
 import { resolveGalleryFileUrl } from "../../../../shared/api/local-file-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { urlBinaryApi } from "../../../../shared/api/url-binary-api";
+import { visualAssetsApi } from "../../../../shared/api/visual-assets-api";
 import {
   createLorebookEntrySchema,
   createLorebookSchema,
@@ -64,6 +65,7 @@ import {
 } from "../../../../engine/modes/game/mechanics/element-reactions.service";
 import { buildPartySystemPrompt } from "../../../../engine/modes/game/prompts/party-prompts";
 import { buildSessionConclusionPrompt, buildSetupPrompt } from "../../../../engine/modes/game/prompts/gm-prompts";
+import { loadCharacterSprites, type CharacterSpriteSubject } from "../../../../engine/modes/game/prompts/sprite.service";
 import {
   GAME_BACKGROUND_PROMPT_OVERRIDE,
   GAME_ILLUSTRATION_PROMPT_OVERRIDE,
@@ -1486,6 +1488,26 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map((entry) => readTrimmed(entry)).filter(Boolean) : [];
 }
 
+async function partySpriteSubjects(
+  partyIds: string[],
+  cards: Array<Record<string, unknown>>,
+): Promise<CharacterSpriteSubject[]> {
+  const subjects: CharacterSpriteSubject[] = [];
+  let cardIndex = 0;
+
+  for (const id of partyIds) {
+    if (id.startsWith("npc:")) continue;
+
+    const cardName = gameCardName(cards[cardIndex] ?? {}, `Party member ${cardIndex + 1}`);
+    cardIndex += 1;
+    const character = await storageApi.get<Record<string, unknown>>("characters", id).catch(() => null);
+    const name = character ? recordName(character) || cardName : cardName;
+    if (name) subjects.push({ id, name });
+  }
+
+  return subjects;
+}
+
 function matchesIllustrationSubject(
   subject: IllustrationReferenceSubject,
   illustration: Record<string, unknown>,
@@ -2544,8 +2566,14 @@ export const gameApi = {
     connectionId?: string | null;
     debugMode?: boolean;
   }) {
-    const meta = chatMeta(await getChat(input.chatId));
+    const chat = await getChat(input.chatId);
+    const meta = chatMeta(chat);
     const cards = Array.isArray(meta.gameCharacterCards) ? meta.gameCharacterCards.map(asRecord) : [];
+    const partyIds = stringArray(meta.gamePartyCharacterIds);
+    const characterSprites = await loadCharacterSprites(
+      visualAssetsApi,
+      await partySpriteSubjects(partyIds.length > 0 ? partyIds : stringArray(chat?.characterIds), cards),
+    );
     const names = cards.map((card, index) => gameCardName(card, `Party member ${index + 1}`));
     const partyNames = names.length ? names.join(", ") : "The party";
     const connectionId = input.connectionId?.trim();
@@ -2568,6 +2596,7 @@ export const gameApi = {
               typeof meta.gamePlayerName === "string" && meta.gamePlayerName.trim() ? meta.gamePlayerName : "Player",
             gameActiveState: typeof meta.gameActiveState === "string" ? meta.gameActiveState : "exploration",
             partyArcs: Array.isArray(meta.gamePartyArcs) ? (meta.gamePartyArcs as PartyArc[]) : [],
+            characterSprites,
           }),
         },
         {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2135

## Why this change

- Game GM and party prompts still had sprite-availability prompt blocks, but the refactor path never populated `characterSprites`, so models were not told the saved expression names or custom full-body aliases for party characters.

## What changed

- Added a game prompt sprite loader that reads saved character sprites through `VisualAssetGateway`, buckets expression sprites separately from custom full-body aliases, and keeps engine-reserved automatic full-body poses out of model-visible alias lists.
- Wired the loader into game prompt assembly, prompt preview, generation entrypoints, and the party-turn prompt path.
- Added regression coverage for GM prompt assembly and the sprite bucketing/automatic-pose edge case.

## Refactor impact

Primary owner:

- Engine generation / game mode prompt assembly

Impact areas reviewed:

- `src/engine/generation`
- `src/engine/modes/game/prompts`
- `src/features/modes/game/api`
- Prompt preview via chat catalog hooks

Boundary notes:

- Engine code depends only on the existing `VisualAssetGateway` capability.
- Shared/feature code passes `visualAssetsApi`; no raw Tauri calls were added to engine code.
- NPC party members are intentionally skipped because saved sprites are keyed by character/persona owner IDs, not tracked NPC IDs.

Pressure points touched:

- Game prompt assembly
- Game party-turn API
- Prompt preview

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Before proof: copied the new prompt-assembly regression into `C:/tmp/Marinara-Engine-issue-2135-before` at pristine `upstream/refactor`; `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` failed because the prompt did not contain `Available custom sprites per character`.
- After proof: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts src/engine/modes/game/prompts/sprite.service.test.ts` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- `node C:/Users/celia/.codex/tools/marinara-proof-gate.mjs scratch/bugfix-verification.json` passed.
- Bunny pass completed locally on the final diff.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix restoring prompt context parity; no new user-discoverable surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. Backend/prompt assembly fix; proof is the before/after prompt regression and full local validation above.
