### PR TITLE
Fix lorebook conditions without game state

### DIFF
--- a/src/engine/generation-core/lorebooks/keyword-scanner.ts
+++ b/src/engine/generation-core/lorebooks/keyword-scanner.ts
@@ -78,7 +78,7 @@ export interface GameStateForScanning {
  */
 function evaluateConditions(conditions: ActivationCondition[], gameState: GameStateForScanning | null): boolean {
   if (conditions.length === 0) return true;
-  if (!gameState) return false;
+  if (!gameState) return true;
 
   for (const condition of conditions) {
     const fieldValue = getGameStateValue(gameState, condition.field);

--- a/src/engine/generation/active-lorebook-scanner.test.ts
+++ b/src/engine/generation/active-lorebook-scanner.test.ts
@@ -93,6 +93,72 @@ describe("scanActiveLorebooks", () => {
     expect(result.entriesForTiming.map((entry) => entry.id)).toEqual(["entry-a", "entry-c"]);
   });
 
+  it("keeps keyword-matched activation-condition entries active when plain chats have no game state", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const storage = storageWithRows(
+      {
+        lorebooks: [{ id: "book-a", name: "Book A", enabled: true, isGlobal: true }],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-conditional",
+            lorebookId: "book-a",
+            name: "Conditional entry",
+            content: "plain chat lore",
+            keys: ["moon-gate"],
+            enabled: true,
+            activationConditions: [{ field: "location", operator: "equals", value: "Moon Base" }],
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "moon-gate" }],
+      embeddingSource: null,
+    });
+
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual(["entry-conditional"]);
+  });
+
+  it("still enforces activation-condition field values when game state is present", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const storage = storageWithRows(
+      {
+        lorebooks: [{ id: "book-a", name: "Book A", enabled: true, isGlobal: true }],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-conditional",
+            lorebookId: "book-a",
+            name: "Conditional entry",
+            content: "game lore",
+            keys: ["moon-gate"],
+            enabled: true,
+            activationConditions: [{ field: "location", operator: "equals", value: "Moon Base" }],
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "game", metadata: {}, gameState: { location: "Forest" } },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "moon-gate" }],
+      embeddingSource: null,
+    });
+
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual([]);
+  });
+
   it("caps injected entries using lorebook budget priority", async () => {
     const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
     const makeEntry = (

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -791,7 +791,8 @@ async function loadActivatedLore(input: ActiveLorebookScannerInput): Promise<Loa
   const activeLorebookReasons = scopedLorebooks.map((entry) => entry.reason);
   const activeCharacterIds = input.characters.map((character) => character.id);
   const activeCharacterTags = input.characters.flatMap((character) => character.tags);
-  const gameState = parseRecord(input.chat.gameState ?? meta.gameState);
+  const rawGameState = input.chat.gameState ?? meta.gameState;
+  const gameState = rawGameState == null ? null : parseRecord(rawGameState);
   const previousTimingStates = lorebookTimingStateMap(meta.entryTimingStates);
   const previousEntryStateOverrides = lorebookEntryStateOverrideMap(meta.entryStateOverrides);
   const messages = input.storedMessages


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2277

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Plain conversation and roleplay chats can have no game state. In the refactor scanner path, that absence was normalized to an empty object, so lorebook entries with activation conditions were silently blocked even when their keyword matched. This restores the permissive no-game-state behavior expected by existing lorebooks while keeping real game-state gates enforced.

## What changed

<!-- List the key changes in this PR. -->

- Preserves `null` as the active lorebook scanner's absent-game-state signal instead of parsing absence into `{}`.
- Makes activation conditions pass when no game state exists, matching the legacy plain-chat behavior.
- Adds regression coverage for the plain roleplay path and a negative control proving a present non-matching game state still blocks the entry.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

engine generation

Impact areas reviewed:

- Lorebook active scanner game-state normalization.
- Shared keyword scanner activation-condition evaluation.
- Game-state negative control for real condition enforcement.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine-only change. No React, shared API, Rust, storage schema, import/export, dependency, or prompt-pipeline boundary changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Runtime generation lorebook activation only.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex reproduced the bug before the fix with `pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts`: the new regression expected `entry-conditional` and received `[]`.
- Codex reran `pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts` after the fix: 1 file passed, 8 tests passed.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed.
- Codex ran `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`: passed.
- Bunny review before PR: passed with no blocking findings.
- Manual human verification: none required for the core claim; this is covered by the scanner regression harness and full repo baseline.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A: compatibility bugfix for existing lorebook activation behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note files changed. This PR does not restore old staging/package-workspace/release claims.

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A: engine scanner behavior with no visible UI surface changed. Proof is the before/after scanner regression command and `pnpm check`.
