### PR TITLE
Fix game time-of-day scene jumps

### DIFF
--- a/src/engine/modes/game/world/time.service.test.ts
+++ b/src/engine/modes/game/world/time.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { advanceTime, setTimeOfDay } from "./time.service";
+import { advanceTime, formatGameTime, setTimeOfDay } from "./time.service";
 
 describe("game time progression", () => {
   it("jumps scene time-of-day labels to their canonical hours", () => {
@@ -23,6 +23,7 @@ describe("game time progression", () => {
       hour: 12,
       minute: 0,
     });
+    expect(formatGameTime({ day: 1, hour: 12, minute: 0 })).toBe("Day 1, 12:00 (noon)");
   });
 
   it("keeps action duration advancement separate from scene labels", () => {

--- a/src/engine/modes/game/world/time.service.test.ts
+++ b/src/engine/modes/game/world/time.service.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { advanceTime, setTimeOfDay } from "./time.service";
+
+describe("game time progression", () => {
+  it("jumps scene time-of-day labels to their canonical hours", () => {
+    expect(setTimeOfDay({ day: 1, hour: 8, minute: 45 }, "night")).toEqual({
+      day: 1,
+      hour: 21,
+      minute: 0,
+    });
+    expect(setTimeOfDay({ day: 1, hour: 23, minute: 10 }, "morning")).toEqual({
+      day: 2,
+      hour: 8,
+      minute: 0,
+    });
+    expect(setTimeOfDay({ day: 1, hour: 21, minute: 30 }, "night")).toEqual({
+      day: 1,
+      hour: 21,
+      minute: 30,
+    });
+    expect(setTimeOfDay({ day: 1, hour: 11, minute: 50 }, "noon")).toEqual({
+      day: 1,
+      hour: 12,
+      minute: 0,
+    });
+  });
+
+  it("keeps action duration advancement separate from scene labels", () => {
+    expect(advanceTime({ day: 1, hour: 8, minute: 45 }, "night")).toEqual({
+      day: 1,
+      hour: 9,
+      minute: 0,
+    });
+  });
+});

--- a/src/engine/modes/game/world/time.service.ts
+++ b/src/engine/modes/game/world/time.service.ts
@@ -15,7 +15,6 @@ export interface GameTime {
 }
 
 export type SceneTimeOfDayLabel = "dawn" | "morning" | "noon" | "afternoon" | "evening" | "night" | "midnight";
-type TimeOfDay = Exclude<SceneTimeOfDayLabel, "noon">;
 
 const TIME_OF_DAY_HOURS: Record<SceneTimeOfDayLabel, number> = {
   dawn: 6,
@@ -65,9 +64,10 @@ function addMinutes(current: GameTime, minutes: number): GameTime {
 }
 
 /** Get the time-of-day label for the current hour. */
-function getTimeOfDay(hour: number): TimeOfDay {
+function getTimeOfDay(hour: number): SceneTimeOfDayLabel {
   if (hour >= 5 && hour < 7) return "dawn";
   if (hour >= 7 && hour < 12) return "morning";
+  if (hour === 12) return "noon";
   if (hour >= 12 && hour < 17) return "afternoon";
   if (hour >= 17 && hour < 20) return "evening";
   if (hour >= 20) return "night";
@@ -75,7 +75,6 @@ function getTimeOfDay(hour: number): TimeOfDay {
 }
 
 function timeMatchesLabel(time: GameTime, label: SceneTimeOfDayLabel): boolean {
-  if (label === "noon") return time.hour === 12;
   return getTimeOfDay(time.hour) === label;
 }
 

--- a/src/engine/modes/game/world/time.service.ts
+++ b/src/engine/modes/game/world/time.service.ts
@@ -14,7 +14,18 @@ export interface GameTime {
   minute: number;
 }
 
-type TimeOfDay = "dawn" | "morning" | "afternoon" | "evening" | "night" | "midnight";
+export type SceneTimeOfDayLabel = "dawn" | "morning" | "noon" | "afternoon" | "evening" | "night" | "midnight";
+type TimeOfDay = Exclude<SceneTimeOfDayLabel, "noon">;
+
+const TIME_OF_DAY_HOURS: Record<SceneTimeOfDayLabel, number> = {
+  dawn: 6,
+  morning: 8,
+  noon: 12,
+  afternoon: 14,
+  evening: 18,
+  night: 21,
+  midnight: 0,
+};
 
 /** Minutes advanced per action type. */
 const ACTION_DURATIONS: Record<string, number> = {
@@ -37,6 +48,10 @@ export function advanceTime(current: GameTime, action: string): GameTime {
   return addMinutes(current, minutes);
 }
 
+export function isTimeOfDayLabel(action: string): action is SceneTimeOfDayLabel {
+  return Object.prototype.hasOwnProperty.call(TIME_OF_DAY_HOURS, action);
+}
+
 /** Add a specific number of minutes to the clock. */
 function addMinutes(current: GameTime, minutes: number): GameTime {
   let totalMinutes = current.day * 24 * 60 + current.hour * 60 + current.minute + minutes;
@@ -57,6 +72,20 @@ function getTimeOfDay(hour: number): TimeOfDay {
   if (hour >= 17 && hour < 20) return "evening";
   if (hour >= 20) return "night";
   return "midnight";
+}
+
+function timeMatchesLabel(time: GameTime, label: SceneTimeOfDayLabel): boolean {
+  if (label === "noon") return time.hour === 12;
+  return getTimeOfDay(time.hour) === label;
+}
+
+/** Apply a scene analyzer time-of-day label without inventing a day skip on repeated labels. */
+export function setTimeOfDay(current: GameTime, label: SceneTimeOfDayLabel): GameTime {
+  if (timeMatchesLabel(current, label)) return current;
+
+  const targetHour = TIME_OF_DAY_HOURS[label];
+  const targetDay = targetHour <= current.hour ? current.day + 1 : current.day;
+  return { ...current, day: targetDay, hour: targetHour, minute: 0 };
 }
 
 /** Format time as a human-readable string for narration injection. */

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -95,6 +95,8 @@ import {
   createInitialTime,
   formatGameTime,
   advanceTime as advanceGameTime,
+  isTimeOfDayLabel,
+  setTimeOfDay,
   type GameTime,
 } from "../../../../engine/modes/game/world/time.service";
 import {
@@ -2514,7 +2516,10 @@ export const gameApi = {
     action: string;
   }): Promise<{ time: GameTime; formatted: string; sessionChat: Chat }> {
     const meta = chatMeta(await getChat(data.chatId));
-    const time = advanceGameTime(gameTimeFromMeta(meta), data.action);
+    const currentTime = gameTimeFromMeta(meta);
+    const time = isTimeOfDayLabel(data.action)
+      ? setTimeOfDay(currentTime, data.action)
+      : advanceGameTime(currentTime, data.action);
     const formatted = formatGameTime(time);
     const sessionChat = await patchChatMetadata(data.chatId, { gameTime: time, gameTimeFormatted: formatted });
     return { time, formatted, sessionChat };

--- a/src/features/modes/game/api/game-time-api.test.ts
+++ b/src/features/modes/game/api/game-time-api.test.ts
@@ -77,4 +77,18 @@ describe("gameApi.advanceTime", () => {
 
     expect(result.time).toEqual({ day: 1, hour: 9, minute: 15 });
   });
+
+  it("formats noon scene labels as noon after jumping the clock", async () => {
+    const chat = makeChat({
+      gameTime: { day: 1, hour: 11, minute: 50 },
+    });
+
+    storage.get.mockResolvedValue(chat);
+    storage.update.mockImplementation(async (_entity, _id, patch) => ({ ...chat, ...patch }));
+
+    const result = await gameApi.advanceTime({ chatId: "chat-1", action: "noon" });
+
+    expect(result.time).toEqual({ day: 1, hour: 12, minute: 0 });
+    expect(result.formatted).toBe("Day 1, 12:00 (noon)");
+  });
 });

--- a/src/features/modes/game/api/game-time-api.test.ts
+++ b/src/features/modes/game/api/game-time-api.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "../../../../engine/contracts/types/chat";
+
+const storage = {
+  get: vi.fn(),
+  update: vi.fn(),
+};
+
+vi.mock("../../../../shared/api/storage-api", () => ({
+  storageApi: storage,
+}));
+
+const { gameApi } = await import("./game-api");
+
+function makeChat(metadata: Partial<Chat["metadata"]>): Chat {
+  return {
+    id: "chat-1",
+    name: "Game",
+    mode: "game",
+    characterIds: [],
+    groupId: null,
+    personaId: null,
+    promptPresetId: null,
+    connectionId: null,
+    connectedChatId: null,
+    folderId: null,
+    sortOrder: 0,
+    createdAt: "2026-06-04T00:00:00.000Z",
+    updatedAt: "2026-06-04T00:00:00.000Z",
+    metadata: {
+      summary: null,
+      tags: [],
+      agentOverrides: {},
+      activeAgentIds: [],
+      activeToolIds: [],
+      presetChoices: {},
+      ...metadata,
+    },
+  };
+}
+
+describe("gameApi.advanceTime", () => {
+  beforeEach(() => {
+    storage.get.mockReset();
+    storage.update.mockReset();
+  });
+
+  it("routes scene time-of-day labels to canonical clock jumps", async () => {
+    const chat = makeChat({
+      gameTime: { day: 1, hour: 8, minute: 45 },
+    });
+
+    storage.get.mockResolvedValue(chat);
+    storage.update.mockImplementation(async (_entity, _id, patch) => ({ ...chat, ...patch }));
+
+    const result = await gameApi.advanceTime({ chatId: "chat-1", action: "night" });
+
+    expect(result.time).toEqual({ day: 1, hour: 21, minute: 0 });
+    expect(result.formatted).toBe("Day 1, 21:00 (night)");
+    expect(storage.update).toHaveBeenCalledWith("chats", "chat-1", {
+      metadata: expect.objectContaining({
+        gameTime: { day: 1, hour: 21, minute: 0 },
+        gameTimeFormatted: "Day 1, 21:00 (night)",
+      }),
+    });
+  });
+
+  it("keeps ordinary action durations on advanceTime", async () => {
+    const chat = makeChat({
+      gameTime: { day: 1, hour: 8, minute: 45 },
+    });
+
+    storage.get.mockResolvedValue(chat);
+    storage.update.mockImplementation(async (_entity, _id, patch) => ({ ...chat, ...patch }));
+
+    const result = await gameApi.advanceTime({ chatId: "chat-1", action: "explore" });
+
+    expect(result.time).toEqual({ day: 1, hour: 9, minute: 15 });
+  });
+});


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2149

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Scene analyzer time-of-day labels such as `night` were being passed through the game time API as ordinary action names. Because `advanceTime` does not know those labels, the game clock advanced by the 15-minute default instead of jumping to the canonical scene time.

## What changed

<!-- List the key changes in this PR. -->

- Restored engine-level scene time-of-day jump handling with canonical hours and same-label no-op behavior.
- Routed recognized scene time labels through `setTimeOfDay` in `gameApi.advanceTime`, while preserving ordinary action-duration advancement for actions like `explore`.
- Added focused regression coverage for engine clock jumps, API persistence formatting, rollover behavior, repeated labels, the analyzer's `noon` label, and ordinary action durations.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

- Game mode.

Impact areas reviewed:

- Game time progression service.
- Game API time persistence path.
- Scene analyzer time-of-day labels that currently flow through `GameSurface` into `gameApi.advanceTime`.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine owns the time label/jump contract. Feature API now consumes that engine helper rather than duplicating label logic in UI code.
- No Rust, storage schema, remote runtime, prompt assembly, dependency, or release metadata changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src/features/modes/game/api/game-api.ts`
- `src/engine/modes/game/world/time.service.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm exec vitest run src/engine/modes/game/world/time.service.test.ts src/features/modes/game/api/game-time-api.test.ts`.
- Codex ran `pnpm typecheck`.
- Codex ran full `pnpm check`.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification-2149.json`.
- Bunny review pass: no blocking findings before opening the draft PR.
- No human-only verification is required for the core claim; this is a deterministic non-UI game-time contract.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A. This restores existing game-mode behavior and does not add a discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

- No docs or release note changes needed for this focused regression fix.
- This PR does not restore old staging/package-workspace/release claims.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is deterministic non-UI game-time logic; command proof is listed above.
