### PR TITLE
Fix branch chat bootstrap game state fallback

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -1285,11 +1285,6 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
                 &new_chat_id,
                 json!({ "gameState": visible_game_state }),
             )?;
-        } else if !chat_game_state_is_bootstrap(&new_chat) {
-            new_chat =
-                state
-                    .storage
-                    .patch("chats", &new_chat_id, json!({ "gameState": Value::Null }))?;
         } else if let Some(bootstrap_game_state) =
             game_state_snapshots::copy_bootstrap_tracker_snapshot(state, chat_id, &new_chat_id)?
         {
@@ -1298,6 +1293,11 @@ pub(crate) fn branch_chat(state: &AppState, chat_id: &str, body: Value) -> AppRe
                 &new_chat_id,
                 json!({ "gameState": bootstrap_game_state }),
             )?;
+        } else if !chat_game_state_is_bootstrap(&new_chat) {
+            new_chat =
+                state
+                    .storage
+                    .patch("chats", &new_chat_id, json!({ "gameState": Value::Null }))?;
         }
     }
     Ok(new_chat)
@@ -2368,6 +2368,100 @@ mod tests {
                 .all(|message| message.get("content").and_then(Value::as_str)
                     != Some("You enter the future.")),
             "branch should not copy messages after the selected turn"
+        );
+    }
+
+    #[test]
+    fn branch_chat_preserves_bootstrap_game_state_when_no_message_snapshot_is_copied() {
+        let state = test_state("branch-game-bootstrap-tracker-state");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "game-root",
+                    "name": "Game Run",
+                    "mode": "game",
+                    "characterIds": [],
+                    "gameState": {
+                        "messageId": "assistant-2",
+                        "swipeIndex": 0,
+                        "location": "Future path",
+                        "recentEvents": ["future reached"]
+                    },
+                    "metadata": {}
+                }),
+            )
+            .expect("source game chat should be created");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "greeting-1",
+                    "chatId": "game-root",
+                    "role": "assistant",
+                    "content": "You wake at camp.",
+                    "createdAt": "2026-06-01T09:00:00.000Z"
+                }),
+            )
+            .expect("greeting message should be created");
+        state
+            .storage
+            .create(
+                "messages",
+                json!({
+                    "id": "assistant-2",
+                    "chatId": "game-root",
+                    "role": "assistant",
+                    "content": "You reach the pass.",
+                    "createdAt": "2026-06-01T10:00:00.000Z"
+                }),
+            )
+            .expect("future assistant message should be created");
+        game_state_snapshots::save_tracker_snapshot(
+            &state,
+            "game-root",
+            json!({
+                "messageId": "",
+                "swipeIndex": 0,
+                "location": "Camp",
+                "recentEvents": ["camp established"],
+                "committed": true
+            }),
+        )
+        .expect("bootstrap tracker snapshot should be saved");
+        game_state_snapshots::save_tracker_snapshot(
+            &state,
+            "game-root",
+            json!({
+                "messageId": "assistant-2",
+                "swipeIndex": 0,
+                "location": "Future path",
+                "recentEvents": ["future reached"],
+                "committed": true
+            }),
+        )
+        .expect("future tracker snapshot should be saved");
+
+        let branch = branch_chat(
+            &state,
+            "game-root",
+            json!({ "upToMessageId": "greeting-1" }),
+        )
+        .expect("branch should be created");
+
+        assert_eq!(branch["gameState"]["location"], "Camp");
+        assert_eq!(
+            branch["gameState"]["recentEvents"],
+            json!(["camp established"])
+        );
+        let branch_id = branch["id"].as_str().expect("branch id should be a string");
+        assert!(
+            game_state_snapshots::bootstrap_tracker_snapshot(&state, branch_id)
+                .expect("branch bootstrap snapshot lookup should not fail")
+                .is_some(),
+            "branch should copy the bootstrap tracker snapshot"
         );
     }
 


### PR DESCRIPTION
## Linked issue

Closes #2323

## Why this change

- Partial branches from tracker-backed game/roleplay chats could wipe the new branch's visible `gameState` when the copied message range had no active assistant tracker snapshot. The bootstrap tracker snapshot existed, but `branch_chat` nulled the cloned message-bound state before trying the bootstrap fallback.

## What changed

- Reordered `branch_chat` tracker fallback handling so it copies the bootstrap tracker snapshot before nulling a stale message-bound `gameState`.
- Added a Rust regression test for branching up to an early message that predates any copied per-message tracker snapshot.

## Refactor impact

Primary owner:

Rust storage (`src-tauri/src/commands/storage/chats.rs`)

Impact areas reviewed:

- Branch chat storage path
- Tracker snapshot copy path
- Game/roleplay world-state convenience field behavior

Boundary notes:

- Rust-only storage fix; no React, TypeScript engine, shared API, command registration, or remote-runtime boundary changes.

Pressure points touched:

- None of the listed pressure points; only existing Rust chat storage branching logic changed.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Reproduced before fix with `cargo test --manifest-path src-tauri/Cargo.toml branch_chat_preserves_bootstrap_game_state_when_no_message_snapshot_is_copied --lib`; failed with `left: Null`, `right: "Camp"`.
- After fix: `cargo test --manifest-path src-tauri/Cargo.toml branch_chat_ --lib` passed, 5 tests.
- After fix: `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- Pre-PR gate: `pnpm check` passed.
- Manual Tauri UI verification was not run; this is covered at the Rust storage behavior level.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix to existing branch-chat storage behavior; no new user-discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; Rust storage bugfix only, no visible UI surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat branching to properly preserve bootstrap tracker game state when creating conversation branches, ensuring consistent game context is maintained across branched conversations.

* **Tests**
  * Added unit test coverage for bootstrap game state preservation during chat branching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->