### PR TITLE
Preserve embedded character book lore fields

### DIFF
--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -1,3 +1,4 @@
+use super::imports::{lorebook_entries, normalize_lorebook_entry};
 use super::shared::*;
 use super::*;
 use serde_json::Map;
@@ -115,11 +116,7 @@ pub(crate) fn import_character_embedded_lorebook(
         })
         .cloned()
         .unwrap_or(Value::Null);
-    let entries = book
-        .get("entries")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
+    let entries = lorebook_entries(&book);
     if entries.is_empty() {
         return Err(AppError::invalid_input(
             "Character does not contain an embedded lorebook",
@@ -169,7 +166,7 @@ pub(crate) fn import_character_embedded_lorebook(
         .to_string();
     let mut imported = 0;
     for (index, entry) in entries.into_iter().enumerate() {
-        let normalized = normalize_character_book_entry(&entry, index, &lorebook_id);
+        let normalized = normalize_lorebook_entry(&lorebook_id, &entry, index);
         state.storage.create("lorebook-entries", normalized)?;
         imported += 1;
     }
@@ -613,27 +610,6 @@ fn remove_duplicate_embedded_lorebooks(
         state.storage.delete("lorebooks", id)?;
     }
     Ok(())
-}
-
-fn normalize_character_book_entry(entry: &Value, index: usize, lorebook_id: &str) -> Value {
-    let keys = entry
-        .get("keys")
-        .or_else(|| entry.get("key"))
-        .cloned()
-        .unwrap_or_else(|| json!([]));
-    json!({
-        "lorebookId": lorebook_id,
-        "name": entry.get("name").or_else(|| entry.get("comment")).and_then(Value::as_str).unwrap_or("Entry"),
-        "content": entry.get("content").and_then(Value::as_str).unwrap_or(""),
-        "keys": keys,
-        "secondaryKeys": entry.get("secondary_keys").or_else(|| entry.get("secondaryKeys")).cloned().unwrap_or_else(|| json!([])),
-        "constant": entry.get("constant").and_then(Value::as_bool).unwrap_or(false),
-        "selective": entry.get("selective").and_then(Value::as_bool).unwrap_or(false),
-        "enabled": entry.get("enabled").and_then(Value::as_bool).unwrap_or(true),
-        "order": entry.get("insertion_order").or_else(|| entry.get("order")).and_then(Value::as_i64).unwrap_or(index as i64),
-        "position": entry.get("position").and_then(Value::as_str).unwrap_or("before_char"),
-        "folderId": Value::Null
-    })
 }
 
 fn patch_character_embedded_lorebook_pointer(
@@ -1260,6 +1236,86 @@ mod tests {
             gallery[0].get("data").and_then(Value::as_str),
             Some(inline_data)
         );
+    }
+
+    #[test]
+    fn embedded_lorebook_import_preserves_st_character_book_fields() {
+        let state = test_state("embedded-lorebook-st-fields");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "character-1",
+                    "name": "Mira",
+                    "data": {
+                        "name": "Mira",
+                        "character_book": {
+                            "entries": {
+                                "0": {
+                                    "comment": "Moon Memory",
+                                    "content": "moon lore",
+                                    "key": ["moon"],
+                                    "keysecondary": ["tide"],
+                                    "disable": true,
+                                    "order": 12,
+                                    "position": "at_depth",
+                                    "role": "assistant",
+                                    "depth": 7,
+                                    "scan_depth": 9,
+                                    "probability": 45,
+                                    "useProbability": true,
+                                    "match_whole_words": true,
+                                    "case_sensitive": true,
+                                    "regex": true,
+                                    "sticky": 2,
+                                    "cooldown": 3,
+                                    "delay": 4,
+                                    "ephemeral": 5,
+                                    "group": "memory",
+                                    "groupWeight": 6,
+                                    "excludeRecursion": true,
+                                    "locked": true
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("character should be created");
+
+        let imported = import_character_embedded_lorebook(&state, "character-1")
+            .expect("embedded lorebook should import");
+        let lorebook_id = imported
+            .get("lorebookId")
+            .and_then(Value::as_str)
+            .expect("import should return lorebook id");
+        let entries = entries_for_lorebook(&state, lorebook_id);
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry["name"], "Moon Memory");
+        assert_eq!(entry["content"], "moon lore");
+        assert_eq!(entry["keys"], json!(["moon"]));
+        assert_eq!(entry["secondaryKeys"], json!(["tide"]));
+        assert_eq!(entry["enabled"], false);
+        assert_eq!(entry["order"], 12);
+        assert_eq!(entry["position"], 2);
+        assert_eq!(entry["role"], "assistant");
+        assert_eq!(entry["depth"], 7);
+        assert_eq!(entry["scanDepth"], 9);
+        assert_eq!(entry["probability"], 45);
+        assert_eq!(entry["matchWholeWords"], true);
+        assert_eq!(entry["caseSensitive"], true);
+        assert_eq!(entry["useRegex"], true);
+        assert_eq!(entry["sticky"], 2);
+        assert_eq!(entry["cooldown"], 3);
+        assert_eq!(entry["delay"], 4);
+        assert_eq!(entry["ephemeral"], 5);
+        assert_eq!(entry["group"], "memory");
+        assert_eq!(entry["groupWeight"], 6);
+        assert_eq!(entry["preventRecursion"], true);
+        assert_eq!(entry["locked"], true);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/exports.rs
+++ b/src-tauri/src/commands/storage/exports.rs
@@ -1251,8 +1251,8 @@ mod tests {
                     "data": {
                         "name": "Mira",
                         "character_book": {
-                            "entries": {
-                                "0": {
+                            "entries": [
+                                {
                                     "comment": "Moon Memory",
                                     "content": "moon lore",
                                     "key": ["moon"],
@@ -1276,8 +1276,14 @@ mod tests {
                                     "groupWeight": 6,
                                     "excludeRecursion": true,
                                     "locked": true
+                                },
+                                {
+                                    "comment": "Sun Signal",
+                                    "content": "sun lore",
+                                    "keys": ["sun"],
+                                    "secondaryKeys": ["flare"]
                                 }
-                            }
+                            ]
                         }
                     }
                 }),
@@ -1292,8 +1298,11 @@ mod tests {
             .expect("import should return lorebook id");
         let entries = entries_for_lorebook(&state, lorebook_id);
 
-        assert_eq!(entries.len(), 1);
-        let entry = &entries[0];
+        assert_eq!(entries.len(), 2);
+        let entry = entries
+            .iter()
+            .find(|entry| entry.get("name").and_then(Value::as_str) == Some("Moon Memory"))
+            .expect("moon entry should import");
         assert_eq!(entry["name"], "Moon Memory");
         assert_eq!(entry["content"], "moon lore");
         assert_eq!(entry["keys"], json!(["moon"]));
@@ -1316,6 +1325,13 @@ mod tests {
         assert_eq!(entry["groupWeight"], 6);
         assert_eq!(entry["preventRecursion"], true);
         assert_eq!(entry["locked"], true);
+
+        let camel_case_entry = entries
+            .iter()
+            .find(|entry| entry.get("name").and_then(Value::as_str) == Some("Sun Signal"))
+            .expect("camelCase secondary key entry should import");
+        assert_eq!(camel_case_entry["secondaryKeys"], json!(["flare"]));
+        assert_eq!(camel_case_entry["order"], 1);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/imports.rs
+++ b/src-tauri/src/commands/storage/imports.rs
@@ -3,6 +3,8 @@ use super::*;
 #[path = "imports/service.rs"]
 mod service;
 
+pub(crate) use service::{lorebook_entries, normalize_lorebook_entry};
+
 pub(crate) fn import_call(state: &AppState, rest: &[&str], body: Value) -> AppResult<Value> {
     service::import_call(state, rest, body)
 }

--- a/src-tauri/src/commands/storage/imports/normalization.rs
+++ b/src-tauri/src/commands/storage/imports/normalization.rs
@@ -238,7 +238,8 @@ pub(crate) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: 
     let keys = entry.get("key").or_else(|| entry.get("keys"));
     let secondary = entry
         .get("keysecondary")
-        .or_else(|| entry.get("secondary_keys"));
+        .or_else(|| entry.get("secondary_keys"))
+        .or_else(|| entry.get("secondaryKeys"));
     let enabled = entry
         .get("disable")
         .and_then(Value::as_bool)
@@ -288,7 +289,7 @@ pub(crate) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: 
         "additionalMatchingSources": [],
         "position": position,
         "depth": number(entry.get("depth"), 4),
-        "order": number(entry.get("order").or_else(|| entry.get("insertion_order")).or_else(|| entry.get("uid")).or_else(|| entry.get("id")), 100),
+        "order": number(entry.get("order").or_else(|| entry.get("insertion_order")).or_else(|| entry.get("uid")).or_else(|| entry.get("id")), index as i64),
         "role": role,
         "sticky": optional_number(entry.get("sticky")),
         "cooldown": optional_number(entry.get("cooldown")),

--- a/src-tauri/src/commands/storage/imports/normalization.rs
+++ b/src-tauri/src/commands/storage/imports/normalization.rs
@@ -185,7 +185,7 @@ impl ImportStringFallback for String {
     }
 }
 
-pub(super) fn lorebook_entries(value: &Value) -> Vec<Value> {
+pub(crate) fn lorebook_entries(value: &Value) -> Vec<Value> {
     match value.get("entries") {
         Some(Value::Array(items)) => items.clone(),
         Some(Value::Object(map)) => map.values().cloned().collect(),
@@ -193,7 +193,7 @@ pub(super) fn lorebook_entries(value: &Value) -> Vec<Value> {
     }
 }
 
-pub(super) fn lorebook_entry_count(value: &Value) -> usize {
+pub(crate) fn lorebook_entry_count(value: &Value) -> usize {
     lorebook_entries(value).len()
 }
 
@@ -234,7 +234,7 @@ fn selective_logic_value(value: Option<&Value>) -> &'static str {
     }
 }
 
-pub(super) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: usize) -> Value {
+pub(crate) fn normalize_lorebook_entry(lorebook_id: &str, entry: &Value, index: usize) -> Value {
     let keys = entry.get("key").or_else(|| entry.get("keys"));
     let secondary = entry
         .get("keysecondary")

--- a/src-tauri/src/commands/storage/imports/service.rs
+++ b/src-tauri/src/commands/storage/imports/service.rs
@@ -30,6 +30,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use timestamps::{apply_timestamp_overrides, timestamp_overrides_from_value};
 
+pub(crate) use normalization::{lorebook_entries, normalize_lorebook_entry};
+
 fn create_lorebook_from_payload(
     state: &AppState,
     payload: &Value,


### PR DESCRIPTION
## Linked issue

Closes #2191

## Why this change

- Embedded character-book import/reimport used a narrow converter that dropped ST/V2 lorebook entry fields. Direct ST lorebook import already preserved those fields through the full lorebook normalizer, so the Character Lorebook tab path could silently lose behavior on reimport.

## What changed

- Reused the existing ST lorebook entry normalization for `character_embedded_lorebook_import`.
- Reused the existing lorebook entry extraction helper so embedded `character_book.entries` works as either an array or object map.
- Removed the narrower embedded character-book entry converter.
- Added a focused Rust regression test covering object-form entries and ST/V2 fields such as disable/enabled, order, position, role, depth, scan depth, probability, matching flags, timing fields, group weight, recursion, and locked.

## Refactor impact

Primary owner:

Rust storage, imports, and catalog resource compatibility.

Impact areas reviewed:

- Embedded character lorebook import/reimport storage command.
- Direct ST lorebook import normalizer reused by the command.
- Existing character-book sync tests for linked lorebook behavior.
- Tauri and remote-runtime command boundary, which stays unchanged.

Boundary notes:

- No React, engine, or shared API changes.
- No new command, route, allowlist entry, or HTTP dispatch change.
- The fix stays inside Rust storage/import modules and reuses the existing import normalizer rather than adding a second compatibility mapper.

Pressure points touched:

- `src-tauri/src/commands/storage/exports.rs`
- `src-tauri/src/commands/storage/imports.rs`
- `src-tauri/src/commands/storage/imports/service.rs`
- `src-tauri/src/commands/storage/imports/normalization.rs`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml embedded_lorebook_import_preserves_st_character_book_fields`
- `cargo test --manifest-path src-tauri/Cargo.toml character_book`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix for an existing import/reimport workflow; no new discoverable feature or workflow added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. Rust storage/import compatibility fix with no visible UI changes.
