### PR TITLE
Fix game lorebook keeper setup metadata

### DIFF
--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -977,7 +977,7 @@ function gameSetupMetadataPatch(config: GameSetupConfig): Record<string, unknown
     gameSpotifyPlaylistId: config.spotifyPlaylistId ?? null,
     gameSpotifyPlaylistName: config.spotifyPlaylistName ?? null,
     gameSpotifyArtist: config.spotifyArtist ?? null,
-    gameEnableLorebookKeeper: Boolean(config.enableLorebookKeeper),
+    gameLorebookKeeperEnabled: Boolean(config.enableLorebookKeeper),
     gameGenerationParameters: config.generationParameters ?? null,
     gameLanguage: config.language ?? null,
     gameRating: config.rating ?? "sfw",


### PR DESCRIPTION
## Linked issue

Closes #2192

## Why this change

- Game setup's Lorebook Keeper toggle was persisted under `gameEnableLorebookKeeper`, but every refactor reader checks `gameLorebookKeeperEnabled`. That made the setup toggle disappear after creating a game until the user enabled Game Lorebook Keeper again from chat settings.

## What changed

- Updated the game setup metadata patch to persist `enableLorebookKeeper` as `gameLorebookKeeperEnabled`.

## Refactor impact

Primary owner:

Game mode

Impact areas reviewed:

- Game setup metadata creation
- Game chat metadata contract
- Shared chat settings Game Lorebook Keeper readers
- Game Lorebook Keeper scope checks

Boundary notes:

- The change stays in the game feature API metadata patch.
- No engine import direction, shared API wrapper, Rust command, or remote-runtime boundary changes.

Pressure points touched:

- Game setup metadata patch in `src/features/modes/game/api/game-api.ts`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check` passed.
- Static search confirmed the setup writer now uses `gameLorebookKeeperEnabled` and no `gameEnableLorebookKeeper` references remain in the affected game/shared/engine paths.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing Game Lorebook Keeper setup metadata; no new discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots included; this is a metadata persistence fix with no UI rendering change.
