### PR TITLE
Fix legacy context injection normalization

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -6,8 +6,10 @@
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2170"
   },
   "pr": {
-    "number": null,
-    "url": null
+    "number": 2246,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2246",
+    "base": "refactor",
+    "draft": true
   },
   "coreClaim": "Legacy bare-string context injections are preserved as prose-guardian injections in engine generation normalization.",
   "preflight": {
@@ -86,7 +88,7 @@
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": false,
     "claimBoundariesProven": true,
-    "notes": "Focused repro passed after the fix, edge rows passed, proof gate passed, pnpm typecheck passed, and pnpm check passed. PR acceptance remains pending Bunny, commit, draft PR health, CI, and CodeRabbit."
+    "notes": "Focused repro passed after the fix, edge rows passed, proof gate passed, pnpm typecheck passed, and pnpm check passed. PR acceptance remains pending current-head Bunny, CI, and CodeRabbit."
   },
   "bunny": {
     "status": "pass",

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -36,13 +36,15 @@
     "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.",
     "focusedProof": [
       "Before fix, the focused Vitest test failed because the regenerate patch dropped the legacy prose-guardian row.",
-      "After fix, the focused Vitest test passed and preserved legacy string plus current object rows while appending the new override."
+      "After fix, the focused Vitest test passed and preserved legacy string plus current object rows while appending the new override.",
+      "After review follow-up, the focused Vitest suite passed with a direct target lookup fallback row."
     ],
     "edgeCases": [
       "Existing object-shaped injection remains preserved while merging a new override.",
-      "Blank legacy string entries are skipped instead of becoming empty prose-guardian injections."
+      "Blank legacy string entries are skipped instead of becoming empty prose-guardian injections.",
+      "Regenerate merge falls back to direct target lookup when the loaded history list does not contain the target message extra."
     ],
-    "visualProof": "Non-UI logic proof captured as raw Vitest JSON output in scratch/issue-2170-before.json and scratch/issue-2170-after.json."
+    "visualProof": "Non-UI logic proof captured as raw Vitest JSON output in scratch/issue-2170-before.json, scratch/issue-2170-after.json, and scratch/issue-2170-after-review.json."
   },
   "manualBlockers": [],
   "riskClaimMatrix": {
@@ -59,7 +61,8 @@
     ],
     "positiveRowsTested": [
       "legacy bare string plus new object override merge",
-      "existing object-shaped injection plus new object override merge"
+      "existing object-shaped injection plus new object override merge",
+      "legacy bare string merge when the regenerated target extra is recovered by direct lookup fallback"
     ],
     "negativeRowsTested": [
       "blank legacy string entry is skipped"

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,109 +1,95 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2159,
-    "title": "[Issue]: Chub card import merge drops most field overrides and flips extensions precedence",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2159"
+    "number": 2170,
+    "title": "[Issue]: Bare-string context injections are silently dropped by the engine normalizer (legacy-format migration lost)",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2170"
   },
   "pr": {
-    "number": 2237,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2237",
-    "base": "refactor",
-    "draft": true
+    "number": null,
+    "url": null
   },
-  "coreClaim": "Chub PNG imports overlay legacy-supported Chub detail fields onto embedded PNG card data and Chub detail extension keys win.",
+  "coreClaim": "Legacy bare-string context injections are preserved as prose-guardian injections in engine generation normalization.",
   "preflight": {
     "noAssociatedPr": true,
     "issueAssigned": true,
-    "evidence": "gh PR search for issue 2159 returned no matches; timeline showed no linked PR; local branch/worktree search found no 2159 branch; issue is assigned to cha1latte."
+    "evidence": "gh PR search for issue 2170 returned no matches; keyword search found only older adjacent agent PRs; local branch/worktree search found no 2170 branch; issue assigned to @me."
   },
   "dependencies": {
     "installedFromLockfile": true,
-    "evidence": "pnpm install --frozen-lockfile completed in the issue worktree and did not change package.json or pnpm-lock.yaml."
+    "evidence": "pnpm install --frozen-lockfile completed in the issue worktree and did not change dependency declarations."
   },
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "command": "pnpm exec vitest run --config scratch/vitest.issue2159.config.ts --reporter=verbose",
-    "beforeSummary": "Before the fix, the focused merge proof failed because the embedded PNG name stayed `Embedded Name` instead of being overlaid with `Chub Name`."
+    "method": "Vitest regression test for regenerate merge over legacy string contextInjections.",
+    "evidence": [
+      "scratch/issue-2170-before.json: failing test shows only the new secret-plot row remains and the legacy prose-guardian row is missing."
+    ]
   },
   "verification": {
     "originalReproPassed": true,
-    "originalReproCommand": "pnpm exec vitest run --config scratch/vitest.issue2159.config.ts --reporter=verbose",
-    "originalReproEvidence": "Scratch Vitest passed 5 rows after the fix: Chub detail field/extension precedence, top-level character JSON precedence, no-detail fallback, blank detail string negative control, and existing embedded lorebook preservation.",
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
     "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.",
     "focusedProof": [
-      "Before fix, the scratch merge proof failed on the original repro because embedded PNG fields won.",
-      "After fix, the original Chub detail field and extension precedence row passed.",
-      "After fix, the top-level character JSON row passed.",
-      "After fix, null detail still returns the parsed PNG unchanged.",
-      "After fix, blank detail strings do not erase embedded PNG text fields.",
-      "After fix, existing embedded lorebooks remain preserved."
+      "Before fix, the focused Vitest test failed because the regenerate patch dropped the legacy prose-guardian row.",
+      "After fix, the focused Vitest test passed and preserved legacy string plus current object rows while appending the new override."
     ],
     "edgeCases": [
-      "Top-level/non-V2 character JSON receives the same detail precedence.",
-      "Missing detail leaves the parsed PNG payload unchanged.",
-      "Blank detail strings do not erase embedded text fields.",
-      "Existing embedded PNG lorebook is not overwritten by detail lorebook."
+      "Existing object-shaped injection remains preserved while merging a new override.",
+      "Blank legacy string entries are skipped instead of becoming empty prose-guardian injections."
     ],
-    "visualProof": "Non-UI logic proof captured as raw verification output in scratch/issue2159-proof-output.txt."
+    "visualProof": "Non-UI logic proof captured as raw Vitest JSON output in scratch/issue-2170-before.json and scratch/issue-2170-after.json."
   },
+  "manualBlockers": [],
   "riskClaimMatrix": {
-    "coreClaim": "Chub PNG imports overlay legacy-supported Chub detail fields onto embedded PNG card data and Chub detail extension keys win.",
-    "riskType": "legacy import parity",
+    "coreClaim": "Legacy bare-string context injections are preserved as prose-guardian injections in engine generation normalization.",
+    "riskType": "legacy-format compatibility regression",
     "entrypoints": [
-      "BotBrowserView PNG download import path for chub/chartavern sources",
-      "mergeCharacterDetailIntoCharacterJson helper"
+      "startGeneration regenerate path merging existing message extra.contextInjections"
     ],
     "currentPathsOrFormats": [
-      "chara_card_v2/chara_card_v3 data object payloads",
-      "top-level character JSON payloads",
-      "CardDetail fields from provider.fetchDetail/detail view state",
-      "BrowseCard summary name/creator/tags passed into import detail"
+      "object entries with agentType/text"
     ],
     "legacyPathsOrFormats": [
-      "main packages/client/src/lib/chub-character-card.ts mergeChubDetailIntoCharacterJson"
+      "bare string entries meaning prose-guardian text"
     ],
     "positiveRowsTested": [
-      "V2 card with stale embedded values and fresh Chub detail values",
-      "Top-level card with stale embedded values and fresh detail values"
+      "legacy bare string plus new object override merge",
+      "existing object-shaped injection plus new object override merge"
     ],
     "negativeRowsTested": [
-      "No detail available leaves parsed PNG data unchanged",
-      "Blank detail strings do not erase embedded text fields",
-      "Existing embedded lorebook is preserved instead of overwritten"
+      "blank legacy string entry is skipped"
     ],
     "groundTruthFacts": [
       {
-        "fact": "Legacy merged description, personality, scenario, first_mes, mes_example, creator_notes, system_prompt, post_history_instructions, character_version, name, creator, tags, alternate_greetings, and detail-winning extensions.",
+        "fact": "Legacy bare string context injection entries map to prose-guardian injections.",
         "sourceType": "derived",
-        "evidence": "git show origin/main:packages/client/src/lib/chub-character-card.ts"
+        "evidence": "Issue #2170 regression notes cite main packages/server/src/routes/generate/agent-normalizers.ts mapping string entries to prose-guardian objects."
       },
       {
-        "fact": "Refactor only merged system_prompt, post_history_instructions, character_version, character_book, and embedded-winning extensions before the fix.",
+        "fact": "The refactor UI display normalizer still treats string entries as prose-guardian injections.",
         "sourceType": "measured",
-        "evidence": "src/features/shell/bot-browser/lib/character-detail-merge.ts before the production patch and the failing scratch proof."
+        "evidence": "src/features/modes/roleplay/components/ContextInjectionPanel.tsx normalizes string entries to { agentType: 'prose-guardian', text }."
       }
     ],
-    "userActionCopy": "No user-facing copy or destructive-action copy changed.",
+    "userActionCopy": [],
     "manualBlockers": []
   },
-  "manualBlockers": [],
   "notes": [
-    "UI/browser proof is not applicable because the bug is pure import merge logic; raw command output is captured in scratch/issue2159-proof-output.txt.",
-    "Proof gate script unavailable: C:/Users/celia/.codex/tools/marinara-proof-gate.mjs was not present on this machine."
+    "UI/browser proof is not applicable because the bug is pure engine normalization logic.",
+    "pnpm typecheck also passed before the full baseline."
   ],
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,
-    "prWouldBeAccepted": true,
+    "prWouldBeAccepted": false,
     "claimBoundariesProven": true,
-    "notes": "Focused repro passed after the fix, edge rows passed, pnpm typecheck passed, and pnpm check passed."
+    "notes": "Focused repro passed after the fix, edge rows passed, proof gate passed, pnpm typecheck passed, and pnpm check passed. PR acceptance remains pending Bunny, commit, draft PR health, CI, and CodeRabbit."
   },
   "bunny": {
     "status": "pass",
-    "evidence": "Issue match is direct, import parity risk matrix is covered with positive and negative rows including the blank-string erosion case, diff is focused to the merge helper plus import call-site summary wiring, no dependencies/version/schema/auth/storage/prompt paths changed, and pnpm check passed. Optional proof-gate script is unavailable on this machine and recorded in notes."
+    "evidence": "Issue match is direct, diff is limited to src/engine normalize/regen merge behavior plus a focused regression test and verification artifact, git diff --check passed, proof gate passed, pnpm typecheck passed, and pnpm check passed. No dependency, schema, auth, storage, release, or prompt-pipeline scope expansion."
   }
 }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -279,4 +279,54 @@ describe("startGeneration context injection compatibility", () => {
       },
     });
   });
+
+  it("falls back to direct target lookup when regenerated message extra is not in loaded history", async () => {
+    const capture: { extraPatches: Array<{ messageId: string; patch: Record<string, unknown> }> } = {
+      extraPatches: [],
+    };
+    const deps = createDeps("idle", { capture });
+    const target = {
+      id: "assistant-1",
+      chatId: "chat-1",
+      role: "assistant",
+      characterId: "char-1",
+      content: "Previous response.",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      extra: {
+        contextInjections: ["Legacy prose guidance."],
+      },
+    };
+    const originalGet = deps.storage.get;
+    let targetReads = 0;
+    deps.storage.get = async <T = unknown>(
+      entity: StorageEntity,
+      id: string,
+      options?: Parameters<StorageGateway["get"]>[2],
+    ): Promise<T | null> => {
+      if (entity === "messages" && id === "assistant-1") {
+        targetReads += 1;
+        return (targetReads >= 3 ? target : null) as T | null;
+      }
+      return originalGet<T>(entity, id, options);
+    };
+
+    for await (const event of startGeneration(deps, {
+      chatId: "chat-1",
+      message: "Regenerate that.",
+      regenerateMessageId: "assistant-1",
+      agentInjectionOverrides: [{ agentType: "secret-plot", text: "New secret plot guidance." }],
+    })) {
+      if (event.type === "done") break;
+    }
+
+    expect(capture.extraPatches.at(-1)).toMatchObject({
+      messageId: "assistant-1",
+      patch: {
+        contextInjections: [
+          { agentType: "prose-guardian", text: "Legacy prose guidance." },
+          { agentType: "secret-plot", text: "New secret plot guidance." },
+        ],
+      },
+    });
+  });
 });

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -25,7 +25,7 @@ function scheduleFor(status: "idle" | "dnd" | "offline"): WeekSchedule {
 
 function createStore(
   status: "idle" | "dnd" | "offline",
-  options: { secondStatus?: "idle" | "dnd" | "offline" } = {},
+  options: { secondStatus?: "idle" | "dnd" | "offline"; messages?: Record<string, Record<string, unknown>> } = {},
 ): Store {
   const characterIds = options.secondStatus ? ["char-1", "char-2"] : ["char-1"];
   return {
@@ -50,10 +50,14 @@ function createStore(
     connections: {
       "conn-1": { id: "conn-1", provider: "test", model: "test-model" },
     },
+    messages: options.messages,
   };
 }
 
-function createStorage(store: Store): StorageGateway {
+function createStorage(
+  store: Store,
+  capture: { extraPatches?: Array<{ messageId: string; patch: Record<string, unknown> }> } = {},
+): StorageGateway {
   return {
     async list<T = unknown>(entity: StorageEntity): Promise<T[]> {
       return Object.values(store[entity] ?? {}) as T[];
@@ -94,6 +98,7 @@ function createStorage(store: Store): StorageGateway {
       return { deleted: true };
     },
     async patchChatMessageExtra<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T> {
+      capture.extraPatches?.push({ messageId, patch });
       return { id: messageId, extra: patch } as T;
     },
     async addChatMessageSwipe<T = unknown>(): Promise<T> {
@@ -128,7 +133,14 @@ function createStorage(store: Store): StorageGateway {
   };
 }
 
-function createDeps(status: "idle" | "dnd" | "offline", options: { secondStatus?: "idle" | "dnd" | "offline" } = {}) {
+function createDeps(
+  status: "idle" | "dnd" | "offline",
+  options: {
+    secondStatus?: "idle" | "dnd" | "offline";
+    messages?: Record<string, Record<string, unknown>>;
+    capture?: { extraPatches?: Array<{ messageId: string; patch: Record<string, unknown> }> };
+  } = {},
+) {
   const llm: LlmGateway = {
     async complete() {
       return "";
@@ -141,7 +153,7 @@ function createDeps(status: "idle" | "dnd" | "offline", options: { secondStatus?
     },
   };
   return {
-    storage: createStorage(createStore(status, options)),
+    storage: createStorage(createStore(status, options), options.capture),
     integrations: {} as IntegrationGateway,
     llm,
   };
@@ -218,5 +230,53 @@ describe("startGeneration conversation availability delays", () => {
     } finally {
       random.mockRestore();
     }
+  });
+});
+
+describe("startGeneration context injection compatibility", () => {
+  it("keeps legacy bare-string context injections when merging regenerated agent injections", async () => {
+    const capture: { extraPatches: Array<{ messageId: string; patch: Record<string, unknown> }> } = {
+      extraPatches: [],
+    };
+    const deps = createDeps("idle", {
+      capture,
+      messages: {
+        "assistant-1": {
+          id: "assistant-1",
+          chatId: "chat-1",
+          role: "assistant",
+          characterId: "char-1",
+          content: "Previous response.",
+          createdAt: "2026-06-01T00:00:00.000Z",
+          extra: {
+            contextInjections: [
+              "Legacy prose guidance.",
+              { agentType: "memory-recall", agentName: "Memory Recall", text: "Remembered facts." },
+              "   ",
+            ],
+          },
+        },
+      },
+    });
+
+    for await (const event of startGeneration(deps, {
+      chatId: "chat-1",
+      message: "Regenerate that.",
+      regenerateMessageId: "assistant-1",
+      agentInjectionOverrides: [{ agentType: "secret-plot", text: "New secret plot guidance." }],
+    })) {
+      if (event.type === "done") break;
+    }
+
+    expect(capture.extraPatches.at(-1)).toMatchObject({
+      messageId: "assistant-1",
+      patch: {
+        contextInjections: [
+          { agentType: "prose-guardian", text: "Legacy prose guidance." },
+          { agentType: "memory-recall", agentName: "Memory Recall", text: "Remembered facts." },
+          { agentType: "secret-plot", text: "New secret plot guidance." },
+        ],
+      },
+    });
   });
 });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1047,13 +1047,18 @@ function messagesBeforeRegenerationTarget(
   return targetIndex >= 0 ? storedMessages.slice(0, targetIndex) : storedMessages;
 }
 
-function regenerationTargetExtra(
+async function regenerationTargetExtra(
+  storage: StorageGateway,
+  chatId: string,
   storedMessages: JsonRecord[],
   regenerateMessageId: string | null | undefined,
-): unknown {
+): Promise<unknown> {
   const targetId = readString(regenerateMessageId).trim();
   if (!targetId) return undefined;
-  return storedMessages.find((message) => readString(message.id) === targetId)?.extra;
+  const loadedTarget = storedMessages.find((message) => readString(message.id) === targetId);
+  if (loadedTarget) return loadedTarget.extra;
+  const target = await loadChatMessage(storage, targetId).catch(() => null);
+  return targetBelongsToChat(target, chatId) ? target.extra : undefined;
 }
 
 function roleplayIndividualGroupCharacterIds(chat: JsonRecord): string[] {
@@ -2906,7 +2911,7 @@ export async function* startGeneration(
           promptSnapshot,
           spriteExpressions: preSaveSpriteExpressions,
           contextInjections: runtime?.preInjections ?? null,
-          existingExtra: regenerationTargetExtra(storedMessages, input.regenerateMessageId),
+          existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
         });
     let latestSaved = saved;
     if (saved) {
@@ -3102,7 +3107,7 @@ export async function* startGeneration(
         attachments: connected.assistantAttachments,
         usage,
         promptSnapshot: promptSnapshotDirect,
-        existingExtra: regenerationTargetExtra(storedMessages, input.regenerateMessageId),
+        existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
       });
   if (saved) {
     await persistLorebookTimingStatesSafely(

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1047,6 +1047,15 @@ function messagesBeforeRegenerationTarget(
   return targetIndex >= 0 ? storedMessages.slice(0, targetIndex) : storedMessages;
 }
 
+function regenerationTargetExtra(
+  storedMessages: JsonRecord[],
+  regenerateMessageId: string | null | undefined,
+): unknown {
+  const targetId = readString(regenerateMessageId).trim();
+  if (!targetId) return undefined;
+  return storedMessages.find((message) => readString(message.id) === targetId)?.extra;
+}
+
 function roleplayIndividualGroupCharacterIds(chat: JsonRecord): string[] {
   if (readString(chat.mode || chat.chatMode) !== "roleplay") return [];
   const ids = activeCharacterIds(chat);
@@ -1857,6 +1866,11 @@ function normalizeContextInjections(value: unknown): AgentInjectionOverride[] {
   if (!Array.isArray(value)) return [];
   const injections: AgentInjectionOverride[] = [];
   for (const entry of value) {
+    if (typeof entry === "string") {
+      const text = entry.trim();
+      if (text) injections.push({ agentType: "prose-guardian", text });
+      continue;
+    }
     if (!isRecord(entry)) continue;
     const agentType = readString(entry.agentType).trim();
     const text = readString(entry.text).trim();
@@ -1931,6 +1945,7 @@ async function saveAssistantMessage(args: {
   promptSnapshot?: MainGenerationPromptSnapshot | null;
   spriteExpressions?: Record<string, string> | null;
   contextInjections?: AgentInjectionOverride[] | null;
+  existingExtra?: unknown;
 }): Promise<unknown | null> {
   const regenerateMessageId = readString(args.input.regenerateMessageId).trim();
   const generationReplay = buildGenerationReplay(args.input);
@@ -1945,6 +1960,8 @@ async function saveAssistantMessage(args: {
   const agentExtra = agentExtraFromResults({
     results: args.agentResults,
     contextInjections: args.contextInjections,
+    existingExtra: regenerateMessageId ? args.existingExtra : undefined,
+    mergeContextInjectionUpdates: !!regenerateMessageId,
   });
 
   if (args.input.impersonate === true) {
@@ -2889,6 +2906,7 @@ export async function* startGeneration(
           promptSnapshot,
           spriteExpressions: preSaveSpriteExpressions,
           contextInjections: runtime?.preInjections ?? null,
+          existingExtra: regenerationTargetExtra(storedMessages, input.regenerateMessageId),
         });
     let latestSaved = saved;
     if (saved) {
@@ -3084,6 +3102,7 @@ export async function* startGeneration(
         attachments: connected.assistantAttachments,
         usage,
         promptSnapshot: promptSnapshotDirect,
+        existingExtra: regenerationTargetExtra(storedMessages, input.regenerateMessageId),
       });
   if (saved) {
     await persistLorebookTimingStatesSafely(


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2170

## Why this change

- Legacy persisted `extra.contextInjections` can contain bare strings. The refactor engine path dropped those rows during regenerate/retry merges, so legacy prose-guardian guidance could silently disappear.

## What changed

- Normalize string context-injection entries as `{ agentType: "prose-guardian", text }` in the engine generation normalizer.
- Merge regenerate agent-injection updates against the target message's existing `extra`, so legacy/current cached rows survive when a regenerated message receives new agent output.
- Added a focused regression test covering legacy string rows, existing object rows, and blank-string skip behavior.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- `src/engine/generation/start-generation.ts`
- `src/engine/generation/start-generation.test.ts`
- `scratch/bugfix-verification.json`

Boundary notes:

- Stays in `src/engine`; no React, Tauri, shared API, storage schema, dependency, or release metadata changes.

Pressure points touched:

- Regenerate save path and context-injection normalization inside engine generation.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex proof: `pnpm exec vitest run src\engine\generation\start-generation.test.ts --reporter=json --outputFile=scratch\issue-2170-before.json` failed before the fix with the legacy prose-guardian row missing.
- Codex proof: `pnpm exec vitest run src\engine\generation\start-generation.test.ts --reporter=json --outputFile=scratch\issue-2170-after.json` passed after the fix.
- Codex proof: `pnpm exec vitest run src\engine\generation\start-generation.test.ts --reporter=json --outputFile=scratch\issue-2170-after-review.json` passed after the review follow-up covering direct target lookup fallback.
- Codex proof: `pnpm exec vitest run src\engine\generation\start-generation.test.ts --reporter=json --outputFile=scratch\issue-2170-after-conflict-resolution.json` passed after resolving upstream/refactor conflicts.
- Codex proof: `pnpm exec vitest run src\engine\generation\active-lorebook-scanner.test.ts` passed after merging upstream/refactor.
- Codex proof: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Codex proof: `pnpm typecheck` passed.
- Codex proof: `pnpm check` passed.
- Manual verification needed: none for the core claim; this is non-UI engine normalization logic.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix only; no new user-facing feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This bug is pure engine normalization behavior; proof is captured in Vitest output and `scratch/bugfix-verification.json`.
