### PR TITLE
Fix legacy HUD bottom widgets

### DIFF
--- a/src/features/modes/game/components/GameSurface.tsx
+++ b/src/features/modes/game/components/GameSurface.tsx
@@ -69,6 +69,7 @@ import {
   gameKeys,
   patchChatMetadata,
 } from "../hooks/use-game";
+import { normalizeHudWidgets } from "../lib/hud-widget-normalization";
 import {
   chatKeys,
   useBranchChat,
@@ -7878,7 +7879,7 @@ export function GameSurface({
     gameSceneIllustrationAllowed,
   ]);
 
-  const normalizedWidgets = hudWidgets;
+  const normalizedWidgets = useMemo(() => normalizeHudWidgets(hudWidgets), [hudWidgets]);
 
   const handleStartGameRequest = useCallback(() => {
     if (startGame.isPending || startGameRequested || startGameGuardRef.current) return;

--- a/src/features/modes/game/hooks/use-game.ts
+++ b/src/features/modes/game/hooks/use-game.ts
@@ -13,6 +13,7 @@ import {
   getPendingHudWidgetPersistenceSignature,
   useGameModeStore,
 } from "../stores/game-mode.store";
+import { normalizeHudWidgets } from "../lib/hud-widget-normalization";
 import { useGameStateStore } from "../../../runtime/world-state/index";
 import { useChatStore } from "../../../../shared/stores/chat.store";
 import { useUIStore } from "../../../../shared/stores/ui.store";
@@ -502,74 +503,6 @@ export function useUpdateGameWidgets() {
 // ── Queries ──
 
 // ── Sync hook — reads chat metadata and updates game store ──
-
-function isNumericHudWidgetType(type: HudWidget["type"]) {
-  return type === "progress_bar" || type === "gauge" || type === "relationship_meter";
-}
-
-function finiteNumber(value: unknown): number | null {
-  const raw = typeof value === "string" && value.trim() ? Number(value.trim()) : value;
-  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
-}
-
-type LegacyInventoryGridItem = { name: string; slot?: string; quantity?: number };
-
-function positiveInventoryQuantity(value: unknown): number {
-  const quantity = finiteNumber(value) ?? 1;
-  return Math.max(1, Math.floor(quantity));
-}
-
-function legacyInventoryGridItems(value: unknown): LegacyInventoryGridItem[] | null {
-  if (!Array.isArray(value)) return null;
-  const items: LegacyInventoryGridItem[] = [];
-  for (const item of value) {
-    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-    const record = item as Record<string, unknown>;
-    const name = typeof record.name === "string" ? record.name : "";
-    if (!name) continue;
-    const slot = typeof record.slot === "string" ? record.slot : undefined;
-    items.push({
-      name,
-      ...(slot ? { slot } : {}),
-      quantity: positiveInventoryQuantity(record.quantity),
-    });
-  }
-  return items;
-}
-
-function normalizeHudWidgets(widgets: readonly HudWidget[]): HudWidget[] {
-  return widgets.map((w) => {
-    if (isNumericHudWidgetType(w.type)) {
-      const max = Math.max(1, finiteNumber(w.config.max) ?? 100);
-      const value = finiteNumber(w.config.value) ?? finiteNumber(w.config.startingValue) ?? 0;
-      const startingValue = finiteNumber(w.config.startingValue) ?? value;
-
-      if (w.config.max !== max || w.config.value !== value || w.config.startingValue !== startingValue) {
-        return {
-          ...w,
-          config: {
-            ...w.config,
-            max,
-            startingValue,
-            value,
-          },
-        };
-      }
-    }
-
-    const legacyItems = legacyInventoryGridItems((w.config as HudWidget["config"] & { items?: unknown }).items);
-    if (w.type === "inventory_grid" && !w.config.contents && legacyItems) {
-      return {
-        ...w,
-        config: {
-          ...w.config,
-          contents: legacyItems,
-        },
-      };
-    }
-    return w;
-  });
-}
 
 export function useSyncGameState(activeChatId: string, chatMeta: Record<string, unknown>) {
   const prevChatIdRef = useRef<string | null>(null);

--- a/src/features/modes/game/lib/hud-widget-normalization.test.ts
+++ b/src/features/modes/game/lib/hud-widget-normalization.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import type { HudWidget } from "../../../../engine/contracts/types/game";
+import { normalizeHudWidgets } from "./hud-widget-normalization";
+
+type LegacyHudWidget = Omit<HudWidget, "position"> & { position: HudWidget["position"] | "hud_bottom" };
+
+function widget(id: string, position: LegacyHudWidget["position"]): LegacyHudWidget {
+  return {
+    id,
+    type: "counter",
+    label: id,
+    position,
+    config: { count: 1 },
+  };
+}
+
+describe("normalizeHudWidgets", () => {
+  it("remaps legacy hud_bottom widgets onto alternating visible HUD columns", () => {
+    const normalized = normalizeHudWidgets([widget("first", "hud_bottom"), widget("second", "hud_bottom")]);
+
+    expect(normalized.map((entry) => entry.position)).toEqual(["hud_left", "hud_right"]);
+  });
+
+  it("preserves supported HUD positions while counting only legacy bottom widgets for alternation", () => {
+    const normalized = normalizeHudWidgets([
+      widget("left", "hud_left"),
+      widget("legacy-a", "hud_bottom"),
+      widget("right", "hud_right"),
+      widget("legacy-b", "hud_bottom"),
+    ]);
+
+    expect(normalized.map((entry) => [entry.id, entry.position])).toEqual([
+      ["left", "hud_left"],
+      ["legacy-a", "hud_left"],
+      ["right", "hud_right"],
+      ["legacy-b", "hud_right"],
+    ]);
+  });
+});

--- a/src/features/modes/game/lib/hud-widget-normalization.test.ts
+++ b/src/features/modes/game/lib/hud-widget-normalization.test.ts
@@ -36,4 +36,19 @@ describe("normalizeHudWidgets", () => {
       ["legacy-b", "hud_right"],
     ]);
   });
+
+  it("migrates legacy inventory items when contents is malformed", () => {
+    const normalized = normalizeHudWidgets([
+      {
+        ...widget("inventory", "hud_left"),
+        type: "inventory_grid",
+        config: {
+          contents: "not-an-array" as never,
+          items: [{ name: "Torch", quantity: "2" }] as never,
+        },
+      },
+    ]);
+
+    expect(normalized[0]?.config.contents).toEqual([{ name: "Torch", quantity: 2 }]);
+  });
 });

--- a/src/features/modes/game/lib/hud-widget-normalization.ts
+++ b/src/features/modes/game/lib/hud-widget-normalization.ts
@@ -75,7 +75,7 @@ export function normalizeHudWidgets(widgets: readonly LegacyHudWidget[]): HudWid
     }
 
     const legacyItems = legacyInventoryGridItems((normalized.config as HudWidget["config"] & { items?: unknown }).items);
-    if (normalized.type === "inventory_grid" && !normalized.config.contents && legacyItems) {
+    if (normalized.type === "inventory_grid" && !Array.isArray(normalized.config.contents) && legacyItems) {
       normalized = {
         ...normalized,
         config: {

--- a/src/features/modes/game/lib/hud-widget-normalization.ts
+++ b/src/features/modes/game/lib/hud-widget-normalization.ts
@@ -1,0 +1,90 @@
+import type { HudWidget } from "../../../../engine/contracts/types/game";
+
+type LegacyHudWidget = Omit<HudWidget, "position"> & {
+  position: HudWidget["position"] | "hud_bottom";
+};
+
+function isNumericHudWidgetType(type: HudWidget["type"]) {
+  return type === "progress_bar" || type === "gauge" || type === "relationship_meter";
+}
+
+function finiteNumber(value: unknown): number | null {
+  const raw = typeof value === "string" && value.trim() ? Number(value.trim()) : value;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+}
+
+type LegacyInventoryGridItem = { name: string; slot?: string; quantity?: number };
+
+function positiveInventoryQuantity(value: unknown): number {
+  const quantity = finiteNumber(value) ?? 1;
+  return Math.max(1, Math.floor(quantity));
+}
+
+function legacyInventoryGridItems(value: unknown): LegacyInventoryGridItem[] | null {
+  if (!Array.isArray(value)) return null;
+  const items: LegacyInventoryGridItem[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name : "";
+    if (!name) continue;
+    const slot = typeof record.slot === "string" ? record.slot : undefined;
+    items.push({
+      name,
+      ...(slot ? { slot } : {}),
+      quantity: positiveInventoryQuantity(record.quantity),
+    });
+  }
+  return items;
+}
+
+function normalizeLegacyHudWidgetPosition(widget: LegacyHudWidget, legacyBottomIndex: number): HudWidget {
+  if (widget.position !== "hud_bottom") return widget as HudWidget;
+  return {
+    ...widget,
+    position: legacyBottomIndex % 2 === 0 ? "hud_left" : "hud_right",
+  };
+}
+
+export function normalizeHudWidgets(widgets: readonly LegacyHudWidget[]): HudWidget[] {
+  let legacyBottomCount = 0;
+  return widgets.map((widget) => {
+    let normalized = normalizeLegacyHudWidgetPosition(widget, legacyBottomCount);
+    if (widget.position === "hud_bottom") legacyBottomCount += 1;
+
+    if (isNumericHudWidgetType(normalized.type)) {
+      const max = Math.max(1, finiteNumber(normalized.config.max) ?? 100);
+      const value = finiteNumber(normalized.config.value) ?? finiteNumber(normalized.config.startingValue) ?? 0;
+      const startingValue = finiteNumber(normalized.config.startingValue) ?? value;
+
+      if (
+        normalized.config.max !== max ||
+        normalized.config.value !== value ||
+        normalized.config.startingValue !== startingValue
+      ) {
+        normalized = {
+          ...normalized,
+          config: {
+            ...normalized.config,
+            max,
+            startingValue,
+            value,
+          },
+        };
+      }
+    }
+
+    const legacyItems = legacyInventoryGridItems((normalized.config as HudWidget["config"] & { items?: unknown }).items);
+    if (normalized.type === "inventory_grid" && !normalized.config.contents && legacyItems) {
+      normalized = {
+        ...normalized,
+        config: {
+          ...normalized.config,
+          contents: legacyItems,
+        },
+      };
+    }
+
+    return normalized;
+  });
+}


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2152

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Legacy persisted game HUD widgets with `position: "hud_bottom"` were silently hidden on the refactor branch because the rendering panels only accept `hud_left` and `hud_right`.

## What changed

<!-- List the key changes in this PR. -->

- Restored the legacy `hud_bottom` compatibility remap, alternating those widgets into `hud_left` and `hud_right`.
- Moved existing HUD widget normalization into a pure game helper so sync and render paths share the same behavior.
- Added a regression test for legacy bottom widgets and for preserving existing left/right widget positions.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

Game mode

Impact areas reviewed:

- Game HUD widget metadata sync
- Game HUD widget rendering
- Legacy persisted `gameWidgetState` compatibility

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Feature-layer compatibility normalization only. No engine, shared API, Rust, storage, schema, dependency, or persisted-data migration changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- `GameSurface`
- `useSyncGameState`

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex ran `pnpm exec vitest run src/features/modes/game/lib/hud-widget-normalization.test.ts` - passed, 1 file / 3 tests.
- Codex ran `pnpm typecheck` - passed.
- Codex ran `pnpm check` - passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` - passed.
- Full visual repro in the Tauri game surface with a real legacy user profile was not run; the core compatibility behavior is covered by static before-proof plus focused normalization regression tests.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

- Not attached. This draft should stay draft until a reviewer/contributor either accepts the focused compatibility proof or manually opens a legacy game profile with `hud_bottom` widget metadata in Tauri and confirms the widget appears in a HUD column.
