### PR TITLE
Fix game generation failure retry event

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1116,10 +1116,6 @@ fn delete_lorebook_folder_with_entry_reparent_sync(
     )
 }
 
-type LorebookEntryAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
-type LorebookFolderDeleteAtomicRows<'a> =
-    (&'a mut Vec<Value>, &'a mut Vec<Value>, &'a mut Vec<Value>);
-
 fn lorebook_entry_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
 ) -> Result<LorebookEntryAtomicRows<'_>, AppError> {

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -124,6 +124,14 @@ function showGenerationFailureToast(message: string): void {
   });
 }
 
+function dispatchGenerationFailureEvent(chatId: string, message: string): void {
+  window.dispatchEvent(
+    new CustomEvent("marinara:generation-error", {
+      detail: { chatId, message },
+    }),
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -1652,6 +1660,7 @@ export async function runGenerationWithUi(
   } catch (error) {
     if (!isAbortError(error)) {
       const message = errorMessage(error);
+      dispatchGenerationFailureEvent(chatId, message);
       showGenerationFailureToast(message);
     }
     throw error;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2141

## Why this change

- Failed game GM generations only showed a toast in the refactor branch, even though `GameSurface` still had the inline Retry UI wired to `marinara:generation-error`.

## What changed

- Dispatch `marinara:generation-error` from the shared generation failure path for non-aborted errors.
- Include the failing `chatId` and error message in the event detail so the existing GameSurface listener can gate the inline Retry state to the active chat.
- Keep abort/cancel paths quiet so user-initiated cancellation does not show a retry failure affordance.
- Remove duplicate lorebook atomic row type aliases that were breaking the current `refactor` Rust check baseline.

## Refactor impact

Primary owner:

game mode, runtime generation

Impact areas reviewed:

- `GameSurface` already listens for `marinara:generation-error` and sets `generationFailed` only for the active chat.
- `runGenerationWithUi` handles the non-abort generation failure path and still shows the existing toast.
- Abort failures remain excluded from the retry event.
- Rust storage command aliases were reviewed only enough to remove duplicate definitions; behavior is unchanged.

Boundary notes:

- The user-facing fix stays in `src/features/runtime/generation`; no engine, shared API, storage behavior, prompt, import/export, or remote-runtime contracts changed. The Rust edit is a mechanical duplicate-alias removal to restore the `refactor` baseline.

Pressure points touched:

- `src/features/runtime/generation/hooks/use-generate.ts`
- `src-tauri/src/commands/storage/commands/entities.rs`
- Reviewed existing `GameSurface` retry listener; no UI patch was needed.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run --config scratch/vitest.issue2141.config.ts scratch/issue-2141-generation-error.test.ts` passed with 2 tests: provider failure dispatches `marinara:generation-error`; `AbortError` does not dispatch it.
- `pnpm typecheck` passed.
- `git diff --check` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `pnpm check` passed after removing duplicate lorebook atomic row type aliases that were already present on `origin/refactor`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only. It restores an existing GameSurface retry affordance by reconnecting the existing generation failure event.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A for screenshots. The UI listener already existed; the production change restores the DOM event that drives it. The scratch jsdom proof exercises the event contract directly.
