### PR TITLE
Fix game JSONish parser wiring

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -9,6 +9,13 @@ use serde_json::{json, Map, Value};
 use std::collections::HashSet;
 use tauri::State;
 
+type LorebookEntryAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
+type LorebookFolderDeleteAtomicRows<'a> = (
+    &'a mut Vec<Value>,
+    &'a mut Vec<Value>,
+    &'a mut Vec<Value>,
+);
+
 fn validate_storage_entity(entity: &str) -> Result<(), AppError> {
     if contracts::collection_contract(entity).is_some() {
         Ok(())
@@ -1111,7 +1118,7 @@ fn delete_lorebook_folder_with_entry_reparent_sync(
 
 fn lorebook_entry_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
-) -> Result<(&mut Vec<Value>, &mut Vec<Value>), AppError> {
+) -> Result<LorebookEntryAtomicRows<'_>, AppError> {
     let [left, right] = collections else {
         return Err(AppError::new(
             "storage_error",
@@ -1129,7 +1136,7 @@ fn lorebook_entry_atomic_rows(
 
 fn lorebook_folder_delete_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
-) -> Result<(&mut Vec<Value>, &mut Vec<Value>, &mut Vec<Value>), AppError> {
+) -> Result<LorebookFolderDeleteAtomicRows<'_>, AppError> {
     let [folders, entries, characters] = collections else {
         return Err(AppError::new(
             "storage_error",

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -50,6 +50,7 @@ import {
   resolveSkillCheck,
 } from "../../../../engine/modes/game/mechanics/skill-check.service";
 import { serializeResolvedSkillCheckTag } from "../../../../engine/shared/scoring/skill-check-format";
+import { parseGameJsonish } from "../../../../engine/shared/parsing-jsonish";
 import {
   applyMoraleEvent,
   getMoraleTier,
@@ -461,23 +462,9 @@ async function createAutomaticGameCheckpoint(data: {
 
 function parseJsonObject(text: string): Record<string, unknown> | null {
   try {
-    const parsed = JSON.parse(text);
+    const parsed = parseGameJsonish(text);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
   } catch {
-    const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1];
-    if (fenced) return parseJsonObject(fenced);
-    const start = text.indexOf("{");
-    const end = text.lastIndexOf("}");
-    if (start >= 0 && end > start) {
-      try {
-        const parsed = JSON.parse(text.slice(start, end + 1));
-        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-          ? (parsed as Record<string, unknown>)
-          : null;
-      } catch {
-        return null;
-      }
-    }
     return null;
   }
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2138

## Why this change

- Game-mode model JSON and JSON-repair apply paths were still using a weak local object parser, so recoverable JSONish output that legacy/main accepts could fail into the repair modal and then fail again when applied.

## What changed

- Routed the game API's object parser helper through the existing `parseGameJsonish` implementation while keeping the object-only guard.
- Left the existing generated-JSON and repair-apply call sites in place so both paths now share the tolerant parser.

## Refactor impact

Primary owner:

- game mode

Impact areas reviewed:

- Game-mode LLM JSON generation paths: setup, map, session conclusion, session lorebook, campaign progression, party cards.
- Game JSON repair apply path.

Boundary notes:

- Feature API code now imports the existing engine shared JSONish parser. Engine code still does not import feature/runtime code.
- No storage, schema, remote runtime, provider transport, or dependency changes.

Pressure points touched:

- `src/features/modes/game/api/game-api.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Reproduced before fix with a scratch Vitest harness: recoverable JSONish repair input threw `Repaired JSON is not a JSON object.`
- Verified after fix with the same scratch harness: raw newline plus trailing comma, line comment, fenced JSONish with trailing junk, and double-stringified valid object all passed the parser gate; array JSON still failed the object-only negative control.
- Ran `pnpm typecheck` locally: passed.
- Ran `pnpm check:architecture` locally: passed.
- Ran full `pnpm check` locally: passed.
- Ran `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` locally after the CI fix: passed.
- Local Bunny review found no code/proof findings for the diff. The optional local proof-gate helper referenced by workflow notes was unavailable at `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs`, so this remains a draft pending normal review gates.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable user-facing feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A - no visible UI change. This is game-mode JSON parsing behavior verified with a scratch logic harness and full local checks.
