### PR TITLE
Fix chat branch display labels

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -295,6 +295,25 @@ fn prune_branch_summary_metadata(chat: &mut Value) {
     }
 }
 
+fn initialize_branch_display_name(chat: &mut Value) {
+    let Some(object) = chat.as_object_mut() else {
+        return;
+    };
+    let metadata = object
+        .entry("metadata".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !metadata.is_object() {
+        *metadata = Value::Object(Map::new());
+    }
+    let Some(metadata) = metadata.as_object_mut() else {
+        return;
+    };
+    metadata.insert(
+        "branchName".to_string(),
+        Value::String("New Branch".to_string()),
+    );
+}
+
 fn object_extra(value: Option<&Value>) -> Option<Value> {
     json_object_value(value)
 }
@@ -1194,12 +1213,10 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
         .clone()
         .unwrap_or_else(|| chat_id.to_string());
     object.insert("id".to_string(), Value::String(new_chat_id.clone()));
-    object.insert(
-        "name".to_string(),
-        Value::String(format!("{base_name} Branch")),
-    );
+    object.insert("name".to_string(), Value::String(base_name));
     object.insert("groupId".to_string(), Value::String(group_id.clone()));
     prune_branch_summary_metadata(&mut chat);
+    initialize_branch_display_name(&mut chat);
     let source_has_tracker_snapshots =
         game_state_snapshots::latest_tracker_snapshot(state, chat_id)?.is_some();
     let mut new_chat = state.storage.create("chats", chat)?;
@@ -2168,6 +2185,57 @@ mod tests {
             .list_where("chats", &filters)
             .expect("group listing should not fail");
         assert_eq!(group_members.len(), 2);
+    }
+
+    #[test]
+    fn branch_chat_preserves_stable_name_and_sets_branch_display_name() {
+        let state = test_state("branch-display-name");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "root-1",
+                    "name": "Stable Chat Name",
+                    "mode": "conversation",
+                    "characterIds": [],
+                    "folderId": "folder-1",
+                    "metadata": {
+                        "tags": ["ongoing"]
+                    }
+                }),
+            )
+            .expect("source chat should be created");
+
+        let branch = branch_chat(&state, "root-1", json!({})).expect("branch should be created");
+
+        assert_eq!(branch["name"], "Stable Chat Name");
+        assert_eq!(branch["metadata"]["branchName"], "New Branch");
+        assert_eq!(branch["metadata"]["tags"], json!(["ongoing"]));
+        assert_eq!(branch["folderId"], "folder-1");
+
+        let source = state
+            .storage
+            .get("chats", "root-1")
+            .expect("source lookup should not fail")
+            .expect("source chat should still exist");
+        assert_eq!(source["name"], "Stable Chat Name");
+        assert_eq!(source["metadata"].get("branchName"), None);
+
+        let mut filters = Map::new();
+        filters.insert("groupId".to_string(), Value::String("root-1".to_string()));
+        let group_members = state
+            .storage
+            .list_where("chats", &filters)
+            .expect("group listing should not fail");
+        let grouped_branch = group_members
+            .iter()
+            .find(|chat| {
+                chat.get("id").and_then(Value::as_str) == branch.get("id").and_then(Value::as_str)
+            })
+            .expect("new branch should be visible in group list");
+        assert_eq!(grouped_branch["name"], "Stable Chat Name");
+        assert_eq!(grouped_branch["metadata"]["branchName"], "New Branch");
     }
 
     #[test]

--- a/src/features/modes/shared/chat-ui/components/ChatBranchSelector.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatBranchSelector.tsx
@@ -2,6 +2,7 @@ import { createPortal } from "react-dom";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, GitBranch, Loader2, MessageSquare } from "lucide-react";
 import { useChatGroup } from "../../../../catalog/chats/index";
+import { getChatDisplayName } from "../../../../../shared/lib/chat-display";
 import { useChatStore } from "../../../../../shared/stores/chat.store";
 import { cn } from "../../../../../shared/lib/utils";
 
@@ -91,7 +92,7 @@ export function ChatBranchSelector({
   if (!groupId) return null;
   if (!isLoading && branches.length <= 1) return null;
 
-  const branchLabel = currentBranch?.name ?? activeChatName ?? "Current branch";
+  const branchLabel = currentBranch ? getChatDisplayName(currentBranch) : (activeChatName ?? "Current branch");
   const buttonClassName =
     variant === "roleplay"
       ? "border border-foreground/10 bg-foreground/5 text-foreground/80 hover:bg-foreground/10 hover:text-foreground"
@@ -190,7 +191,7 @@ export function ChatBranchSelector({
                     </div>
 
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium">{branch.name}</div>
+                      <div className="truncate text-sm font-medium">{getChatDisplayName(branch)}</div>
                       <div className="text-[0.6875rem] text-[var(--muted-foreground)]">Updated {updatedAt}</div>
                     </div>
 


### PR DESCRIPTION
## Linked issue

Closes #2276

## Why this change

Refactor branch creation stored the new branch label by mutating the chat's stable `name` field to `{base_name} Branch`, while Manage Chat Files renames and displays branch labels through `metadata.branchName`. That let newly created and renamed branch labels drift between storage, Manage Chat Files, and the in-chat branch selector.

## What changed

- Preserve the source chat `name` when creating a branch.
- Initialize new branches with `metadata.branchName: "New Branch"` after pruning future summary metadata.
- Render branch selector labels with `getChatDisplayName`, matching Manage Chat Files.
- Add focused Rust storage proof for stable names, branch label metadata, folder carry-over, metadata carry-over, and branch-group list visibility.

## Refactor impact

Primary owner:

Rust storage, shared mode UI.

Impact areas reviewed:

- Chat branch creation in `src-tauri/src/commands/storage/chats.rs`.
- Branch group listing data consumed by Manage Chat Files and the branch selector.
- Shared chat display-name helper used by Manage Chat Files.

Boundary notes:

- Product storage behavior remains in `src-tauri`.
- React UI display behavior remains in `src/features/modes/shared/chat-ui`.
- No engine, shared API wrapper, or remote runtime routing changes.

Pressure points touched:

- Shared mode UI: `ChatBranchSelector`.
- Rust storage branch lifecycle: `branch_chat`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml branch_chat_` passed: 5 tests, including `branch_chat_preserves_stable_name_and_sets_branch_display_name`.
- `pnpm typecheck` passed.
- `pnpm check` ran through line endings, scratch, architecture, frontend, Rust, docs, discovery, launcher safety, and unused gates. The session ended immediately after starting the final unused gate, so `pnpm check:unused` was rerun separately and passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

This fixes existing branch label parity and does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not captured. The UI change routes branch selector text through the same display-name helper already used by Manage Chat Files; storage and typecheck proof are included above.
