### PR TITLE
Fix chat export compatibility

### DIFF
--- a/src-tauri/src/commands/storage/imports/marinara.rs
+++ b/src-tauri/src/commands/storage/imports/marinara.rs
@@ -2,12 +2,15 @@ use super::*;
 
 #[path = "marinara_assets.rs"]
 mod marinara_assets;
+#[path = "marinara_chat_bulk.rs"]
+mod marinara_chat_bulk;
 #[path = "marinara_helpers.rs"]
 mod marinara_helpers;
 #[path = "marinara_rollback.rs"]
 mod marinara_rollback;
 
 use marinara_assets::*;
+use marinara_chat_bulk::*;
 use marinara_helpers::*;
 use marinara_rollback::*;
 
@@ -19,6 +22,13 @@ pub(super) fn import_marinara_file(state: &AppState, body: Value) -> AppResult<V
         body.get("file")
             .ok_or_else(|| AppError::invalid_input("file is required"))?,
     )?;
+    if let Ok(text) = std::str::from_utf8(&uploaded.bytes) {
+        if let Ok(payload) = parse_json_text(text) {
+            if payload.get("format").and_then(Value::as_str) == Some("marinara-chat-bulk") {
+                return import_marinara_chat_bulk(state, payload);
+            }
+        }
+    }
     if uploaded.bytes.len() < 4 || uploaded.bytes[0] != 0x50 || uploaded.bytes[1] != 0x4b {
         return Err(AppError::invalid_input(
             "Not a .marinara file (zip signature missing)",

--- a/src-tauri/src/commands/storage/imports/marinara_chat_bulk.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_chat_bulk.rs
@@ -1,0 +1,166 @@
+use super::*;
+use std::collections::HashMap;
+
+fn imported_string_id(value: Option<&Value>, field: &str) -> AppResult<Option<String>> {
+    match value {
+        Some(Value::String(id)) => {
+            let id = id.trim();
+            if id.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(id.to_string()))
+            }
+        }
+        Some(Value::Null) | None => Ok(None),
+        _ => Err(AppError::invalid_input(format!(
+            "Chat bulk entry {field} must be a string or null"
+        ))),
+    }
+}
+
+fn chat_bulk_identity_maps(
+    chats: &[Value],
+) -> AppResult<(HashMap<String, String>, HashMap<String, String>)> {
+    let mut chat_id_map = HashMap::new();
+    for entry in chats {
+        let entry = entry
+            .as_object()
+            .ok_or_else(|| AppError::invalid_input("Chat bulk entry must be an object"))?;
+        let chat = entry
+            .get("chat")
+            .and_then(Value::as_object)
+            .ok_or_else(|| AppError::invalid_input("Chat bulk entry is missing chat"))?;
+        if let Some(old_chat_id) = imported_string_id(chat.get("id"), "chat.id")? {
+            chat_id_map.entry(old_chat_id).or_insert_with(new_id);
+        }
+    }
+
+    let mut group_id_map = HashMap::new();
+    for entry in chats {
+        let entry = entry
+            .as_object()
+            .ok_or_else(|| AppError::invalid_input("Chat bulk entry must be an object"))?;
+        let chat = entry
+            .get("chat")
+            .and_then(Value::as_object)
+            .ok_or_else(|| AppError::invalid_input("Chat bulk entry is missing chat"))?;
+        let Some(old_group_id) = imported_string_id(chat.get("groupId"), "chat.groupId")? else {
+            continue;
+        };
+        if let Some(mapped_chat_id) = chat_id_map.get(&old_group_id) {
+            group_id_map
+                .entry(old_group_id)
+                .or_insert_with(|| mapped_chat_id.clone());
+        } else {
+            group_id_map.entry(old_group_id).or_insert_with(new_id);
+        }
+    }
+
+    Ok((chat_id_map, group_id_map))
+}
+
+pub(super) fn import_marinara_chat_bulk(state: &AppState, payload: Value) -> AppResult<Value> {
+    let object = payload
+        .as_object()
+        .ok_or_else(|| AppError::invalid_input("Invalid Marinara chat bulk export"))?;
+    if object.get("version").and_then(Value::as_i64) != Some(1) {
+        return Err(AppError::invalid_input(
+            "Unsupported Marinara chat bulk export version",
+        ));
+    }
+    let chats = object
+        .get("chats")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::invalid_input("Marinara chat bulk export is missing chats"))?;
+    if chats.is_empty() {
+        return Err(AppError::invalid_input(
+            "Marinara chat bulk export must contain at least one chat",
+        ));
+    }
+
+    let mut created_chat_ids = Vec::new();
+    let mut created_message_ids = Vec::new();
+    let (chat_id_map, group_id_map) = chat_bulk_identity_maps(chats)?;
+    let result = (|| -> AppResult<Value> {
+        let mut imported = Vec::new();
+        let mut messages_imported = 0usize;
+        for entry in chats {
+            let entry = entry
+                .as_object()
+                .ok_or_else(|| AppError::invalid_input("Chat bulk entry must be an object"))?;
+            let mut chat = ensure_object(
+                entry
+                    .get("chat")
+                    .cloned()
+                    .ok_or_else(|| AppError::invalid_input("Chat bulk entry is missing chat"))?,
+            )?;
+            let old_chat_id = imported_string_id(chat.get("id"), "chat.id")?;
+            if let Some(old_chat_id) = old_chat_id.as_deref() {
+                if let Some(new_chat_id) = chat_id_map.get(old_chat_id) {
+                    chat.insert("id".to_string(), Value::String(new_chat_id.clone()));
+                } else {
+                    chat.remove("id");
+                }
+            } else {
+                chat.remove("id");
+            }
+            chat.remove("rowid");
+            if let Some(old_group_id) = imported_string_id(chat.get("groupId"), "chat.groupId")? {
+                if let Some(new_group_id) = group_id_map.get(&old_group_id) {
+                    chat.insert("groupId".to_string(), Value::String(new_group_id.clone()));
+                } else {
+                    chat.insert("groupId".to_string(), Value::Null);
+                }
+            } else {
+                chat.insert("groupId".to_string(), Value::Null);
+            }
+            chat.insert("folderId".to_string(), Value::Null);
+            let chat_record = state.storage.create("chats", Value::Object(chat))?;
+            let chat_id = created_record_id(&chat_record, "chat")?;
+            created_chat_ids.push(chat_id.clone());
+
+            let messages = entry
+                .get("messages")
+                .and_then(Value::as_array)
+                .ok_or_else(|| AppError::invalid_input("Chat bulk entry is missing messages"))?;
+            for message in messages {
+                let mut message = ensure_object(message.clone())?;
+                message.remove("id");
+                message.remove("rowid");
+                message.insert("chatId".to_string(), Value::String(chat_id.clone()));
+                let created = crate::storage_commands::message_swipes::create_message(
+                    state,
+                    Value::Object(message),
+                )?;
+                created_message_ids.push(created_record_id(&created, "message")?);
+                messages_imported += 1;
+            }
+            imported.push(json!({
+                "chatId": chat_id,
+                "name": chat_record.get("name").cloned().unwrap_or(Value::Null),
+                "messagesImported": messages.len(),
+                "chat": chat_record
+            }));
+        }
+        flush_import_writes(state)?;
+        Ok(json!({
+            "success": true,
+            "format": "marinara-chat-bulk",
+            "count": imported.len(),
+            "messagesImported": messages_imported,
+            "chats": imported
+        }))
+    })();
+
+    result.map_err(|error| {
+        let mut rollback_errors = Vec::new();
+        rollback_created_records_collect(
+            state,
+            "messages",
+            &created_message_ids,
+            &mut rollback_errors,
+        );
+        rollback_created_records_collect(state, "chats", &created_chat_ids, &mut rollback_errors);
+        append_marinara_rollback_errors(error, "chat bulk import", rollback_errors)
+    })
+}

--- a/src-tauri/src/commands/storage/imports/marinara_tests.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_tests.rs
@@ -49,6 +49,15 @@ fn embedded_avatar() -> String {
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==".to_string()
 }
 
+fn uploaded_json(name: &str, payload: Value) -> Value {
+    let bytes = serde_json::to_vec(&payload).expect("fixture payload should serialize");
+    json!({
+        "name": name,
+        "type": "application/json",
+        "base64": general_purpose::STANDARD.encode(bytes),
+    })
+}
+
 fn assert_managed_character_avatar(character: &Value) {
     let avatar_path = test_string(character, "avatarPath");
     assert!(
@@ -103,6 +112,190 @@ fn generic_marinara_import_directs_profile_exports_to_profile_import() {
     assert_eq!(error.code, "invalid_input");
     assert!(error.message.contains("Import Profile"));
     assert!(!error.message.contains("Unknown Marinara import type"));
+}
+
+#[test]
+fn marinara_file_import_recovers_native_chat_bulk_json() {
+    let state = test_state("native-chat-bulk");
+    let imported = import_marinara_file(
+        &state,
+        json!({
+            "file": uploaded_json("marinara-chats.json", json!({
+                "format": "marinara-chat-bulk",
+                "version": 1,
+                "chats": [{
+                    "chat": {
+                        "id": "old-chat",
+                        "name": "Recovered Branch",
+                        "mode": "roleplay",
+                        "characterIds": ["char-1"],
+                        "groupId": "group-1",
+                        "personaId": "persona-1",
+                        "promptPresetId": "preset-1",
+                        "connectionId": "connection-1",
+                        "folderId": "missing-folder",
+                        "metadata": { "branchName": "Alt Route" }
+                    },
+                    "messages": [{
+                        "id": "old-message",
+                        "chatId": "old-chat",
+                        "role": "assistant",
+                        "characterId": "char-1",
+                        "content": "Recovered line",
+                        "createdAt": "2026-06-05T01:02:03Z",
+                        "extra": { "displayText": null, "isGenerated": true, "tokenCount": null, "generationInfo": null }
+                    }]
+                }]
+            }))
+        }),
+    )
+    .expect("native chat bulk JSON should import through Marinara file import");
+
+    assert_eq!(imported["success"], true);
+    assert_eq!(imported["count"], 1);
+    assert_eq!(imported["messagesImported"], 1);
+
+    let chats = state.storage.list("chats").expect("chats should list");
+    assert_eq!(chats.len(), 1);
+    let chat = &chats[0];
+    assert_ne!(test_string(chat, "id"), "old-chat");
+    assert_eq!(test_string(chat, "name"), "Recovered Branch");
+    assert_eq!(test_string(chat, "mode"), "roleplay");
+    assert_ne!(test_string(chat, "groupId"), "group-1");
+    assert!(!test_string(chat, "groupId").is_empty());
+    assert_eq!(test_string(chat, "personaId"), "persona-1");
+    assert_eq!(test_string(chat, "promptPresetId"), "preset-1");
+    assert_eq!(test_string(chat, "connectionId"), "connection-1");
+    assert!(chat.get("folderId").is_none_or(Value::is_null));
+    assert_eq!(chat["metadata"]["branchName"], "Alt Route");
+
+    let messages = state
+        .storage
+        .list("messages")
+        .expect("messages should list");
+    assert_eq!(messages.len(), 1);
+    assert_ne!(test_string(&messages[0], "id"), "old-message");
+    assert_eq!(messages[0]["chatId"], chat["id"]);
+    assert_eq!(messages[0]["content"], "Recovered line");
+    assert_eq!(
+        test_string(&messages[0], "createdAt"),
+        "2026-06-05T01:02:03Z"
+    );
+}
+
+#[test]
+fn marinara_chat_bulk_import_remaps_groups_without_local_collision() {
+    let state = test_state("native-chat-bulk-groups");
+    state
+        .storage
+        .create(
+            "chats",
+            json!({
+                "id": "local-chat",
+                "name": "Local Branch",
+                "mode": "roleplay",
+                "groupId": "shared-old-group"
+            }),
+        )
+        .expect("local chat should seed");
+
+    let imported = import_marinara_file(
+        &state,
+        json!({
+            "file": uploaded_json("marinara-chats.json", json!({
+                "format": "marinara-chat-bulk",
+                "version": 1,
+                "chats": [
+                    {
+                        "chat": {
+                            "id": "old-chat-a",
+                            "name": "Imported A",
+                            "mode": "roleplay",
+                            "groupId": "shared-old-group",
+                            "metadata": { "branchName": "Imported A" }
+                        },
+                        "messages": [{
+                            "id": "old-message-a",
+                            "chatId": "old-chat-a",
+                            "role": "user",
+                            "characterId": null,
+                            "content": "A",
+                            "extra": { "displayText": null, "isGenerated": false, "tokenCount": null, "generationInfo": null }
+                        }]
+                    },
+                    {
+                        "chat": {
+                            "id": "old-chat-b",
+                            "name": "Imported B",
+                            "mode": "roleplay",
+                            "groupId": "shared-old-group",
+                            "metadata": { "branchName": "Imported B" }
+                        },
+                        "messages": [{
+                            "id": "old-message-b",
+                            "chatId": "old-chat-b",
+                            "role": "assistant",
+                            "characterId": null,
+                            "content": "B",
+                            "extra": { "displayText": null, "isGenerated": true, "tokenCount": null, "generationInfo": null }
+                        }]
+                    }
+                ]
+            }))
+        }),
+    )
+    .expect("native chat bulk JSON should import");
+
+    assert_eq!(imported["count"], 2);
+    let chats = state.storage.list("chats").expect("chats should list");
+    let local = record_with_field(&chats, "id", "local-chat");
+    assert_eq!(test_string(local, "groupId"), "shared-old-group");
+    let imported_a = record_with_field(&chats, "name", "Imported A");
+    let imported_b = record_with_field(&chats, "name", "Imported B");
+    let imported_group = test_string(imported_a, "groupId");
+    assert_eq!(imported_group, test_string(imported_b, "groupId"));
+    assert_ne!(imported_group, "shared-old-group");
+    assert_ne!(test_string(imported_a, "id"), "old-chat-a");
+    assert_ne!(test_string(imported_b, "id"), "old-chat-b");
+
+    let messages = state
+        .storage
+        .list("messages")
+        .expect("messages should list");
+    let message_a = messages
+        .iter()
+        .find(|message| message.get("content").and_then(Value::as_str) == Some("A"))
+        .expect("message A should import");
+    let message_b = messages
+        .iter()
+        .find(|message| message.get("content").and_then(Value::as_str) == Some("B"))
+        .expect("message B should import");
+    assert_eq!(message_a["chatId"], imported_a["id"]);
+    assert_eq!(message_b["chatId"], imported_b["id"]);
+}
+
+#[test]
+fn marinara_file_import_does_not_treat_other_json_as_chat_bulk() {
+    let state = test_state("native-chat-bulk-negative");
+    let error = import_marinara_file(
+        &state,
+        json!({
+            "file": uploaded_json("not-chat-bulk.json", json!({
+                "format": "not-chat-bulk",
+                "version": 1,
+                "chats": []
+            }))
+        }),
+    )
+    .expect_err("unmatched JSON should keep the existing file import rejection");
+
+    assert_eq!(error.code, "invalid_input");
+    assert!(error.message.contains("zip signature"));
+    assert!(state
+        .storage
+        .list("chats")
+        .expect("chats should list")
+        .is_empty());
 }
 
 #[test]

--- a/src/app/shell/ChatSidebar.tsx
+++ b/src/app/shell/ChatSidebar.tsx
@@ -1238,7 +1238,7 @@ export function ChatSidebar({
               {batchExportMenuOpen && (
                 <div className="absolute bottom-full left-0 z-20 mb-2 w-40 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--popover)] p-1 shadow-xl">
                   {[
-                    ["jsonl", "JSONL ZIP"],
+                    ["jsonl", "Transcript JSONL ZIP"],
                     ["text", "Text ZIP"],
                     ["native", "Native JSON"],
                   ].map(([format, label]) => (

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -1069,7 +1069,7 @@ export function useExportChat() {
       ]);
       const filename = chatExportFilename(chat, format);
       if (format === "text") {
-        downloadTextFile(formatChatText(messages), filename, "text/plain;charset=utf-8");
+        downloadTextFile(formatChatText(chat, messages), filename, "text/plain;charset=utf-8");
       } else {
         downloadTextFile(formatChatJsonl(messages), filename, "application/x-ndjson;charset=utf-8");
       }

--- a/src/features/catalog/chats/lib/chat-transcript-export.ts
+++ b/src/features/catalog/chats/lib/chat-transcript-export.ts
@@ -4,6 +4,43 @@ import type { StoredZipFile } from "../../../../shared/lib/zip";
 export type ChatTranscriptExportFormat = "jsonl" | "text";
 export type BulkChatExportFormat = ChatTranscriptExportFormat | "native";
 
+type ChatTranscriptFormatRow = {
+  format: "marinara-chat-transcript-jsonl";
+  version: 1;
+  rowType: "format";
+};
+
+type ChatTranscriptHeaderRow = {
+  rowType: "header";
+  user_name: string;
+  character_name: string;
+  create_date: string;
+  chat_metadata: {
+    chatId: string;
+    chatName: string;
+    mode: Chat["mode"];
+    groupId: string | null;
+    characterIds: string[];
+    personaId: string | null;
+    connectionId: string | null;
+    promptPresetId: string | null;
+    branchName: string | null;
+  };
+};
+
+type ChatTranscriptMessageRow = {
+  rowType: "message";
+  name: string;
+  is_user: boolean;
+  is_system: boolean;
+  mes: string;
+  send_date: string;
+  characterId?: string | null;
+  role?: Message["role"];
+};
+
+type ChatTranscriptJsonlRow = ChatTranscriptFormatRow | ChatTranscriptHeaderRow | ChatTranscriptMessageRow;
+
 function getChatNameForExport(chat: Chat) {
   const metadata = chat.metadata;
   if (metadata && typeof metadata === "object" && "branchName" in metadata) {
@@ -13,6 +50,24 @@ function getChatNameForExport(chat: Chat) {
   return typeof chat.name === "string" ? chat.name.trim() : "";
 }
 
+function getBranchName(chat: Chat): string | null {
+  const metadata = chat.metadata;
+  if (metadata && typeof metadata === "object" && "branchName" in metadata) {
+    const branchName = (metadata as { branchName?: unknown }).branchName;
+    if (typeof branchName === "string" && branchName.trim()) return branchName.trim();
+  }
+  return null;
+}
+
+function speakerNameForMessage(message: Message): string {
+  if (message.role === "user") {
+    return message.extra?.personaSnapshot?.name?.trim() || "You";
+  }
+  if (message.role === "system") return "System";
+  if (message.role === "narrator") return "Narrator";
+  return message.characterId?.trim() || "Assistant";
+}
+
 export function chatExportFilename(chat: Chat, format: ChatTranscriptExportFormat) {
   const ext = format === "text" ? ".txt" : ".jsonl";
   const sourceName = getChatNameForExport(chat) || chat.id;
@@ -20,13 +75,57 @@ export function chatExportFilename(chat: Chat, format: ChatTranscriptExportForma
   return `${safeName || `chat-${chat.id}`}${ext}`;
 }
 
-export function formatChatText(messages: Message[]) {
-  return messages
-    .map((message) => {
-      const role = message.role ? `${message.role}: ` : "";
-      return `${role}${message.content ?? ""}`;
-    })
-    .join("\n\n");
+function chatTranscriptHeaderRow(chat: Chat): ChatTranscriptHeaderRow {
+  const branchName = getBranchName(chat);
+  return {
+    rowType: "header",
+    user_name: "You",
+    character_name: getChatNameForExport(chat) || chat.name || "Assistant",
+    create_date: chat.createdAt,
+    chat_metadata: {
+      chatId: chat.id,
+      chatName: chat.name,
+      mode: chat.mode,
+      groupId: chat.groupId,
+      characterIds: chat.characterIds,
+      personaId: chat.personaId,
+      connectionId: chat.connectionId,
+      promptPresetId: chat.promptPresetId,
+      branchName,
+    },
+  };
+}
+
+function chatTranscriptMessageRow(message: Message): ChatTranscriptMessageRow {
+  return {
+    rowType: "message",
+    name: speakerNameForMessage(message),
+    is_user: message.role === "user",
+    is_system: message.role === "system",
+    mes: message.content ?? "",
+    send_date: message.createdAt,
+    characterId: message.characterId,
+    role: message.role,
+  };
+}
+
+export function formatChatText(chat: Chat, messages: Message[]) {
+  const title = getChatNameForExport(chat) || chat.name || chat.id;
+  const header = [
+    `Chat: ${title}`,
+    `Mode: ${chat.mode}`,
+    `Created: ${chat.createdAt}`,
+    `Updated: ${chat.updatedAt}`,
+    chat.groupId ? `Group: ${chat.groupId}` : null,
+    getBranchName(chat) ? `Branch: ${getBranchName(chat)}` : null,
+  ].filter(Boolean);
+
+  const body = messages.map((message) => {
+    const timestamp = message.createdAt ? ` [${message.createdAt}]` : "";
+    return `${speakerNameForMessage(message)}${timestamp}\n${message.content ?? ""}`;
+  });
+
+  return [...header, "", ...body].join("\n\n");
 }
 
 export function formatChatJsonl(messages: Message[]) {
@@ -34,12 +133,47 @@ export function formatChatJsonl(messages: Message[]) {
   return jsonl ? `${jsonl}\n` : "";
 }
 
+function formatChatTranscriptJsonl(chat: Chat, messages: Message[]) {
+  const rows: ChatTranscriptJsonlRow[] = [
+    { format: "marinara-chat-transcript-jsonl", version: 1, rowType: "format" },
+    chatTranscriptHeaderRow(chat),
+    ...messages.map(chatTranscriptMessageRow),
+  ];
+  const jsonl = rows.map((row) => JSON.stringify(row)).join("\n");
+  return jsonl ? `${jsonl}\n` : "";
+}
+
+function chatTranscriptManifest(chats: Array<{ chat: Chat; messages: Message[] }>) {
+  return {
+    format: "marinara-chat-transcripts",
+    version: 1,
+    chats: chats.map(({ chat, messages }) => ({
+      id: chat.id,
+      name: chat.name,
+      mode: chat.mode,
+      groupId: chat.groupId,
+      branchName: getBranchName(chat),
+      characterIds: chat.characterIds,
+      personaId: chat.personaId,
+      connectionId: chat.connectionId,
+      promptPresetId: chat.promptPresetId,
+      messageCount: messages.length,
+    })),
+  };
+}
+
 export function buildChatTranscriptZipFiles(
   chats: Array<{ chat: Chat; messages: Message[] }>,
   format: ChatTranscriptExportFormat,
 ): StoredZipFile[] {
-  return chats.map(({ chat, messages }) => ({
-    name: chatExportFilename(chat, format),
-    data: format === "text" ? formatChatText(messages) : formatChatJsonl(messages),
-  }));
+  return [
+    {
+      name: "manifest.json",
+      data: JSON.stringify(chatTranscriptManifest(chats), null, 2),
+    },
+    ...chats.map(({ chat, messages }) => ({
+      name: chatExportFilename(chat, format),
+      data: format === "text" ? formatChatText(chat, messages) : formatChatTranscriptJsonl(chat, messages),
+    })),
+  ];
 }


### PR DESCRIPTION
## Linked issue

Closes #2308

## Why this change

- Refactor kept JSONL/text chat export affordances, but JSONL emitted raw Marinara message objects instead of the legacy/ST-compatible transcript rows.
- Sidebar Native JSON bulk chat export produced `format: "marinara-chat-bulk"` files with no matching recovery import route.

## What changed

- Restored single-chat JSONL export to emit a header row plus ST-compatible message rows with `name`, `is_user`, `is_system`, `mes`, and `send_date`.
- Restored text transcript context with chat metadata, speaker/display labels, and timestamps.
- Added a manifest to bulk JSONL/text ZIP exports so branch/group/roster metadata travels with the transcript files.
- Added native `marinara-chat-bulk` JSON recovery through Marinara file import, creating fresh chat/message IDs while preserving chat mode, roster, group, persona, connection, prompt preset, metadata, message content, and timestamps.
- Added Rust coverage for native chat-bulk importability and a negative-control JSON shape that must not match the chat-bulk importer.

## Refactor impact

Primary owner:

- Catalog chat export helpers and Rust storage/imports.

Impact areas reviewed:

- Chat/catalog export hook.
- Sidebar bulk export consumer.
- Settings Marinara file import route.
- Native import rollback behavior.

Boundary notes:

- React feature code still calls existing catalog export helpers.
- Import recovery stays inside the existing Rust Marinara file import path rather than adding a broad feature-side router or new raw invoke surface.
- No engine imports, remote-runtime allowlist changes, or command registration changes were needed.

Pressure points touched:

- `src/features/catalog/chats/lib/chat-transcript-export.ts`
- `src-tauri/src/commands/storage/imports/marinara.rs`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck`
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml marinara_file_import_`
- Scratch Vitest export-shape proof passed locally and was removed before commit.
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Compatibility fix for existing chat export/import affordances.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- No screenshots. Export/import data-shape change verified by focused command proof.
