### PR TITLE
Fix Game Lorebook Keeper after session conclusion

### DIFF
--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1981,6 +1981,10 @@ async function writeGameLorebookKeeperEntries(data: {
           },
         }),
       );
+      const staleEntry = await storageApi.get<LorebookEntry>("lorebook-entries", entry.id);
+      if (!staleEntry || staleEntry.enabled === true) {
+        throw new Error(`Game Lorebook Keeper stale entry was not confirmed inactive: ${entry.id}`);
+      }
     }
     for (const entry of createdEntries) {
       await storageApi.update(

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -31,7 +31,11 @@ import { resolveGalleryFileUrl } from "../../../../shared/api/local-file-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { urlBinaryApi } from "../../../../shared/api/url-binary-api";
 import { visualAssetsApi } from "../../../../shared/api/visual-assets-api";
-import { createLorebookEntrySchema, createLorebookSchema } from "../../../../engine/contracts/schemas/lorebook.schema";
+import {
+  createLorebookEntrySchema,
+  createLorebookSchema,
+  updateLorebookEntrySchema,
+} from "../../../../engine/contracts/schemas/lorebook.schema";
 import { resolveCombatRound } from "../../../../engine/modes/game/mechanics/combat.service";
 import { initGameCombatEncounter } from "../../../../engine/modes/game/mechanics/combat-init.service";
 import { rollDice as rollGameDice } from "../../../../engine/modes/game/mechanics/dice.service";
@@ -1904,18 +1908,40 @@ async function writeGameLorebookKeeperEntries(data: {
         ),
       ];
   const entriesToCreate = normalizedEntries.map((entry) =>
-    createLorebookEntrySchema.parse({ ...entry, lorebookId: lorebook.id }),
+    createLorebookEntrySchema.parse({
+      ...entry,
+      lorebookId: lorebook.id,
+      enabled: false,
+      dynamicState: { ...asRecord(entry.dynamicState), gameLorebookKeeperPending: true },
+    }),
   );
 
   const createdEntries: LorebookEntry[] = [];
-  const cleanupCreatedEntries = () =>
-    Promise.all(createdEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id).catch(() => null)));
+  const disableCreatedEntries = () =>
+    Promise.all(
+      createdEntries.map((entry) =>
+        storageApi
+          .update(
+            "lorebook-entries",
+            entry.id,
+            updateLorebookEntrySchema.parse({
+              enabled: false,
+              dynamicState: {
+                ...asRecord(entry.dynamicState),
+                gameLorebookKeeperPending: true,
+                gameLorebookKeeperFinalizationFailedAt: nowIso(),
+              },
+            }),
+          )
+          .catch(() => null),
+      ),
+    );
   try {
     for (const entry of entriesToCreate) {
       createdEntries.push(await storageApi.create<LorebookEntry>("lorebook-entries", entry));
     }
   } catch (error) {
-    await cleanupCreatedEntries();
+    await Promise.all(createdEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id).catch(() => null)));
     throw error;
   }
 
@@ -1926,26 +1952,45 @@ async function writeGameLorebookKeeperEntries(data: {
   const staleEntries = existingEntries.filter(
     (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
   );
-  await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
-
-  const sessionChat = await patchChatMetadata(data.chat.id, {
-    gameLorebookKeeperLorebookId: lorebook.id,
-    activeLorebookIds: Array.from(
-      new Set([
-        ...(Array.isArray(data.meta.activeLorebookIds)
-          ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
-          : []),
-        lorebook.id,
-      ]),
-    ),
-    gameLorebookKeeperLastRun: {
-      sessionNumber: data.sessionNumber,
-      status: "success",
-      updatedAt: nowIso(),
-      lorebookId: lorebook.id,
-      entryCount: entriesToCreate.length,
-    },
-  });
+  let sessionChat: Chat;
+  try {
+    await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
+    for (const entry of createdEntries) {
+      await storageApi.update(
+        "lorebook-entries",
+        entry.id,
+        updateLorebookEntrySchema.parse({
+          enabled: true,
+          dynamicState: {
+            ...asRecord(entry.dynamicState),
+            gameLorebookKeeperPending: false,
+            gameLorebookKeeperCommittedAt: nowIso(),
+          },
+        }),
+      );
+    }
+    sessionChat = await patchChatMetadata(data.chat.id, {
+      gameLorebookKeeperLorebookId: lorebook.id,
+      activeLorebookIds: Array.from(
+        new Set([
+          ...(Array.isArray(data.meta.activeLorebookIds)
+            ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
+            : []),
+          lorebook.id,
+        ]),
+      ),
+      gameLorebookKeeperLastRun: {
+        sessionNumber: data.sessionNumber,
+        status: "success",
+        updatedAt: nowIso(),
+        lorebookId: lorebook.id,
+        entryCount: entriesToCreate.length,
+      },
+    });
+  } catch (error) {
+    await disableCreatedEntries();
+    throw error;
+  }
   return { lorebookId: lorebook.id, entryCount: entriesToCreate.length, sessionChat };
 }
 

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1952,8 +1952,36 @@ async function writeGameLorebookKeeperEntries(data: {
   const staleEntries = existingEntries.filter(
     (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
   );
+  const restoreStaleEntries = () =>
+    Promise.all(
+      staleEntries.map((entry) =>
+        storageApi
+          .update(
+            "lorebook-entries",
+            entry.id,
+            updateLorebookEntrySchema.parse({
+              enabled: entry.enabled,
+              dynamicState: asRecord(entry.dynamicState),
+            }),
+          )
+          .catch(() => null),
+      ),
+    );
   let sessionChat: Chat;
   try {
+    for (const entry of staleEntries) {
+      await storageApi.update(
+        "lorebook-entries",
+        entry.id,
+        updateLorebookEntrySchema.parse({
+          enabled: false,
+          dynamicState: {
+            ...asRecord(entry.dynamicState),
+            gameLorebookKeeperSupersededAt: nowIso(),
+          },
+        }),
+      );
+    }
     for (const entry of createdEntries) {
       await storageApi.update(
         "lorebook-entries",
@@ -1987,26 +2015,12 @@ async function writeGameLorebookKeeperEntries(data: {
       },
     });
   } catch (error) {
+    await restoreStaleEntries();
     await disableCreatedEntries();
     throw error;
   }
 
   for (const entry of staleEntries) {
-    try {
-      await storageApi.update(
-        "lorebook-entries",
-        entry.id,
-        updateLorebookEntrySchema.parse({
-          enabled: false,
-          dynamicState: {
-            ...asRecord(entry.dynamicState),
-            gameLorebookKeeperSupersededAt: nowIso(),
-          },
-        }),
-      );
-    } catch (error) {
-      console.warn("[game] Game Lorebook Keeper stale entry disable failed", { entryId: entry.id, error });
-    }
     try {
       await storageApi.delete("lorebook-entries", entry.id);
     } catch (error) {

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -20,7 +20,7 @@ import type {
   SkillCheckResult,
 } from "../../../../engine/contracts/types/game";
 import type { RPGAttributes } from "../../../../engine/contracts/types/game-state";
-import { ApiError, type JsonRepairRequest } from "../../../../shared/api/api-errors";
+import { ApiError, isJsonRepairApiError, type JsonRepairRequest } from "../../../../shared/api/api-errors";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
 import { imageGenerationApi, spriteApi } from "../../../../shared/api/image-generation-api";
 import { integrationGateway } from "../../../../shared/api/integration-gateway";
@@ -1890,12 +1890,6 @@ async function writeGameLorebookKeeperEntries(data: {
   entries: unknown[];
 }): Promise<{ lorebookId: string; entryCount: number; sessionChat: Chat }> {
   const lorebook = await resolveGameLorebookKeeperLorebook(data.chat, data.meta);
-  const existingEntries = await storageApi.list<LorebookEntry>("lorebook-entries", {
-    filters: { lorebookId: lorebook.id },
-  });
-  const staleEntries = existingEntries.filter((entry) => keeperEntrySessionNumber(entry) === data.sessionNumber);
-  await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
-
   const normalizedEntries = data.entries.length
     ? data.entries.map((entry, index) => normalizeGameLorebookKeeperEntry(entry, data.sessionNumber, index))
     : [
@@ -1909,9 +1903,28 @@ async function writeGameLorebookKeeperEntries(data: {
           0,
         ),
       ];
-  for (const entry of normalizedEntries) {
-    await storageApi.create("lorebook-entries", createLorebookEntrySchema.parse({ ...entry, lorebookId: lorebook.id }));
+  const entriesToCreate = normalizedEntries.map((entry) =>
+    createLorebookEntrySchema.parse({ ...entry, lorebookId: lorebook.id }),
+  );
+
+  const createdEntries: LorebookEntry[] = [];
+  try {
+    for (const entry of entriesToCreate) {
+      createdEntries.push(await storageApi.create<LorebookEntry>("lorebook-entries", entry));
+    }
+  } catch (error) {
+    await Promise.all(createdEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id).catch(() => null)));
+    throw error;
   }
+
+  const existingEntries = await storageApi.list<LorebookEntry>("lorebook-entries", {
+    filters: { lorebookId: lorebook.id },
+  });
+  const createdEntryIds = new Set(createdEntries.map((entry) => entry.id));
+  const staleEntries = existingEntries.filter(
+    (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
+  );
+  await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
 
   const sessionChat = await patchChatMetadata(data.chat.id, {
     gameLorebookKeeperLorebookId: lorebook.id,
@@ -1928,10 +1941,10 @@ async function writeGameLorebookKeeperEntries(data: {
       status: "success",
       updatedAt: nowIso(),
       lorebookId: lorebook.id,
-      entryCount: normalizedEntries.length,
+      entryCount: entriesToCreate.length,
     },
   });
-  return { lorebookId: lorebook.id, entryCount: normalizedEntries.length, sessionChat };
+  return { lorebookId: lorebook.id, entryCount: entriesToCreate.length, sessionChat };
 }
 
 async function runGameLorebookKeeperAfterConclusion(data: {
@@ -1941,6 +1954,7 @@ async function runGameLorebookKeeperAfterConclusion(data: {
   summary: SessionSummary;
   connectionId?: string;
   generated?: Record<string, unknown>;
+  propagateRepairErrors?: boolean;
 }): Promise<{ lorebookId: string | null; entryCount?: number; sessionChat: Chat }> {
   const startedAt = nowIso();
   await patchChatMetadata(data.chat.id, {
@@ -2006,6 +2020,9 @@ async function runGameLorebookKeeperAfterConclusion(data: {
         error: error instanceof Error ? error.message : "Game Lorebook Keeper failed.",
       },
     });
+    if (data.propagateRepairErrors && isJsonRepairApiError(error)) {
+      throw error;
+    }
     return { lorebookId, sessionChat };
   }
 }
@@ -2372,6 +2389,7 @@ export const gameApi = {
       summary,
       connectionId: data.connectionId,
       generated: data.generated,
+      propagateRepairErrors: true,
     });
     if (keeperRun.entryCount === undefined || !keeperRun.lorebookId) {
       throw new Error("Game Lorebook Keeper failed to regenerate this session.");

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1953,8 +1953,8 @@ async function writeGameLorebookKeeperEntries(data: {
     (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
   );
   let sessionChat: Chat;
+  let replacementsCommitted = false;
   try {
-    await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
     for (const entry of createdEntries) {
       await storageApi.update(
         "lorebook-entries",
@@ -1987,8 +1987,23 @@ async function writeGameLorebookKeeperEntries(data: {
         entryCount: entriesToCreate.length,
       },
     });
+    replacementsCommitted = true;
+    for (const entry of staleEntries) {
+      await storageApi.update(
+        "lorebook-entries",
+        entry.id,
+        updateLorebookEntrySchema.parse({
+          enabled: false,
+          dynamicState: {
+            ...asRecord(entry.dynamicState),
+            gameLorebookKeeperSupersededAt: nowIso(),
+          },
+        }),
+      );
+    }
+    await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
   } catch (error) {
-    await disableCreatedEntries();
+    if (!replacementsCommitted) await disableCreatedEntries();
     throw error;
   }
   return { lorebookId: lorebook.id, entryCount: entriesToCreate.length, sessionChat };

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1,4 +1,5 @@
 import type { Chat } from "../../../../engine/contracts/types/chat";
+import type { Lorebook, LorebookEntry } from "../../../../engine/contracts/types/lorebook";
 import type {
   CombatInitState,
   CombatMechanic,
@@ -129,6 +130,8 @@ const DEFAULT_COMBAT_ENCOUNTER_SETTINGS: EncounterSettings = {
   },
   historyDepth: 10,
 };
+
+const GAME_LOREBOOK_KEEPER_SOURCE_ID = "game-lorebook-keeper";
 
 export interface CreateGameResponse {
   sessionChat: Chat;
@@ -977,7 +980,7 @@ function gameSetupMetadataPatch(config: GameSetupConfig): Record<string, unknown
     gameSpotifyPlaylistId: config.spotifyPlaylistId ?? null,
     gameSpotifyPlaylistName: config.spotifyPlaylistName ?? null,
     gameSpotifyArtist: config.spotifyArtist ?? null,
-    gameEnableLorebookKeeper: Boolean(config.enableLorebookKeeper),
+    gameLorebookKeeperEnabled: Boolean(config.enableLorebookKeeper),
     gameGenerationParameters: config.generationParameters ?? null,
     gameLanguage: config.language ?? null,
     gameRating: config.rating ?? "sfw",
@@ -1131,6 +1134,9 @@ function gameCarryoverPatch(meta: Record<string, unknown>) {
     "gameJournal",
     "gameSessionLorebookId",
     "gameSessionLorebookEntryCount",
+    "gameLorebookKeeperEnabled",
+    "gameLorebookKeeperLorebookId",
+    "gameLorebookKeeperLastRun",
     "gameJournal",
     "discordWebhookUrl",
   ];
@@ -1803,6 +1809,207 @@ async function sessionTranscript(chatId: string, limit = 80): Promise<string> {
     .join("\n");
 }
 
+function keeperEntrySessionNumber(entry: LorebookEntry): number | null {
+  const state = asRecord(entry.dynamicState);
+  const value = Number(state.gameLorebookKeeperSessionNumber);
+  return Number.isFinite(value) ? value : null;
+}
+
+function gameLorebookKeeperEnabled(meta: Record<string, unknown>): boolean {
+  return meta.gameLorebookKeeperEnabled === true || meta.gameEnableLorebookKeeper === true;
+}
+
+function normalizeGameLorebookKeeperEntry(
+  rawEntry: unknown,
+  sessionNumber: number,
+  index: number,
+): Record<string, unknown> {
+  const entry = asRecord(rawEntry);
+  const name = readTrimmed(entry.name) || `Session ${sessionNumber} Lore ${index + 1}`;
+  const content =
+    readTrimmed(entry.content) || readTrimmed(entry.description) || "No durable session detail was provided.";
+  const keys = Array.isArray(entry.keys)
+    ? entry.keys.map((key) => readTrimmed(key)).filter(Boolean)
+    : [`session ${sessionNumber}`];
+  const tag = readTrimmed(entry.tag) || `game-session-${sessionNumber}`;
+  return {
+    name,
+    content,
+    keys: keys.length ? keys : [`session ${sessionNumber}`],
+    secondaryKeys: [],
+    enabled: true,
+    constant: false,
+    selective: false,
+    order: index,
+    sortOrder: index,
+    position: 0,
+    role: "system",
+    tag,
+    dynamicState: {
+      ...asRecord(entry.dynamicState),
+      gameLorebookKeeperSessionNumber: sessionNumber,
+      gameLorebookKeeperUpdatedAt: nowIso(),
+    },
+    excludeFromVectorization: false,
+  };
+}
+
+async function resolveGameLorebookKeeperLorebook(chat: Chat, meta: Record<string, unknown>): Promise<Lorebook> {
+  const existingId = readTrimmed(meta.gameLorebookKeeperLorebookId);
+  if (existingId) {
+    const existing = await storageApi.get<Lorebook>("lorebooks", existingId).catch(() => null);
+    if (existing) return existing;
+  }
+
+  const lorebook = await storageApi.create<Lorebook>(
+    "lorebooks",
+    createLorebookSchema.parse({
+      name: `${chat.name || "Game"} Lorebook`,
+      description: "Maintained automatically from concluded game sessions.",
+      category: "game",
+      chatId: chat.id,
+      enabled: true,
+      generatedBy: "game-session",
+      sourceAgentId: GAME_LOREBOOK_KEEPER_SOURCE_ID,
+    }),
+  );
+  const activeLorebookIds = Array.isArray(meta.activeLorebookIds)
+    ? meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
+    : [];
+  await patchChatMetadata(chat.id, {
+    gameLorebookKeeperLorebookId: lorebook.id,
+    activeLorebookIds: Array.from(new Set([...activeLorebookIds, lorebook.id])),
+  });
+  return lorebook;
+}
+
+async function writeGameLorebookKeeperEntries(data: {
+  chat: Chat;
+  meta: Record<string, unknown>;
+  sessionNumber: number;
+  entries: unknown[];
+}): Promise<{ lorebookId: string; entryCount: number; sessionChat: Chat }> {
+  const lorebook = await resolveGameLorebookKeeperLorebook(data.chat, data.meta);
+  const existingEntries = await storageApi.list<LorebookEntry>("lorebook-entries", {
+    filters: { lorebookId: lorebook.id },
+  });
+  const staleEntries = existingEntries.filter((entry) => keeperEntrySessionNumber(entry) === data.sessionNumber);
+  await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
+
+  const normalizedEntries = data.entries.length
+    ? data.entries.map((entry, index) => normalizeGameLorebookKeeperEntry(entry, data.sessionNumber, index))
+    : [
+        normalizeGameLorebookKeeperEntry(
+          {
+            name: `Session ${data.sessionNumber} Recap`,
+            content: "No durable lore was generated for this concluded session.",
+            keys: [`session ${data.sessionNumber}`],
+          },
+          data.sessionNumber,
+          0,
+        ),
+      ];
+  for (const entry of normalizedEntries) {
+    await storageApi.create("lorebook-entries", createLorebookEntrySchema.parse({ ...entry, lorebookId: lorebook.id }));
+  }
+
+  const sessionChat = await patchChatMetadata(data.chat.id, {
+    gameLorebookKeeperLorebookId: lorebook.id,
+    activeLorebookIds: Array.from(
+      new Set([
+        ...(Array.isArray(data.meta.activeLorebookIds)
+          ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
+          : []),
+        lorebook.id,
+      ]),
+    ),
+    gameLorebookKeeperLastRun: {
+      sessionNumber: data.sessionNumber,
+      status: "success",
+      updatedAt: nowIso(),
+      lorebookId: lorebook.id,
+      entryCount: normalizedEntries.length,
+    },
+  });
+  return { lorebookId: lorebook.id, entryCount: normalizedEntries.length, sessionChat };
+}
+
+async function runGameLorebookKeeperAfterConclusion(data: {
+  chat: Chat;
+  meta: Record<string, unknown>;
+  sessionNumber: number;
+  summary: SessionSummary;
+  connectionId?: string;
+  generated?: Record<string, unknown>;
+}): Promise<{ lorebookId: string | null; entryCount?: number; sessionChat: Chat }> {
+  const startedAt = nowIso();
+  await patchChatMetadata(data.chat.id, {
+    gameLorebookKeeperLastRun: {
+      sessionNumber: data.sessionNumber,
+      status: "running",
+      updatedAt: startedAt,
+      lorebookId: readTrimmed(data.meta.gameLorebookKeeperLorebookId) || null,
+    },
+  });
+
+  try {
+    const transcript = await sessionTranscript(data.chat.id, 160);
+    const fallbackEntries = [
+      {
+        name: `Session ${data.sessionNumber} Recap`,
+        content: data.summary.summary || transcript.split("\n").slice(-12).join("\n"),
+        keys: [`session ${data.sessionNumber}`, "recap", "campaign"],
+      },
+    ];
+    const parsed =
+      data.generated ??
+      (await llmJson({
+        connectionId: data.connectionId,
+        fallback: { entries: fallbackEntries },
+        system:
+          "Extract durable game campaign lore from this concluded session. Return strict JSON with an entries array; each entry has name, content, keys array, and optional tag.",
+        user: [
+          `Session number: ${data.sessionNumber}`,
+          ``,
+          `Session summary:`,
+          JSON.stringify(data.summary, null, 2),
+          ``,
+          `Session transcript:`,
+          transcript,
+        ].join("\n"),
+        parameters: { temperature: 0.3, maxTokens: 2500 },
+        repair: {
+          kind: "session_lorebook",
+          title: `Repair Session ${data.sessionNumber} Lorebook JSON`,
+          applyBody: {
+            chatId: data.chat.id,
+            sessionNumber: data.sessionNumber,
+            connectionId: data.connectionId,
+          },
+        },
+      }));
+    const entries = Array.isArray(parsed.entries) && parsed.entries.length ? parsed.entries : fallbackEntries;
+    return await writeGameLorebookKeeperEntries({
+      chat: data.chat,
+      meta: data.meta,
+      sessionNumber: data.sessionNumber,
+      entries,
+    });
+  } catch (error) {
+    const lorebookId = readTrimmed(data.meta.gameLorebookKeeperLorebookId) || null;
+    const sessionChat = await patchChatMetadata(data.chat.id, {
+      gameLorebookKeeperLastRun: {
+        sessionNumber: data.sessionNumber,
+        status: "failed",
+        updatedAt: nowIso(),
+        lorebookId,
+        error: error instanceof Error ? error.message : "Game Lorebook Keeper failed.",
+      },
+    });
+    return { lorebookId, sessionChat };
+  }
+}
+
 export const gameApi = {
   async createGame(data: {
     name: string;
@@ -2118,18 +2325,29 @@ export const gameApi = {
       ? [...(meta.gamePreviousSessionSummaries as SessionSummary[])]
       : [];
     const nextSummaries = summaries.filter((item) => item.sessionNumber !== sessionNumber).concat(summary);
-    const sessionChat = await patchChatMetadata(data.chatId, {
+    let sessionChat = await patchChatMetadata(data.chatId, {
       gameSessionStatus: "concluded",
       gameJournal: journalFromChat(chat, meta, { includeCurrentLocation: false }),
       gamePreviousSessionSummaries: nextSummaries,
       gameCampaignProgression: campaignProgression,
       gameCharacterCards: characterCards,
+      ...(gameLorebookKeeperEnabled(meta) ? { gameLorebookKeeperEnabled: true } : {}),
     });
     const checkpointWarning = await createAutomaticGameCheckpoint({
       chatId: data.chatId,
       label: "Session ended",
       triggerType: "session_end",
     });
+    if (gameLorebookKeeperEnabled(meta)) {
+      const keeperRun = await runGameLorebookKeeperAfterConclusion({
+        chat: sessionChat,
+        meta: { ...meta, ...chatMeta(sessionChat), gameLorebookKeeperEnabled: true },
+        sessionNumber,
+        summary,
+        connectionId: data.connectionId,
+      });
+      sessionChat = keeperRun.sessionChat;
+    }
     return { summary, sessionChat, ...(checkpointWarning ? { checkpointWarning } : {}) };
   },
 
@@ -2139,80 +2357,31 @@ export const gameApi = {
     connectionId?: string;
     generated?: Record<string, unknown>;
   }): Promise<RegenerateSessionLorebookResponse> {
-    const transcript = await sessionTranscript(data.chatId);
-    const fallbackEntries = transcript.trim()
-      ? [
-          {
-            name: `Session ${data.sessionNumber} Recap`,
-            content: transcript.split("\n").slice(0, 12).join("\n"),
-            keys: [`session ${data.sessionNumber}`, "recap", "campaign"],
-          },
-        ]
-      : [
-          {
-            name: `Session ${data.sessionNumber} State`,
-            content: "No transcript was available; preserve the current campaign state from the chat metadata.",
-            keys: [`session ${data.sessionNumber}`],
-          },
-        ];
-    const parsed =
-      data.generated ??
-      (await llmJson({
-        connectionId: data.connectionId,
-        fallback: { entries: fallbackEntries },
-        system:
-          "Extract durable campaign lore from the session transcript. Return strict JSON with an entries array; each entry has name, content, and keys array.",
-        user: transcript,
-        parameters: { temperature: 0.3, maxTokens: 2500 },
-        repair: {
-          kind: "session_lorebook",
-          title: `Repair Session ${data.sessionNumber} Lorebook JSON`,
-          applyBody: {
-            chatId: data.chatId,
-            sessionNumber: data.sessionNumber,
-            connectionId: data.connectionId,
-          },
-        },
-      }));
-    const entries = Array.isArray(parsed.entries) && parsed.entries.length ? parsed.entries : fallbackEntries;
-    const lorebook = await storageApi.create<{ id: string }>(
-      "lorebooks",
-      createLorebookSchema.parse({
-        name: `Game Session ${data.sessionNumber} Lore`,
-        description: "Generated from local game session state.",
-        category: "game",
-        chatId: data.chatId,
-        enabled: true,
-        generatedBy: "game-session",
-      }),
-    );
-    let entryCount = 0;
-    for (const [index, rawEntry] of entries.entries()) {
-      const entry = asRecord(rawEntry);
-      await storageApi.create(
-        "lorebook-entries",
-        createLorebookEntrySchema.parse({
-          lorebookId: lorebook.id,
-          name: typeof entry.name === "string" ? entry.name : "Session Lore",
-          content: typeof entry.content === "string" ? entry.content : "",
-          keys: Array.isArray(entry.keys) ? entry.keys : [`session ${data.sessionNumber}`],
-          secondaryKeys: [],
-          enabled: true,
-          constant: false,
-          selective: false,
-          order: index,
-          position: 0,
-          role: "system",
-          excludeFromVectorization: false,
-        }),
-      );
-      entryCount += 1;
-    }
-    const sessionChat = await patchChatMetadata(data.chatId, {
-      gameSessionLorebookId: lorebook.id,
-      gameSessionLorebookEntryCount: entryCount,
+    const chat = await getChat(data.chatId);
+    const meta = chatMeta(chat);
+    const summaries = Array.isArray(meta.gamePreviousSessionSummaries)
+      ? (meta.gamePreviousSessionSummaries as SessionSummary[])
+      : [];
+    const summary =
+      summaries.find((item) => item.sessionNumber === data.sessionNumber) ??
+      sessionSummary(data.sessionNumber, chat, meta);
+    const keeperRun = await runGameLorebookKeeperAfterConclusion({
+      chat,
+      meta: { ...meta, gameLorebookKeeperEnabled: true },
+      sessionNumber: data.sessionNumber,
+      summary,
+      connectionId: data.connectionId,
+      generated: data.generated,
     });
-    return { sessionNumber: data.sessionNumber, lorebookId: lorebook.id, entryCount, sessionChat };
+    if (keeperRun.entryCount === undefined || !keeperRun.lorebookId) {
+      throw new Error("Game Lorebook Keeper failed to regenerate this session.");
+    }
+    return {
+      sessionNumber: data.sessionNumber,
+      lorebookId: keeperRun.lorebookId,
+      entryCount: keeperRun.entryCount,
+      sessionChat: keeperRun.sessionChat,
+    };
   },
 
   async updateCampaignProgression(data: {
@@ -2585,7 +2754,11 @@ export const gameApi = {
   }): Promise<{ journal: Journal; sessionChat: Chat }> {
     const chat = await getChat(data.chatId);
     const meta = chatMeta(chat);
-    const journal = applyJournalEntry(journalFromChat(chat, meta, { includeCurrentLocation: false }), data.type, data.data);
+    const journal = applyJournalEntry(
+      journalFromChat(chat, meta, { includeCurrentLocation: false }),
+      data.type,
+      data.data,
+    );
     const sessionChat = await patchChatMetadata(data.chatId, { gameJournal: journal });
     return { journal, sessionChat };
   },

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1908,12 +1908,14 @@ async function writeGameLorebookKeeperEntries(data: {
   );
 
   const createdEntries: LorebookEntry[] = [];
+  const cleanupCreatedEntries = () =>
+    Promise.all(createdEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id).catch(() => null)));
   try {
     for (const entry of entriesToCreate) {
       createdEntries.push(await storageApi.create<LorebookEntry>("lorebook-entries", entry));
     }
   } catch (error) {
-    await Promise.all(createdEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id).catch(() => null)));
+    await cleanupCreatedEntries();
     throw error;
   }
 
@@ -1924,26 +1926,31 @@ async function writeGameLorebookKeeperEntries(data: {
   const staleEntries = existingEntries.filter(
     (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
   );
-  await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
-
-  const sessionChat = await patchChatMetadata(data.chat.id, {
-    gameLorebookKeeperLorebookId: lorebook.id,
-    activeLorebookIds: Array.from(
-      new Set([
-        ...(Array.isArray(data.meta.activeLorebookIds)
-          ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
-          : []),
-        lorebook.id,
-      ]),
-    ),
-    gameLorebookKeeperLastRun: {
-      sessionNumber: data.sessionNumber,
-      status: "success",
-      updatedAt: nowIso(),
-      lorebookId: lorebook.id,
-      entryCount: entriesToCreate.length,
-    },
-  });
+  let sessionChat: Chat;
+  try {
+    await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
+    sessionChat = await patchChatMetadata(data.chat.id, {
+      gameLorebookKeeperLorebookId: lorebook.id,
+      activeLorebookIds: Array.from(
+        new Set([
+          ...(Array.isArray(data.meta.activeLorebookIds)
+            ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
+            : []),
+          lorebook.id,
+        ]),
+      ),
+      gameLorebookKeeperLastRun: {
+        sessionNumber: data.sessionNumber,
+        status: "success",
+        updatedAt: nowIso(),
+        lorebookId: lorebook.id,
+        entryCount: entriesToCreate.length,
+      },
+    });
+  } catch (error) {
+    await cleanupCreatedEntries();
+    throw error;
+  }
   return { lorebookId: lorebook.id, entryCount: entriesToCreate.length, sessionChat };
 }
 

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1926,31 +1926,26 @@ async function writeGameLorebookKeeperEntries(data: {
   const staleEntries = existingEntries.filter(
     (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
   );
-  let sessionChat: Chat;
-  try {
-    await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
-    sessionChat = await patchChatMetadata(data.chat.id, {
-      gameLorebookKeeperLorebookId: lorebook.id,
-      activeLorebookIds: Array.from(
-        new Set([
-          ...(Array.isArray(data.meta.activeLorebookIds)
-            ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
-            : []),
-          lorebook.id,
-        ]),
-      ),
-      gameLorebookKeeperLastRun: {
-        sessionNumber: data.sessionNumber,
-        status: "success",
-        updatedAt: nowIso(),
-        lorebookId: lorebook.id,
-        entryCount: entriesToCreate.length,
-      },
-    });
-  } catch (error) {
-    await cleanupCreatedEntries();
-    throw error;
-  }
+  await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
+
+  const sessionChat = await patchChatMetadata(data.chat.id, {
+    gameLorebookKeeperLorebookId: lorebook.id,
+    activeLorebookIds: Array.from(
+      new Set([
+        ...(Array.isArray(data.meta.activeLorebookIds)
+          ? data.meta.activeLorebookIds.filter((id): id is string => typeof id === "string")
+          : []),
+        lorebook.id,
+      ]),
+    ),
+    gameLorebookKeeperLastRun: {
+      sessionNumber: data.sessionNumber,
+      status: "success",
+      updatedAt: nowIso(),
+      lorebookId: lorebook.id,
+      entryCount: entriesToCreate.length,
+    },
+  });
   return { lorebookId: lorebook.id, entryCount: entriesToCreate.length, sessionChat };
 }
 

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -1953,7 +1953,6 @@ async function writeGameLorebookKeeperEntries(data: {
     (entry) => !createdEntryIds.has(entry.id) && keeperEntrySessionNumber(entry) === data.sessionNumber,
   );
   let sessionChat: Chat;
-  let replacementsCommitted = false;
   try {
     for (const entry of createdEntries) {
       await storageApi.update(
@@ -1987,8 +1986,13 @@ async function writeGameLorebookKeeperEntries(data: {
         entryCount: entriesToCreate.length,
       },
     });
-    replacementsCommitted = true;
-    for (const entry of staleEntries) {
+  } catch (error) {
+    await disableCreatedEntries();
+    throw error;
+  }
+
+  for (const entry of staleEntries) {
+    try {
       await storageApi.update(
         "lorebook-entries",
         entry.id,
@@ -2000,11 +2004,14 @@ async function writeGameLorebookKeeperEntries(data: {
           },
         }),
       );
+    } catch (error) {
+      console.warn("[game] Game Lorebook Keeper stale entry disable failed", { entryId: entry.id, error });
     }
-    await Promise.all(staleEntries.map((entry) => storageApi.delete("lorebook-entries", entry.id)));
-  } catch (error) {
-    if (!replacementsCommitted) await disableCreatedEntries();
-    throw error;
+    try {
+      await storageApi.delete("lorebook-entries", entry.id);
+    } catch (error) {
+      console.warn("[game] Game Lorebook Keeper stale entry cleanup failed", { entryId: entry.id, error });
+    }
   }
   return { lorebookId: lorebook.id, entryCount: entriesToCreate.length, sessionChat };
 }


### PR DESCRIPTION
## Linked issue

Closes #2193

## Why this change

- Game session conclusion stopped running Game Lorebook Keeper automatically, so enabled game lorebooks were not created or updated after End Session. Setup also stored the keeper toggle under the wrong metadata key, leaving setup-created games disabled from the UI/runtime contract.

## What changed

- Store `gameLorebookKeeperEnabled` during game setup so setup-created games use the same key as settings, history, and runtime code.
- Carry Game Lorebook Keeper metadata into new sessions.
- Run Game Lorebook Keeper from the session conclusion path when enabled, recording `running`, `success`, or `failed` in `gameLorebookKeeperLastRun`.
- Create or reuse the game-scoped keeper lorebook, attach it to the chat, and activate it.
- Reuse the same keeper path for manual regenerate/retry and replace existing entries for the requested session.

## Refactor impact

Primary owner:

Game mode

Impact areas reviewed:

- Game setup metadata
- Game session conclusion
- Game session carryover
- Game Lorebook Keeper regenerate/retry
- Lorebook and lorebook-entry storage writes from the game feature API

Boundary notes:

- Kept the change inside the game feature API owner.
- Used existing shared storage and LLM API wrappers.
- Did not add raw Tauri calls, remote-runtime routing, Rust commands, or cross-mode imports.

Pressure points touched:

- `src/features/modes/game/api/game-api.ts`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed locally.
- `pnpm check:architecture` passed locally.
- `pnpm check` passed locally.
- No browser/provider runtime validation was performed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores existing Game Lorebook Keeper behavior; does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No visible UI changes.
