### PR TITLE
Reparent lorebook entries on folder delete

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -788,6 +788,9 @@ fn apply_delete_cleanup(
             contracts::DeleteCleanup::ClearConnectionFolder => {
                 unfile_connections_in_folder(state, id)?
             }
+            contracts::DeleteCleanup::ClearLorebookFolderEntries => {
+                reparent_lorebook_entries_in_deleted_folder(state, id, existing)?
+            }
             contracts::DeleteCleanup::ClearLorebookReferences => {
                 clear_deleted_lorebook_references(state, id)?;
             }
@@ -907,6 +910,36 @@ fn unfile_connections_in_folder(state: &AppState, folder_id: &str) -> Result<(),
         .collect::<Vec<_>>();
     if !patches.is_empty() {
         state.storage.patch_many("connections", patches)?;
+    }
+    Ok(())
+}
+
+fn reparent_lorebook_entries_in_deleted_folder(
+    state: &AppState,
+    folder_id: &str,
+    folder: Option<&Value>,
+) -> Result<(), AppError> {
+    let Some(lorebook_id) = folder
+        .and_then(|record| record.get("lorebookId"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+
+    let mut filters = Map::new();
+    filters.insert(
+        "lorebookId".to_string(),
+        Value::String(lorebook_id.to_string()),
+    );
+    filters.insert("folderId".to_string(), Value::String(folder_id.to_string()));
+    let rows = state.storage.list_where("lorebook-entries", &filters)?;
+    let patches = rows
+        .into_iter()
+        .filter_map(|row| row.get("id").and_then(Value::as_str).map(str::to_string))
+        .map(|id| (id, json!({ "folderId": Value::Null })))
+        .collect::<Vec<_>>();
+    if !patches.is_empty() {
+        state.storage.patch_many("lorebook-entries", patches)?;
     }
     Ok(())
 }
@@ -1306,6 +1339,7 @@ fn delete_cleanup_needs_existing_record(cleanup: &contracts::DeleteCleanup) -> b
     matches!(
         cleanup,
         contracts::DeleteCleanup::ActivateDefaultChatPreset
+            | contracts::DeleteCleanup::ClearLorebookFolderEntries
             | contracts::DeleteCleanup::DeleteMessageTrackerSnapshots
             | contracts::DeleteCleanup::RemoveOwnedMedia
     )
@@ -2414,6 +2448,75 @@ mod tests {
             ids_for_lorebook(&state, "lorebook-folders", "book-keep"),
             vec!["folder-keep".to_string()]
         );
+    }
+
+    #[test]
+    fn deleting_lorebook_folder_reparents_entries_for_that_lorebook_only() {
+        assert!(cleanup_registered(
+            "lorebook-folders",
+            contracts::DeleteCleanup::ClearLorebookFolderEntries
+        ));
+        let state = test_state("lorebook-folder-delete-reparent");
+        state
+            .storage
+            .create(
+                "lorebooks",
+                json!({ "id": "book-delete", "name": "Delete folder" }),
+            )
+            .expect("lorebook should be created");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "book-keep", "name": "Keep" }))
+            .expect("other lorebook should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "folder-delete", "lorebookId": "book-delete", "name": "Delete" }),
+            )
+            .expect("folder should be created");
+        state
+            .storage
+            .create(
+                "lorebook-entries",
+                json!({
+                    "id": "entry-reparent",
+                    "lorebookId": "book-delete",
+                    "folderId": "folder-delete",
+                    "name": "Reparent",
+                    "content": "x"
+                }),
+            )
+            .expect("entry should be created");
+        state
+            .storage
+            .create(
+                "lorebook-entries",
+                json!({
+                    "id": "entry-other-lorebook",
+                    "lorebookId": "book-keep",
+                    "folderId": "folder-delete",
+                    "name": "Other",
+                    "content": "x"
+                }),
+            )
+            .expect("negative-control entry should be created");
+
+        delete_entity(&state, "lorebook-folders", "folder-delete", false)
+            .expect("folder delete should succeed");
+
+        let reparented = state
+            .storage
+            .get("lorebook-entries", "entry-reparent")
+            .expect("entry should read")
+            .expect("entry should remain");
+        assert!(reparented.get("folderId").is_none_or(Value::is_null));
+        let other = state
+            .storage
+            .get("lorebook-entries", "entry-other-lorebook")
+            .expect("negative-control entry should read")
+            .expect("negative-control entry should remain");
+        assert_eq!(other["folderId"], "folder-delete");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -741,6 +741,10 @@ pub(crate) fn delete_entity(
         let deleted = delete_lorebook_entry_with_character_book_sync(state, id)?;
         return Ok(json!({ "deleted": deleted }));
     }
+    if entity == "lorebook-folders" {
+        let deleted = delete_lorebook_folder_with_entry_reparent_sync(state, id)?;
+        return Ok(json!({ "deleted": deleted }));
+    }
     let existing = owned_record_for_delete(state, entity, id)?;
     let message_chat_id = if entity == "messages" {
         existing
@@ -787,9 +791,6 @@ fn apply_delete_cleanup(
             }
             contracts::DeleteCleanup::ClearConnectionFolder => {
                 unfile_connections_in_folder(state, id)?
-            }
-            contracts::DeleteCleanup::ClearLorebookFolderEntries => {
-                reparent_lorebook_entries_in_deleted_folder(state, id, existing)?
             }
             contracts::DeleteCleanup::ClearLorebookReferences => {
                 clear_deleted_lorebook_references(state, id)?;
@@ -910,36 +911,6 @@ fn unfile_connections_in_folder(state: &AppState, folder_id: &str) -> Result<(),
         .collect::<Vec<_>>();
     if !patches.is_empty() {
         state.storage.patch_many("connections", patches)?;
-    }
-    Ok(())
-}
-
-fn reparent_lorebook_entries_in_deleted_folder(
-    state: &AppState,
-    folder_id: &str,
-    folder: Option<&Value>,
-) -> Result<(), AppError> {
-    let Some(lorebook_id) = folder
-        .and_then(|record| record.get("lorebookId"))
-        .and_then(Value::as_str)
-    else {
-        return Ok(());
-    };
-
-    let mut filters = Map::new();
-    filters.insert(
-        "lorebookId".to_string(),
-        Value::String(lorebook_id.to_string()),
-    );
-    filters.insert("folderId".to_string(), Value::String(folder_id.to_string()));
-    let rows = state.storage.list_where("lorebook-entries", &filters)?;
-    let patches = rows
-        .into_iter()
-        .filter_map(|row| row.get("id").and_then(Value::as_str).map(str::to_string))
-        .map(|id| (id, json!({ "folderId": Value::Null })))
-        .collect::<Vec<_>>();
-    if !patches.is_empty() {
-        state.storage.patch_many("lorebook-entries", patches)?;
     }
     Ok(())
 }
@@ -1095,6 +1066,49 @@ fn delete_lorebook_entry_with_character_book_sync(
     )
 }
 
+fn delete_lorebook_folder_with_entry_reparent_sync(
+    state: &AppState,
+    folder_id: &str,
+) -> Result<bool, AppError> {
+    state.storage.update_collections_atomically(
+        vec!["lorebook-folders", "lorebook-entries", "characters"],
+        move |collections| {
+            let (folder_rows, entry_rows, character_rows) =
+                lorebook_folder_delete_atomic_rows(collections)?;
+            let before = folder_rows.len();
+            folder_rows.retain(|row| row.get("id").and_then(Value::as_str) != Some(folder_id));
+            let deleted = folder_rows.len() != before;
+            if !deleted {
+                return Ok(false);
+            }
+
+            let now = now_iso();
+            let mut changed_entries = Vec::new();
+            for entry in entry_rows.iter_mut() {
+                if entry.get("folderId").and_then(Value::as_str) != Some(folder_id) {
+                    continue;
+                }
+                let Some(object) = entry.as_object_mut() else {
+                    return Err(AppError::invalid_input("Stored record is not an object"));
+                };
+                object.insert("folderId".to_string(), Value::Null);
+                object.insert("updatedAt".to_string(), Value::String(now.clone()));
+                changed_entries.push(Value::Object(object.clone()));
+            }
+
+            if !changed_entries.is_empty() {
+                let changed_refs = changed_entries.iter().collect::<Vec<_>>();
+                sync_linked_character_books_for_entry_rows_in_place(
+                    character_rows,
+                    entry_rows,
+                    &changed_refs,
+                )?;
+            }
+            Ok(true)
+        },
+    )
+}
+
 fn lorebook_entry_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
 ) -> Result<(&mut Vec<Value>, &mut Vec<Value>), AppError> {
@@ -1109,6 +1123,32 @@ fn lorebook_entry_atomic_rows(
         _ => Err(AppError::new(
             "storage_error",
             "Lorebook entry sync received unexpected collections",
+        )),
+    }
+}
+
+fn lorebook_folder_delete_atomic_rows(
+    collections: &mut [marinara_storage::AtomicCollectionRows],
+) -> Result<(&mut Vec<Value>, &mut Vec<Value>, &mut Vec<Value>), AppError> {
+    let [folders, entries, characters] = collections else {
+        return Err(AppError::new(
+            "storage_error",
+            "Lorebook folder delete expected folder, entry, and character collections",
+        ));
+    };
+    match (
+        folders.collection(),
+        entries.collection(),
+        characters.collection(),
+    ) {
+        ("lorebook-folders", "lorebook-entries", "characters") => Ok((
+            folders.rows_mut(),
+            entries.rows_mut(),
+            characters.rows_mut(),
+        )),
+        _ => Err(AppError::new(
+            "storage_error",
+            "Lorebook folder delete received unexpected collections",
         )),
     }
 }
@@ -1339,7 +1379,6 @@ fn delete_cleanup_needs_existing_record(cleanup: &contracts::DeleteCleanup) -> b
     matches!(
         cleanup,
         contracts::DeleteCleanup::ActivateDefaultChatPreset
-            | contracts::DeleteCleanup::ClearLorebookFolderEntries
             | contracts::DeleteCleanup::DeleteMessageTrackerSnapshots
             | contracts::DeleteCleanup::RemoveOwnedMedia
     )
@@ -2451,11 +2490,7 @@ mod tests {
     }
 
     #[test]
-    fn deleting_lorebook_folder_reparents_entries_for_that_lorebook_only() {
-        assert!(cleanup_registered(
-            "lorebook-folders",
-            contracts::DeleteCleanup::ClearLorebookFolderEntries
-        ));
+    fn deleting_lorebook_folder_reparents_entries_with_matching_folder_id() {
         let state = test_state("lorebook-folder-delete-reparent");
         state
             .storage
@@ -2493,9 +2528,22 @@ mod tests {
             .create(
                 "lorebook-entries",
                 json!({
-                    "id": "entry-other-lorebook",
+                    "id": "entry-stale-cross-lorebook",
                     "lorebookId": "book-keep",
                     "folderId": "folder-delete",
+                    "name": "Stale",
+                    "content": "x"
+                }),
+            )
+            .expect("stale cross-lorebook entry should be created");
+        state
+            .storage
+            .create(
+                "lorebook-entries",
+                json!({
+                    "id": "entry-other-folder",
+                    "lorebookId": "book-keep",
+                    "folderId": "folder-keep",
                     "name": "Other",
                     "content": "x"
                 }),
@@ -2511,12 +2559,82 @@ mod tests {
             .expect("entry should read")
             .expect("entry should remain");
         assert!(reparented.get("folderId").is_none_or(Value::is_null));
-        let other = state
+        let stale = state
             .storage
-            .get("lorebook-entries", "entry-other-lorebook")
+            .get("lorebook-entries", "entry-stale-cross-lorebook")
+            .expect("stale cross-lorebook entry should read")
+            .expect("stale cross-lorebook entry should remain");
+        assert!(stale.get("folderId").is_none_or(Value::is_null));
+        let other_folder = state
+            .storage
+            .get("lorebook-entries", "entry-other-folder")
             .expect("negative-control entry should read")
             .expect("negative-control entry should remain");
-        assert_eq!(other["folderId"], "folder-delete");
+        assert_eq!(other_folder["folderId"], "folder-keep");
+    }
+
+    #[test]
+    fn deleting_lorebook_folder_reparent_rolls_back_when_character_book_sync_fails() {
+        let state = test_state("lorebook-folder-delete-reparent-atomic");
+        seed_linked_character_book(&state);
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "folder-linked", "lorebookId": "linked-book", "name": "Linked" }),
+            )
+            .expect("folder should be created");
+        storage_create_inner(
+            &state,
+            "lorebook-entries".to_string(),
+            json!({
+                "id": "entry-linked",
+                "lorebookId": "linked-book",
+                "folderId": "folder-linked",
+                "name": "Linked",
+                "content": "linked text",
+                "keys": ["linked"]
+            }),
+        )
+        .expect("entry should seed through sync path");
+        state
+            .storage
+            .patch(
+                "characters",
+                "character-1",
+                json!({
+                    "data": {
+                        "name": "Mira",
+                        "character_book": "malformed",
+                        "extensions": {
+                            "importMetadata": {
+                                "embeddedLorebook": {
+                                    "hasEmbeddedLorebook": true,
+                                    "lorebookId": "linked-book",
+                                    "entriesImported": 1
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("malformed linked character book should seed");
+
+        let error = delete_entity(&state, "lorebook-folders", "folder-linked", false)
+            .expect_err("malformed linked character book should reject folder delete");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(state
+            .storage
+            .get("lorebook-folders", "folder-linked")
+            .expect("folder should read")
+            .is_some());
+        let entry = state
+            .storage
+            .get("lorebook-entries", "entry-linked")
+            .expect("entry should read")
+            .expect("entry should remain");
+        assert_eq!(entry["folderId"], "folder-linked");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -17,7 +17,6 @@ pub(crate) struct TypedJsonField {
 pub(crate) enum DeleteCleanup {
     ActivateDefaultChatPreset,
     ClearConnectionFolder,
-    ClearLorebookFolderEntries,
     ClearLorebookReferences,
     DeleteCharacterGallery,
     DeleteLorebookChildren,
@@ -188,7 +187,6 @@ const LOREBOOK_CLEANUP: &[DeleteCleanup] = &[
 const PROMPT_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::DeletePromptChildren];
 const CHAT_PRESET_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ActivateDefaultChatPreset];
 const CONNECTION_FOLDER_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ClearConnectionFolder];
-const LOREBOOK_FOLDER_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ClearLorebookFolderEntries];
 const CHARACTER_CLEANUP: &[DeleteCleanup] = &[
     DeleteCleanup::RemoveOwnedMedia,
     DeleteCleanup::DeleteCharacterGallery,
@@ -259,7 +257,7 @@ pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
         false,
         EMPTY_DEFAULTS,
         EMPTY_FIELDS,
-        LOREBOOK_FOLDER_CLEANUP,
+        EMPTY_CLEANUP,
     ),
     contract(
         "prompts",

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -17,6 +17,7 @@ pub(crate) struct TypedJsonField {
 pub(crate) enum DeleteCleanup {
     ActivateDefaultChatPreset,
     ClearConnectionFolder,
+    ClearLorebookFolderEntries,
     ClearLorebookReferences,
     DeleteCharacterGallery,
     DeleteLorebookChildren,
@@ -187,6 +188,7 @@ const LOREBOOK_CLEANUP: &[DeleteCleanup] = &[
 const PROMPT_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::DeletePromptChildren];
 const CHAT_PRESET_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ActivateDefaultChatPreset];
 const CONNECTION_FOLDER_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ClearConnectionFolder];
+const LOREBOOK_FOLDER_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::ClearLorebookFolderEntries];
 const CHARACTER_CLEANUP: &[DeleteCleanup] = &[
     DeleteCleanup::RemoveOwnedMedia,
     DeleteCleanup::DeleteCharacterGallery,
@@ -257,7 +259,7 @@ pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
         false,
         EMPTY_DEFAULTS,
         EMPTY_FIELDS,
-        EMPTY_CLEANUP,
+        LOREBOOK_FOLDER_CLEANUP,
     ),
     contract(
         "prompts",


### PR DESCRIPTION
## Linked issue

Closes #2187

## Why this change

- Deleting a lorebook folder removed the folder row but left child `lorebook-entries.folderId` values pointing at the deleted folder in storage.

## What changed

- Registers a storage delete cleanup for `lorebook-folders`.
- When a folder is deleted, entries in the same lorebook and folder are patched to `folderId: null`.
- Adds Rust coverage for the positive reparent path and a negative-control entry in another lorebook.

## Refactor impact

Primary owner:

- Rust storage entity delete cleanup

Impact areas reviewed:

- Generic `storage_delete` cleanup dispatch
- Lorebook folder/entry persistence invariants
- Existing connection-folder cleanup pattern

Boundary notes:

- The fix stays inside the Rust storage command layer, so embedded Tauri and remote runtime callers using `storage_delete` share the same behavior.
- No React, engine, shared API, or remote-runtime allowlist changes were needed.

Pressure points touched:

- None.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml deleting_lorebook_folder_reparents_entries_for_that_lorebook_only` passes locally.
- `cargo check --manifest-path src-tauri/Cargo.toml` passes locally.
- `pnpm check` was attempted locally but stopped at `check:line-endings` because the working tree reports pre-existing CRLF line endings across many unrelated files before reaching architecture/frontend/Rust/docs checks.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No visible UI change; storage cleanup behavior only.