### PR TITLE
Fix character display JSON data parsing

### DIFF
--- a/src/shared/lib/character-display.ts
+++ b/src/shared/lib/character-display.ts
@@ -120,7 +120,12 @@ export function getCharacterTitle(character: CharacterDisplayInfo | null | undef
 export function parseCharacterDisplayData(raw: { data: unknown; comment?: string | null }): CharacterDisplayInfo {
   const comment = typeof raw.comment === "string" ? raw.comment.trim() : "";
 
-  const record = raw.data && typeof raw.data === "object" ? (raw.data as Record<string, unknown>) : null;
-  const name = typeof record?.name === "string" && record.name.trim() ? record.name.trim() : "Unknown";
-  return { name, comment };
+  try {
+    const parsed = typeof raw.data === "string" ? JSON.parse(raw.data) : raw.data;
+    const record = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+    const name = typeof record?.name === "string" && record.name.trim() ? record.name.trim() : "Unknown";
+    return { name, comment };
+  } catch {
+    return { name: "Unknown", comment };
+  }
 }


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2161

## Why this change

- `parseCharacterDisplayData` regressed from legacy behavior by only reading `raw.data` when it was already an object. Refactor callers can still receive character `data` as a JSON string, which made valid character names display as `Unknown`.

## What changed

- Restored JSON-string parsing for `raw.data` in `src/shared/lib/character-display.ts`.
- Restored the legacy try/catch fallback so malformed character payloads resolve to `Unknown` instead of throwing.

## Refactor impact

Primary owner:

- Shared character display parsing.

Impact areas reviewed:

- Catalog resources and shared parser consumers in TTS config, tracker display/color metadata, chat surfaces, and setup wizards.

Boundary notes:

- No React, Tauri, remote-runtime, storage, schema, dependency, or provider boundary changes. The change stays in `src/shared/lib`.

Pressure points touched:

- None.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused before-proof: `node scratch\character-display-repro.ts` failed on `json string data name: expected Professor Mari, received Unknown`.
- Focused after-proof: `node scratch\character-display-repro.ts` passed object data, JSON-string data, malformed JSON fallback, and blank-name fallback rows.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- Bunny review pass-for-draft completed locally.
- Workflow-health script and proof-gate script referenced by local guidance were unavailable in this checkout/machine; this is a tooling availability gap, not a product validation failure.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This is shared parser behavior with no direct UI surface change; proof is the focused before/after command harness output in `scratch/`.
