### PR TITLE
Compact Bunny walkthrough repair prompt

### DIFF
--- a/.github/bunny-review/bunny_review.py
+++ b/.github/bunny-review/bunny_review.py
@@ -35,6 +35,7 @@ MAX_FILE_SUMMARY_CHARS = 9_000
 MAX_REVIEW_CHUNKS = 8
 MAX_CHUNK_PATCH_CHARS = 90_000
 MAX_INLINE_COMMENT_CHARS = 1_200
+MAX_COPY_PROMPT_FIELD_CHARS = 90
 MAX_CONTRACT_STATE_ENTRIES = 12
 MAX_CONTRACT_STATE_TEXT_CHARS = 320
 MAX_CONTRACT_STATE_LIST_ITEMS = 3
@@ -118,6 +119,13 @@ def inline_truncate(text, limit=MAX_INLINE_COMMENT_CHARS):
     suffix = f"\n\n[truncated: inline finding was {len(text)} chars, limit is {limit} chars]"
     keep = max(0, limit - len(suffix))
     return text[:keep].rstrip() + suffix
+
+
+def plain_truncate(text, limit):
+    text = str(text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
 
 
 def compact_state_text(value, limit=MAX_CONTRACT_STATE_TEXT_CHARS):
@@ -1183,25 +1191,20 @@ def code_block_text(text):
 
 
 def agent_prompt_for_finding(finding):
+    contract = finding.repair_contract or {}
+    expected_proof = "; ".join(compact_state_values(contract.get("expected_proof")))
+    invariant = "; ".join(compact_state_values(contract.get("invariant")))
     lines = [
-        f"Task: verify and repair `{finding.path}` around line {finding.line}.",
-        f"Finding: {finding.title}",
-        f"Severity: {finding.severity}",
+        f"Repair `{finding.path}:{finding.line}` ({finding.severity}): {plain_truncate(finding.title, MAX_COPY_PROMPT_FIELD_CHARS)}",
+        f"Problem: {plain_truncate(finding.body, MAX_COPY_PROMPT_FIELD_CHARS)}",
     ]
     if finding.fix_hint:
-        lines.append(f"Suggested repair: {finding.fix_hint}")
-    if finding.repair_contract and finding.severity != "nitpick":
-        lines.append("Repair contract:")
-        for key, label in CONTRACT_LABELS:
-            values = compact_state_values(finding.repair_contract.get(key))
-            if values:
-                lines.append(f"- {label}: " + "; ".join(values))
-    lines.extend(
-        [
-            "Validate the fix with the narrowest relevant check.",
-            "If the finding is stale, leave the code unchanged and record why.",
-        ]
-    )
+        lines.append(f"Fix: {plain_truncate(finding.fix_hint, MAX_COPY_PROMPT_FIELD_CHARS)}")
+    if invariant and finding.severity != "nitpick":
+        lines.append(f"Invariant: {plain_truncate(invariant, MAX_COPY_PROMPT_FIELD_CHARS)}")
+    if expected_proof and finding.severity != "nitpick":
+        lines.append(f"Proof: {plain_truncate(expected_proof, MAX_COPY_PROMPT_FIELD_CHARS)}")
+    lines.append("If stale, leave code unchanged and record why.")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- compact the walkthrough copy prompt without removing the affordance
- keep each finding structurally complete with repair target, problem, fix, invariant, and proof
- avoid replaying full repair-contract sections in the copy prompt

## Verification
- python3 -m py_compile .github/bunny-review/bunny_review.py
- focused harness confirmed a 3-finding prompt keeps Problem/Fix/Invariant/Proof for every finding
- focused harness confirmed inline selection remains blocking/high/medium
- git diff --check