### PR TITLE
Fix chat validation parity

### DIFF
--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -621,10 +621,25 @@ pub(crate) fn bulk_delete_messages(
     let ids = body
         .get("messageIds")
         .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default();
+        .ok_or_else(|| AppError::invalid_input("messageIds must be an array of strings"))?;
+    if ids.iter().any(|id| !id.is_string()) {
+        return Err(AppError::invalid_input(
+            "messageIds must be an array of strings",
+        ));
+    }
     let mut deleted_ids = Vec::new();
-    for id in ids.iter().filter_map(Value::as_str) {
+    let requested_ids: Vec<&str> = ids
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .collect();
+    if requested_ids.is_empty() {
+        return Err(AppError::invalid_input(
+            "Deleting messages requires at least one message",
+        ));
+    }
+    for id in requested_ids {
         // Only delete messages that actually belong to this chat. Without the chatId check a
         // caller could pass message ids from another chat and destroy that chat's messages
         // (and their swipe sidecars) — the pre-scan must gate on parentage, not mere existence.
@@ -2990,6 +3005,26 @@ mod tests {
         assert_eq!(updated["swipeCount"], json!(2));
         assert_eq!(updated["content"], json!("first"));
         assert_eq!(updated["swipes"][1]["content"], json!("second"));
+    }
+
+    #[test]
+    fn bulk_delete_messages_rejects_empty_or_invalid_id_payloads() {
+        let state = test_state("bulk-delete-empty-invalid");
+        state
+            .storage
+            .create("chats", json!({ "id": "chat-1", "name": "Chat" }))
+            .expect("chat should seed");
+
+        for body in [
+            json!({ "messageIds": [] }),
+            json!({ "messageIds": [" ", ""] }),
+            json!({ "messageIds": ["message-1", 3] }),
+            json!({}),
+        ] {
+            let error = bulk_delete_messages(&state, "chat-1", body)
+                .expect_err("invalid bulk delete payload should reject");
+            assert_eq!(error.code, "invalid_input");
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1,5 +1,5 @@
 use super::{
-    avatars, characters, chats, connection_secrets, contracts, game_state_snapshots,
+    avatars, characters, chats, connection_secrets, contracts, game_state_snapshots, integrations,
     lorebook_images, media_uploads, message_swipes, personas, prompts, shared,
 };
 use crate::builtins::is_protected_record;
@@ -34,6 +34,104 @@ fn reject_message_swipe_mutation(entity: &str) -> Result<(), AppError> {
         return Err(AppError::invalid_input(
             "message-swipes is internal sidecar storage; mutate swipes through message commands",
         ));
+    }
+    Ok(())
+}
+
+fn validate_chat_metadata_patch(
+    state: &AppState,
+    chat_id: &str,
+    patch: &mut Value,
+) -> Result<(), AppError> {
+    let mut metadata_patch = match patch.get("metadata") {
+        Some(Value::Object(object)) => Some(object.clone()),
+        Some(_) => return Err(AppError::invalid_input("Chat metadata must be an object")),
+        None => None,
+    };
+    if metadata_patch.is_none() && patch.get("characterIds").is_none() {
+        return Ok(());
+    };
+
+    if let Some(metadata_object) = metadata_patch.as_mut() {
+        if let Some(webhook_url) = metadata_object.get_mut("discordWebhookUrl") {
+            if webhook_url.is_null() {
+                // Null clears the setting.
+            } else if let Some(raw_url) = webhook_url.as_str() {
+                let trimmed_url = raw_url.trim();
+                if !trimmed_url.is_empty()
+                    && !integrations::is_valid_discord_webhook_url(trimmed_url)
+                {
+                    return Err(AppError::invalid_input("Invalid Discord webhook URL"));
+                }
+                if trimmed_url != raw_url {
+                    *webhook_url = Value::String(trimmed_url.to_string());
+                }
+            } else {
+                return Err(AppError::invalid_input(
+                    "Discord webhook URL must be a string",
+                ));
+            }
+        }
+    }
+
+    let chat = state
+        .storage
+        .get("chats", chat_id)?
+        .ok_or_else(|| AppError::not_found(format!("Chat {chat_id} was not found")))?;
+    let active_ids_source = patch
+        .get("characterIds")
+        .or_else(|| chat.get("characterIds"));
+    let active_ids: HashSet<String> = shared::string_array_from_value(active_ids_source)
+        .into_iter()
+        .collect();
+    let mut effective_metadata = shared::json_object_value(chat.get("metadata"))
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    let submitted_inactive = metadata_patch
+        .as_ref()
+        .and_then(|metadata| metadata.get("inactiveCharacterIds"))
+        .cloned();
+    if let Some(metadata_patch) = metadata_patch {
+        for (key, value) in metadata_patch {
+            effective_metadata.insert(key, value);
+        }
+    }
+
+    let inactive_value = submitted_inactive
+        .as_ref()
+        .or_else(|| effective_metadata.get("inactiveCharacterIds"));
+    let Some(inactive_value) = inactive_value else {
+        if patch.get("metadata").is_some() {
+            patch["metadata"] = Value::Object(effective_metadata);
+        }
+        return Ok(());
+    };
+    let Some(inactive_ids) = inactive_value.as_array() else {
+        return Err(AppError::invalid_input(
+            "inactiveCharacterIds must be an array of strings",
+        ));
+    };
+    if inactive_ids.iter().any(|id| !id.is_string()) {
+        return Err(AppError::invalid_input(
+            "inactiveCharacterIds must be an array of strings",
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    let normalized: Vec<Value> = inactive_ids
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty() && active_ids.contains(*id))
+        .filter(|id| seen.insert((*id).to_string()))
+        .map(|id| Value::String(id.to_string()))
+        .collect();
+    let normalized_value = Value::Array(normalized);
+    let inactive_changed =
+        effective_metadata.get("inactiveCharacterIds") != Some(&normalized_value);
+    effective_metadata.insert("inactiveCharacterIds".to_string(), normalized_value);
+    if patch.get("metadata").is_some() || inactive_changed {
+        patch["metadata"] = Value::Object(effective_metadata);
     }
     Ok(())
 }
@@ -643,8 +741,11 @@ pub(crate) fn storage_update_inner(
     }
     validate_chat_folder_for_patch(state, &entity, &id, &patch)?;
     validate_connection_folder_for_patch(state, &entity, &patch)?;
-    let normalized_patch =
+    let mut normalized_patch =
         normalize_chat_for_update(&entity, shared::normalize_update_patch(&entity, patch)?)?;
+    if entity == "chats" {
+        validate_chat_metadata_patch(state, &id, &mut normalized_patch)?;
+    }
     if entity == "lorebook-entries" {
         return update_lorebook_entry_with_character_book_sync(state, &id, normalized_patch);
     }
@@ -2228,6 +2329,131 @@ mod tests {
             .expect("connection should read")
             .and_then(|row| row.get("defaultForAgents").and_then(Value::as_bool))
             .unwrap_or(false)
+    }
+
+    #[test]
+    fn chat_metadata_patch_rejects_invalid_discord_webhook_url() {
+        let state = test_state("chat-metadata-invalid-discord-webhook");
+        storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({ "id": "chat-a", "name": "Chat A", "metadata": {} }),
+        )
+        .expect("chat should seed");
+
+        let error = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({ "metadata": { "discordWebhookUrl": "not-a-discord-webhook" } }),
+        )
+        .expect_err("invalid Discord webhook metadata should reject");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Invalid Discord webhook URL"));
+    }
+
+    #[test]
+    fn chat_metadata_patch_normalizes_inactive_character_ids() {
+        let state = test_state("chat-metadata-inactive-characters");
+        storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "characterIds": ["char-a", "char-b"],
+                "metadata": { "theme": "kept" }
+            }),
+        )
+        .expect("chat should seed");
+
+        let updated = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({ "metadata": { "inactiveCharacterIds": [" char-a ", "missing", "char-a", "char-b"] } }),
+        )
+        .expect("valid inactive character metadata should update");
+
+        assert_eq!(
+            updated["metadata"]["inactiveCharacterIds"],
+            json!(["char-a", "char-b"])
+        );
+        assert_eq!(updated["metadata"]["theme"], json!("kept"));
+
+        let error = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({ "metadata": { "inactiveCharacterIds": ["char-a", 3] } }),
+        )
+        .expect_err("non-string inactive character ids should reject");
+        assert_eq!(error.code, "invalid_input");
+    }
+
+    #[test]
+    fn chat_metadata_patch_prunes_stored_inactive_ids_after_character_patch() {
+        let state = test_state("chat-character-patch-prunes-inactive");
+        storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "characterIds": ["char-a", "char-b"],
+                "metadata": {
+                    "inactiveCharacterIds": ["char-b"],
+                    "theme": "kept"
+                }
+            }),
+        )
+        .expect("chat should seed");
+
+        let updated = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({ "characterIds": ["char-a"] }),
+        )
+        .expect("character-only patch should prune stale inactive ids");
+
+        assert_eq!(updated["characterIds"], json!(["char-a"]));
+        assert_eq!(updated["metadata"]["inactiveCharacterIds"], json!([]));
+        assert_eq!(updated["metadata"]["theme"], json!("kept"));
+    }
+
+    #[test]
+    fn chat_metadata_patch_normalizes_inactive_ids_against_patched_character_ids() {
+        let state = test_state("chat-metadata-inactive-patched-characters");
+        storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "characterIds": ["char-a", "char-b"],
+                "metadata": {}
+            }),
+        )
+        .expect("chat should seed");
+
+        let updated = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({
+                "characterIds": ["char-c"],
+                "metadata": { "inactiveCharacterIds": ["char-a", "char-c"] }
+            }),
+        )
+        .expect("same patch should use the patched chat membership");
+
+        assert_eq!(updated["characterIds"], json!(["char-c"]));
+        assert_eq!(
+            updated["metadata"]["inactiveCharacterIds"],
+            json!(["char-c"])
+        );
     }
 
     fn seed_linked_character_book(state: &AppState) {

--- a/src-tauri/src/commands/storage/integrations.rs
+++ b/src-tauri/src/commands/storage/integrations.rs
@@ -40,3 +40,7 @@ pub(crate) async fn haptic_call(rest: &[&str], body: Value) -> AppResult<Value> 
 pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
     discord::discord_webhook_send(body).await
 }
+
+pub(crate) fn is_valid_discord_webhook_url(raw: &str) -> bool {
+    discord::is_valid_discord_webhook_url(raw)
+}

--- a/src-tauri/src/commands/storage/integrations/discord.rs
+++ b/src-tauri/src/commands/storage/integrations/discord.rs
@@ -84,7 +84,7 @@ fn truncate_chars(value: &str, limit: usize) -> String {
     value.chars().take(limit).collect()
 }
 
-fn is_valid_discord_webhook_url(raw: &str) -> bool {
+pub(crate) fn is_valid_discord_webhook_url(raw: &str) -> bool {
     let trimmed = raw.trim();
     let Some(rest) = trimmed
         .strip_prefix("https://discord.com/api/webhooks/")

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -578,19 +578,30 @@ export function useDeleteMessage(chatId: string | null) {
   });
 }
 
+function compactMessageIdList(messageIds: string[]): string[] {
+  return Array.from(new Set(messageIds.map((id) => id.trim()).filter(Boolean)));
+}
+
+function requireMessageIdList(messageIds: string[], action: string): string[] {
+  const uniqueIds = compactMessageIdList(messageIds);
+  if (uniqueIds.length === 0) throw new Error(`${action} requires at least one message.`);
+  return uniqueIds;
+}
+
 export function useDeleteMessages(chatId: string | null) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (messageIds: string[]) => {
       if (!chatId) throw new Error("Chat was not found.");
-      const uniqueIds = Array.from(new Set(messageIds.filter((id) => id.trim().length > 0)));
+      const uniqueIds = requireMessageIdList(messageIds, "Deleting messages");
       const result = await chatCommandApi.bulkDeleteMessages(chatId, uniqueIds);
       assertDeletedMessages(result, uniqueIds.length);
       return result;
     },
     onMutate: (messageIds: string[]) => {
       if (!chatId) return;
-      const uniqueIds = Array.from(new Set(messageIds.filter((id) => id.trim().length > 0)));
+      const uniqueIds = compactMessageIdList(messageIds);
+      if (uniqueIds.length === 0) return;
       const idSet = new Set(uniqueIds);
       void qc.cancelQueries({ queryKey: chatKeys.messages(chatId), exact: true }).catch(() => undefined);
       const previousMessages = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId));
@@ -719,7 +730,7 @@ export function useBulkSetMessagesHiddenFromAI(chatId: string | null) {
   return useMutation({
     mutationFn: async ({ messageIds, hidden }: { messageIds: string[]; hidden: boolean }) => {
       if (!chatId) throw new Error("Chat was not found.");
-      const uniqueIds = Array.from(new Set(messageIds.filter((id) => id.trim().length > 0)));
+      const uniqueIds = requireMessageIdList(messageIds, "Updating hidden message state");
       await Promise.all(
         uniqueIds.map(async (messageId) => {
           const message = await storageApi.get<Message>("messages", messageId);
@@ -731,9 +742,11 @@ export function useBulkSetMessagesHiddenFromAI(chatId: string | null) {
     },
     onMutate: async ({ messageIds, hidden }) => {
       if (!chatId) return;
+      const uniqueIds = compactMessageIdList(messageIds);
+      if (uniqueIds.length === 0) return;
       await qc.cancelQueries({ queryKey: chatKeys.messages(chatId) });
       const previous = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId));
-      const idSet = new Set(messageIds);
+      const idSet = new Set(uniqueIds);
       qc.setQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId), (old) => {
         if (!old?.pages) return old;
         return {

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -194,11 +194,55 @@ function chatMessageSwipeBody(content: string, options?: AddChatMessageSwipeOpti
   return body;
 }
 
-async function patchChatObjectField<T>(chatId: string, field: string, patch: Record<string, unknown>): Promise<T> {
-  const chat = await storageApi.get<Record<string, unknown>>("chats", chatId, { fields: [field] });
+const DISCORD_WEBHOOK_URL_PATTERN = /^https:\/\/discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/;
+
+function normalizeChatInactiveCharacterIds(chat: Record<string, unknown>, value: unknown): string[] {
+  if (!Array.isArray(value) || value.some((id) => typeof id !== "string")) {
+    throw new ApiError("inactiveCharacterIds must be an array of strings", 400);
+  }
+  const activeIds = new Set(
+    Array.isArray(chat.characterIds) ? chat.characterIds.filter((id) => typeof id === "string") : [],
+  );
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const rawId of value) {
+    const id = rawId.trim();
+    if (!id || !activeIds.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push(id);
+  }
+  return normalized;
+}
+
+function normalizeChatMetadataPatch(
+  chat: Record<string, unknown>,
+  current: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const metadata = { ...current, ...patch };
+  if (Object.prototype.hasOwnProperty.call(patch, "discordWebhookUrl")) {
+    const value = patch.discordWebhookUrl;
+    if (value !== undefined && value !== null) {
+      if (typeof value !== "string") throw new ApiError("Discord webhook URL must be a string", 400);
+      const trimmed = value.trim();
+      if (trimmed && !DISCORD_WEBHOOK_URL_PATTERN.test(trimmed)) {
+        throw new ApiError("Invalid Discord webhook URL", 400);
+      }
+      metadata.discordWebhookUrl = trimmed || undefined;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, "inactiveCharacterIds")) {
+    metadata.inactiveCharacterIds = normalizeChatInactiveCharacterIds(chat, patch.inactiveCharacterIds);
+  }
+  return metadata;
+}
+
+async function patchChatMetadataField<T>(chatId: string, patch: Record<string, unknown>): Promise<T> {
+  const chat = await storageApi.get<Record<string, unknown>>("chats", chatId, { fields: ["metadata", "characterIds"] });
   if (!chat) throw new ApiError(`Chat ${chatId} was not found`, 404);
-  const current = asRecord(chat[field]);
-  return storageApi.update<T>("chats", chatId, { [field]: { ...current, ...patch } });
+  return storageApi.update<T>("chats", chatId, {
+    metadata: normalizeChatMetadataPatch(chat, asRecord(chat.metadata), patch),
+  });
 }
 
 // Day/week summary maps live inside chat metadata, but callers send only the
@@ -428,7 +472,7 @@ export const storageApi: StorageGateway = {
     }),
   evictPromptSnapshots: (chatId, keepLast) =>
     invokeTauri("chat_evict_prompt_snapshots", { chatId, keepLast }) as Promise<{ evicted: number }>,
-  patchChatMetadata: (chatId, patch) => patchChatObjectField(chatId, "metadata", patch),
+  patchChatMetadata: (chatId, patch) => patchChatMetadataField(chatId, patch),
   patchChatSummaries: (chatId, patch) => patchChatSummariesField(chatId, patch),
   listChatMemories: <T = unknown>(chatId: string, options?: ListChatMemoriesOptions) =>
     chatCommandApi.memoriesList<T[]>(chatId, options),


### PR DESCRIPTION
## Linked issue

Closes #2275

## Why this change

`09-CHAT-ERROR-chat-message-validation` had parity gaps where refactor accepted chat metadata and bulk message payloads that legacy rejected or normalized.

## What changed

- Reject invalid Discord webhook URLs on chat metadata writes.
- Require `inactiveCharacterIds` to be an array of strings and normalize it to IDs present in the chat.
- Reject empty, blank-only, or invalid bulk message delete payloads instead of returning successful no-ops.
- Reject empty bulk hidden-message updates in the shared chat hook before optimistic cache changes.

## Refactor impact

Primary owner:

Rust storage, shared API, shared chat catalog hooks

Impact areas reviewed:

- Chat metadata durable write path
- Bulk message delete command
- Shared chat hook optimistic updates
- Embedded and hostable invoke path through shared `storage_update`

Boundary notes:

- Validation sits at the durable Rust storage update boundary for raw `storage_update` callers.
- `src/shared/api/storage-api.ts` mirrors the user-facing validation before crossing the runtime adapter.
- No engine imports from React, Tauri, or feature internals were added.

Pressure points touched:

- `src-tauri/src/commands/storage/commands/entities.rs`
- `src-tauri/src/commands/storage/chats.rs`
- `src/shared/api/storage-api.ts`
- `src/features/catalog/chats/hooks/use-chats.ts`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml chat_metadata_patch`
- `cargo test --manifest-path src-tauri/Cargo.toml bulk_delete_messages_rejects_empty_or_invalid_id_payloads`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `git diff --check`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Validation parity fix only; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes; validation/storage behavior only.
