### PR TITLE
Apply active chat presets on new chat starts

### DIFF
--- a/src/app/shell/useStartNewChat.ts
+++ b/src/app/shell/useStartNewChat.ts
@@ -3,10 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { CHAT_MODES } from "../../engine/contracts/constants/chat-modes";
 import type { ChatMode } from "../../engine/contracts/types/chat";
 import {
-  chatPresetKeys,
-  findUserStarredChatPreset,
-  listChatPresets,
-  useApplyChatPreset,
+  useApplyUserStarredChatPreset,
 } from "../../features/catalog/chat-presets/index";
 import { useCreateChat } from "../../features/catalog/chats/sidebar";
 import { connectionKeys } from "../../features/catalog/connections/index";
@@ -26,7 +23,7 @@ function hasEmbeddedTauriIpc(): boolean {
 export function useStartNewChat() {
   const queryClient = useQueryClient();
   const createChat = useCreateChat();
-  const applyChatPreset = useApplyChatPreset();
+  const applyUserStarredChatPreset = useApplyUserStarredChatPreset();
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const setPendingNewChatMode = useChatStore((s) => s.setPendingNewChatMode);
   const remoteRuntimeUrl = useUIStore((s) => s.remoteRuntimeUrl);
@@ -85,16 +82,6 @@ export function useStartNewChat() {
         closeAllDetails();
       }
 
-      const presetMode: ChatMode | null = mode === "conversation" || mode === "roleplay" ? mode : null;
-      const presets = presetMode
-        ? await queryClient.fetchQuery({
-            queryKey: chatPresetKeys.list(null),
-            queryFn: () => listChatPresets(null),
-            staleTime: 60_000,
-          })
-        : [];
-      const starred = findUserStarredChatPreset(presets, presetMode);
-
       createChat.mutate(
         {
           name: `New ${CHAT_MODES[mode]?.name ?? mode}`,
@@ -105,12 +92,10 @@ export function useStartNewChat() {
         {
           onSuccess: async (chat) => {
             setActiveChatId(chat.id);
-            if (starred) {
-              try {
-                await applyChatPreset.mutateAsync({ presetId: starred.id, chatId: chat.id });
-              } catch {
-                /* non-fatal: chat still opens with system defaults */
-              }
+            try {
+              await applyUserStarredChatPreset({ mode, chatId: chat.id });
+            } catch {
+              /* non-fatal: chat still opens with system defaults */
             }
             useChatStore.getState().setShouldOpenSettings(true, chat.id);
             useChatStore.getState().setShouldOpenWizard(true, chat.id);
@@ -119,7 +104,7 @@ export function useStartNewChat() {
       );
     },
     [
-      applyChatPreset,
+      applyUserStarredChatPreset,
       closeAllDetails,
       createChat,
       hasAnyDetailOpen,

--- a/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
+++ b/src/features/catalog/chat-presets/hooks/use-chat-presets.ts
@@ -1,6 +1,7 @@
 // ──────────────────────────────────────────────
 // React Query: Chat Preset hooks
 // ──────────────────────────────────────────────
+import { useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { chatPresetKeys } from "../query-keys";
 import {
@@ -18,8 +19,6 @@ import {
   type ChatPreset,
   type ChatPresetSettings,
 } from "../../../../engine/contracts/types/chat-preset";
-
-export { chatPresetKeys } from "../query-keys";
 
 const EXCLUDED_METADATA_KEYS = new Set<string>(CHAT_PRESET_EXCLUDED_METADATA_KEYS);
 const CHAT_PRESET_METADATA_DEFAULTS: Record<string, unknown> = {
@@ -71,7 +70,7 @@ function normalizeChatPresetFlags<T extends RawChatPreset>(preset: T): T & ChatP
   };
 }
 
-export async function listChatPresets(mode?: ChatMode | null): Promise<ChatPreset[]> {
+async function listChatPresets(mode?: ChatMode | null): Promise<ChatPreset[]> {
   const presets = (await storageApi.list<RawChatPreset>("chat-presets")).map(normalizeChatPresetFlags);
   return mode ? presets.filter((preset) => preset.mode === mode) : presets;
 }
@@ -272,4 +271,25 @@ export function useApplyChatPreset() {
       qc.invalidateQueries({ queryKey: chatKeys.list() });
     },
   });
+}
+
+export function useApplyUserStarredChatPreset() {
+  const queryClient = useQueryClient();
+  const { mutateAsync: applyChatPreset } = useApplyChatPreset();
+
+  return useCallback(
+    async ({ mode, chatId }: { mode: ChatMode; chatId: string }): Promise<ChatPreset | null> => {
+      const presets = await queryClient.fetchQuery({
+        queryKey: chatPresetKeys.list(null),
+        queryFn: () => listChatPresets(null),
+        staleTime: 60_000,
+      });
+      const starred = findUserStarredChatPreset(presets, mode);
+      if (!starred) return null;
+
+      await applyChatPreset({ presetId: starred.id, chatId });
+      return starred;
+    },
+    [applyChatPreset, queryClient],
+  );
 }

--- a/src/features/modes/router/components/ModeHomeSurface.tsx
+++ b/src/features/modes/router/components/ModeHomeSurface.tsx
@@ -3,6 +3,7 @@ import { BookOpen, HelpCircle, MessageSquare, Theater } from "lucide-react";
 import { APP_VERSION } from "../../../../engine/contracts/constants/defaults";
 import { useConnections } from "../../../catalog/connections/index";
 import { useCreateChat } from "../../../catalog/chats/index";
+import { useApplyUserStarredChatPreset } from "../../../catalog/chat-presets/index";
 import { NewChatConnectionGate } from "../../shared/chat-ui/index";
 import { filterLanguageGenerationConnections } from "../../../../shared/lib/connection-filters";
 import { cn } from "../../../../shared/lib/utils";
@@ -34,6 +35,7 @@ function prewarmAllQuickStartModes(): void {
 export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?: ReactNode }) {
   const { data: connections } = useConnections();
   const createChat = useCreateChat();
+  const applyUserStarredChatPreset = useApplyUserStarredChatPreset();
   const pendingNewChatMode = useChatStore((state) => state.pendingNewChatMode);
 
   useEffect(() => {
@@ -65,15 +67,21 @@ export function ModeHomeSurface({ discoverySurface = null }: { discoverySurface?
       createChat.mutate(
         { name: `New ${label}`, mode, characterIds: [], connectionId: connectionRows[0]!.id },
         {
-          onSuccess: (chat) => {
-            useChatStore.getState().setActiveChatId(chat.id);
-            useChatStore.getState().setShouldOpenSettings(true, chat.id);
-            useChatStore.getState().setShouldOpenWizard(true, chat.id);
+          onSuccess: async (chat) => {
+            const store = useChatStore.getState();
+            store.setActiveChatId(chat.id);
+            try {
+              await applyUserStarredChatPreset({ mode, chatId: chat.id });
+            } catch {
+              /* non-fatal: chat still opens with system defaults */
+            }
+            store.setShouldOpenSettings(true, chat.id);
+            store.setShouldOpenWizard(true, chat.id);
           },
         },
       );
     },
-    [connections, createChat],
+    [applyUserStarredChatPreset, connections, createChat],
   );
 
   const showEmptyStateEffects = true;

--- a/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
+++ b/src/features/modes/shared/chat-ui/components/NewChatConnectionGate.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useMemo, useState } from "react";
 import { AlertTriangle, BookOpen, Loader2, MessageCircle, Plug, Settings, X } from "lucide-react";
 import { useCreateChat } from "../../../../catalog/chats/index";
-import { findUserStarredChatPreset, useApplyChatPreset, useChatPresets } from "../../../../catalog/chat-presets/index";
+import { useApplyUserStarredChatPreset } from "../../../../catalog/chat-presets/index";
 import { useConnections } from "../../../../catalog/connections/index";
 import { checkRemoteRuntimeHealth, type RemoteRuntimeHealthCheck } from "../../../../../shared/api/remote-runtime";
 import { filterLanguageGenerationConnections } from "../../../../../shared/lib/connection-filters";
@@ -46,8 +46,7 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
   const remoteRuntimeReady = !shouldCheckRemoteRuntime || remoteRuntimeHealth?.status === "ok";
   const { data: connections, isLoading, isError, error } = useConnections(remoteRuntimeReady);
   const createChat = useCreateChat();
-  const { data: chatPresetsData } = useChatPresets(undefined, remoteRuntimeReady);
-  const applyChatPreset = useApplyChatPreset();
+  const applyUserStarredChatPreset = useApplyUserStarredChatPreset();
 
   useEffect(() => {
     if (!shouldCheckRemoteRuntime) {
@@ -92,9 +91,6 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
   const handleCreate = () => {
     if (!connectionId) return;
     const label = MODE_META[mode].label;
-    const presets = chatPresetsData ?? [];
-    const presetMode = mode === "conversation" || mode === "roleplay" ? mode : null;
-    const starred = findUserStarredChatPreset(presets, presetMode);
     createChat.mutate(
       {
         name: `New ${label}`,
@@ -107,12 +103,10 @@ export function NewChatConnectionGate({ mode, onClose }: NewChatConnectionGatePr
           const store = useChatStore.getState();
           store.setPendingNewChatMode(null);
           store.setActiveChatId(chat.id);
-          if (starred) {
-            try {
-              await applyChatPreset.mutateAsync({ presetId: starred.id, chatId: chat.id });
-            } catch {
-              /* non-fatal - chat still opens with system defaults */
-            }
+          try {
+            await applyUserStarredChatPreset({ mode, chatId: chat.id });
+          } catch {
+            /* non-fatal - chat still opens with system defaults */
           }
           store.setShouldOpenSettings(true, chat.id);
           store.setShouldOpenWizard(true, chat.id);


### PR DESCRIPTION
## Linked issue

Closes #2265

## Why this change

- Active/starred chat-settings presets were not applied consistently when starting new chats. The shared shell and connection-gate paths skipped `game`, and the mode-home quick-start path bypassed chat preset application entirely.

## What changed

- Added a shared chat-preset hook that resolves the active user preset by exact chat mode and applies it to a newly created chat.
- Updated the app shell new-chat path and shared connection gate to use the shared helper, including `game` mode.
- Updated mode-home quick start so conversation, roleplay, and game starts use the same active/starred preset apply behavior.
- Removed now-unused chat-preset exports caught by the full repo gate.

## Refactor impact

Primary owner:

- App shell, catalog chat-presets, shared mode UI, and mode router quick-start UI.

Impact areas reviewed:

- Conversation, roleplay, and game new-chat entrypoints.
- Chat preset selection and apply contract.
- Existing character-start path, which remains conversation/roleplay only.

Boundary notes:

- Feature code continues to use catalog hooks and shared storage API wrappers.
- No engine, shared API adapter, Rust, or remote-runtime command boundary changes.

Pressure points touched:

- Shared mode UI: `NewChatConnectionGate`.
- Mode router home surface quick-start flow.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm build` passed.
- `pnpm check` passed after removing unused chat-preset exports.
- Manual Tauri click-through for conversation, roleplay, game, and quick-start paths was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores existing preset-apply behavior on new-chat start paths; no new discoverable surface was added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots or recordings. This is storage-apply wiring for new-chat start paths; manual Tauri proof remains the visible behavior follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified chat preset application by consolidating duplicate logic into a centralized, reusable hook
  * Ensures user's starred presets are automatically applied consistently across all chat creation flows
  * Simplified preset lookup and application workflow by centralizing previously scattered implementation details across multiple components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->