### PR TITLE
Fix agent JSON repair ellipsis handling

### DIFF
--- a/src/engine/agents-runtime/executor/agent-executor.test.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.test.ts
@@ -13,13 +13,12 @@ class CapturingProvider implements BaseLLMProvider {
   maxTokensOverrideValue = null;
   messages: ChatMessage[] = [];
 
+  constructor(private readonly content = JSON.stringify({ editedText: "unchanged", changes: [] })) {}
+
   async chatComplete(messages: ChatMessage[], _options: ChatCompleteOptions): Promise<ChatCompleteResult> {
     this.messages = messages;
     return {
-      content: JSON.stringify({
-        editedText: "unchanged",
-        changes: [],
-      }),
+      content: this.content,
     };
   }
 }
@@ -72,5 +71,15 @@ describe("executeAgent", () => {
     expect(prompt).toContain(`<section class="social-card" data-theme="neon">`);
     expect(prompt).toContain(`<style>.social-card { color: #7dd3fc; }</style>`);
     expect(prompt).toContain(`<p style="font-weight: 700">She is safe now.</p>`);
+  });
+
+  it("repairs inline ellipsis placeholders without dropping following JSON fields", async () => {
+    const provider = new CapturingProvider('{"editedText":"fixed... still literal", ... "changes":[]}');
+
+    const result = await executeAgent(editorConfig, createAgentContext("original"), provider, "test-model");
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ editedText: "fixed... still literal", changes: [] });
   });
 });

--- a/src/engine/agents-runtime/executor/agent-executor.ts
+++ b/src/engine/agents-runtime/executor/agent-executor.ts
@@ -2051,7 +2051,6 @@ function removeEllipsesOutsideJsonStrings(str: string): string {
     }
     if (char === "." && str.slice(index, index + 3) === "...") {
       index += 2;
-      while (index + 1 < str.length && str[index + 1] !== "\n" && str[index + 1] !== "\r") index += 1;
       continue;
     }
     result += char;


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

Closes #2168

## Why this change

- Agent JSON repair should remove inline `...` placeholders without deleting valid same-line JSON fields that follow them.
- The refactor was skipping from `...` through the end of the line, so recoverable agent JSON like `{"a":1, ... "b":2}` stayed broken after repair.

## What changed

- Updated the agent JSON repair ellipsis pass to skip only the three-dot placeholder outside JSON strings.
- Added an `executeAgent` regression test covering inline placeholder recovery and preserving literal ellipses inside string values.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- `src/engine/agents-runtime/executor/agent-executor.ts`
- `src/engine/agents-runtime/executor/agent-executor.test.ts`

Boundary notes:

- Engine-only change; no React, shared API, remote runtime, storage, or Tauri boundary changes.

Pressure points touched:

- Agent JSON response repair fallback after the initial `JSON.parse` fails.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the bug before the fix with `pnpm exec vitest run src\engine\agents-runtime\executor\agent-executor.test.ts`; the new regression failed because inline ellipsis JSON produced `result.success === false`.
- Codex re-ran the same targeted command after the fix; it passed with 2 tests.
- Codex ran `pnpm typecheck`; it passed.
- Codex ran full `pnpm check`; it passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`; it passed.
- Bunny review pass: passed before opening the PR.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is an internal engine compatibility bugfix for agent JSON repair behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. This is a React-free engine parsing bug with command-based proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed JSON parsing to correctly handle ellipsis placeholders without dropping subsequent data fields
* Improved JSON comment removal logic for more accurate recovery during parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->