### PR TITLE
Preserve invoke rate-limit headers

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -1377,7 +1377,7 @@ async fn api_controls_middleware(
         Ok(()) => {
             let mut response = next.run(request).await;
             if let Some(outcome) = &rate_limit {
-                apply_rate_limit_headers(response.headers_mut(), outcome);
+                apply_rate_limit_headers_when_missing(response.headers_mut(), outcome);
             }
             apply_security_headers(response.headers_mut());
             apply_api_no_store_headers(response.headers_mut(), &path);
@@ -1914,6 +1914,12 @@ fn apply_rate_limit_headers(headers: &mut HeaderMap, outcome: &ApiRateLimitOutco
         if let Ok(value) = HeaderValue::from_str(&duration_header_seconds(retry_after)) {
             headers.insert(header::RETRY_AFTER, value);
         }
+    }
+}
+
+fn apply_rate_limit_headers_when_missing(headers: &mut HeaderMap, outcome: &ApiRateLimitOutcome) {
+    if !headers.contains_key("ratelimit-limit") {
+        apply_rate_limit_headers(headers, outcome);
     }
 }
 
@@ -2580,6 +2586,46 @@ mod tests {
             .and_then(|value| value.parse::<u64>().ok())
             .expect("retry-after should be present");
         assert!((1..=60).contains(&retry_after));
+    }
+
+    #[tokio::test]
+    async fn api_invoke_router_preserves_command_specific_rate_limit_headers() {
+        let listener =
+            tokio::net::TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+                .await
+                .expect("test server should bind");
+        let addr = listener.local_addr().expect("test server addr should load");
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                router(test_state("invoke-router-rate-limit-headers"))
+                    .into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("test server should run");
+        });
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/api/invoke"))
+            .header(CSRF_HEADER_NAME, CSRF_HEADER_VALUE)
+            .json(&json!({
+                "command": "update_apply",
+                "args": { "input": { "confirm": false } }
+            }))
+            .send()
+            .await
+            .expect("invoke request should complete");
+
+        assert_ne!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get("ratelimit-limit")
+                .and_then(|value| value.to_str().ok()),
+            Some("5")
+        );
+
+        server.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Linked issue

Closes #2332

## Why this change

- `/api/invoke` responses were losing command-specific rate-limit advisory headers because the API middleware reapplied the coarse pre-extraction bucket after the handler set the command bucket.

## What changed

- Preserve handler-owned `ratelimit-*` headers when present after `/api/invoke` dispatch.
- Added a router-level regression test that exercises the production middleware path and verifies `update_apply` reports its command-specific limit.

## Refactor impact

Primary owner:

Rust remote runtime / HTTP server

Impact areas reviewed:

- `/api/invoke` middleware rate-limit headers
- Command-specific invoke rate-limit enforcement
- API security and no-store header application order

Boundary notes:

- Rust-only server runtime change in `src-tauri/src/http_server.rs`.
- No React, engine, shared API, storage schema, or command-registration boundary changes.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Red repro before fix: `cargo test --manifest-path src-tauri/Cargo.toml api_invoke_router_preserves_command_specific_rate_limit_headers -- --nocapture` failed with `ratelimit-limit` returning `6000` instead of `5`.
- After fix: `cargo test --manifest-path src-tauri/Cargo.toml api_invoke_ -- --nocapture` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` passed.
- `git diff --check` passed.
- `pnpm check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Server runtime advisory-header bugfix only; no new user-discoverable behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; server runtime header fix only.
