### PR TITLE
Fix lorebook regex timeout

### DIFF
--- a/src/engine/agents-runtime/knowledge/knowledge-router.ts
+++ b/src/engine/agents-runtime/knowledge/knowledge-router.ts
@@ -165,14 +165,17 @@ function buildKnowledgeRouterQuery(context: AgentContext): string {
   return parts.join("\n\n");
 }
 
-function buildKeywordActivatedRouterEntries(
+async function buildKeywordActivatedRouterEntries(
   entries: LorebookEntry[],
   messages: ScanMessage[],
   options: KnowledgeRouterCandidateOptions["scanOptions"] = {},
-): LorebookEntry[] {
-  return scanForActivatedEntries(messages, entries, { ...options, scanDepth: 0, ignoreTiming: true }).map(
-    (activated) => activated.entry,
-  );
+): Promise<LorebookEntry[]> {
+  const activatedEntries = await scanForActivatedEntries(messages, entries, {
+    ...options,
+    scanDepth: 0,
+    ignoreTiming: true,
+  });
+  return activatedEntries.map((activated) => activated.entry);
 }
 
 function mergeKnowledgeRouterCandidates(
@@ -208,10 +211,14 @@ async function prepareKnowledgeRouterCandidates(
     }));
   const activatedEntries =
     options.activatedEntries ??
-    buildKeywordActivatedRouterEntries(options.keywordScanEntries ?? entries, scanMessages, options.scanOptions);
+    (await buildKeywordActivatedRouterEntries(
+      options.keywordScanEntries ?? entries,
+      scanMessages,
+      options.scanOptions,
+    ));
   const keywordScanEntries =
     options.activatedEntries && options.keywordScanEntries
-      ? buildKeywordActivatedRouterEntries(options.keywordScanEntries, scanMessages, options.scanOptions)
+      ? await buildKeywordActivatedRouterEntries(options.keywordScanEntries, scanMessages, options.scanOptions)
       : [];
   const fallbackCandidates = mergeKnowledgeRouterCandidates(
     [],

--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -5,7 +5,7 @@ import type {
   LorebookMatchingSource,
   LorebookSchedule,
 } from "../../contracts/types/lorebook";
-import { testPrimaryKeys, testSecondaryKeys } from "../../shared/regex/lorebook-keyword-matching";
+import { testPrimaryKeysAsync, testSecondaryKeysAsync } from "../../shared/regex/lorebook-keyword-matching";
 import { vmRegexExecutor } from "./regex-timeout.js";
 
 /** Compute cosine similarity between two vectors. Returns 0 for empty/mismatched vectors. */
@@ -416,11 +416,11 @@ export interface ScanOptions {
  * Main scanning function: given messages and lorebook entries,
  * returns the list of activated entries.
  */
-export function scanForActivatedEntries(
+export async function scanForActivatedEntries(
   messages: ScanMessage[],
   entries: LorebookEntry[],
   options: ScanOptions = {},
-): ActivatedEntry[] {
+): Promise<ActivatedEntry[]> {
   const {
     scanDepth = 0,
     gameState = null,
@@ -506,15 +506,15 @@ export function scanForActivatedEntries(
     };
 
     // Test primary keys
-    const { matched, matchedKeys } = testPrimaryKeys(entry.keys, entryScanText, matchOptions);
+    const { matched, matchedKeys } = await testPrimaryKeysAsync(entry.keys, entryScanText, matchOptions);
     if (!matched) continue;
     const matchedLatestUserMessage =
-      latestUserText.length > 0 && testPrimaryKeys(entry.keys, latestUserText, matchOptions).matched;
+      latestUserText.length > 0 && (await testPrimaryKeysAsync(entry.keys, latestUserText, matchOptions)).matched;
 
     // Test secondary keys only for selective entries. Older imports can carry
     // secondary keys while keeping selective disabled.
     if (entry.selective && entry.secondaryKeys.length > 0) {
-      if (!testSecondaryKeys(entry.secondaryKeys, entryScanText, entry.selectiveLogic, matchOptions)) {
+      if (!(await testSecondaryKeysAsync(entry.secondaryKeys, entryScanText, entry.selectiveLogic, matchOptions))) {
         continue;
       }
     }

--- a/src/engine/generation-core/lorebooks/prompt-injector.test.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.test.ts
@@ -59,8 +59,8 @@ function entry(
 }
 
 describe("processActivatedEntries", () => {
-  it("keeps latest user-message primary-key matches ahead of older context matches", () => {
-    const activated = scanForActivatedEntries(
+  it("keeps latest user-message primary-key matches ahead of older context matches", async () => {
+    const activated = await scanForActivatedEntries(
       [
         { role: "user", content: "Earlier chat mentioned old-key." },
         { role: "assistant", content: "Acknowledged." },

--- a/src/engine/generation-core/lorebooks/regex-timeout.test.ts
+++ b/src/engine/generation-core/lorebooks/regex-timeout.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, "createObjectURL");
+const originalWorker = globalThis.Worker;
+
+async function importExecutor() {
+  vi.resetModules();
+  return import("./regex-timeout");
+}
+
+function installCreateObjectUrl() {
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: vi.fn(() => "blob:regex-worker"),
+  });
+}
+
+function installWorker(worker: unknown) {
+  vi.stubGlobal("Worker", worker);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  if (createObjectUrlDescriptor) {
+    Object.defineProperty(URL, "createObjectURL", createObjectUrlDescriptor);
+  } else {
+    delete (URL as { createObjectURL?: unknown }).createObjectURL;
+  }
+  Object.defineProperty(globalThis, "Worker", {
+    configurable: true,
+    writable: true,
+    value: originalWorker,
+  });
+});
+
+beforeEach(() => {
+  installCreateObjectUrl();
+});
+
+describe("vmRegexExecutor", () => {
+  it("resolves safe regex matches through a worker", async () => {
+    class MatchingWorker {
+      onmessage:
+        | ((event: MessageEvent<{ type: "ready" } | { type: "result"; matched: boolean }>) => void)
+        | null = null;
+
+      constructor(readonly url: string) {}
+
+      terminate() {}
+
+      postMessage(message: { type: "ready" } | { type: "test"; source: string; flags: string; text: string }) {
+        if (message.type === "ready") {
+          queueMicrotask(() => this.onmessage?.({ data: { type: "ready" } } as MessageEvent));
+          return;
+        }
+        const matched = new RegExp(message.source, message.flags).test(message.text);
+        queueMicrotask(() => this.onmessage?.({ data: { type: "result", matched } } as MessageEvent));
+      }
+    }
+
+    installWorker(MatchingWorker);
+    const { vmRegexExecutor } = await importExecutor();
+
+    await expect(vmRegexExecutor(/hello/i, "well hello there")).resolves.toBe(true);
+  });
+
+  it("does not count worker startup time against the regex execution deadline", async () => {
+    vi.useFakeTimers();
+
+    class SlowStartupWorker {
+      onmessage:
+        | ((event: MessageEvent<{ type: "ready" } | { type: "result"; matched: boolean }>) => void)
+        | null = null;
+
+      constructor(readonly url: string) {}
+
+      terminate() {}
+
+      postMessage(message: { type: "ready" } | { type: "test"; source: string; flags: string; text: string }) {
+        if (message.type === "ready") {
+          setTimeout(() => this.onmessage?.({ data: { type: "ready" } } as MessageEvent), 75);
+          return;
+        }
+        const matched = new RegExp(message.source, message.flags).test(message.text);
+        queueMicrotask(() => this.onmessage?.({ data: { type: "result", matched } } as MessageEvent));
+      }
+    }
+
+    installWorker(SlowStartupWorker);
+    const { vmRegexExecutor } = await importExecutor();
+
+    const result = vmRegexExecutor(/hello/i, "well hello there");
+    await vi.advanceTimersByTimeAsync(75);
+
+    await expect(result).resolves.toBe(true);
+  });
+
+  it("falls back when the worker never becomes ready", async () => {
+    vi.useFakeTimers();
+
+    class NeverReadyWorker {
+      static last: NeverReadyWorker | null = null;
+      terminated = false;
+
+      constructor(readonly url: string) {
+        NeverReadyWorker.last = this;
+      }
+
+      terminate() {
+        this.terminated = true;
+      }
+
+      postMessage() {}
+    }
+
+    installWorker(NeverReadyWorker);
+    const { vmRegexExecutor } = await importExecutor();
+
+    const result = vmRegexExecutor(/hello/i, "well hello there");
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(result).resolves.toBe(true);
+    expect(NeverReadyWorker.last?.terminated).toBe(true);
+  });
+
+  it("fails closed when the worker times out", async () => {
+    vi.useFakeTimers();
+
+    class SilentWorker {
+      static last: SilentWorker | null = null;
+      onmessage: ((event: MessageEvent<{ type: "ready" }>) => void) | null = null;
+      terminated = false;
+
+      constructor(readonly url: string) {
+        SilentWorker.last = this;
+      }
+
+      terminate() {
+        this.terminated = true;
+      }
+
+      postMessage(message: { type: "ready" } | { type: "test" }) {
+        if (message.type === "ready") {
+          queueMicrotask(() => this.onmessage?.({ data: { type: "ready" } } as MessageEvent));
+        }
+      }
+    }
+
+    installWorker(SilentWorker);
+    const { vmRegexExecutor } = await importExecutor();
+
+    const result = vmRegexExecutor(/hello/i, "hello");
+    await vi.advanceTimersByTimeAsync(51);
+
+    await expect(result).resolves.toBe(false);
+    expect(SilentWorker.last?.terminated).toBe(true);
+  });
+
+  it("contains worker construction failures inside the bounded fallback", async () => {
+    class ThrowingWorker {
+      constructor(readonly url: string) {
+        throw new Error(`cannot construct ${url}`);
+      }
+    }
+
+    installWorker(ThrowingWorker);
+    const { vmRegexExecutor } = await importExecutor();
+
+    await expect(vmRegexExecutor(/hello/i, "well hello there")).resolves.toBe(true);
+    await expect(vmRegexExecutor(/hello/i, `${"x".repeat(10_001)}hello`)).resolves.toBe(false);
+  });
+
+  it("uses the bounded fallback when workers are unavailable", async () => {
+    installWorker(undefined);
+    const { vmRegexExecutor } = await importExecutor();
+
+    await expect(vmRegexExecutor(/hello/i, "well hello there")).resolves.toBe(true);
+    await expect(vmRegexExecutor(/hello/i, `${"x".repeat(10_001)}hello`)).resolves.toBe(false);
+  });
+});

--- a/src/engine/generation-core/lorebooks/regex-timeout.ts
+++ b/src/engine/generation-core/lorebooks/regex-timeout.ts
@@ -1,20 +1,153 @@
 import { isPatternSafe } from "../../shared/regex/regex-safety.js";
 
+const DEFAULT_REGEX_TIMEOUT_MS = 50;
+const DEFAULT_WORKER_STARTUP_TIMEOUT_MS = 250;
 const MAX_REGEX_SCAN_TEXT_LENGTH = 100_000;
+const MAX_UNTIMED_FALLBACK_TEXT_LENGTH = 10_000;
+
+const WORKER_SOURCE = `
+self.onmessage = (event) => {
+  if (event.data?.type === "ready") {
+    self.postMessage({ type: "ready" });
+    return;
+  }
+  const { source, flags, text } = event.data;
+  try {
+    const matched = new RegExp(source, flags).test(text);
+    self.postMessage({ type: "result", matched });
+  } catch (error) {
+    self.postMessage({
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+`;
+
+let workerUrl: string | null = null;
+
+function getRegexWorkerUrl(): string | null {
+  if (workerUrl) return workerUrl;
+  if (typeof URL === "undefined" || typeof Blob === "undefined") return null;
+  try {
+    workerUrl = URL.createObjectURL(new Blob([WORKER_SOURCE], { type: "text/javascript" }));
+    return workerUrl;
+  } catch {
+    return null;
+  }
+}
+
+function canRunInterruptibleWorker(): boolean {
+  return typeof Worker !== "undefined" && getRegexWorkerUrl() !== null;
+}
+
+function testWithBoundedUntimedFallback(regex: RegExp, text: string): boolean {
+  if (text.length > MAX_UNTIMED_FALLBACK_TEXT_LENGTH) return false;
+  const flags = regex.flags.replace(/[gy]/g, "");
+  return new RegExp(regex.source, flags).test(text);
+}
+
+function testInWorker(regex: RegExp, text: string, timeoutMs: number, startupTimeoutMs: number): Promise<boolean> {
+  const url = getRegexWorkerUrl();
+  if (!url) return Promise.resolve(testWithBoundedUntimedFallback(regex, text));
+
+  return new Promise((resolve) => {
+    let worker: Worker;
+    let executionTimer: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+    let ready = false;
+    try {
+      worker = new Worker(url);
+    } catch {
+      resolve(testWithBoundedUntimedFallback(regex, text));
+      return;
+    }
+
+    const finish = (matched: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(startupTimer);
+      if (executionTimer) clearTimeout(executionTimer);
+      worker.terminate();
+      resolve(matched);
+    };
+
+    const fallbackAndFinish = () => {
+      finish(testWithBoundedUntimedFallback(regex, text));
+    };
+
+    const startRegexTest = () => {
+      if (ready) return;
+      ready = true;
+      executionTimer = setTimeout(() => {
+        finish(false);
+      }, timeoutMs);
+
+      const flags = regex.flags.replace(/[gy]/g, "");
+      try {
+        worker.postMessage({ type: "test", source: regex.source, flags, text });
+      } catch {
+        fallbackAndFinish();
+      }
+    };
+
+    const startupTimer = setTimeout(() => {
+      fallbackAndFinish();
+    }, startupTimeoutMs);
+
+    worker.onmessage = (
+      event: MessageEvent<
+        { type: "ready" } | { type: "result"; matched: boolean } | { type: "error"; message: string }
+      >,
+    ) => {
+      if (event.data.type === "ready") {
+        clearTimeout(startupTimer);
+        startRegexTest();
+        return;
+      }
+
+      finish(event.data.type === "result" ? Boolean(event.data.matched) : false);
+    };
+
+    worker.onerror = () => {
+      fallbackAndFinish();
+    };
+
+    try {
+      worker.postMessage({ type: "ready" });
+    } catch {
+      fallbackAndFinish();
+    }
+  });
+}
 
 /**
  * Browser-safe lorebook regex executor.
  *
- * The original Node server used `vm.runInContext` with a hard timeout. The
- * Tauri frontend cannot synchronously interrupt JavaScript RegExp execution, so
- * this executor keeps the same call boundary while relying on the shared static
- * safety check plus a scan-size cap. Unsafe or oversized scans fail closed and
- * the keyword matcher falls back to literal matching where appropriate.
+ * The legacy Node server used `vm.runInContext` with a hard timeout. Refactor
+ * runs in browser/Tauri contexts, so user regexes execute inside a disposable
+ * Worker. Worker startup gets a small separate budget so first-use load time
+ * does not count as regex execution time. Once the worker is ready, the regex
+ * deadline applies to the actual match. If the worker does not answer before
+ * that deadline, it is terminated and the match fails closed.
+ *
+ * If the runtime cannot create a Worker, safe regex scans use a much smaller
+ * bounded fallback so worker capability loss does not silently turn every regex
+ * activation into a non-match. Oversized fallback scans still fail closed.
  */
-export function vmRegexExecutor(regex: RegExp, text: string): boolean {
-  if (text.length > MAX_REGEX_SCAN_TEXT_LENGTH || !isPatternSafe(regex.source)) {
-    return false;
-  }
-  const flags = regex.flags.replace(/[gy]/g, "");
-  return new RegExp(regex.source, flags).test(text);
+function createTimeoutRegexExecutor(
+  timeoutMs: number = DEFAULT_REGEX_TIMEOUT_MS,
+  startupTimeoutMs: number = DEFAULT_WORKER_STARTUP_TIMEOUT_MS,
+) {
+  return async function vmRegexExecutor(regex: RegExp, text: string): Promise<boolean> {
+    if (text.length > MAX_REGEX_SCAN_TEXT_LENGTH || !isPatternSafe(regex.source)) {
+      return false;
+    }
+    if (!canRunInterruptibleWorker()) {
+      return testWithBoundedUntimedFallback(regex, text);
+    }
+    return testInWorker(regex, text, timeoutMs, startupTimeoutMs);
+  };
 }
+
+export const vmRegexExecutor = createTimeoutRegexExecutor();

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -639,7 +639,7 @@ function selectBudgetedLorebookEntries(
   };
 }
 
-function scanActiveLorebookEntrySet(
+async function scanActiveLorebookEntrySet(
   messages: ScanMessage[],
   entries: LorebookEntry[],
   lorebooksById: ReadonlyMap<string, ActiveLorebookBudgetMetadata>,
@@ -648,11 +648,11 @@ function scanActiveLorebookEntrySet(
   chatBudget: number,
   maxEntries: number,
   contentResolver?: LorebookContentResolver,
-): { activatedEntries: ActivatedEntry[]; budgetSkippedEntries: BudgetSkippedLorebookEntry[] } {
+): Promise<{ activatedEntries: ActivatedEntry[]; budgetSkippedEntries: BudgetSkippedLorebookEntry[] }> {
   const state = createLorebookBudgetSelectionState();
   const processedIds = new Set<string>();
   const budgetSkippedEntries: BudgetSkippedLorebookEntry[] = [];
-  let frontier = scanForActivatedEntries(messages, entries, options);
+  let frontier = await scanForActivatedEntries(messages, entries, options);
 
   for (let depth = 0; frontier.length > 0; depth += 1) {
     const candidates = frontier.filter(
@@ -687,7 +687,7 @@ function scanActiveLorebookEntrySet(
     const remaining = entries.filter((entry) => !processedIds.has(entry.id) && !state.selectedIds.has(entry.id));
     if (remaining.length === 0) break;
 
-    frontier = scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, options);
+    frontier = await scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, options);
   }
 
   return {
@@ -860,7 +860,7 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
       boolish(book.recursiveScanning, false) ? Math.max(maxDepth, resolveLorebookRecursionDepth(book)) : maxDepth,
     1,
   );
-  const scanned = scanActiveLorebookEntrySet(
+  const scanned = await scanActiveLorebookEntrySet(
     messages,
     entriesByBook.flatMap((item) => item.entries),
     lorebooksById,

--- a/src/engine/shared/regex/lorebook-keyword-matching.test.ts
+++ b/src/engine/shared/regex/lorebook-keyword-matching.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { testSecondaryKeys, testSecondaryKeysAsync } from "./lorebook-keyword-matching";
+
+const regexOptions = {
+  useRegex: true,
+  matchWholeWords: false,
+  caseSensitive: false,
+};
+
+describe("testSecondaryKeys", () => {
+  it("short-circuits secondary-key logic", () => {
+    const calls: string[] = [];
+    const options = {
+      ...regexOptions,
+      regexExecutor(regex: RegExp, text: string) {
+        calls.push(regex.source);
+        return regex.test(text);
+      },
+    };
+
+    expect(testSecondaryKeys(["missing", "present"], "present", "and", options)).toBe(false);
+    expect(calls).toEqual(["missing"]);
+
+    calls.length = 0;
+    expect(testSecondaryKeys(["present", "missing"], "present", "or", options)).toBe(true);
+    expect(calls).toEqual(["present"]);
+
+    calls.length = 0;
+    expect(testSecondaryKeys(["present", "missing"], "present", "not", options)).toBe(false);
+    expect(calls).toEqual(["present"]);
+  });
+});
+
+describe("testSecondaryKeysAsync", () => {
+  it("evaluates secondary keys sequentially instead of spawning every regex executor at once", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const calls: string[] = [];
+    const options = {
+      ...regexOptions,
+      async regexExecutor(regex: RegExp, text: string) {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        calls.push(regex.source);
+        await Promise.resolve();
+        active -= 1;
+        return regex.test(text);
+      },
+    };
+
+    await expect(testSecondaryKeysAsync(["one", "two", "three"], "one two three", "and", options)).resolves.toBe(
+      true,
+    );
+
+    expect(calls).toEqual(["one", "two", "three"]);
+    expect(maxActive).toBe(1);
+  });
+
+  it("short-circuits async secondary-key logic", async () => {
+    const calls: string[] = [];
+    const options = {
+      ...regexOptions,
+      async regexExecutor(regex: RegExp, text: string) {
+        calls.push(regex.source);
+        return regex.test(text);
+      },
+    };
+
+    await expect(testSecondaryKeysAsync(["missing", "present"], "present", "and", options)).resolves.toBe(false);
+    expect(calls).toEqual(["missing"]);
+
+    calls.length = 0;
+    await expect(testSecondaryKeysAsync(["present", "missing"], "present", "or", options)).resolves.toBe(true);
+    expect(calls).toEqual(["present"]);
+
+    calls.length = 0;
+    await expect(testSecondaryKeysAsync(["present", "missing"], "present", "not", options)).resolves.toBe(false);
+    expect(calls).toEqual(["present"]);
+  });
+});

--- a/src/engine/shared/regex/lorebook-keyword-matching.ts
+++ b/src/engine/shared/regex/lorebook-keyword-matching.ts
@@ -7,6 +7,7 @@ import { isPatternSafe } from "./regex-safety.js";
 
 /** Pluggable executor for compiled regex test calls. Runtime-specific callers can add extra guards. */
 type RegexExecutor = (regex: RegExp, text: string) => boolean;
+type AsyncRegexExecutor = (regex: RegExp, text: string) => boolean | Promise<boolean>;
 
 const defaultRegexExecutor: RegexExecutor = (regex, text) => regex.test(text);
 
@@ -20,7 +21,13 @@ export interface KeywordMatchOptions {
   regexExecutor?: RegexExecutor;
 }
 
-function literalMatch(keyword: string, text: string, options: KeywordMatchOptions): boolean {
+export interface AsyncKeywordMatchOptions extends Omit<KeywordMatchOptions, "regexExecutor"> {
+  regexExecutor?: AsyncRegexExecutor;
+}
+
+type KeywordMatchBaseOptions = Pick<KeywordMatchOptions, "caseSensitive">;
+
+function literalMatch(keyword: string, text: string, options: KeywordMatchBaseOptions): boolean {
   const needle = options.caseSensitive ? keyword : keyword.toLowerCase();
   const haystack = options.caseSensitive ? text : text.toLowerCase();
   return haystack.includes(needle);
@@ -60,6 +67,34 @@ function testKeyword(keyword: string, text: string, options: KeywordMatchOptions
   }
 }
 
+async function testKeywordAsync(keyword: string, text: string, options: AsyncKeywordMatchOptions): Promise<boolean> {
+  if (!keyword) return false;
+
+  try {
+    if (options.useRegex) {
+      if (!isPatternSafe(keyword)) {
+        return literalMatch(keyword, text, options);
+      }
+      const flags = options.caseSensitive ? "g" : "gi";
+      const regex = new RegExp(keyword, flags);
+      const exec = options.regexExecutor ?? defaultRegexExecutor;
+      return await exec(regex, text);
+    }
+
+    if (options.matchWholeWords) {
+      const needle = options.caseSensitive ? keyword : keyword.toLowerCase();
+      const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const flags = options.caseSensitive ? "g" : "gi";
+      const regex = new RegExp(`\\b${escaped}\\b`, flags);
+      return regex.test(text);
+    }
+
+    return literalMatch(keyword, text, options);
+  } catch {
+    return literalMatch(keyword, text, options);
+  }
+}
+
 /** Primary key set: any single key matching counts as a match. */
 export function testPrimaryKeys(
   keys: string[],
@@ -75,6 +110,20 @@ export function testPrimaryKeys(
   return { matched: matchedKeys.length > 0, matchedKeys };
 }
 
+export async function testPrimaryKeysAsync(
+  keys: string[],
+  text: string,
+  options: AsyncKeywordMatchOptions,
+): Promise<{ matched: boolean; matchedKeys: string[] }> {
+  const matchedKeys: string[] = [];
+  for (const key of keys) {
+    if (await testKeywordAsync(key, text, options)) {
+      matchedKeys.push(key);
+    }
+  }
+  return { matched: matchedKeys.length > 0, matchedKeys };
+}
+
 /** Secondary key set with selective logic (and/or/not). Empty list passes. */
 export function testSecondaryKeys(
   secondaryKeys: string[],
@@ -84,15 +133,51 @@ export function testSecondaryKeys(
 ): boolean {
   if (secondaryKeys.length === 0) return true;
 
-  const results = secondaryKeys.map((key) => testKeyword(key, text, options));
+  switch (logic) {
+    case "and":
+      for (const key of secondaryKeys) {
+        if (!testKeyword(key, text, options)) return false;
+      }
+      return true;
+    case "or":
+      for (const key of secondaryKeys) {
+        if (testKeyword(key, text, options)) return true;
+      }
+      return false;
+    case "not":
+      for (const key of secondaryKeys) {
+        if (testKeyword(key, text, options)) return false;
+      }
+      return true;
+    default:
+      return true;
+  }
+}
+
+export async function testSecondaryKeysAsync(
+  secondaryKeys: string[],
+  text: string,
+  logic: SelectiveLogic,
+  options: AsyncKeywordMatchOptions,
+): Promise<boolean> {
+  if (secondaryKeys.length === 0) return true;
 
   switch (logic) {
     case "and":
-      return results.every(Boolean);
+      for (const key of secondaryKeys) {
+        if (!(await testKeywordAsync(key, text, options))) return false;
+      }
+      return true;
     case "or":
-      return results.some(Boolean);
+      for (const key of secondaryKeys) {
+        if (await testKeywordAsync(key, text, options)) return true;
+      }
+      return false;
     case "not":
-      return !results.some(Boolean);
+      for (const key of secondaryKeys) {
+        if (await testKeywordAsync(key, text, options)) return false;
+      }
+      return true;
     default:
       return true;
   }


### PR DESCRIPTION
## Linked issue

Closes #2199

## Why this change

- Lorebook regex keyword matching preserved static pattern checks but lost the legacy hard execution timeout, so accepted user regexes could still monopolize generation or preview scans.

## What changed

- Runs lorebook regex execution through a disposable browser Worker with a hard timeout and fail-closed behavior.
- Adds a documented bounded fallback for safe, short regex scans when Worker support is unavailable, instead of silently turning every regex activation into a non-match.
- Makes lorebook keyword scanning asynchronous so runtime scans can await the timeout-protected executor.
- Updates active lorebook scanning and knowledge-router keyword prefiltering to await the async scanner.
- Keeps shared keyword helpers available for both sync and async match paths.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Chat, roleplay, and game lorebook activation paths.
- Recursive lorebook scanning.
- Knowledge-router keyword candidate prefiltering.
- Existing prompt injector coverage that consumes activated lorebook entries.

Boundary notes:

- Behavior stays in `src/engine` and shared regex helpers.
- No React, Tauri, shared API, storage, provider, or remote-runtime boundary changes.
- Browser/Tauri hard timeout uses a local Worker rather than a Node `vm` import, keeping engine code hostable in the frontend runtime.
- Worker-unavailable runtimes use a smaller bounded sync fallback only after static safety checks and scan-length caps pass.

Pressure points touched:

- Runtime generation lorebook keyword scanning.
- Knowledge-router candidate selection.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck`
- `pnpm check:unused`
- Earlier on this branch before the fallback repair: `pnpm check:architecture`, `pnpm build`, `pnpm exec vitest run src/engine/generation-core/lorebooks/prompt-injector.test.ts`, `pnpm check`
- Browser proof through Vite on `http://127.0.0.1:4177/`: imported the runtime modules, confirmed normal regex match succeeds, oversized scan text fails closed, static-safety accepts `^(a|aa)+$`, and the timeout executor returns `false` for `^(a|aa)+$` against a long `aaaa...!` input at the configured deadline.
- Browser no-Worker proof: temporarily removed `window.Worker` before module import and confirmed the bounded fallback returns `true` for a safe short regex match and `false` for fallback text over 10,000 characters.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores internal lorebook regex safety behavior and does not add a discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes.
