### PR TITLE
Batch character summary reads by ID

### DIFF
--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -493,6 +493,56 @@ fn is_sampling_parameter_key(key: &str) -> bool {
     )
 }
 
+fn is_stop_parameter_key(key: &str) -> bool {
+    matches!(key, "stop" | "stopSequences" | "stop_sequences")
+}
+
+fn is_reserved_custom_parameter_key(key: &str) -> bool {
+    matches!(
+        key,
+        "model" | "messages" | "input" | "contents" | "systemInstruction" | "stream" | "tools"
+    )
+}
+
+fn should_apply_custom_parameter(
+    key: &str,
+    strip_sampling: bool,
+    strip_stop: bool,
+    skip_keys: &[&str],
+) -> bool {
+    !(skip_keys.contains(&key)
+        || is_reserved_custom_parameter_key(key)
+        || strip_sampling && is_sampling_parameter_key(key)
+        || strip_stop && is_stop_parameter_key(key))
+}
+
+fn apply_custom_parameters_to_object(
+    body: &mut Value,
+    parameters: &Value,
+    strip_sampling: bool,
+    strip_stop: bool,
+    skip_keys: &[&str],
+) {
+    let Some(entries) = parameters
+        .get("customParameters")
+        .or_else(|| parameters.get("custom_params"))
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    let Some(body) = body.as_object_mut() else {
+        return;
+    };
+    for (key, value) in entries {
+        if !should_apply_custom_parameter(key, strip_sampling, strip_stop, skip_keys) {
+            continue;
+        }
+        if !body.contains_key(key) {
+            body.insert(key.clone(), value.clone());
+        }
+    }
+}
+
 fn is_gemini_3_model(model: &str) -> bool {
     let normalized = model.to_ascii_lowercase();
     normalized.starts_with("gemini-3")
@@ -1038,24 +1088,7 @@ fn build_openai_responses_body(request: &LlmRequest, stream: bool) -> Value {
         );
         body["tool_choice"] = json!("auto");
     }
-    if let Some(extra) = request
-        .parameters
-        .get("customParameters")
-        .or_else(|| request.parameters.get("custom_params"))
-    {
-        if let Some(entries) = extra.as_object() {
-            for (key, value) in entries {
-                if !should_send_openai_sampling_parameters(request)
-                    && is_sampling_parameter_key(key)
-                {
-                    continue;
-                }
-                if body.get(key).is_none() {
-                    body[key] = value.clone();
-                }
-            }
-        }
-    }
+    apply_custom_parameters_to_object(&mut body, &request.parameters, true, true, &[]);
     body
 }
 
@@ -1428,8 +1461,11 @@ fn apply_openai_parameters(body: &mut Value, request: &LlmRequest) {
     if let Some(seed) = param_i64(parameters, &["seed"]) {
         body["seed"] = json!(seed);
     }
-    if let Some(stop) = stop_sequences(parameters) {
-        body["stop"] = json!(stop);
+    let send_sampling = should_send_openai_sampling_parameters(request);
+    if send_sampling {
+        if let Some(stop) = stop_sequences(parameters) {
+            body["stop"] = json!(stop);
+        }
     }
     if let Some(format) = param_string(parameters, &["responseFormat", "response_format"]) {
         body["response_format"] = json!({ "type": format });
@@ -1458,23 +1494,7 @@ fn apply_openai_parameters(body: &mut Value, request: &LlmRequest) {
             body["service_tier"] = json!(service_tier);
         }
     }
-    if let Some(extra) = parameters
-        .get("customParameters")
-        .or_else(|| parameters.get("custom_params"))
-    {
-        if let Some(entries) = extra.as_object() {
-            for (key, value) in entries {
-                if !should_send_openai_sampling_parameters(request)
-                    && is_sampling_parameter_key(key)
-                {
-                    continue;
-                }
-                if body.get(key).is_none() {
-                    body[key] = value.clone();
-                }
-            }
-        }
-    }
+    apply_custom_parameters_to_object(body, parameters, !send_sampling, !send_sampling, &[]);
     if let Some(openrouter) = parameters
         .get("openrouter")
         .or_else(|| parameters.get("openRouter"))
@@ -2183,9 +2203,18 @@ fn build_anthropic_body(request: &LlmRequest, stream: bool) -> Value {
         body["thinking"] = json!({ "type": "enabled", "budget_tokens": budget_tokens });
         body["max_tokens"] = json!(request_max_tokens(request, 1024) + budget_tokens);
     }
-    if let Some(stop) = stop_sequences(&request.parameters) {
-        body["stop_sequences"] = json!(stop);
+    if !adaptive_only {
+        if let Some(stop) = stop_sequences(&request.parameters) {
+            body["stop_sequences"] = json!(stop);
+        }
     }
+    apply_custom_parameters_to_object(
+        &mut body,
+        &request.parameters,
+        adaptive_only,
+        adaptive_only,
+        &[],
+    );
     body
 }
 
@@ -2518,6 +2547,33 @@ fn google_generation_config(request: &LlmRequest) -> Value {
             generation_config["stopSequences"] = json!(stop);
         }
     }
+    if let Some(entries) = request
+        .parameters
+        .get("customParameters")
+        .or_else(|| request.parameters.get("custom_params"))
+        .and_then(Value::as_object)
+    {
+        if let Some(custom_generation_config) =
+            entries.get("generationConfig").and_then(Value::as_object)
+        {
+            for (key, value) in custom_generation_config {
+                if should_apply_custom_parameter(key, is_gemini_3, is_gemini_3, &[]) {
+                    if let Some(config) = generation_config.as_object_mut() {
+                        if !config.contains_key(key) {
+                            config.insert(key.clone(), value.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    apply_custom_parameters_to_object(
+        &mut generation_config,
+        &request.parameters,
+        is_gemini_3,
+        is_gemini_3,
+        &["generationConfig"],
+    );
     generation_config
 }
 

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -13,6 +13,11 @@ type LorebookEntryAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
 type LorebookFolderDeleteAtomicRows<'a> =
     (&'a mut Vec<Value>, &'a mut Vec<Value>, &'a mut Vec<Value>);
 
+struct StorageWhereIn {
+    field: String,
+    values: HashSet<String>,
+}
+
 fn validate_storage_entity(entity: &str) -> Result<(), AppError> {
     if contracts::collection_contract(entity).is_some() {
         Ok(())
@@ -50,15 +55,67 @@ pub(crate) fn storage_list_inner(
     options: Option<Value>,
 ) -> Result<Value, AppError> {
     validate_storage_entity(&entity)?;
+    let where_in = storage_where_in(options.as_ref())?;
     let filters = options
         .as_ref()
         .and_then(|value| value.get("filters"))
         .and_then(Value::as_object);
     let projection_fields = shared::projection_fields(options.as_ref());
     let empty_filters = filters.is_none_or(|filters| filters.is_empty());
+    if where_in.is_some() && !empty_filters {
+        return Err(AppError::invalid_input(
+            "storage_list whereIn cannot be combined with filters",
+        ));
+    }
     let has_search = shared::has_storage_search(options.as_ref());
-    let mut rows = match (entity.as_str(), filters) {
-        ("messages", Some(filters))
+    let mut rows = match (entity.as_str(), filters, where_in.as_ref()) {
+        (_, _, Some(where_in)) if where_in.values.is_empty() => Vec::new(),
+        (_, _, Some(where_in))
+            if has_search
+                && projection_fields
+                    .as_ref()
+                    .is_some_and(|fields| !fields.is_empty()) =>
+        {
+            let search_projection_fields = shared::search_projection_fields(options.as_ref());
+            let search_projection_field_selections =
+                shared::search_projection_field_selections(options.as_ref());
+            let read_projection_fields = storage_list_projection_fields_for_read(
+                &entity,
+                &search_projection_fields,
+                options.as_ref(),
+            );
+            state.storage.list_projected_where_in(
+                &entity,
+                &where_in.field,
+                &where_in.values,
+                &read_projection_fields,
+                &search_projection_field_selections,
+            )?
+        }
+        (_, _, Some(where_in))
+            if projection_fields
+                .as_ref()
+                .is_some_and(|fields| !fields.is_empty()) =>
+        {
+            let read_projection_fields = storage_list_projection_fields_for_read(
+                &entity,
+                projection_fields.as_deref().unwrap_or(&[]),
+                options.as_ref(),
+            );
+            state.storage.list_projected_where_in(
+                &entity,
+                &where_in.field,
+                &where_in.values,
+                &read_projection_fields,
+                shared::projection_field_selections(options.as_ref()),
+            )?
+        }
+        (_, _, Some(where_in)) => {
+            state
+                .storage
+                .list_where_in(&entity, &where_in.field, &where_in.values)?
+        }
+        ("messages", Some(filters), None)
             if filters.len() == 1 && filters.get("chatId").and_then(Value::as_str).is_some() =>
         {
             let chat_id = filters
@@ -106,7 +163,7 @@ pub(crate) fn storage_list_inner(
                 state.storage.list_messages_for_chat(chat_id)?
             }
         }
-        (_, _)
+        (_, _, None)
             if empty_filters
                 && has_search
                 && projection_fields
@@ -116,26 +173,38 @@ pub(crate) fn storage_list_inner(
             let search_projection_fields = shared::search_projection_fields(options.as_ref());
             let search_projection_field_selections =
                 shared::search_projection_field_selections(options.as_ref());
-            state.storage.list_projected(
+            let read_projection_fields = storage_list_projection_fields_for_read(
                 &entity,
                 &search_projection_fields,
+                options.as_ref(),
+            );
+            state.storage.list_projected(
+                &entity,
+                &read_projection_fields,
                 &search_projection_field_selections,
             )?
         }
-        (_, _)
+        (_, _, None)
             if empty_filters
                 && !has_search
                 && projection_fields
                     .as_ref()
                     .is_some_and(|fields| !fields.is_empty()) =>
         {
-            state.storage.list_projected(
+            let read_projection_fields = storage_list_projection_fields_for_read(
                 &entity,
                 projection_fields.as_deref().unwrap_or(&[]),
+                options.as_ref(),
+            );
+            state.storage.list_projected(
+                &entity,
+                &read_projection_fields,
                 shared::projection_field_selections(options.as_ref()),
             )?
         }
-        (_, Some(filters)) if !filters.is_empty() => state.storage.list_where(&entity, filters)?,
+        (_, Some(filters), None) if !filters.is_empty() => {
+            state.storage.list_where(&entity, filters)?
+        }
         _ => state.storage.list(&entity)?,
     };
     let message_materialization = message_swipes::MessageSwipeMaterialization::for_message_output(
@@ -220,6 +289,44 @@ pub(crate) fn storage_list_inner(
     )))
 }
 
+fn storage_where_in(options: Option<&Value>) -> Result<Option<StorageWhereIn>, AppError> {
+    let Some(value) = options.and_then(|value| value.get("whereIn")) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(object) = value.as_object() else {
+        return Err(AppError::invalid_input(
+            "storage_list whereIn must be an object",
+        ));
+    };
+    let field = object
+        .get("field")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| AppError::invalid_input("storage_list whereIn.field is required"))?
+        .to_string();
+    let values_array = object
+        .get("values")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::invalid_input("storage_list whereIn.values must be an array"))?;
+    let mut values = HashSet::new();
+    for value in values_array {
+        let Some(value) = value.as_str() else {
+            return Err(AppError::invalid_input(
+                "storage_list whereIn.values must contain only strings",
+            ));
+        };
+        let value = value.trim();
+        if !value.is_empty() {
+            values.insert(value.to_string());
+        }
+    }
+    Ok(Some(StorageWhereIn { field, values }))
+}
+
 #[tauri::command]
 pub async fn lorebook_entries_list_by_lorebook_ids(
     state: State<'_, AppState>,
@@ -276,6 +383,18 @@ fn message_id_projection_only(options: Option<&Value>) -> bool {
         return false;
     };
     fields.len() == 1 && fields.first().and_then(Value::as_str) == Some("id")
+}
+
+fn storage_list_projection_fields_for_read(
+    entity: &str,
+    fields: &[String],
+    options: Option<&Value>,
+) -> Vec<String> {
+    if entity == "messages" {
+        message_projection_fields_for_materialization(fields, options)
+    } else {
+        fields.to_vec()
+    }
 }
 
 fn message_projection_fields_for_materialization(
@@ -2031,6 +2150,187 @@ mod tests {
         let read = storage_get_inner(&state, "characters".to_string(), "char-1".to_string(), None)
             .expect("supported get should succeed");
         assert_eq!(read["id"], "char-1");
+    }
+
+    #[test]
+    fn storage_list_where_in_reads_projected_character_rows() {
+        let state = test_state("where-in-character-projection");
+        state
+            .storage
+            .replace_all(
+                "characters",
+                vec![
+                    json!({
+                        "id": "char-c",
+                        "createdAt": "2026-01-03T00:00:00Z",
+                        "data": {
+                            "name": "Cora",
+                            "description": "not requested",
+                            "extensions": { "fav": false, "nameColor": "#abcdef" }
+                        }
+                    }),
+                    json!({
+                        "id": "char-b",
+                        "createdAt": "2026-01-02T00:00:00Z",
+                        "data": { "name": "Bex", "extensions": { "fav": true } }
+                    }),
+                    json!({
+                        "id": "char-a",
+                        "createdAt": "2026-01-01T00:00:00Z",
+                        "avatarPath": "data:image/png;base64,large-avatar",
+                        "avatarFilePath": "C:\\Marinara\\avatars\\characters\\char-a.png",
+                        "avatarFilename": "char-a.png",
+                        "data": {
+                            "name": "Ari",
+                            "description": "not requested",
+                            "extensions": { "fav": true, "nameColor": "#123456" }
+                        }
+                    }),
+                ],
+            )
+            .expect("characters should seed");
+
+        let result = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "whereIn": {
+                    "field": "id",
+                    "values": ["char-c", "char-a", "char-a"]
+                },
+                "fields": ["id", "data", "avatarPath", "avatarFilePath", "avatarFilename", "createdAt"],
+                "fieldSelections": { "data": ["name", "extensions.fav"] },
+                "orderBy": "id"
+            })),
+        )
+        .expect("whereIn projected list should succeed");
+
+        let rows = result.as_array().expect("storage_list returns an array");
+        let ids: Vec<_> = rows
+            .iter()
+            .filter_map(|row| row.get("id").and_then(Value::as_str))
+            .collect();
+        assert_eq!(ids, vec!["char-a", "char-c"]);
+        assert_eq!(
+            rows[0],
+            json!({
+                "id": "char-a",
+                "data": {
+                    "name": "Ari",
+                    "extensions": { "fav": true }
+                },
+                "avatarFilePath": "C:\\Marinara\\avatars\\characters\\char-a.png",
+                "avatarFilename": "char-a.png",
+                "createdAt": "2026-01-01T00:00:00Z"
+            })
+        );
+        assert_eq!(
+            rows[1],
+            json!({
+                "id": "char-c",
+                "data": {
+                    "name": "Cora",
+                    "extensions": { "fav": false }
+                },
+                "createdAt": "2026-01-03T00:00:00Z"
+            })
+        );
+    }
+
+    #[test]
+    fn storage_list_where_in_rejects_non_string_values() {
+        let state = test_state("where-in-invalid-values");
+
+        let error = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "whereIn": {
+                    "field": "id",
+                    "values": ["char-a", 42]
+                }
+            })),
+        )
+        .expect_err("non-string whereIn values should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error
+            .message
+            .contains("storage_list whereIn.values must contain only strings"));
+    }
+
+    #[test]
+    fn storage_list_where_in_projected_messages_materializes_swipe_summary() {
+        let state = test_state("where-in-message-projection-materialization");
+        state
+            .storage
+            .replace_all(
+                "messages",
+                vec![json!({
+                    "id": "message-1",
+                    "chatId": "chat-1",
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "activeSwipeIndex": 1,
+                    "extra": { "hiddenFromAI": true }
+                })],
+            )
+            .expect("message should seed");
+        state
+            .storage
+            .replace_all(
+                message_swipes::COLLECTION,
+                vec![
+                    json!({
+                        "id": "message-1::swipe::0",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 0,
+                        "content": "first sidecar",
+                        "extra": { "thinking": "first sidecar thought" }
+                    }),
+                    json!({
+                        "id": "message-1::swipe::1",
+                        "chatId": "chat-1",
+                        "messageId": "message-1",
+                        "index": 1,
+                        "content": "active sidecar",
+                        "characterId": "character-1",
+                        "extra": { "thinking": "active sidecar thought" }
+                    }),
+                ],
+            )
+            .expect("sidecar swipes should seed");
+
+        let result = storage_list_inner(
+            &state,
+            "messages".to_string(),
+            Some(json!({
+                "whereIn": {
+                    "field": "id",
+                    "values": ["message-1"]
+                },
+                "fields": ["extra", "swipeCount", "swipePreviews"],
+                "fieldSelections": { "extra": ["hiddenFromAI", "thinking"] }
+            })),
+        )
+        .expect("projected whereIn message list should materialize sidecars");
+
+        assert_eq!(
+            result,
+            json!([
+                {
+                    "extra": {
+                        "hiddenFromAI": true,
+                        "thinking": "active sidecar thought"
+                    },
+                    "swipeCount": 2,
+                    "swipePreviews": [
+                        { "content": "first sidecar" },
+                        { "content": "active sidecar", "characterId": "character-1" }
+                    ]
+                }
+            ])
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -390,10 +390,34 @@ fn storage_list_projection_fields_for_read(
     fields: &[String],
     options: Option<&Value>,
 ) -> Vec<String> {
-    if entity == "messages" {
+    let mut projection = if entity == "messages" {
         message_projection_fields_for_materialization(fields, options)
     } else {
         fields.to_vec()
+    };
+    append_storage_list_sort_projection_fields(&mut projection, options);
+    projection
+}
+
+fn append_storage_list_sort_projection_fields(
+    projection: &mut Vec<String>,
+    options: Option<&Value>,
+) {
+    if let Some(order_by) = options
+        .and_then(|value| value.get("orderBy"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !projection.iter().any(|existing| existing == order_by) {
+            projection.push(order_by.to_string());
+        }
+        return;
+    }
+    for field in ["sortOrder", "order", "createdAt"] {
+        if !projection.iter().any(|existing| existing == field) {
+            projection.push(field.to_string());
+        }
     }
 }
 
@@ -2235,6 +2259,66 @@ mod tests {
                 "createdAt": "2026-01-03T00:00:00Z"
             })
         );
+    }
+
+    #[test]
+    fn storage_list_where_in_projected_rows_sort_by_unrequested_field() {
+        let state = test_state("where-in-character-sort-projection");
+        state
+            .storage
+            .replace_all(
+                "characters",
+                vec![
+                    json!({
+                        "id": "char-c",
+                        "createdAt": "2026-01-03T00:00:00Z",
+                        "data": { "name": "Cora" }
+                    }),
+                    json!({
+                        "id": "char-a",
+                        "createdAt": "2026-01-01T00:00:00Z",
+                        "data": { "name": "Ari" }
+                    }),
+                ],
+            )
+            .expect("characters should seed");
+
+        let explicit_sort = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "whereIn": {
+                    "field": "id",
+                    "values": ["char-c", "char-a"]
+                },
+                "fields": ["id"],
+                "orderBy": "createdAt"
+            })),
+        )
+        .expect("projected whereIn list should sort by unrequested orderBy field");
+
+        assert_eq!(
+            explicit_sort,
+            json!([
+                { "id": "char-a" },
+                { "id": "char-c" }
+            ])
+        );
+
+        let default_sort = storage_list_inner(
+            &state,
+            "characters".to_string(),
+            Some(json!({
+                "whereIn": {
+                    "field": "id",
+                    "values": ["char-c", "char-a"]
+                },
+                "fields": ["id"]
+            })),
+        )
+        .expect("projected whereIn list should sort by unrequested default field");
+
+        assert_eq!(default_sort, explicit_sort);
     }
 
     #[test]

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -39,6 +39,10 @@ export type StorageEntity = (typeof GENERIC_STORAGE_ENTITIES)[number];
 
 export interface StorageListOptions {
   filters?: Record<string, unknown>;
+  whereIn?: {
+    field: string;
+    values: string[];
+  };
   orderBy?: string;
   descending?: boolean;
   limit?: number;
@@ -47,6 +51,8 @@ export interface StorageListOptions {
   fieldSelections?: Record<string, string[]>;
   search?: string;
 }
+
+export type ChatMessageListOptions = Omit<StorageListOptions, "filters" | "whereIn">;
 
 export interface AddChatMessageSwipeOptions {
   extra?: Record<string, unknown>;
@@ -75,7 +81,7 @@ export interface StorageGateway {
   create<T = unknown>(entity: StorageEntity, value: Record<string, unknown>): Promise<T>;
   update<T = unknown>(entity: StorageEntity, id: string, patch: Record<string, unknown>): Promise<T>;
   delete(entity: StorageEntity, id: string): Promise<{ deleted: boolean }>;
-  listChatMessages<T = unknown>(chatId: string, options?: Omit<StorageListOptions, "filters">): Promise<T[]>;
+  listChatMessages<T = unknown>(chatId: string, options?: ChatMessageListOptions): Promise<T[]>;
   createChatMessage<T = unknown>(chatId: string, value: Record<string, unknown>): Promise<T>;
   updateChatMessage<T = unknown>(messageId: string, patch: Record<string, unknown>): Promise<T>;
   updateChatMessageContentIfUnchanged?<T = unknown>(

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -37,12 +37,7 @@ const GENERIC_STORAGE_ENTITIES = [
 
 export type StorageEntity = (typeof GENERIC_STORAGE_ENTITIES)[number];
 
-export interface StorageListOptions {
-  filters?: Record<string, unknown>;
-  whereIn?: {
-    field: string;
-    values: string[];
-  };
+export interface StorageListBaseOptions {
   orderBy?: string;
   descending?: boolean;
   limit?: number;
@@ -52,7 +47,14 @@ export interface StorageListOptions {
   search?: string;
 }
 
-export type ChatMessageListOptions = Omit<StorageListOptions, "filters" | "whereIn">;
+type StorageListSelector =
+  | { filters?: Record<string, unknown>; whereIn?: never }
+  | { whereIn?: { field: string; values: string[] }; filters?: never }
+  | { filters?: undefined; whereIn?: undefined };
+
+export type StorageListOptions = StorageListBaseOptions & StorageListSelector;
+
+export type ChatMessageListOptions = StorageListBaseOptions;
 
 export interface AddChatMessageSwipeOptions {
   extra?: Record<string, unknown>;

--- a/src/features/catalog/characters/hooks/use-characters.ts
+++ b/src/features/catalog/characters/hooks/use-characters.ts
@@ -11,7 +11,6 @@ import {
   updateGroupSchema,
 } from "../../../../engine/contracts/schemas/character.schema";
 import { characterApi } from "../../../../shared/api/character-api";
-import { ApiError } from "../../../../shared/api/api-errors";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { storageCommandsApi } from "../../../../shared/api/storage-commands-api";
 import { galleryApi } from "../../../../shared/api/image-generation-api";
@@ -112,7 +111,6 @@ const CHARACTER_SUMMARY_OPTIONS = {
     ],
   },
 };
-const CHARACTER_SUMMARY_BY_ID_CONCURRENCY = 8;
 const EMPTY_CHARACTER_SUMMARIES: CharacterSummary[] = [];
 
 const CHARACTER_PANEL_SUMMARY_OPTIONS = {
@@ -168,29 +166,15 @@ async function getCharacter(id: string): Promise<unknown> {
 }
 
 async function listCharacterSummariesByIds(ids: string[]): Promise<CharacterSummary[]> {
-  const results = new Array<CharacterSummary | null>(ids.length).fill(null);
-  let nextIndex = 0;
-  const workerCount = Math.min(CHARACTER_SUMMARY_BY_ID_CONCURRENCY, ids.length);
-  await Promise.all(
-    Array.from({ length: workerCount }, async () => {
-      while (nextIndex < ids.length) {
-        const index = nextIndex;
-        nextIndex += 1;
-        try {
-          results[index] = normalizeCharacterAvatarFields(
-            await storageApi.get<CharacterSummary>("characters", ids[index]!, CHARACTER_SUMMARY_OPTIONS),
-          );
-        } catch (error) {
-          if (error instanceof ApiError && error.status === 404) {
-            results[index] = null;
-            continue;
-          }
-          throw error;
-        }
-      }
-    }),
-  );
-  return results.filter(isPresent);
+  if (ids.length === 0) return EMPTY_CHARACTER_SUMMARIES;
+  const characters = (
+    await storageApi.list<CharacterSummary>("characters", {
+      ...CHARACTER_SUMMARY_OPTIONS,
+      whereIn: { field: "id", values: ids },
+    })
+  ).map(normalizeCharacterAvatarFields);
+  const byId = new Map(characters.map((character) => [character.id, character]));
+  return ids.map((id) => byId.get(id)).filter(isPresent);
 }
 
 // ── Characters ──

--- a/src/features/catalog/chats/lib/timeline-message.ts
+++ b/src/features/catalog/chats/lib/timeline-message.ts
@@ -1,4 +1,4 @@
-import type { StorageListOptions } from "../../../../engine/capabilities/storage";
+import type { ChatMessageListOptions } from "../../../../engine/capabilities/storage";
 import type { Message } from "../../../../engine/contracts/types/chat";
 
 const CHAT_MESSAGE_TIMELINE_FIELDS = [
@@ -42,7 +42,7 @@ const CHAT_MESSAGE_TIMELINE_EXTRA_FIELDS = [
   "translation",
 ];
 
-type TimelineMessageOptions = Omit<StorageListOptions, "filters">;
+type TimelineMessageOptions = ChatMessageListOptions;
 
 function parseRecord(value: unknown): Record<string, unknown> {
   if (typeof value === "string") {


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Character summary-by-ID loading made many individual storage `get` calls. Batched reads reduce command overhead while preserving missing-ID handling and caller order.

## What changed

- Added `whereIn` support to the public `storage_list` command, including projected reads and stricter input validation.
- Updated character summary-by-ID loading to read all requested IDs through one projected `storageApi.list` call, then restore caller order.
- Tightened the chat message list option type so callers cannot pass `whereIn` to a wrapper that always adds a `chatId` filter.
- Added Rust coverage for projected character reads, invalid `whereIn.values`, and projected message swipe materialization through `whereIn`.

## Refactor impact

Primary owner:

Rust storage command, shared storage capability contract, and catalog character hooks.

Impact areas reviewed:

- Character summary-by-ID consumers in chat/sidebar, lorebook, mode, and setup surfaces.
- Storage list projection, search, ordering, limit, and missing-record behavior.
- Message swipe materialization for projected message list reads.
- Remote runtime dispatch path that reuses `storage_list_inner`.

Boundary notes:

- Feature code continues to call the focused `storageApi` wrapper, not raw Tauri or raw remote-runtime fetch.
- `src/engine/capabilities/storage.ts` owns the shared storage option contract.
- `src-tauri` owns the privileged storage filtering and projection behavior.
- Remote-capable behavior remains behind the existing explicit `storage_list` invoke/dispatch path.

Pressure points touched:

- None of the listed pressure points were touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml storage_list_where_in`
- `cargo test --manifest-path src-tauri/Cargo.toml storage_list_`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm check`
- `git diff --check`

No manual UI or native Tauri pass was run; this is a storage/API batching fix with focused machine coverage.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal storage/API batching fix; no new user-discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `whereIn` query parameter to storage list operations, enabling more flexible filtering options based on field values

* **Refactor**
  * Improved character summary lookup performance through optimized batch retrieval

* **Tests**
  * Added comprehensive test coverage for `whereIn` functionality, including field projection and message handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->