### PR TITLE
Fix legacy game narration segment parsing

### DIFF
--- a/src/features/modes/game/components/GameNarration.test.tsx
+++ b/src/features/modes/game/components/GameNarration.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Message } from "../../../../engine/contracts/types/chat";
+import { parseSegmentInventoryUpdates } from "../lib/game-tag-parser";
+import { GameNarration } from "./GameNarration";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+Object.defineProperty(HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  value: vi.fn(() => Promise.resolve()),
+});
+Object.defineProperty(HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  value: vi.fn(),
+});
+
+vi.mock("../../../../shared/hooks/use-translate", () => ({
+  useTranslate: () => ({ translations: {}, translating: {} }),
+}));
+
+vi.mock("../../../../shared/hooks/use-tts", () => ({
+  useTTSConfig: () => ({ data: null }),
+}));
+
+vi.mock("../../../catalog/agents/regex-application", () => ({
+  useApplyRegex: () => ({ applyToAIOutput: (text: string) => text }),
+}));
+
+vi.mock("../../../../shared/stores/chat.store", () => ({
+  useChatStore: <T,>(selector: (state: { activeChat: { metadata: Record<string, unknown> } }) => T) =>
+    selector({ activeChat: { metadata: {} } }),
+}));
+
+vi.mock("../stores/game-asset.store", () => ({
+  useGameAssetStore: <T,>(selector: (state: { manifest: null }) => T) => selector({ manifest: null }),
+}));
+
+vi.mock("../stores/game-mode.store", () => ({
+  useGameModeStore: <T,>(selector: (state: { npcs: [] }) => T) => selector({ npcs: [] }),
+}));
+
+vi.mock("../../../../shared/stores/ui.store", () => ({
+  useUIStore: <T,>(
+    selector: (state: {
+      messagesPerPage: number;
+      gameDialogueDisplayMode: "single";
+      gameInstantTextReveal: boolean;
+      gameTextSpeed: number;
+      gameAutoPlayDelay: number;
+      chatFontColor: string;
+      chatFontSize: number;
+      gameAvatarScale: number;
+      textBlipMode: "off";
+      customTextBlipSound: null;
+    }) => T,
+  ) =>
+    selector({
+      messagesPerPage: 20,
+      gameDialogueDisplayMode: "single",
+      gameInstantTextReveal: true,
+      gameTextSpeed: 100,
+      gameAutoPlayDelay: 1000,
+      chatFontColor: "",
+      chatFontSize: 16,
+      gameAvatarScale: 1,
+      textBlipMode: "off",
+      customTextBlipSound: null,
+    }),
+}));
+
+const legacyContent = [
+  "Narration: The old road bends toward the village.",
+  'Dialogue [Alice] [happy]: "We made it."',
+  'Dialogue [Cara]: "No sprite needed."',
+  '[Bob] [thinking]: "Something feels off."',
+].join("\n");
+
+const legacyMessage: Message = {
+  id: "legacy-message",
+  role: "assistant",
+  chatId: "game-chat",
+  characterId: null,
+  content: legacyContent,
+  activeSwipeIndex: 0,
+  createdAt: "2026-06-04T00:00:00.000Z",
+  extra: {
+    displayText: null,
+    isGenerated: true,
+    tokenCount: null,
+    generationInfo: null,
+  },
+};
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderGameNarration(onInterruptRequest = vi.fn()) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root?.render(
+      <GameNarration
+        messages={[legacyMessage]}
+        isStreaming={false}
+        characterMap={new Map()}
+        onInterruptRequest={onInterruptRequest}
+      />,
+    );
+  });
+
+  return { container, onInterruptRequest };
+}
+
+afterEach(() => {
+  if (root) {
+    act(() => {
+      root?.unmount();
+    });
+  }
+  container?.remove();
+  root = null;
+  container = null;
+  vi.clearAllMocks();
+});
+
+describe("GameNarration legacy segment parsing", () => {
+  it("renders legacy narration without leaking its prefix", () => {
+    const view = renderGameNarration().container;
+
+    expect(view.textContent).toContain("The old road bends toward the village.");
+    expect(view.textContent).not.toContain("Narration:");
+  });
+
+  it("truncates unread legacy content at the active segment boundary when interrupting", () => {
+    const onInterruptRequest = vi.fn();
+    const view = renderGameNarration(onInterruptRequest).container;
+
+    const interruptButton = view.querySelector<HTMLButtonElement>('button[aria-label="Interrupt"]');
+    expect(interruptButton).not.toBeNull();
+    act(() => {
+      interruptButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onInterruptRequest).toHaveBeenCalledWith({
+      messageId: "legacy-message",
+      truncatedContent: "Narration: The old road bends toward the village.",
+    });
+  });
+
+  it("keeps inventory timing aligned with legacy segment boundaries", () => {
+    const rawContent = [
+      "Narration: The old road bends toward the village.",
+      'Dialogue [Alice] [happy]: "We made it." [inventory: action=add item="Map"]',
+      '[Bob] [thinking]: "Something feels off."',
+    ].join("\n");
+
+    expect(parseSegmentInventoryUpdates(rawContent)).toEqual([
+      {
+        segment: 1,
+        update: {
+          action: "add",
+          items: ["Map"],
+        },
+      },
+    ]);
+  });
+});

--- a/src/features/modes/game/components/GameNarration.tsx
+++ b/src/features/modes/game/components/GameNarration.tsx
@@ -5173,6 +5173,8 @@ function parseNarrationSegments(message: NarrationMessage, speakerColors: Map<st
   const parsed: NarrationSegment[] = [];
   const readablePlaceholderRe = /^__READABLE_(\d+)__$/;
   const compactDialogueRegex = /^\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/;
+  const legacyDialogueRegex = /^\s*Dialogue\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+  const narrationPrefixRegex = /^\s*Narration\s*:\s*(.+)$/i;
   const partyLineRegex =
     /^\s*\[([^\]]+)\]\s*\[(main|side|extra|action|thought|whisper(?::([^\]]+))?)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
 
@@ -5266,7 +5268,25 @@ function parseNarrationSegments(message: NarrationMessage, speakerColors: Map<st
       continue;
     }
 
-    const dialogueMatch = line.match(compactDialogueRegex);
+    const narrationMatch = line.match(narrationPrefixRegex);
+    if (narrationMatch) {
+      if (fallbackText.trim()) {
+        parsed.push({
+          id: `${message.id}-fallback-${parsed.length}`,
+          type: "narration",
+          content: fallbackText.trim(),
+        });
+        fallbackText = "";
+      }
+      parsed.push({
+        id: `${message.id}-n-${parsed.length}`,
+        type: "narration",
+        content: narrationMatch[1]!.trim(),
+      });
+      continue;
+    }
+
+    const dialogueMatch = line.match(legacyDialogueRegex) || line.match(compactDialogueRegex);
     if (dialogueMatch) {
       if (fallbackText.trim()) {
         parsed.push({
@@ -5328,6 +5348,8 @@ function truncateMessageContentAtSegment(rawContent: string, segmentIndexInclusi
   const lines = buildTruncationLines(rawContent || "");
   const readablePlaceholderRe = /^__READABLE_(\d+)__$/;
   const compactDialogueRegex = /^\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/;
+  const legacyDialogueRegex = /^\s*Dialogue\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+  const narrationPrefixRegex = /^\s*Narration\s*:\s*(.+)$/i;
   const partyLineRegex =
     /^\s*\[([^\]]+)\]\s*\[(main|side|extra|action|thought|whisper(?::([^\]]+))?)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
 
@@ -5348,7 +5370,12 @@ function truncateMessageContentAtSegment(rawContent: string, segmentIndexInclusi
       continue;
     }
 
-    const isSpecial = readablePlaceholderRe.test(line) || partyLineRegex.test(line) || compactDialogueRegex.test(line);
+    const isSpecial =
+      readablePlaceholderRe.test(line) ||
+      partyLineRegex.test(line) ||
+      narrationPrefixRegex.test(line) ||
+      legacyDialogueRegex.test(line) ||
+      compactDialogueRegex.test(line);
 
     if (isSpecial) {
       if (pendingFallback) {

--- a/src/features/modes/game/lib/game-tag-parser.ts
+++ b/src/features/modes/game/lib/game-tag-parser.ts
@@ -623,6 +623,8 @@ export function parseSegmentInventoryUpdates(content: string): SegmentInventoryU
 
   const readablePlaceholderRe = /^__READABLE_(\d+)__$/;
   const compactDialogueRegex = /^\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/;
+  const legacyDialogueRegex = /^\s*Dialogue\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+  const narrationPrefixRegex = /^\s*Narration\s*:\s*(.+)$/i;
   const partyLineRegex =
     /^\s*\[([^\]]+)\]\s*\[(main|side|extra|action|thought|whisper(?::([^\]]+))?)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
   const inventoryRegex = /\[inventory:\s*([^\]]+)\]/gi;
@@ -680,7 +682,11 @@ export function parseSegmentInventoryUpdates(content: string): SegmentInventoryU
     }
 
     const isStandaloneSegment =
-      readablePlaceholderRe.test(line) || partyLineRegex.test(line) || compactDialogueRegex.test(line);
+      readablePlaceholderRe.test(line) ||
+      partyLineRegex.test(line) ||
+      narrationPrefixRegex.test(line) ||
+      legacyDialogueRegex.test(line) ||
+      compactDialogueRegex.test(line);
 
     if (isStandaloneSegment) {
       if (fallbackActive) {


### PR DESCRIPTION
## Linked issue

Closes #2150

## Why this change

Old saved game histories can contain `Narration: ...` and `Dialogue [Name] [expr]: "..."` lines. The engine edit parser still treated those as standalone segments, but GameNarration display/truncation no longer did, so prefixes leaked into the UI and edit/delete/interrupt segment indices could diverge.

## What changed

- Restored legacy `Narration:` parsing in GameNarration display so the prefix is stripped and the line remains a standalone narration segment.
- Restored legacy `Dialogue [Name] [expr]:` / `Dialogue [Name]:` parsing for display and interrupt truncation while preserving compact `[Name] [expr]:` dialogue.
- Kept segment-timed inventory updates aligned with the same legacy segment boundaries.
- Added focused regression coverage for rendered narration, interrupt truncation, and inventory segment timing.

## Refactor impact

Primary owner:

game mode

Impact areas reviewed:

- `src/features/modes/game/components/GameNarration.tsx`
- `src/features/modes/game/lib/game-tag-parser.ts`
- `src/engine/modes/game/state/segment-edits.ts` for existing legacy edit parser behavior

Boundary notes:

- Feature/UI parser fix only; no engine, shared API, Rust, storage, schema, prompt pipeline, dependency, or release metadata changes.
- Engine edit parsing already recognizes the legacy forms, so this PR restores feature-side agreement rather than changing engine behavior.

Pressure points touched:

- `GameNarration` segment display and interrupt truncation
- Segment-timed inventory parser used by game runtime UI timing

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Codex ran:

- Before-fix focused Vitest harness in a temporary `upstream/refactor` worktree: failed with legacy narration/dialogue collapsed into fallback narration and truncation segment 0 including the following legacy dialogue line.
- `pnpm exec vitest run src/features/modes/game/components/GameNarration.test.tsx --reporter verbose`: passed, 3 tests.
- `pnpm typecheck`: passed.
- `pnpm check:unused`: passed.
- `pnpm check`: passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/issue-2150-bugfix-verification.json`: passed locally.
- Bunny review: pass before opening draft.

Manual/UI note: no reviewer-visible before/after screenshot from an actual old saved Tauri game chat is attached yet; the core parser claim is covered by the component-level regression test and full local checks. External CI, Bunny, and CodeRabbit are clean; this is kept draft for any desired human visual check.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix for legacy saved game narration formats; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No uploaded screenshot evidence yet. The draft relies on focused component regression proof for rendered text and interrupt truncation, plus local and GitHub baseline checks.


