### PR TITLE
Fix preset choice option truncation

### DIFF
--- a/src/features/catalog/presets/components/ChoiceSelectionModal.test.tsx
+++ b/src/features/catalog/presets/components/ChoiceSelectionModal.test.tsx
@@ -1,0 +1,124 @@
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChoiceSelectionModal } from "./ChoiceSelectionModal";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockPresetDetail = vi.hoisted(() => ({ current: null as unknown }));
+const mockUpdateMetadataMutate = vi.hoisted(() => vi.fn());
+const mockUpdatePresetMutate = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../../shared/components/ui/Modal", () => ({
+  Modal: ({
+    children,
+    open,
+    title,
+  }: {
+    children: ReactNode;
+    open: boolean;
+    title: string;
+  }) => (open ? <section aria-label={title}>{children}</section> : null),
+}));
+
+vi.mock("../hooks/use-presets", () => ({
+  usePresetFull: () => ({ data: mockPresetDetail.current, isError: false, isLoading: false }),
+  useUpdatePreset: () => ({ mutate: mockUpdatePresetMutate }),
+}));
+
+vi.mock("../../chats/index", () => ({
+  useUpdateChatMetadata: () => ({ isPending: false, mutate: mockUpdateMetadataMutate }),
+}));
+
+const longOptionValue =
+  "Offer warm therapeutic roleplay support with gentle check-ins, grounded reflection, collaborative next steps, " +
+  "and a calm closing note that the user can read before choosing. UNIQUE_FULL_TEXT_TAIL";
+
+function renderModal({
+  multiSelect = false,
+  options = [
+    { id: "support", label: "Support mode", value: longOptionValue },
+    { id: "short", label: "Short mode", value: "Keep the reply short." },
+  ],
+}: {
+  multiSelect?: boolean;
+  options?: Array<{ id: string; label: string; value: string }>;
+} = {}) {
+  mockPresetDetail.current = {
+    choiceBlocks: [
+      {
+        id: "support-mode",
+        variableName: "SUPPORT_MODE",
+        question: "Choose support mode",
+        options,
+        multiSelect,
+        randomPick: false,
+      },
+    ],
+    preset: { defaultChoices: {} },
+  };
+
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <ChoiceSelectionModal open chatId="chat-1" existingChoices={{}} onClose={vi.fn()} presetId="preset-1" />,
+    );
+  });
+
+  return { container, root };
+}
+
+function cleanup(root: Root, container: HTMLElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+function findButton(container: HTMLElement, text: string) {
+  const button = Array.from(container.querySelectorAll("button")).find((item) => item.textContent?.includes(text));
+  if (!button) throw new Error(`Button containing "${text}" was not found`);
+  return button;
+}
+
+describe("ChoiceSelectionModal", () => {
+  beforeEach(() => {
+    mockPresetDetail.current = null;
+    mockUpdateMetadataMutate.mockReset();
+    mockUpdatePresetMutate.mockReset();
+    document.body.replaceChildren();
+  });
+
+  it.each([
+    ["single-select", false, undefined],
+    ["multi-select", true, undefined],
+    ["boolean toggle", false, [{ id: "support", label: "Support mode", value: longOptionValue }]],
+  ])("renders the complete long option value for %s choices", (_name, multiSelect, options) => {
+    const { container, root } = renderModal({ multiSelect, options });
+
+    expect(container.textContent).toContain(longOptionValue);
+    expect(container.textContent).toContain("UNIQUE_FULL_TEXT_TAIL");
+
+    cleanup(root, container);
+  });
+
+  it("keeps single-select option confirmation behavior intact", () => {
+    const { container, root } = renderModal();
+
+    act(() => {
+      findButton(container, "Short mode").click();
+    });
+    act(() => {
+      findButton(container, "Confirm Choices").click();
+    });
+
+    expect(mockUpdateMetadataMutate).toHaveBeenCalledWith(
+      { id: "chat-1", presetChoices: { SUPPORT_MODE: "Keep the reply short." } },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+
+    cleanup(root, container);
+  });
+});

--- a/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
+++ b/src/features/catalog/presets/components/ChoiceSelectionModal.tsx
@@ -52,6 +52,15 @@ function legacyField(block: ChoiceBlock, field: string): unknown {
   return (block as unknown as Record<string, unknown>)[field];
 }
 
+function ChoiceOptionValue({ value }: { value: string }) {
+  if (!value) return null;
+  return (
+    <p className="mt-0.5 whitespace-pre-wrap break-words text-[0.625rem] leading-snug text-[var(--muted-foreground)] [overflow-wrap:anywhere]">
+      {value}
+    </p>
+  );
+}
+
 export function ChoiceSelectionModal({
   open,
   onClose,
@@ -230,12 +239,7 @@ export function ChoiceSelectionModal({
                             <span className={cn("text-xs font-medium", isSelected && "text-purple-400")}>
                               {opt.label}
                             </span>
-                            {opt.value && (
-                              <p className="mt-0.5 line-clamp-2 text-[0.625rem] text-[var(--muted-foreground)]">
-                                {opt.value.slice(0, 150)}
-                                {opt.value.length > 150 ? "…" : ""}
-                              </p>
-                            )}
+                            <ChoiceOptionValue value={opt.value} />
                           </div>
                         </button>
                       );
@@ -260,12 +264,7 @@ export function ChoiceSelectionModal({
                           >
                             <div className="min-w-0 flex-1">
                               <span className={cn("text-xs font-medium", isOn && "text-purple-400")}>{opt.label}</span>
-                              {opt.value && (
-                                <p className="mt-0.5 line-clamp-2 text-[0.625rem] text-[var(--muted-foreground)]">
-                                  {opt.value.slice(0, 150)}
-                                  {opt.value.length > 150 ? "…" : ""}
-                                </p>
-                              )}
+                              <ChoiceOptionValue value={opt.value} />
                             </div>
                             <div
                               className={cn(
@@ -304,12 +303,7 @@ export function ChoiceSelectionModal({
                               <span className={cn("text-xs font-medium", isSelected && "text-purple-400")}>
                                 {opt.label}
                               </span>
-                              {opt.value && (
-                                <p className="mt-0.5 line-clamp-2 text-[0.625rem] text-[var(--muted-foreground)]">
-                                  {opt.value.slice(0, 150)}
-                                  {opt.value.length > 150 ? "…" : ""}
-                                </p>
-                              )}
+                              <ChoiceOptionValue value={opt.value} />
                             </div>
                           </button>
                         );


### PR DESCRIPTION
## Linked issue

Closes #2245

## Why this change

- Long preset variable option text was being sliced to 150 characters and line-clamped in the choice selector, so users could not read the full option before choosing.

## What changed

- Render preset choice option values through one shared full-text preview component instead of repeating sliced, two-line-clamped snippets.
- Added a focused regression test covering full text rendering for single-select, multi-select, and boolean toggle options, plus unchanged single-select confirmation behavior.

## Refactor impact

Primary owner:

- catalog preset UI

Impact areas reviewed:

- `src/features/catalog/presets/components/ChoiceSelectionModal.tsx`
- preset variable choice selection for single-select, multi-select, and one-option boolean toggle rows

Boundary notes:

- Feature UI only; no engine, shared API, Rust, storage, provider, prompt assembly, dependency, schema, or release metadata changes.

Pressure points touched:

- Shared preset variable choice modal used by chat/roleplay setup flows.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex focused repro before fix: `pnpm test -- src/features/catalog/presets/components/ChoiceSelectionModal.test.tsx` failed the long-text rows because `UNIQUE_FULL_TEXT_TAIL` was absent after the 150-character slice.
- Codex focused proof after fix: `pnpm test -- src/features/catalog/presets/components/ChoiceSelectionModal.test.tsx` passed 4 tests.
- Codex lane check: `pnpm typecheck` passed.
- Codex PR gate after final tracked diff: `pnpm check` passed.
- Bunny local review: pass with one non-blocking draft limitation below.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Draft limitation: no GitHub-renderable before/after screenshots were uploaded from this local component-level repro. The core behavior is covered by the focused regression test and full `pnpm check`, but the PR should stay draft if reviewer-visible visual evidence is required before ready-for-review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Option values in the preset selection modal now display in full with text wrapping instead of truncation.

* **Tests**
  * Added comprehensive test coverage for the preset choice selection modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->