### PR TITLE
Fix prompt preset import compatibility

### DIFF
--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -116,6 +116,8 @@ const PROMPT_FIELDS: &[TypedJsonField] = &[
     object("parameters"),
     object("defaultChoices"),
     array("variableGroups"),
+    boolish("isDefault"),
+    boolish("default"),
 ];
 const PROMPT_SECTION_FIELDS: &[TypedJsonField] = &[nullable_object("markerConfig")];
 const PROMPT_VARIABLE_FIELDS: &[TypedJsonField] = &[array("options")];

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -463,6 +463,66 @@ fn generic_marinara_preset_import_rolls_back_outer_records_on_section_failure() 
 }
 
 #[test]
+fn marinara_preset_import_normalizes_default_alias() {
+    let state = test_state("preset-default-alias");
+    let imported = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_preset",
+            "version": 1,
+            "data": {
+                "preset": {
+                    "id": "old-preset",
+                    "name": "Default Alias Preset",
+                    "default": "true"
+                }
+            }
+        }),
+    )
+    .expect("preset default alias should import");
+    let preset_id = test_string(&imported, "id");
+
+    let preset = state
+        .storage
+        .get("prompts", preset_id)
+        .expect("preset should be readable")
+        .expect("preset should exist");
+    assert_eq!(preset["isDefault"], json!(true));
+    assert!(preset.get("default").is_none());
+}
+
+#[test]
+fn marinara_preset_import_rejects_conflicting_default_flags() {
+    let state = test_state("preset-default-conflict");
+    let error = import_marinara_envelope(
+        &state,
+        json!({
+            "type": "marinara_preset",
+            "version": 1,
+            "data": {
+                "preset": {
+                    "id": "old-preset",
+                    "name": "Conflicting Default Preset",
+                    "isDefault": false,
+                    "default": true
+                }
+            }
+        }),
+    )
+    .expect_err("conflicting preset default flags should reject");
+
+    assert_eq!(error.code, "invalid_input");
+    assert!(error.message.contains("default must match isDefault"));
+    assert!(state
+        .storage
+        .list("prompts")
+        .expect("prompts should be readable")
+        .iter()
+        .all(|prompt| prompt.get("name").and_then(Value::as_str)
+            != Some("Conflicting Default Preset")));
+}
+
+#[test]
 fn marinara_lorebook_import_remaps_nested_folders_and_entry_folders() {
     let state = test_state("lorebook-folders");
     let imported = import_marinara_envelope(

--- a/src-tauri/src/commands/storage/imports/service_tests.rs
+++ b/src-tauri/src/commands/storage/imports/service_tests.rs
@@ -60,6 +60,18 @@ fn collection_ids(state: &AppState, collection: &str) -> Vec<String> {
     ids
 }
 
+fn created_prompt_from_import_result(state: &AppState, result: &Value) -> Value {
+    let preset_id = result
+        .get("presetId")
+        .and_then(Value::as_str)
+        .expect("import result should include a preset id");
+    state
+        .storage
+        .get("prompts", preset_id)
+        .expect("prompt preset should be readable")
+        .expect("prompt preset should exist")
+}
+
 #[test]
 fn normalizes_sillytavern_selective_logic_numbers() {
     let entry = normalize_lorebook_entry(
@@ -381,6 +393,78 @@ fn import_st_character_materializes_mixed_case_inline_avatar() {
         Path::new(avatar_file_path).exists(),
         "managed avatar file should exist"
     );
+
+    let _ = fs::remove_dir_all(app_root);
+}
+
+#[test]
+fn import_st_preset_keeps_reasoning_effort_auto_unset_and_keeps_fallbacks() {
+    for (label, raw_effort, expected_effort) in [
+        ("auto", "auto", Value::Null),
+        ("xhigh", "xhigh", json!("xhigh")),
+        ("unknown", "surprise", Value::Null),
+    ] {
+        let app_root = temp_path(&format!("st-preset-reasoning-{label}"));
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+        let result = import_call(
+            &state,
+            &["st-preset"],
+            json!({
+                "name": format!("Reasoning {label}"),
+                "reasoning_effort": raw_effort,
+                "prompts": []
+            }),
+        )
+        .expect("ST preset import should succeed");
+
+        let preset = created_prompt_from_import_result(&state, &result);
+        assert_eq!(preset["parameters"]["reasoningEffort"], expected_effort);
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+}
+
+#[test]
+fn import_st_preset_normalizes_default_alias_and_rejects_conflict() {
+    let app_root = temp_path("st-preset-default-alias");
+    let state =
+        AppState::from_data_dir(&app_root, Vec::new()).expect("test app state should initialize");
+    let result = import_call(
+        &state,
+        &["st-preset"],
+        json!({
+            "name": "Default Alias Preset",
+            "default": "true",
+            "prompts": []
+        }),
+    )
+    .expect("ST preset default alias should import");
+
+    let preset = created_prompt_from_import_result(&state, &result);
+    assert_eq!(preset["isDefault"], json!(true));
+    assert!(preset.get("default").is_none());
+
+    let error = import_call(
+        &state,
+        &["st-preset"],
+        json!({
+            "name": "Conflicting Default Alias Preset",
+            "isDefault": false,
+            "default": true,
+            "prompts": []
+        }),
+    )
+    .expect_err("conflicting ST preset default flags should reject");
+    assert_eq!(error.code, "invalid_input");
+    assert!(error.message.contains("default must match isDefault"));
+    assert!(state
+        .storage
+        .list("prompts")
+        .expect("prompts should be readable")
+        .iter()
+        .all(|prompt| prompt.get("name").and_then(Value::as_str)
+            != Some("Imported: Conflicting Default Alias Preset")));
 
     let _ = fs::remove_dir_all(app_root);
 }

--- a/src-tauri/src/commands/storage/imports/st_preset.rs
+++ b/src-tauri/src/commands/storage/imports/st_preset.rs
@@ -49,6 +49,7 @@ fn st_prompt_name(raw: &Value, file_name: Option<&str>) -> String {
 
 fn st_reasoning_effort(value: Option<&Value>) -> Value {
     match value.and_then(Value::as_str) {
+        Some("auto") => Value::Null,
         Some("low" | "medium" | "high" | "xhigh" | "maximum") => {
             value.cloned().unwrap_or(Value::Null)
         }
@@ -264,42 +265,47 @@ pub(super) fn import_st_preset_payload(
     let mut created_section_ids = Vec::new();
 
     let result = (|| -> AppResult<Value> {
-        let preset = state.storage.create(
-            "prompts",
-            with_entity_defaults(
-                "prompts",
-                json!({
-                    "name": format!("Imported: {}", st_prompt_name(&raw, file_name)),
-                    "description": "Imported from SillyTavern",
-                    "variableGroups": st_variable_groups(&prompts),
-                    "variableValues": {},
-                    "defaultChoices": {},
-                    "wrapFormat": "xml",
-                    "sectionOrder": [],
-                    "groupOrder": [],
-                    "parameters": {
-                        "temperature": clamp_number(raw.get("temperature").and_then(Value::as_f64), 1.0, 0.0, 2.0),
-                        "topP": normalize_top_p(raw.get("top_p").and_then(Value::as_f64)),
-                        "topK": top_k,
-                        "minP": clamp_number(raw.get("min_p").and_then(Value::as_f64), 0.0, 0.0, 1.0),
-                        "maxTokens": max_tokens,
-                        "maxContext": max_context,
-                        "frequencyPenalty": clamp_number(raw.get("frequency_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
-                        "presencePenalty": clamp_number(raw.get("presence_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
-                        "reasoningEffort": st_reasoning_effort(raw.get("reasoning_effort")),
-                        "verbosity": Value::Null,
-                        "assistantPrefill": "",
-                        "customParameters": {},
-                        "squashSystemMessages": raw.get("squash_system_messages").and_then(Value::as_bool).unwrap_or(true),
-                        "showThoughts": raw.get("show_thoughts").and_then(Value::as_bool).unwrap_or(true),
-                        "useMaxContext": false,
-                        "stopSequences": [],
-                        "strictRoleFormatting": true,
-                        "singleUserMessage": false
-                    }
-                }),
-            )?,
-        )?;
+        let mut preset_body = json!({
+            "name": format!("Imported: {}", st_prompt_name(&raw, file_name)),
+            "description": "Imported from SillyTavern",
+            "variableGroups": st_variable_groups(&prompts),
+            "variableValues": {},
+            "defaultChoices": {},
+            "wrapFormat": "xml",
+            "sectionOrder": [],
+            "groupOrder": [],
+            "parameters": {
+                "temperature": clamp_number(raw.get("temperature").and_then(Value::as_f64), 1.0, 0.0, 2.0),
+                "topP": normalize_top_p(raw.get("top_p").and_then(Value::as_f64)),
+                "topK": top_k,
+                "minP": clamp_number(raw.get("min_p").and_then(Value::as_f64), 0.0, 0.0, 1.0),
+                "maxTokens": max_tokens,
+                "maxContext": max_context,
+                "frequencyPenalty": clamp_number(raw.get("frequency_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
+                "presencePenalty": clamp_number(raw.get("presence_penalty").and_then(Value::as_f64), 0.0, -2.0, 2.0),
+                "reasoningEffort": st_reasoning_effort(raw.get("reasoning_effort")),
+                "verbosity": Value::Null,
+                "assistantPrefill": "",
+                "customParameters": {},
+                "squashSystemMessages": raw.get("squash_system_messages").and_then(Value::as_bool).unwrap_or(true),
+                "showThoughts": raw.get("show_thoughts").and_then(Value::as_bool).unwrap_or(true),
+                "useMaxContext": false,
+                "stopSequences": [],
+                "strictRoleFormatting": true,
+                "singleUserMessage": false
+            }
+        });
+        if let Some(object) = preset_body.as_object_mut() {
+            if let Some(value) = raw.get("isDefault") {
+                object.insert("isDefault".to_string(), value.clone());
+            }
+            if let Some(value) = raw.get("default") {
+                object.insert("default".to_string(), value.clone());
+            }
+        }
+        let preset = state
+            .storage
+            .create("prompts", with_entity_defaults("prompts", preset_body)?)?;
         let preset_id = created_record_id(&preset, "preset")?;
         created_preset_id = Some(preset_id.clone());
 

--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -2088,6 +2088,96 @@ mod tests {
     }
 
     #[test]
+    fn profile_import_prompts_normalizes_default_alias() {
+        let state = test_state("profile-prompt-default-alias");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "prompts".to_string(),
+            json!([{
+                "id": "profile-preset",
+                "name": "Profile Default Alias Preset",
+                "default": "true"
+            }]),
+        );
+
+        import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }),
+        )
+        .expect("profile import should normalize prompt default aliases");
+
+        let preset = state
+            .storage
+            .get("prompts", "profile-preset")
+            .expect("prompt preset should be readable")
+            .expect("prompt preset should import");
+        assert_eq!(preset["isDefault"], json!(true));
+        assert!(preset.get("default").is_none());
+    }
+
+    #[test]
+    fn profile_import_prompts_rejects_conflicting_default_flags_without_wiping() {
+        let state = test_state("profile-prompt-default-conflict");
+        state
+            .storage
+            .create(
+                "prompts",
+                json!({
+                    "id": "existing-preset",
+                    "name": "Existing Preset"
+                }),
+            )
+            .expect("existing prompt preset should write");
+        let mut collections = complete_empty_profile_collections();
+        collections.insert(
+            "prompts".to_string(),
+            json!([{
+                "id": "conflicting-preset",
+                "name": "Conflicting Profile Preset",
+                "isDefault": false,
+                "default": true
+            }]),
+        );
+
+        let error = import_profile(
+            &state,
+            json!({
+                "type": "marinara_profile",
+                "version": 1,
+                "data": {
+                    "collections": collections,
+                    "assets": []
+                }
+            }),
+        )
+        .expect_err("conflicting prompt default flags should reject profile import");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(
+            error.message.contains("default") && error.message.contains("isDefault"),
+            "unexpected error message: {}",
+            error.message
+        );
+        assert!(state
+            .storage
+            .get("prompts", "existing-preset")
+            .expect("existing prompt preset should be readable")
+            .is_some());
+        assert!(state
+            .storage
+            .get("prompts", "conflicting-preset")
+            .expect("conflicting prompt preset lookup should not fail")
+            .is_none());
+    }
+
+    #[test]
     fn profile_import_collections_normalizes_prompt_overrides() {
         let state = test_state("prompt-overrides-normalize");
         let mut collections = Map::new();

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -643,6 +643,29 @@ pub(crate) fn normalize_typed_json_fields(
     collection: &str,
     object: &mut Map<String, Value>,
 ) -> AppResult<()> {
+    normalize_typed_json_fields_with_prompt_default_mode(
+        collection,
+        object,
+        PromptDefaultAliasMode::RejectConflicts,
+    )
+}
+
+pub(crate) fn repair_typed_json_fields_for_startup(
+    collection: &str,
+    object: &mut Map<String, Value>,
+) -> AppResult<()> {
+    normalize_typed_json_fields_with_prompt_default_mode(
+        collection,
+        object,
+        PromptDefaultAliasMode::RepairLegacyConflicts,
+    )
+}
+
+fn normalize_typed_json_fields_with_prompt_default_mode(
+    collection: &str,
+    object: &mut Map<String, Value>,
+    prompt_default_mode: PromptDefaultAliasMode,
+) -> AppResult<()> {
     if collection == "characters" {
         if let Some(data) = object.get("data") {
             object.insert(
@@ -665,6 +688,9 @@ pub(crate) fn normalize_typed_json_fields(
                 TypedJsonKind::Boolish => normalize_boolish_fields(object, &[field.name]),
             }
         }
+    }
+    if collection == "prompts" {
+        normalize_prompt_default_alias(object, prompt_default_mode)?;
     }
     if collection == "messages" {
         normalize_message_text_fields(object);
@@ -735,6 +761,42 @@ fn normalize_boolish_fields(object: &mut Map<String, Value>, fields: &[&str]) {
         };
         *value = Value::Bool(normalized);
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PromptDefaultAliasMode {
+    RejectConflicts,
+    RepairLegacyConflicts,
+}
+
+fn normalize_prompt_default_alias(
+    object: &mut Map<String, Value>,
+    mode: PromptDefaultAliasMode,
+) -> AppResult<()> {
+    let is_default = object.get("isDefault").and_then(Value::as_bool);
+    let legacy_default = object.get("default").and_then(Value::as_bool);
+    if let (Some(is_default), Some(legacy_default)) = (is_default, legacy_default) {
+        if is_default != legacy_default {
+            if mode == PromptDefaultAliasMode::RepairLegacyConflicts {
+                object.insert(
+                    "isDefault".to_string(),
+                    Value::Bool(is_default || legacy_default),
+                );
+                object.remove("default");
+                return Ok(());
+            }
+            return Err(AppError::invalid_input(
+                "Prompt preset default must match isDefault when both flags are provided.",
+            ));
+        }
+    }
+    if is_default.is_none() {
+        if let Some(legacy_default) = legacy_default {
+            object.insert("isDefault".to_string(), Value::Bool(legacy_default));
+        }
+    }
+    object.remove("default");
+    Ok(())
 }
 
 fn normalize_nullable_json_object_fields(
@@ -909,6 +971,9 @@ fn apply_create_default_field(
 
 pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> AppResult<Value> {
     let mut object = ensure_object(body)?;
+    if collection == "prompts" {
+        normalize_typed_json_fields(collection, &mut object)?;
+    }
     if let Some(contract) = contracts::collection_contract(collection) {
         for field in contract.create_default_fields {
             apply_create_default_field(collection, field, &mut object)?;
@@ -1907,6 +1972,37 @@ mod tests {
         assert_eq!(row["default"], json!(false));
         assert_eq!(row["isActive"], json!(true));
         assert_eq!(row["active"], json!(true));
+    }
+
+    #[test]
+    fn prompt_defaults_normalize_legacy_default_alias() {
+        let row = with_entity_defaults(
+            "prompts",
+            json!({
+                "name": "Imported Preset",
+                "default": "yes"
+            }),
+        )
+        .expect("prompt defaults should normalize the default alias");
+
+        assert_eq!(row["isDefault"], json!(true));
+        assert!(row.get("default").is_none());
+    }
+
+    #[test]
+    fn prompt_defaults_reject_conflicting_default_flags() {
+        let error = with_entity_defaults(
+            "prompts",
+            json!({
+                "name": "Conflicting Preset",
+                "isDefault": false,
+                "default": true
+            }),
+        )
+        .expect_err("conflicting prompt default flags should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("default must match isDefault"));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -18,6 +18,7 @@ use crate::storage_commands::{
     shared::{
         agent_run_config_info_from_rows, compact_message_legacy_prompt_snapshots,
         normalize_agent_run_row_fields, normalize_typed_json_fields,
+        repair_typed_json_fields_for_startup,
     },
 };
 
@@ -218,7 +219,7 @@ fn migrate_collection_json_fields(storage: &FileStorage, collection: &str) -> Ap
                 if collection == "game-state-snapshots" {
                     repair_snapshot_persona_stats_for_startup(object);
                 }
-                normalize_typed_json_fields(collection, object)?;
+                repair_typed_json_fields_for_startup(collection, object)?;
             }
         }
         changed = changed || row != before;
@@ -1063,6 +1064,42 @@ mod tests {
         for row in rows {
             assert!(row["personaStats"].is_null());
         }
+    }
+
+    #[test]
+    fn app_state_startup_repairs_legacy_prompt_default_conflicts() {
+        let root = temp_root("legacy-prompt-default-conflict");
+        let storage = FileStorage::new(root.0.join("data")).expect("storage should initialize");
+        storage
+            .replace_all(
+                "prompts",
+                vec![json!({
+                    "id": "legacy-default-preset",
+                    "name": "Legacy Default Preset",
+                    "sectionOrder": "[]",
+                    "groupOrder": "[]",
+                    "variableOrder": "[]",
+                    "variableGroups": "[]",
+                    "variableValues": "{}",
+                    "parameters": "{}",
+                    "defaultChoices": "{}",
+                    "isDefault": false,
+                    "default": true
+                })],
+            )
+            .expect("legacy prompt should be seeded");
+        persist_fixture_storage(&storage);
+
+        let state = AppState::from_data_dir(&root.0, Vec::new()).expect("state should initialize");
+        let prompt = state
+            .storage
+            .get("prompts", "legacy-default-preset")
+            .expect("prompt should be readable")
+            .expect("prompt should remain");
+
+        assert_eq!(prompt["isDefault"], json!(true));
+        assert!(prompt.get("default").is_none());
+        assert!(prompt["parameters"].is_object());
     }
 
     #[test]

--- a/src/engine/contracts/schemas/prompt.schema.ts
+++ b/src/engine/contracts/schemas/prompt.schema.ts
@@ -118,16 +118,36 @@ export const updatePromptGroupSchema = z.object({
 
 // ── Presets ──
 
-export const createPromptPresetSchema = z.object({
-  name: z.string().min(1).max(200),
-  description: z.string().default(""),
-  variableGroups: z.array(promptVariableGroupSchema).default([]),
-  variableValues: z.record(z.string()).default({}),
-  parameters: generationParametersSchema.default({}),
-  wrapFormat: wrapFormatSchema.default("xml"),
-  isDefault: z.boolean().default(false),
-  author: z.string().default(""),
-});
+function validatePromptPresetDefaultFlags(
+  value: { isDefault?: boolean; default?: boolean },
+  ctx: z.RefinementCtx,
+) {
+  if (value.isDefault !== undefined && value.default !== undefined && value.isDefault !== value.default) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["default"],
+      message: "default must match isDefault when both flags are provided.",
+    });
+  }
+}
+
+export const createPromptPresetSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    description: z.string().default(""),
+    variableGroups: z.array(promptVariableGroupSchema).default([]),
+    variableValues: z.record(z.string()).default({}),
+    parameters: generationParametersSchema.default({}),
+    wrapFormat: wrapFormatSchema.default("xml"),
+    isDefault: z.boolean().optional(),
+    default: z.boolean().optional(),
+    author: z.string().default(""),
+  })
+  .superRefine(validatePromptPresetDefaultFlags)
+  .transform(({ default: legacyDefault, ...value }) => ({
+    ...value,
+    isDefault: value.isDefault ?? legacyDefault ?? false,
+  }));
 
 export const updatePromptPresetSchema = z
   .object({
@@ -145,15 +165,7 @@ export const updatePromptPresetSchema = z
     author: z.string().optional(),
     defaultChoices: z.record(z.union([z.string(), z.array(z.string())])).optional(),
   })
-  .superRefine((value, ctx) => {
-    if (value.isDefault !== undefined && value.default !== undefined && value.isDefault !== value.default) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["default"],
-        message: "default must match isDefault when both flags are provided.",
-      });
-    }
-  })
+  .superRefine(validatePromptPresetDefaultFlags)
   .transform(({ default: legacyDefault, ...value }) => ({
     ...value,
     ...(value.isDefault === undefined && legacyDefault !== undefined ? { isDefault: legacyDefault } : {}),


### PR DESCRIPTION
## Linked issue

Closes https://github.com/Pasta-Devs/Marinara-Engine/issues/2263 and https://github.com/Pasta-Devs/Marinara-Engine/issues/2262

## Why this change

- Imported prompt presets could carry legacy `default` flags that were not normalized consistently with `isDefault`.
- Existing legacy rows with conflicting prompt default flags could fail startup repair instead of being healed.
- SillyTavern `reasoning_effort: "auto"` should preserve automatic provider behavior instead of forcing maximum reasoning.

## What changed

- Added prompt preset default alias normalization for create, update, profile import, Marinara preset import, and SillyTavern preset import paths.
- Kept strict conflict rejection for new create/import/profile payloads while allowing startup repair to heal legacy prompt rows.
- Changed SillyTavern reasoning effort `auto` imports to store `null`.
- Added focused Rust coverage for alias normalization, conflict rejection, startup repair, and SillyTavern reasoning fallback behavior.
- Updated the prompt preset Zod schema to accept and normalize the legacy `default` alias.

## Refactor impact

Primary owner:

Rust storage and imports, with a matching engine prompt schema update.

Impact areas reviewed:

- Prompt preset create/update normalization
- Native profile import
- Marinara preset import
- SillyTavern preset import
- Startup JSON repair
- Prompt generation parameter consumers for reasoning effort

Boundary notes:

- Product prompt schema remains in `src/engine/contracts`.
- Storage/import compatibility stays in Rust storage modules.
- No React UI, shared API wrapper, command registration, or remote runtime route changes.

Pressure points touched:

- Import modules under `src-tauri/src/commands/storage/imports`.
- Startup storage repair in `src-tauri/src/state.rs`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Local validation run:

- `cargo test --manifest-path src-tauri/Cargo.toml app_state_startup_repairs_legacy_prompt_default_conflicts`
- `cargo test --manifest-path src-tauri/Cargo.toml import_st_preset_keeps_reasoning_effort_auto_unset_and_keeps_fallbacks`
- `cargo test --manifest-path src-tauri/Cargo.toml default_alias`
- `cargo test --manifest-path src-tauri/Cargo.toml conflicting_default`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm check`
- `git diff --check`

No native Tauri manual QA was run; this is covered by focused storage/import tests and the full local PR gate.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Compatibility bugfix for existing prompt preset import and startup repair behavior; no new discoverable user surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

Docs/release notes: no tracked changelog, release-note, or changeset file exists; no docs changes needed for this compatibility bugfix.

## UI evidence

N/A - no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of prompt preset default field settings during profile and preset imports and application startup, with automatic conversion of legacy field format to current standard.
  * Enhanced validation to detect and reject conflicting default flag configurations, preventing data inconsistency.

* **Tests**
  * Added comprehensive test coverage for prompt default field format migration, validation, and conflict detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->