### PR TITLE
Run ST bulk import stream on blocking pool

### DIFF
--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -972,11 +972,23 @@ async fn import_st_bulk_run_stream(
     tokio::spawn(async move {
         let started = Instant::now();
         request_log("import_st_bulk_run_stream started");
-        let result =
-            imports::import_stream_callback(&state.app, &["st-bulk", "run"], body, |event| {
-                tx.send(Ok(Event::default().data(event.to_string())))
+        let import_state = state.app.clone();
+        let progress_tx = tx.clone();
+        let result = match tokio::task::spawn_blocking(move || {
+            imports::import_stream_callback(&import_state, &["st-bulk", "run"], body, |event| {
+                progress_tx
+                    .send(Ok(Event::default().data(event.to_string())))
                     .map_err(|error| AppError::new("sse_stream_error", error.to_string()))
-            });
+            })
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => Err(AppError::new(
+                "import_st_bulk_task_error",
+                error.to_string(),
+            )),
+        };
 
         match result {
             Ok(()) => {

--- a/src/features/shell/plugins/components/CoreModulesSettings.tsx
+++ b/src/features/shell/plugins/components/CoreModulesSettings.tsx
@@ -17,7 +17,7 @@ function permissionLabel(permission: string) {
 }
 
 function CoreModulesSettings() {
-  const { data: modules = [], error, isError, isLoading, refetch, isFetching } = useCoreModules();
+  const { data: modules, error, isError, isLoading, refetch, isFetching } = useCoreModules();
   const setEnabled = useSetCoreModuleEnabled();
   const controlsDisabled = setEnabled.isPending || isError;
 
@@ -54,14 +54,20 @@ function CoreModulesSettings() {
       </div>
 
       <div className="flex flex-col gap-2">
-        {isError && (
+        {isLoading && (
+          <p className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-3 text-center text-xs text-[var(--muted-foreground)]">
+            Loading core modules...
+          </p>
+        )}
+
+        {!isLoading && isError && (
           <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs leading-snug text-[var(--foreground)]">
             Core modules are registered, but Marinara could not read module settings from app storage.{" "}
             {error instanceof Error ? error.message : "Open this in the Tauri app shell and try again."}
           </div>
         )}
 
-        {modules.map((module) => (
+        {!isLoading && !isError && modules?.map((module) => (
           <article
             key={module.id}
             className={cn(
@@ -175,7 +181,7 @@ function CoreModulesSettings() {
           </article>
         ))}
 
-        {!isLoading && modules.length === 0 && (
+        {!isLoading && !isError && modules?.length === 0 && (
           <p className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-3 text-center text-xs text-[var(--muted-foreground)]">
             No core modules are registered in this build.
           </p>

--- a/src/features/shell/plugins/hooks/use-core-modules.ts
+++ b/src/features/shell/plugins/hooks/use-core-modules.ts
@@ -2,8 +2,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { coreModulesApi } from "../../../../shared/api/core-modules-api";
 import { coreModuleViews, enabledCoreModuleStyles, isCoreModuleEnabled } from "../lib/core-module-registry";
 
-const DEFAULT_CORE_MODULE_SETTINGS = { enabled: {} };
-
 const coreModuleKeys = {
   all: ["core-modules"] as const,
   settings: () => [...coreModuleKeys.all, "settings"] as const,
@@ -23,7 +21,7 @@ export function useCoreModules() {
   const query = useCoreModuleSettings();
   return {
     ...query,
-    data: coreModuleViews(query.data ?? DEFAULT_CORE_MODULE_SETTINGS),
+    data: query.data ? coreModuleViews(query.data) : undefined,
   };
 }
 
@@ -48,7 +46,8 @@ export function useSetCoreModuleEnabled() {
   return useMutation({
     mutationFn: ({ moduleId, enabled }: { moduleId: string; enabled: boolean }) =>
       coreModulesApi.settings.setEnabled(moduleId, enabled),
-    onSuccess: () => {
+    onSuccess: (settings) => {
+      qc.setQueryData(coreModuleKeys.settings(), settings);
       qc.invalidateQueries({ queryKey: coreModuleKeys.all });
     },
   });

--- a/src/features/shell/plugins/settings.ts
+++ b/src/features/shell/plugins/settings.ts
@@ -1,0 +1,1 @@
+export { default as CoreModulesSettings } from "./components/CoreModulesSettings";

--- a/src/features/shell/plugins/shell.ts
+++ b/src/features/shell/plugins/shell.ts
@@ -1,2 +1,1 @@
 export * from "./components/CoreModuleRuntimeProvider";
-export { default as CoreModulesSettings } from "./components/CoreModulesSettings";

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -22,7 +22,7 @@ import { cn } from "../../../../shared/lib/utils";
 import { TEMPERATURE_UNITS } from "../../../../shared/lib/temperature-units";
 import { QUOTE_FORMATS } from "../../../../shared/lib/dialogue-quotes";
 import { useExtensions, useCreateExtension, useDeleteExtension, useUpdateExtension } from "../hooks/use-extensions";
-import { CoreModulesSettings } from "../../plugins/shell";
+import { CoreModulesSettings } from "../../plugins/settings";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { gameAssetsApi } from "../../../../shared/api/assets-api";
 import { openExternalUrl } from "../../../../shared/api/external-link-api";


### PR DESCRIPTION
## Linked issue

Closes #2331

## Why this change

- The server-runtime ST bulk import SSE route ran synchronous import work on a Tokio async worker, which could starve concurrent server requests during large imports.
- The current Settings surface still has a discoverable Plugins/Core Modules entrypoint, so the PR keeps that surface attached while making its loading/error state explicit.

## What changed

- Moved the synchronous ST bulk import callback into `tokio::task::spawn_blocking`.
- Kept SSE progress/error forwarding through the existing unbounded channel.
- Added a join-error mapping for failed blocking tasks.
- Kept core module settings attached through a focused `plugins/settings` entrypoint.
- Changed core module settings UI so loading/error states do not render fallback module cards as persisted state.
- Seeded the core module settings query cache from successful toggle mutations before invalidating/refetching.

## Refactor impact

Primary owner:

Rust remote runtime HTTP route / imports; shell plugin settings

Impact areas reviewed:

- `/api/import/st-bulk/run` SSE route
- ST bulk import callback progress, done, and error event contract
- Sibling profile import streaming route pattern
- Core module settings loading, error, and mutation state

Boundary notes:

- Dedicated `src-tauri/src/http_server.rs` route for the import fix.
- Shell settings import core module settings through the focused `src/features/shell/plugins/settings.ts` entrypoint.
- No engine, shared API, command registration, or import service behavior changed.
- Remote-capable behavior stays inside the existing Rust HTTP/import pipeline.

Pressure points touched:

- `src-tauri/src/http_server.rs` dedicated streaming route.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- `pnpm check:unused`
- `pnpm typecheck`
- `pnpm check`
- Static review verified the core module settings UI now renders loading/error bodies without fallback module cards.
- Live large ST bulk import concurrency test was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Keeps the existing Discover entrypoint and settings surface wired; does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. No new visible layout changes beyond preserving the existing core module settings surface and clarifying loading/error content.