### PR TITLE
Retry malformed lorebook maker batches

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1109,9 +1109,13 @@ fn delete_lorebook_folder_with_entry_reparent_sync(
     )
 }
 
+type LorebookEntryAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
+type LorebookFolderDeleteAtomicRows<'a> =
+    (&'a mut Vec<Value>, &'a mut Vec<Value>, &'a mut Vec<Value>);
+
 fn lorebook_entry_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
-) -> Result<(&mut Vec<Value>, &mut Vec<Value>), AppError> {
+) -> Result<LorebookEntryAtomicRows<'_>, AppError> {
     let [left, right] = collections else {
         return Err(AppError::new(
             "storage_error",
@@ -1129,7 +1133,7 @@ fn lorebook_entry_atomic_rows(
 
 fn lorebook_folder_delete_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
-) -> Result<(&mut Vec<Value>, &mut Vec<Value>, &mut Vec<Value>), AppError> {
+) -> Result<LorebookFolderDeleteAtomicRows<'_>, AppError> {
     let [folders, entries, characters] = collections else {
         return Err(AppError::new(
             "storage_error",

--- a/src/engine/generation/makers.ts
+++ b/src/engine/generation/makers.ts
@@ -231,31 +231,19 @@ export async function* generateLorebookMaker(
         ? `Generate exactly ${batchSize} lorebook entries based on: ${input.prompt}`
         : buildContinuationLorebookPrompt(input.prompt, batchSize, allEntries);
 
-    const raw = yield* runMakerRequest(
-      capabilities.llm,
-      input,
-      [
-        { role: "system", content: LOREBOOK_SYSTEM_PROMPT },
-        { role: "user", content: userPrompt },
-      ],
-      16384,
-      signal,
-    );
+    const messages = [
+      { role: "system", content: LOREBOOK_SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ] satisfies LlmMessage[];
+    const result = yield* runLorebookMakerBatchWithParseRetry(capabilities.llm, input, messages, index + 1, signal);
 
-    const parsed = parseObject<LorebookMakerData>(raw);
     if (index === 0) {
-      lorebookName = stringOrEmpty(parsed.lorebook_name);
-      lorebookDescription = stringOrEmpty(parsed.lorebook_description);
-      category = stringOrEmpty(parsed.category);
+      lorebookName = stringOrEmpty(result.parsed.lorebook_name);
+      lorebookDescription = stringOrEmpty(result.parsed.lorebook_description);
+      category = stringOrEmpty(result.parsed.category);
     }
 
-    const entries = (Array.isArray(parsed.entries) ? parsed.entries : []).map(normalizeLorebookEntry);
-    if (entries.length === 0) {
-      yield {
-        type: "batch_warning",
-        data: { batch: index + 1, message: `Batch ${index + 1} did not produce valid entries.` },
-      };
-    }
+    const entries = result.entries;
     allEntries.push(...entries);
 
     if (batchSizes.length > 1) {
@@ -289,6 +277,36 @@ export async function* generateLorebookMaker(
     entries: allEntries,
   };
   yield { type: "done", data: JSON.stringify(payload) };
+}
+
+async function* runLorebookMakerBatchWithParseRetry(
+  llm: LlmGateway,
+  input: CharacterOrPersonaMakerInput,
+  messages: LlmMessage[],
+  batch: number,
+  signal?: AbortSignal,
+): AsyncGenerator<MakerEvent, { parsed: LorebookMakerData; entries: LorebookMakerEntry[] }> {
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const raw = yield* runMakerRequest(llm, input, messages, 16384, signal);
+    const parsed = parseObject<LorebookMakerData>(raw);
+    const entries = (Array.isArray(parsed.entries) ? parsed.entries : []).map(normalizeLorebookEntry);
+    if (entries.length > 0 || attempt === 2) {
+      if (entries.length === 0) {
+        yield {
+          type: "batch_warning",
+          data: { batch, message: `Batch ${batch} did not produce valid entries.` },
+        };
+      }
+      return { parsed, entries };
+    }
+
+    yield {
+      type: "batch_warning",
+      data: { batch, message: `Batch ${batch} did not produce valid entries. Retrying once.` },
+    };
+  }
+
+  return { parsed: {}, entries: [] };
 }
 
 async function* generateJsonMaker(

--- a/src/engine/generation/makers.ts
+++ b/src/engine/generation/makers.ts
@@ -42,7 +42,6 @@ export type MakerEvent =
         totalEntriesSoFar: number;
       };
     }
-  | { type: "batch_retry"; data: { batch: number; message: string } }
   | { type: "batch_warning"; data: { batch: number; message: string } }
   | { type: "saved"; data: { count: number; lorebookId: string } }
   | { type: "error"; data: string }
@@ -288,7 +287,16 @@ async function* runLorebookMakerBatchWithParseRetry(
   signal?: AbortSignal,
 ): AsyncGenerator<MakerEvent, { parsed: LorebookMakerData; entries: LorebookMakerEntry[] }> {
   for (let attempt = 1; attempt <= 2; attempt += 1) {
-    const { raw, tokenEvents } = await collectMakerRequest(llm, input, messages, 16384, signal);
+    const isFinalAttempt = attempt === 2;
+    let raw = "";
+    let tokenEvents: MakerEvent[] = [];
+    if (isFinalAttempt) {
+      raw = yield* runMakerRequest(llm, input, messages, 16384, signal);
+    } else {
+      const collected = await collectMakerRequest(llm, input, messages, 16384, signal);
+      raw = collected.raw;
+      tokenEvents = collected.tokenEvents;
+    }
     const parsed = parseObject<LorebookMakerData>(raw);
     const entries = (Array.isArray(parsed.entries) ? parsed.entries : []).map(normalizeLorebookEntry);
     if (entries.length > 0 || attempt === 2) {
@@ -306,7 +314,7 @@ async function* runLorebookMakerBatchWithParseRetry(
     }
 
     yield {
-      type: "batch_retry",
+      type: "batch_warning",
       data: { batch, message: `Batch ${batch} did not produce valid entries. Retrying once.` },
     };
   }

--- a/src/engine/generation/makers.ts
+++ b/src/engine/generation/makers.ts
@@ -42,6 +42,7 @@ export type MakerEvent =
         totalEntriesSoFar: number;
       };
     }
+  | { type: "batch_retry"; data: { batch: number; message: string } }
   | { type: "batch_warning"; data: { batch: number; message: string } }
   | { type: "saved"; data: { count: number; lorebookId: string } }
   | { type: "error"; data: string }
@@ -287,7 +288,7 @@ async function* runLorebookMakerBatchWithParseRetry(
   signal?: AbortSignal,
 ): AsyncGenerator<MakerEvent, { parsed: LorebookMakerData; entries: LorebookMakerEntry[] }> {
   for (let attempt = 1; attempt <= 2; attempt += 1) {
-    const raw = yield* runMakerRequest(llm, input, messages, 16384, signal);
+    const { raw, tokenEvents } = await collectMakerRequest(llm, input, messages, 16384, signal);
     const parsed = parseObject<LorebookMakerData>(raw);
     const entries = (Array.isArray(parsed.entries) ? parsed.entries : []).map(normalizeLorebookEntry);
     if (entries.length > 0 || attempt === 2) {
@@ -296,17 +297,37 @@ async function* runLorebookMakerBatchWithParseRetry(
           type: "batch_warning",
           data: { batch, message: `Batch ${batch} did not produce valid entries.` },
         };
+      } else {
+        for (const event of tokenEvents) {
+          yield event;
+        }
       }
       return { parsed, entries };
     }
 
     yield {
-      type: "batch_warning",
+      type: "batch_retry",
       data: { batch, message: `Batch ${batch} did not produce valid entries. Retrying once.` },
     };
   }
 
   return { parsed: {}, entries: [] };
+}
+
+async function collectMakerRequest(
+  llm: LlmGateway,
+  input: CharacterOrPersonaMakerInput,
+  messages: LlmMessage[],
+  maxTokens: number,
+  signal?: AbortSignal,
+): Promise<{ raw: string; tokenEvents: MakerEvent[] }> {
+  const tokenEvents: MakerEvent[] = [];
+  const request = runMakerRequest(llm, input, messages, maxTokens, signal);
+  for (;;) {
+    const next = await request.next();
+    if (next.done) return { raw: next.value, tokenEvents };
+    tokenEvents.push(next.value);
+  }
 }
 
 async function* generateJsonMaker(


### PR DESCRIPTION
## Linked issue

Closes #2198

## Why this change

- Lorebook Maker parsed each generated batch once and continued after malformed or empty output. Legacy retried one failed batch before accepting the partial result, which made transient provider formatting failures less likely to drop entries.

## What changed

- Adds a one-retry parse recovery loop around each Lorebook Maker batch.
- Emits a warning before the retry and preserves the existing final `batch_warning` event shape if the second attempt still yields no valid entries.
- Keeps the retry inside the engine-owned maker path without changing the modal, storage API, shared API, or provider transport boundaries.

## Refactor impact

Primary owner:

- Engine generation / Lorebook Maker.

Impact areas reviewed:

- Catalog Lorebook Maker UI event handling.
- Shared maker request path for streaming and non-streaming LLM completions.

Boundary notes:

- Engine-only change; no React component, storage adapter, Tauri command, or remote runtime routing changes.

Pressure points touched:

- `generateLorebookMaker` batch request, parse, warning, and continuation flow.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed locally.
- `pnpm check` passed locally.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable user workflow or setting.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; engine-only retry behavior fix with no visible UI change.