### PR TITLE
Restore combat init debug logging

### DIFF
--- a/src/engine/contracts/types/combat-encounter.ts
+++ b/src/engine/contracts/types/combat-encounter.ts
@@ -196,6 +196,9 @@ export interface EncounterInitRequest {
   settings: EncounterSettings;
   /** Optional spellbook lorebook ID to inject spell/attack data into combat */
   spellbookId?: string | null;
+  /** When enabled, emit the generated combat request/response diagnostics. */
+  debugMode?: boolean;
+  debugSink?: import("./agent.js").AgentContext["debugSink"];
 }
 
 /** Response from encounter initialization. */

--- a/src/engine/modes/game/mechanics/combat-init.service.ts
+++ b/src/engine/modes/game/mechanics/combat-init.service.ts
@@ -64,12 +64,27 @@ export async function initGameCombatEncounter(
   const context = await buildGameCombatInitContext(capabilities.storage, input);
   const history = await recentHistory(capabilities.storage, input.chatId, input.settings.historyDepth);
   const messages = buildInitPrompt(context, history);
-  const parsed = await completeJsonObject(capabilities, context.chat, input.connectionId ?? null, messages, {
+  const debug = createCombatInitDebug(input);
+  debug("[debug/game/combat:init] request", {
+    chatId: input.chatId,
+    connectionId: input.connectionId ?? null,
+    historyMessages: history.length,
+    settings: input.settings,
+    messages,
+  });
+  const result = await completeJsonObject(capabilities, context.chat, input.connectionId ?? null, messages, {
     temperature: 0.8,
     maxTokens: COMBAT_BLUEPRINT_OUTPUT_TOKENS,
   });
+  debug("[debug/game/combat:init] raw response", {
+    chatId: input.chatId,
+    chars: result.raw.length,
+    raw: result.raw,
+  });
+  const parsed = result.parsed;
   const rawCombatState = recordValue(parsed?.combatState) ?? parsed;
   const combatState = sanitizeCombatInitState(rawCombatState, context.fallbackState);
+  debug("[debug/game/combat:init] parsed response", { chatId: input.chatId, combatState });
 
   return { combatState };
 }
@@ -342,15 +357,27 @@ async function completeJsonObject(
   overrideConnectionId: string | null,
   messages: LlmMessage[],
   parameters: Record<string, unknown>,
-): Promise<JsonRecord | null> {
+): Promise<{ parsed: JsonRecord | null; raw: string }> {
   const connectionId = await resolveConnectionId(capabilities.storage, chat, overrideConnectionId);
   const raw = await capabilities.llm.complete({ connectionId, messages, parameters });
   try {
     const parsed = parseGameJsonish(raw);
-    return isRecord(parsed) ? parsed : null;
+    return { parsed: isRecord(parsed) ? parsed : null, raw };
   } catch {
-    return null;
+    return { parsed: null, raw };
   }
+}
+
+function createCombatInitDebug(input: Pick<EncounterInitRequest, "debugMode" | "debugSink">) {
+  return (message: string, payload: unknown) => {
+    if (input.debugMode !== true) return;
+    input.debugSink?.({
+      level: "debug",
+      phase: "game-combat-init",
+      message,
+      args: [payload],
+    });
+  };
 }
 
 async function resolveConnectionId(

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -4,6 +4,7 @@ import type {
   CombatMechanic,
   EncounterSettings,
 } from "../../../../engine/contracts/types/combat-encounter";
+import type { AgentDebugEntry } from "../../../../engine/contracts/types/agent";
 import type {
   Combatant,
   CombatPlayerAction,
@@ -2858,6 +2859,8 @@ export const gameApi = {
     connectionId?: string | null;
     settings?: EncounterSettings | null;
     spellbookId?: string | null;
+    debugMode?: boolean;
+    debugSink?: (entry: Omit<AgentDebugEntry, "timestamp"> & { timestamp?: number }) => void;
   }): Promise<{ combatState: CombatInitState }> {
     return initGameCombatEncounter(
       { storage: storageApi, llm: llmApi },
@@ -2866,6 +2869,8 @@ export const gameApi = {
         connectionId: input.connectionId ?? null,
         settings: input.settings ?? DEFAULT_COMBAT_ENCOUNTER_SETTINGS,
         spellbookId: input.spellbookId ?? null,
+        debugMode: input.debugMode === true,
+        debugSink: input.debugSink,
       },
     );
   },

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -32,6 +32,7 @@ import { gameApi } from "../api/game-api";
 import { gameTrackerApi } from "../api/game-tracker-api";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
+import { useAgentStore } from "../../../../shared/stores/agent.store";
 import { useGameStateStore } from "../../../runtime/world-state/index";
 import { useGameStatePatcher } from "../../../runtime/world-state/index";
 import type { GameStatePatchField, GameStatePatchValue } from "../../../runtime/world-state/types";
@@ -6197,6 +6198,8 @@ export function GameSurface({
         connectionId: null,
         settings: GAME_COMBAT_GENERATION_SETTINGS,
         spellbookId: null,
+        debugMode: useUIStore.getState().debugMode,
+        debugSink: useAgentStore.getState().addDebugEntry,
       })
       .then(async (response) => {
         const combatants = hydrateGeneratedCombatState(response.combatState);


### PR DESCRIPTION
## Linked issue

Closes #2143

## Why this change

- Game-mode combat encounter initialization lost its debug-mode diagnostic trace during the refactor. Debug Mode could still be enabled globally, but the combat-init request contract and service no longer accepted or emitted the `[debug/game/combat:init]` request/response details.

## What changed

- Restored `debugMode` on `EncounterInitRequest` and added an optional debug sink for structured diagnostics.
- Emitted combat-init request, raw response, and parsed response debug entries from the React-free game combat-init service when debug mode is enabled.
- Forwarded debug mode and the existing agent debug log sink from the game combat generation caller into `gameApi.initCombatEncounter`.
- Preserved quiet behavior when debug mode is disabled.

## Refactor impact

Primary owner:

Game mode / engine combat generation

Impact areas reviewed:

- `src/engine/contracts/types/combat-encounter.ts`
- `src/engine/modes/game/mechanics/combat-init.service.ts`
- `src/features/modes/game/api/game-api.ts`
- `src/features/modes/game/components/GameSurface.tsx`

Boundary notes:

- Product behavior stays in `src/engine`.
- React UI stays in `src/features`.
- The feature API wrapper forwards the existing UI debug setting/sink into the engine contract; the engine service remains React-free.
- No Rust, storage, schema, dependency, auth, prompt-pipeline, or remote-runtime routing changes.

Pressure points touched:

- `GameSurface` automatic combat generation path now forwards Debug Mode into combat init.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Scratch repro before fix: `pnpm exec vitest run --config scratch/vitest.config.mts` failed because combat init returned a generated encounter but emitted `debugEntryCount: 0`.
- Scratch repro after fix: `pnpm exec vitest run --config scratch/vitest.config.mts` passed with two cases: debug mode on emits `[debug/game/combat:init]` entries, debug mode off emits none while generation still succeeds.
- Focused validation: `pnpm typecheck` passed.
- Full baseline: `pnpm check` passed.
- Bunny review: pass against `origin/refactor`.
- Workflow note: the optional local proof-gate helper referenced by workflow notes was unavailable at `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs`; this does not block the core claim because the scratch repro and full baseline passed.
- No human-only verification is required for the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing Debug Mode diagnostics; no new discoverable product surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A for screenshots; this is a developer diagnostic/logging bug. Evidence is captured in `scratch/repro-before.txt`, `scratch/repro-after.txt`, and `scratch/bugfix-verification.json`.
