### PR TITLE
Persist persona-stats inventory acquisitions in game journal

### DIFF
--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -95,6 +95,7 @@ import {
   resolveVisibleGameStateFallbackMessageIds,
   selectTrackerSnapshotForGeneration,
   trackerSnapshotTargetFromMessage,
+  type TrackerSnapshotSavedHook,
 } from "./tracker-snapshots";
 
 export type { StartGenerationInput } from "./start-generation-input";
@@ -105,6 +106,7 @@ export interface GenerationEngineDeps {
   integrations: IntegrationGateway;
   visuals?: VisualAssetGateway;
   events?: EventGateway;
+  onTrackerSnapshotSaved?: TrackerSnapshotSavedHook;
 }
 
 export interface RetryAgentsInput extends JsonRecord {
@@ -1671,11 +1673,16 @@ async function persistTrackerSnapshotSafely(
   results: AgentResult[],
   baseSnapshot?: GameState | null,
   sourceText?: string | null,
+  onSavedSnapshot?: TrackerSnapshotSavedHook,
 ): Promise<void> {
   const target = trackerSnapshotTargetFromMessage(targetMessage);
   if (!target) return;
   try {
-    await persistTrackerSnapshotForTurn(storage, chatId, target, results, { baseSnapshot, sourceText });
+    await persistTrackerSnapshotForTurn(storage, chatId, target, results, {
+      baseSnapshot,
+      sourceText,
+      onSavedSnapshot,
+    });
   } catch (error) {
     console.warn("[generation] tracker snapshot persist failed", error);
   }
@@ -2535,7 +2542,15 @@ async function runGenerationAgentsForTarget(args: {
     runtime.availableSprites,
   );
   if (target) {
-    await persistTrackerSnapshotSafely(deps.storage, chatId, target, finalResults, retryBaseline, mainResponse);
+    await persistTrackerSnapshotSafely(
+      deps.storage,
+      chatId,
+      target,
+      finalResults,
+      retryBaseline,
+      mainResponse,
+      deps.onTrackerSnapshotSaved,
+    );
   }
   await persistSecretPlotAgentMemorySafely(deps.storage, chatId, finalResults, {
     rerollMode: secretPlotRerollMode(input),
@@ -3063,6 +3078,7 @@ export async function* startGeneration(
         allAgentResults,
         generationTrackerBaseline,
         readString(parseRecord(latestSaved).content),
+        deps.onTrackerSnapshotSaved,
       );
     }
     throwIfAborted(signal);

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -7,6 +7,7 @@ import type {
   InventoryItem,
   PresentCharacter,
 } from "../contracts/types/game-state";
+import { createJournal, syncInventoryJournalFromPlayerStats, type Journal } from "../modes/game/world/journal.service";
 import { preserveTrackerCharacterUiFields } from "./generate-route-utils";
 import { boolish, isRecord, nowIso, parseRecord, readNonNegativeInteger, readString } from "./runtime-records";
 import { worldStatePatchFromAgentData } from "./world-state-agent-result";
@@ -66,6 +67,39 @@ type TrackerStatePatch = Partial<
 >;
 const MANUAL_OVERRIDE_FIELDS = ["date", "time", "location", "weather", "temperature"] as const;
 type ManualOverrideField = (typeof MANUAL_OVERRIDE_FIELDS)[number];
+
+function isPersonaStatsResult(result: AgentResult): boolean {
+  return result.agentType === "persona-stats" || result.type === "persona_stats_update";
+}
+
+function journalFromMetadata(metadata: unknown): Journal {
+  const raw = parseRecord(parseRecord(metadata).gameJournal);
+  const empty = createJournal();
+  return {
+    entries: Array.isArray(raw.entries) ? (raw.entries as Journal["entries"]) : empty.entries,
+    quests: Array.isArray(raw.quests) ? (raw.quests as Journal["quests"]) : empty.quests,
+    locations: Array.isArray(raw.locations) ? (raw.locations as Journal["locations"]) : empty.locations,
+    npcLog: Array.isArray(raw.npcLog) ? (raw.npcLog as Journal["npcLog"]) : empty.npcLog,
+    inventoryLog: Array.isArray(raw.inventoryLog) ? (raw.inventoryLog as Journal["inventoryLog"]) : empty.inventoryLog,
+  };
+}
+
+function isGameChat(chat: Record<string, unknown> | null): boolean {
+  return readString(chat?.mode || chat?.chatMode).trim() === "game";
+}
+
+async function persistGameInventoryJournalFromSnapshot(
+  storage: StorageGateway,
+  chatId: string,
+  chat: Record<string, unknown> | null,
+  snapshot: GameState,
+): Promise<void> {
+  if (!isGameChat(chat) || !snapshot.playerStats?.inventory.length) return;
+  const journal = journalFromMetadata(parseRecord(chat?.metadata));
+  const synced = syncInventoryJournalFromPlayerStats(journal, snapshot.playerStats);
+  if (synced === journal) return;
+  await storage.patchChatMetadata(chatId, { gameJournal: synced });
+}
 
 function readNullableString(value: unknown): string | null {
   if (value === null || value === undefined) return null;
@@ -496,11 +530,10 @@ export async function persistTrackerSnapshotForTurn(
   const hasCharacterTrackerResult = results.some(
     (result) => result.agentType === "character-tracker" || result.type === "character_tracker_update",
   );
+  const hasPersonaStatsResult = results.some(isPersonaStatsResult);
   const needsChatBaseline = !existing && !options.baseSnapshot;
-  const chat =
-    needsChatBaseline || hasCharacterTrackerResult
-      ? parseRecord(await storage.get("chats", chatId).catch(() => null))
-      : null;
+  const needsChat = needsChatBaseline || hasCharacterTrackerResult || hasPersonaStatsResult;
+  const chat = needsChat ? parseRecord(await storage.get("chats", chatId).catch(() => null)) : null;
   const persona = hasCharacterTrackerResult ? await loadPersonaSnapshotForChat(storage, chat).catch(() => null) : null;
   let snapshot = normalizeGameState(existing ?? options.baseSnapshot ?? chat?.gameState, chatId, target, persona);
   if (!existing) {
@@ -521,5 +554,8 @@ export async function persistTrackerSnapshotForTurn(
   const saved = await storage.saveTrackerSnapshot<GameState>(chatId, snapshot as unknown as Record<string, unknown>);
   const savedState = normalizeGameState(saved, chatId, target);
   await storage.update("chats", chatId, { gameState: savedState as unknown as Record<string, unknown> });
+  if (hasPersonaStatsResult) {
+    await persistGameInventoryJournalFromSnapshot(storage, chatId, chat, savedState);
+  }
   return savedState;
 }

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -7,7 +7,6 @@ import type {
   InventoryItem,
   PresentCharacter,
 } from "../contracts/types/game-state";
-import { createJournal, syncInventoryJournalFromPlayerStats, type Journal } from "../modes/game/world/journal.service";
 import { preserveTrackerCharacterUiFields } from "./generate-route-utils";
 import { boolish, isRecord, nowIso, parseRecord, readNonNegativeInteger, readString } from "./runtime-records";
 import { worldStatePatchFromAgentData } from "./world-state-agent-result";
@@ -50,6 +49,16 @@ export interface TrackerSnapshotMessageRebase {
   swipeCount?: unknown;
 }
 
+export interface TrackerSnapshotSavedContext {
+  chatId: string;
+  target: TrackerSnapshotTurnTarget;
+  chat: Record<string, unknown> | null;
+  snapshot: GameState;
+  results: AgentResult[];
+}
+
+export type TrackerSnapshotSavedHook = (context: TrackerSnapshotSavedContext) => Promise<void> | void;
+
 type TrackerStatePatch = Partial<
   Pick<
     GameState,
@@ -67,39 +76,6 @@ type TrackerStatePatch = Partial<
 >;
 const MANUAL_OVERRIDE_FIELDS = ["date", "time", "location", "weather", "temperature"] as const;
 type ManualOverrideField = (typeof MANUAL_OVERRIDE_FIELDS)[number];
-
-function isPersonaStatsResult(result: AgentResult): boolean {
-  return result.agentType === "persona-stats" || result.type === "persona_stats_update";
-}
-
-function journalFromMetadata(metadata: unknown): Journal {
-  const raw = parseRecord(parseRecord(metadata).gameJournal);
-  const empty = createJournal();
-  return {
-    entries: Array.isArray(raw.entries) ? (raw.entries as Journal["entries"]) : empty.entries,
-    quests: Array.isArray(raw.quests) ? (raw.quests as Journal["quests"]) : empty.quests,
-    locations: Array.isArray(raw.locations) ? (raw.locations as Journal["locations"]) : empty.locations,
-    npcLog: Array.isArray(raw.npcLog) ? (raw.npcLog as Journal["npcLog"]) : empty.npcLog,
-    inventoryLog: Array.isArray(raw.inventoryLog) ? (raw.inventoryLog as Journal["inventoryLog"]) : empty.inventoryLog,
-  };
-}
-
-function isGameChat(chat: Record<string, unknown> | null): boolean {
-  return readString(chat?.mode || chat?.chatMode).trim() === "game";
-}
-
-async function persistGameInventoryJournalFromSnapshot(
-  storage: StorageGateway,
-  chatId: string,
-  chat: Record<string, unknown> | null,
-  snapshot: GameState,
-): Promise<void> {
-  if (!isGameChat(chat) || !snapshot.playerStats?.inventory.length) return;
-  const journal = journalFromMetadata(parseRecord(chat?.metadata));
-  const synced = syncInventoryJournalFromPlayerStats(journal, snapshot.playerStats);
-  if (synced === journal) return;
-  await storage.patchChatMetadata(chatId, { gameJournal: synced });
-}
 
 function readNullableString(value: unknown): string | null {
   if (value === null || value === undefined) return null;
@@ -523,16 +499,19 @@ export async function persistTrackerSnapshotForTurn(
   chatId: string,
   target: TrackerSnapshotTurnTarget | null,
   results: AgentResult[],
-  options: { baseSnapshot?: GameState | null; sourceText?: string | null } = {},
+  options: {
+    baseSnapshot?: GameState | null;
+    sourceText?: string | null;
+    onSavedSnapshot?: TrackerSnapshotSavedHook;
+  } = {},
 ): Promise<GameState | null> {
   if (!target || !target.messageId || results.length === 0) return null;
   const existing = await getTrackerSnapshotForTarget(storage, chatId, target);
   const hasCharacterTrackerResult = results.some(
     (result) => result.agentType === "character-tracker" || result.type === "character_tracker_update",
   );
-  const hasPersonaStatsResult = results.some(isPersonaStatsResult);
   const needsChatBaseline = !existing && !options.baseSnapshot;
-  const needsChat = needsChatBaseline || hasCharacterTrackerResult || hasPersonaStatsResult;
+  const needsChat = needsChatBaseline || hasCharacterTrackerResult || !!options.onSavedSnapshot;
   const chat = needsChat ? parseRecord(await storage.get("chats", chatId).catch(() => null)) : null;
   const persona = hasCharacterTrackerResult ? await loadPersonaSnapshotForChat(storage, chat).catch(() => null) : null;
   let snapshot = normalizeGameState(existing ?? options.baseSnapshot ?? chat?.gameState, chatId, target, persona);
@@ -554,8 +533,8 @@ export async function persistTrackerSnapshotForTurn(
   const saved = await storage.saveTrackerSnapshot<GameState>(chatId, snapshot as unknown as Record<string, unknown>);
   const savedState = normalizeGameState(saved, chatId, target);
   await storage.update("chats", chatId, { gameState: savedState as unknown as Record<string, unknown> });
-  if (hasPersonaStatsResult) {
-    await persistGameInventoryJournalFromSnapshot(storage, chatId, chat, savedState);
+  if (options.onSavedSnapshot) {
+    await options.onSavedSnapshot({ chatId, target, chat, snapshot: savedState, results });
   }
   return savedState;
 }

--- a/src/engine/modes/game/turn/game-turn.service.ts
+++ b/src/engine/modes/game/turn/game-turn.service.ts
@@ -1,6 +1,9 @@
+import type { AgentResult } from "../../../contracts/types/agent";
+import type { TrackerSnapshotSavedContext } from "../../../generation/tracker-snapshots";
 import type { GenerationEngineDeps, StartGenerationInput } from "../../../generation/start-generation";
 import { startGeneration } from "../../../generation/start-generation";
 import { isRecord, parseRecord, readString, type JsonRecord } from "../../../generation/runtime-records";
+import { createJournal, syncInventoryJournalFromPlayerStats, type Journal } from "../world/journal.service";
 
 export type GameTurnKind = "start" | "turn" | "retry";
 
@@ -37,6 +40,37 @@ function assertGameChat(chat: JsonRecord, kind: GameTurnKind): void {
   }
 }
 
+function isPersonaStatsResult(result: AgentResult): boolean {
+  return result.agentType === "persona-stats" || result.type === "persona_stats_update";
+}
+
+function journalFromMetadata(metadata: unknown): Journal {
+  const raw = parseRecord(parseRecord(metadata).gameJournal);
+  const empty = createJournal();
+  return {
+    entries: Array.isArray(raw.entries) ? (raw.entries as Journal["entries"]) : empty.entries,
+    quests: Array.isArray(raw.quests) ? (raw.quests as Journal["quests"]) : empty.quests,
+    locations: Array.isArray(raw.locations) ? (raw.locations as Journal["locations"]) : empty.locations,
+    npcLog: Array.isArray(raw.npcLog) ? (raw.npcLog as Journal["npcLog"]) : empty.npcLog,
+    inventoryLog: Array.isArray(raw.inventoryLog) ? (raw.inventoryLog as Journal["inventoryLog"]) : empty.inventoryLog,
+  };
+}
+
+async function persistGameInventoryJournalFromSnapshot(
+  deps: GenerationEngineDeps,
+  context: TrackerSnapshotSavedContext,
+): Promise<void> {
+  if (!context.results.some(isPersonaStatsResult) || !context.snapshot.playerStats) return;
+  const latestRawChat = await deps.storage.get("chats", context.chatId).catch(() => context.chat);
+  const latestChat = isRecord(latestRawChat) ? latestRawChat : context.chat;
+  if (readString(latestChat?.mode || latestChat?.chatMode).trim() !== "game") return;
+
+  const journal = journalFromMetadata(parseRecord(latestChat?.metadata));
+  const synced = syncInventoryJournalFromPlayerStats(journal, context.snapshot.playerStats);
+  if (synced === journal) return;
+  await deps.storage.patchChatMetadata(context.chatId, { gameJournal: synced });
+}
+
 function hasPlayerTurnInput(input: StartGameTurnInput): boolean {
   const text = readString(input.message).trim() || readString(input.userMessage).trim();
   const attachments = Array.isArray(input.attachments) ? input.attachments : [];
@@ -64,5 +98,14 @@ export async function* startGameTurnGeneration(
     generationGuideSource: gameGuideSourceFor(input.kind),
   };
 
-  yield* startGeneration(deps, generationInput, signal);
+  const upstreamOnTrackerSnapshotSaved = deps.onTrackerSnapshotSaved;
+  const gameDeps: GenerationEngineDeps = {
+    ...deps,
+    onTrackerSnapshotSaved: async (context) => {
+      await upstreamOnTrackerSnapshotSaved?.(context);
+      await persistGameInventoryJournalFromSnapshot(deps, context);
+    },
+  };
+
+  yield* startGeneration(gameDeps, generationInput, signal);
 }

--- a/src/engine/modes/game/world/journal.service.ts
+++ b/src/engine/modes/game/world/journal.service.ts
@@ -1,5 +1,5 @@
 import type { GameNpc, SessionSummary, GameMap } from "../../../contracts/types/game";
-import type { PlayerStats, QuestProgress } from "../../../contracts/types/game-state";
+import type { InventoryItem, PlayerStats, QuestProgress } from "../../../contracts/types/game-state";
 
 // ── Types ──
 
@@ -249,6 +249,64 @@ function readText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function inventoryNameKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function inventoryQuantity(value: unknown): number {
+  const quantity = typeof value === "number" ? value : Number(value ?? 1);
+  return Number.isFinite(quantity) && quantity > 0 ? quantity : 0;
+}
+
+function journaledInventoryQuantities(journal: Journal): Map<string, number> {
+  const quantities = new Map<string, number>();
+  for (const entry of journal.inventoryLog) {
+    const key = inventoryNameKey(entry.item);
+    if (!key) continue;
+    const quantity = inventoryQuantity(entry.quantity);
+    const current = quantities.get(key) ?? 0;
+    const nextQuantity =
+      entry.action === "acquired" ? current + quantity : Math.max(0, current - Math.max(1, quantity));
+    quantities.set(key, nextQuantity);
+  }
+  return quantities;
+}
+
+function currentInventoryQuantities(items: readonly InventoryItem[]): Map<string, { name: string; quantity: number }> {
+  const quantities = new Map<string, { name: string; quantity: number }>();
+  for (const item of items) {
+    const name = readText(item.name);
+    const key = inventoryNameKey(name);
+    const quantity = inventoryQuantity(item.quantity);
+    if (!key || quantity <= 0) continue;
+    const current = quantities.get(key);
+    quantities.set(key, { name: current?.name ?? name, quantity: (current?.quantity ?? 0) + quantity });
+  }
+  return quantities;
+}
+
+function syncInventoryEntriesFromPlayerStats(journal: Journal, playerStats: PlayerStats | null | undefined): Journal {
+  if (!playerStats?.inventory?.length) return journal;
+
+  let next = journal;
+  const journaled = journaledInventoryQuantities(journal);
+  for (const [key, item] of currentInventoryQuantities(playerStats.inventory)) {
+    const journaledQuantity = journaled.get(key) ?? 0;
+    if (item.quantity <= journaledQuantity) continue;
+    const addedQuantity = item.quantity - journaledQuantity;
+    next = addInventoryEntry(next, item.name, "acquired", addedQuantity);
+    journaled.set(key, item.quantity);
+  }
+  return next;
+}
+
+export function syncInventoryJournalFromPlayerStats(
+  journal: Journal,
+  playerStats: PlayerStats | null | undefined,
+): Journal {
+  return syncInventoryEntriesFromPlayerStats(journal, playerStats);
+}
+
 function normalizeJournalEntry(
   type: string,
   data: Record<string, unknown>,
@@ -395,6 +453,7 @@ export function syncJournalFromGameState(
     gameNpcs?: GameNpc[] | null;
     playerStats?: PlayerStats | null;
     currentLocation?: string | null;
+    syncInventory?: boolean;
   },
 ): Journal {
   let next = journal;
@@ -414,6 +473,9 @@ export function syncJournalFromGameState(
   }
   for (const quest of options.playerStats?.activeQuests ?? []) {
     next = upsertQuest(next, questJournalData(quest));
+  }
+  if (options.syncInventory !== false) {
+    next = syncInventoryEntriesFromPlayerStats(next, options.playerStats);
   }
   return next;
 }

--- a/src/engine/modes/game/world/journal.service.ts
+++ b/src/engine/modes/game/world/journal.service.ts
@@ -258,22 +258,29 @@ function inventoryQuantity(value: unknown): number {
   return Number.isFinite(quantity) && quantity > 0 ? quantity : 0;
 }
 
-function journaledInventoryQuantities(journal: Journal): Map<string, number> {
-  const quantities = new Map<string, number>();
+interface InventoryQuantity {
+  name: string;
+  quantity: number;
+}
+
+function journaledInventoryQuantities(journal: Journal): Map<string, InventoryQuantity> {
+  const quantities = new Map<string, InventoryQuantity>();
   for (const entry of journal.inventoryLog) {
     const key = inventoryNameKey(entry.item);
     if (!key) continue;
+    const name = readText(entry.item);
     const quantity = inventoryQuantity(entry.quantity);
-    const current = quantities.get(key) ?? 0;
+    const current = quantities.get(key);
+    const currentQuantity = current?.quantity ?? 0;
     const nextQuantity =
-      entry.action === "acquired" ? current + quantity : Math.max(0, current - Math.max(1, quantity));
-    quantities.set(key, nextQuantity);
+      entry.action === "acquired" ? currentQuantity + quantity : Math.max(0, currentQuantity - quantity);
+    quantities.set(key, { name: current?.name ?? name, quantity: nextQuantity });
   }
   return quantities;
 }
 
-function currentInventoryQuantities(items: readonly InventoryItem[]): Map<string, { name: string; quantity: number }> {
-  const quantities = new Map<string, { name: string; quantity: number }>();
+function currentInventoryQuantities(items: readonly InventoryItem[]): Map<string, InventoryQuantity> {
+  const quantities = new Map<string, InventoryQuantity>();
   for (const item of items) {
     const name = readText(item.name);
     const key = inventoryNameKey(name);
@@ -286,16 +293,26 @@ function currentInventoryQuantities(items: readonly InventoryItem[]): Map<string
 }
 
 function syncInventoryEntriesFromPlayerStats(journal: Journal, playerStats: PlayerStats | null | undefined): Journal {
-  if (!playerStats?.inventory?.length) return journal;
+  if (!playerStats) return journal;
 
   let next = journal;
   const journaled = journaledInventoryQuantities(journal);
-  for (const [key, item] of currentInventoryQuantities(playerStats.inventory)) {
-    const journaledQuantity = journaled.get(key) ?? 0;
-    if (item.quantity <= journaledQuantity) continue;
-    const addedQuantity = item.quantity - journaledQuantity;
-    next = addInventoryEntry(next, item.name, "acquired", addedQuantity);
-    journaled.set(key, item.quantity);
+  const current = currentInventoryQuantities(playerStats.inventory);
+  const keys = new Set([...journaled.keys(), ...current.keys()]);
+  for (const key of keys) {
+    const currentItem = current.get(key);
+    const journaledItem = journaled.get(key);
+    const currentQuantity = currentItem?.quantity ?? 0;
+    const journaledQuantity = journaledItem?.quantity ?? 0;
+    if (currentQuantity > journaledQuantity) {
+      const addedQuantity = currentQuantity - journaledQuantity;
+      next = addInventoryEntry(next, currentItem?.name ?? journaledItem?.name ?? key, "acquired", addedQuantity);
+      journaled.set(key, { name: currentItem?.name ?? journaledItem?.name ?? key, quantity: currentQuantity });
+    } else if (currentQuantity < journaledQuantity) {
+      const removedQuantity = journaledQuantity - currentQuantity;
+      next = addInventoryEntry(next, journaledItem?.name ?? currentItem?.name ?? key, "removed", removedQuantity);
+      journaled.set(key, { name: journaledItem?.name ?? currentItem?.name ?? key, quantity: currentQuantity });
+    }
   }
   return next;
 }

--- a/src/features/modes/game/api/game-api.ts
+++ b/src/features/modes/game/api/game-api.ts
@@ -941,7 +941,7 @@ function journalFromMeta(meta: Record<string, unknown>): Journal {
 function journalFromChat(
   chat: Chat,
   meta: Record<string, unknown> = chatMeta(chat),
-  options: { includeCurrentLocation?: boolean } = {},
+  options: { includeCurrentLocation?: boolean; syncInventory?: boolean } = {},
 ): Journal {
   const gameState = asRecord((chat as { gameState?: unknown }).gameState);
   const playerStats = gameState.playerStats == null ? null : clonePlayerStats(gameState.playerStats);
@@ -950,6 +950,7 @@ function journalFromChat(
     playerStats,
     currentLocation:
       options.includeCurrentLocation === true && typeof gameState.location === "string" ? gameState.location : null,
+    syncInventory: options.syncInventory,
   });
 }
 
@@ -2860,7 +2861,7 @@ export const gameApi = {
     const chat = await getChat(data.chatId);
     const meta = chatMeta(chat);
     const journal = applyJournalEntry(
-      journalFromChat(chat, meta, { includeCurrentLocation: false }),
+      journalFromChat(chat, meta, { includeCurrentLocation: false, syncInventory: false }),
       data.type,
       data.data,
     );


### PR DESCRIPTION
## Linked issue

Closes #2295

## Why this change

- Game-mode persona-stats tracker snapshots could add an inventory item to `playerStats.inventory` without writing an acquired row to the game journal, so the item appeared in live inventory but the acquisition history was missing.

## What changed

- Sync missing acquired inventory rows from `playerStats.inventory` through the game journal service.
- Persist game-mode persona-stats snapshot acquisitions into `metadata.gameJournal` when tracker snapshots are saved, so the acquired row survives later item removal.
- Keep direct item journal writes from pre-syncing inventory so `[inventory:]` tag/manual item writes do not duplicate acquired rows.

## Refactor impact

Primary owner:

- Game mode journal/world-state tracker snapshot persistence.

Impact areas reviewed:

- Game journal inventory log derivation and recap input.
- Persona-stats tracker snapshot persistence.
- Direct `gameApi.addJournalEntry()` item writes.
- Non-game chat gating for persona-stats snapshot journal persistence.

Boundary notes:

- Engine generation now calls the game journal service for game-mode-only journal metadata sync after saving tracker snapshots.
- No shared API, Rust, Tauri command, or remote-runtime routing changes.

Pressure points touched:

- None of the named pressure-point files were changed.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/tracker-snapshot-journal-2295.tmp.test.ts` passed with 2 focused assertions; proof-only test file was removed before commit.
- `pnpm typecheck` passed.
- `git diff --check` passed.
- `pnpm check` passed after the final diff.
- Native Tauri/UI manual validation was not run; this is a storage/engine journal persistence fix with no visible layout change.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores expected game journal behavior for an existing tracker path; it does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots or recordings. The change persists game journal inventory rows and does not change visible layout or controls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory is now automatically synchronized with the game journal when character stats are updated
  * Game journal accurately tracks and records all inventory changes from the current game state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->