### PR TITLE
Preserve xhigh reasoning for GPT-5.1-Codex-Max

### DIFF
--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -365,10 +365,51 @@ fn should_use_openai_responses(request: &LlmRequest) -> bool {
         || model.contains("codex")
 }
 
-fn reasoning_effort(parameters: &Value) -> Option<String> {
-    let effort = param_string(parameters, &["reasoningEffort", "reasoning_effort"])?;
+fn openai_model_id(model: &str) -> String {
+    model
+        .to_ascii_lowercase()
+        .rsplit('/')
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+fn gpt5_minor_version(model: &str) -> Option<u32> {
+    let model = openai_model_id(model);
+    let tail = model.strip_prefix("gpt-5.")?;
+    let digits = tail
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse::<u32>().ok()
+}
+
+fn supports_openai_xhigh_reasoning_model(model: &str) -> bool {
+    let model = openai_model_id(model);
+    if model == "gpt-5-pro" || model.starts_with("gpt-5-pro-") {
+        return false;
+    }
+    if model == "gpt-5.1-codex-max" || model.starts_with("gpt-5.1-codex-max-") {
+        return true;
+    }
+    gpt5_minor_version(&model)
+        .map(|minor| minor >= 2)
+        .unwrap_or(false)
+}
+
+fn openai_reasoning_effort(request: &LlmRequest) -> Option<String> {
+    let effort = param_string(
+        &request.parameters,
+        &["reasoningEffort", "reasoning_effort"],
+    )?;
     match effort.as_str() {
         "low" | "medium" | "high" => Some(effort),
+        "maximum" | "xhigh" if supports_openai_xhigh_reasoning_model(&request.connection.model) => {
+            Some("xhigh".to_string())
+        }
         "maximum" | "xhigh" => Some("high".to_string()),
         _ => None,
     }
@@ -969,7 +1010,7 @@ fn build_openai_responses_body(request: &LlmRequest, stream: bool) -> Value {
         "stream": stream,
         "max_output_tokens": request_max_tokens(request, 1024),
     });
-    if let Some(effort) = reasoning_effort(&request.parameters) {
+    if let Some(effort) = openai_reasoning_effort(request) {
         body["reasoning"] = json!({ "effort": effort, "summary": "auto" });
     }
     if let Some(format) = param_string(&request.parameters, &["responseFormat", "response_format"])
@@ -1395,7 +1436,7 @@ fn apply_openai_parameters(body: &mut Value, request: &LlmRequest) {
     }
     if request.connection.provider == "openrouter" {
         if is_openrouter_claude_reasoning_model(request) {
-            if let Some(effort) = reasoning_effort(parameters) {
+            if let Some(effort) = openai_reasoning_effort(request) {
                 body["reasoning"] = json!({ "effort": effort });
             }
         }
@@ -3035,6 +3076,104 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
         assert!(!message.contains(":\\"));
         assert!(!message.contains("/Users/"));
         assert!(!message.contains("/home/"));
+    }
+
+    #[test]
+    fn openai_responses_body_preserves_xhigh_for_supported_models() {
+        let request = request_for(
+            "openai",
+            "gpt-5.2",
+            json!({
+                "reasoningEffort": "xhigh",
+                "responseFormat": "json_object",
+                "verbosity": "high",
+                "customParameters": {
+                    "metadata": { "surface": "preset-proof" }
+                }
+            }),
+        );
+        let body = build_openai_responses_body(&request, false);
+
+        assert_eq!(
+            body["reasoning"],
+            json!({ "effort": "xhigh", "summary": "auto" })
+        );
+        assert_eq!(
+            body["text"],
+            json!({ "format": { "type": "json_object" }, "verbosity": "high" })
+        );
+        assert_eq!(body["metadata"], json!({ "surface": "preset-proof" }));
+    }
+
+    #[test]
+    fn openai_responses_body_resolves_maximum_to_supported_xhigh() {
+        let request = request_for(
+            "openai",
+            "gpt-5.2-codex",
+            json!({ "reasoningEffort": "maximum" }),
+        );
+        let body = build_openai_responses_body(&request, false);
+
+        assert_eq!(body["reasoning"]["effort"], json!("xhigh"));
+    }
+
+    #[test]
+    fn openai_responses_body_preserves_xhigh_aliases_for_gpt51_codex_max() {
+        let xhigh_request = request_for(
+            "openai",
+            "gpt-5.1-codex-max",
+            json!({ "reasoningEffort": "xhigh" }),
+        );
+        let maximum_request = request_for(
+            "openai",
+            "gpt-5.1-codex-max",
+            json!({ "reasoningEffort": "maximum" }),
+        );
+
+        assert_eq!(
+            build_openai_responses_body(&xhigh_request, false)["reasoning"]["effort"],
+            json!("xhigh")
+        );
+        assert_eq!(
+            build_openai_responses_body(&maximum_request, false)["reasoning"]["effort"],
+            json!("xhigh")
+        );
+    }
+
+    #[test]
+    fn openai_responses_body_downgrades_xhigh_for_unsupported_models() {
+        let xhigh_request = request_for(
+            "openai",
+            "gpt-5.1",
+            json!({ "reasoningEffort": "xhigh" }),
+        );
+        let maximum_request = request_for(
+            "openai",
+            "gpt-5-pro",
+            json!({ "reasoningEffort": "maximum" }),
+        );
+
+        assert_eq!(
+            build_openai_responses_body(&xhigh_request, false)["reasoning"]["effort"],
+            json!("high")
+        );
+        assert_eq!(
+            build_openai_responses_body(&maximum_request, false)["reasoning"]["effort"],
+            json!("high")
+        );
+    }
+
+    #[test]
+    fn openrouter_claude_reasoning_still_downgrades_xhigh_to_high() {
+        let request = request_for(
+            "openrouter",
+            "anthropic/claude-3.7-sonnet",
+            json!({ "reasoningEffort": "xhigh" }),
+        );
+        let mut body = json!({});
+        apply_openai_parameters(&mut body, &request);
+
+        assert_eq!(body["reasoning"], json!({ "effort": "high" }));
     }
 
     #[test]

--- a/src/engine/generation/provider-visible-parameters.ts
+++ b/src/engine/generation/provider-visible-parameters.ts
@@ -107,11 +107,29 @@ function shouldUseOpenAiResponses(provider: string, model: string): boolean {
   );
 }
 
-function openAiReasoningEffort(parameters: JsonRecord): string | null {
+function openAiModelId(model: string): string {
+  return model.toLowerCase().split("/").pop() ?? "";
+}
+
+function gpt5MinorVersion(model: string): number | null {
+  const match = /^gpt-5\.(\d+)/.exec(openAiModelId(model));
+  if (!match) return null;
+  return Number(match[1]);
+}
+
+function supportsOpenAiXhighReasoningModel(model: string): boolean {
+  const id = openAiModelId(model);
+  if (id === "gpt-5-pro" || id.startsWith("gpt-5-pro-")) return false;
+  if (id === "gpt-5.1-codex-max" || id.startsWith("gpt-5.1-codex-max-")) return true;
+  const minor = gpt5MinorVersion(id);
+  return minor !== null && minor >= 2;
+}
+
+function openAiReasoningEffort(model: string, parameters: JsonRecord): string | null {
   const effort = parameterString(parameters, ["reasoningEffort", "reasoning_effort"]);
   if (!effort) return null;
   if (["low", "medium", "high"].includes(effort)) return effort;
-  if (effort === "maximum" || effort === "xhigh") return "high";
+  if (effort === "maximum" || effort === "xhigh") return supportsOpenAiXhighReasoningModel(model) ? "xhigh" : "high";
   return null;
 }
 
@@ -253,7 +271,7 @@ function visibleOpenAiResponsesParameters(
     stream: options.stream === true,
     max_output_tokens: requestMaxTokens(connection, parameters),
   };
-  const effort = openAiReasoningEffort(parameters);
+  const effort = openAiReasoningEffort(readString(connection.model), parameters);
   if (effort) body.reasoning = { effort, summary: "auto" };
   const responseFormat = parameterString(parameters, ["responseFormat", "response_format"]);
   const verbosity = parameterString(parameters, ["verbosity"]);
@@ -306,7 +324,7 @@ function visibleOpenAiCompatibleParameters(
 
   if (provider === "openrouter") {
     if (isOpenrouterClaudeReasoningModel(provider, model)) {
-      const effort = openAiReasoningEffort(parameters);
+      const effort = openAiReasoningEffort(model, parameters);
       if (effort) body.reasoning = { effort };
     }
     const openrouterProvider = readString(connection.openrouterProvider ?? connection.openrouter_provider).trim();


### PR DESCRIPTION
## Linked issue

Closes https://github.com/Pasta-Devs/Marinara-Engine/issues/2264

## Why this change

- `gpt-5.1-codex-max` supports `xhigh` reasoning, but Marinara's OpenAI request shaping still downgraded `xhigh` and the `maximum` alias to `high`.
- That made the user-selected X High setting disagree with the actual OpenAI Responses payload and the visible prompt snapshot.

## What changed

- Added OpenAI model-id parsing and an `xhigh` support gate shared by the Rust OpenAI Responses body path.
- Preserved `xhigh` for `gpt-5.1-codex-max` and `gpt-5.2+` model ids while keeping `gpt-5-pro` and unsupported GPT-5.1 models on `high`.
- Kept the TypeScript provider-visible-parameters mirror aligned with the Rust transport behavior.
- Added Rust regression coverage for supported `xhigh`, `maximum`, unsupported downgrade, and OpenRouter Claude downgrade behavior.

## Refactor impact

Primary owner:

Rust LLM provider transport and engine generation parameter visibility.

Impact areas reviewed:

- OpenAI Responses request body shaping.
- OpenRouter Claude reasoning parameter behavior.
- Prompt snapshot and prompt-preview visible parameter mirrors.
- Static model-list exposure for `gpt-5.1-codex-max`.

Boundary notes:

- Product-level visible request metadata remains in `src/engine/generation`.
- Provider transport behavior remains in `src-tauri/crates/llm`.
- No React UI, shared API wrapper, command registration, storage, or remote-runtime route changes.

Pressure points touched:

- None of the known broad UI or command-registration pressure points were touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm openai_responses_body -- --nocapture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml -p marinara-llm` passed.
- `pnpm typecheck` passed.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` passed.
- `pnpm exec prettier --check src/engine/generation/provider-visible-parameters.ts` passed.
- `git diff --check` passed.
- `pnpm check` passed.
- No live provider/Tauri request was run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing generation parameter compatibility; no new discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed for this provider compatibility bugfix.

## UI evidence

N/A. No visible UI layout or interaction changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5 models including minor versions (e.g., gpt-5.2).
  * Implemented model-aware reasoning effort handling that intelligently adapts parameter values based on model capabilities.

* **Tests**
  * Extended test coverage for reasoning effort parameter handling across different model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->