### PR TITLE
Clean agent bookkeeping on chat delete

### DIFF
--- a/src-tauri/src/commands/storage/agents.rs
+++ b/src-tauri/src/commands/storage/agents.rs
@@ -101,6 +101,13 @@ fn memory_chat_id(memory: &Value) -> Option<&str> {
         .and_then(Value::as_str)
 }
 
+fn memory_agent_config_id(memory: &Value) -> Option<&str> {
+    memory
+        .get("agentConfigId")
+        .or_else(|| memory.get("agent_config_id"))
+        .and_then(Value::as_str)
+}
+
 fn run_agent_config_id(run: &Value) -> Option<&str> {
     run.get("agentConfigId")
         .or_else(|| run.get("agent_config_id"))
@@ -392,14 +399,8 @@ fn read_agent_memory(
     agent_config_id: &str,
     chat_id: &str,
 ) -> AppResult<Map<String, Value>> {
-    let mut filters = Map::new();
-    filters.insert(
-        "agentConfigId".to_string(),
-        Value::String(agent_config_id.to_string()),
-    );
-    filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
     let mut memory = Map::new();
-    for row in state.storage.list_where("agent-memory", &filters)? {
+    for row in agent_memory_rows_for_chat_config(state, agent_config_id, chat_id)? {
         let Some(key) = row.get("key").and_then(Value::as_str) else {
             continue;
         };
@@ -413,6 +414,22 @@ fn read_agent_memory(
     Ok(memory)
 }
 
+fn agent_memory_rows_for_chat_config(
+    state: &AppState,
+    agent_config_id: &str,
+    chat_id: &str,
+) -> AppResult<Vec<Value>> {
+    Ok(state
+        .storage
+        .list("agent-memory")?
+        .into_iter()
+        .filter(|row| {
+            memory_agent_config_id(row) == Some(agent_config_id)
+                && memory_chat_id(row) == Some(chat_id)
+        })
+        .collect())
+}
+
 fn set_agent_memory_value(
     state: &AppState,
     agent_config_id: &str,
@@ -420,21 +437,19 @@ fn set_agent_memory_value(
     key: &str,
     value: Value,
 ) -> AppResult<()> {
-    let mut filters = Map::new();
-    filters.insert(
-        "agentConfigId".to_string(),
-        Value::String(agent_config_id.to_string()),
-    );
-    filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
-    filters.insert("key".to_string(), Value::String(key.to_string()));
     let stored_value = match value {
         Value::String(raw) => Value::String(raw),
         other => Value::String(serde_json::to_string(&other)?),
     };
     if let Some(existing) = state
         .storage
-        .list_where("agent-memory", &filters)?
+        .list("agent-memory")?
         .into_iter()
+        .filter(|row| {
+            memory_agent_config_id(row) == Some(agent_config_id)
+                && memory_chat_id(row) == Some(chat_id)
+                && row.get("key").and_then(Value::as_str) == Some(key)
+        })
         .next()
     {
         let id = existing
@@ -459,13 +474,7 @@ fn set_agent_memory_value(
 }
 
 fn clear_agent_memory(state: &AppState, agent_config_id: &str, chat_id: &str) -> AppResult<()> {
-    let mut filters = Map::new();
-    filters.insert(
-        "agentConfigId".to_string(),
-        Value::String(agent_config_id.to_string()),
-    );
-    filters.insert("chatId".to_string(), Value::String(chat_id.to_string()));
-    for row in state.storage.list_where("agent-memory", &filters)? {
+    for row in agent_memory_rows_for_chat_config(state, agent_config_id, chat_id)? {
         if let Some(id) = row.get("id").and_then(Value::as_str) {
             state.storage.delete("agent-memory", id)?;
         }
@@ -529,6 +538,113 @@ mod tests {
                 }),
             )
             .expect("message should write");
+    }
+
+    #[test]
+    fn clear_agent_bookkeeping_preserves_legacy_secret_plot_arc() {
+        let state = test_state("legacy-secret-plot-arc");
+        state
+            .storage
+            .upsert_with_id(
+                "agents",
+                "secret-plot-agent",
+                json!({
+                    "id": "secret-plot-agent",
+                    "type": "secret-plot-driver",
+                    "name": "Secret Plot Driver",
+                    "settings": {}
+                }),
+            )
+            .expect("secret plot agent should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "legacy-secret-arc",
+                json!({
+                    "id": "legacy-secret-arc",
+                    "agent_config_id": "secret-plot-agent",
+                    "chat_id": "chat-1",
+                    "key": "overarchingArc",
+                    "value": "legacy arc"
+                }),
+            )
+            .expect("legacy secret plot memory should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "legacy-director-note",
+                json!({
+                    "id": "legacy-director-note",
+                    "agent_config_id": "agent-director",
+                    "chat_id": "chat-1",
+                    "key": "note",
+                    "value": "delete me"
+                }),
+            )
+            .expect("legacy ordinary memory should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "legacy-other-chat-note",
+                json!({
+                    "id": "legacy-other-chat-note",
+                    "agent_config_id": "agent-director",
+                    "chat_id": "other-chat",
+                    "key": "note",
+                    "value": "keep me"
+                }),
+            )
+            .expect("legacy other chat memory should write");
+
+        let result = clear_agent_runs_and_memory_for_chat(&state, "chat-1")
+            .expect("agent bookkeeping clear should succeed");
+
+        assert_eq!(result["deletedMemory"], json!(2));
+        assert_eq!(result["preservedSecretPlotArc"], json!(true));
+        assert!(
+            state
+                .storage
+                .get("agent-memory", "legacy-secret-arc")
+                .expect("legacy secret arc lookup should succeed")
+                .is_none(),
+            "legacy secret plot row should be replaced by the preserved current row"
+        );
+        assert!(
+            state
+                .storage
+                .get("agent-memory", "legacy-director-note")
+                .expect("legacy ordinary row lookup should succeed")
+                .is_none(),
+            "ordinary legacy memory for the cleared chat should be removed"
+        );
+        assert!(
+            state
+                .storage
+                .get("agent-memory", "legacy-other-chat-note")
+                .expect("legacy other chat row lookup should succeed")
+                .is_some(),
+            "legacy memory for other chats should stay"
+        );
+
+        let rows = state
+            .storage
+            .list("agent-memory")
+            .expect("agent memory should be readable");
+        let restored_arc = rows
+            .iter()
+            .find(|row| {
+                row.get("chatId").and_then(Value::as_str) == Some("chat-1")
+                    && row.get("agentConfigId").and_then(Value::as_str) == Some("secret-plot-agent")
+                    && row.get("key").and_then(Value::as_str) == Some("overarchingArc")
+            })
+            .expect("secret plot arc should be restored in current shape");
+        assert_eq!(
+            restored_arc.get("value").and_then(Value::as_str),
+            Some("legacy arc")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/agents.rs
+++ b/src-tauri/src/commands/storage/agents.rs
@@ -94,6 +94,13 @@ fn run_chat_id(run: &Value) -> Option<&str> {
         .and_then(Value::as_str)
 }
 
+fn memory_chat_id(memory: &Value) -> Option<&str> {
+    memory
+        .get("chatId")
+        .or_else(|| memory.get("chat_id"))
+        .and_then(Value::as_str)
+}
+
 fn run_agent_config_id(run: &Value) -> Option<&str> {
     run.get("agentConfigId")
         .or_else(|| run.get("agent_config_id"))
@@ -347,13 +354,7 @@ pub(crate) fn clear_agent_runs_and_memory_for_chat(
         }
     }
 
-    let deleted_runs = state
-        .storage
-        .delete_where_matching("agent-runs", |row| run_chat_id(row) == Some(chat_id))?;
-
-    let deleted_memory = state.storage.delete_where_matching("agent-memory", |row| {
-        row.get("chatId").and_then(Value::as_str) == Some(chat_id)
-    })?;
+    let (deleted_runs, deleted_memory) = delete_agent_bookkeeping_rows_for_chat(state, chat_id)?;
 
     let preserved_secret_plot_arc = secret_plot_config_id.is_some() && preserved_arc.is_some();
     if let (Some(config_id), Some(arc)) = (secret_plot_config_id, preserved_arc) {
@@ -365,6 +366,25 @@ pub(crate) fn clear_agent_runs_and_memory_for_chat(
         "deletedMemory": deleted_memory,
         "preservedSecretPlotArc": preserved_secret_plot_arc
     }))
+}
+
+pub(crate) fn delete_agent_bookkeeping_for_chat(state: &AppState, chat_id: &str) -> AppResult<()> {
+    delete_agent_bookkeeping_rows_for_chat(state, chat_id).map(|_| ())
+}
+
+fn delete_agent_bookkeeping_rows_for_chat(
+    state: &AppState,
+    chat_id: &str,
+) -> AppResult<(usize, usize)> {
+    let deleted_runs = state
+        .storage
+        .delete_where_matching("agent-runs", |row| run_chat_id(row) == Some(chat_id))?;
+
+    let deleted_memory = state
+        .storage
+        .delete_where_matching("agent-memory", |row| memory_chat_id(row) == Some(chat_id))?;
+
+    Ok((deleted_runs, deleted_memory))
 }
 
 fn read_agent_memory(

--- a/src-tauri/src/commands/storage/agents.rs
+++ b/src-tauri/src/commands/storage/agents.rs
@@ -441,7 +441,7 @@ fn set_agent_memory_value(
         Value::String(raw) => Value::String(raw),
         other => Value::String(serde_json::to_string(&other)?),
     };
-    if let Some(existing) = state
+    let matching_rows = state
         .storage
         .list("agent-memory")?
         .into_iter()
@@ -450,15 +450,39 @@ fn set_agent_memory_value(
                 && memory_chat_id(row) == Some(chat_id)
                 && row.get("key").and_then(Value::as_str) == Some(key)
         })
-        .next()
-    {
+        .collect::<Vec<_>>();
+    if !matching_rows.is_empty() {
+        let existing = matching_rows
+            .iter()
+            .find(|row| {
+                row.get("agentConfigId").and_then(Value::as_str) == Some(agent_config_id)
+                    && row.get("chatId").and_then(Value::as_str) == Some(chat_id)
+            })
+            .or_else(|| matching_rows.first())
+            .expect("matching rows should not be empty");
         let id = existing
             .get("id")
             .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
             .ok_or_else(|| AppError::invalid_input("Agent memory row is missing id"))?;
-        state
-            .storage
-            .patch("agent-memory", id, json!({ "value": stored_value }))?;
+        state.storage.patch(
+            "agent-memory",
+            &id,
+            json!({
+                "agentConfigId": agent_config_id,
+                "chatId": chat_id,
+                "key": key,
+                "value": stored_value
+            }),
+        )?;
+        for duplicate in matching_rows {
+            let Some(duplicate_id) = duplicate.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            if duplicate_id != id {
+                state.storage.delete("agent-memory", duplicate_id)?;
+            }
+        }
     } else {
         state.storage.create(
             "agent-memory",
@@ -645,6 +669,123 @@ mod tests {
             restored_arc.get("value").and_then(Value::as_str),
             Some("legacy arc")
         );
+    }
+
+    #[test]
+    fn set_agent_memory_value_normalizes_legacy_only_row() {
+        let state = test_state("legacy-memory-write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "legacy-note",
+                json!({
+                    "id": "legacy-note",
+                    "agent_config_id": "agent-director",
+                    "chat_id": "chat-1",
+                    "key": "note",
+                    "value": "old"
+                }),
+            )
+            .expect("legacy memory should write");
+
+        set_agent_memory_value(&state, "agent-director", "chat-1", "note", json!("updated"))
+            .expect("memory write should succeed");
+
+        let row = state
+            .storage
+            .get("agent-memory", "legacy-note")
+            .expect("memory lookup should succeed")
+            .expect("legacy row should be normalized in place");
+        assert_eq!(
+            row.get("agentConfigId").and_then(Value::as_str),
+            Some("agent-director")
+        );
+        assert_eq!(row.get("chatId").and_then(Value::as_str), Some("chat-1"));
+        assert_eq!(row.get("key").and_then(Value::as_str), Some("note"));
+        assert_eq!(row.get("value").and_then(Value::as_str), Some("updated"));
+
+        let mut filters = Map::new();
+        filters.insert(
+            "agentConfigId".to_string(),
+            Value::String("agent-director".to_string()),
+        );
+        filters.insert("chatId".to_string(), Value::String("chat-1".to_string()));
+        filters.insert("key".to_string(), Value::String("note".to_string()));
+        let current_rows = state
+            .storage
+            .list_where("agent-memory", &filters)
+            .expect("current-shape memory should be queryable");
+        assert_eq!(current_rows.len(), 1);
+        assert_eq!(
+            current_rows[0].get("value").and_then(Value::as_str),
+            Some("updated")
+        );
+    }
+
+    #[test]
+    fn set_agent_memory_value_prefers_current_row_over_legacy_duplicate() {
+        let state = test_state("mixed-memory-write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "legacy-note",
+                json!({
+                    "id": "legacy-note",
+                    "agent_config_id": "agent-director",
+                    "chat_id": "chat-1",
+                    "key": "note",
+                    "value": "legacy stale"
+                }),
+            )
+            .expect("legacy memory should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "current-note",
+                json!({
+                    "id": "current-note",
+                    "agentConfigId": "agent-director",
+                    "chatId": "chat-1",
+                    "key": "note",
+                    "value": "current old"
+                }),
+            )
+            .expect("current memory should write");
+
+        set_agent_memory_value(
+            &state,
+            "agent-director",
+            "chat-1",
+            "note",
+            json!("current updated"),
+        )
+        .expect("memory write should succeed");
+
+        assert!(
+            state
+                .storage
+                .get("agent-memory", "legacy-note")
+                .expect("legacy memory lookup should succeed")
+                .is_none(),
+            "legacy duplicate should be removed after current row wins"
+        );
+        let row = state
+            .storage
+            .get("agent-memory", "current-note")
+            .expect("current memory lookup should succeed")
+            .expect("current row should remain");
+        assert_eq!(
+            row.get("value").and_then(Value::as_str),
+            Some("current updated")
+        );
+        assert_eq!(
+            row.get("agentConfigId").and_then(Value::as_str),
+            Some("agent-director")
+        );
+        assert_eq!(row.get("chatId").and_then(Value::as_str), Some("chat-1"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -1,3 +1,4 @@
+use super::agents;
 use super::game_state_snapshots;
 use super::media_uploads::remove_managed_record_file;
 use super::message_swipes as message_swipe_storage;
@@ -1325,6 +1326,9 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
     let delete_id_set = delete_ids.iter().cloned().collect::<HashSet<_>>();
     delete_gallery_for_chats(state, &delete_id_set)?;
     message_swipe_storage::delete_message_rows_for_chats_with_swipes(state, &delete_id_set)?;
+    for delete_id in &delete_ids {
+        agents::delete_agent_bookkeeping_for_chat(state, delete_id)?;
+    }
 
     for delete_id in &delete_ids {
         state.storage.delete("chats", delete_id)?;
@@ -2052,6 +2056,158 @@ mod tests {
         assert!(
             !image_path.exists(),
             "managed gallery file should be removed"
+        );
+    }
+
+    #[test]
+    fn delete_chat_removes_agent_bookkeeping_for_deleted_chat_scope() {
+        let state = test_state("agent-bookkeeping-delete");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "origin-chat",
+                    "name": "Origin",
+                    "metadata": { "activeSceneChatId": "scene-chat" }
+                }),
+            )
+            .expect("origin chat should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "scene-chat",
+                    "name": "Scene",
+                    "metadata": { "sceneOriginChatId": "origin-chat" }
+                }),
+            )
+            .expect("scene chat should be created");
+        state
+            .storage
+            .create(
+                "chats",
+                json!({
+                    "id": "other-chat",
+                    "name": "Other"
+                }),
+            )
+            .expect("other chat should be created");
+        state
+            .storage
+            .upsert_with_id(
+                "agents",
+                "secret-plot-agent",
+                json!({
+                    "id": "secret-plot-agent",
+                    "type": "secret-plot-driver",
+                    "name": "Secret Plot Driver",
+                    "settings": {}
+                }),
+            )
+            .expect("secret plot agent should write");
+        for (id, chat_id) in [
+            ("run-origin", "origin-chat"),
+            ("run-scene", "scene-chat"),
+            ("run-other", "other-chat"),
+        ] {
+            state
+                .storage
+                .upsert_with_id(
+                    "agent-runs",
+                    id,
+                    json!({
+                        "id": id,
+                        "agentConfigId": "agent-director",
+                        "chatId": chat_id,
+                        "success": true
+                    }),
+                )
+                .expect("agent run should write");
+        }
+        for (id, chat_id) in [
+            ("memory-origin", "origin-chat"),
+            ("memory-scene", "scene-chat"),
+            ("memory-other", "other-chat"),
+        ] {
+            state
+                .storage
+                .upsert_with_id(
+                    "agent-memory",
+                    id,
+                    json!({
+                        "id": id,
+                        "agentConfigId": "agent-director",
+                        "chatId": chat_id,
+                        "key": "note",
+                        "value": "kept"
+                    }),
+                )
+                .expect("agent memory should write");
+        }
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "memory-origin-arc",
+                json!({
+                    "id": "memory-origin-arc",
+                    "agentConfigId": "secret-plot-agent",
+                    "chatId": "origin-chat",
+                    "key": "overarchingArc",
+                    "value": "delete me too"
+                }),
+            )
+            .expect("secret plot memory should write");
+        state
+            .storage
+            .upsert_with_id(
+                "agent-memory",
+                "memory-scene-legacy",
+                json!({
+                    "id": "memory-scene-legacy",
+                    "agent_config_id": "agent-director",
+                    "chat_id": "scene-chat",
+                    "key": "legacy-note",
+                    "value": "delete legacy row too"
+                }),
+            )
+            .expect("legacy agent memory should write");
+
+        delete_chat_with_messages(&state, "origin-chat").expect("chat delete should succeed");
+
+        let mut remaining_run_ids = state
+            .storage
+            .list("agent-runs")
+            .expect("agent runs should be readable")
+            .iter()
+            .filter_map(|run| run.get("id").and_then(Value::as_str).map(ToOwned::to_owned))
+            .collect::<Vec<_>>();
+        remaining_run_ids.sort();
+        assert_eq!(
+            remaining_run_ids,
+            vec!["run-other"],
+            "agent runs should only remain for chats outside the delete scope"
+        );
+
+        let mut remaining_memory_ids = state
+            .storage
+            .list("agent-memory")
+            .expect("agent memory should be readable")
+            .iter()
+            .filter_map(|memory| {
+                memory
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .collect::<Vec<_>>();
+        remaining_memory_ids.sort();
+        assert_eq!(
+            remaining_memory_ids,
+            vec!["memory-other"],
+            "agent memory should only remain for chats outside the delete scope"
         );
     }
 

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -43,7 +43,7 @@ fn validate_chat_metadata_patch(
     chat_id: &str,
     patch: &mut Value,
 ) -> Result<(), AppError> {
-    let mut metadata_patch = match patch.get("metadata") {
+    let metadata_patch = match patch.get("metadata") {
         Some(Value::Object(object)) => Some(object.clone()),
         Some(_) => return Err(AppError::invalid_input("Chat metadata must be an object")),
         None => None,
@@ -52,28 +52,6 @@ fn validate_chat_metadata_patch(
         return Ok(());
     };
 
-    if let Some(metadata_object) = metadata_patch.as_mut() {
-        if let Some(webhook_url) = metadata_object.get_mut("discordWebhookUrl") {
-            if webhook_url.is_null() {
-                // Null clears the setting.
-            } else if let Some(raw_url) = webhook_url.as_str() {
-                let trimmed_url = raw_url.trim();
-                if !trimmed_url.is_empty()
-                    && !integrations::is_valid_discord_webhook_url(trimmed_url)
-                {
-                    return Err(AppError::invalid_input("Invalid Discord webhook URL"));
-                }
-                if trimmed_url != raw_url {
-                    *webhook_url = Value::String(trimmed_url.to_string());
-                }
-            } else {
-                return Err(AppError::invalid_input(
-                    "Discord webhook URL must be a string",
-                ));
-            }
-        }
-    }
-
     let chat = state
         .storage
         .get("chats", chat_id)?
@@ -81,29 +59,71 @@ fn validate_chat_metadata_patch(
     let active_ids_source = patch
         .get("characterIds")
         .or_else(|| chat.get("characterIds"));
-    let active_ids: HashSet<String> = shared::string_array_from_value(active_ids_source)
-        .into_iter()
-        .collect();
+    let active_ids = chat_active_character_ids(active_ids_source);
     let mut effective_metadata = shared::json_object_value(chat.get("metadata"))
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
-    let submitted_inactive = metadata_patch
-        .as_ref()
-        .and_then(|metadata| metadata.get("inactiveCharacterIds"))
-        .cloned();
     if let Some(metadata_patch) = metadata_patch {
         for (key, value) in metadata_patch {
             effective_metadata.insert(key, value);
         }
     }
+    let previous_metadata = effective_metadata.clone();
+    normalize_chat_metadata_object(&mut effective_metadata, &active_ids)?;
 
-    let inactive_value = submitted_inactive
-        .as_ref()
-        .or_else(|| effective_metadata.get("inactiveCharacterIds"));
-    let Some(inactive_value) = inactive_value else {
-        if patch.get("metadata").is_some() {
-            patch["metadata"] = Value::Object(effective_metadata);
+    if patch.get("metadata").is_some() || effective_metadata != previous_metadata {
+        patch["metadata"] = Value::Object(effective_metadata);
+    }
+    Ok(())
+}
+
+fn chat_active_character_ids(value: Option<&Value>) -> HashSet<String> {
+    shared::string_array_from_value(value).into_iter().collect()
+}
+
+fn normalize_chat_metadata_object(
+    metadata: &mut Map<String, Value>,
+    active_ids: &HashSet<String>,
+) -> Result<(), AppError> {
+    normalize_discord_webhook_metadata(metadata)?;
+    normalize_inactive_character_metadata(metadata, active_ids)?;
+    Ok(())
+}
+
+fn normalize_discord_webhook_metadata(metadata: &mut Map<String, Value>) -> Result<(), AppError> {
+    let Some(webhook_url) = metadata.get("discordWebhookUrl") else {
+        return Ok(());
+    };
+    let normalized = if webhook_url.is_null() {
+        None
+    } else if let Some(raw_url) = webhook_url.as_str() {
+        let trimmed_url = raw_url.trim();
+        if trimmed_url.is_empty() {
+            None
+        } else {
+            if !integrations::is_valid_discord_webhook_url(trimmed_url) {
+                return Err(AppError::invalid_input("Invalid Discord webhook URL"));
+            }
+            Some(Value::String(trimmed_url.to_string()))
         }
+    } else {
+        return Err(AppError::invalid_input(
+            "Discord webhook URL must be a string",
+        ));
+    };
+    if let Some(value) = normalized {
+        metadata.insert("discordWebhookUrl".to_string(), value);
+    } else {
+        metadata.remove("discordWebhookUrl");
+    }
+    Ok(())
+}
+
+fn normalize_inactive_character_metadata(
+    metadata: &mut Map<String, Value>,
+    active_ids: &HashSet<String>,
+) -> Result<(), AppError> {
+    let Some(inactive_value) = metadata.get("inactiveCharacterIds") else {
         return Ok(());
     };
     let Some(inactive_ids) = inactive_value.as_array() else {
@@ -126,13 +146,7 @@ fn validate_chat_metadata_patch(
         .filter(|id| seen.insert((*id).to_string()))
         .map(|id| Value::String(id.to_string()))
         .collect();
-    let normalized_value = Value::Array(normalized);
-    let inactive_changed =
-        effective_metadata.get("inactiveCharacterIds") != Some(&normalized_value);
-    effective_metadata.insert("inactiveCharacterIds".to_string(), normalized_value);
-    if patch.get("metadata").is_some() || inactive_changed {
-        patch["metadata"] = Value::Object(effective_metadata);
-    }
+    metadata.insert("inactiveCharacterIds".to_string(), Value::Array(normalized));
     Ok(())
 }
 
@@ -780,6 +794,7 @@ fn normalize_chat_for_create(value: Value) -> Result<Value, AppError> {
     let mut object = ensure_object(value)?;
     normalize_chat_mode_object(&mut object);
     normalize_chat_folder_id_object(&mut object)?;
+    normalize_chat_metadata_for_create(&mut object)?;
     Ok(Value::Object(object))
 }
 
@@ -791,6 +806,17 @@ fn normalize_chat_for_update(entity: &str, patch: Value) -> Result<Value, AppErr
     normalize_chat_mode_object(&mut object);
     normalize_chat_folder_id_object(&mut object)?;
     Ok(Value::Object(object))
+}
+
+fn normalize_chat_metadata_for_create(object: &mut Map<String, Value>) -> Result<(), AppError> {
+    let active_ids = chat_active_character_ids(object.get("characterIds"));
+    let Some(metadata) = object.get_mut("metadata") else {
+        return Ok(());
+    };
+    let Some(metadata) = metadata.as_object_mut() else {
+        return Err(AppError::invalid_input("Chat metadata must be an object"));
+    };
+    normalize_chat_metadata_object(metadata, &active_ids)
 }
 
 fn normalize_chat_mode_object(object: &mut Map<String, Value>) {
@@ -2351,6 +2377,191 @@ mod tests {
 
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("Invalid Discord webhook URL"));
+    }
+
+    #[test]
+    fn chat_metadata_create_rejects_invalid_discord_webhook_url() {
+        let state = test_state("chat-metadata-create-invalid-webhook");
+
+        let error = storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "metadata": { "discordWebhookUrl": "not-a-discord-webhook" }
+            }),
+        )
+        .expect_err("invalid Discord webhook metadata should reject on create");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains("Invalid Discord webhook URL"));
+        assert!(
+            state
+                .storage
+                .get("chats", "chat-a")
+                .expect("chat lookup should succeed")
+                .is_none(),
+            "invalid chat metadata should not persist"
+        );
+    }
+
+    #[test]
+    fn chat_metadata_create_normalizes_discord_webhook_url() {
+        let state = test_state("chat-metadata-create-normalize-webhook");
+
+        let created = storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "metadata": {
+                    "discordWebhookUrl": "  https://discord.com/api/webhooks/123456789/token_AB-12  ",
+                    "theme": "kept"
+                }
+            }),
+        )
+        .expect("valid Discord webhook metadata should create");
+
+        assert_eq!(
+            created["metadata"]["discordWebhookUrl"],
+            json!("https://discord.com/api/webhooks/123456789/token_AB-12")
+        );
+        assert_eq!(created["metadata"]["theme"], json!("kept"));
+
+        let cleared = storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-b",
+                "name": "Chat B",
+                "metadata": {
+                    "discordWebhookUrl": null,
+                    "theme": "kept"
+                }
+            }),
+        )
+        .expect("null Discord webhook metadata should clear on create");
+        assert!(!cleared["metadata"]
+            .as_object()
+            .expect("metadata should stay an object")
+            .contains_key("discordWebhookUrl"));
+
+        let blank = storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-c",
+                "name": "Chat C",
+                "metadata": { "discordWebhookUrl": "   " }
+            }),
+        )
+        .expect("blank Discord webhook metadata should clear on create");
+        assert!(!blank["metadata"]
+            .as_object()
+            .expect("metadata should stay an object")
+            .contains_key("discordWebhookUrl"));
+    }
+
+    #[test]
+    fn chat_metadata_patch_clears_discord_webhook_url() {
+        let state = test_state("chat-metadata-patch-clear-webhook");
+        storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "metadata": {
+                    "discordWebhookUrl": "https://discord.com/api/webhooks/123456789/token_AB-12",
+                    "theme": "kept"
+                }
+            }),
+        )
+        .expect("chat should seed");
+
+        let updated = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({ "metadata": { "discordWebhookUrl": null } }),
+        )
+        .expect("null Discord webhook metadata should clear");
+
+        assert!(!updated["metadata"]
+            .as_object()
+            .expect("metadata should stay an object")
+            .contains_key("discordWebhookUrl"));
+        assert_eq!(updated["metadata"]["theme"], json!("kept"));
+
+        let restored = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({
+                "metadata": {
+                    "discordWebhookUrl": " https://discordapp.com/api/webhooks/123456789/token_AB-12 "
+                }
+            }),
+        )
+        .expect("valid Discord webhook metadata should update");
+        assert_eq!(
+            restored["metadata"]["discordWebhookUrl"],
+            json!("https://discordapp.com/api/webhooks/123456789/token_AB-12")
+        );
+
+        let cleared = storage_update_inner(
+            &state,
+            "chats".to_string(),
+            "chat-a".to_string(),
+            json!({ "metadata": { "discordWebhookUrl": "  " } }),
+        )
+        .expect("blank Discord webhook metadata should clear");
+        assert!(!cleared["metadata"]
+            .as_object()
+            .expect("metadata should stay an object")
+            .contains_key("discordWebhookUrl"));
+    }
+
+    #[test]
+    fn chat_metadata_create_normalizes_inactive_character_ids() {
+        let state = test_state("chat-metadata-create-inactive-characters");
+
+        let created = storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-a",
+                "name": "Chat A",
+                "characterIds": ["char-a", "char-b"],
+                "metadata": {
+                    "theme": "kept",
+                    "inactiveCharacterIds": [" char-a ", "missing", "char-a", "char-b"]
+                }
+            }),
+        )
+        .expect("valid inactive character metadata should create");
+
+        assert_eq!(
+            created["metadata"]["inactiveCharacterIds"],
+            json!(["char-a", "char-b"])
+        );
+        assert_eq!(created["metadata"]["theme"], json!("kept"));
+
+        let error = storage_create_inner(
+            &state,
+            "chats".to_string(),
+            json!({
+                "id": "chat-b",
+                "name": "Chat B",
+                "characterIds": ["char-a"],
+                "metadata": { "inactiveCharacterIds": ["char-a", 3] }
+            }),
+        )
+        .expect_err("non-string inactive character ids should reject on create");
+
+        assert_eq!(error.code, "invalid_input");
     }
 
     #[test]

--- a/src/features/shell/plugins/shell.ts
+++ b/src/features/shell/plugins/shell.ts
@@ -1,2 +1,2 @@
 export * from "./components/CoreModuleRuntimeProvider";
-export * from "./components/CoreModulesSettings";
+export { CoreModulesSettings } from "./components/CoreModulesSettings";

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -219,16 +219,26 @@ function normalizeChatMetadataPatch(
   current: Record<string, unknown>,
   patch: Record<string, unknown>,
 ): Record<string, unknown> {
-  const metadata = { ...current, ...patch };
+  const metadata = { ...current };
+  for (const [key, value] of Object.entries(patch)) {
+    if (key === "discordWebhookUrl" || key === "inactiveCharacterIds") continue;
+    metadata[key] = value;
+  }
   if (Object.prototype.hasOwnProperty.call(patch, "discordWebhookUrl")) {
     const value = patch.discordWebhookUrl;
-    if (value !== undefined && value !== null) {
+    if (value === undefined || value === null) {
+      delete metadata.discordWebhookUrl;
+    } else {
       if (typeof value !== "string") throw new ApiError("Discord webhook URL must be a string", 400);
       const trimmed = value.trim();
       if (trimmed && !DISCORD_WEBHOOK_URL_PATTERN.test(trimmed)) {
         throw new ApiError("Invalid Discord webhook URL", 400);
       }
-      metadata.discordWebhookUrl = trimmed || undefined;
+      if (trimmed) {
+        metadata.discordWebhookUrl = trimmed;
+      } else {
+        delete metadata.discordWebhookUrl;
+      }
     }
   }
   if (Object.prototype.hasOwnProperty.call(patch, "inactiveCharacterIds")) {


### PR DESCRIPTION
## Linked issue

Closes #2296

## Why this change

Deleting a chat removed messages, swipes, tracker snapshots, scene memories, and gallery rows, but left that chat's agent bookkeeping in `agent-runs` and `agent-memory`. Deleted chats could accumulate inert per-chat agent state over time.

## What changed

- Added shared Rust storage cleanup for agent bookkeeping rows keyed to a chat.
- Wired chat deletion to clear agent runs and memory for every chat in the delete scope, including owned scene chats.
- Preserved the existing reset-world-state behavior that can restore the secret-plot overarching arc, including legacy `agent_config_id` / `chat_id` memory rows.
- Added regression coverage for current `chatId` rows, legacy `chat_id` memory rows, scene-child cleanup, unrelated chat preservation, and legacy secret-plot arc preservation.
- Switched the plugin shell public entrypoint from wildcard to named settings export so the Linux unused-export check can trace the existing settings usage.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Chat delete cascade
- Chat group delete caller through `delete_chat_with_messages`
- Agent runs and agent memory storage rows
- Scene child delete scope
- Reset-world-state agent cleanup helper
- Plugin shell public barrel export used by settings

Boundary notes:

- Storage behavior stays in Rust storage modules; no React, engine, shared API, Tauri command shape, or remote runtime contract changes.
- Existing storage command entrypoints continue to call the same chat delete helper.
- Shell plugin barrel remains the public import boundary for settings; only the export style changed from wildcard to named export.

Pressure points touched:

- None of the listed broad UI or command-registration pressure points were touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml clear_agent_bookkeeping_preserves_legacy_secret_plot_arc` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml delete_chat_removes_agent_bookkeeping_for_deleted_chat_scope` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `pnpm check:architecture` passed.
- `pnpm check:unused` passed.
- `pnpm check` passed.
- Native app manual QA not run; storage-level Rust tests cover the owning delete/reset paths.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal storage cleanup bugfix and public export maintenance; no new user-discoverable workflow or setting.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not applicable; no visible UI behavior changed.
