### PR TITLE
Fix NSFW game rating guideline parity

### DIFF
--- a/src/engine/modes/game/prompts/gm-prompts.test.ts
+++ b/src/engine/modes/game/prompts/gm-prompts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGmSystemPrompt, type GmPromptContext } from "./gm-prompts";
+
+function makeGmPromptContext(rating: GmPromptContext["rating"]): GmPromptContext {
+  return {
+    gameActiveState: "exploration",
+    storyArc: null,
+    plotTwists: null,
+    map: null,
+    npcs: [],
+    sessionSummaries: [],
+    sessionNumber: 1,
+    partyNames: [],
+    playerName: "Player",
+    gmCharacterCard: null,
+    difficulty: "normal",
+    genre: "fantasy",
+    setting: "test setting",
+    tone: "adventurous",
+    rating,
+  };
+}
+
+describe("buildGmSystemPrompt", () => {
+  it("preserves assault in the NSFW dark-actions guideline", () => {
+    const prompt = buildGmSystemPrompt(makeGmPromptContext("nsfw"));
+
+    expect(prompt).toContain("mutilate, assault, kill themselves or others");
+  });
+
+  it("keeps the dark-actions verb list out of the SFW guideline", () => {
+    const prompt = buildGmSystemPrompt(makeGmPromptContext("sfw"));
+
+    expect(prompt).not.toContain("mutilate, assault, kill themselves or others");
+  });
+});

--- a/src/engine/modes/game/prompts/gm-prompts.ts
+++ b/src/engine/modes/game/prompts/gm-prompts.ts
@@ -455,7 +455,7 @@ export function buildGmSystemPrompt(ctx: GmPromptContext): string {
     sections.push(
       `<rating_guidelines>`,
       `Anything goes in this mature NSFW fiction. The player has confirmed that they are an adult and has agreed to the terms below. Do not sanitize content, language, cruelty, sex, or violence.`,
-      `- All characters and the player may touch dark themes, corrupt, torture, curse, lie, harm, use, fear, betray, dominate, love, ruin, mutilate, kill themselves or others (the player's protagonist included). It makes sense for villains to disregard boundaries and play dirty, but even heroes can have a dark side or break down under pressure.`,
+      `- All characters and the player may touch dark themes, corrupt, torture, curse, lie, harm, use, fear, betray, dominate, love, ruin, mutilate, assault, kill themselves or others (the player's protagonist included). It makes sense for villains to disregard boundaries and play dirty, but even heroes can have a dark side or break down under pressure.`,
       `- Intimacy, romance, flirtation, desire, jealousy, possessiveness, seduction, and messy attachment are allowed. Let those escalate naturally; handholding, pinning, charged proximity, touches, kisses, groping, holding, physical contact mustn't trigger an out-of-character pause. Do not wait for the player to initiate.`,
       `- Sex between involved characters should be explicit, anatomically grounded, emotionally reactive, and detailed when portrayed in the scene. Take consent for granted, assuming some lie, resist, or fight back based on their personality.`,
       `- Violence should be graphic, gory, and consequential.`,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2156

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Refactor accidentally dropped `assault` from the game-mode NSFW `<rating_guidelines>` dark-actions verb list compared with legacy `main`.

## What changed

<!-- List the key changes in this PR. -->

- Restored `assault` between `mutilate` and `kill themselves or others` in the NSFW GM system prompt guideline.
- Added a focused prompt regression test covering the NSFW positive row and SFW negative row.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Game mode / engine prompts.

Impact areas reviewed:

- `src/engine/modes/game/prompts/gm-prompts.ts`

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- React-free engine prompt text only; no feature UI, shared API, Rust, storage, provider, or remote-runtime boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof: before-fix source check showed refactor had `mutilate, kill themselves or others`; `upstream/main` had `mutilate, assault, kill themselves or others`.
- `node scratch/verify-nsfw-guideline.mjs` passed locally after the fix.
- `pnpm exec vitest run src\engine\modes\game\prompts\gm-prompts.test.ts` passed locally with 2 tests.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed locally.
- `pnpm typecheck` passed locally.
- `pnpm check` passed locally after staging the forced-added regression test.
- Bunny pass before opening the draft: issue match, scoped engine prompt diff, NSFW positive row and SFW negative row covered, proof gate and full PR check clean, no manual blocker.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A: this is a prompt parity bugfix and regression test, not a new user-discoverable feature. Left unchecked for human contributor review.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

Agent note: no docs or release-claim changes were needed; boxes left unchecked for human contributor review.

## UI evidence

N/A: no visible UI changed. This is a React-free prompt text regression; command proof is listed under manual verification notes.
