### PR TITLE
Fix Memory Recall relevance bounds

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -769,6 +769,17 @@ fn chat_memory_recency_key(memory: &Value) -> &str {
         .unwrap_or("")
 }
 
+fn chat_memory_values(chat: &Value) -> Vec<Value> {
+    match chat.get("memories") {
+        Some(Value::Array(values)) => values.clone(),
+        Some(Value::String(raw)) => serde_json::from_str::<Value>(raw)
+            .ok()
+            .and_then(|parsed| parsed.as_array().cloned())
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
 pub(crate) fn list_chat_memories(
     state: &AppState,
     chat_id: &str,
@@ -776,11 +787,7 @@ pub(crate) fn list_chat_memories(
     order: Option<&str>,
 ) -> AppResult<Value> {
     let chat = get_required(state, "chats", chat_id)?;
-    let mut values = chat
-        .get("memories")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
+    let mut values = chat_memory_values(&chat);
 
     match order
         .filter(|value| !value.trim().is_empty())
@@ -1485,6 +1492,35 @@ mod tests {
                     .map(ToOwned::to_owned)
             })
             .collect()
+    }
+
+    #[test]
+    fn list_chat_memories_accepts_string_serialized_chunks() {
+        let state = test_state("chat-memory-list-string");
+        let memories = serde_json::to_string(&json!([
+            { "id": "stored-old", "lastMessageAt": "2026-01-01T00:00:00.000Z" },
+            { "id": "stored-new", "lastMessageAt": "2026-01-02T00:00:00.000Z" }
+        ]))
+        .expect("memory fixture should serialize");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Serialized memory chat",
+                    "memories": memories
+                }),
+            )
+            .expect("chat should be created");
+
+        let stored = list_chat_memories(&state, "chat-1", None, None)
+            .expect("serialized memories should list in stored order");
+        assert_eq!(memory_ids(&stored), vec!["stored-old", "stored-new"]);
+
+        let recent = list_chat_memories(&state, "chat-1", Some(1), Some("recent"))
+            .expect("serialized memories should sort by recency");
+        assert_eq!(memory_ids(&recent), vec!["stored-new"]);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -780,14 +780,119 @@ fn chat_memory_values(chat: &Value) -> Vec<Value> {
     }
 }
 
-pub(crate) fn list_chat_memories(
+fn chat_memory_values_for_mutation(chat: &Value) -> AppResult<Vec<Value>> {
+    match chat.get("memories") {
+        Some(Value::Array(values)) => Ok(values.clone()),
+        Some(Value::String(raw)) => {
+            let parsed = serde_json::from_str::<Value>(raw).map_err(|_| {
+                AppError::invalid_input("Chat memories are not a valid serialized array")
+            })?;
+            match parsed {
+                Value::Array(values) => Ok(values),
+                _ => Err(AppError::invalid_input(
+                    "Chat memories are not a valid serialized array",
+                )),
+            }
+        }
+        Some(Value::Null) | None => Ok(Vec::new()),
+        _ => Err(AppError::invalid_input("Chat memories must be an array")),
+    }
+}
+
+fn chat_memory_message_ids(memory: &Value) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    if let Some(message_ids) = memory.get("messageIds").and_then(Value::as_array) {
+        for value in message_ids {
+            if let Some(id) = value
+                .as_str()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+    for field in ["firstMessageId", "lastMessageId"] {
+        if let Some(id) = memory
+            .get(field)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            ids.insert(id.to_string());
+        }
+    }
+    ids
+}
+
+fn memory_overlaps_excluded_recent(
+    memory: &Value,
+    recent_ids: &HashSet<String>,
+    recent_start_at: &str,
+) -> bool {
+    if recent_ids.is_empty() {
+        return false;
+    }
+    let chunk_ids = chat_memory_message_ids(memory);
+    if !chunk_ids.is_empty() {
+        return chunk_ids.iter().any(|id| recent_ids.contains(id));
+    }
+
+    memory
+        .get("lastMessageAt")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some_and(|last_message_at| {
+            !recent_start_at.is_empty() && last_message_at >= recent_start_at
+        })
+}
+
+fn exclude_recent_chat_memories(
+    values: Vec<Value>,
+    exclude_recent_message_ids: &[String],
+    exclude_recent_start_at: Option<&str>,
+) -> Vec<Value> {
+    let recent_ids = exclude_recent_message_ids
+        .iter()
+        .map(|id| id.trim())
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<HashSet<_>>();
+    let recent_start_at = exclude_recent_start_at.unwrap_or("").trim();
+    if recent_ids.is_empty() {
+        return values;
+    }
+    values
+        .into_iter()
+        .filter(|memory| !memory_overlaps_excluded_recent(memory, &recent_ids, recent_start_at))
+        .collect()
+}
+
+#[cfg(test)]
+fn list_chat_memories(
     state: &AppState,
     chat_id: &str,
     limit: Option<usize>,
     order: Option<&str>,
 ) -> AppResult<Value> {
+    list_chat_memories_excluding_recent(state, chat_id, limit, order, &[], None)
+}
+
+pub(crate) fn list_chat_memories_excluding_recent(
+    state: &AppState,
+    chat_id: &str,
+    limit: Option<usize>,
+    order: Option<&str>,
+    exclude_recent_message_ids: &[String],
+    exclude_recent_start_at: Option<&str>,
+) -> AppResult<Value> {
     let chat = get_required(state, "chats", chat_id)?;
-    let mut values = chat_memory_values(&chat);
+    let mut values = exclude_recent_chat_memories(
+        chat_memory_values(&chat),
+        exclude_recent_message_ids,
+        exclude_recent_start_at,
+    );
 
     match order
         .filter(|value| !value.trim().is_empty())
@@ -844,6 +949,19 @@ pub(crate) fn delete_chat_array_item(
         .filter(|item| item.get("id").and_then(Value::as_str) != Some(item_id))
         .collect::<Vec<_>>();
     set_chat_array_field(state, chat_id, field, values)
+}
+
+pub(crate) fn delete_chat_memory(
+    state: &AppState,
+    chat_id: &str,
+    memory_id: &str,
+) -> AppResult<Value> {
+    let chat = get_required(state, "chats", chat_id)?;
+    let values = chat_memory_values_for_mutation(&chat)?
+        .into_iter()
+        .filter(|item| item.get("id").and_then(Value::as_str) != Some(memory_id))
+        .collect::<Vec<_>>();
+    set_chat_array_field(state, chat_id, "memories", values)
 }
 
 pub(crate) async fn refresh_chat_memories(state: &AppState, chat_id: &str) -> AppResult<Value> {
@@ -1521,6 +1639,128 @@ mod tests {
         let recent = list_chat_memories(&state, "chat-1", Some(1), Some("recent"))
             .expect("serialized memories should sort by recency");
         assert_eq!(memory_ids(&recent), vec!["stored-new"]);
+    }
+
+    #[test]
+    fn delete_chat_memory_preserves_serialized_non_target_chunks() {
+        let state = test_state("chat-memory-delete-serialized");
+        let memories = serde_json::to_string(&json!([
+            { "id": "delete-me", "lastMessageAt": "2026-01-01T00:00:00.000Z" },
+            { "id": "keep-me", "lastMessageAt": "2026-01-02T00:00:00.000Z" }
+        ]))
+        .expect("memory fixture should serialize");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Serialized memory delete chat",
+                    "memories": memories
+                }),
+            )
+            .expect("chat should be created");
+
+        let listed = list_chat_memories(&state, "chat-1", None, None)
+            .expect("serialized memories should be visible before deletion");
+        assert_eq!(memory_ids(&listed), vec!["delete-me", "keep-me"]);
+
+        delete_chat_memory(&state, "chat-1", "delete-me")
+            .expect("serialized memory deletion should preserve non-target chunks");
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat should read")
+            .expect("chat should exist");
+        assert_eq!(memory_ids(&chat["memories"]), vec!["keep-me"]);
+    }
+
+    #[test]
+    fn delete_chat_memory_preserves_array_non_target_chunks() {
+        let state = test_state("chat-memory-delete-array");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Array memory delete chat",
+                    "memories": [
+                        { "id": "delete-me", "lastMessageAt": "2026-01-01T00:00:00.000Z" },
+                        { "id": "keep-me", "lastMessageAt": "2026-01-02T00:00:00.000Z" }
+                    ]
+                }),
+            )
+            .expect("chat should be created");
+
+        delete_chat_memory(&state, "chat-1", "delete-me")
+            .expect("array memory deletion should preserve non-target chunks");
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat should read")
+            .expect("chat should exist");
+        assert_eq!(memory_ids(&chat["memories"]), vec!["keep-me"]);
+    }
+
+    #[test]
+    fn delete_chat_memory_rejects_malformed_serialized_chunks() {
+        let state = test_state("chat-memory-delete-malformed");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Malformed memory delete chat",
+                    "memories": "{not valid json"
+                }),
+            )
+            .expect("chat should be created");
+
+        let error = delete_chat_memory(&state, "chat-1", "delete-me")
+            .expect_err("malformed serialized memory deletion should be rejected");
+        assert_eq!(error.code, "invalid_input");
+
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat should read")
+            .expect("chat should exist");
+        assert_eq!(chat["memories"], json!("{not valid json"));
+    }
+
+    #[test]
+    fn list_chat_memories_excludes_recent_overlap_before_limit() {
+        let state = test_state("chat-memory-list-filter-before-limit");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Filtered memory chat",
+                    "memories": [
+                        { "id": "recent-legacy-a", "lastMessageAt": "2026-01-10T00:00:00.000Z" },
+                        { "id": "recent-legacy-b", "lastMessageAt": "2026-01-10T00:01:00.000Z" },
+                        { "id": "older-eligible", "lastMessageAt": "2026-01-01T00:00:00.000Z" }
+                    ]
+                }),
+            )
+            .expect("chat should be created");
+        let exclude_recent_message_ids = vec!["recent-message".to_string()];
+
+        let filtered = list_chat_memories_excluding_recent(
+            &state,
+            "chat-1",
+            Some(1),
+            Some("recent"),
+            &exclude_recent_message_ids,
+            Some("2026-01-10T00:00:00.000Z"),
+        )
+        .expect("recent overlap should filter before limit");
+
+        assert_eq!(memory_ids(&filtered), vec!["older-eligible"]);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -749,6 +749,67 @@ pub(crate) fn chat_array_field(state: &AppState, chat_id: &str, field: &str) -> 
     Ok(chat.get(field).cloned().unwrap_or_else(|| json!([])))
 }
 
+fn chat_memory_recency_key(memory: &Value) -> &str {
+    memory
+        .get("lastMessageAt")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            memory
+                .get("createdAt")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            memory
+                .get("firstMessageAt")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or("")
+}
+
+pub(crate) fn list_chat_memories(
+    state: &AppState,
+    chat_id: &str,
+    limit: Option<usize>,
+    order: Option<&str>,
+) -> AppResult<Value> {
+    let chat = get_required(state, "chats", chat_id)?;
+    let mut values = chat
+        .get("memories")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    match order
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("stored")
+    {
+        "stored" => {}
+        "recent" => values.sort_by(|a, b| {
+            chat_memory_recency_key(b)
+                .cmp(chat_memory_recency_key(a))
+                .then_with(|| {
+                    let a_id = a.get("id").and_then(Value::as_str).unwrap_or("");
+                    let b_id = b.get("id").and_then(Value::as_str).unwrap_or("");
+                    b_id.cmp(a_id)
+                })
+        }),
+        other => {
+            return Err(AppError::invalid_input(format!(
+                "Unsupported chat memory order: {other}"
+            )));
+        }
+    }
+
+    if let Some(limit) = limit {
+        values.truncate(limit);
+    }
+
+    Ok(Value::Array(values))
+}
+
 pub(crate) fn set_chat_array_field(
     state: &AppState,
     chat_id: &str,
@@ -1410,6 +1471,60 @@ mod tests {
             std::fs::remove_dir_all(&path).expect("stale temp chat delete dir should be removable");
         }
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
+    }
+
+    fn memory_ids(value: &Value) -> Vec<String> {
+        value
+            .as_array()
+            .expect("memory list should be an array")
+            .iter()
+            .filter_map(|memory| {
+                memory
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn list_chat_memories_can_return_recent_limited_chunks() {
+        let state = test_state("chat-memory-list-limit");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Memory chat",
+                    "memories": [
+                        { "id": "old", "lastMessageAt": "2026-01-01T00:00:00.000Z" },
+                        { "id": "new", "lastMessageAt": "2026-01-04T00:00:00.000Z" },
+                        { "id": "created-only", "createdAt": "2026-01-03T00:00:00.000Z" },
+                        { "id": "first-only", "firstMessageAt": "2026-01-02T00:00:00.000Z" },
+                        { "id": "missing-date" }
+                    ]
+                }),
+            )
+            .expect("chat should be created");
+
+        let recent = list_chat_memories(&state, "chat-1", Some(3), Some("recent"))
+            .expect("recent limited memories should list");
+        assert_eq!(
+            memory_ids(&recent),
+            vec!["new", "created-only", "first-only"]
+        );
+
+        let stored = list_chat_memories(&state, "chat-1", None, None)
+            .expect("default memories should list in stored order");
+        assert_eq!(
+            memory_ids(&stored),
+            vec!["old", "new", "created-only", "first-only", "missing-date"]
+        );
+
+        let invalid = list_chat_memories(&state, "chat-1", None, Some("popular"))
+            .expect_err("unsupported ordering should be rejected");
+        assert_eq!(invalid.code, "invalid_input");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/chats.rs
+++ b/src-tauri/src/commands/storage/commands/chats.rs
@@ -5,8 +5,18 @@ use serde_json::{json, Value};
 use tauri::State;
 
 #[tauri::command]
-pub fn chat_memories_list(state: State<'_, AppState>, chat_id: String) -> Result<Value, AppError> {
-    chats::chat_array_field(&state, &chat_id, "memories")
+pub fn chat_memories_list(
+    state: State<'_, AppState>,
+    chat_id: String,
+    limit: Option<u32>,
+    order: Option<String>,
+) -> Result<Value, AppError> {
+    chats::list_chat_memories(
+        &state,
+        &chat_id,
+        limit.map(|value| value as usize),
+        order.as_deref(),
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/storage/commands/chats.rs
+++ b/src-tauri/src/commands/storage/commands/chats.rs
@@ -10,12 +10,17 @@ pub fn chat_memories_list(
     chat_id: String,
     limit: Option<u32>,
     order: Option<String>,
+    exclude_recent_message_ids: Option<Vec<String>>,
+    exclude_recent_start_at: Option<String>,
 ) -> Result<Value, AppError> {
-    chats::list_chat_memories(
+    let exclude_recent_message_ids = exclude_recent_message_ids.unwrap_or_default();
+    chats::list_chat_memories_excluding_recent(
         &state,
         &chat_id,
         limit.map(|value| value as usize),
         order.as_deref(),
+        &exclude_recent_message_ids,
+        exclude_recent_start_at.as_deref(),
     )
 }
 
@@ -25,7 +30,7 @@ pub fn chat_memory_delete(
     chat_id: String,
     memory_id: String,
 ) -> Result<Value, AppError> {
-    chats::delete_chat_array_item(&state, &chat_id, "memories", &memory_id)
+    chats::delete_chat_memory(&state, &chat_id, &memory_id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -543,7 +543,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "chat_memories_list" => chats::list_chat_memories(
             state,
             required_string(&args, "chatId")?,
-            optional_u32(&args, "limit").map(|value| value as usize),
+            optional_u32_strict(&args, "limit")?.map(|value| value as usize),
             optional_string(&args, "order").as_deref(),
         ),
         "chat_memory_delete" => chats::delete_chat_array_item(
@@ -1297,6 +1297,35 @@ mod tests {
             .join("collections")
             .join("typo-collection.json")
             .exists());
+    }
+
+    #[tokio::test]
+    async fn dispatch_chat_memories_list_rejects_malformed_limit() {
+        let state = test_state("chat-memories-malformed-limit");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Memory chat",
+                    "memories": []
+                }),
+            )
+            .expect("chat should be created");
+
+        let error = dispatch(
+            &state,
+            InvokeRequest {
+                command: "chat_memories_list".to_string(),
+                args: Some(json!({ "chatId": "chat-1", "limit": "500" })),
+            },
+        )
+        .await
+        .expect_err("remote memory listing should reject malformed limits");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("limit"));
     }
 
     #[test]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -89,6 +89,24 @@ fn required_string_vec(args: &Map<String, Value>, key: &str) -> AppResult<Vec<St
         .collect()
 }
 
+fn optional_string_vec(args: &Map<String, Value>, key: &str) -> AppResult<Vec<String>> {
+    let Some(value) = args.get(key) else {
+        return Ok(Vec::new());
+    };
+    let Some(values) = value.as_array() else {
+        return Err(AppError::invalid_input(format!("{key} must be an array")));
+    };
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| AppError::invalid_input(format!("{key} must contain strings")))
+        })
+        .collect()
+}
+
 pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Value> {
     let command = request.command.as_str();
     let args = args_object(request.args)?;
@@ -540,16 +558,21 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "tracker_snapshot_latest" => tracker_snapshot_latest(state, &args).await,
         "tracker_snapshot_get" => tracker_snapshot_get(state, &args).await,
         "tracker_snapshot_save" => tracker_snapshot_save(state, &args).await,
-        "chat_memories_list" => chats::list_chat_memories(
+        "chat_memories_list" => {
+            let exclude_recent_message_ids = optional_string_vec(&args, "excludeRecentMessageIds")?;
+            let exclude_recent_start_at = optional_string(&args, "excludeRecentStartAt");
+            chats::list_chat_memories_excluding_recent(
+                state,
+                required_string(&args, "chatId")?,
+                optional_u32_strict(&args, "limit")?.map(|value| value as usize),
+                optional_string(&args, "order").as_deref(),
+                &exclude_recent_message_ids,
+                exclude_recent_start_at.as_deref(),
+            )
+        }
+        "chat_memory_delete" => chats::delete_chat_memory(
             state,
             required_string(&args, "chatId")?,
-            optional_u32_strict(&args, "limit")?.map(|value| value as usize),
-            optional_string(&args, "order").as_deref(),
-        ),
-        "chat_memory_delete" => chats::delete_chat_array_item(
-            state,
-            required_string(&args, "chatId")?,
-            "memories",
             required_string(&args, "memoryId")?,
         ),
         "chat_memories_clear" => chats::set_chat_array_field(
@@ -1326,6 +1349,50 @@ mod tests {
 
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("limit"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_chat_memory_delete_preserves_serialized_non_target_chunks() {
+        let state = test_state("chat-memory-delete-serialized");
+        let memories = serde_json::to_string(&json!([
+            { "id": "delete-me", "lastMessageAt": "2026-01-01T00:00:00.000Z" },
+            { "id": "keep-me", "lastMessageAt": "2026-01-02T00:00:00.000Z" }
+        ]))
+        .expect("memory fixture should serialize");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "chat-1",
+                    "name": "Serialized memory chat",
+                    "memories": memories
+                }),
+            )
+            .expect("chat should be created");
+
+        dispatch(
+            &state,
+            InvokeRequest {
+                command: "chat_memory_delete".to_string(),
+                args: Some(json!({ "chatId": "chat-1", "memoryId": "delete-me" })),
+            },
+        )
+        .await
+        .expect("remote memory delete should dispatch");
+
+        let chat = state
+            .storage
+            .get("chats", "chat-1")
+            .expect("chat should read")
+            .expect("chat should exist");
+        let memory_ids = chat["memories"]
+            .as_array()
+            .expect("memories should normalize to an array")
+            .iter()
+            .filter_map(|memory| memory.get("id").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(memory_ids, vec!["keep-me"]);
     }
 
     #[test]

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -540,9 +540,12 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "tracker_snapshot_latest" => tracker_snapshot_latest(state, &args).await,
         "tracker_snapshot_get" => tracker_snapshot_get(state, &args).await,
         "tracker_snapshot_save" => tracker_snapshot_save(state, &args).await,
-        "chat_memories_list" => {
-            chats::chat_array_field(state, required_string(&args, "chatId")?, "memories")
-        }
+        "chat_memories_list" => chats::list_chat_memories(
+            state,
+            required_string(&args, "chatId")?,
+            optional_u32(&args, "limit").map(|value| value as usize),
+            optional_string(&args, "order").as_deref(),
+        ),
         "chat_memory_delete" => chats::delete_chat_array_item(
             state,
             required_string(&args, "chatId")?,

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -62,6 +62,8 @@ export type ChatMemoryListOrder = "stored" | "recent";
 export interface ListChatMemoriesOptions {
   limit?: number;
   order?: ChatMemoryListOrder;
+  excludeRecentMessageIds?: string[];
+  excludeRecentStartAt?: string;
 }
 
 export interface AddChatMessageSwipeOptions {

--- a/src/engine/capabilities/storage.ts
+++ b/src/engine/capabilities/storage.ts
@@ -57,6 +57,13 @@ export type StorageListOptions = StorageListBaseOptions & StorageListSelector;
 
 export type ChatMessageListOptions = StorageListBaseOptions;
 
+export type ChatMemoryListOrder = "stored" | "recent";
+
+export interface ListChatMemoriesOptions {
+  limit?: number;
+  order?: ChatMemoryListOrder;
+}
+
 export interface AddChatMessageSwipeOptions {
   extra?: Record<string, unknown>;
   activate?: boolean;
@@ -111,7 +118,7 @@ export interface StorageGateway {
   ): Promise<T>;
   patchChatMetadata<T = unknown>(chatId: string, patch: Record<string, unknown>): Promise<T>;
   patchChatSummaries<T = unknown>(chatId: string, patch: Record<string, unknown>): Promise<T>;
-  listChatMemories<T = unknown>(chatId: string): Promise<T[]>;
+  listChatMemories<T = unknown>(chatId: string, options?: ListChatMemoriesOptions): Promise<T[]>;
   refreshChatMemories?<T = unknown>(chatId: string): Promise<T>;
   getWorldState<T = unknown>(chatId: string): Promise<T | null>;
   saveTrackerSnapshot<T = unknown>(chatId: string, snapshot: Record<string, unknown>): Promise<T>;

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2,7 +2,7 @@ import type { LorebookEntryTimingState } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
 import type { CharacterData } from "../contracts/types/character";
 import { BUILT_IN_AGENTS } from "../contracts/types/agent";
-import type { StorageGateway } from "../capabilities/storage";
+import type { ListChatMemoriesOptions, StorageGateway } from "../capabilities/storage";
 import type { VisualAssetGateway } from "../capabilities/visual-assets";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
 import { injectAtDepth } from "../generation-core/lorebooks/prompt-injector";
@@ -1899,10 +1899,6 @@ function memoryRecallReadBehind(chat: JsonRecord): number {
   return Math.max(0, Math.min(MAX_MEMORY_RECALL_READ_BEHIND_MESSAGES, Math.trunc(raw)));
 }
 
-function memoryRecallFetchLimit(chat: JsonRecord): number {
-  return MAX_MEMORY_RECALL_SCORING_CHUNKS + memoryRecallReadBehind(chat);
-}
-
 function memoryRecallEligibleMessages(messages: JsonRecord[]): JsonRecord[] {
   return messages.filter((message) => !hiddenFromAi(message) && !!readString(message.content).trim());
 }
@@ -1914,6 +1910,24 @@ function recentMemoryRecallMessages(messages: JsonRecord[], readBehind: number):
 
 function messageIdSet(messages: JsonRecord[]): Set<string> {
   return new Set(messages.map((message) => readString(message.id).trim()).filter(Boolean));
+}
+
+function memoryRecallReadBehindExclusion(
+  chat: JsonRecord,
+  storedMessages: JsonRecord[],
+): Pick<ListChatMemoriesOptions, "excludeRecentMessageIds" | "excludeRecentStartAt"> {
+  const readBehind = memoryRecallReadBehind(chat);
+  if (readBehind <= 0) return {};
+
+  const recentMessages = recentMemoryRecallMessages(storedMessages, readBehind);
+  const excludeRecentMessageIds = Array.from(messageIdSet(recentMessages));
+  if (excludeRecentMessageIds.length === 0) return {};
+
+  const excludeRecentStartAt = readString(recentMessages[0]?.createdAt).trim();
+  return {
+    excludeRecentMessageIds,
+    ...(excludeRecentStartAt ? { excludeRecentStartAt } : {}),
+  };
 }
 
 function memoryChunkMessageIds(memory: JsonRecord): Set<string> {
@@ -1986,8 +2000,9 @@ async function buildMemoryRecallBlock(
   let memories: JsonRecord[] = [];
   try {
     const rows = await storage.listChatMemories<unknown>(chatId, {
-      limit: memoryRecallFetchLimit(chat),
+      limit: MAX_MEMORY_RECALL_SCORING_CHUNKS,
       order: "recent",
+      ...memoryRecallReadBehindExclusion(chat, storedMessages),
     });
     memories = memoryRecallRows(rows);
   } catch {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1731,9 +1731,58 @@ const MAX_MEMORY_RECALL_BUDGET_TOKENS = 2048;
 const MAX_RECALLED_MEMORY_TOKENS = 384;
 const MIN_RECALLED_MEMORY_TOKENS = 96;
 const MEMORY_RECALL_CONTEXT_SHARE = 0.15;
+const MEMORY_RECALL_SIMILARITY_THRESHOLD = 0.25;
+const MAX_MEMORY_RECALL_SCORING_CHUNKS = 500;
+const MIN_MEMORY_RECALL_STRONG_LEXICAL_TOKENS = 2;
+const MIN_MEMORY_RECALL_STRONG_LEXICAL_COVERAGE = 0.75;
 const DEFAULT_MEMORY_RECALL_READ_BEHIND_MESSAGES = 1;
 const MAX_MEMORY_RECALL_READ_BEHIND_MESSAGES = 100;
 const RECALL_TRUNCATION_MARKER = "\n...[recalled memory truncated]...\n";
+const MEMORY_RECALL_QUERY_STOPWORDS = new Set([
+  "about",
+  "and",
+  "are",
+  "been",
+  "but",
+  "did",
+  "does",
+  "find",
+  "for",
+  "from",
+  "had",
+  "has",
+  "have",
+  "her",
+  "him",
+  "his",
+  "how",
+  "its",
+  "know",
+  "our",
+  "recall",
+  "remember",
+  "she",
+  "show",
+  "tell",
+  "that",
+  "the",
+  "their",
+  "them",
+  "then",
+  "there",
+  "they",
+  "this",
+  "was",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+  "you",
+  "your",
+]);
 
 function estimateTextTokens(text: string): number {
   const trimmed = text.trim();
@@ -1752,6 +1801,30 @@ function lexicalMemoryEmbedding(text: string): number[] {
   }
   const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
   return magnitude > 0 ? vector.map((value) => value / magnitude) : vector;
+}
+
+function memoryRecallTokenSet(text: string): Set<string> {
+  return new Set(text.toLowerCase().match(/[a-z0-9]{2,}/g) ?? []);
+}
+
+function memoryRecallQueryTokens(text: string): string[] {
+  return Array.from(memoryRecallTokenSet(text)).filter((token) => !MEMORY_RECALL_QUERY_STOPWORDS.has(token));
+}
+
+function memoryRecallLexicalOverlap(queryTokens: string[], contentTokens: Set<string>): number {
+  return queryTokens.reduce((score, token) => score + (contentTokens.has(token) ? 1 : 0), 0);
+}
+
+function hasStrongMemoryRecallLexicalMatch(queryTokenCount: number, lexicalScore: number): boolean {
+  if (queryTokenCount < MIN_MEMORY_RECALL_STRONG_LEXICAL_TOKENS) return false;
+  if (lexicalScore < MIN_MEMORY_RECALL_STRONG_LEXICAL_TOKENS) return false;
+  return lexicalScore / queryTokenCount >= MIN_MEMORY_RECALL_STRONG_LEXICAL_COVERAGE;
+}
+
+function passesMemoryRecallRelevanceFloor(similarity: number, queryTokenCount: number, lexicalScore: number): boolean {
+  return (
+    similarity >= MEMORY_RECALL_SIMILARITY_THRESHOLD || hasStrongMemoryRecallLexicalMatch(queryTokenCount, lexicalScore)
+  );
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {
@@ -1875,6 +1948,21 @@ function memoriesAfterReadBehind(chat: JsonRecord, storedMessages: JsonRecord[],
   return memories.filter((memory) => !memoryOverlapsRecentMessages(memory, recentIds, recentStartAt));
 }
 
+function memoryRecallRecencyKey(memory: JsonRecord): string {
+  return (
+    readString(memory.lastMessageAt).trim() ||
+    readString(memory.createdAt).trim() ||
+    readString(memory.firstMessageAt).trim()
+  );
+}
+
+function recentMemoryRecallScoringSet(memories: JsonRecord[]): JsonRecord[] {
+  if (memories.length <= MAX_MEMORY_RECALL_SCORING_CHUNKS) return memories;
+  return [...memories]
+    .sort((a, b) => memoryRecallRecencyKey(b).localeCompare(memoryRecallRecencyKey(a)))
+    .slice(0, MAX_MEMORY_RECALL_SCORING_CHUNKS);
+}
+
 async function buildMemoryRecallBlock(
   storage: StorageGateway,
   chat: JsonRecord,
@@ -1888,12 +1976,15 @@ async function buildMemoryRecallBlock(
   if (!chatId) return null;
   let memories: JsonRecord[] = [];
   try {
-    const rows = await storage.listChatMemories<unknown>(chatId);
+    const rows = await storage.listChatMemories<unknown>(chatId, {
+      limit: MAX_MEMORY_RECALL_SCORING_CHUNKS,
+      order: "recent",
+    });
     memories = Array.isArray(rows) ? rows.filter(isRecord) : [];
   } catch {
     memories = Array.isArray(chat.memories) ? chat.memories.filter(isRecord) : [];
   }
-  memories = memoriesAfterReadBehind(chat, storedMessages, memories);
+  memories = recentMemoryRecallScoringSet(memoriesAfterReadBehind(chat, storedMessages, memories));
   if (memories.length === 0) return null;
 
   let semanticQueryVector: number[] | null = null;
@@ -1905,7 +1996,7 @@ async function buildMemoryRecallBlock(
     semanticQueryVector = null;
   }
   const queryVector = lexicalMemoryEmbedding(latestUserInput);
-  const queryTokens = new Set(latestUserInput.toLowerCase().match(/[a-z0-9]{2,}/g) ?? []);
+  const queryTokens = memoryRecallQueryTokens(latestUserInput);
   const recalled = memories
     .map((memory) => {
       const content = readString(memory.content).trim();
@@ -1913,15 +2004,14 @@ async function buildMemoryRecallBlock(
       const providerVector = semanticQueryVector ? memoryVector(memory, semanticQueryVector.length) : null;
       const vector = providerVector ?? memoryVector(memory, MEMORY_EMBEDDING_DIMS) ?? lexicalMemoryEmbedding(content);
       const baseQueryVector = providerVector && semanticQueryVector ? semanticQueryVector : queryVector;
-      const haystack = content.toLowerCase();
-      const lexicalScore = Array.from(queryTokens).reduce(
-        (score, token) => score + (haystack.includes(token) ? 1 : 0),
-        0,
-      );
+      const lexicalScore = memoryRecallLexicalOverlap(queryTokens, memoryRecallTokenSet(content));
       const similarity = cosineSimilarity(baseQueryVector, vector) + Math.min(0.2, lexicalScore * 0.025);
-      return { content, similarity };
+      return { content, similarity, lexicalScore };
     })
-    .filter((memory): memory is { content: string; similarity: number } => !!memory && memory.similarity > 0)
+    .filter(
+      (memory): memory is { content: string; similarity: number; lexicalScore: number } =>
+        !!memory && passesMemoryRecallRelevanceFloor(memory.similarity, queryTokens.length, memory.lexicalScore),
+    )
     .sort((a, b) => b.similarity - a.similarity)
     .slice(0, 8);
   if (recalled.length === 0) return null;

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1733,7 +1733,7 @@ const MIN_RECALLED_MEMORY_TOKENS = 96;
 const MEMORY_RECALL_CONTEXT_SHARE = 0.15;
 const MEMORY_RECALL_SIMILARITY_THRESHOLD = 0.25;
 const MAX_MEMORY_RECALL_SCORING_CHUNKS = 500;
-const MIN_MEMORY_RECALL_STRONG_LEXICAL_TOKENS = 2;
+const MIN_MEMORY_RECALL_MULTI_TOKEN_STRONG_LEXICAL_TOKENS = 2;
 const MIN_MEMORY_RECALL_STRONG_LEXICAL_COVERAGE = 0.75;
 const DEFAULT_MEMORY_RECALL_READ_BEHIND_MESSAGES = 1;
 const MAX_MEMORY_RECALL_READ_BEHIND_MESSAGES = 100;
@@ -1816,8 +1816,9 @@ function memoryRecallLexicalOverlap(queryTokens: string[], contentTokens: Set<st
 }
 
 function hasStrongMemoryRecallLexicalMatch(queryTokenCount: number, lexicalScore: number): boolean {
-  if (queryTokenCount < MIN_MEMORY_RECALL_STRONG_LEXICAL_TOKENS) return false;
-  if (lexicalScore < MIN_MEMORY_RECALL_STRONG_LEXICAL_TOKENS) return false;
+  if (queryTokenCount === 1) return lexicalScore >= 1;
+  if (queryTokenCount < MIN_MEMORY_RECALL_MULTI_TOKEN_STRONG_LEXICAL_TOKENS) return false;
+  if (lexicalScore < MIN_MEMORY_RECALL_MULTI_TOKEN_STRONG_LEXICAL_TOKENS) return false;
   return lexicalScore / queryTokenCount >= MIN_MEMORY_RECALL_STRONG_LEXICAL_COVERAGE;
 }
 
@@ -1898,6 +1899,10 @@ function memoryRecallReadBehind(chat: JsonRecord): number {
   return Math.max(0, Math.min(MAX_MEMORY_RECALL_READ_BEHIND_MESSAGES, Math.trunc(raw)));
 }
 
+function memoryRecallFetchLimit(chat: JsonRecord): number {
+  return MAX_MEMORY_RECALL_SCORING_CHUNKS + memoryRecallReadBehind(chat);
+}
+
 function memoryRecallEligibleMessages(messages: JsonRecord[]): JsonRecord[] {
   return messages.filter((message) => !hiddenFromAi(message) && !!readString(message.content).trim());
 }
@@ -1963,6 +1968,10 @@ function recentMemoryRecallScoringSet(memories: JsonRecord[]): JsonRecord[] {
     .slice(0, MAX_MEMORY_RECALL_SCORING_CHUNKS);
 }
 
+function memoryRecallRows(value: unknown): JsonRecord[] {
+  return parseArray(value).filter(isRecord);
+}
+
 async function buildMemoryRecallBlock(
   storage: StorageGateway,
   chat: JsonRecord,
@@ -1977,12 +1986,12 @@ async function buildMemoryRecallBlock(
   let memories: JsonRecord[] = [];
   try {
     const rows = await storage.listChatMemories<unknown>(chatId, {
-      limit: MAX_MEMORY_RECALL_SCORING_CHUNKS,
+      limit: memoryRecallFetchLimit(chat),
       order: "recent",
     });
-    memories = Array.isArray(rows) ? rows.filter(isRecord) : [];
+    memories = memoryRecallRows(rows);
   } catch {
-    memories = Array.isArray(chat.memories) ? chat.memories.filter(isRecord) : [];
+    memories = memoryRecallRows(chat.memories);
   }
   memories = recentMemoryRecallScoringSet(memoriesAfterReadBehind(chat, storedMessages, memories));
   if (memories.length === 0) return null;

--- a/src/shared/api/chat-command-api.ts
+++ b/src/shared/api/chat-command-api.ts
@@ -1,4 +1,17 @@
+import type { ListChatMemoriesOptions } from "../../engine/capabilities/storage";
 import { invokeTauri } from "./tauri-client";
+
+function memoryListArgs(chatId: string | null, options?: ListChatMemoriesOptions): Record<string, unknown> {
+  const limit =
+    typeof options?.limit === "number" && Number.isFinite(options.limit)
+      ? Math.max(0, Math.trunc(options.limit))
+      : null;
+  return {
+    chatId,
+    limit,
+    order: options?.order ?? null,
+  };
+}
 
 export interface ChatGroupDeleteResult {
   deleted: number;
@@ -7,7 +20,8 @@ export interface ChatGroupDeleteResult {
 
 export const chatCommandApi = {
   messageCount: (chatId: string | null) => invokeTauri<{ count: number }>("chat_message_count", { chatId }),
-  memoriesList: <T = unknown>(chatId: string | null) => invokeTauri<T>("chat_memories_list", { chatId }),
+  memoriesList: <T = unknown>(chatId: string | null, options?: ListChatMemoriesOptions) =>
+    invokeTauri<T>("chat_memories_list", memoryListArgs(chatId, options)),
   memoryDelete: (chatId: string | null, memoryId: string) => invokeTauri("chat_memory_delete", { chatId, memoryId }),
   memoriesClear: (chatId: string | null) => invokeTauri("chat_memories_clear", { chatId }),
   memoriesRefresh: <T = unknown>(chatId: string | null) => invokeTauri<T>("chat_memories_refresh", { chatId }),

--- a/src/shared/api/chat-command-api.ts
+++ b/src/shared/api/chat-command-api.ts
@@ -7,6 +7,17 @@ function memoryListArgs(chatId: string | null, options?: ListChatMemoriesOptions
     args.limit = Math.max(0, Math.trunc(options.limit));
   }
   if (options?.order) args.order = options.order;
+  const excludeRecentMessageIds = Array.from(
+    new Set(
+      (options?.excludeRecentMessageIds ?? [])
+        .map((id) => (typeof id === "string" ? id.trim() : ""))
+        .filter(Boolean),
+    ),
+  );
+  if (excludeRecentMessageIds.length > 0) args.excludeRecentMessageIds = excludeRecentMessageIds;
+  const excludeRecentStartAt =
+    typeof options?.excludeRecentStartAt === "string" ? options.excludeRecentStartAt.trim() : "";
+  if (excludeRecentStartAt) args.excludeRecentStartAt = excludeRecentStartAt;
   return args;
 }
 

--- a/src/shared/api/chat-command-api.ts
+++ b/src/shared/api/chat-command-api.ts
@@ -2,15 +2,12 @@ import type { ListChatMemoriesOptions } from "../../engine/capabilities/storage"
 import { invokeTauri } from "./tauri-client";
 
 function memoryListArgs(chatId: string | null, options?: ListChatMemoriesOptions): Record<string, unknown> {
-  const limit =
-    typeof options?.limit === "number" && Number.isFinite(options.limit)
-      ? Math.max(0, Math.trunc(options.limit))
-      : null;
-  return {
-    chatId,
-    limit,
-    order: options?.order ?? null,
-  };
+  const args: Record<string, unknown> = { chatId };
+  if (typeof options?.limit === "number" && Number.isFinite(options.limit)) {
+    args.limit = Math.max(0, Math.trunc(options.limit));
+  }
+  if (options?.order) args.order = options.order;
+  return args;
 }
 
 export interface ChatGroupDeleteResult {

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -1,5 +1,6 @@
 import type {
   AddChatMessageSwipeOptions,
+  ListChatMemoriesOptions,
   StorageImageAttachmentReference,
   StorageEntity,
   StorageGateway,
@@ -13,6 +14,7 @@ import {
   type RemoteManagedAssetKind,
 } from "./local-file-api";
 import { blobToDataUrl } from "../lib/url-blob";
+import { chatCommandApi } from "./chat-command-api";
 import { invokeTauri } from "./tauri-client";
 import { trackerSnapshotApi, type TrackerSnapshotInput } from "./tracker-snapshot-api";
 import { urlBinaryApi } from "./url-binary-api";
@@ -27,10 +29,6 @@ function asRecord(value: unknown): Record<string, unknown> {
     }
   }
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
-}
-
-function asArray<T = unknown>(value: unknown): T[] {
-  return Array.isArray(value) ? (value as T[]) : [];
 }
 
 function parseStoredJson(value: unknown): unknown {
@@ -432,10 +430,8 @@ export const storageApi: StorageGateway = {
     invokeTauri("chat_evict_prompt_snapshots", { chatId, keepLast }) as Promise<{ evicted: number }>,
   patchChatMetadata: (chatId, patch) => patchChatObjectField(chatId, "metadata", patch),
   patchChatSummaries: (chatId, patch) => patchChatSummariesField(chatId, patch),
-  listChatMemories: async (chatId) => {
-    const chat = await storageApi.get<Record<string, unknown>>("chats", chatId);
-    return asArray(chat?.memories);
-  },
+  listChatMemories: <T = unknown>(chatId: string, options?: ListChatMemoriesOptions) =>
+    chatCommandApi.memoriesList<T[]>(chatId, options),
   refreshChatMemories: (chatId) => invokeTauri("chat_memories_refresh", { chatId }),
   getWorldState: async (chatId) => {
     const chat = await storageApi.get<Record<string, unknown>>("chats", chatId);


### PR DESCRIPTION
## Linked issue

Closes #2286
Closes #2287

## Why this change

- Memory Recall regressed from the legacy relevance floor and admitted weak positive matches.
- Long chats also scored every stored memory chunk on each generation instead of bounding the working set.
- The first pass fixed scoring locally, then the command/API boundary was updated so prompt assembly requests a bounded recent memory list from embedded and remote runtimes.

## What changed

- Restored a `0.25` Memory Recall relevance floor while allowing strong exact-token lexical matches to pass when semantic score is just below the floor.
- Limited Memory Recall scoring to the 500 most-recent chunks before cosine/lexical scoring.
- Added `listChatMemories` options on the engine storage port and routed the shared storage adapter through the focused chat command API.
- Updated embedded Tauri and remote `/api/invoke` `chat_memories_list` handling to support `limit` and `order: "recent"`.
- Added native coverage for recent limited Memory Recall chunk listing, default stored order, and invalid order rejection.

## Refactor impact

Primary owner:

- Engine generation / Memory Recall prompt assembly

Impact areas reviewed:

- React-free prompt assembly
- Shared storage API wrapper and chat command wrapper
- Embedded Tauri chat memory commands
- Remote runtime HTTP dispatch for `/api/invoke`

Boundary notes:

- Engine code still uses the `StorageGateway` port and does not import Tauri or shared API adapters.
- Shared API code owns the Tauri/remote command arguments for memory listing.
- Rust storage command code owns sorting, limiting, and validation for `chat_memories_list`.
- Remote-capable behavior stays on the existing allowlisted `chat_memories_list` command path.

Pressure points touched:

- `src/engine/generation/prompt-assembly.ts`
- `src-tauri/src/http_dispatch.rs`
- No `src-tauri/src/lib.rs` command registration changes.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `cargo test --manifest-path src-tauri/Cargo.toml list_chat_memories_can_return_recent_limited_chunks`
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace`
- `pnpm check`
- Local temporary harnesses, not committed, reproduced and verified weak semantic matches, recent-500 chunk capping, and the `blue umbrella` strong lexical match case.
- Manual Tauri UI QA was not run because this changes prompt assembly and command/API behavior without visible UI changes.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This fixes Memory Recall scoring and command boundary behavior for an existing feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A; no visible UI changes.

## Remaining risk

- Memory chunks are still embedded on the chat record as `chat.memories`, so the Rust command still materializes the chat record internally before applying the bounded command response. Moving chunks to a dedicated collection or sidecar storage path is a larger storage migration and is left for follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat memory listing now supports optional pagination via `limit` parameter and sorting options: retrieve memories in stored insertion order (default) or sorted by recency.

* **Improvements**
  * Enhanced memory recall with improved relevance filtering and recency-based chunk scoring for more accurate context retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->