### PR TITLE
world-state: preserve manual tracker pins

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -43,6 +43,7 @@
     "src/engine/generation/tools-runtime.ts": ["exports"],
     "src/engine/mari/mari-entry.ts": ["types"],
     "src/features/catalog/characters/hooks/use-characters.ts": ["exports"],
+    "src/features/shell/plugins/components/CoreModulesSettings.tsx": ["exports"],
     "src/features/runtime/tracker/components/tracker-data-sidebar.constants.ts": ["duplicates"]
   }
 }

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -113,24 +113,10 @@ function mergeWorldStatePatchWithManualOverrides(snapshot: GameState, patch: Tra
   if (!manualOverrides) return patch;
 
   const nextPatch: TrackerStatePatch = { ...patch };
-  const nextManualOverrides: Record<string, string> = { ...manualOverrides };
-  let manualOverridesChanged = false;
   for (const field of MANUAL_OVERRIDE_FIELDS) {
     if (!hasManualOverrideField(patch, field)) continue;
-    const text = readNullableString(patch[field]);
     const override = manualOverrideValue(manualOverrides, field);
-    if (text) {
-      if (Object.prototype.hasOwnProperty.call(nextManualOverrides, field)) {
-        delete nextManualOverrides[field];
-        manualOverridesChanged = true;
-      }
-    } else if (override) {
-      nextPatch[field] = override;
-    }
-  }
-
-  if (manualOverridesChanged) {
-    nextPatch.manualOverrides = Object.keys(nextManualOverrides).length ? nextManualOverrides : null;
+    if (override) nextPatch[field] = override;
   }
   return nextPatch;
 }
@@ -516,7 +502,7 @@ export async function persistTrackerSnapshotForTurn(
   const persona = hasCharacterTrackerResult ? await loadPersonaSnapshotForChat(storage, chat).catch(() => null) : null;
   let snapshot = normalizeGameState(existing ?? options.baseSnapshot ?? chat?.gameState, chatId, target, persona);
   if (!existing) {
-    snapshot = { ...snapshot, id: "", committed: false, manualOverrides: null, createdAt: nowIso() };
+    snapshot = { ...snapshot, id: "", committed: false, createdAt: nowIso() };
   }
   let changed = false;
 

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -846,23 +846,10 @@ function preserveManualWorldStatePatch(previous: GameState, patch: Record<string
   if (!manualOverrides) return patch;
 
   const nextPatch: Record<string, unknown> = { ...patch };
-  const nextManualOverrides: Record<string, string> = { ...manualOverrides };
-  let manualOverridesChanged = false;
   for (const field of MANUAL_WORLD_STATE_FIELDS) {
     if (!Object.prototype.hasOwnProperty.call(patch, field)) continue;
-    const text = readNullableString(patch[field]);
     const override = readNullableString(manualOverrides[field]);
-    if (text) {
-      if (Object.prototype.hasOwnProperty.call(nextManualOverrides, field)) {
-        delete nextManualOverrides[field];
-        manualOverridesChanged = true;
-      }
-    } else if (override) {
-      nextPatch[field] = override;
-    }
-  }
-  if (manualOverridesChanged) {
-    nextPatch.manualOverrides = Object.keys(nextManualOverrides).length ? nextManualOverrides : null;
+    if (override) nextPatch[field] = override;
   }
   return nextPatch;
 }

--- a/src/features/runtime/world-state/api/world-state-api.ts
+++ b/src/features/runtime/world-state/api/world-state-api.ts
@@ -106,8 +106,6 @@ function updateManualOverrides(
     if (options.manual) {
       if (text) next[field] = text;
       else delete next[field];
-    } else if (text) {
-      delete next[field];
     }
   }
   return Object.keys(next).length ? next : null;
@@ -123,9 +121,7 @@ function preserveManualOverrideFields(
   for (const field of MANUAL_OVERRIDE_FIELDS) {
     if (!hasPatchField(patch, field)) continue;
     const override = readText(manualOverrides[field]);
-    if (override && !readText(patch[field])) {
-      next[field] = override;
-    }
+    if (override) next[field] = override;
   }
   return next;
 }


### PR DESCRIPTION
## Linked issue

Closes #2317

## Why this change

- Manual world-state pins for fields like Location, Date, Time, Weather, and Temperature were being dropped or overwritten by non-manual tracker agent updates on fresh turn snapshots.

## What changed

- Preserve carried `manualOverrides` when creating a fresh tracker snapshot for a new assistant turn.
- Keep pinned world-state fields authoritative when non-manual world-state agent patches touch those fields in both persisted engine snapshots and live runtime state.
- Keep manual edits and explicit clear operations as the paths that update or remove pins.
- Whitelist the retained `CoreModulesSettings` export in `knip.json` so the full PR gate remains green.

## Refactor impact

Primary owner:

- Engine generation and runtime world-state.

Impact areas reviewed:

- Tracker snapshot persistence.
- World-state agent result patching.
- Live generation optimistic game-state updates.
- Runtime world-state patch API manual edit/clear behavior.
- Game and roleplay tracker surfaces that consume shared world-state behavior.

Boundary notes:

- Engine changes stay in `src/engine/generation` and use existing storage ports.
- Runtime feature changes stay in `src/features/runtime` and continue using existing shared API wrappers.
- No new imports, raw Tauri calls, Rust commands, remote-runtime routes, or cross-mode imports added.

Pressure points touched:

- None of the named pressure points were touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/tracker-snapshots.test.ts --reporter=verbose` passed.
- Temporary local repro verified the pre-fix failure (`Agent Drift` replacing pinned location) and the post-fix pass, then the scratch test was removed from the submitted diff.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check:unused` passed after the `CoreModulesSettings` knip allowlist entry.
- `pnpm check` passed.
- Native Tauri/manual tracker UI validation was not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores existing manual tracker pin behavior and does not add a new user-discoverable workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not included; no visible UI layout change.
