### PR TITLE
Fix scene-forced weather generation

### DIFF
--- a/src/engine/capabilities/visual-assets.ts
+++ b/src/engine/capabilities/visual-assets.ts
@@ -29,7 +29,7 @@ export interface GameAssetManifest {
   [key: string]: unknown;
 }
 
-export interface VisualReferenceImageSource {
+interface VisualReferenceImageSource {
   image?: string | null;
   url?: string | null;
   base64?: string | null;

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -2533,20 +2533,22 @@ export const gameApi = {
     type?: string;
   }): Promise<{ changed: boolean; weather: WeatherState; sessionChat: Chat }> {
     const chat = await getChat(data.chatId);
-    let forced: WeatherState;
+    const biome = inferBiome(data.location ?? "");
+    const season = weatherSeason(data.season);
+    if (data.season && season === "summer" && data.season !== "summer") {
+      console.warn("[game] Invalid weather season; defaulting to summer", {
+        season: data.season,
+        biome,
+        location: data.location ?? "",
+      });
+    }
+    let forced = generateWeather(biome, season);
     if (data.type) {
-      forced = { type: data.type, temperature: 20, description: "", wind: "calm", visibility: "clear" } as WeatherState;
-    } else {
-      const biome = inferBiome(data.location ?? "");
-      const season = weatherSeason(data.season);
-      if (data.season && season === "summer" && data.season !== "summer") {
-        console.warn("[game] Invalid weather season; defaulting to summer", {
-          season: data.season,
-          biome,
-          location: data.location ?? "",
-        });
-      }
-      forced = generateWeather(biome, season);
+      forced = {
+        ...forced,
+        type: data.type as WeatherState["type"],
+        description: `The weather is ${data.type}.`,
+      };
     }
     const changed =
       Boolean(data.type) ||

--- a/src/features/modes/game/api/game-time-api.test.ts
+++ b/src/features/modes/game/api/game-time-api.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "../../../../engine/contracts/types/chat";
 
 const storage = {
@@ -43,6 +43,10 @@ describe("gameApi.advanceTime", () => {
   beforeEach(() => {
     storage.get.mockReset();
     storage.update.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("routes scene time-of-day labels to canonical clock jumps", async () => {
@@ -90,5 +94,51 @@ describe("gameApi.advanceTime", () => {
 
     expect(result.time).toEqual({ day: 1, hour: 12, minute: 0 });
     expect(result.formatted).toBe("Day 1, 12:00 (noon)");
+  });
+});
+
+describe("gameApi.updateWeather", () => {
+  beforeEach(() => {
+    storage.get.mockReset();
+    storage.update.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves generated biome and season values when scene analysis forces the weather type", async () => {
+    const chat = makeChat({});
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0.65)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0);
+
+    storage.get.mockResolvedValue(chat);
+    storage.update.mockImplementation(async (_entity, _id, patch) => ({ ...chat, ...patch }));
+
+    const result = await gameApi.updateWeather({
+      chatId: "chat-1",
+      action: "set",
+      location: "frozen glacier",
+      season: "winter",
+      type: "blizzard",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.weather).toEqual({
+      type: "blizzard",
+      temperature: -50,
+      description: "The weather is blizzard.",
+      wind: "gale",
+      visibility: "poor",
+    });
+    expect(storage.update).toHaveBeenCalledWith("chats", "chat-1", {
+      metadata: expect.objectContaining({
+        gameWeather: result.weather,
+      }),
+    });
   });
 });


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2153

## Why this change

- Scene-forced weather in game mode was bypassing biome/season generation and stamping a hardcoded `20C`, empty description, `calm` wind, and `clear` visibility.
- That made forced cold weather like a blizzard appear warm and clear in player-visible game state and LLM context.

## What changed

- `gameApi.updateWeather` now derives the biome/season weather baseline before applying a forced scene weather type.
- Forced weather now preserves generated temperature, wind, and visibility while overriding the type and description.
- Added a focused regression row for an arctic winter forced blizzard.
- Made an internal visual-assets parameter type file-local so `check:unused` no longer fails on an exported type that is only used by its owning interface.

## Refactor impact

Primary owner:

- Game mode.

Impact areas reviewed:

- `src/features/modes/game/api/game-api.ts`
- `src/features/modes/game/api/game-time-api.test.ts`
- `src/engine/capabilities/visual-assets.ts` for the CI-only unused-export cleanup.

Boundary notes:

- The weather behavior change stays in the React feature API wrapper and uses the existing React-free weather service.
- The visual-assets change is type-export hygiene only; it does not change the `VisualAssetGateway` runtime shape.
- No storage schema, import/export, prompt pipeline, dependency, Rust, or shared API contract changes.

Pressure points touched:

- Game weather update API used by scene analysis and game-state weather metadata.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused repro before fix: `pnpm exec vitest run src/features/modes/game/api/game-time-api.test.ts` failed because forced blizzard returned `20C`, empty description, `calm`, and `clear`.
- Focused verification after fix: `pnpm exec vitest run src/features/modes/game/api/game-time-api.test.ts --reporter=json --outputFile=scratch/issue-2153-vitest-after.json` passed with 4 tests, including the forced arctic winter blizzard row.
- CI failure repro: GitHub Actions failed `Frontend, Architecture, and Organization` at `pnpm check:unused` because `VisualReferenceImageSource` was exported but only used inside `src/engine/capabilities/visual-assets.ts`.
- CI fix verification: `pnpm check:unused` passed after making `VisualReferenceImageSource` file-local.
- Focused verification after CI fix: `pnpm exec vitest run src/features/modes/game/api/game-time-api.test.ts --reporter=json --outputFile=scratch/issue-2153-vitest-after-ci-fix.json` passed.
- `git diff --check` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\issue-2153-bugfix-verification.json` passed.
- Full `pnpm check` passed after the CI fix.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A: bugfix to existing game weather behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: non-UI game API logic fix. Verification is via focused local command proof.
