### PR TITLE
Fix lorebook tool key search

### DIFF
--- a/src/engine/contracts/types/agent.ts
+++ b/src/engine/contracts/types/agent.ts
@@ -169,7 +169,15 @@ export interface AgentContext {
   /** Optional sink for structured runtime debug entries when debugMode is enabled. */
   debugSink?: (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => void;
   /** Lorebook entries activated for this generation (read context) */
-  activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }> | null;
+  activatedLorebookEntries: Array<{
+    id: string;
+    name: string;
+    content: string;
+    tag: string;
+    matchedKeys?: string[];
+    keys?: string[];
+    secondaryKeys?: string[];
+  }> | null;
   /** All lorebook IDs the agent can write to */
   writableLorebookIds: string[] | null;
   /** Chat summary text (if any) — helps agents avoid duplicating summarized info */

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -82,7 +82,15 @@ export interface GenerationAgentRuntimeInput {
   cadenceMessages?: JsonRecord[];
   characters: GenerationCharacterContext[];
   persona: GenerationPersonaContext | null;
-  activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }>;
+  activatedLorebookEntries: Array<{
+    id: string;
+    name: string;
+    content: string;
+    tag: string;
+    matchedKeys?: string[];
+    keys?: string[];
+    secondaryKeys?: string[];
+  }>;
   chatSummary: string | null;
   embeddingSource?: { embed(texts: string[]): Promise<number[][] | null> } | null;
   debugMode?: boolean;

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -162,6 +162,16 @@ function stringArrayArg(args: JsonRecord, key: string): string[] {
   return value.map((item) => readString(item).trim()).filter(Boolean);
 }
 
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) return false;
+    seen.add(trimmed);
+    return true;
+  });
+}
+
 function toolError(message: string): never {
   throw new Error(message);
 }
@@ -262,29 +272,35 @@ async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInp
   const category = stringArg(args, "category").toLowerCase();
   const tokens = query.split(/\s+/).filter((token) => token.length > 1);
   const rows = await loadSearchableStoredLorebookEntries(storage, input);
+  const storedById = new Map(rows.map((entry) => [entry.id, entry]));
+  const activatedIds = new Set(input.activatedLorebookEntries.map((entry) => entry.id).filter(Boolean));
   const activated = input.activatedLorebookEntries.map((entry) => ({
     id: entry.id,
-    name: entry.name,
-    content: entry.content,
-    tag: entry.tag,
-    keys: [...(entry.matchedKeys ?? []), ...(entry.keys ?? [])],
-    secondaryKeys: entry.secondaryKeys ?? [],
+    name: storedById.get(entry.id)?.name || entry.name,
+    content: storedById.get(entry.id)?.content || entry.content,
+    tag: storedById.get(entry.id)?.tag || entry.tag,
+    keys: uniqueStrings([
+      ...(entry.matchedKeys ?? []),
+      ...(entry.keys ?? []),
+      ...(storedById.get(entry.id)?.keys ?? []),
+    ]),
+    secondaryKeys: uniqueStrings([...(entry.secondaryKeys ?? []), ...(storedById.get(entry.id)?.secondaryKeys ?? [])]),
     source: "activated",
   }));
-  const stored = rows.map((entry) => ({
-    id: entry.id,
-    name: entry.name || "Lorebook entry",
-    content: entry.content,
-    tag: entry.tag || String(entry.position),
-    keys: entry.keys,
-    secondaryKeys: entry.secondaryKeys,
-    source: "stored",
-  }));
-  const seen = new Set<string>();
+  const stored = rows
+    .filter((entry) => !activatedIds.has(entry.id))
+    .map((entry) => ({
+      id: entry.id,
+      name: entry.name || "Lorebook entry",
+      content: entry.content,
+      tag: entry.tag || String(entry.position),
+      keys: entry.keys,
+      secondaryKeys: entry.secondaryKeys,
+      source: "stored",
+    }));
   const scored = [...activated, ...stored]
     .filter((entry) => {
-      if (!entry.id || seen.has(entry.id)) return false;
-      seen.add(entry.id);
+      if (!entry.id) return false;
       if (category && !`${entry.name} ${entry.tag}`.toLowerCase().includes(category)) return false;
       return true;
     })

--- a/src/engine/generation/tools-runtime.ts
+++ b/src/engine/generation/tools-runtime.ts
@@ -30,7 +30,15 @@ import {
 export interface ToolRuntimeInput {
   chat: JsonRecord;
   storedMessages?: JsonRecord[];
-  activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }>;
+  activatedLorebookEntries: Array<{
+    id: string;
+    name: string;
+    content: string;
+    tag: string;
+    matchedKeys?: string[];
+    keys?: string[];
+    secondaryKeys?: string[];
+  }>;
   characters: GenerationCharacterContext[];
   persona: GenerationPersonaContext | null;
   chatSummary: string | null;
@@ -259,6 +267,8 @@ async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInp
     name: entry.name,
     content: entry.content,
     tag: entry.tag,
+    keys: [...(entry.matchedKeys ?? []), ...(entry.keys ?? [])],
+    secondaryKeys: entry.secondaryKeys ?? [],
     source: "activated",
   }));
   const stored = rows.map((entry) => ({
@@ -266,6 +276,8 @@ async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInp
     name: entry.name || "Lorebook entry",
     content: entry.content,
     tag: entry.tag || String(entry.position),
+    keys: entry.keys,
+    secondaryKeys: entry.secondaryKeys,
     source: "stored",
   }));
   const seen = new Set<string>();
@@ -277,7 +289,8 @@ async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInp
       return true;
     })
     .map((entry) => {
-      const haystack = `${entry.name} ${entry.tag} ${entry.content}`.toLowerCase();
+      const keyText = [...entry.keys, ...entry.secondaryKeys].join(" ");
+      const haystack = `${entry.name} ${entry.tag} ${entry.content} ${keyText}`.toLowerCase();
       const score =
         (haystack.includes(query) ? 10 : 0) +
         tokens.reduce((sum, token) => sum + (haystack.includes(token) ? 1 : 0), 0);
@@ -292,6 +305,8 @@ async function searchLorebookTool(storage: StorageGateway, input: ToolRuntimeInp
       tag: entry.tag || null,
       source: entry.source,
       score: entry.score,
+      keys: entry.keys.slice(0, 12),
+      secondaryKeys: entry.secondaryKeys.slice(0, 12),
       content: entry.content.slice(0, 4000),
     }));
   return { query, entries: scored };


### PR DESCRIPTION
## Linked issue

Closes #2197

## Why this change

- `search_lorebook` could miss scoped lorebook entries when the query matched only entry trigger keys. Legacy searched entry keys, so agents and tool-enabled generation lost a parity path for key-only lorebook lookups.

## What changed

- Includes activated matched keys and stored primary/secondary keys in the `search_lorebook` scoring haystack.
- Returns primary and secondary key context with search results so agents can see why a lorebook entry matched.
- Widens the agent/tool runtime activated lorebook entry contract to preserve optional key fields already available from prompt assembly.

## Refactor impact

Primary owner:

- Engine generation / built-in tool runtime.

Impact areas reviewed:

- Catalog lorebook entries loaded through scoped active lorebook search.
- Chat, roleplay, and game tool-enabled generation paths that share `search_lorebook`.

Boundary notes:

- Kept behavior in `src/engine`; no React, Tauri, shared API, or remote runtime boundary changes.

Pressure points touched:

- Built-in tool result contract for `search_lorebook` now includes key context in addition to existing id/name/tag/source/score/content fields.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed locally.
- `pnpm check` passed locally.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable user workflow or setting.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; engine-only behavior fix with no visible UI change.