### PR TITLE
Fix party turn quote formatting

### DIFF
--- a/src/engine/capabilities/visual-assets.ts
+++ b/src/engine/capabilities/visual-assets.ts
@@ -29,7 +29,7 @@ export interface GameAssetManifest {
   [key: string]: unknown;
 }
 
-export interface VisualReferenceImageSource {
+interface VisualReferenceImageSource {
   image?: string | null;
   url?: string | null;
   base64?: string | null;

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -277,9 +277,9 @@ function usableImageReference(value: unknown, fallbackMimeType = "image/png"): s
   return estimateImageReferenceBytes(dataUrl) <= IMAGE_REFERENCE_PROVIDER_BYTE_LIMIT ? dataUrl : "";
 }
 
-function firstUsableReference(...values: unknown[]): string {
+function firstUsableReference(fallbackMimeType: string, ...values: unknown[]): string {
   for (const value of values) {
-    const image = usableImageReference(value);
+    const image = usableImageReference(value, fallbackMimeType);
     if (image) return image;
   }
   return "";
@@ -296,7 +296,8 @@ async function resolveReferenceImage(
     avatarFilename?: unknown;
   },
 ): Promise<string> {
-  const inline = firstUsableReference(source.image, source.url, source.base64);
+  const fallbackMimeType = readString(source.mimeType).trim() || "image/png";
+  const inline = firstUsableReference(fallbackMimeType, source.image, source.url, source.base64);
   if (inline) return inline;
   const resolved = visuals?.resolveReferenceImage
     ? await visuals
@@ -310,7 +311,7 @@ async function resolveReferenceImage(
         })
         .catch(() => null)
     : null;
-  return usableImageReference(resolved);
+  return usableImageReference(resolved, fallbackMimeType);
 }
 
 async function fullBodySpriteReference(

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -260,6 +260,13 @@ function estimateImageReferenceBytes(dataUrl: string): number {
   return Math.max(0, Math.floor((payload.length * 3) / 4) - padding);
 }
 
+function supportedImageMimeType(value: unknown): string {
+  const normalized = readString(value).trim().toLowerCase().split(";")[0] ?? "";
+  if (normalized === "image/jpg") return "image/jpeg";
+  if (["image/png", "image/jpeg", "image/webp", "image/gif"].includes(normalized)) return normalized;
+  return "image/png";
+}
+
 function imageDataUrl(value: unknown, fallbackMimeType = "image/png"): string {
   const text = readString(value).trim();
   if (!text) return "";
@@ -296,7 +303,7 @@ async function resolveReferenceImage(
     avatarFilename?: unknown;
   },
 ): Promise<string> {
-  const fallbackMimeType = readString(source.mimeType).trim() || "image/png";
+  const fallbackMimeType = supportedImageMimeType(source.mimeType);
   const inline = firstUsableReference(fallbackMimeType, source.image, source.url, source.base64);
   if (inline) return inline;
   const resolved = visuals?.resolveReferenceImage

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -260,31 +260,37 @@ function estimateImageReferenceBytes(dataUrl: string): number {
   return Math.max(0, Math.floor((payload.length * 3) / 4) - padding);
 }
 
-function supportedImageMimeType(value: unknown): string {
+function supportedImageMimeType(value: unknown): string | null {
   const normalized = readString(value).trim().toLowerCase().split(";")[0] ?? "";
   if (normalized === "image/jpg") return "image/jpeg";
   if (["image/png", "image/jpeg", "image/webp", "image/gif"].includes(normalized)) return normalized;
-  return "image/png";
+  return null;
 }
 
-function imageDataUrl(value: unknown, fallbackMimeType = "image/png"): string {
+function referenceImageFallbackMimeType(value: unknown): string | null {
+  return readString(value).trim() ? supportedImageMimeType(value) : "image/png";
+}
+
+function imageDataUrl(value: unknown, fallbackMimeType: string | null = "image/png"): string {
   const text = readString(value).trim();
   if (!text) return "";
-  if (text.startsWith("data:image/")) return text;
+  if (/^data:image\/(?:png|jpe?g|webp|gif);base64,/i.test(text)) return text;
   const wrapped = text.match(/^[a-z][a-z0-9+.-]*:\/\/(data:image\/(?:png|jpe?g|webp|gif);base64,.*)$/i);
   if (wrapped?.[1]) return wrapped[1];
   const base64 = text.replace(/\s+/g, "");
-  if (/^[A-Za-z0-9+/=]+$/.test(base64) && base64.length > 80) return `data:${fallbackMimeType};base64,${base64}`;
+  if (fallbackMimeType && /^[A-Za-z0-9+/=]+$/.test(base64) && base64.length > 80) {
+    return `data:${fallbackMimeType};base64,${base64}`;
+  }
   return "";
 }
 
-function usableImageReference(value: unknown, fallbackMimeType = "image/png"): string {
+function usableImageReference(value: unknown, fallbackMimeType: string | null = "image/png"): string {
   const dataUrl = imageDataUrl(value, fallbackMimeType);
   if (!dataUrl) return "";
   return estimateImageReferenceBytes(dataUrl) <= IMAGE_REFERENCE_PROVIDER_BYTE_LIMIT ? dataUrl : "";
 }
 
-function firstUsableReference(fallbackMimeType: string, ...values: unknown[]): string {
+function firstUsableReference(fallbackMimeType: string | null, ...values: unknown[]): string {
   for (const value of values) {
     const image = usableImageReference(value, fallbackMimeType);
     if (image) return image;
@@ -303,7 +309,7 @@ async function resolveReferenceImage(
     avatarFilename?: unknown;
   },
 ): Promise<string> {
-  const fallbackMimeType = supportedImageMimeType(source.mimeType);
+  const fallbackMimeType = referenceImageFallbackMimeType(source.mimeType);
   const inline = firstUsableReference(fallbackMimeType, source.image, source.url, source.base64);
   if (inline) return inline;
   const resolved = visuals?.resolveReferenceImage

--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -7246,14 +7246,15 @@ export function GameSurface({
           clearCommittedPendingMapMove();
           return false;
         }
-        const playerAction = stripGameDirectAddressPrefix(message);
+        const formattedMessage = formatTextQuotes(message, quoteFormat);
+        const playerAction = stripGameDirectAddressPrefix(formattedMessage);
         const requestId = partyTurnRequestIdRef.current + 1;
         partyTurnRequestIdRef.current = requestId;
         partyTurnInFlightRef.current = true;
         setPartyDialogue([]);
         setPartyChatMessageId(null);
         try {
-          await createMessage.mutateAsync({ role: "user", content: message });
+          await createMessage.mutateAsync({ role: "user", content: formattedMessage });
           if (partyTurnRequestIdRef.current !== requestId) return false;
           setPartyChatInput(playerAction);
           const result = await partyTurn.mutateAsync({
@@ -7295,6 +7296,7 @@ export function GameSurface({
       pendingInterrupt,
       pendingMapMove,
       partyTurn,
+      quoteFormat,
       latestNarrationText,
       sendMessage,
       sessionInteractive,

--- a/src/shared/api/visual-assets-api.ts
+++ b/src/shared/api/visual-assets-api.ts
@@ -61,12 +61,7 @@ async function fetchBlobUrl(url: string, fallbackMimeType: string): Promise<stri
 
 async function loadUrlDataUrl(url: string, fallbackMimeType: string): Promise<string | null> {
   if (url.startsWith("blob:")) return fetchBlobUrl(url, fallbackMimeType);
-  try {
-    return blobToDataUrl(await urlBinaryApi.load(url, fallbackMimeType), fallbackMimeType);
-  } catch (error) {
-    if (typeof fetch !== "function") throw error;
-    return fetchBlobUrl(url, fallbackMimeType);
-  }
+  return blobToDataUrl(await urlBinaryApi.load(url, fallbackMimeType), fallbackMimeType);
 }
 
 export const visualAssetsApi: VisualAssetGateway = {

--- a/src/shared/api/visual-assets-api.ts
+++ b/src/shared/api/visual-assets-api.ts
@@ -11,6 +11,13 @@ function cleanString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function supportedImageMimeType(value: unknown): string {
+  const normalized = cleanString(value).toLowerCase().split(";")[0] ?? "";
+  if (normalized === "image/jpg") return "image/jpeg";
+  if (["image/png", "image/jpeg", "image/webp", "image/gif"].includes(normalized)) return normalized;
+  return "image/png";
+}
+
 function inlineImageDataUrl(value: unknown): string | null {
   const text = cleanString(value);
   if (!text) return null;
@@ -69,7 +76,7 @@ export const visualAssetsApi: VisualAssetGateway = {
   listBackgrounds: () => backgroundsApi.list(),
   gameAssetsManifest: () => gameAssetsApi.manifest(),
   resolveReferenceImage: async (source) => {
-    const fallbackMimeType = cleanString(source.mimeType) || "image/png";
+    const fallbackMimeType = supportedImageMimeType(source.mimeType);
     const inline =
       usableDataUrl(inlineImageDataUrl(source.image)) ??
       usableDataUrl(inlineImageDataUrl(source.url)) ??

--- a/src/shared/api/visual-assets-api.ts
+++ b/src/shared/api/visual-assets-api.ts
@@ -11,11 +11,15 @@ function cleanString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function supportedImageMimeType(value: unknown): string {
+function supportedImageMimeType(value: unknown): string | null {
   const normalized = cleanString(value).toLowerCase().split(";")[0] ?? "";
   if (normalized === "image/jpg") return "image/jpeg";
   if (["image/png", "image/jpeg", "image/webp", "image/gif"].includes(normalized)) return normalized;
-  return "image/png";
+  return null;
+}
+
+function referenceImageFallbackMimeType(value: unknown): string | null {
+  return cleanString(value) ? supportedImageMimeType(value) : "image/png";
 }
 
 function inlineImageDataUrl(value: unknown): string | null {
@@ -26,9 +30,9 @@ function inlineImageDataUrl(value: unknown): string | null {
   return wrapped?.[1] ?? null;
 }
 
-function rawBase64ImageDataUrl(value: unknown, mimeType = "image/png"): string | null {
+function rawBase64ImageDataUrl(value: unknown, mimeType: string | null = "image/png"): string | null {
   const text = cleanString(value).replace(/\s+/g, "");
-  if (!text || text.length <= 80 || !/^[A-Za-z0-9+/=]+$/.test(text)) return null;
+  if (!mimeType || !text || text.length <= 80 || !/^[A-Za-z0-9+/=]+$/.test(text)) return null;
   return `data:${mimeType};base64,${text}`;
 }
 
@@ -53,22 +57,25 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
-async function blobToDataUrl(blob: Blob, fallbackMimeType: string): Promise<string | null> {
+async function blobToDataUrl(blob: Blob, fallbackMimeType: string | null): Promise<string | null> {
   if (blob.size > IMAGE_REFERENCE_PROVIDER_BYTE_LIMIT) return null;
-  const mimeType = blob.type.startsWith("image/") ? blob.type : fallbackMimeType;
+  const blobMimeType = supportedImageMimeType(blob.type);
+  if (cleanString(blob.type) && !blobMimeType) return null;
+  const mimeType = blobMimeType ?? fallbackMimeType;
+  if (!mimeType) return null;
   const base64 = bytesToBase64(new Uint8Array(await blob.arrayBuffer()));
   return `data:${mimeType};base64,${base64}`;
 }
 
-async function fetchBlobUrl(url: string, fallbackMimeType: string): Promise<string | null> {
+async function fetchBlobUrl(url: string, fallbackMimeType: string | null): Promise<string | null> {
   const response = await fetch(url);
   if (!response.ok) throw new Error(`Reference image returned ${response.status}`);
   return blobToDataUrl(await response.blob(), fallbackMimeType);
 }
 
-async function loadUrlDataUrl(url: string, fallbackMimeType: string): Promise<string | null> {
+async function loadUrlDataUrl(url: string, fallbackMimeType: string | null): Promise<string | null> {
   if (url.startsWith("blob:")) return fetchBlobUrl(url, fallbackMimeType);
-  return blobToDataUrl(await urlBinaryApi.load(url, fallbackMimeType), fallbackMimeType);
+  return blobToDataUrl(await urlBinaryApi.load(url, fallbackMimeType ?? "application/octet-stream"), fallbackMimeType);
 }
 
 export const visualAssetsApi: VisualAssetGateway = {
@@ -76,7 +83,7 @@ export const visualAssetsApi: VisualAssetGateway = {
   listBackgrounds: () => backgroundsApi.list(),
   gameAssetsManifest: () => gameAssetsApi.manifest(),
   resolveReferenceImage: async (source) => {
-    const fallbackMimeType = supportedImageMimeType(source.mimeType);
+    const fallbackMimeType = referenceImageFallbackMimeType(source.mimeType);
     const inline =
       usableDataUrl(inlineImageDataUrl(source.image)) ??
       usableDataUrl(inlineImageDataUrl(source.url)) ??


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2151

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Game mode's Talk-to-Party branch persisted and sent the raw addressed message before the shared game turn send path could apply typographic quote formatting. With Typographic quotes enabled, party turns kept straight quotes while normal game turns used curly quotes.

## What changed

<!-- List the key changes in this PR. -->

- Formats Talk-to-Party messages with the current quote preference before persisting the user message.
- Uses that same formatted addressed message to derive the party action payload, matching the normal game turn behavior.
- Adds `quoteFormat` to the `handleSendGameTurn` callback dependencies because the party branch now reads it directly.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

- Game mode

Impact areas reviewed:

- Talk-to-Party send branch in `GameSurface`
- Existing normal game turn send path that already applies `formatTextQuotes`

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature-only change under `src/features/modes/game`; no engine, shared API, Rust, storage, provider, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `GameSurface`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Focused repro: `node --experimental-strip-types scratch\verify-party-quote-format.mts`
  - Before fix: failed because Talk-to-Party persisted `[To the party] say "follow me"` and sent player action `say "follow me"`.
  - After fix: passed with persisted `[To the party] say “follow me”` and player action `say “follow me”`.
- Focused lane check: `pnpm typecheck` passed.
- PR boundary check: `pnpm check` passed.
- Local proof-gate helper was unavailable at `C:\Users\celia\.codex\tools\marinara-proof-gate.mjs`; the repo checks and focused repro above passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a focused bugfix for an existing game mode turn path.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

- N/A: no layout or visual rendering change. The affected persisted payload was proven with the focused repro above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quote formatting for messages sent in party chat so outgoing messages respect the active quote style.
* **Improvements**
  * Improved image reference selection to more reliably pick compatible image types.
  * Simplified image-loading behavior for more consistent handling of visual assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->