### PR TITLE
Fix Secret Plot turn-only reroll memory

### DIFF
--- a/src/engine/generation/agent-memory-runtime.ts
+++ b/src/engine/generation/agent-memory-runtime.ts
@@ -3,6 +3,12 @@ import type { StorageGateway } from "../capabilities/storage";
 import { normalizeSecretPlotSceneDirections, normalizeStringArray } from "./agent-normalizers";
 import { isRecord, nowIso, readString, type JsonRecord } from "./runtime-records";
 
+export type SecretPlotRerollMode = "full" | "turn_only";
+
+interface SecretPlotAgentMemoryPersistOptions {
+  rerollMode?: SecretPlotRerollMode | null;
+}
+
 export async function loadAgentMemory(
   storage: StorageGateway,
   agentId: string,
@@ -35,13 +41,14 @@ export async function persistSecretPlotAgentMemory(
   storage: StorageGateway,
   chatId: string,
   results: AgentResult[],
+  options: SecretPlotAgentMemoryPersistOptions = {},
 ): Promise<void> {
   const result = results.find((entry) => entry.success && entry.type === "secret_plot" && isRecord(entry.data));
   if (!result || !isRecord(result.data)) return;
   const agentConfigId = result.agentId;
   const data = result.data;
 
-  if (data.overarchingArc) {
+  if (data.overarchingArc && options.rerollMode !== "turn_only") {
     await setAgentMemoryValue(storage, agentConfigId, chatId, "overarchingArc", data.overarchingArc);
   }
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -17,7 +17,7 @@ import {
   assertChatHasActiveCharacters,
   assertRequestedCharacterIsActive,
 } from "./active-characters";
-import { persistSecretPlotAgentMemory } from "./agent-memory-runtime";
+import { persistSecretPlotAgentMemory, type SecretPlotRerollMode } from "./agent-memory-runtime";
 import { createGenerationAgentRuntime } from "./agent-runner";
 import { consumePendingConnectedInfluences, persistConnectedCommandTags } from "./connected-commands";
 import { fitMessagesToContextWindow } from "./context-window";
@@ -1621,9 +1621,10 @@ async function persistSecretPlotAgentMemorySafely(
   storage: StorageGateway,
   chatId: string,
   results: AgentResult[],
+  options: { rerollMode?: SecretPlotRerollMode | null } = {},
 ): Promise<void> {
   try {
-    await persistSecretPlotAgentMemory(storage, chatId, results);
+    await persistSecretPlotAgentMemory(storage, chatId, results, options);
   } catch (error) {
     console.warn("[generation] secret plot memory persist failed", error);
   }
@@ -2332,6 +2333,11 @@ function retryBypassesCustomAgentActivation(input: RetryAgentsInput): boolean {
   return boolish(parseRecord(input.options).bypassActivation, false);
 }
 
+function secretPlotRerollMode(input: RetryAgentsInput): SecretPlotRerollMode | null {
+  const mode = readString(input.options?.secretPlotRerollMode).trim();
+  return mode === "full" || mode === "turn_only" ? mode : null;
+}
+
 async function commitVisibleTrackerSnapshotSafely(
   storage: StorageGateway,
   chatId: string,
@@ -2456,7 +2462,9 @@ async function runGenerationAgentsForTarget(args: {
   if (target) {
     await persistTrackerSnapshotSafely(deps.storage, chatId, target, finalResults, retryBaseline, mainResponse);
   }
-  await persistSecretPlotAgentMemorySafely(deps.storage, chatId, finalResults);
+  await persistSecretPlotAgentMemorySafely(deps.storage, chatId, finalResults, {
+    rerollMode: secretPlotRerollMode(input),
+  });
   await persistAgentResults(deps.storage, chatId, target ? readString(target.id) || null : null, finalResults);
 
   const events: GenerationEvent[] = [];


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2165

## Why this change

- Secret Plot's "re-roll this turn only" action promised to preserve the long-running arc, but the refactor engine ignored `secretPlotRerollMode` and always persisted a new `overarchingArc`.

## What changed

- Thread `secretPlotRerollMode` from targeted agent retry into Secret Plot agent-memory persistence.
- Skip only the `overarchingArc` write when the reroll mode is `turn_only`, while keeping scene directions, fulfilled-direction history, pacing, and stale detection updates.
- Preserve existing behavior for full rerolls and normal Secret Plot persistence.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Secret Plot targeted retry options
- Secret Plot agent-memory persistence
- Full reroll/default persistence behavior

Boundary notes:

- The fix stays in `src/engine`; no React UI, shared API wrapper, Rust, storage schema, dependency, or remote-runtime changes.

Pressure points touched:

- Secret Plot agent-memory persistence in `src/engine/generation/agent-memory-runtime.ts`
- Targeted retry persistence wiring in `src/engine/generation/start-generation.ts`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Before fix, focused scratch Vitest proof failed because `turn_only` overwrote the existing `overarchingArc`.
- After fix, `pnpm exec vitest run --config scratch\vitest.issue-2165.config.ts` passed 3 cases: `turn_only` preserves the arc while refreshing per-turn memory, `full` replaces the arc, and ordinary persistence replaces the arc.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\issue-2165-bugfix-verification.json` passed.
- Bunny review pass completed on the current diff before opening this PR.
- No human-only verification is currently blocking the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing Secret Plot behavior; no new user-discoverable capability.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This is React-free engine persistence behavior; the core proof is the before/after scratch harness plus full repo validation.
