### PR TITLE
Fix mobile game party bar

### DIFF
--- a/src/features/modes/game/components/GamePartyBar.tsx
+++ b/src/features/modes/game/components/GamePartyBar.tsx
@@ -1,9 +1,10 @@
 // ──────────────────────────────────────────────
 // Game: Compact Party Portraits Bar (top-left, horizontal)
 // ──────────────────────────────────────────────
+import { useEffect, useMemo, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { useGameModeStore } from "../stores/game-mode.store";
-import { getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../../../shared/lib/utils";
 
 interface PartyBarMember {
   id: string;
@@ -34,6 +35,46 @@ interface GamePartyBarProps {
   removingPartyMemberId?: string | null;
 }
 
+type PartyMemberVisual = {
+  member: PartyBarMember;
+  avatarSrc?: string | null;
+  avatarCrop?: AvatarCropValue | null;
+};
+
+function PartyAvatar({ visual, className }: { visual: PartyMemberVisual; className?: string }) {
+  const { member, avatarSrc, avatarCrop } = visual;
+
+  if (avatarSrc) {
+    return (
+      <span
+        className={cn(
+          "relative block h-9 w-9 overflow-hidden rounded-full border-2 border-white/20 shadow-lg transition-colors group-hover:border-white/40",
+          className,
+        )}
+      >
+        <img
+          src={avatarSrc}
+          alt={member.name}
+          className="h-full w-full object-cover"
+          style={getAvatarCropStyle(avatarCrop)}
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "flex h-9 w-9 items-center justify-center rounded-full border-2 border-white/20 bg-[var(--accent)] text-xs font-bold shadow-lg transition-colors group-hover:border-white/40",
+        className,
+      )}
+      style={member.nameColor ? { color: member.nameColor } : undefined}
+    >
+      {member.name[0]}
+    </span>
+  );
+}
+
 export function GamePartyBar({
   partyMembers,
   partyCards,
@@ -41,60 +82,150 @@ export function GamePartyBar({
   removingPartyMemberId,
 }: GamePartyBarProps) {
   const openCharacterSheet = useGameModeStore((s) => s.openCharacterSheet);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [previewIndex, setPreviewIndex] = useState(0);
+  const mobileMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const memberVisuals = useMemo(
+    () =>
+      partyMembers.map((member) => {
+        const card = partyCards[member.id];
+        return {
+          member,
+          avatarSrc: card?.avatarUrl ?? member.avatarUrl,
+          avatarCrop: card?.avatarCrop ?? member.avatarCrop ?? null,
+        };
+      }),
+    [partyCards, partyMembers],
+  );
+
+  useEffect(() => {
+    setPreviewIndex((index) => (memberVisuals.length > 0 ? Math.min(index, memberVisuals.length - 1) : 0));
+    if (memberVisuals.length <= 1) setMobileMenuOpen(false);
+  }, [memberVisuals.length]);
+
+  useEffect(() => {
+    if (memberVisuals.length <= 1) return undefined;
+    const intervalId = window.setInterval(() => {
+      setPreviewIndex((index) => (index + 1) % memberVisuals.length);
+    }, 2500);
+    return () => window.clearInterval(intervalId);
+  }, [memberVisuals.length]);
+
+  useEffect(() => {
+    if (!mobileMenuOpen) return undefined;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (mobileMenuRef.current?.contains(target)) return;
+      setMobileMenuOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [mobileMenuOpen]);
 
   if (partyMembers.length === 0) return null;
 
   return (
-    <div className="scrollbar-hide flex max-w-full touch-pan-x items-center gap-1.5 overflow-x-auto px-0.5 py-1 [-webkit-overflow-scrolling:touch]">
-      {partyMembers.map((member) => {
-        const card = partyCards[member.id];
-        const avatarSrc = card?.avatarUrl ?? member.avatarUrl;
-        const avatarCrop = card?.avatarCrop ?? member.avatarCrop ?? null;
+    <>
+      <div ref={mobileMenuRef} className="relative shrink-0 md:hidden">
+        {memberVisuals[previewIndex] && (
+          <button
+            type="button"
+            onClick={() => {
+              if (memberVisuals.length === 1) {
+                openCharacterSheet(memberVisuals[0].member.id);
+                return;
+              }
+              setMobileMenuOpen((open) => !open);
+            }}
+            className="group relative block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
+            aria-expanded={mobileMenuOpen}
+            aria-label={mobileMenuOpen ? "Close party members" : "Open party members"}
+            title={memberVisuals.length === 1 ? "Open character sheet" : "Open party members"}
+          >
+            <PartyAvatar visual={memberVisuals[previewIndex]} />
+            {memberVisuals.length > 1 && (
+              <span className="absolute -bottom-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full border border-white/25 bg-black/85 px-1 text-[0.55rem] font-bold leading-none text-white shadow-md">
+                {memberVisuals.length}
+              </span>
+            )}
+          </button>
+        )}
 
-        return (
-          <div key={member.id} className="group relative shrink-0 transition-transform hover:scale-110">
-            <button
-              type="button"
-              onClick={() => openCharacterSheet(member.id)}
-              className="block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
-              title={`${member.name} - Click to open character sheet`}
-            >
-              {avatarSrc ? (
-                <span className="relative block h-9 w-9 overflow-hidden rounded-full border-2 border-white/20 shadow-lg transition-colors group-hover:border-white/40">
-                  <img
-                    src={avatarSrc}
-                    alt={member.name}
-                    className="h-full w-full object-cover"
-                    style={getAvatarCropStyle(avatarCrop)}
-                  />
-                </span>
-              ) : (
-                <div
-                  className="flex h-9 w-9 items-center justify-center rounded-full border-2 border-white/20 bg-[var(--accent)] text-xs font-bold shadow-lg transition-colors group-hover:border-white/40"
-                  style={member.nameColor ? { color: member.nameColor } : undefined}
-                >
-                  {member.name[0]}
+        {mobileMenuOpen && memberVisuals.length > 1 && (
+          <div className="absolute left-0 top-11 z-50 rounded-full border border-white/15 bg-black/80 p-1.5 shadow-2xl backdrop-blur-md">
+            <div className="flex max-h-[min(44svh,18rem)] flex-col items-center gap-1.5 overflow-y-auto overscroll-contain pr-0.5 [-webkit-overflow-scrolling:touch]">
+              {memberVisuals.map((visual) => (
+                <div key={visual.member.id} className="group relative shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      openCharacterSheet(visual.member.id);
+                      setMobileMenuOpen(false);
+                    }}
+                    className="block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
+                    title={`${visual.member.name} - Click to open character sheet`}
+                  >
+                    <PartyAvatar visual={visual} />
+                  </button>
+                  {visual.member.canRemove && onRemovePartyMember && (
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onRemovePartyMember(visual.member);
+                      }}
+                      disabled={removingPartyMemberId === visual.member.id}
+                      className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-white/30 bg-black/85 text-white shadow-md transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60"
+                      aria-label={`Remove ${visual.member.name} from party`}
+                      title={`Remove ${visual.member.name} from party`}
+                    >
+                      <X className="h-2.5 w-2.5" aria-hidden="true" />
+                    </button>
+                  )}
                 </div>
-              )}
-            </button>
-            {member.canRemove && onRemovePartyMember && (
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="scrollbar-hide hidden max-w-full touch-pan-x items-center gap-1.5 overflow-x-auto px-0.5 py-1 [-webkit-overflow-scrolling:touch] md:flex">
+        {memberVisuals.map((visual) => {
+          const { member } = visual;
+
+          return (
+            <div key={member.id} className="group relative shrink-0 transition-transform hover:scale-110">
               <button
                 type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRemovePartyMember(member);
-                }}
-                disabled={removingPartyMemberId === member.id}
-                className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-white/30 bg-black/80 text-white opacity-80 shadow-md transition-opacity hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60 group-hover:opacity-100 focus:opacity-100 md:opacity-0"
-                aria-label={`Remove ${member.name} from party`}
-                title={`Remove ${member.name} from party`}
+                onClick={() => openCharacterSheet(member.id)}
+                className="block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
+                title={`${member.name} - Click to open character sheet`}
               >
-                <X className="h-2.5 w-2.5" aria-hidden="true" />
+                <PartyAvatar visual={visual} />
               </button>
-            )}
-          </div>
-        );
-      })}
-    </div>
+              {member.canRemove && onRemovePartyMember && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onRemovePartyMember(member);
+                  }}
+                  disabled={removingPartyMemberId === member.id}
+                  className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-white/30 bg-black/80 text-white opacity-80 shadow-md transition-opacity hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60 group-hover:opacity-100 focus:opacity-100 md:opacity-0"
+                  aria-label={`Remove ${member.name} from party`}
+                  title={`Remove ${member.name} from party`}
+                >
+                  <X className="h-2.5 w-2.5" aria-hidden="true" />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/src/features/modes/game/components/GamePartyBar.tsx
+++ b/src/features/modes/game/components/GamePartyBar.tsx
@@ -143,7 +143,6 @@ export function GamePartyBar({
             }}
             className="group relative block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
             aria-expanded={mobileMenuOpen}
-            aria-haspopup="menu"
             aria-label={mobileMenuOpen ? "Close party members" : "Open party members"}
             title={memberVisuals.length === 1 ? "Open character sheet" : "Open party members"}
           >

--- a/src/features/modes/game/components/GamePartyBar.tsx
+++ b/src/features/modes/game/components/GamePartyBar.tsx
@@ -143,6 +143,7 @@ export function GamePartyBar({
             }}
             className="group relative block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
             aria-expanded={mobileMenuOpen}
+            aria-haspopup="menu"
             aria-label={mobileMenuOpen ? "Close party members" : "Open party members"}
             title={memberVisuals.length === 1 ? "Open character sheet" : "Open party members"}
           >


### PR DESCRIPTION
## Linked issue

Closes #2146

## Why this change

- Game mode lost the mobile-collapsed party bar from the legacy UI. Below the `md` breakpoint, the refactor branch showed the full horizontally scrolling avatar strip instead of a single rotating preview avatar with a count badge and tap-open member popover.

## What changed

- Restored the mobile-only collapsed party preview with a rotating avatar, numeric count badge, and member popover.
- Kept the desktop `md` party bar as the horizontal strip.
- Shared avatar rendering between mobile and desktop so avatar crop/name-color behavior remains consistent.

## Refactor impact

Primary owner:

game mode

Impact areas reviewed:

- `src/features/modes/game/components/GamePartyBar.tsx`
- `src/features/modes/game/components/GameSurface.tsx` call site was reviewed for the party bar container and props.

Boundary notes:

- Feature-only React UI change under `src/features`.
- No engine, shared API, Rust, storage, prompt, dependency, schema, or remote-runtime boundary changes.

Pressure points touched:

- Game mode party HUD inside `GameSurface`; no `ModeSurface` or shared mode UI changes.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused Vite/Playwright proof harness:
  - Before fix at 375px: mobile viewport showed four visible character buttons and no party-members toggle.
  - After fix at 375px: collapsed state showed one accessible `Open party members` toggle with count badge `4`.
  - After fix at 375px: tapping the preview opened all four members in the popover.
  - After fix at 375px: selecting `Cai` opened the character sheet and closed the popover.
  - After fix at 375px: tapping outside closed the popover.
  - After fix at 1024px: desktop kept the horizontal four-member strip and did not show the mobile toggle.
- `pnpm typecheck` passed.
- `pnpm check` passed locally on 2026-06-04.
- Bunny review pass: no blocking findings before opening the PR.
- Local proof artifact: `scratch/bugfix-verification.json`.
- Local helper note: `.agents/automation/scripts/workflow-health.mjs` and `C:/Users/celia/.codex/tools/marinara-proof-gate.mjs` were not present in this checkout, so validation used the focused browser proof plus `pnpm check`.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores existing mobile Game mode party-bar behavior; it does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Before, mobile viewport shows the full party strip:

![Before mobile party strip](https://gist.githubusercontent.com/cha1latte/bda992db62e7ea7dc561259b150e293d/raw/cacf540602862ca2cc1aed794deebc7df33e5568/party-bar-before.svg)

After, mobile viewport is collapsed with count badge:

![After mobile collapsed](https://gist.githubusercontent.com/cha1latte/bda992db62e7ea7dc561259b150e293d/raw/9e405b6ec1348f29bd9da36823fb758d63bf419d/party-bar-after-collapsed.svg)

After, tapping opens the member popover:

![After mobile popover](https://gist.githubusercontent.com/cha1latte/bda992db62e7ea7dc561259b150e293d/raw/e9371dec2383c236182b28765c6e372a6f0ead20/party-bar-after-popover.svg)

After, desktop still shows the horizontal strip:

![After desktop strip](https://gist.githubusercontent.com/cha1latte/bda992db62e7ea7dc561259b150e293d/raw/dffad76f06da543bf3ea9fa542e2e16a1dbcf8d4/party-bar-after-desktop.svg)

Raw proof log:

https://gist.githubusercontent.com/cha1latte/bda992db62e7ea7dc561259b150e293d/raw/3bf04b6e2227496f35af216065d47af57d8ecc67/party-bar-proof-results.txt
