### PR TITLE
Fix lorebook marker runtime state gating

### DIFF
--- a/scratch/bugfix-verification.json
+++ b/scratch/bugfix-verification.json
@@ -1,81 +1,76 @@
 {
   "schemaVersion": 1,
   "issue": {
-    "number": 2184,
-    "title": "[Issue]: Lorebook runtime no longer enforces max activated entry cap",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2184"
+    "number": 2188,
+    "title": "Lorebook prompt assembly consumes runtime state before marker insertion is known",
+    "url": "https://github.com/Pasta-Devs/Marinara-Engine/issues/2188"
   },
-  "pr": {
-    "number": "2247",
-    "url": "https://github.com/Pasta-Devs/Marinara-Engine/pull/2247",
-    "base": "refactor",
-    "draft": true
-  },
-  "coreClaim": "Prompt-time active lorebook scanning includes no more than LIMITS.MAX_LOREBOOK_ENTRIES entries while preserving the existing priority order: constants first, fresh latest-user-message matches next, then injection order.",
+  "pr": null,
+  "coreClaim": "Prompt assembly only returns lorebook runtime-state deltas for lore entries whose position can actually be inserted into the prompt.",
   "reproduction": {
     "attempted": true,
     "reproducedBeforeFix": true,
-    "command": "pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts",
-    "evidence": "Before the production fix, the focused scanner test failed because processedLore.includedEntries had 105 entries instead of LIMITS.MAX_LOREBOOK_ENTRIES=100."
+    "command": "pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts",
+    "evidence": "Markerless preset test failed before the production fix: activatedLorebookEntries contained entry-1 even though the preview prompt was only system prompt + trigger."
   },
   "verification": {
     "originalReproPassed": true,
-    "originalReproCommand": "pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts",
-    "originalReproEvidence": "After the fix, active-lorebook-scanner.test.ts passed with 2 tests, including the cap/priority regression.",
-    "focusedProof": [
-      "The regression row creates 105 active entries with unlimited token budget and verifies only 100 are included.",
-      "The regression row verifies constant entries stay ahead of fresh latest-user-message entries even with higher injection order.",
-      "The regression row verifies older-message matches are dropped when constants plus fresh matches fill the cap."
-    ],
-    "edgeCases": [
-      "Existing batched active-lorebook storage and disabled-folder behavior still passes in the same scanner suite."
-    ],
-    "visualProof": "scratch/issue-2184-after-vitest.txt",
+    "focusedCommand": "pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts",
+    "focusedEvidence": "8 prompt assembly tests passed after the fix, including markerless no-state negative control, lore-marker positive control, selected-preset fallback positive control, and existing depth-injection rows.",
+    "visualProof": "scratch/issue-2188-proof.txt",
     "baselinePassed": true,
     "baselineCommand": "pnpm check",
-    "baselineEvidence": "Passed line endings, architecture, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks."
+    "baselineEvidence": "Passed line endings, architecture/import rules, frontend/typecheck, Rust cargo check, docs, discovery metadata, launcher safety, and unused-code checks.",
+    "typecheckCommand": "pnpm typecheck",
+    "typecheckEvidence": "tsc -b passed."
   },
   "manualBlockers": [],
-  "notes": [
-    "UI/browser proof is not applicable because this is a React-free engine prompt-selection bug; raw Vitest output is captured in scratch/issue-2184-after-vitest.txt."
-  ],
+  "notes": [],
   "preflight": {
     "noAssociatedPr": true,
     "issueAssigned": true,
-    "evidence": "GitHub PR searches for #2184, MAX_LOREBOOK_ENTRIES, and max activated entry cap found no associated open/closed fix PR; issue comments had no linked fix; local branch/worktree search found no 2184 branch or worktree; issue assigned to @me."
+    "evidence": "GitHub PR searches for #2188 and scanActiveLorebooks/markerless terms found no associated fix PR; issue comments had no linked fix; local branch/worktree search found no 2188 branch or worktree; issue assigned to @me."
   },
   "dependencies": {
     "installedFromLockfile": true,
     "evidence": "pnpm install --frozen-lockfile completed in the issue worktree and did not change package.json or pnpm-lock.yaml."
   },
   "riskClaimMatrix": {
-    "coreClaim": "Prompt-time active lorebook scanning caps injected entries at LIMITS.MAX_LOREBOOK_ENTRIES while preserving existing priority order.",
-    "riskType": "prompt assembly regression parity",
+    "coreClaim": "Prompt assembly only returns lorebook runtime-state deltas for lore entries whose position can actually be inserted into the prompt.",
+    "riskType": "prompt assembly runtime state compatibility",
     "entrypoints": [
-      "scanActiveLorebooks shared engine scanner",
-      "assemblePrompt activatedLorebookEntries",
-      "scanActiveLorebookEntries Active World Info data"
+      "assembleGenerationPrompt",
+      "scanActiveLorebooks"
     ],
     "currentPathsOrFormats": [
-      "Refactor active lorebook scanner",
-      "Shared prompt-injector budget processing"
+      "Prompt sections with world_info_before/world_info_after/lorebook markers",
+      "Depth-position lore injection",
+      "Game prompt lore merge",
+      "No selected preset fallback prompt lore insertion",
+      "Selected preset that produces no messages and falls back to default prompt lore insertion"
     ],
     "legacyPathsOrFormats": [
-      "Legacy lorebook selection capped by LIMITS.MAX_LOREBOOK_ENTRIES"
+      "Legacy marker expansion scanned world-info when markers expanded",
+      "Refactor depth-position entries are injected independently of world-info markers"
     ],
     "positiveRowsTested": [
-      "105 matching entries with unlimited token budget caps to 100 included entries.",
-      "Constants outrank fresh latest-user-message matches.",
-      "Fresh latest-user-message matches outrank older-message matches."
+      "A lorebook marker includes a position 0 ephemeral entry and returns the expected runtime-state override.",
+      "Existing depth-position lore entries still inject without a world-info marker.",
+      "An empty selected preset falls back to the default prompt and still includes/consumes matching world-info lore."
     ],
     "negativeRowsTested": [
-      "Disabled-folder entry remains excluded by the existing scanner test."
+      "A markerless roleplay preset with a matching position 0 ephemeral entry returns no activatedLorebookEntries and no runtime-state deltas."
     ],
     "groundTruthFacts": [
       {
-        "fact": "LIMITS.MAX_LOREBOOK_ENTRIES is 100 in src/engine/contracts/constants/defaults.ts.",
+        "fact": "Prompt assembly computes which lorebook positions can be inserted by the selected prompt shape.",
+        "sourceType": "harness",
+        "evidence": "src/engine/generation/prompt-assembly.test.ts exercises markerless roleplay, lorebook-marker roleplay, selected-preset fallback, and existing depth-injection prompt shapes."
+      },
+      {
+        "fact": "The active lorebook scanner filters entries by included positions before activation, budgeting, semantic embedding selection, and runtime-state updates.",
         "sourceType": "derived",
-        "evidence": "Imported LIMITS in the regression test."
+        "evidence": "src/engine/generation/active-lorebook-scanner.ts filters entriesByBook with lorebookEntryIncludedByPosition before vectorizedEntryCount, embeddingRequest, scanLorebookEntries, updateTimingStatesForScan, and updateEntryStateOverridesForScan."
       }
     ],
     "userActionCopy": "No user-facing copy changed.",
@@ -86,10 +81,10 @@
     "hasProfessionalVisualProof": true,
     "prWouldBeAccepted": true,
     "claimBoundariesProven": true,
-    "notes": "Focused proof, pnpm typecheck, pnpm check, proof gate, and Bunny review passed."
+    "notes": "Focused proof, pnpm check, proof gate, and Bunny review passed. PR creation and external health checks are pending."
   },
   "bunny": {
     "status": "pass",
-    "evidence": "Issue match is direct; the shared prompt-injector now applies LIMITS.MAX_LOREBOOK_ENTRIES through the same constant/latest/order priority used by token budgets; the active scanner is the single prompt-time call site; focused before/after Vitest, pnpm typecheck, pnpm check, and marinara-proof-gate passed; no dependencies, schema, auth, storage persistence, UI, or release files changed."
+    "evidence": "Issue match is direct. Scanner now filters active lorebook entries by prompt-insertable positions before activation, budgeting, semantic embedding selection, and runtime-state updates. Prompt assembly passes world-before/world-after eligibility from selected markers, game prompt behavior, and actual fallback widening while preserving depth-position injection. Focused before/after Vitest, pnpm check, marinara-proof-gate, diff check, and Bunny self-review passed. No dependencies, schema, auth, storage persistence, UI, or release files changed."
   }
 }

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -115,6 +115,12 @@ interface LoadedActivatedLore {
   previousEntryStateOverrides: Map<string, LorebookEntryStateOverride>;
 }
 
+export interface ActiveLorebookIncludedPositions {
+  worldInfoBefore?: boolean;
+  worldInfoAfter?: boolean;
+  depth?: boolean;
+}
+
 export interface ActiveLorebookScannerInput {
   storage: StorageGateway;
   chat: JsonRecord;
@@ -127,6 +133,7 @@ export interface ActiveLorebookScannerInput {
   embeddingSource?: LorebookEmbeddingSource | null;
   ignoreTiming?: boolean;
   contentResolver?: LorebookContentResolver;
+  includedPositions?: ActiveLorebookIncludedPositions;
 }
 
 export interface ActiveLorebookScannerResult {
@@ -523,6 +530,13 @@ export async function loadLorebookEntriesForActivationBatch(
   );
 }
 
+function lorebookEntryIncludedByPosition(entry: LorebookEntry, positions?: ActiveLorebookIncludedPositions): boolean {
+  if (!positions) return true;
+  if (entry.position <= 0) return positions.worldInfoBefore === true;
+  if (entry.position === 1) return positions.worldInfoAfter === true;
+  return positions.depth !== false;
+}
+
 function scanLorebookEntries(
   messages: ScanMessage[],
   entries: LorebookEntry[],
@@ -667,9 +681,9 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
     const id = readString(book.id);
     return {
       book,
-      entries: (entriesForActivationByBookId.get(id) ?? []).map((entry) =>
-        entryWithChatState(entry, previousEntryStateOverrides),
-      ),
+      entries: (entriesForActivationByBookId.get(id) ?? [])
+        .map((entry) => entryWithChatState(entry, previousEntryStateOverrides))
+        .filter((entry) => lorebookEntryIncludedByPosition(entry, input.includedPositions)),
     };
   });
   const vectorizedEntryCount = entriesByBook.reduce(

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -127,6 +127,122 @@ describe("assembleGenerationPrompt depth injection", () => {
   });
 });
 
+describe("assembleGenerationPrompt lorebook marker gating", () => {
+  function lorebookRuntimeRows(includeLorebookMarker: boolean): RowMap {
+    return {
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "system",
+          presetId: "preset-1",
+          role: "system",
+          content: "system prompt",
+          enabled: true,
+        },
+        ...(includeLorebookMarker
+          ? [
+              {
+                id: "lore",
+                presetId: "preset-1",
+                identifier: "lorebook",
+                role: "system",
+                enabled: true,
+              },
+            ]
+          : []),
+        {
+          id: "history",
+          presetId: "preset-1",
+          identifier: "chat_history",
+          enabled: true,
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [],
+      personas: [],
+      lorebooks: [{ id: "lorebook-1", name: "Runtime lore", enabled: true, isGlobal: true }],
+      "lorebook-folders": [],
+      "lorebook-entries": [
+        {
+          id: "entry-1",
+          lorebookId: "lorebook-1",
+          name: "Runtime entry",
+          content: "matched runtime lore",
+          keys: ["trigger"],
+          ephemeral: 1,
+          position: 0,
+          enabled: true,
+        },
+      ],
+      "regex-scripts": [],
+    };
+  }
+
+  it("does not scan or consume runtime state when the selected preset has no lore marker", async () => {
+    const storage = storageWithRows(lorebookRuntimeRows(false));
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", promptPresetId: "preset-1", metadata: {} },
+      storedMessages: [{ id: "message-1", role: "user", content: "trigger" }],
+      connection: {},
+      request: {},
+      latestUserInput: "trigger",
+    });
+
+    expect(assembly.previewMessages.map((message) => message.content)).toEqual(["system prompt", "trigger"]);
+    expect(assembly.activatedLorebookEntries).toEqual([]);
+    expect(assembly.lorebookTimingStates).toBeNull();
+    expect(assembly.lorebookEntryStateOverrides).toBeNull();
+    expect(assembly.budgetSkippedLorebookEntries).toEqual([]);
+  });
+
+  it("still scans and consumes runtime state when a lore marker is present", async () => {
+    const storage = storageWithRows(lorebookRuntimeRows(true));
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", promptPresetId: "preset-1", metadata: {} },
+      storedMessages: [{ id: "message-1", role: "user", content: "trigger" }],
+      connection: {},
+      request: {},
+      latestUserInput: "trigger",
+    });
+
+    expect(assembly.previewMessages.map((message) => message.content)).toEqual([
+      "system prompt",
+      "matched runtime lore",
+      "trigger",
+    ]);
+    expect(assembly.activatedLorebookEntries).toHaveLength(1);
+    expect(assembly.lorebookEntryStateOverrides).toEqual({ "entry-1": { ephemeral: 0, enabled: false } });
+  });
+
+  it("still scans world-info entries when an empty selected preset falls back to the default prompt", async () => {
+    const rows = lorebookRuntimeRows(false);
+    rows["prompt-sections"] = [];
+    const storage = storageWithRows(rows);
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", promptPresetId: "preset-1", metadata: {} },
+      storedMessages: [{ id: "message-1", role: "user", content: "trigger" }],
+      connection: {},
+      request: {},
+      latestUserInput: "trigger",
+    });
+
+    expect(assembly.previewMessages.map((message) => message.content).join("\n\n")).toContain("matched runtime lore");
+    expect(assembly.activatedLorebookEntries).toHaveLength(1);
+    expect(assembly.lorebookEntryStateOverrides).toEqual({ "entry-1": { ephemeral: 0, enabled: false } });
+  });
+});
+
 describe("assembleGenerationPrompt character markers", () => {
   it("resolves character field macros against each rendered character in a group", async () => {
     const storage = storageWithRows({

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -51,6 +51,7 @@ import {
 import {
   lorebookActivatedEntryForEvent,
   scanActiveLorebooks,
+  type ActiveLorebookIncludedPositions,
   type BudgetSkippedLorebookEntry,
 } from "./active-lorebook-scanner";
 
@@ -2773,6 +2774,28 @@ function sectionContent(args: {
   }
 }
 
+function lorebookIncludedPositionsForPrompt(
+  selectedPreset: SelectedPromptPreset | null | undefined,
+  chatMode: string,
+): ActiveLorebookIncludedPositions {
+  const positions: ActiveLorebookIncludedPositions = {
+    worldInfoBefore: !selectedPreset || chatMode === "game",
+    worldInfoAfter: !selectedPreset || chatMode === "game",
+    depth: true,
+  };
+  for (const section of selectedPreset?.sections ?? []) {
+    if (!boolish(section.enabled, true)) continue;
+    const marker = markerConfig(section);
+    if (marker?.type === "world_info_before" || marker?.type === "lorebook") {
+      positions.worldInfoBefore = true;
+    }
+    if (marker?.type === "world_info_after" || marker?.type === "lorebook") {
+      positions.worldInfoAfter = true;
+    }
+  }
+  return positions;
+}
+
 function agentDataPromptBlock(
   agentData: Record<string, string>,
   wrapFormat: WrapFormat,
@@ -2847,20 +2870,24 @@ export async function assembleGenerationPrompt(
     request: input.request,
   });
   await seedPromptVariablesFromGreeting(storage, input, macros);
-  const loreScan = await scanActiveLorebooks({
-    storage,
-    chat: input.chat,
-    characters,
-    persona,
-    storedMessages: input.storedMessages,
-    request: input.request,
-    latestUserInput: input.latestUserInput,
-    embeddingSource,
-    contentResolver: {
-      resolve: (content) => cleanPromptText(resolveMacros(content, macros)),
-    },
-  });
-  const processedLore = loreScan.processedLore;
+  const baseLorebookIncludedPositions = lorebookIncludedPositionsForPrompt(selectedPreset, chatMode);
+  const scanLorebooksForPositions = (includedPositions: ActiveLorebookIncludedPositions) =>
+    scanActiveLorebooks({
+      storage,
+      chat: input.chat,
+      characters,
+      persona,
+      storedMessages: input.storedMessages,
+      request: input.request,
+      latestUserInput: input.latestUserInput,
+      embeddingSource,
+      includedPositions,
+      contentResolver: {
+        resolve: (content) => cleanPromptText(resolveMacros(content, macros)),
+      },
+    });
+  let loreScan = await scanLorebooksForPositions(baseLorebookIncludedPositions);
+  let processedLore = loreScan.processedLore;
   const summary = chatSummaryForGeneration(input.chat);
   const memoryRecallBlock = await buildMemoryRecallBlock(
     storage,
@@ -2942,6 +2969,14 @@ export async function assembleGenerationPrompt(
   }
 
   if (messages.length === 0) {
+    if (!baseLorebookIncludedPositions.worldInfoBefore || !baseLorebookIncludedPositions.worldInfoAfter) {
+      loreScan = await scanLorebooksForPositions({
+        ...baseLorebookIncludedPositions,
+        worldInfoBefore: true,
+        worldInfoAfter: true,
+      });
+      processedLore = loreScan.processedLore;
+    }
     usedFallbackSystemPrompt = true;
     messages.push({
       role: "system",


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2188

## Why this change

- Markerless prompt presets could still return lorebook activation and runtime-state deltas for world-info entries even though those entries were never inserted into the assembled prompt.
- That let sticky/cooldown/delay/ephemeral state be consumed outside the prompt path that actually used the lore.

## What changed

- Added a prompt-position scope for active lorebook scans so world-info-before/world-info-after entries are only eligible when those positions can be inserted.
- Preserved depth-position lore injection, game prompt lore merge behavior, and fallback prompt lore insertion.
- Added regression coverage for markerless presets, lore marker presets, empty selected-preset fallback, and existing depth injection behavior.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Prompt assembly marker handling
- Active lorebook scanner activation, budgeting, semantic embedding selection, and runtime-state updates
- Lorebook depth injection compatibility
- Game/fallback prompt lore insertion paths

Boundary notes:

- Stays inside `src/engine`; no React, shared API, Tauri/Rust storage, or remote-runtime boundary changes.

Pressure points touched:

- `assembleGenerationPrompt`
- `scanActiveLorebooks`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex focused proof: `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` passed with 8 tests after the fix. Before the production fix, the new markerless preset regression failed because `activatedLorebookEntries` contained the matched world-info entry while the prompt preview did not include lore.
- Codex conflict-resolution proof: after merging `upstream/refactor`, `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts` passed again with 8 tests.
- Codex baseline: `pnpm check` passed after the final diff and passed again after conflict resolution.
- Bunny review: passed for the original fix and the conflict-resolution diff; post-merge PR diff remains limited to `src/engine/generation/active-lorebook-scanner.ts`, `src/engine/generation/prompt-assembly.ts`, and `src/engine/generation/prompt-assembly.test.ts`.
- No manual verification needed for the core claim; this is React-free engine prompt assembly behavior covered by focused Vitest and the full repo check.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal engine bugfix only; no new discoverable product behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is React-free engine prompt assembly behavior; proof is the focused Vitest repro plus `pnpm check`.
