### PR TITLE
Fix Lorebook Keeper built-in fallback

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -3,7 +3,6 @@ import {
   BUILT_IN_AGENT_IDS,
   BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS,
   DEFAULT_AGENT_TOOLS,
-  getDefaultBuiltInAgentSettings,
   type AgentContext,
   type AgentResult,
 } from "../contracts/types/agent";
@@ -46,6 +45,13 @@ import {
 import { resolveGameLorebookScopeExclusions } from "../generation-core/lorebooks/game-lorebook-scope";
 import { resolveLorebookKeeperTarget } from "../generation-core/lorebooks/lorebook-keeper-target";
 import { applyAllSegmentEdits } from "../modes/game/state/segment-edits";
+import {
+  BUILT_IN_AGENT_TYPES,
+  buildBuiltInAgentFallback,
+  builtInAgentType,
+  canonicalAgentActiveIdSet,
+  isBuiltInAgent,
+} from "./built-in-agent-fallback";
 import { llmParameters } from "./context";
 import { loadAgentMemory, secretPlotStateFromMemory } from "./agent-memory-runtime";
 import {
@@ -129,7 +135,6 @@ interface ResolvedAgentsResult {
   staticInjections: AgentInjection[];
 }
 
-const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const DIRECTOR_AGENT_TYPE = "director";
 const ILLUSTRATOR_AGENT_TYPE = "illustrator";
 const CARD_EVOLUTION_AUDITOR_AGENT_TYPE = "card-evolution-auditor";
@@ -477,7 +482,7 @@ function chatHasActiveAgents(input: GenerationAgentRuntimeInput): boolean {
 }
 
 function chatActiveAgentIds(input: GenerationAgentRuntimeInput): Set<string> {
-  return stringSet(chatMetadata(input).activeAgentIds);
+  return canonicalAgentActiveIdSet(chatMetadata(input).activeAgentIds);
 }
 
 function chatActiveLorebookIds(input: GenerationAgentRuntimeInput): Set<string> {
@@ -741,40 +746,6 @@ function activationScanMessages(input: GenerationAgentRuntimeInput): ActivationS
   return promptVisibleStoredMessages(input)
     .filter((message) => !hiddenFromAi(message))
     .map((message) => ({ content: readString(message.content) }));
-}
-
-function isBuiltInAgent(agent: JsonRecord): boolean {
-  const type = readString(agent.type || agent.agentType).trim();
-  return BUILT_IN_AGENT_TYPES.has(type);
-}
-
-function builtInAgentType(agent: JsonRecord): string {
-  return readString(agent.type || agent.agentType).trim();
-}
-
-function builtInAgentMeta(type: string) {
-  return BUILT_IN_AGENTS.find((agent) => agent.id === type) ?? null;
-}
-
-function builtInAgentFallback(type: string): JsonRecord | null {
-  const meta = builtInAgentMeta(type);
-  if (!meta) return null;
-  if (!meta.enabledByDefault) return null;
-  const settings = {
-    ...getDefaultBuiltInAgentSettings(type),
-    enabledTools: DEFAULT_AGENT_TOOLS[type] ?? [],
-  };
-  return {
-    id: `builtin:${type}`,
-    type,
-    name: meta.name,
-    description: meta.description,
-    enabled: true,
-    phase: meta.phase,
-    connectionId: null,
-    promptTemplate: "",
-    settings,
-  };
 }
 
 function positiveInteger(value: unknown, fallback: number, max: number): number {
@@ -1057,7 +1028,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     .filter((type) => !resolvedBuiltInTypes.has(type))
     .filter((type) => !configuredBuiltInTypes.has(type))
     .filter((type) => requestedAgentTypes || type !== "lorebook-keeper")
-    .map(builtInAgentFallback)
+    .map((type) => buildBuiltInAgentFallback(type, { allowDisabled: true }))
     .filter((agent): agent is JsonRecord => !!agent);
   rows.push(...fallbackRows);
   let customTools: Map<string, CustomToolRecord> | null = null;

--- a/src/engine/generation/built-in-agent-fallback.ts
+++ b/src/engine/generation/built-in-agent-fallback.ts
@@ -1,0 +1,57 @@
+import {
+  BUILT_IN_AGENTS,
+  DEFAULT_AGENT_TOOLS,
+  getDefaultBuiltInAgentSettings,
+} from "../contracts/types/agent";
+import { readString, type JsonRecord } from "./runtime-records";
+
+export const BUILT_IN_AGENT_TYPES = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+const BUILT_IN_AGENT_ID_PREFIX = "builtin:";
+
+function canonicalAgentActiveId(value: unknown): string {
+  const id = readString(value).trim();
+  if (!id.startsWith(BUILT_IN_AGENT_ID_PREFIX)) return id;
+  const type = id.slice(BUILT_IN_AGENT_ID_PREFIX.length).trim();
+  return BUILT_IN_AGENT_TYPES.has(type) ? type : id;
+}
+
+export function canonicalAgentActiveIdSet(value: unknown): Set<string> {
+  if (!Array.isArray(value)) return new Set();
+  return new Set(value.map(canonicalAgentActiveId).filter(Boolean));
+}
+
+export function builtInAgentType(agent: JsonRecord): string {
+  return typeof agent.type === "string"
+    ? agent.type.trim()
+    : typeof agent.agentType === "string"
+      ? agent.agentType.trim()
+      : "";
+}
+
+export function isBuiltInAgent(agent: JsonRecord): boolean {
+  return BUILT_IN_AGENT_TYPES.has(builtInAgentType(agent));
+}
+
+export function buildBuiltInAgentFallback(
+  type: string,
+  options: { allowDisabled?: boolean } = {},
+): JsonRecord | null {
+  const meta = BUILT_IN_AGENTS.find((agent) => agent.id === type) ?? null;
+  if (!meta) return null;
+  if (!meta.enabledByDefault && !options.allowDisabled) return null;
+  const settings = {
+    ...getDefaultBuiltInAgentSettings(type),
+    enabledTools: DEFAULT_AGENT_TOOLS[type] ?? [],
+  };
+  return {
+    id: `builtin:${type}`,
+    type,
+    name: meta.name,
+    description: meta.description,
+    enabled: true,
+    phase: meta.phase,
+    connectionId: null,
+    promptTemplate: "",
+    settings,
+  };
+}

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -24,6 +24,7 @@ import {
 } from "./active-characters";
 import { persistSecretPlotAgentMemory, type SecretPlotRerollMode } from "./agent-memory-runtime";
 import { createGenerationAgentRuntime } from "./agent-runner";
+import { buildBuiltInAgentFallback, canonicalAgentActiveIdSet } from "./built-in-agent-fallback";
 import { consumePendingConnectedInfluences, persistConnectedCommandTags } from "./connected-commands";
 import { fitMessagesToContextWindow } from "./context-window";
 import type { LLMToolCall } from "../generation-core/llm/base-provider";
@@ -2275,11 +2276,7 @@ function lorebookKeeperRunInterval(agent: JsonRecord | null): number {
 }
 
 function chatActiveAgentIds(chat: JsonRecord): Set<string> {
-  return new Set(
-    stringArray(parseRecord(chat.metadata).activeAgentIds)
-      .map((id) => id.trim())
-      .filter(Boolean),
-  );
+  return canonicalAgentActiveIdSet(parseRecord(chat.metadata).activeAgentIds);
 }
 
 function chatHasLorebookKeeperEnabled(chat: JsonRecord, agent: JsonRecord): boolean {
@@ -2287,14 +2284,25 @@ function chatHasLorebookKeeperEnabled(chat: JsonRecord, agent: JsonRecord): bool
   const activeAgentIds = chatActiveAgentIds(chat);
   if (activeAgentIds.size > 0) {
     const id = readString(agent.id).trim();
-    return activeAgentIds.has(LOREBOOK_KEEPER_AGENT_TYPE) || (id ? activeAgentIds.has(id) : false);
+    return (
+      activeAgentIds.has(LOREBOOK_KEEPER_AGENT_TYPE) ||
+      (id ? activeAgentIds.has(id) : false)
+    );
   }
   return false;
 }
 
 async function lorebookKeeperAgent(storage: StorageGateway, chat: JsonRecord): Promise<JsonRecord | null> {
   const agents = await storage.list<JsonRecord>("agents").catch(() => []);
-  return agents.find((agent) => chatHasLorebookKeeperEnabled(chat, agent)) ?? null;
+  const persisted = agents.find((agent) => chatHasLorebookKeeperEnabled(chat, agent)) ?? null;
+  if (persisted) return persisted;
+  const activeAgentIds = chatActiveAgentIds(chat);
+  if (
+    activeAgentIds.has(LOREBOOK_KEEPER_AGENT_TYPE)
+  ) {
+    return buildBuiltInAgentFallback(LOREBOOK_KEEPER_AGENT_TYPE, { allowDisabled: true });
+  }
+  return null;
 }
 
 async function successfulLorebookKeeperMessageIds(storage: StorageGateway, chatId: string): Promise<Set<string>> {


### PR DESCRIPTION
## Linked issue

Closes #2194

## Why this change

Lorebook Keeper backfill and automatic cadence could silently do nothing when a chat explicitly enabled the built-in `lorebook-keeper` but no saved agent config row existed.

Normal agent resolution already had built-in fallback behavior for explicit built-ins, but the Keeper-specific backfill lookup only scanned persisted `agents` rows. That made the backfill/cadence path miss the same built-in Keeper config users selected in chat metadata.

## What changed

- Added a shared engine helper for built-in agent fallback rows.
- Updated normal generation agent resolution to use the shared fallback helper for explicit built-ins.
- Updated the Lorebook Keeper backfill lookup to synthesize `builtin:lorebook-keeper` when chat metadata explicitly enables it and no persisted Keeper row exists.
- Recognized both `lorebook-keeper` and `builtin:lorebook-keeper` active IDs in the Keeper backfill path.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Runtime generation agent resolution
- Lorebook Keeper retry/backfill path
- Automatic post-generation Keeper cadence, via the same backfill helper

Boundary notes:

- Product behavior stays in `src/engine/generation`.
- No React, shared API, Tauri, Rust storage, remote runtime, or persisted schema boundaries changed.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/built-in-agent-fallback.temp.test.ts` passed with a temporary local proof file that verified disabled built-ins remain opt-in by default and explicit Lorebook Keeper fallback resolves to `builtin:lorebook-keeper`; the temporary proof file was removed before commit.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix only. This restores the existing Lorebook Keeper selection behavior for backfill/cadence paths and does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not applicable; no visible UI changes.
