### PR TITLE
Fix Spotify percent decoding panic

### DIFF
--- a/src-tauri/src/commands/storage/integrations.rs
+++ b/src-tauri/src/commands/storage/integrations.rs
@@ -9,6 +9,8 @@ mod haptic;
 mod spotify;
 #[path = "integrations/spotify_callback.rs"]
 mod spotify_callback;
+#[path = "integrations/spotify_query.rs"]
+mod spotify_query;
 #[path = "integrations/tts.rs"]
 mod tts;
 

--- a/src-tauri/src/commands/storage/integrations/spotify.rs
+++ b/src-tauri/src/commands/storage/integrations/spotify.rs
@@ -3,6 +3,7 @@ use super::super::images::percent_encode_component;
 use super::super::shared::*;
 use super::super::*;
 use super::spotify_callback::start_callback_listener;
+use super::spotify_query::parse_query;
 use sha2::{Digest, Sha256};
 use std::sync::{Mutex, OnceLock};
 
@@ -3058,45 +3059,6 @@ fn form_urlencoded(params: &[(&str, &str)]) -> String {
         })
         .collect::<Vec<_>>()
         .join("&")
-}
-
-fn parse_query(query: &str) -> HashMap<String, String> {
-    query
-        .split('&')
-        .filter_map(|pair| {
-            let (key, value) = pair.split_once('=')?;
-            Some((key.to_string(), percent_decode_component(value)))
-        })
-        .collect()
-}
-
-fn percent_decode_component(value: &str) -> String {
-    let bytes = value.as_bytes();
-    let mut output = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'+' => {
-                output.push(b' ');
-                index += 1;
-            }
-            b'%' if index + 2 < bytes.len() => {
-                let hex = &value[index + 1..index + 3];
-                if let Ok(byte) = u8::from_str_radix(hex, 16) {
-                    output.push(byte);
-                    index += 3;
-                } else {
-                    output.push(bytes[index]);
-                    index += 1;
-                }
-            }
-            byte => {
-                output.push(byte);
-                index += 1;
-            }
-        }
-    }
-    String::from_utf8_lossy(&output).to_string()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/storage/integrations/spotify_callback.rs
+++ b/src-tauri/src/commands/storage/integrations/spotify_callback.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use super::spotify::exchange;
+use super::spotify_query::parse_query;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -94,45 +95,6 @@ async fn handle_callback_request(state: &AppState, request: &str) -> Result<(), 
         .await
         .map(|_| ())
         .map_err(|error| error.message)
-}
-
-fn parse_query(query: &str) -> HashMap<String, String> {
-    query
-        .split('&')
-        .filter_map(|pair| {
-            let (key, value) = pair.split_once('=')?;
-            Some((key.to_string(), percent_decode_component(value)))
-        })
-        .collect()
-}
-
-fn percent_decode_component(value: &str) -> String {
-    let bytes = value.as_bytes();
-    let mut output = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'+' => {
-                output.push(b' ');
-                index += 1;
-            }
-            b'%' if index + 2 < bytes.len() => {
-                let hex = &value[index + 1..index + 3];
-                if let Ok(byte) = u8::from_str_radix(hex, 16) {
-                    output.push(byte);
-                    index += 3;
-                } else {
-                    output.push(bytes[index]);
-                    index += 1;
-                }
-            }
-            byte => {
-                output.push(byte);
-                index += 1;
-            }
-        }
-    }
-    String::from_utf8_lossy(&output).to_string()
 }
 
 fn html_escape(value: &str) -> String {

--- a/src-tauri/src/commands/storage/integrations/spotify_query.rs
+++ b/src-tauri/src/commands/storage/integrations/spotify_query.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+
+pub(super) fn parse_query(query: &str) -> HashMap<String, String> {
+    query
+        .split('&')
+        .filter_map(|pair| {
+            let (key, value) = pair.split_once('=')?;
+            Some((key.to_string(), percent_decode_component(value)))
+        })
+        .collect()
+}
+
+fn percent_decode_component(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'+' => {
+                output.push(b' ');
+                index += 1;
+            }
+            b'%' if index + 2 < bytes.len() => {
+                if let (Some(high), Some(low)) =
+                    (hex_nibble(bytes[index + 1]), hex_nibble(bytes[index + 2]))
+                {
+                    output.push((high << 4) | low);
+                    index += 3;
+                } else {
+                    output.push(bytes[index]);
+                    index += 1;
+                }
+            }
+            byte => {
+                output.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&output).to_string()
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_query_decodes_spotify_callback_values() {
+        let params = parse_query("code=hello+world&state=%E2%80%A6");
+
+        assert_eq!(params.get("code").map(String::as_str), Some("hello world"));
+        assert_eq!(params.get("state").map(String::as_str), Some("\u{2026}"));
+    }
+
+    #[test]
+    fn percent_decode_component_preserves_malformed_percent_before_multibyte_char() {
+        assert_eq!(percent_decode_component("%\u{2026}x"), "%\u{2026}x");
+    }
+
+    #[test]
+    fn percent_decode_component_preserves_other_malformed_sequences() {
+        assert_eq!(percent_decode_component("%zz%2\u{2026}%"), "%zz%2\u{2026}%");
+    }
+}


### PR DESCRIPTION
## Linked issue

Closes #2325

## Why this change

- Spotify callback parsing could panic when a percent sign was followed by a multi-byte UTF-8 character, which could kill the OAuth callback task or reject the pasted callback URL exchange.

## What changed

- Added one shared Spotify query parser for the loopback callback and pasted callback URL paths.
- Decode percent escapes from raw bytes instead of slicing a `&str` at byte offsets.
- Added focused Rust coverage for valid callback decoding and malformed percent sequences with multi-byte characters.

## Refactor impact

Primary owner:

Rust storage integrations, Spotify OAuth parsing.

Impact areas reviewed:

- Loopback Spotify OAuth callback request parsing.
- Pasted `callbackUrl` exchange parsing.
- Duplicate Spotify query decoder copies removed from both entrypoints.

Boundary notes:

- Rust-only integration parsing fix under `src-tauri`; no React, engine, shared API, command registration, or remote-runtime boundary changes.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml spotify_query --lib` passed: 3 tests passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `git diff --cached --check` passed before commit.
- `pnpm check` passed.
- No live Spotify OAuth/Tauri callback flow was exercised.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal Spotify OAuth parser crash fix; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; Rust-only parser fix with no visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for Spotify integration utilities by consolidating shared functionality into a reusable module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->