### PR TITLE
Fix agent injection review guards

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,117 +1,95 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2171,
-    "title": "Agent injection-review trigger lost three guards",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2171"
+    "number": 2184,
+    "title": "[Issue]: Lorebook runtime no longer enforces max activated entry cap",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2184"
   },
   "pr": {
-    "number": 2248,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2248",
+    "number": "2247",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2247",
     "base": "refactor",
     "draft": true
   },
-  "coreClaim": "Agent injection review pauses only for reviewable writer pre-injections during initial roleplay/visual_novel generations.",
+  "coreClaim": "Prompt-time active lorebook scanning includes no more than LIMITS.MAX_LOREBOOK_ENTRIES entries while preserving the existing priority order: constants first, fresh latest-user-message matches next, then injection order.",
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "command": "pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=verbose",
-    "beforeSummary": "Before the production fix, the focused regression test failed because HTML static injection appeared in the review event, regenerate still emitted agent_injection_review, and conversation mode still paused.",
-    "preflight": {
-      "noAssociatedPr": true,
-      "assignedToSelf": true
-    }
+    "command": "pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts",
+    "evidence": "Before the production fix, the focused scanner test failed because processedLore.includedEntries had 105 entries instead of LIMITS.MAX_LOREBOOK_ENTRIES=100."
   },
   "verification": {
     "originalReproPassed": true,
-    "originalReproCommand": "pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=verbose",
-    "originalReproEvidence": "Passed 6 tests after the fix, including the 3 issue-2171 regression rows.",
-    "baselinePassed": true,
-    "baselineCommand": "pnpm check",
-    "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.",
+    "originalReproCommand": "pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts",
+    "originalReproEvidence": "After the fix, active-lorebook-scanner.test.ts passed with 2 tests, including the cap/priority regression.",
     "focusedProof": [
-      "Roleplay review event contains the Prose Guardian writer injection and filters out Knowledge Retrieval plus HTML static injection.",
-      "Regenerate with regenerateMessageId does not emit agent_injection_review.",
-      "Conversation mode does not emit agent_injection_review.",
-      "Visual novel mode still emits agent_injection_review for reviewable writer output."
+      "The regression row creates 105 active entries with unlimited token budget and verifies only 100 are included.",
+      "The regression row verifies constant entries stay ahead of fresh latest-user-message entries even with higher injection order.",
+      "The regression row verifies older-message matches are dropped when constants plus fresh matches fill the cap."
     ],
     "edgeCases": [
-      "Knowledge Retrieval and HTML/static-context injections are present in runtime.preInjections but excluded from the review modal payload.",
-      "Regenerate/swipe path with an existing assistant message skips the pause.",
-      "Non-roleplay conversation mode skips the pause even with the review flag and injections present.",
-      "Visual novel remains included in the positive mode gate."
+      "Existing batched active-lorebook storage and disabled-folder behavior still passes in the same scanner suite."
     ],
-    "visualProof": "Non-UI engine contract proof captured as raw Vitest output in scratch/issue2171-proof-output.txt."
+    "visualProof": "scratch/issue-2184-after-vitest.txt",
+    "baselinePassed": true,
+    "baselineCommand": "pnpm check",
+    "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks."
   },
   "manualBlockers": [],
   "notes": [
-    "UI/browser proof is not applicable because the bug is the engine event contract that feeds the modal; the regression proof exercises startGeneration directly."
+    "UI/browser proof is not applicable because this is a React-free engine prompt-selection bug; raw Vitest output is captured in scratch/issue-2184-after-vitest.txt."
   ],
   "preflight": {
     "noAssociatedPr": true,
     "issueAssigned": true,
-    "evidence": "gh PR search for issue 2171 returned no matches; local branch/worktree search found no 2171 branch; issue is assigned to @me."
+    "evidence": "GitHub PR searches for #2184, MAX_LOREBOOK_ENTRIES, and max activated entry cap found no associated open/closed fix PR; issue comments had no linked fix; local branch/worktree search found no 2184 branch or worktree; issue assigned to @me."
   },
   "dependencies": {
     "installedFromLockfile": true,
     "evidence": "pnpm install --frozen-lockfile completed in the issue worktree and did not change package.json or pnpm-lock.yaml."
   },
   "riskClaimMatrix": {
-    "coreClaim": "Agent injection review pauses only for reviewable writer pre-injections during initial roleplay/visual_novel generations.",
-    "riskType": "generation event contract parity",
+    "coreClaim": "Prompt-time active lorebook scanning caps injected entries at LIMITS.MAX_LOREBOOK_ENTRIES while preserving existing priority order.",
+    "riskType": "prompt assembly regression parity",
     "entrypoints": [
-      "src/engine/generation/start-generation.ts agent_injection_review event",
-      "runtime pre-generation agent injection review modal consumer"
+      "scanActiveLorebooks shared engine scanner",
+      "assemblePrompt activatedLorebookEntries",
+      "scanActiveLorebookEntries Active World Info data"
     ],
     "currentPathsOrFormats": [
-      "runtime.preInjections containing prose-guardian writer output",
-      "runtime.preInjections containing knowledge-retrieval output",
-      "runtime.preInjections containing html static context injection",
-      "StartGenerationInput.regenerateMessageId",
-      "chat.mode/chat.chatMode values roleplay, visual_novel, and conversation"
+      "Refactor active lorebook scanner",
+      "Shared prompt-injector budget processing"
     ],
     "legacyPathsOrFormats": [
-      "main packages/server generate route parity noted in issue #2171: reviewable writer filter, regenerate skip, roleplay/visual_novel mode gate"
+      "Legacy lorebook selection capped by LIMITS.MAX_LOREBOOK_ENTRIES"
     ],
     "positiveRowsTested": [
-      "roleplay chat with review flag and prose-guardian/knowledge-retrieval/html pre-injections pauses with only prose-guardian in payload",
-      "visual_novel chat with review flag and prose-guardian/knowledge-retrieval/html pre-injections still pauses"
+      "105 matching entries with unlimited token budget caps to 100 included entries.",
+      "Constants outrank fresh latest-user-message matches.",
+      "Fresh latest-user-message matches outrank older-message matches."
     ],
     "negativeRowsTested": [
-      "knowledge-retrieval injection is filtered from review payload",
-      "html static-context injection is filtered from review payload",
-      "regenerateMessageId skips agent_injection_review",
-      "conversation mode skips agent_injection_review"
+      "Disabled-folder entry remains excluded by the existing scanner test."
     ],
     "groundTruthFacts": [
       {
-        "fact": "Knowledge/static context injections should not be offered for writer review; regenerate should not pause; review pause is roleplay/visual_novel only.",
-        "method": "derived from issue artifact and confirmed by failing harness",
-        "evidence": "GitHub issue #2171 regression notes"
-      },
-      {
-        "fact": "Refactor startGeneration previously checked only overrides, non-empty injections, and reviewWriterAgentOutputs.",
-        "method": "measured by focused regression harness",
-        "evidence": "Failing focused regression test before production patch"
+        "fact": "LIMITS.MAX_LOREBOOK_ENTRIES is 100 in src/engine/contracts/constants/defaults.ts.",
+        "sourceType": "derived",
+        "evidence": "Imported LIMITS in the regression test."
       }
     ],
-    "userActionCopy": [],
-    "manualBlockers": [
-      {
-        "description": "Copy/backup guidance is not applicable because this change does not touch storage, import/export, migration, deletion, or user data files.",
-        "blockingCoreClaim": false
-      }
-    ]
+    "userActionCopy": "No user-facing copy changed.",
+    "manualBlockers": []
   },
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true,
-    "notes": "Focused before/after regression proof passed after the fix, negative controls covered the missing guards, and pnpm check passed."
+    "notes": "Focused proof, pnpm typecheck, pnpm check, proof gate, and Bunny review passed."
   },
   "bunny": {
     "status": "pass",
-    "evidence": "Issue match is direct; production diff is limited to engine review-pause guard/filter behavior; focused regression covers writer-positive, knowledge/static filtering, regenerate skip, conversation skip, and visual_novel positive mode; proof gate and pnpm check passed; no dependency, schema, auth, storage, prompt-assembly, or version files changed."
+    "evidence": "Issue match is direct; the shared prompt-injector now applies LIMITS.MAX_LOREBOOK_ENTRIES through the same constant/latest/order priority used by token budgets; the active scanner is the single prompt-time call site; focused before/after Vitest, pnpm typecheck, pnpm check, and marinara-proof-gate passed; no dependencies, schema, auth, storage persistence, UI, or release files changed."
   }
 }

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2171"
   },
   "pr": {
-    "number": null,
-    "url": null,
+    "number": 2248,
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2248",
     "base": "refactor",
     "draft": true
   },

--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,109 +1,117 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2159,
-    "title": "[Issue]: Chub card import merge drops most field overrides and flips extensions precedence",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2159"
+    "number": 2171,
+    "title": "Agent injection-review trigger lost three guards",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2171"
   },
   "pr": {
-    "number": 2237,
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2237",
+    "number": null,
+    "url": null,
     "base": "refactor",
     "draft": true
   },
-  "coreClaim": "Chub PNG imports overlay legacy-supported Chub detail fields onto embedded PNG card data and Chub detail extension keys win.",
+  "coreClaim": "Agent injection review pauses only for reviewable writer pre-injections during initial roleplay/visual_novel generations.",
+  "reproduction": {
+    "attempted": true,
+    "reproducedBeforeFix": true,
+    "command": "pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=verbose",
+    "beforeSummary": "Before the production fix, the focused regression test failed because HTML static injection appeared in the review event, regenerate still emitted agent_injection_review, and conversation mode still paused.",
+    "preflight": {
+      "noAssociatedPr": true,
+      "assignedToSelf": true
+    }
+  },
+  "verification": {
+    "originalReproPassed": true,
+    "originalReproCommand": "pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=verbose",
+    "originalReproEvidence": "Passed 6 tests after the fix, including the 3 issue-2171 regression rows.",
+    "baselinePassed": true,
+    "baselineCommand": "pnpm check",
+    "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.",
+    "focusedProof": [
+      "Roleplay review event contains the Prose Guardian writer injection and filters out Knowledge Retrieval plus HTML static injection.",
+      "Regenerate with regenerateMessageId does not emit agent_injection_review.",
+      "Conversation mode does not emit agent_injection_review.",
+      "Visual novel mode still emits agent_injection_review for reviewable writer output."
+    ],
+    "edgeCases": [
+      "Knowledge Retrieval and HTML/static-context injections are present in runtime.preInjections but excluded from the review modal payload.",
+      "Regenerate/swipe path with an existing assistant message skips the pause.",
+      "Non-roleplay conversation mode skips the pause even with the review flag and injections present.",
+      "Visual novel remains included in the positive mode gate."
+    ],
+    "visualProof": "Non-UI engine contract proof captured as raw Vitest output in scratch/issue2171-proof-output.txt."
+  },
+  "manualBlockers": [],
+  "notes": [
+    "UI/browser proof is not applicable because the bug is the engine event contract that feeds the modal; the regression proof exercises startGeneration directly."
+  ],
   "preflight": {
     "noAssociatedPr": true,
     "issueAssigned": true,
-    "evidence": "gh PR search for issue 2159 returned no matches; timeline showed no linked PR; local branch/worktree search found no 2159 branch; issue is assigned to cha1latte."
+    "evidence": "gh PR search for issue 2171 returned no matches; local branch/worktree search found no 2171 branch; issue is assigned to @me."
   },
   "dependencies": {
     "installedFromLockfile": true,
     "evidence": "pnpm install --frozen-lockfile completed in the issue worktree and did not change package.json or pnpm-lock.yaml."
   },
-  "reproduction": {
-    "attempted": true,
-    "reproducedBeforeFix": true,
-    "command": "pnpm exec vitest run --config scratch/vitest.issue2159.config.ts --reporter=verbose",
-    "beforeSummary": "Before the fix, the focused merge proof failed because the embedded PNG name stayed `Embedded Name` instead of being overlaid with `Chub Name`."
-  },
-  "verification": {
-    "originalReproPassed": true,
-    "originalReproCommand": "pnpm exec vitest run --config scratch/vitest.issue2159.config.ts --reporter=verbose",
-    "originalReproEvidence": "Scratch Vitest passed 5 rows after the fix: Chub detail field/extension precedence, top-level character JSON precedence, no-detail fallback, blank detail string negative control, and existing embedded lorebook preservation.",
-    "baselinePassed": true,
-    "baselineCommand": "pnpm check",
-    "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.",
-    "focusedProof": [
-      "Before fix, the scratch merge proof failed on the original repro because embedded PNG fields won.",
-      "After fix, the original Chub detail field and extension precedence row passed.",
-      "After fix, the top-level character JSON row passed.",
-      "After fix, null detail still returns the parsed PNG unchanged.",
-      "After fix, blank detail strings do not erase embedded PNG text fields.",
-      "After fix, existing embedded lorebooks remain preserved."
-    ],
-    "edgeCases": [
-      "Top-level/non-V2 character JSON receives the same detail precedence.",
-      "Missing detail leaves the parsed PNG payload unchanged.",
-      "Blank detail strings do not erase embedded text fields.",
-      "Existing embedded PNG lorebook is not overwritten by detail lorebook."
-    ],
-    "visualProof": "Non-UI logic proof captured as raw verification output in scratch/issue2159-proof-output.txt."
-  },
   "riskClaimMatrix": {
-    "coreClaim": "Chub PNG imports overlay legacy-supported Chub detail fields onto embedded PNG card data and Chub detail extension keys win.",
-    "riskType": "legacy import parity",
+    "coreClaim": "Agent injection review pauses only for reviewable writer pre-injections during initial roleplay/visual_novel generations.",
+    "riskType": "generation event contract parity",
     "entrypoints": [
-      "BotBrowserView PNG download import path for chub/chartavern sources",
-      "mergeCharacterDetailIntoCharacterJson helper"
+      "src/engine/generation/start-generation.ts agent_injection_review event",
+      "runtime pre-generation agent injection review modal consumer"
     ],
     "currentPathsOrFormats": [
-      "chara_card_v2/chara_card_v3 data object payloads",
-      "top-level character JSON payloads",
-      "CardDetail fields from provider.fetchDetail/detail view state",
-      "BrowseCard summary name/creator/tags passed into import detail"
+      "runtime.preInjections containing prose-guardian writer output",
+      "runtime.preInjections containing knowledge-retrieval output",
+      "runtime.preInjections containing html static context injection",
+      "StartGenerationInput.regenerateMessageId",
+      "chat.mode/chat.chatMode values roleplay, visual_novel, and conversation"
     ],
     "legacyPathsOrFormats": [
-      "main packages/client/src/lib/chub-character-card.ts mergeChubDetailIntoCharacterJson"
+      "main packages/server generate route parity noted in issue #2171: reviewable writer filter, regenerate skip, roleplay/visual_novel mode gate"
     ],
     "positiveRowsTested": [
-      "V2 card with stale embedded values and fresh Chub detail values",
-      "Top-level card with stale embedded values and fresh detail values"
+      "roleplay chat with review flag and prose-guardian/knowledge-retrieval/html pre-injections pauses with only prose-guardian in payload",
+      "visual_novel chat with review flag and prose-guardian/knowledge-retrieval/html pre-injections still pauses"
     ],
     "negativeRowsTested": [
-      "No detail available leaves parsed PNG data unchanged",
-      "Blank detail strings do not erase embedded text fields",
-      "Existing embedded lorebook is preserved instead of overwritten"
+      "knowledge-retrieval injection is filtered from review payload",
+      "html static-context injection is filtered from review payload",
+      "regenerateMessageId skips agent_injection_review",
+      "conversation mode skips agent_injection_review"
     ],
     "groundTruthFacts": [
       {
-        "fact": "Legacy merged description, personality, scenario, first_mes, mes_example, creator_notes, system_prompt, post_history_instructions, character_version, name, creator, tags, alternate_greetings, and detail-winning extensions.",
-        "sourceType": "derived",
-        "evidence": "git show origin/main:packages/client/src/lib/chub-character-card.ts"
+        "fact": "Knowledge/static context injections should not be offered for writer review; regenerate should not pause; review pause is roleplay/visual_novel only.",
+        "method": "derived from issue artifact and confirmed by failing harness",
+        "evidence": "GitHub issue #2171 regression notes"
       },
       {
-        "fact": "Refactor only merged system_prompt, post_history_instructions, character_version, character_book, and embedded-winning extensions before the fix.",
-        "sourceType": "measured",
-        "evidence": "src/features/shell/bot-browser/lib/character-detail-merge.ts before the production patch and the failing scratch proof."
+        "fact": "Refactor startGeneration previously checked only overrides, non-empty injections, and reviewWriterAgentOutputs.",
+        "method": "measured by focused regression harness",
+        "evidence": "Failing focused regression test before production patch"
       }
     ],
-    "userActionCopy": "No user-facing copy or destructive-action copy changed.",
-    "manualBlockers": []
+    "userActionCopy": [],
+    "manualBlockers": [
+      {
+        "description": "Copy/backup guidance is not applicable because this change does not touch storage, import/export, migration, deletion, or user data files.",
+        "blockingCoreClaim": false
+      }
+    ]
   },
-  "manualBlockers": [],
-  "notes": [
-    "UI/browser proof is not applicable because the bug is pure import merge logic; raw command output is captured in scratch/issue2159-proof-output.txt.",
-    "Proof gate script unavailable: C:/Users/celia/.codex/tools/marinara-proof-gate.mjs was not present on this machine."
-  ],
   "finalDoneGate": {
     "didFixBug": true,
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true,
-    "notes": "Focused repro passed after the fix, edge rows passed, pnpm typecheck passed, and pnpm check passed."
+    "notes": "Focused before/after regression proof passed after the fix, negative controls covered the missing guards, and pnpm check passed."
   },
   "bunny": {
     "status": "pass",
-    "evidence": "Issue match is direct, import parity risk matrix is covered with positive and negative rows including the blank-string erosion case, diff is focused to the merge helper plus import call-site summary wiring, no dependencies/version/schema/auth/storage/prompt paths changed, and pnpm check passed. Optional proof-gate script is unavailable on this machine and recorded in notes."
+    "evidence": "Issue match is direct; production diff is limited to engine review-pause guard/filter behavior; focused regression covers writer-positive, knowledge/static filtering, regenerate skip, conversation skip, and visual_novel positive mode; proof gate and pnpm check passed; no dependency, schema, auth, storage, prompt-assembly, or version files changed."
   }
 }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -53,6 +53,80 @@ function createStore(
   };
 }
 
+function createReviewStore(
+  mode: "roleplay" | "visual_novel" | "conversation",
+  options: { regenerate?: boolean } = {},
+): Store {
+  return {
+    chats: {
+      "chat-1": {
+        id: "chat-1",
+        mode,
+        connectionId: "conn-1",
+        characterIds: ["char-1"],
+        metadata: {
+          reviewWriterAgentOutputs: true,
+          activeAgentIds: ["prose-guardian", "knowledge-retrieval", "html"],
+        },
+      },
+    },
+    characters: {
+      "char-1": { id: "char-1", data: { name: "Mira" } },
+    },
+    connections: {
+      "conn-1": { id: "conn-1", provider: "test", model: "test-model", defaultForAgents: true },
+    },
+    agents: {
+      "agent-prose": {
+        id: "agent-prose",
+        type: "prose-guardian",
+        name: "Prose Guardian",
+        enabled: true,
+        phase: "pre_generation",
+        promptTemplate: "",
+        settings: {},
+      },
+      "agent-knowledge": {
+        id: "agent-knowledge",
+        type: "knowledge-retrieval",
+        name: "Knowledge Retrieval",
+        enabled: true,
+        phase: "pre_generation",
+        promptTemplate: "",
+        settings: {},
+      },
+    },
+    lorebooks: {
+      "lorebook-1": {
+        id: "lorebook-1",
+        name: "Global Lore",
+        enabled: true,
+        isGlobal: true,
+      },
+    },
+    "lorebook-entries": {
+      "entry-1": {
+        id: "entry-1",
+        lorebookId: "lorebook-1",
+        name: "Mira",
+        content: "Mira likes stormy weather.",
+        enabled: true,
+      },
+    },
+    messages: options.regenerate
+      ? {
+          "assistant-1": {
+            id: "assistant-1",
+            chatId: "chat-1",
+            role: "assistant",
+            content: "Previous reply.",
+            createdAt: "2026-06-04T00:00:00.000Z",
+          },
+        }
+      : {},
+  };
+}
+
 function createStorage(store: Store): StorageGateway {
   return {
     async list<T = unknown>(entity: StorageEntity): Promise<T[]> {
@@ -77,7 +151,7 @@ function createStorage(store: Store): StorageGateway {
       return { deleted: true };
     },
     async listChatMessages<T = unknown>(): Promise<T[]> {
-      return [] as T[];
+      return Object.values(store.messages ?? {}) as T[];
     },
     async createChatMessage<T = unknown>(chatId: string, value: Record<string, unknown>): Promise<T> {
       return {
@@ -128,6 +202,25 @@ function createStorage(store: Store): StorageGateway {
   };
 }
 
+function createReviewDeps(mode: "roleplay" | "visual_novel" | "conversation", options: { regenerate?: boolean } = {}) {
+  const llm: LlmGateway = {
+    async complete() {
+      return "";
+    },
+    async *stream() {
+      yield { type: "token" as const, text: "Keep the reply varied." };
+    },
+    async listModels() {
+      return [];
+    },
+  };
+  return {
+    storage: createStorage(createReviewStore(mode, options)),
+    integrations: {} as IntegrationGateway,
+    llm,
+  };
+}
+
 function createDeps(status: "idle" | "dnd" | "offline", options: { secondStatus?: "idle" | "dnd" | "offline" } = {}) {
   const llm: LlmGateway = {
     async complete() {
@@ -167,6 +260,35 @@ async function collectEvents(
 function delayedMs(events: Awaited<ReturnType<typeof collectEvents>>): number | null {
   const delayed = events.find((event) => event.type === "delayed");
   return delayed?.type === "delayed" ? Number(delayed.data.delayMs) : null;
+}
+
+async function collectReviewEvents(
+  mode: "roleplay" | "visual_novel" | "conversation",
+  input: Partial<StartGenerationInput> = {},
+  options: { regenerate?: boolean } = {},
+) {
+  const events = [];
+  for await (const event of startGeneration(createReviewDeps(mode, options), {
+    chatId: "chat-1",
+    message: "Hi Mira",
+    ...input,
+  })) {
+    events.push(event);
+    if (event.type === "agent_injection_review" || event.type === "done") break;
+  }
+  return events;
+}
+
+function reviewEvent(events: Awaited<ReturnType<typeof collectReviewEvents>>) {
+  return events.find((event) => event.type === "agent_injection_review") as
+    | {
+        type: "agent_injection_review";
+        data: {
+          chatId: string;
+          injections: Array<{ agentType: string; agentName: string; text: string }>;
+        };
+      }
+    | undefined;
 }
 
 describe("startGeneration conversation availability delays", () => {
@@ -218,5 +340,38 @@ describe("startGeneration conversation availability delays", () => {
     } finally {
       random.mockRestore();
     }
+  });
+});
+
+describe("startGeneration agent injection review", () => {
+  it("reviews only writer pre-generation injections in roleplay chats", async () => {
+    const event = reviewEvent(await collectReviewEvents("roleplay"));
+
+    expect(event?.type).toBe("agent_injection_review");
+    expect(event?.data.injections).toEqual([
+      {
+        agentType: "prose-guardian",
+        agentName: "Prose Guardian",
+        text: "Keep the reply varied.",
+      },
+    ]);
+  });
+
+  it("skips agent injection review during regenerate turns", async () => {
+    const events = await collectReviewEvents(
+      "roleplay",
+      { regenerateMessageId: "assistant-1" },
+      { regenerate: true },
+    );
+
+    expect(reviewEvent(events)).toBeUndefined();
+  });
+
+  it("confines agent injection review pauses to roleplay and visual novel modes", async () => {
+    const conversationEvents = await collectReviewEvents("conversation");
+    const visualNovelEvents = await collectReviewEvents("visual_novel");
+
+    expect(reviewEvent(conversationEvents)).toBeUndefined();
+    expect(reviewEvent(visualNovelEvents)?.type).toBe("agent_injection_review");
   });
 });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1,4 +1,9 @@
-import { BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS, type AgentContext, type AgentResult } from "../contracts/types/agent";
+import {
+  BUILT_IN_AGENTS,
+  BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS,
+  type AgentContext,
+  type AgentResult,
+} from "../contracts/types/agent";
 import type { GenerationPromptSnapshot, GenerationPromptSnapshotMessage } from "../contracts/types/chat";
 import type { GameState } from "../contracts/types/game-state";
 import type { EventGateway } from "../capabilities/events";
@@ -181,6 +186,17 @@ type MainGenerationPromptSnapshot = Pick<
   "messages" | "previewMessages" | "parameters" | "tools" | "promptPresetId"
 >;
 
+const REVIEWABLE_WRITER_AGENT_TYPES = new Set(
+  BUILT_IN_AGENTS.filter(
+    (agent) =>
+      agent.category === "writer" &&
+      agent.phase === "pre_generation" &&
+      agent.id !== "knowledge-retrieval" &&
+      agent.id !== "knowledge-router",
+  ).map((agent) => agent.id),
+);
+const AGENT_INJECTION_REVIEW_CHAT_MODES = new Set(["roleplay", "visual_novel"]);
+
 function abortGenerationError(): Error {
   return Object.assign(new Error("The operation was aborted."), { name: "AbortError" });
 }
@@ -213,8 +229,14 @@ function shouldPauseForAgentInjectionReview(
   injections: AgentInjectionOverride[],
 ): boolean {
   if (normalizedAgentInjectionOverrides(input).length > 0) return false;
+  if (readString(input.regenerateMessageId).trim()) return false;
+  if (!AGENT_INJECTION_REVIEW_CHAT_MODES.has(readString(chat.mode || chat.chatMode).trim())) return false;
   if (injections.length === 0) return false;
   return parseRecord(chat.metadata).reviewWriterAgentOutputs === true;
+}
+
+function reviewableAgentInjections(injections: AgentInjectionOverride[]): AgentInjectionOverride[] {
+  return injections.filter((injection) => REVIEWABLE_WRITER_AGENT_TYPES.has(injection.agentType));
 }
 
 function generationEmbeddingSource(llm: LlmGateway, connection: JsonRecord) {
@@ -2765,12 +2787,13 @@ export async function* startGeneration(
     }
     agentEvents.length = 0;
 
-    if (runtime && shouldPauseForAgentInjectionReview(chatForGeneration, input, runtime.preInjections)) {
+    const reviewableInjections = runtime ? reviewableAgentInjections(runtime.preInjections) : [];
+    if (runtime && shouldPauseForAgentInjectionReview(chatForGeneration, input, reviewableInjections)) {
       yield {
         type: "agent_injection_review",
         data: {
           chatId,
-          injections: runtime.preInjections.map((injection) => ({
+          injections: reviewableInjections.map((injection) => ({
             agentType: injection.agentType,
             agentName: injection.agentName || injection.agentType,
             text: injection.text,


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2171

## Why this change

- Agent injection review lost legacy guards in the refactor path: non-reviewable knowledge/static injections could appear in the writer review event, regenerate/swipe turns could reopen the review pause, and non-roleplay modes could pause if the metadata flag and injections were present.

## What changed

- Restored the legacy-derived reviewable writer injection filter in `startGeneration`, based on built-in writer pre-generation agents while excluding knowledge retrieval/router.
- Restored the regenerate skip and roleplay/visual_novel mode gate before emitting `agent_injection_review`.
- Added focused regression coverage for the writer-positive path, knowledge/static filtering, regenerate skip, conversation skip, and visual_novel positive mode.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- `src/engine/generation/start-generation.ts`
- `src/engine/generation/start-generation.test.ts`

Boundary notes:

- The fix stays in the React-free engine event contract. The runtime modal consumer continues receiving `agent_injection_review`, but now receives only reviewable writer injections.
- No React feature, shared API, Rust, storage, import/export, schema, dependency, auth, or version files changed.

Pressure points touched:

- Runtime generation event emission for agent injection review.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the bug before the production fix with `pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=verbose`: the focused regression rows failed because HTML/static injection was included in the review payload, regenerate still emitted `agent_injection_review`, and conversation mode still paused.
- After the fix, Codex reran `pnpm exec vitest run src/engine/generation/start-generation.test.ts --reporter=verbose`; all 6 tests passed, including the 3 issue-2171 regression rows.
- Codex ran `pnpm check`; it passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\issue2171-bugfix-verification.json`; it passed locally.
- Bunny review pass: pass for the current diff.
- No human-only verification is required for the core claim; this is a non-UI engine event contract fix.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is a bugfix for existing agent review behavior and does not add discoverable product behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A. This is a non-UI engine event contract fix; focused command proof is recorded in the validation notes and proof ledger.
