### PR TITLE
Fix character field macro scoping

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -164,6 +164,7 @@ describe("assembleGenerationPrompt character markers", () => {
             name: "Alice",
             description: "Alice description.",
             personality: "Alice personality",
+            scenario: "Alice scenario",
           },
         },
         {
@@ -171,7 +172,8 @@ describe("assembleGenerationPrompt character markers", () => {
           data: {
             name: "Bob",
             description: "Bob description references {{personality}} for {{char}} and {{user}}.",
-            personality: "Bob personality",
+            personality: "Bob personality with {{scenario}}",
+            scenario: "Bob scenario",
           },
         },
       ],
@@ -192,8 +194,9 @@ describe("assembleGenerationPrompt character markers", () => {
 
     const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
     expect(prompt).toContain("Global speaker is Alice.");
-    expect(prompt).toContain("Bob description references Bob personality for Bob and Celia.");
-    expect(prompt).not.toContain("Bob description references Alice personality for Alice and Celia.");
+    expect(prompt).toContain("Bob description references Bob personality with Bob scenario for Bob and Celia.");
+    expect(prompt).not.toContain("Bob description references Alice personality");
+    expect(prompt).not.toContain("Alice scenario for Bob");
   });
 });
 

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -127,6 +127,76 @@ describe("assembleGenerationPrompt depth injection", () => {
   });
 });
 
+describe("assembleGenerationPrompt character markers", () => {
+  it("resolves character field macros against each rendered character in a group", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "system",
+          presetId: "preset-1",
+          role: "system",
+          content: "Global speaker is {{char}}.",
+          enabled: true,
+        },
+        {
+          id: "characters",
+          presetId: "preset-1",
+          identifier: "character",
+          role: "system",
+          enabled: true,
+          markerConfig: { type: "character", characterFields: ["description", "personality"] },
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice description.",
+            personality: "Alice personality",
+          },
+        },
+        {
+          id: "char-2",
+          data: {
+            name: "Bob",
+            description: "Bob description references {{personality}} for {{char}} and {{user}}.",
+            personality: "Bob personality",
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", characterIds: ["char-1", "char-2"], metadata: {} },
+      storedMessages: [],
+      connection: {},
+      request: {},
+      latestUserInput: "",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Global speaker is Alice.");
+    expect(prompt).toContain("Bob description references Bob personality for Bob and Celia.");
+    expect(prompt).not.toContain("Bob description references Alice personality for Alice and Celia.");
+  });
+});
+
 describe("assembleGenerationPrompt game sprites", () => {
   const visuals: VisualAssetGateway = {
     listSprites: async (ownerId) =>

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1147,6 +1147,15 @@ function characterFieldValue(character: GenerationCharacterContext, fieldName: s
   }
 }
 
+function characterMarkerFieldValue(
+  character: GenerationCharacterContext,
+  fieldName: string,
+  macros: MacroContext | null,
+): string {
+  const value = characterFieldValue(character, fieldName);
+  return macros ? resolveMacros(value, macroContextForCharacter(macros, character), { trimResult: false }) : value;
+}
+
 function characterMarkerFields(marker: MarkerConfig | null): string[] {
   const fields = marker?.characterFields?.filter((fieldName) => typeof fieldName === "string" && fieldName.trim());
   return fields?.length ? fields : [...DEFAULT_CHARACTER_MARKER_FIELDS];
@@ -1167,6 +1176,7 @@ function renderCharacters(
   characters: GenerationCharacterContext[],
   wrapFormat: WrapFormat,
   marker: MarkerConfig | null,
+  macros: MacroContext | null = null,
 ): string {
   const fields = characterMarkerFields(marker);
   return characters
@@ -1176,7 +1186,7 @@ function renderCharacters(
           ["Name", character.name],
           ...fields.map((fieldName): [string, string] => [
             CHARACTER_FIELD_LABELS[fieldName] ?? fieldName,
-            characterFieldValue(character, fieldName),
+            characterMarkerFieldValue(character, fieldName, macros),
           ]),
         ],
         wrapFormat,
@@ -2733,10 +2743,11 @@ function sectionContent(args: {
   summary: string | null;
   agentData: Record<string, string>;
   wrapFormat: WrapFormat;
+  macros: MacroContext | null;
 }) {
   switch (args.marker?.type) {
     case "character":
-      return renderCharacters(args.characters, args.wrapFormat, args.marker);
+      return renderCharacters(args.characters, args.wrapFormat, args.marker, args.macros);
     case "persona":
       return renderPersona(args.persona, args.wrapFormat);
     case "dialogue_examples":
@@ -2902,6 +2913,7 @@ export async function assembleGenerationPrompt(
         summary,
         agentData,
         wrapFormat,
+        macros,
       });
       const resolved = cleanPromptText(resolveMacros(rawContent, macros));
       if (!resolved.trim()) continue;

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2915,7 +2915,8 @@ export async function assembleGenerationPrompt(
         wrapFormat,
         macros,
       });
-      const resolved = cleanPromptText(resolveMacros(rawContent, macros));
+      const resolvedContent = marker?.type === "character" ? rawContent : resolveMacros(rawContent, macros);
+      const resolved = cleanPromptText(resolvedContent);
       if (!resolved.trim()) continue;
       if (marker?.type === "chat_summary" && summary?.trim()) insertedSummary = true;
       if (marker?.type === "agent_data") {


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2162

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- In multi-character roleplay prompts, character marker sections rendered all character fields raw and then resolved the whole assembled section with the global first-character macro context. A bare field macro such as `{{personality}}` inside Bob's card could therefore expand to Alice's personality.

## What changed

<!-- List the key changes in this PR. -->

- Resolve character marker field values with the existing per-character macro context before the later global prompt-section macro pass.
- Added a focused prompt assembly regression row that proves Bob's card-owned `{{personality}}`, nested `{{scenario}}`, and `{{char}}` resolve against Bob while an ordinary preset section `{{char}}` still resolves against the global first character.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Engine generation.

Impact areas reviewed:

- Character prompt marker rendering in `assembleGenerationPrompt`.
- Existing character depth-prompt macro scoping helper path.
- Global preset-section macro resolution boundary.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Stays inside `src/engine`; no React, shared API, Tauri, storage, provider, or remote-runtime boundary changes.
- No schema, dependency, version, import/export, or persisted-data changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `src/engine/generation/prompt-assembly.ts` character marker rendering only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex before-fix repro: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts -t "resolves character field macros" --reporter=verbose` failed because Bob's rendered description contained Alice's personality.
- Codex after-fix original repro: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts -t "resolves character field macros" --reporter=verbose` passed.
- Codex adjacent check: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts --reporter=verbose` passed, including the nested field macro row added after Bunny's first review.
- Codex lane check: `pnpm typecheck` passed.
- Codex baseline: `pnpm check` passed.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny: initial nested-field finding was addressed in commit `56a17402`; current-head Bunny review reports no actionable defects.
- CodeRabbit: review command completed on the current head and the status context is success.
- No manual UI verification needed for the core claim; this is React-free prompt assembly behavior.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new user-discoverable feature, setting, mode, panel, import path, agent, media capability, or tool.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A: no visible UI changed. The affected behavior is generated prompt text from React-free engine prompt assembly; proof is the before/after command output above.
