### PR TITLE
Fix ST chat JSONL imports defaulting to conversation

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -927,7 +927,7 @@ fn import_st_chat_text(
     chat.remove("id");
     chat.insert("name".to_string(), Value::String(chat_name));
     chat.entry("mode".to_string())
-        .or_insert(Value::String("conversation".to_string()));
+        .or_insert(Value::String("roleplay".to_string()));
     if character_ids.is_empty() {
         chat.entry("characterIds".to_string())
             .or_insert_with(|| json!([]));
@@ -1955,6 +1955,72 @@ mod tests {
 
         let _ = fs::remove_dir_all(app_root);
         let _ = fs::remove_dir_all(st_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_defaults_to_roleplay_mode() {
+        let app_root = temp_path("chat-default-mode");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        let result = import_st_chat_text(
+            &state,
+            r#"{"character_name":"Bot","mes":"hello"}"#,
+            "Imported Chat".to_string(),
+            None,
+            StChatImportContext::default(),
+        )
+        .expect("chat import should succeed");
+
+        let chat_id = result
+            .get("chatId")
+            .and_then(Value::as_str)
+            .expect("import result should include chat id");
+        let chat = state
+            .storage
+            .get("chats", chat_id)
+            .expect("chat should be readable")
+            .expect("chat should exist");
+        assert_eq!(
+            chat.get("mode").and_then(Value::as_str),
+            Some("roleplay"),
+            "single-file SillyTavern JSONL imports should default to roleplay"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn import_st_chat_text_preserves_inherited_mode() {
+        let app_root = temp_path("chat-inherited-mode");
+        let state = AppState::from_data_dir(&app_root, Vec::new())
+            .expect("test app state should initialize");
+
+        let result = import_st_chat_text(
+            &state,
+            r#"{"character_name":"Bot","mes":"hello"}"#,
+            "Imported Chat".to_string(),
+            Some(json!({ "mode": "conversation", "metadata": {}, "characterIds": [] })),
+            StChatImportContext::default(),
+        )
+        .expect("chat import should succeed");
+
+        let chat_id = result
+            .get("chatId")
+            .and_then(Value::as_str)
+            .expect("import result should include chat id");
+        let chat = state
+            .storage
+            .get("chats", chat_id)
+            .expect("chat should be readable")
+            .expect("chat should exist");
+        assert_eq!(
+            chat.get("mode").and_then(Value::as_str),
+            Some("conversation"),
+            "inherited/imported mode should not be overwritten by the ST default"
+        );
+
+        let _ = fs::remove_dir_all(app_root);
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #2297

## Why this change

- Single-file SillyTavern JSONL imports were creating chats in `conversation` mode when the import path had no explicit mode. Legacy/default ST import behavior treats these transcripts as roleplay chats, so imported transcripts landed under the wrong mode tab and continued through the wrong generation path.

## What changed

- Updated the ST JSONL import fallback so a missing chat `mode` defaults to `roleplay`.
- Added Rust coverage for the standalone default and for preserving an inherited/explicit mode.

## Refactor impact

Primary owner:

Rust storage imports.

Impact areas reviewed:

- Single-file `import_st_chat` path
- Import-into-group inherited mode path
- ST bulk import paths that already set `roleplay`
- Shared import API and remote runtime dispatch surface

Boundary notes:

- Behavior stays in `src-tauri` import storage code.
- No React, engine, shared API, or command-registration boundary changes.
- Remote runtime continues through the existing explicit `import_st_chat` dispatch path.

Pressure points touched:

- `src-tauri/src/commands/storage/imports/bulk_imports.rs`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri\Cargo.toml`
- `cargo test --manifest-path src-tauri\Cargo.toml import_st_chat_text` passed, 11/11
- `cargo check --manifest-path src-tauri\Cargo.toml --workspace` passed
- `pnpm check` passed
- Manual Tauri import flow not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores the existing ST JSONL import behavior; it does not add a new discoverable workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots or recordings; this is a storage import compatibility fix with command-level validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat imports from SillyTavern JSONL files now correctly default to "roleplay" mode instead of "conversation" mode when no inherited mode is specified. Imported chats now properly preserve inherited modes from parent objects.

* **Tests**
  * Added tests to verify correct default chat mode assignment and preservation of inherited modes during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->