### PR TITLE
Fix built-in agent interval gating

### DIFF
--- a/src/engine/generation/agent-runner.test.ts
+++ b/src/engine/generation/agent-runner.test.ts
@@ -34,11 +34,41 @@ function storageWithAgentRuns(agentRuns: unknown[]): StorageGateway {
   } as unknown as StorageGateway;
 }
 
+function storageWithAgents(agents: Array<Record<string, unknown>>, agentRuns: unknown[]): StorageGateway {
+  const connections = [{ id: "conn-1", provider: "mock", model: "mock-model" }];
+  return {
+    async list(collection: string) {
+      if (collection === "agents") return agents;
+      if (collection === "connections") return connections;
+      if (collection === "agent-runs") return agentRuns;
+      if (collection === "tools") return [];
+      if (collection === "lorebooks") return [];
+      if (collection === "agent-memory") return [];
+      return [];
+    },
+    async get() {
+      return null;
+    },
+    async listLorebookEntries() {
+      return [];
+    },
+  } as unknown as StorageGateway;
+}
+
 function llmWithDirectorNote(calls: { count: number }): LlmGateway {
   return {
     async *stream() {
       calls.count += 1;
       yield { type: "token", text: "[Director's note: Take the reroll in a new direction.]" };
+    },
+  } as unknown as LlmGateway;
+}
+
+function llmWithJsonAgentResponse(calls: { count: number }): LlmGateway {
+  return {
+    async *stream() {
+      calls.count += 1;
+      yield { type: "token", text: "{}" };
     },
   } as unknown as LlmGateway;
 }
@@ -54,6 +84,24 @@ const storedMessages = [
   { id: "user-1", role: "user", content: "Start." },
   { id: "assistant-1", role: "assistant", content: "First guided reply." },
 ];
+const cardCharacter = {
+  id: "char-1",
+  name: "Ari",
+  description: "Careful observer.",
+  avatarUrl: "",
+  avatarFilePath: "",
+  avatarFilename: "",
+  personality: "",
+  scenario: "",
+  creatorNotes: "",
+  systemPrompt: "",
+  backstory: "",
+  appearance: "",
+  mesExample: "",
+  firstMes: "",
+  postHistoryInstructions: "",
+  tags: [],
+};
 
 describe("createGenerationAgentRuntime regeneration cadence", () => {
   it("reruns Narrative Director when its last successful interval run is on the regenerated message", async () => {
@@ -126,5 +174,217 @@ describe("createGenerationAgentRuntime regeneration cadence", () => {
 
     expect(calls.count).toBe(0);
     expect(runtime.preInjections).toEqual([]);
+  });
+});
+
+describe("createGenerationAgentRuntime built-in post-processing cadence", () => {
+  it("skips Automated Chat Summary until enough user messages pass", async () => {
+    const calls = { count: 0 };
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgents(
+          [
+            {
+              id: "chat-summary",
+              type: "chat-summary",
+              name: "Automated Chat Summary",
+              enabled: true,
+              phase: "post_processing",
+              settings: { runInterval: 5 },
+            },
+          ],
+          [
+            {
+              chatId: "chat-1",
+              messageId: "user-2",
+              agentType: "chat-summary",
+              success: true,
+              createdAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        ),
+        llm: llmWithJsonAgentResponse(calls),
+        integrations,
+      },
+      {
+        chat: { ...chat, metadata: { activeAgentIds: ["chat-summary"] } },
+        connection,
+        storedMessages: [
+          { id: "user-1", role: "user", content: "Start." },
+          { id: "assistant-1", role: "assistant", content: "Opening." },
+          { id: "user-2", role: "user", content: "Continue." },
+          { id: "assistant-2", role: "assistant", content: "Reply." },
+          { id: "user-3", role: "user", content: "Only one new user message." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: "Earlier summary.",
+      },
+    );
+
+    await runtime.runPost("Latest assistant response.");
+
+    expect(calls.count).toBe(0);
+  });
+
+  it("runs Automated Chat Summary when the user-message interval is reached", async () => {
+    const calls = { count: 0 };
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgents(
+          [
+            {
+              id: "chat-summary",
+              type: "chat-summary",
+              name: "Automated Chat Summary",
+              enabled: true,
+              phase: "post_processing",
+              settings: { runInterval: 5 },
+            },
+          ],
+          [
+            {
+              chatId: "chat-1",
+              messageId: "user-1",
+              agentType: "chat-summary",
+              success: true,
+              createdAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        ),
+        llm: llmWithJsonAgentResponse(calls),
+        integrations,
+      },
+      {
+        chat: { ...chat, metadata: { activeAgentIds: ["chat-summary"] } },
+        connection,
+        storedMessages: [
+          { id: "user-1", role: "user", content: "Start." },
+          { id: "assistant-1", role: "assistant", content: "Opening." },
+          { id: "user-2", role: "user", content: "Beat 2." },
+          { id: "assistant-2", role: "assistant", content: "Reply 2." },
+          { id: "user-3", role: "user", content: "Beat 3." },
+          { id: "assistant-3", role: "assistant", content: "Reply 3." },
+          { id: "user-4", role: "user", content: "Beat 4." },
+          { id: "assistant-4", role: "assistant", content: "Reply 4." },
+          { id: "user-5", role: "user", content: "Beat 5." },
+          { id: "assistant-5", role: "assistant", content: "Reply 5." },
+          { id: "user-6", role: "user", content: "Beat 6." },
+        ],
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: "Earlier summary.",
+      },
+    );
+
+    await runtime.runPost("Latest assistant response.");
+
+    expect(calls.count).toBe(1);
+  });
+
+  it("skips Card Evolution Auditor until enough assistant messages pass", async () => {
+    const calls = { count: 0 };
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgents(
+          [
+            {
+              id: "card-evolution-auditor",
+              type: "card-evolution-auditor",
+              name: "Card Evolution Auditor",
+              enabled: true,
+              phase: "post_processing",
+              settings: { runInterval: 8 },
+            },
+          ],
+          [
+            {
+              chatId: "chat-1",
+              messageId: "assistant-1",
+              agentType: "card-evolution-auditor",
+              success: true,
+              createdAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        ),
+        llm: llmWithJsonAgentResponse(calls),
+        integrations,
+      },
+      {
+        chat: { ...chat, metadata: { activeAgentIds: ["card-evolution-auditor"] } },
+        connection,
+        storedMessages: [
+          { id: "user-1", role: "user", content: "Start." },
+          { id: "assistant-1", role: "assistant", content: "Opening." },
+          { id: "user-2", role: "user", content: "Continue." },
+          { id: "assistant-2", role: "assistant", content: "Only one new assistant message." },
+        ],
+        characters: [cardCharacter],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    await runtime.runPost("Latest assistant response.");
+
+    expect(calls.count).toBe(0);
+  });
+
+  it("runs Card Evolution Auditor when the assistant-message interval is reached by the pending response", async () => {
+    const calls = { count: 0 };
+    const messages = [
+      { id: "user-1", role: "user", content: "Start." },
+      { id: "assistant-1", role: "assistant", content: "Opening." },
+    ];
+    for (let index = 2; index <= 8; index += 1) {
+      messages.push(
+        { id: `user-${index}`, role: "user", content: `Beat ${index}.` },
+        { id: `assistant-${index}`, role: "assistant", content: `Reply ${index}.` },
+      );
+    }
+
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgents(
+          [
+            {
+              id: "card-evolution-auditor",
+              type: "card-evolution-auditor",
+              name: "Card Evolution Auditor",
+              enabled: true,
+              phase: "post_processing",
+              settings: { runInterval: 8 },
+            },
+          ],
+          [
+            {
+              chatId: "chat-1",
+              messageId: "assistant-1",
+              agentType: "card-evolution-auditor",
+              success: true,
+              createdAt: "2026-06-01T00:00:00.000Z",
+            },
+          ],
+        ),
+        llm: llmWithJsonAgentResponse(calls),
+        integrations,
+      },
+      {
+        chat: { ...chat, metadata: { activeAgentIds: ["card-evolution-auditor"] } },
+        connection,
+        storedMessages: messages,
+        characters: [cardCharacter],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    await runtime.runPost("Latest assistant response.");
+
+    expect(calls.count).toBe(1);
   });
 });

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -132,11 +132,18 @@ interface ResolvedAgentsResult {
 const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const DIRECTOR_AGENT_TYPE = "director";
 const ILLUSTRATOR_AGENT_TYPE = "illustrator";
+const CARD_EVOLUTION_AUDITOR_AGENT_TYPE = "card-evolution-auditor";
+const CHAT_SUMMARY_AGENT_TYPE = "chat-summary";
 const HAPTIC_AGENT_TYPE = "haptic";
 const KNOWLEDGE_RETRIEVAL_AGENT_TYPE = "knowledge-retrieval";
 const KNOWLEDGE_ROUTER_AGENT_TYPE = "knowledge-router";
 const KNOWLEDGE_AGENT_TYPES = new Set([KNOWLEDGE_RETRIEVAL_AGENT_TYPE, KNOWLEDGE_ROUTER_AGENT_TYPE]);
-const ASSISTANT_INTERVAL_AGENT_TYPES = new Set([DIRECTOR_AGENT_TYPE, ILLUSTRATOR_AGENT_TYPE]);
+const ASSISTANT_INTERVAL_AGENT_TYPES = new Set([
+  DIRECTOR_AGENT_TYPE,
+  ILLUSTRATOR_AGENT_TYPE,
+  CARD_EVOLUTION_AUDITOR_AGENT_TYPE,
+]);
+const USER_INTERVAL_AGENT_TYPES = new Set([CHAT_SUMMARY_AGENT_TYPE]);
 const STATIC_CONTEXT_INJECTION_AGENT_TYPES = new Set<string>([BUILT_IN_AGENT_IDS.HTML]);
 const TRACKER_AGENT_TYPES = new Set(
   BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker").map((agent) => agent.id),
@@ -783,15 +790,17 @@ function automaticIntervalGate(
   builtInAgent: boolean,
 ): AutomaticIntervalGate | null {
   if (input.agentTypes && input.agentTypes.size > 0) return null;
-  if (builtInAgent && ASSISTANT_INTERVAL_AGENT_TYPES.has(type)) {
-    const fallback = positiveInteger(BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[type], 5, MAX_ASSISTANT_RUN_INTERVAL);
-    const runInterval = positiveInteger(settings.runInterval, fallback, MAX_ASSISTANT_RUN_INTERVAL);
+  if (builtInAgent && (ASSISTANT_INTERVAL_AGENT_TYPES.has(type) || USER_INTERVAL_AGENT_TYPES.has(type))) {
+    const messageRole: AutomaticIntervalMessageRole = USER_INTERVAL_AGENT_TYPES.has(type) ? "user" : "assistant";
+    const maxInterval = messageRole === "user" ? MAX_CUSTOM_AGENT_USER_RUN_INTERVAL : MAX_ASSISTANT_RUN_INTERVAL;
+    const fallback = positiveInteger(BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[type], 5, maxInterval);
+    const runInterval = positiveInteger(settings.runInterval, fallback, maxInterval);
     return runInterval > 1
       ? {
           agentId: id,
           agentType: type,
-          messageRole: "assistant",
-          includePendingMessage: true,
+          messageRole,
+          includePendingMessage: messageRole === "assistant",
           runInterval,
         }
       : null;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2163

## Why this change

- Automated Chat Summary and Card Evolution Auditor still exposed run interval controls, but the refactor branch no longer built interval gates for those built-ins. That let both post-processing agents call the LLM every turn instead of waiting for their configured cadence.

## What changed

- Restored built-in interval-gate metadata for `chat-summary` and `card-evolution-auditor`.
- Kept chat summary on user-message cadence and card evolution auditor on assistant-message cadence.
- Added focused engine tests for skip/run boundaries on both built-ins, plus kept existing director regeneration cadence coverage intact.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- `src/engine/generation/agent-runner.ts`
- `src/engine/generation/agent-runner.test.ts`

Boundary notes:

- React-free engine behavior only. No feature UI, shared API, Rust, storage schema, dependency, or remote-runtime boundary changes.
- The issue's secondary `summaryContextSize` parity note is intentionally out of scope for this cadence fix.

Pressure points touched:

- Post-processing agent resolution and automatic interval gating.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the bug with a focused Vitest regression before the production fix: `chat-summary` and `card-evolution-auditor` each called the mock LLM once when they should have been suppressed.
- `pnpm exec vitest run src\engine\generation\agent-runner.test.ts` passed after the fix: 6 tests passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\issue-2163-bugfix-verification.json` passed.
- Bunny review pass: issue match, proof quality, boundary, diff scope, and repo gates are clean for draft PR.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal cadence bugfix for existing built-in agents; no new discoverable behavior or UI surface.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This is React-free engine cadence behavior with no visible UI state; proof is the before/after command evidence above.
