### PR TITLE
Fix default agent billing warning

### DIFF
--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -116,10 +116,20 @@ export interface GenerationAgentRuntimeInput {
 export interface GenerationAgentRuntime {
   preInjections: AgentInjection[];
   preResults: AgentResult[];
+  agentWarnings: AgentConnectionWarning[];
   agentData: Record<string, string>;
   availableSprites: AvailableSpriteCharacter[];
   runParallel(): Promise<AgentResult[]>;
   runPost(mainResponse: string): Promise<AgentResult[]>;
+}
+
+export interface AgentConnectionWarning {
+  code: "default_agent_connection_active";
+  severity: "warning";
+  message: string;
+  agentNames: string[];
+  connectionName: string;
+  model: string;
 }
 
 interface AgentDeps {
@@ -133,6 +143,7 @@ interface ResolvedAgentsResult {
   agents: ResolvedAgent[];
   skippedResults: AgentResult[];
   staticInjections: AgentInjection[];
+  agentWarnings: AgentConnectionWarning[];
 }
 
 const DIRECTOR_AGENT_TYPE = "director";
@@ -234,6 +245,51 @@ function uniqueStrings(values: string[]): string[] {
     result.push(text);
   }
   return result;
+}
+
+function formatAgentNameList(agentNames: string[]): string {
+  if (agentNames.length === 0) return "Agent";
+  if (agentNames.length === 1) return agentNames[0]!;
+  return `${agentNames.slice(0, -1).join(", ")} and ${agentNames.at(-1)}`;
+}
+
+function buildDefaultAgentConnectionWarning(args: {
+  agentNames: string[];
+  connectionName: string;
+  model: string;
+}): AgentConnectionWarning {
+  const normalizedNames = args.agentNames.length > 0 ? args.agentNames : ["Agent"];
+  const agentList = formatAgentNameList(normalizedNames);
+  const noun = normalizedNames.length === 1 ? "agent is" : "agents are";
+
+  return {
+    code: "default_agent_connection_active",
+    severity: "warning",
+    agentNames: normalizedNames,
+    connectionName: args.connectionName,
+    model: args.model,
+    message: `${agentList} ${noun} using the default agent connection "${args.connectionName}" (${args.model}). If this is a paid API model, agent calls may bill that provider.`,
+  };
+}
+
+function recordDefaultAgentConnectionWarning(
+  warnings: Map<string, AgentConnectionWarning>,
+  agentName: string,
+  connection: JsonRecord,
+  model: string,
+): void {
+  const connectionName = readString(connection.name).trim() || "Default agent connection";
+  const key = `${connectionName}\0${model}`;
+  const existing = warnings.get(key);
+  const agentNames = uniqueStrings([...(existing?.agentNames ?? []), agentName]);
+  warnings.set(
+    key,
+    buildDefaultAgentConnectionWarning({
+      agentNames,
+      connectionName,
+      model,
+    }),
+  );
 }
 
 function isFullBodySpriteExpression(expression: string): boolean {
@@ -996,7 +1052,7 @@ async function resolveLorebookKeeperRuntimeTarget(
 }
 
 async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput): Promise<ResolvedAgentsResult> {
-  if (!chatHasActiveAgents(input)) return { agents: [], skippedResults: [], staticInjections: [] };
+  if (!chatHasActiveAgents(input)) return { agents: [], skippedResults: [], staticInjections: [], agentWarnings: [] };
   const scopedAgentIds = chatActiveAgentIds(input);
   const activationMessages = activationScanMessages(input);
   const requestedAgentTypes = input.agentTypes ?? null;
@@ -1035,6 +1091,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
   const resolved: ResolvedAgent[] = [];
   const skippedResults: AgentResult[] = [];
   const staticInjections: AgentInjection[] = [];
+  const defaultConnectionWarnings = new Map<string, AgentConnectionWarning>();
   let defaultAgentConnection: JsonRecord | null | undefined;
   for (const agent of rows) {
     const type = readString(agent.type || agent.agentType) || "agent";
@@ -1072,6 +1129,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     const fallbackConnection = defaultAgentConnection ?? input.connection;
     const fallbackConnectionId = readString(fallbackConnection.id).trim() || null;
     const connectionId = requestedConnectionId || fallbackConnectionId;
+    const usesDefaultAgentConnection = !requestedConnectionId && !!defaultAgentConnection;
     let connection: JsonRecord;
     if (requestedConnectionId) {
       const loadedConnection = await loadConnection(deps.storage, requestedConnectionId);
@@ -1085,12 +1143,16 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
     }
     const model = readString(agent.model).trim() || readString(connection.model).trim();
     if (!model) continue;
+    const name = readString(agent.name) || readString(agent.type) || "Agent";
+    if (usesDefaultAgentConnection) {
+      recordDefaultAgentConnectionWarning(defaultConnectionWarnings, name, connection, model);
+    }
     const parameters = llmParameters(connection, {}, input.chat);
     customTools ??= await loadCustomTools(deps.storage);
     resolved.push({
       id: readString(agent.id) || readString(agent.type) || "agent",
       type,
-      name: readString(agent.name) || readString(agent.type) || "Agent",
+      name,
       phase: normalizePhase(agent),
       promptTemplate: readString(agent.promptTemplate),
       connectionId,
@@ -1101,7 +1163,7 @@ async function resolveAgents(deps: AgentDeps, input: GenerationAgentRuntimeInput
       toolContext: buildAgentToolContext(deps, input, agent, settings, customTools),
     });
   }
-  return { agents: resolved, skippedResults, staticInjections };
+  return { agents: resolved, skippedResults, staticInjections, agentWarnings: [...defaultConnectionWarnings.values()] };
 }
 
 type SpotifyDjSourceType = "liked" | "playlist" | "artist" | "any";
@@ -1554,7 +1616,7 @@ export async function createGenerationAgentRuntime(
   input: GenerationAgentRuntimeInput,
   onResult?: (result: AgentResult) => void,
 ): Promise<GenerationAgentRuntime> {
-  const { agents, skippedResults, staticInjections } = await resolveAgents(deps, input);
+  const { agents, skippedResults, staticInjections, agentWarnings } = await resolveAgents(deps, input);
   const preResults: AgentResult[] = [...skippedResults];
   const overrideInjections = normalizedAgentInjectionOverrides(input.agentInjectionOverrides);
   const initialInjections = mergeAgentInjections(staticInjections, overrideInjections);
@@ -1566,6 +1628,7 @@ export async function createGenerationAgentRuntime(
     return {
       preInjections: initialInjections,
       preResults,
+      agentWarnings,
       agentData,
       availableSprites: [],
       runParallel: async () => [],
@@ -1586,6 +1649,7 @@ export async function createGenerationAgentRuntime(
     return {
       preInjections: initialInjections,
       preResults,
+      agentWarnings,
       agentData,
       availableSprites,
       runParallel: async () => pipeline.runParallel(),
@@ -1615,6 +1679,7 @@ export async function createGenerationAgentRuntime(
   return {
     preInjections,
     preResults,
+    agentWarnings,
     agentData,
     availableSprites,
     runParallel: async () => pipeline.runParallel(),

--- a/src/engine/generation/generation-events.ts
+++ b/src/engine/generation/generation-events.ts
@@ -1,3 +1,5 @@
+import type { AgentConnectionWarning } from "./agent-runner";
+
 export type GenerationEvent =
   | { type: "phase"; data: string }
   | { type: "thinking"; data: string }
@@ -12,6 +14,7 @@ export type GenerationEvent =
   | { type: "user_message"; data: unknown }
   | { type: "assistant_message"; data: unknown }
   | { type: "agent_injection_review"; data: unknown }
+  | { type: "agent_warning"; data: AgentConnectionWarning }
   | { type: "agent_result"; data: unknown }
   | { type: "cross_post"; data: unknown }
   | { type: "assistant_action"; data: unknown }

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -4,7 +4,7 @@ import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway } from "../capabilities/llm";
 import type { StorageEntity, StorageGateway } from "../capabilities/storage";
 import type { WeekSchedule } from "../modes/chat/schedules/schedule.service";
-import { startGeneration, type StartGenerationInput } from "./start-generation";
+import { retryGenerationAgents, startGeneration, type StartGenerationInput } from "./start-generation";
 
 type Store = Partial<Record<StorageEntity, Record<string, Record<string, unknown>>>>;
 
@@ -168,6 +168,61 @@ function createDefaultAgentConnectionWarningStore(options: { defaultForAgents?: 
   };
 }
 
+function createLorebookKeeperDefaultConnectionWarningStore(): Store {
+  return {
+    chats: {
+      "chat-1": {
+        id: "chat-1",
+        mode: "roleplay",
+        connectionId: "chat-conn",
+        characterIds: ["char-1"],
+        metadata: { activeAgentIds: ["lorebook-keeper"], lorebookKeeperTargetLorebookId: "lorebook-1" },
+      },
+    },
+    characters: {
+      "char-1": { id: "char-1", data: { name: "Mira" } },
+    },
+    connections: {
+      "chat-conn": { id: "chat-conn", provider: "test", model: "chat-model" },
+      "agent-default": {
+        id: "agent-default",
+        name: "Paid Agents",
+        provider: "test",
+        model: "paid-agent-model",
+        defaultForAgents: true,
+      },
+    },
+    agents: {
+      "lorebook-keeper": {
+        id: "lorebook-keeper",
+        type: "lorebook-keeper",
+        name: "Lorebook Keeper",
+        enabled: true,
+        phase: "post_processing",
+        promptTemplate: "",
+        settings: { runInterval: 1 },
+      },
+    },
+    lorebooks: {
+      "lorebook-1": {
+        id: "lorebook-1",
+        name: "Global Lore",
+        enabled: true,
+        isGlobal: true,
+      },
+    },
+    messages: {
+      "assistant-1": {
+        id: "assistant-1",
+        chatId: "chat-1",
+        role: "assistant",
+        content: "Mira found a clue.",
+        createdAt: "2026-06-04T00:00:00.000Z",
+      },
+    },
+  };
+}
+
 function createStorage(
   store: Store,
   capture: { extraPatches?: Array<{ messageId: string; patch: Record<string, unknown> }> } = {},
@@ -311,6 +366,25 @@ function createDefaultAgentConnectionWarningDeps(options: { defaultForAgents?: b
   };
 }
 
+function createLorebookKeeperDefaultConnectionWarningDeps() {
+  const llm: LlmGateway = {
+    async complete() {
+      return "";
+    },
+    async *stream() {
+      yield { type: "token" as const, text: "{}" };
+    },
+    async listModels() {
+      return [];
+    },
+  };
+  return {
+    storage: createStorage(createLorebookKeeperDefaultConnectionWarningStore()),
+    integrations: {} as IntegrationGateway,
+    llm,
+  };
+}
+
 async function collectEvents(
   status: "idle" | "dnd" | "offline",
   input: Partial<StartGenerationInput>,
@@ -372,6 +446,22 @@ async function collectDefaultAgentConnectionWarningEvents(options: { defaultForA
     if ((event as { type: string }).type === "agent_warning" || event.type === "done") break;
   }
   return events;
+}
+
+async function collectDefaultAgentConnectionRetryEvents() {
+  return retryGenerationAgents(createDefaultAgentConnectionWarningDeps(), {
+    chatId: "chat-1",
+    agentTypes: ["director"],
+    options: { bypassActivation: true },
+  });
+}
+
+async function collectLorebookKeeperBackfillEvents() {
+  return retryGenerationAgents(createLorebookKeeperDefaultConnectionWarningDeps(), {
+    chatId: "chat-1",
+    agentTypes: ["lorebook-keeper"],
+    options: { lorebookKeeperBackfill: true },
+  });
 }
 
 describe("startGeneration conversation availability delays", () => {
@@ -619,5 +709,37 @@ describe("startGeneration agent connection warnings", () => {
     const events = await collectDefaultAgentConnectionWarningEvents({ defaultForAgents: false });
 
     expect(events.some((event) => (event as { type: string }).type === "agent_warning")).toBe(false);
+  });
+
+  it("warns through the manual agent retry path", async () => {
+    const { events } = await collectDefaultAgentConnectionRetryEvents();
+    const warning = events.find((event) => (event as { type: string }).type === "agent_warning");
+
+    expect(warning).toMatchObject({
+      type: "agent_warning",
+      data: {
+        code: "default_agent_connection_active",
+        severity: "warning",
+        agentNames: ["Narrative Director"],
+        connectionName: "Paid Agents",
+        model: "paid-agent-model",
+      },
+    });
+  });
+
+  it("propagates warnings through Lorebook Keeper backfill retries", async () => {
+    const { events } = await collectLorebookKeeperBackfillEvents();
+    const warning = events.find((event) => (event as { type: string }).type === "agent_warning");
+
+    expect(warning).toMatchObject({
+      type: "agent_warning",
+      data: {
+        code: "default_agent_connection_active",
+        severity: "warning",
+        agentNames: ["Lorebook Keeper"],
+        connectionName: "Paid Agents",
+        model: "paid-agent-model",
+      },
+    });
   });
 });

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -128,6 +128,46 @@ function createReviewStore(
   };
 }
 
+function createDefaultAgentConnectionWarningStore(options: { defaultForAgents?: boolean } = {}): Store {
+  const defaultForAgents = options.defaultForAgents ?? true;
+  return {
+    chats: {
+      "chat-1": {
+        id: "chat-1",
+        mode: "roleplay",
+        connectionId: "chat-conn",
+        characterIds: ["char-1"],
+        metadata: { activeAgentIds: ["director"] },
+      },
+    },
+    characters: {
+      "char-1": { id: "char-1", data: { name: "Mira" } },
+    },
+    connections: {
+      "chat-conn": { id: "chat-conn", provider: "test", model: "chat-model" },
+      "agent-default": {
+        id: "agent-default",
+        name: "Paid Agents",
+        provider: "test",
+        model: "paid-agent-model",
+        defaultForAgents,
+      },
+    },
+    agents: {
+      director: {
+        id: "director",
+        type: "director",
+        name: "Narrative Director",
+        enabled: true,
+        phase: "pre_generation",
+        promptTemplate: "",
+        settings: {},
+      },
+    },
+    messages: {},
+  };
+}
+
 function createStorage(
   store: Store,
   capture: { extraPatches?: Array<{ messageId: string; patch: Record<string, unknown> }> } = {},
@@ -252,6 +292,25 @@ function createReviewDeps(mode: "roleplay" | "visual_novel" | "conversation", op
   };
 }
 
+function createDefaultAgentConnectionWarningDeps(options: { defaultForAgents?: boolean } = {}) {
+  const llm: LlmGateway = {
+    async complete() {
+      return "";
+    },
+    async *stream() {
+      yield { type: "token" as const, text: "Keep the reply varied." };
+    },
+    async listModels() {
+      return [];
+    },
+  };
+  return {
+    storage: createStorage(createDefaultAgentConnectionWarningStore(options)),
+    integrations: {} as IntegrationGateway,
+    llm,
+  };
+}
+
 async function collectEvents(
   status: "idle" | "dnd" | "offline",
   input: Partial<StartGenerationInput>,
@@ -301,6 +360,18 @@ function reviewEvent(events: Awaited<ReturnType<typeof collectReviewEvents>>) {
         };
       }
     | undefined;
+}
+
+async function collectDefaultAgentConnectionWarningEvents(options: { defaultForAgents?: boolean } = {}) {
+  const events = [];
+  for await (const event of startGeneration(createDefaultAgentConnectionWarningDeps(options), {
+    chatId: "chat-1",
+    message: "Hi Mira",
+  })) {
+    events.push(event);
+    if ((event as { type: string }).type === "agent_warning" || event.type === "done") break;
+  }
+  return events;
 }
 
 describe("startGeneration conversation availability delays", () => {
@@ -514,5 +585,39 @@ describe("startGeneration agent injection review", () => {
 
     expect(reviewEvent(conversationEvents)).toBeUndefined();
     expect(reviewEvent(visualNovelEvents)?.type).toBe("agent_injection_review");
+  });
+});
+
+describe("startGeneration agent connection warnings", () => {
+  it("warns when an agent uses the default-for-agents connection", async () => {
+    const events = await collectDefaultAgentConnectionWarningEvents();
+    const warning = events.find((event) => (event as { type: string }).type === "agent_warning") as
+      | {
+          type: "agent_warning";
+          data: {
+            code: string;
+            severity: string;
+            agentNames: string[];
+            connectionName: string;
+            model: string;
+            message: string;
+          };
+        }
+      | undefined;
+
+    expect(warning?.data).toMatchObject({
+      code: "default_agent_connection_active",
+      severity: "warning",
+      agentNames: ["Narrative Director"],
+      connectionName: "Paid Agents",
+      model: "paid-agent-model",
+    });
+    expect(warning?.data.message).toContain("may bill that provider");
+  });
+
+  it("does not warn when agents fall back to the chat connection without a default-for-agents connection", async () => {
+    const events = await collectDefaultAgentConnectionWarningEvents({ defaultForAgents: false });
+
+    expect(events.some((event) => (event as { type: string }).type === "agent_warning")).toBe(false);
   });
 });

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2557,7 +2557,7 @@ async function runGenerationAgentsForTarget(args: {
   });
   await persistAgentResults(deps.storage, chatId, target ? readString(target.id) || null : null, finalResults);
 
-  const events: GenerationEvent[] = [];
+  const events: GenerationEvent[] = runtime.agentWarnings.map((warning) => ({ type: "agent_warning", data: warning }));
   const hasIllustrationRequest = finalResults.some((result) => illustratorPromptData(result) !== null);
   if (target && hasIllustrationRequest) {
     const illustration = await generateIllustrationAttachments({
@@ -2861,6 +2861,9 @@ export async function* startGeneration(
         )
       : null;
     throwIfAborted(signal);
+    for (const warning of runtime?.agentWarnings ?? []) {
+      yield { type: "agent_warning", data: warning };
+    }
     for (const result of agentEvents) {
       yield { type: "agent_result", data: result };
     }

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -2586,10 +2586,10 @@ async function runLorebookKeeperBackfill(
     storedMessages?: JsonRecord[];
     signal?: AbortSignal;
   },
-): Promise<AgentResult[]> {
+): Promise<{ results: AgentResult[]; events: GenerationEvent[] }> {
   const chatId = readString(input.chatId).trim();
   const agent = await lorebookKeeperAgent(deps.storage, args.chat);
-  if (!agent) return [];
+  if (!agent) return { results: [], events: [] };
 
   const storedMessages =
     args.storedMessages ??
@@ -2606,6 +2606,7 @@ async function runLorebookKeeperBackfill(
   });
   const agentTypes = new Set([LOREBOOK_KEEPER_AGENT_TYPE]);
   const allResults: AgentResult[] = [];
+  const allEvents: GenerationEvent[] = [];
 
   for (const target of targets) {
     const targetMessages = await loadMessagesForGenerationTarget({
@@ -2619,23 +2620,21 @@ async function runLorebookKeeperBackfill(
       targetMessages.find((message) => readString(message.id).trim() === readString(target.message.id).trim()) ??
       target.message;
     if (!readString(hydratedTarget.content).trim()) continue;
-    allResults.push(
-      ...(
-        await runGenerationAgentsForTarget({
-          deps,
-          input,
-          chat: args.chat,
-          connection: args.connection,
-          storedMessages: targetMessages,
-          target: hydratedTarget,
-          agentTypes,
-          signal: args.signal,
-        })
-      ).results,
-    );
+    const run = await runGenerationAgentsForTarget({
+      deps,
+      input,
+      chat: args.chat,
+      connection: args.connection,
+      storedMessages: targetMessages,
+      target: hydratedTarget,
+      agentTypes,
+      signal: args.signal,
+    });
+    allResults.push(...run.results);
+    allEvents.push(...run.events);
   }
 
-  return allResults;
+  return { results: allResults, events: allEvents };
 }
 
 export async function retryGenerationAgents(
@@ -2652,10 +2651,7 @@ export async function retryGenerationAgents(
   assertChatCanGenerate(chat);
   const connection = await resolveGenerationConnection(deps.storage, chat, input);
   if (isLorebookKeeperBackfill(input)) {
-    return {
-      results: await runLorebookKeeperBackfill(deps, input, { chat, connection, signal }),
-      events: [],
-    };
+    return runLorebookKeeperBackfill(deps, input, { chat, connection, signal });
   }
   const targetMessageId = readString(input.options?.forMessageId).trim();
   const storedMessages = await loadMessagesForGenerationTarget({
@@ -3090,7 +3086,7 @@ export async function* startGeneration(
     await persistAgentResults(deps.storage, chatId, messageId(latestSaved), allAgentResults);
     throwIfAborted(signal);
     if (saved && input.impersonate !== true) {
-      const autoLorebookResults = await runLorebookKeeperBackfill(
+      const autoLorebookBackfill = await runLorebookKeeperBackfill(
         deps,
         {
           chatId,
@@ -3100,7 +3096,10 @@ export async function* startGeneration(
         },
         { chat, connection, signal },
       );
-      for (const result of autoLorebookResults) {
+      for (const event of autoLorebookBackfill.events) {
+        yield event;
+      }
+      for (const result of autoLorebookBackfill.results) {
         yield { type: "agent_result", data: result };
       }
     }
@@ -3226,7 +3225,7 @@ export async function* startGeneration(
   }
   throwIfAborted(signal);
   if (saved && input.impersonate !== true) {
-    const autoLorebookResults = await runLorebookKeeperBackfill(
+    const autoLorebookBackfill = await runLorebookKeeperBackfill(
       deps,
       {
         chatId,
@@ -3236,7 +3235,10 @@ export async function* startGeneration(
       },
       { chat, connection, signal },
     );
-    for (const result of autoLorebookResults) {
+    for (const event of autoLorebookBackfill.events) {
+      yield event;
+    }
+    for (const result of autoLorebookBackfill.results) {
       yield { type: "agent_result", data: result };
     }
   }

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -455,6 +455,16 @@ function readGenerationReplay(value: unknown): GenerationReplay | null {
   return isRecord(replay) ? (replay as GenerationReplay) : null;
 }
 
+function showAgentWarningToast(rawData: unknown, shownKeys: Set<string>): void {
+  const data = parseMaybeRecord(rawData);
+  const message = readString(data.message).trim();
+  if (!message) return;
+  const key = `${readString(data.code).trim()}\0${message}`;
+  if (shownKeys.has(key)) return;
+  shownKeys.add(key);
+  toast.warning(message, { duration: 10_000 });
+}
+
 const editableCharacterCardFieldSet = new Set<string>(EDITABLE_CHARACTER_CARD_FIELDS);
 
 function parseCardFieldUpdate(raw: unknown): CharacterCardFieldUpdate | null {
@@ -1425,6 +1435,7 @@ export async function runGenerationWithUi(
   let groupTurnActive = false;
   let groupTurnIndex = -1;
   let groupTurnTotal = 0;
+  const shownAgentWarningKeys = new Set<string>();
 
   const releaseForegroundGenerationUi = () => {
     if (foregroundGenerationReleased) return;
@@ -1581,9 +1592,7 @@ export async function runGenerationWithUi(
           queueAgentResultEffect(event.data);
           break;
         case "agent_warning": {
-          const data = parseMaybeRecord(event.data);
-          const message = readString(data.message).trim();
-          if (message) toast.warning(message, { duration: 10_000 });
+          showAgentWarningToast(event.data, shownAgentWarningKeys);
           break;
         }
         case "tool_call": {
@@ -1853,6 +1862,7 @@ export function useGenerate() {
           },
         );
         const failedRetries: AgentFailure[] = [];
+        const shownAgentWarningKeys = new Set<string>();
         for (const rawResult of results) {
           const result = parseAgentResult(rawResult);
           if (!result || result.success) continue;
@@ -1869,9 +1879,7 @@ export function useGenerate() {
         }
         for (const event of events) {
           if (event.type === "agent_warning") {
-            const data = parseMaybeRecord(event.data);
-            const message = readString(data.message).trim();
-            if (message) toast.warning(message, { duration: 10_000 });
+            showAgentWarningToast(event.data, shownAgentWarningKeys);
           } else if (event.type === "illustration") {
             toast("Illustration generated.");
             // The chat-query refresh is fired unconditionally after this loop;

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1580,6 +1580,12 @@ export async function runGenerationWithUi(
         case "agent_result":
           queueAgentResultEffect(event.data);
           break;
+        case "agent_warning": {
+          const data = parseMaybeRecord(event.data);
+          const message = readString(data.message).trim();
+          if (message) toast.warning(message, { duration: 10_000 });
+          break;
+        }
         case "tool_call": {
           const name = toolEventName(event.data);
           useChatStore.getState().setGenerationPhase(name ? `Running tool: ${name}...` : "Running tool...");
@@ -1862,7 +1868,11 @@ export function useGenerate() {
           toast.error(formatAgentFailuresToast(failedRetries), { duration: 10_000 });
         }
         for (const event of events) {
-          if (event.type === "illustration") {
+          if (event.type === "agent_warning") {
+            const data = parseMaybeRecord(event.data);
+            const message = readString(data.message).trim();
+            if (message) toast.warning(message, { duration: 10_000 });
+          } else if (event.type === "illustration") {
             toast("Illustration generated.");
             // The chat-query refresh is fired unconditionally after this loop;
             // here we only need the illustration-specific gallery invalidate.


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2169

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Restores the legacy billing-safety warning for agents that fall back to the configured default-for-agents connection, so users are told when background agent calls may bill a paid provider.

## What changed

<!-- List the key changes in this PR. -->

- Added a `default_agent_connection_active` warning payload while resolving agents that use `connections.defaultForAgents`.
- Emits the warning as an `agent_warning` generation event for normal generation and manual agent retry paths.
- Displays the warning through the generation UI toast handler.
- Added regression coverage for the warning path and a negative control where no default-for-agents connection exists.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

engine generation

Impact areas reviewed:

- `src/engine/generation/agent-runner.ts`
- `src/engine/generation/start-generation.ts`
- `src/features/runtime/generation/hooks/use-generate.ts`

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- Engine owns warning construction and event emission; feature runtime only consumes the typed stream event and shows the toast. No raw Tauri or remote-runtime adapter changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Runtime generation event handling in `use-generate`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex machine proof:
- `pnpm exec vitest run src/engine/generation/start-generation.test.ts` passed. The regression tests prove `agent_warning` is emitted with `default_agent_connection_active`, connection name, model, and agent name for normal generation, manual agent retry, and Lorebook Keeper backfill when an agent uses the default-for-agents connection. The negative control proves no warning is emitted when no default-for-agents connection exists.
- `pnpm check` passed after the final diff.
- `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch/bugfix-verification.json` passed locally.
- Bunny review passed locally before opening this draft.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix restoring an existing safety warning; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is an event/warning restoration with provider-free machine proof; no real API call or desktop UI state is required to prove the core claim.
