### PR TITLE
Fix legacy game revelations normalization

### DIFF
--- a/src/engine/capabilities/visual-assets.ts
+++ b/src/engine/capabilities/visual-assets.ts
@@ -29,7 +29,7 @@ export interface GameAssetManifest {
   [key: string]: unknown;
 }
 
-export interface VisualReferenceImageSource {
+interface VisualReferenceImageSource {
   image?: string | null;
   url?: string | null;
   base64?: string | null;

--- a/src/engine/modes/game/state/session-summary-normalization.ts
+++ b/src/engine/modes/game/state/session-summary-normalization.ts
@@ -1,5 +1,6 @@
 export interface SessionSummaryFactLists {
   keyDiscoveries: string[];
+  legacyRevelations?: string[];
   characterMoments: string[];
   littleDetails: string[];
   npcUpdates: string[];
@@ -33,7 +34,7 @@ export function dedupeSessionSummaryLists(lists: SessionSummaryFactLists): Sessi
   const characterMoments = dedupeBucket(lists.characterMoments, seen);
   const npcUpdates = dedupeBucket(lists.npcUpdates, seen);
   const littleDetails = dedupeBucket(lists.littleDetails, seen);
-  const keyDiscoveries = dedupeBucket(lists.keyDiscoveries, seen);
+  const keyDiscoveries = dedupeBucket([...lists.keyDiscoveries, ...(lists.legacyRevelations ?? [])], seen);
 
   return {
     keyDiscoveries,

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1003,6 +1003,7 @@ function normalizeSessionSummaryPayload(
   const record = asRecord(raw);
   const factLists = dedupeSessionSummaryLists({
     keyDiscoveries: normalizeSessionSummaryTextList(record.keyDiscoveries, fallback.keyDiscoveries),
+    legacyRevelations: normalizeSessionSummaryTextList(record.revelations, []),
     characterMoments: normalizeSessionSummaryTextList(record.characterMoments, fallback.characterMoments),
     littleDetails: normalizeSessionSummaryTextList(record.littleDetails, fallback.littleDetails),
     npcUpdates: normalizeSessionSummaryTextList(record.npcUpdates, fallback.npcUpdates),


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2154

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Game session conclusion payloads can still arrive with the legacy `revelations` field instead of `keyDiscoveries`.
- Before this change, the refactor conclude-time normalizer dropped those legacy facts before they could reach persisted session summaries, next-session recap context, or Session History.

## What changed

<!-- List the key changes in this PR. -->

- Restored an optional legacy revelations input on the shared session-summary list dedupe helper.
- Mapped `record.revelations` into that helper from the game conclude payload normalizer so legacy facts are persisted as `keyDiscoveries`.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Game mode session-summary normalization and conclude-time metadata persistence.

Impact areas reviewed:

- `src/engine/modes/game/state/session-summary-normalization.ts`
- `src/features/modes/game/api/game-api.ts`
- Existing downstream defensive reads in GM prompt/session-history paths already normalize stored `revelations` when present.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine helper remains React-free and receives only plain string-list data.
- Feature API stays the persistence adapter that maps raw model payload fields into the engine helper.
- No shared API, Rust, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None. This does not touch `ModeSurface`, `GameSurface`, shared mode UI, Rust command registration, or import modules.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Focused before/after proof: `pnpm vitest run --config scratch/vitest.legacy-revelations.config.ts --reporter=dot`
  - Before the fix, the scratch harness failed because legacy revelations were ignored and `keyDiscoveries` stayed empty.
  - After the fix, 3 rows passed: legacy-only revelations fold into `keyDiscoveries`, duplicate current/legacy discoveries dedupe, and a more-specific `characterMoments` duplicate is not re-added as a broader discovery.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed.
- Bunny review pass completed for the first commit. A follow-up commit removes an internal-only exported type so the unused-code gate can pass.
- Proof-gate helper was unavailable locally: `C:\Users\celia\.codex\tools\marinara-proof-gate.mjs` was not present.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only: restores legacy session-summary field compatibility and does not add a new discoverable feature.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is a React-free normalization/persistence compatibility fix; focused command proof is listed above.
