### PR TITLE
Fix character version avatar assets

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -26,16 +26,18 @@ pub(crate) fn update_character_avatar(
         "avatar",
     )?;
     if collection == "characters" {
-        let snapshot_record = character_avatar_snapshot_record(state, collection, &previous);
-        super::characters::create_character_version_snapshot_from_record(
+        if let Err(error) = super::characters::create_character_version_snapshot_from_record(
             state,
             id,
-            &snapshot_record,
+            &previous,
             "manual",
             "Avatar update",
-        )?;
+        ) {
+            remove_copied_avatar_path(&stored.absolute_path, "rolled-back avatar upload");
+            return Err(error);
+        }
     }
-    let updated = state.storage.patch(
+    let updated = match state.storage.patch(
         collection,
         id,
         json!({
@@ -45,9 +47,21 @@ pub(crate) fn update_character_avatar(
             "avatarFilename": stored.filename,
             "avatarUpdatedAt": now_iso()
         }),
-    )?;
+    ) {
+        Ok(updated) => updated,
+        Err(error) => {
+            remove_copied_avatar_path(&stored.absolute_path, "rolled-back avatar upload");
+            return Err(error);
+        }
+    };
     remove_avatar_file_preserving_persona_snapshots(state, collection, &previous);
     Ok(updated)
+}
+
+fn remove_copied_avatar_path(path: &str, context: &str) {
+    if let Err(error) = fs::remove_file(path) {
+        log::warn!("could not remove {context} at {path}: {error}");
+    }
 }
 
 pub(crate) fn remove_character_avatar(state: &AppState, id: &str) -> AppResult<Value> {
@@ -57,11 +71,10 @@ pub(crate) fn remove_character_avatar(state: &AppState, id: &str) -> AppResult<V
         return Ok(previous);
     }
 
-    let snapshot_record = character_avatar_snapshot_record(state, "characters", &previous);
     super::characters::create_character_version_snapshot_from_record(
         state,
         id,
-        &snapshot_record,
+        &previous,
         "manual",
         "Avatar removal",
     )?;
@@ -109,73 +122,6 @@ fn character_data_without_avatar_crop(record: &Value) -> AppResult<Option<Value>
         Ok(Some(data))
     } else {
         Ok(None)
-    }
-}
-
-fn character_avatar_snapshot_record(state: &AppState, collection: &str, record: &Value) -> Value {
-    let mut snapshot = record.clone();
-    if let Some(object) = snapshot.as_object_mut() {
-        if let Some(data_url) = managed_avatar_data_url(state, collection, record) {
-            object.insert("avatar".to_string(), Value::String(data_url.clone()));
-            object.insert("avatarPath".to_string(), Value::String(data_url));
-            object.insert("avatarFilePath".to_string(), Value::Null);
-            object.insert("avatarFilename".to_string(), Value::Null);
-        }
-    }
-    snapshot
-}
-
-fn managed_avatar_data_url(state: &AppState, collection: &str, record: &Value) -> Option<String> {
-    let path = managed_record_file_path(
-        state,
-        &format!("avatars/{}", safe_filename(collection)),
-        record,
-        "avatarFilePath",
-        "avatarFilename",
-    )
-    .ok()
-    .flatten()?;
-    avatar_data_url_from_path(
-        &path.to_string_lossy(),
-        record
-            .get("avatarFilename")
-            .and_then(Value::as_str)
-            .or_else(|| path.file_name().and_then(|value| value.to_str())),
-    )
-    .ok()
-}
-
-fn avatar_data_url_from_path(path: &str, filename: Option<&str>) -> AppResult<String> {
-    let path = Path::new(path);
-    let bytes = fs::read(path).map_err(|error| {
-        AppError::new(
-            "avatar_file_read_error",
-            format!("Avatar file could not be read: {error}"),
-        )
-    })?;
-    let mime =
-        avatar_mime_type(filename.or_else(|| path.file_name().and_then(|value| value.to_str())));
-    Ok(format!(
-        "data:{mime};base64,{}",
-        general_purpose::STANDARD.encode(bytes)
-    ))
-}
-
-fn avatar_mime_type(filename: Option<&str>) -> &'static str {
-    let Some(filename) = filename else {
-        return "image/png";
-    };
-    match filename
-        .rsplit_once('.')
-        .map(|(_, ext)| ext.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("jpg" | "jpeg") => "image/jpeg",
-        Some("webp") => "image/webp",
-        Some("gif") => "image/gif",
-        Some("avif") => "image/avif",
-        Some("svg") => "image/svg+xml",
-        _ => "image/png",
     }
 }
 
@@ -659,15 +605,6 @@ mod tests {
     }
 
     #[test]
-    fn avatar_data_url_from_path_reports_missing_file() {
-        let missing = std::env::temp_dir().join("marinara-missing-avatar.png");
-        let error = avatar_data_url_from_path(&missing.to_string_lossy(), Some("missing.png"))
-            .expect_err("missing avatar file should fail instead of falling back");
-
-        assert_eq!(error.code, "avatar_file_read_error");
-    }
-
-    #[test]
     fn character_avatar_upload_stores_managed_asset_url() {
         let state = test_state("character-avatar-upload-managed");
         state
@@ -999,12 +936,14 @@ mod tests {
     }
 
     #[test]
-    fn character_avatar_update_snapshot_does_not_restore_deleted_file_metadata() {
+    fn character_avatar_update_snapshot_copies_previous_managed_avatar() {
         let state = test_state("character-avatar-version");
         let avatar_dir = state.data_dir.join("avatars").join("characters");
         std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
         let old_avatar_path = avatar_dir.join("old.png");
-        std::fs::write(&old_avatar_path, b"old").expect("old avatar should be written");
+        let (_, old_avatar_bytes) =
+            decode_image_payload(small_png_data_url(), "avatar").expect("tiny png should decode");
+        std::fs::write(&old_avatar_path, &old_avatar_bytes).expect("old avatar should be written");
         let old_avatar_path = old_avatar_path.to_string_lossy().to_string();
 
         state
@@ -1040,9 +979,33 @@ mod tests {
             .list("character-versions")
             .expect("versions should list");
         assert_eq!(versions.len(), 1);
-        assert_eq!(versions[0]["avatarPath"], "data:image/png;base64,b2xk");
-        assert_eq!(versions[0]["avatarFilePath"], Value::Null);
-        assert_eq!(versions[0]["avatarFilename"], Value::Null);
+        let version_avatar_url = versions[0]["avatarPath"]
+            .as_str()
+            .expect("version avatar URL should be stored");
+        assert!(
+            !version_avatar_url.starts_with("data:image/"),
+            "version snapshots should not store inline avatar data"
+        );
+        assert!(
+            version_avatar_url.starts_with("asset://localhost")
+                || version_avatar_url.starts_with("http://asset.localhost"),
+            "version snapshots should store a managed asset URL"
+        );
+        let version_avatar_path = versions[0]["avatarFilePath"]
+            .as_str()
+            .expect("version avatar file path should be stored");
+        assert_ne!(
+            version_avatar_path, old_avatar_path,
+            "version snapshot should own a copied avatar file"
+        );
+        assert!(
+            !Path::new(&old_avatar_path).exists(),
+            "replaced character avatar file should still be cleaned up"
+        );
+        assert_eq!(
+            std::fs::read(version_avatar_path).expect("version avatar copy should exist"),
+            old_avatar_bytes
+        );
 
         let version_id = versions[0]
             .get("id")
@@ -1052,13 +1015,48 @@ mod tests {
             super::super::characters::restore_character_version(&state, "char-1", version_id)
                 .expect("version should restore");
 
-        assert_eq!(restored["avatarPath"], "data:image/png;base64,b2xk");
-        assert_eq!(restored["avatarFilePath"], Value::Null);
-        assert_eq!(restored["avatarFilename"], Value::Null);
+        let restored_avatar_path = restored["avatarFilePath"]
+            .as_str()
+            .expect("restored live avatar file path should be stored");
+        assert_ne!(
+            restored_avatar_path, version_avatar_path,
+            "restoring a version should copy the version avatar into a live-owned file"
+        );
+        assert_eq!(
+            std::fs::read(restored_avatar_path).expect("restored live avatar copy should exist"),
+            old_avatar_bytes
+        );
+        assert!(
+            restored["avatarFilename"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("restored-char-1-")),
+            "restored live avatar should have a distinct live-owned filename"
+        );
+        assert!(
+            Path::new(version_avatar_path).is_file(),
+            "version avatar copy should remain available after restore"
+        );
+
+        update_character_avatar(
+            &state,
+            "characters",
+            "char-1",
+            json!({ "avatar": small_png_data_url(), "filename": "latest.png" }),
+        )
+        .expect("replacing restored avatar should update");
+
+        assert!(
+            !Path::new(restored_avatar_path).exists(),
+            "replacing the restored live avatar should clean up only the live-owned copy"
+        );
+        assert!(
+            Path::new(version_avatar_path).is_file(),
+            "replacing the restored live avatar must not delete the saved version avatar copy"
+        );
     }
 
     #[test]
-    fn character_avatar_snapshot_preserves_metadata_when_inline_read_fails() {
+    fn character_avatar_snapshot_preserves_metadata_when_managed_copy_is_missing() {
         let state = test_state("character-avatar-version-missing-file");
         let missing_path = state
             .data_dir
@@ -1076,11 +1074,74 @@ mod tests {
             "avatarFilename": "missing.png"
         });
 
-        let snapshot = character_avatar_snapshot_record(&state, "characters", &record);
+        let snapshot = super::super::characters::create_character_version_snapshot_from_record(
+            &state,
+            "char-1",
+            &record,
+            "manual",
+            "Avatar update",
+        )
+        .expect("version snapshot should still be created");
 
         assert_eq!(snapshot["avatarPath"], "http://asset.localhost/missing.png");
         assert_eq!(snapshot["avatarFilePath"], record["avatarFilePath"]);
         assert_eq!(snapshot["avatarFilename"], "missing.png");
+    }
+
+    #[test]
+    fn character_avatar_update_fails_before_cleanup_when_snapshot_copy_is_invalid() {
+        let state = test_state("character-avatar-version-invalid-file");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let corrupt_avatar_path = avatar_dir.join("corrupt.png");
+        std::fs::write(&corrupt_avatar_path, b"not an image").expect("corrupt avatar should write");
+        let corrupt_avatar_path = corrupt_avatar_path.to_string_lossy().to_string();
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": { "name": "Rina" },
+                    "avatar": "http://asset.localhost/corrupt.png",
+                    "avatarPath": "http://asset.localhost/corrupt.png",
+                    "avatarFilePath": corrupt_avatar_path,
+                    "avatarFilename": "corrupt.png"
+                }),
+            )
+            .expect("character should be created");
+
+        let error = update_character_avatar(
+            &state,
+            "characters",
+            "char-1",
+            json!({ "avatar": small_png_data_url(), "filename": "new.png" }),
+        )
+        .expect_err("invalid previous avatar should fail snapshot creation");
+
+        assert_eq!(error.code, "character_version_avatar_copy_error");
+        assert!(
+            Path::new(&corrupt_avatar_path).is_file(),
+            "failed snapshot copy must leave the previous avatar file in place"
+        );
+        assert!(
+            state
+                .storage
+                .list("character-versions")
+                .expect("versions should list")
+                .is_empty(),
+            "failed snapshot copy must not create a broken version row"
+        );
+        let remaining_files = std::fs::read_dir(&avatar_dir)
+            .expect("avatar dir should list")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().is_file())
+            .count();
+        assert_eq!(
+            remaining_files, 1,
+            "failed snapshot copy should roll back the newly uploaded avatar file"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -85,22 +85,44 @@ where
 }
 
 pub(crate) fn remove_character_avatar(state: &AppState, id: &str) -> AppResult<Value> {
+    remove_character_avatar_inner(state, id, || {})
+}
+
+fn remove_character_avatar_inner<F>(
+    state: &AppState,
+    id: &str,
+    before_live_patch: F,
+) -> AppResult<Value>
+where
+    F: FnOnce(),
+{
     let previous = shared::get_required(state, "characters", id)?;
     let patch = character_avatar_remove_patch(&previous)?;
     if patch.is_empty() {
         return Ok(previous);
     }
 
-    super::characters::create_character_version_snapshot_from_record(
+    let created_snapshot = super::characters::create_character_version_snapshot_from_record(
         state,
         id,
         &previous,
         "manual",
         "Avatar removal",
     )?;
-    let updated = state
-        .storage
-        .patch("characters", id, Value::Object(patch))?;
+    before_live_patch();
+    let updated = match state.storage.patch("characters", id, Value::Object(patch)) {
+        Ok(updated) => updated,
+        Err(error) => {
+            let rollback_error = super::characters::rollback_character_version_snapshot(
+                state,
+                Some(&created_snapshot),
+                "character avatar removal",
+                &error,
+            )
+            .err();
+            return Err(rollback_error.unwrap_or(error));
+        }
+    };
     remove_avatar_file(state, "characters", &previous);
     Ok(updated)
 }
@@ -587,6 +609,38 @@ mod tests {
 
     fn small_png_data_url() -> &'static str {
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lTmZsgAAAABJRU5ErkJggg=="
+    }
+
+    fn create_character_with_managed_avatar(state: &AppState, filename: &str) -> PathBuf {
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join(filename);
+        let (_, avatar_bytes) =
+            decode_image_payload(small_png_data_url(), "avatar").expect("tiny png should decode");
+        std::fs::write(&avatar_path, &avatar_bytes).expect("avatar should be written");
+        let avatar_path_string = avatar_path.to_string_lossy().to_string();
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Original",
+                        "character_version": "1.0"
+                    },
+                    "comment": "Original title",
+                    "avatar": format!("http://asset.localhost/{filename}"),
+                    "avatarPath": format!("http://asset.localhost/{filename}"),
+                    "avatarFilePath": avatar_path_string,
+                    "avatarFilename": filename
+                }),
+            )
+            .expect("character should be created");
+
+        avatar_path
     }
 
     fn assert_managed_avatar_upload(value: &Value, collection: &str) {
@@ -1231,6 +1285,129 @@ mod tests {
         assert!(
             remaining_files.is_empty(),
             "failed avatar update should remove uploaded and snapshot files: {remaining_files:?}"
+        );
+    }
+
+    #[test]
+    fn character_avatar_removal_rolls_back_snapshot_when_live_patch_fails() {
+        let state = test_state("character-avatar-removal-patch-failure-rollback");
+        let old_avatar_path = create_character_with_managed_avatar(&state, "old.png");
+        let avatar_dir = old_avatar_path
+            .parent()
+            .expect("managed avatar should have a parent")
+            .to_path_buf();
+
+        let error = remove_character_avatar_inner(&state, "char-1", || {
+            state
+                .storage
+                .delete("characters", "char-1")
+                .expect("live character should delete before final patch");
+        })
+        .expect_err("avatar removal should fail when the live patch misses");
+
+        assert_eq!(error.code, "not_found");
+        assert!(
+            state
+                .storage
+                .list("character-versions")
+                .expect("versions should list")
+                .is_empty(),
+            "failed avatar removal must not leave a version row"
+        );
+        assert!(
+            old_avatar_path.is_file(),
+            "failed avatar removal must leave the previous live avatar file in place"
+        );
+        let remaining_files = std::fs::read_dir(&avatar_dir)
+            .expect("avatar dir should list")
+            .filter_map(Result::ok)
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| name != "old.png")
+            .collect::<Vec<_>>();
+        assert!(
+            remaining_files.is_empty(),
+            "failed avatar removal should remove the snapshot copy: {remaining_files:?}"
+        );
+    }
+
+    #[test]
+    fn character_avatar_removal_reports_rollback_error_when_snapshot_delete_fails() {
+        let state = test_state("character-avatar-removal-rollback-failure-contract");
+        let old_avatar_path = create_character_with_managed_avatar(&state, "old.png");
+        let snapshot_avatar_path = std::cell::RefCell::new(None::<String>);
+
+        let error = remove_character_avatar_inner(&state, "char-1", || {
+            let snapshot = state
+                .storage
+                .list("character-versions")
+                .expect("versions should list")
+                .into_iter()
+                .find(|version| {
+                    version.get("reason").and_then(Value::as_str) == Some("Avatar removal")
+                })
+                .expect("snapshot should exist before final patch");
+            let snapshot_id = snapshot
+                .get("id")
+                .and_then(Value::as_str)
+                .expect("snapshot should have id")
+                .to_string();
+            *snapshot_avatar_path.borrow_mut() = snapshot
+                .get("avatarFilePath")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            super::super::characters::force_character_version_snapshot_rollback_failure(
+                &snapshot_id,
+            );
+            state
+                .storage
+                .delete("characters", "char-1")
+                .expect("live character should delete before final patch");
+        })
+        .expect_err("avatar removal should surface rollback failure");
+
+        assert_eq!(error.code, "character_version_snapshot_rollback_error");
+        let details = error
+            .details
+            .as_ref()
+            .and_then(Value::as_object)
+            .expect("rollback error should include details");
+        assert_eq!(
+            details.get("operation").and_then(Value::as_str),
+            Some("character avatar removal")
+        );
+        assert_eq!(
+            details
+                .get("livePatchError")
+                .and_then(|value| value.get("code"))
+                .and_then(Value::as_str),
+            Some("not_found")
+        );
+        assert_eq!(
+            details
+                .get("rollbackError")
+                .and_then(|value| value.get("code"))
+                .and_then(Value::as_str),
+            Some("forced_rollback_error")
+        );
+        assert_eq!(
+            state
+                .storage
+                .list("character-versions")
+                .expect("versions should list")
+                .len(),
+            1,
+            "forced rollback failure leaves the row visible while surfacing a hard error"
+        );
+        let snapshot_avatar_path = snapshot_avatar_path
+            .into_inner()
+            .expect("snapshot avatar path should be captured");
+        assert!(
+            Path::new(&snapshot_avatar_path).is_file(),
+            "forced rollback failure keeps the snapshot avatar because the row still references it"
+        );
+        assert!(
+            old_avatar_path.is_file(),
+            "failed avatar removal must leave the previous live avatar file in place"
         );
     }
 

--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -1,5 +1,5 @@
 use super::media_uploads::{
-    decode_image_payload, managed_record_file_path, persist_image_upload,
+    decode_image_payload, managed_record_file_path, persist_image_upload, remove_copied_file_path,
     remove_managed_record_file, safe_filename,
 };
 use super::*;
@@ -17,6 +17,19 @@ pub(crate) fn update_character_avatar(
     id: &str,
     body: Value,
 ) -> AppResult<Value> {
+    update_character_avatar_inner(state, collection, id, body, || {})
+}
+
+fn update_character_avatar_inner<F>(
+    state: &AppState,
+    collection: &str,
+    id: &str,
+    body: Value,
+    before_live_patch: F,
+) -> AppResult<Value>
+where
+    F: FnOnce(),
+{
     let previous = shared::get_required(state, collection, id)?;
     let stored = persist_image_upload(
         state,
@@ -25,18 +38,24 @@ pub(crate) fn update_character_avatar(
         &body,
         "avatar",
     )?;
-    if collection == "characters" {
-        if let Err(error) = super::characters::create_character_version_snapshot_from_record(
+    let created_snapshot = if collection == "characters" {
+        match super::characters::create_character_version_snapshot_from_record(
             state,
             id,
             &previous,
             "manual",
             "Avatar update",
         ) {
-            remove_copied_avatar_path(&stored.absolute_path, "rolled-back avatar upload");
-            return Err(error);
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                remove_copied_file_path(Some(&stored.absolute_path), "rolled-back avatar upload");
+                return Err(error);
+            }
         }
-    }
+    } else {
+        None
+    };
+    before_live_patch();
     let updated = match state.storage.patch(
         collection,
         id,
@@ -50,18 +69,16 @@ pub(crate) fn update_character_avatar(
     ) {
         Ok(updated) => updated,
         Err(error) => {
-            remove_copied_avatar_path(&stored.absolute_path, "rolled-back avatar upload");
+            super::characters::rollback_character_version_snapshot(
+                state,
+                created_snapshot.as_ref(),
+            );
+            remove_copied_file_path(Some(&stored.absolute_path), "rolled-back avatar upload");
             return Err(error);
         }
     };
     remove_avatar_file_preserving_persona_snapshots(state, collection, &previous);
     Ok(updated)
-}
-
-fn remove_copied_avatar_path(path: &str, context: &str) {
-    if let Err(error) = fs::remove_file(path) {
-        log::warn!("could not remove {context} at {path}: {error}");
-    }
 }
 
 pub(crate) fn remove_character_avatar(state: &AppState, id: &str) -> AppResult<Value> {
@@ -1141,6 +1158,76 @@ mod tests {
         assert_eq!(
             remaining_files, 1,
             "failed snapshot copy should roll back the newly uploaded avatar file"
+        );
+    }
+
+    #[test]
+    fn character_avatar_update_rolls_back_snapshot_when_live_patch_fails() {
+        let state = test_state("character-avatar-patch-failure-rollback");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let old_avatar_path = avatar_dir.join("old.png");
+        let (_, old_avatar_bytes) =
+            decode_image_payload(small_png_data_url(), "avatar").expect("tiny png should decode");
+        std::fs::write(&old_avatar_path, &old_avatar_bytes).expect("old avatar should be written");
+        let old_avatar_path_string = old_avatar_path.to_string_lossy().to_string();
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Original",
+                        "character_version": "1.0"
+                    },
+                    "comment": "Original title",
+                    "avatar": "http://asset.localhost/old.png",
+                    "avatarPath": "http://asset.localhost/old.png",
+                    "avatarFilePath": old_avatar_path_string,
+                    "avatarFilename": "old.png"
+                }),
+            )
+            .expect("character should be created");
+
+        let error = update_character_avatar_inner(
+            &state,
+            "characters",
+            "char-1",
+            json!({ "avatar": small_png_data_url(), "filename": "new.png" }),
+            || {
+                state
+                    .storage
+                    .delete("characters", "char-1")
+                    .expect("live character should delete before final patch");
+            },
+        )
+        .expect_err("avatar update should fail when the live patch misses");
+
+        assert_eq!(error.code, "not_found");
+        assert!(
+            state
+                .storage
+                .list("character-versions")
+                .expect("versions should list")
+                .is_empty(),
+            "failed avatar update must not leave a version row"
+        );
+        assert!(
+            old_avatar_path.is_file(),
+            "failed avatar update must leave the previous avatar file in place"
+        );
+        let remaining_files = std::fs::read_dir(&avatar_dir)
+            .expect("avatar dir should list")
+            .filter_map(Result::ok)
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| name != "old.png")
+            .collect::<Vec<_>>();
+        assert!(
+            remaining_files.is_empty(),
+            "failed avatar update should remove uploaded and snapshot files: {remaining_files:?}"
         );
     }
 

--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -69,12 +69,15 @@ where
     ) {
         Ok(updated) => updated,
         Err(error) => {
-            super::characters::rollback_character_version_snapshot(
+            let rollback_error = super::characters::rollback_character_version_snapshot(
                 state,
                 created_snapshot.as_ref(),
-            );
+                "character avatar update",
+                &error,
+            )
+            .err();
             remove_copied_file_path(Some(&stored.absolute_path), "rolled-back avatar upload");
-            return Err(error);
+            return Err(rollback_error.unwrap_or(error));
         }
     };
     remove_avatar_file_preserving_persona_snapshots(state, collection, &previous);

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -18,6 +18,11 @@ const VERSIONED_CHARACTER_FIELDS: [&str; 6] = [
     "avatarFilename",
 ];
 
+#[cfg(test)]
+static FORCED_CHARACTER_VERSION_SNAPSHOT_ROLLBACK_FAILURES: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<String>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
 struct CharacterVersionSnapshotOptions {
     source: String,
     reason: String,
@@ -77,7 +82,12 @@ where
     {
         Ok(updated) => Ok(updated),
         Err(error) => {
-            rollback_character_version_snapshot(state, created_snapshot.as_ref());
+            rollback_character_version_snapshot(
+                state,
+                created_snapshot.as_ref(),
+                "character update",
+                &error,
+            )?;
             Err(error)
         }
     }
@@ -130,23 +140,108 @@ pub(crate) fn create_character_version_snapshot_from_record(
     }
 }
 
-pub(crate) fn rollback_character_version_snapshot(state: &AppState, snapshot: Option<&Value>) {
+pub(crate) fn rollback_character_version_snapshot(
+    state: &AppState,
+    snapshot: Option<&Value>,
+    operation: &str,
+    live_error: &AppError,
+) -> AppResult<()> {
     let Some(snapshot) = snapshot else {
-        return;
+        return Ok(());
     };
     let Some(snapshot_id) = snapshot.get("id").and_then(Value::as_str) else {
-        log::warn!("could not roll back character version snapshot because it has no id");
-        return;
+        return Err(character_version_snapshot_rollback_error(
+            "<missing>",
+            operation,
+            live_error,
+            None,
+            "Character version snapshot could not be rolled back because it has no id",
+        ));
     };
-    match state.storage.delete("character-versions", snapshot_id) {
-        Ok(true) => remove_character_version_avatar_file(state, snapshot),
-        Ok(false) => log::warn!(
-            "could not roll back character version snapshot {snapshot_id} because it was already missing"
-        ),
-        Err(error) => {
-            log::warn!("could not roll back character version snapshot {snapshot_id}: {error}");
+    #[cfg(test)]
+    {
+        let forced = FORCED_CHARACTER_VERSION_SNAPSHOT_ROLLBACK_FAILURES
+            .lock()
+            .expect("forced rollback failure set should lock")
+            .remove(snapshot_id);
+        if forced {
+            return Err(character_version_snapshot_rollback_error(
+                snapshot_id,
+                operation,
+                live_error,
+                Some(&AppError::new(
+                    "forced_rollback_error",
+                    "forced character version snapshot rollback failure",
+                )),
+                "Character version snapshot rollback failed after the live character patch failed",
+            ));
         }
     }
+    match state.storage.delete("character-versions", snapshot_id) {
+        Ok(true) => {
+            remove_character_version_avatar_file(state, snapshot);
+            Ok(())
+        }
+        Ok(false) => Err(character_version_snapshot_rollback_error(
+            snapshot_id,
+            operation,
+            live_error,
+            None,
+            "Character version snapshot rollback could not find the newly created snapshot row",
+        )),
+        Err(error) => Err(character_version_snapshot_rollback_error(
+            snapshot_id,
+            operation,
+            live_error,
+            Some(&error),
+            "Character version snapshot rollback failed after the live character patch failed",
+        )),
+    }
+}
+
+fn character_version_snapshot_rollback_error(
+    snapshot_id: &str,
+    operation: &str,
+    live_error: &AppError,
+    rollback_error: Option<&AppError>,
+    message: &str,
+) -> AppError {
+    let mut details = Map::new();
+    details.insert(
+        "snapshotId".to_string(),
+        Value::String(snapshot_id.to_string()),
+    );
+    details.insert(
+        "operation".to_string(),
+        Value::String(operation.to_string()),
+    );
+    details.insert("livePatchError".to_string(), app_error_value(live_error));
+    if let Some(rollback_error) = rollback_error {
+        details.insert("rollbackError".to_string(), app_error_value(rollback_error));
+    }
+    AppError::with_details(
+        "character_version_snapshot_rollback_error",
+        message,
+        Value::Object(details),
+    )
+}
+
+fn app_error_value(error: &AppError) -> Value {
+    let mut value = Map::new();
+    value.insert("code".to_string(), Value::String(error.code.clone()));
+    value.insert("message".to_string(), Value::String(error.message.clone()));
+    if let Some(details) = &error.details {
+        value.insert("details".to_string(), details.clone());
+    }
+    Value::Object(value)
+}
+
+#[cfg(test)]
+fn force_character_version_snapshot_rollback_failure(snapshot_id: &str) {
+    FORCED_CHARACTER_VERSION_SNAPSHOT_ROLLBACK_FAILURES
+        .lock()
+        .expect("forced rollback failure set should lock")
+        .insert(snapshot_id.to_string());
 }
 
 fn insert_version_avatar_fields(
@@ -429,12 +524,18 @@ where
     {
         Ok(updated) => updated,
         Err(error) => {
-            rollback_character_version_snapshot(state, created_snapshot.as_ref());
+            let rollback_error = rollback_character_version_snapshot(
+                state,
+                created_snapshot.as_ref(),
+                "character restore",
+                &error,
+            )
+            .err();
             remove_copied_file_path(
                 restored_avatar_path.as_deref(),
                 "rolled-back restored character avatar copy",
             );
-            return Err(error);
+            return Err(rollback_error.unwrap_or(error));
         }
     };
     remove_previous_character_avatar_after_restore(state, &existing, &updated);
@@ -809,6 +910,100 @@ mod tests {
         .expect("noop character update should succeed");
 
         assert!(character_versions(&state).is_empty());
+    }
+
+    #[test]
+    fn update_character_rolls_back_snapshot_when_live_patch_fails() {
+        let state = test_state("update-patch-failure-rollback");
+        create_character(&state);
+
+        let error = update_character_inner(
+            &state,
+            "char-1",
+            json!({
+                "comment": "Updated title",
+                "versionReason": "Patch failure proof"
+            }),
+            || {
+                state
+                    .storage
+                    .delete("characters", "char-1")
+                    .expect("live character should delete before final patch");
+            },
+        )
+        .expect_err("update should fail when the live patch misses");
+
+        assert_eq!(error.code, "not_found");
+        assert!(
+            character_versions(&state).is_empty(),
+            "failed character update must not leave a version row"
+        );
+    }
+
+    #[test]
+    fn update_character_reports_rollback_error_when_snapshot_delete_fails() {
+        let state = test_state("update-rollback-failure-contract");
+        create_character(&state);
+
+        let error = update_character_inner(
+            &state,
+            "char-1",
+            json!({
+                "comment": "Updated title",
+                "versionReason": "Forced rollback failure proof"
+            }),
+            || {
+                let snapshot_id = character_versions(&state)
+                    .into_iter()
+                    .find(|version| {
+                        version.get("reason").and_then(Value::as_str)
+                            == Some("Forced rollback failure proof")
+                    })
+                    .and_then(|version| {
+                        version
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .map(ToOwned::to_owned)
+                    })
+                    .expect("snapshot should exist before final patch");
+                force_character_version_snapshot_rollback_failure(&snapshot_id);
+                state
+                    .storage
+                    .delete("characters", "char-1")
+                    .expect("live character should delete before final patch");
+            },
+        )
+        .expect_err("update should surface rollback failure");
+
+        assert_eq!(error.code, "character_version_snapshot_rollback_error");
+        let details = error
+            .details
+            .as_ref()
+            .and_then(Value::as_object)
+            .expect("rollback error should include details");
+        assert_eq!(
+            details.get("operation").and_then(Value::as_str),
+            Some("character update")
+        );
+        assert_eq!(
+            details
+                .get("livePatchError")
+                .and_then(|value| value.get("code"))
+                .and_then(Value::as_str),
+            Some("not_found")
+        );
+        assert_eq!(
+            details
+                .get("rollbackError")
+                .and_then(|value| value.get("code"))
+                .and_then(Value::as_str),
+            Some("forced_rollback_error")
+        );
+        assert_eq!(
+            character_versions(&state).len(),
+            1,
+            "forced rollback failure leaves the row visible while surfacing a hard error"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -182,13 +182,16 @@ pub(crate) fn rollback_character_version_snapshot(
             remove_character_version_avatar_file(state, snapshot);
             Ok(())
         }
-        Ok(false) => Err(character_version_snapshot_rollback_error(
-            snapshot_id,
-            operation,
-            live_error,
-            None,
-            "Character version snapshot rollback could not find the newly created snapshot row",
-        )),
+        Ok(false) => {
+            remove_character_version_avatar_file(state, snapshot);
+            Err(character_version_snapshot_rollback_error(
+                snapshot_id,
+                operation,
+                live_error,
+                None,
+                "Character version snapshot rollback could not find the newly created snapshot row",
+            ))
+        }
         Err(error) => Err(character_version_snapshot_rollback_error(
             snapshot_id,
             operation,
@@ -237,7 +240,7 @@ fn app_error_value(error: &AppError) -> Value {
 }
 
 #[cfg(test)]
-fn force_character_version_snapshot_rollback_failure(snapshot_id: &str) {
+pub(crate) fn force_character_version_snapshot_rollback_failure(snapshot_id: &str) {
     FORCED_CHARACTER_VERSION_SNAPSHOT_ROLLBACK_FAILURES
         .lock()
         .expect("forced rollback failure set should lock")
@@ -758,6 +761,37 @@ mod tests {
             .expect("character should be created");
     }
 
+    fn create_character_with_managed_avatar(state: &AppState, filename: &str) -> PathBuf {
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join(filename);
+        std::fs::write(&avatar_path, TINY_PNG_BYTES).expect("avatar should be written");
+        let avatar_path_string = avatar_path.to_string_lossy().to_string();
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Original description",
+                        "tags": ["ice"],
+                        "character_version": "1.0"
+                    },
+                    "comment": "Original title",
+                    "avatar": format!("http://asset.localhost/{filename}"),
+                    "avatarPath": format!("http://asset.localhost/{filename}"),
+                    "avatarFilePath": avatar_path_string,
+                    "avatarFilename": filename
+                }),
+            )
+            .expect("character should be created");
+
+        avatar_path
+    }
+
     fn character_versions(state: &AppState) -> Vec<Value> {
         state
             .storage
@@ -943,7 +977,8 @@ mod tests {
     #[test]
     fn update_character_reports_rollback_error_when_snapshot_delete_fails() {
         let state = test_state("update-rollback-failure-contract");
-        create_character(&state);
+        let live_avatar_path = create_character_with_managed_avatar(&state, "old.png");
+        let snapshot_avatar_path = std::cell::RefCell::new(None::<String>);
 
         let error = update_character_inner(
             &state,
@@ -966,6 +1001,20 @@ mod tests {
                             .map(ToOwned::to_owned)
                     })
                     .expect("snapshot should exist before final patch");
+                let snapshot_avatar = character_versions(&state)
+                    .into_iter()
+                    .find(|version| {
+                        version.get("reason").and_then(Value::as_str)
+                            == Some("Forced rollback failure proof")
+                    })
+                    .and_then(|version| {
+                        version
+                            .get("avatarFilePath")
+                            .and_then(Value::as_str)
+                            .map(ToOwned::to_owned)
+                    })
+                    .expect("snapshot should capture an avatar copy");
+                *snapshot_avatar_path.borrow_mut() = Some(snapshot_avatar);
                 force_character_version_snapshot_rollback_failure(&snapshot_id);
                 state
                     .storage
@@ -1003,6 +1052,97 @@ mod tests {
             character_versions(&state).len(),
             1,
             "forced rollback failure leaves the row visible while surfacing a hard error"
+        );
+        let snapshot_avatar_path = snapshot_avatar_path
+            .into_inner()
+            .expect("snapshot avatar path should be captured");
+        assert!(
+            PathBuf::from(&snapshot_avatar_path).is_file(),
+            "forced rollback failure keeps the snapshot avatar because the row still references it"
+        );
+        assert!(
+            live_avatar_path.is_file(),
+            "failed update must leave the previous live avatar file in place"
+        );
+    }
+
+    #[test]
+    fn update_character_cleans_snapshot_avatar_when_snapshot_row_is_already_missing() {
+        let state = test_state("update-missing-row-rollback-avatar-cleanup");
+        let live_avatar_path = create_character_with_managed_avatar(&state, "old.png");
+        let snapshot_avatar_path = std::cell::RefCell::new(None::<String>);
+
+        let error = update_character_inner(
+            &state,
+            "char-1",
+            json!({
+                "comment": "Updated title",
+                "versionReason": "Missing rollback row proof"
+            }),
+            || {
+                let snapshot = character_versions(&state)
+                    .into_iter()
+                    .find(|version| {
+                        version.get("reason").and_then(Value::as_str)
+                            == Some("Missing rollback row proof")
+                    })
+                    .expect("snapshot should exist before final patch");
+                let snapshot_id = snapshot
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .expect("snapshot should have id")
+                    .to_string();
+                *snapshot_avatar_path.borrow_mut() = snapshot
+                    .get("avatarFilePath")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                state
+                    .storage
+                    .delete("character-versions", &snapshot_id)
+                    .expect("snapshot row should delete before rollback");
+                state
+                    .storage
+                    .delete("characters", "char-1")
+                    .expect("live character should delete before final patch");
+            },
+        )
+        .expect_err("update should surface missing-row rollback failure");
+
+        assert_eq!(error.code, "character_version_snapshot_rollback_error");
+        let details = error
+            .details
+            .as_ref()
+            .and_then(Value::as_object)
+            .expect("rollback error should include details");
+        assert_eq!(
+            details.get("operation").and_then(Value::as_str),
+            Some("character update")
+        );
+        assert_eq!(
+            details
+                .get("livePatchError")
+                .and_then(|value| value.get("code"))
+                .and_then(Value::as_str),
+            Some("not_found")
+        );
+        assert!(
+            details.get("rollbackError").is_none(),
+            "missing-row rollback has no secondary delete error"
+        );
+        assert!(
+            character_versions(&state).is_empty(),
+            "missing-row rollback should leave no version rows"
+        );
+        let snapshot_avatar_path = snapshot_avatar_path
+            .into_inner()
+            .expect("snapshot avatar path should be captured");
+        assert!(
+            !PathBuf::from(&snapshot_avatar_path).exists(),
+            "missing-row rollback should remove the orphaned snapshot avatar"
+        );
+        assert!(
+            live_avatar_path.is_file(),
+            "failed update must leave the previous live avatar file in place"
         );
     }
 

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -1,6 +1,9 @@
-use super::media_uploads::{managed_record_file_path, persist_image_file_copy};
+use super::media_uploads::{
+    managed_record_file_path, persist_image_file_copy, safe_filename, StoredManagedImage,
+};
 use super::shared::*;
 use super::*;
+use std::path::{Path, PathBuf};
 
 const VERSION_SOURCE_FIELD: &str = "versionSource";
 const VERSION_REASON_FIELD: &str = "versionReason";
@@ -79,12 +82,8 @@ pub(crate) fn create_character_version_snapshot_from_record(
     );
     snapshot.insert("data".to_string(), data);
     snapshot.insert("comment".to_string(), character_comment(record));
-    for field in ["avatarPath", "avatar", "avatarFilePath", "avatarFilename"] {
-        snapshot.insert(
-            field.to_string(),
-            record.get(field).cloned().unwrap_or(Value::Null),
-        );
-    }
+    let copied_avatar_path =
+        insert_version_avatar_fields(state, character_id, record, &mut snapshot)?;
     snapshot.insert("version".to_string(), Value::String(version));
     snapshot.insert(
         "source".to_string(),
@@ -92,9 +91,224 @@ pub(crate) fn create_character_version_snapshot_from_record(
     );
     snapshot.insert("reason".to_string(), Value::String(reason.to_string()));
 
-    state
+    match state
         .storage
         .create("character-versions", Value::Object(snapshot))
+    {
+        Ok(created) => Ok(created),
+        Err(error) => {
+            if let Some(path) = copied_avatar_path {
+                if let Err(remove_error) = std::fs::remove_file(&path) {
+                    log::warn!(
+                        "could not remove rolled-back character version avatar copy at {path}: {remove_error}"
+                    );
+                }
+            }
+            Err(error)
+        }
+    }
+}
+
+fn insert_version_avatar_fields(
+    state: &AppState,
+    character_id: &str,
+    record: &Value,
+    snapshot: &mut Map<String, Value>,
+) -> AppResult<Option<String>> {
+    for field in ["avatarPath", "avatar", "avatarFilePath", "avatarFilename"] {
+        snapshot.insert(
+            field.to_string(),
+            record.get(field).cloned().unwrap_or(Value::Null),
+        );
+    }
+
+    let Some(avatar_path) = managed_character_avatar_path(state, record)? else {
+        return Ok(None);
+    };
+    let filename_hint = version_avatar_filename_hint(character_id, record, &avatar_path);
+    let stored = persist_image_file_copy(state, "avatars/characters", &filename_hint, &avatar_path)
+        .map_err(|error| {
+            AppError::new(
+                "character_version_avatar_copy_error",
+                format!("Character avatar could not be copied into version snapshot: {error}"),
+            )
+        })?;
+
+    // Legacy version rows kept `avatarPath` as a file-backed URL. Keep that row shape, but point
+    // at a snapshot-owned managed copy instead of embedding base64 in the hot storage record.
+    Ok(Some(apply_stored_avatar_fields(snapshot, stored)))
+}
+
+fn version_avatar_filename_hint(character_id: &str, record: &Value, avatar_path: &Path) -> String {
+    let filename = record
+        .get("avatarFilename")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| avatar_path.file_name().and_then(|value| value.to_str()))
+        .unwrap_or("avatar");
+    format!(
+        "version-{}-{}",
+        safe_filename(character_id),
+        safe_filename(filename)
+    )
+}
+
+fn insert_restored_avatar_fields(
+    state: &AppState,
+    character_id: &str,
+    version: &Value,
+    patch: &mut Map<String, Value>,
+) -> AppResult<Option<String>> {
+    let Some(avatar_path) = managed_character_avatar_path(state, version)? else {
+        return Ok(None);
+    };
+    let filename_hint = restored_avatar_filename_hint(character_id, version, &avatar_path);
+    let stored = persist_image_file_copy(state, "avatars/characters", &filename_hint, &avatar_path)
+        .map_err(|error| {
+            AppError::new(
+                "character_restore_avatar_copy_error",
+                format!("Character version avatar could not be copied for restore: {error}"),
+            )
+        })?;
+    Ok(Some(apply_stored_avatar_fields(patch, stored)))
+}
+
+fn restored_avatar_filename_hint(character_id: &str, record: &Value, avatar_path: &Path) -> String {
+    let filename = record
+        .get("avatarFilename")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| avatar_path.file_name().and_then(|value| value.to_str()))
+        .unwrap_or("avatar");
+    format!(
+        "restored-{}-{}",
+        safe_filename(character_id),
+        safe_filename(filename)
+    )
+}
+
+fn apply_stored_avatar_fields(
+    fields: &mut Map<String, Value>,
+    stored: StoredManagedImage,
+) -> String {
+    fields.insert(
+        "avatarPath".to_string(),
+        Value::String(stored.asset_url.clone()),
+    );
+    if fields.contains_key("avatar") {
+        fields.insert("avatar".to_string(), Value::String(stored.asset_url));
+    }
+    let absolute_path = stored.absolute_path.clone();
+    fields.insert(
+        "avatarFilePath".to_string(),
+        Value::String(stored.absolute_path),
+    );
+    fields.insert("avatarFilename".to_string(), Value::String(stored.filename));
+    absolute_path
+}
+
+fn managed_character_avatar_path(state: &AppState, record: &Value) -> AppResult<Option<PathBuf>> {
+    managed_record_file_path(
+        state,
+        "avatars/characters",
+        record,
+        "avatarFilePath",
+        "avatarFilename",
+    )
+}
+
+fn remove_copied_avatar_path(path: Option<&str>, context: &str) {
+    let Some(path) = path else {
+        return;
+    };
+    if let Err(error) = fs::remove_file(path) {
+        log::warn!("could not remove {context} at {path}: {error}");
+    }
+}
+
+fn remove_previous_character_avatar_after_restore(
+    state: &AppState,
+    previous: &Value,
+    updated: &Value,
+) {
+    let previous_path = match managed_character_avatar_path(state, previous) {
+        Ok(path) => path,
+        Err(error) => {
+            log::warn!("could not resolve previous character avatar for restore cleanup: {error}");
+            return;
+        }
+    };
+    let Some(previous_path) = previous_path else {
+        return;
+    };
+    let updated_path = match managed_character_avatar_path(state, updated) {
+        Ok(path) => path,
+        Err(error) => {
+            log::warn!("could not resolve restored character avatar for cleanup: {error}");
+            return;
+        }
+    };
+    if updated_path.as_ref() != Some(&previous_path) {
+        super::avatars::remove_avatar_file(state, "characters", previous);
+    }
+}
+
+pub(crate) fn remove_character_version_avatar_file(state: &AppState, record: &Value) {
+    match character_version_avatar_referenced_elsewhere(state, record) {
+        Ok(true) => return,
+        Ok(false) => super::avatars::remove_avatar_file(state, "characters", record),
+        Err(error) => log::warn!(
+            "skipping character version avatar cleanup because references could not be scanned: {error}"
+        ),
+    }
+}
+
+fn character_version_avatar_referenced_elsewhere(
+    state: &AppState,
+    record: &Value,
+) -> AppResult<bool> {
+    let Some(path) = record_managed_avatar_canonical_path(state, record)? else {
+        return Ok(false);
+    };
+    for character in state.storage.list("characters")? {
+        if record_managed_avatar_matches_path(state, &character, &path)? {
+            return Ok(true);
+        }
+    }
+    let deleted_version_id = record.get("id").and_then(Value::as_str);
+    for version in state.storage.list("character-versions")? {
+        if deleted_version_id.is_some()
+            && version.get("id").and_then(Value::as_str) == deleted_version_id
+        {
+            continue;
+        }
+        if record_managed_avatar_matches_path(state, &version, &path)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn record_managed_avatar_matches_path(
+    state: &AppState,
+    record: &Value,
+    path: &Path,
+) -> AppResult<bool> {
+    Ok(record_managed_avatar_canonical_path(state, record)?.as_deref() == Some(path))
+}
+
+fn record_managed_avatar_canonical_path(
+    state: &AppState,
+    record: &Value,
+) -> AppResult<Option<PathBuf>> {
+    let Some(path) = managed_character_avatar_path(state, record)? else {
+        return Ok(None);
+    };
+    match fs::canonicalize(path) {
+        Ok(path) => Ok(Some(path)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AppError::from(error)),
+    }
 }
 
 pub(crate) fn restore_character_version(
@@ -108,6 +322,7 @@ pub(crate) fn restore_character_version(
             "Version does not belong to this character",
         ));
     }
+    let existing = get_required(state, "characters", character_id)?;
     let mut patch = Map::new();
     if let Some(data) = version.get("data") {
         patch.insert(
@@ -128,6 +343,8 @@ pub(crate) fn restore_character_version(
             version.get(field).cloned().unwrap_or(Value::Null),
         );
     }
+    let restored_avatar_path =
+        insert_restored_avatar_fields(state, character_id, &version, &mut patch)?;
     let reason = format!(
         "Restored {}",
         version
@@ -136,24 +353,42 @@ pub(crate) fn restore_character_version(
             .filter(|value| !value.trim().is_empty())
             .unwrap_or(version_id)
     );
-    let existing = get_required(state, "characters", character_id)?;
     let options = CharacterVersionSnapshotOptions {
         source: "restore".to_string(),
         reason,
         skip: false,
     };
-    if should_create_version_snapshot(&existing, &patch, &options) {
-        create_character_version_snapshot_from_record(
+    let should_snapshot = should_create_version_snapshot(&existing, &patch, &options);
+    if should_snapshot {
+        if let Err(error) = create_character_version_snapshot_from_record(
             state,
             character_id,
             &existing,
             &options.source,
             &options.reason,
-        )?;
+        ) {
+            remove_copied_avatar_path(
+                restored_avatar_path.as_deref(),
+                "rolled-back restored character avatar copy",
+            );
+            return Err(error);
+        }
     }
-    state
+    let updated = match state
         .storage
         .patch("characters", character_id, Value::Object(patch))
+    {
+        Ok(updated) => updated,
+        Err(error) => {
+            remove_copied_avatar_path(
+                restored_avatar_path.as_deref(),
+                "rolled-back restored character avatar copy",
+            );
+            return Err(error);
+        }
+    };
+    remove_previous_character_avatar_after_restore(state, &existing, &updated);
+    Ok(updated)
 }
 
 pub(crate) fn duplicate_character(state: &AppState, character_id: &str) -> AppResult<Value> {
@@ -575,5 +810,50 @@ mod tests {
             .expect("restore snapshot should exist");
         assert_eq!(restore_snapshot["data"]["name"], "Rina");
         assert_eq!(restore_snapshot["reason"], "Restored 0.9");
+    }
+
+    #[test]
+    fn restore_character_version_missing_character_does_not_copy_avatar() {
+        let state = test_state("restore-missing-character-no-copy");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let version_avatar_path = avatar_dir.join("version.png");
+        std::fs::write(&version_avatar_path, TINY_PNG_BYTES).expect("version avatar should write");
+        state
+            .storage
+            .create(
+                "character-versions",
+                json!({
+                    "id": "version-old",
+                    "characterId": "missing-char",
+                    "data": { "name": "Old Rina" },
+                    "avatarPath": "http://asset.localhost/version.png",
+                    "avatarFilePath": version_avatar_path.to_string_lossy().to_string(),
+                    "avatarFilename": "version.png"
+                }),
+            )
+            .expect("version should be created");
+
+        restore_character_version(&state, "missing-char", "version-old")
+            .expect_err("restore should fail when live character is missing");
+
+        let copied_restores = std::fs::read_dir(&avatar_dir)
+            .expect("avatar dir should list")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with("restored-missing-char-"))
+            })
+            .count();
+        assert_eq!(
+            copied_restores, 0,
+            "missing live character should be checked before copying a restored avatar"
+        );
+        assert!(
+            version_avatar_path.is_file(),
+            "failed restore must leave the saved version avatar in place"
+        );
     }
 }

--- a/src-tauri/src/commands/storage/characters.rs
+++ b/src-tauri/src/commands/storage/characters.rs
@@ -1,5 +1,6 @@
 use super::media_uploads::{
-    managed_record_file_path, persist_image_file_copy, safe_filename, StoredManagedImage,
+    managed_record_file_path, persist_image_file_copy, remove_copied_file_path, safe_filename,
+    StoredManagedImage,
 };
 use super::shared::*;
 use super::*;
@@ -38,25 +39,48 @@ pub(crate) fn update_character(
     character_id: &str,
     patch: Value,
 ) -> AppResult<Value> {
+    update_character_inner(state, character_id, patch, || {})
+}
+
+fn update_character_inner<F>(
+    state: &AppState,
+    character_id: &str,
+    patch: Value,
+    before_live_patch: F,
+) -> AppResult<Value>
+where
+    F: FnOnce(),
+{
     let normalized = normalize_update_patch("characters", patch)?;
     let mut patch = ensure_object(normalized)?;
     let options = take_version_snapshot_options(&mut patch);
     let existing = get_required(state, "characters", character_id)?;
     merge_partial_character_data(&existing, &mut patch)?;
 
-    if should_create_version_snapshot(&existing, &patch, &options) {
-        create_character_version_snapshot_from_record(
+    let created_snapshot = if should_create_version_snapshot(&existing, &patch, &options) {
+        Some(create_character_version_snapshot_from_record(
             state,
             character_id,
             &existing,
             &options.source,
             &options.reason,
-        )?;
-    }
+        )?)
+    } else {
+        None
+    };
 
-    state
+    before_live_patch();
+
+    match state
         .storage
         .patch("characters", character_id, Value::Object(patch))
+    {
+        Ok(updated) => Ok(updated),
+        Err(error) => {
+            rollback_character_version_snapshot(state, created_snapshot.as_ref());
+            Err(error)
+        }
+    }
 }
 
 pub(crate) fn create_character_version_snapshot_from_record(
@@ -97,14 +121,30 @@ pub(crate) fn create_character_version_snapshot_from_record(
     {
         Ok(created) => Ok(created),
         Err(error) => {
-            if let Some(path) = copied_avatar_path {
-                if let Err(remove_error) = std::fs::remove_file(&path) {
-                    log::warn!(
-                        "could not remove rolled-back character version avatar copy at {path}: {remove_error}"
-                    );
-                }
-            }
+            remove_copied_file_path(
+                copied_avatar_path.as_deref(),
+                "rolled-back character version avatar copy",
+            );
             Err(error)
+        }
+    }
+}
+
+pub(crate) fn rollback_character_version_snapshot(state: &AppState, snapshot: Option<&Value>) {
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+    let Some(snapshot_id) = snapshot.get("id").and_then(Value::as_str) else {
+        log::warn!("could not roll back character version snapshot because it has no id");
+        return;
+    };
+    match state.storage.delete("character-versions", snapshot_id) {
+        Ok(true) => remove_character_version_avatar_file(state, snapshot),
+        Ok(false) => log::warn!(
+            "could not roll back character version snapshot {snapshot_id} because it was already missing"
+        ),
+        Err(error) => {
+            log::warn!("could not roll back character version snapshot {snapshot_id}: {error}");
         }
     }
 }
@@ -217,15 +257,6 @@ fn managed_character_avatar_path(state: &AppState, record: &Value) -> AppResult<
     )
 }
 
-fn remove_copied_avatar_path(path: Option<&str>, context: &str) {
-    let Some(path) = path else {
-        return;
-    };
-    if let Err(error) = fs::remove_file(path) {
-        log::warn!("could not remove {context} at {path}: {error}");
-    }
-}
-
 fn remove_previous_character_avatar_after_restore(
     state: &AppState,
     previous: &Value,
@@ -255,7 +286,7 @@ fn remove_previous_character_avatar_after_restore(
 
 pub(crate) fn remove_character_version_avatar_file(state: &AppState, record: &Value) {
     match character_version_avatar_referenced_elsewhere(state, record) {
-        Ok(true) => return,
+        Ok(true) => (),
         Ok(false) => super::avatars::remove_avatar_file(state, "characters", record),
         Err(error) => log::warn!(
             "skipping character version avatar cleanup because references could not be scanned: {error}"
@@ -316,6 +347,18 @@ pub(crate) fn restore_character_version(
     character_id: &str,
     version_id: &str,
 ) -> AppResult<Value> {
+    restore_character_version_inner(state, character_id, version_id, || {})
+}
+
+fn restore_character_version_inner<F>(
+    state: &AppState,
+    character_id: &str,
+    version_id: &str,
+    before_live_patch: F,
+) -> AppResult<Value>
+where
+    F: FnOnce(),
+{
     let version = get_required(state, "character-versions", version_id)?;
     if version.get("characterId").and_then(Value::as_str) != Some(character_id) {
         return Err(AppError::invalid_input(
@@ -359,28 +402,35 @@ pub(crate) fn restore_character_version(
         skip: false,
     };
     let should_snapshot = should_create_version_snapshot(&existing, &patch, &options);
-    if should_snapshot {
-        if let Err(error) = create_character_version_snapshot_from_record(
+    let created_snapshot = if should_snapshot {
+        match create_character_version_snapshot_from_record(
             state,
             character_id,
             &existing,
             &options.source,
             &options.reason,
         ) {
-            remove_copied_avatar_path(
-                restored_avatar_path.as_deref(),
-                "rolled-back restored character avatar copy",
-            );
-            return Err(error);
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                remove_copied_file_path(
+                    restored_avatar_path.as_deref(),
+                    "rolled-back restored character avatar copy",
+                );
+                return Err(error);
+            }
         }
-    }
+    } else {
+        None
+    };
+    before_live_patch();
     let updated = match state
         .storage
         .patch("characters", character_id, Value::Object(patch))
     {
         Ok(updated) => updated,
         Err(error) => {
-            remove_copied_avatar_path(
+            rollback_character_version_snapshot(state, created_snapshot.as_ref());
+            remove_copied_file_path(
                 restored_avatar_path.as_deref(),
                 "rolled-back restored character avatar copy",
             );
@@ -810,6 +860,92 @@ mod tests {
             .expect("restore snapshot should exist");
         assert_eq!(restore_snapshot["data"]["name"], "Rina");
         assert_eq!(restore_snapshot["reason"], "Restored 0.9");
+    }
+
+    #[test]
+    fn restore_character_version_rolls_back_snapshot_and_avatar_when_live_patch_fails() {
+        let state = test_state("restore-patch-failure-rollback");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let live_avatar_path = avatar_dir.join("live.png");
+        std::fs::write(&live_avatar_path, TINY_PNG_BYTES).expect("live avatar should write");
+        let version_avatar_path = avatar_dir.join("version.png");
+        std::fs::write(&version_avatar_path, TINY_PNG_BYTES).expect("version avatar should write");
+
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "data": {
+                        "name": "Rina",
+                        "description": "Current description",
+                        "character_version": "1.0"
+                    },
+                    "comment": "Current title",
+                    "avatar": "http://asset.localhost/live.png",
+                    "avatarPath": "http://asset.localhost/live.png",
+                    "avatarFilePath": live_avatar_path.to_string_lossy().to_string(),
+                    "avatarFilename": "live.png"
+                }),
+            )
+            .expect("character should be created");
+        state
+            .storage
+            .create(
+                "character-versions",
+                json!({
+                    "id": "version-old",
+                    "characterId": "char-1",
+                    "data": {
+                        "name": "Old Rina",
+                        "description": "Old description",
+                        "character_version": "0.9"
+                    },
+                    "comment": "Old title",
+                    "avatar": "http://asset.localhost/version.png",
+                    "avatarPath": "http://asset.localhost/version.png",
+                    "avatarFilePath": version_avatar_path.to_string_lossy().to_string(),
+                    "avatarFilename": "version.png",
+                    "version": "0.9"
+                }),
+            )
+            .expect("version should be created");
+
+        let error = restore_character_version_inner(&state, "char-1", "version-old", || {
+            state
+                .storage
+                .delete("characters", "char-1")
+                .expect("live character should delete before final patch");
+        })
+        .expect_err("restore should fail when the live patch misses");
+
+        assert_eq!(error.code, "not_found");
+        let versions = character_versions(&state);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["id"], "version-old");
+        assert!(
+            live_avatar_path.is_file(),
+            "failed restore must leave the previous live avatar file in place"
+        );
+        assert!(
+            version_avatar_path.is_file(),
+            "failed restore must leave the saved version avatar in place"
+        );
+        let copied_files = std::fs::read_dir(&avatar_dir)
+            .expect("avatar dir should list")
+            .filter_map(Result::ok)
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| {
+                name.starts_with("restored-char-1-version")
+                    || name.starts_with("version-char-1-live")
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            copied_files.is_empty(),
+            "failed restore should remove copied rollback files: {copied_files:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1391,6 +1391,7 @@ fn delete_cleanup_needs_existing_record(cleanup: &contracts::DeleteCleanup) -> b
 fn remove_owned_media(state: &AppState, entity: &str, record: &Value) {
     match entity {
         "characters" => avatars::remove_avatar_file(state, entity, record),
+        "character-versions" => characters::remove_character_version_avatar_file(state, record),
         "personas" => {
             avatars::remove_avatar_file_preserving_persona_snapshots(state, entity, record)
         }
@@ -2850,6 +2851,83 @@ mod tests {
         assert!(
             !image_path.exists(),
             "managed gallery file should be removed"
+        );
+    }
+
+    #[test]
+    fn deleting_character_version_removes_owned_avatar_copy() {
+        assert!(cleanup_registered(
+            "character-versions",
+            contracts::DeleteCleanup::RemoveOwnedMedia
+        ));
+        let state = test_state("character-version-delete-managed-avatar");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join("version.png");
+        std::fs::write(&avatar_path, b"managed").expect("version avatar should be written");
+        state
+            .storage
+            .create(
+                "character-versions",
+                json!({
+                    "id": "version-1",
+                    "characterId": "char-1",
+                    "avatarPath": "http://asset.localhost/version.png",
+                    "avatarFilePath": avatar_path.to_string_lossy().to_string(),
+                    "avatarFilename": "version.png"
+                }),
+            )
+            .expect("version row should be created");
+
+        delete_entity(&state, "character-versions", "version-1", false)
+            .expect("version delete should succeed");
+
+        assert!(
+            !avatar_path.exists(),
+            "deleted version should remove its owned avatar copy"
+        );
+    }
+
+    #[test]
+    fn deleting_character_version_preserves_avatar_still_used_by_character() {
+        let state = test_state("character-version-delete-live-avatar");
+        let avatar_dir = state.data_dir.join("avatars").join("characters");
+        std::fs::create_dir_all(&avatar_dir).expect("avatar dir should be created");
+        let avatar_path = avatar_dir.join("shared.png");
+        std::fs::write(&avatar_path, b"managed").expect("shared avatar should be written");
+        let avatar_path_string = avatar_path.to_string_lossy().to_string();
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "char-1",
+                    "avatarPath": "http://asset.localhost/shared.png",
+                    "avatarFilePath": avatar_path_string,
+                    "avatarFilename": "shared.png"
+                }),
+            )
+            .expect("character row should be created");
+        state
+            .storage
+            .create(
+                "character-versions",
+                json!({
+                    "id": "version-1",
+                    "characterId": "char-1",
+                    "avatarPath": "http://asset.localhost/shared.png",
+                    "avatarFilePath": avatar_path.to_string_lossy().to_string(),
+                    "avatarFilename": "shared.png"
+                }),
+            )
+            .expect("version row should be created");
+
+        delete_entity(&state, "character-versions", "version-1", false)
+            .expect("version delete should succeed");
+
+        assert!(
+            avatar_path.exists(),
+            "version delete must not remove an avatar still used by the live character"
         );
     }
 

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -116,6 +116,8 @@ const PROMPT_FIELDS: &[TypedJsonField] = &[
     object("parameters"),
     object("defaultChoices"),
     array("variableGroups"),
+    boolish("isDefault"),
+    boolish("default"),
 ];
 const PROMPT_SECTION_FIELDS: &[TypedJsonField] = &[nullable_object("markerConfig")];
 const PROMPT_VARIABLE_FIELDS: &[TypedJsonField] = &[array("options")];

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -116,8 +116,6 @@ const PROMPT_FIELDS: &[TypedJsonField] = &[
     object("parameters"),
     object("defaultChoices"),
     array("variableGroups"),
-    boolish("isDefault"),
-    boolish("default"),
 ];
 const PROMPT_SECTION_FIELDS: &[TypedJsonField] = &[nullable_object("markerConfig")];
 const PROMPT_VARIABLE_FIELDS: &[TypedJsonField] = &[array("options")];
@@ -193,6 +191,7 @@ const CHARACTER_CLEANUP: &[DeleteCleanup] = &[
     DeleteCleanup::RemoveOwnedMedia,
     DeleteCleanup::DeleteCharacterGallery,
 ];
+const CHARACTER_VERSION_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::RemoveOwnedMedia];
 const MEDIA_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::RemoveOwnedMedia];
 const MESSAGE_CLEANUP: &[DeleteCleanup] = &[DeleteCleanup::DeleteMessageTrackerSnapshots];
 
@@ -219,7 +218,7 @@ pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
         false,
         EMPTY_DEFAULTS,
         EMPTY_FIELDS,
-        EMPTY_CLEANUP,
+        CHARACTER_VERSION_CLEANUP,
     ),
     contract(
         "personas",

--- a/src-tauri/src/commands/storage/media_uploads.rs
+++ b/src-tauri/src/commands/storage/media_uploads.rs
@@ -165,6 +165,15 @@ pub(crate) fn remove_managed_record_file(
     }
 }
 
+pub(crate) fn remove_copied_file_path(path: Option<&str>, context: &str) {
+    let Some(path) = path else {
+        return;
+    };
+    if let Err(error) = fs::remove_file(path) {
+        log::warn!("could not remove {context} at {path}: {error}");
+    }
+}
+
 pub(crate) fn managed_record_file_path(
     state: &AppState,
     folder: &str,


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Character version snapshots could lose or orphan avatar assets because saved versions, restored live characters, and delete cleanup did not have a single ownership rule for managed avatar files.

## What changed

- Copy managed character avatars into version-owned files when creating character version snapshots.
- Copy version avatars into separate live-owned files when restoring a saved version.
- Fail snapshot creation when a managed source avatar exists but cannot be copied, and roll back newly uploaded files on snapshot or patch failure.
- Register managed media cleanup for `character-versions` and preserve avatar files that are still referenced by a live character or another saved version.
- Add focused Rust regression coverage for snapshot copy, restore copy, copy failure, missing-character restore, and version delete cleanup paths.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Character avatar upload and removal snapshot creation.
- Character version restore behavior.
- Managed avatar file delete cleanup for `characters` and `character-versions`.
- Storage collection cleanup registration.

Boundary notes:

- Rust-only storage capability change under `src-tauri`.
- No React, TypeScript engine, shared API, command registration, or remote-runtime allowlist changes.
- Existing Tauri/HTTP command entrypoints continue to call the same Rust storage owners.

Pressure points touched:

- None of the listed broad pressure points. Touched focused storage modules only.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml character_avatar` passed, 4 tests.
- `cargo test --manifest-path src-tauri/Cargo.toml deleting_character_version` passed, 2 tests.
- `cargo test --manifest-path src-tauri/Cargo.toml restore_character_version` passed, 2 tests.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `pnpm check` passed.
- `git diff --check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal storage bugfix for character version avatar asset ownership. No new user-discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed because this is an internal Rust storage bugfix and does not change documented commands, architecture guidance, or user-facing copy.

## UI evidence

N/A. No visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character versions now capture and preserve avatar files in snapshots
  * Avatar files are properly copied and restored when recovering previous character versions

* **Bug Fixes**
  * Failed avatar uploads no longer leave orphaned files; cleanup is rolled back on failure
  * Avatar file cleanup during character version deletion now correctly preserves files still referenced by other versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->