### PR TITLE
feat: nested lorebook folders

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1209,32 +1209,32 @@ pub(crate) fn validate_lorebook_folder_for_patch(
     let Some(object) = patch.as_object() else {
         return Err(AppError::invalid_input("Patch must be an object"));
     };
-    // Validate when EITHER field that defines the ancestry pair changes — a
-    // lorebookId-only patch could otherwise leave a parent that is now in a
-    // different lorebook, evading a check that only watched parentFolderId.
-    if !object.contains_key("parentFolderId") && !object.contains_key("lorebookId") {
+    let changes_parent = object.contains_key("parentFolderId");
+    let changes_lorebook = object.contains_key("lorebookId");
+    if !changes_parent && !changes_lorebook {
         return Ok(());
     }
     let existing = state
         .storage
         .get("lorebook-folders", id)?
         .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
-    // Resolve the effective post-patch pair: the patched value if present, else
-    // whatever is already stored.
-    let effective_parent = if object.contains_key("parentFolderId") {
-        parse_chat_folder_id(patch.get("parentFolderId"))?
-    } else {
-        parse_chat_folder_id(existing.get("parentFolderId"))?
+    // A folder's lorebook is an immutable ownership key — the app never moves a
+    // folder between lorebooks. Allowing it would strand the folder's parent
+    // and/or its children across books (a root move leaves the children behind
+    // pointing at a parent that left), so reject any change to a different book
+    // outright rather than trying to validate ever-more-elaborate move shapes.
+    if changes_lorebook && lorebook_folder_lorebook_id(patch) != lorebook_folder_lorebook_id(&existing) {
+        return Err(AppError::invalid_input(
+            "A folder cannot be moved to a different lorebook.",
+        ));
+    }
+    if !changes_parent {
+        return Ok(());
+    }
+    let Some(parent_id) = parse_chat_folder_id(patch.get("parentFolderId"))? else {
+        return Ok(()); // moving to the top level is always allowed
     };
-    let Some(parent_id) = effective_parent else {
-        return Ok(()); // a root folder has no ancestry to validate
-    };
-    let effective_lorebook = if object.contains_key("lorebookId") {
-        lorebook_folder_lorebook_id(patch)
-    } else {
-        lorebook_folder_lorebook_id(&existing)
-    };
-    validate_lorebook_folder_parent(state, effective_lorebook, Some(id), &parent_id)
+    validate_lorebook_folder_parent(state, lorebook_folder_lorebook_id(&existing), Some(id), &parent_id)
 }
 
 fn lorebook_folder_lorebook_id(value: &Value) -> Option<String> {
@@ -3830,8 +3830,8 @@ mod tests {
             "nesting under a folder in another lorebook should be rejected"
         );
 
-        // Evasion: a lorebookId-only patch must not move B into another lorebook
-        // while it keeps a parent (A) that lives in the original one.
+        // Immutable lorebook: a child folder can't change lorebookId (it would
+        // keep a parent in the old book).
         assert!(
             storage_update_inner(
                 &state,
@@ -3840,7 +3840,20 @@ mod tests {
                 json!({ "lorebookId": "other" }),
             )
             .is_err(),
-            "changing only lorebookId while keeping a cross-lorebook parent should be rejected"
+            "changing a child folder's lorebookId should be rejected"
+        );
+
+        // Immutable lorebook: a ROOT folder can't change lorebookId either — that
+        // would strand its children (B) in the old book under a parent that left.
+        assert!(
+            storage_update_inner(
+                &state,
+                "lorebook-folders".to_string(),
+                "a".to_string(),
+                json!({ "lorebookId": "other" }),
+            )
+            .is_err(),
+            "changing a root folder's lorebookId would strand its children and must be rejected"
         );
 
         // Valid: move B back to the top level.

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1673,6 +1673,21 @@ fn delete_lorebook_folder_with_entry_reparent_sync(
             }
 
             let now = now_iso();
+            // Reparent direct child folders to root so they don't keep a stale
+            // parentFolderId pointing at the now-deleted folder. Later reorder/
+            // reparent logic reads that id and would otherwise reject or misplace
+            // moves; buildFolderForest already renders them at root, so this just
+            // makes storage match what the UI shows.
+            for folder in folder_rows.iter_mut() {
+                if folder.get("parentFolderId").and_then(Value::as_str) != Some(folder_id) {
+                    continue;
+                }
+                let Some(object) = folder.as_object_mut() else {
+                    return Err(AppError::invalid_input("Stored record is not an object"));
+                };
+                object.insert("parentFolderId".to_string(), Value::Null);
+                object.insert("updatedAt".to_string(), Value::String(now.clone()));
+            }
             let mut changed_entries = Vec::new();
             for entry in entry_rows.iter_mut() {
                 if entry.get("folderId").and_then(Value::as_str) != Some(folder_id) {
@@ -3583,6 +3598,56 @@ mod tests {
             .expect("negative-control entry should read")
             .expect("negative-control entry should remain");
         assert_eq!(other_folder["folderId"], "folder-keep");
+    }
+
+    #[test]
+    fn deleting_lorebook_folder_reparents_child_folders_to_root() {
+        let state = test_state("lorebook-folder-delete-reparent-children");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
+            .expect("lorebook should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "parent", "lorebookId": "book", "name": "Parent" }),
+            )
+            .expect("parent folder should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "child", "lorebookId": "book", "name": "Child", "parentFolderId": "parent" }),
+            )
+            .expect("child folder should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "unrelated", "lorebookId": "book", "name": "Unrelated", "parentFolderId": "other" }),
+            )
+            .expect("unrelated folder should be created");
+
+        delete_entity(&state, "lorebook-folders", "parent", false).expect("folder delete should succeed");
+
+        assert!(state
+            .storage
+            .get("lorebook-folders", "parent")
+            .expect("parent should read")
+            .is_none());
+        let child = state
+            .storage
+            .get("lorebook-folders", "child")
+            .expect("child should read")
+            .expect("child should remain");
+        assert!(child.get("parentFolderId").is_none_or(Value::is_null));
+        let unrelated = state
+            .storage
+            .get("lorebook-folders", "unrelated")
+            .expect("unrelated should read")
+            .expect("unrelated should remain");
+        assert_eq!(unrelated["parentFolderId"], "other");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -665,6 +665,7 @@ pub(crate) fn storage_create_inner(
     reject_message_swipe_mutation(&entity)?;
     validate_chat_folder_for_create(state, &entity, &value)?;
     validate_connection_folder_for_create(state, &entity, &value)?;
+    validate_lorebook_folder_for_create(state, &entity, &value)?;
     if entity == "messages" {
         return Ok(shared::project_timeline_message(
             message_swipes::create_message(
@@ -741,6 +742,7 @@ pub(crate) fn storage_update_inner(
     }
     validate_chat_folder_for_patch(state, &entity, &id, &patch)?;
     validate_connection_folder_for_patch(state, &entity, &patch)?;
+    validate_lorebook_folder_for_patch(state, &entity, &id, &patch)?;
     let mut normalized_patch =
         normalize_chat_for_update(&entity, shared::normalize_update_patch(&entity, patch)?)?;
     if entity == "chats" {
@@ -1169,6 +1171,112 @@ fn validate_chat_folder_assignment(
         return Err(AppError::invalid_input(format!(
             "Chat folder {folder_id} is for {folder_mode} chats, not {chat_mode} chats"
         )));
+    }
+    Ok(())
+}
+
+/// Reject a lorebook folder whose `parentFolderId` would break the tree: a
+/// missing parent, a parent in a different lorebook, a self-parent, or a move
+/// that nests a folder inside one of its own descendants (a cycle). Mirrors the
+/// editor's `canReparentFolder` guard, but at the storage write path so imports,
+/// remote callers, or any non-editor write can't persist a malformed tree the
+/// scanner would then have to defend against.
+pub(crate) fn validate_lorebook_folder_for_create(
+    state: &AppState,
+    entity: &str,
+    value: &Value,
+) -> Result<(), AppError> {
+    if entity != "lorebook-folders" {
+        return Ok(());
+    }
+    let Some(parent_id) = parse_chat_folder_id(value.get("parentFolderId"))? else {
+        return Ok(());
+    };
+    // A brand-new folder has no descendants yet, so only parent existence and
+    // same-lorebook can be violated on create; the cycle walk matters on reparent.
+    validate_lorebook_folder_parent(state, lorebook_folder_lorebook_id(value), None, &parent_id)
+}
+
+pub(crate) fn validate_lorebook_folder_for_patch(
+    state: &AppState,
+    entity: &str,
+    id: &str,
+    patch: &Value,
+) -> Result<(), AppError> {
+    if entity != "lorebook-folders" {
+        return Ok(());
+    }
+    let Some(object) = patch.as_object() else {
+        return Err(AppError::invalid_input("Patch must be an object"));
+    };
+    if !object.contains_key("parentFolderId") {
+        return Ok(());
+    }
+    let Some(parent_id) = parse_chat_folder_id(patch.get("parentFolderId"))? else {
+        return Ok(()); // moving to the top level is always allowed
+    };
+    let existing = state
+        .storage
+        .get("lorebook-folders", id)?
+        .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
+    validate_lorebook_folder_parent(state, lorebook_folder_lorebook_id(&existing), Some(id), &parent_id)
+}
+
+fn lorebook_folder_lorebook_id(value: &Value) -> Option<String> {
+    value
+        .get("lorebookId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .map(str::to_string)
+}
+
+fn validate_lorebook_folder_parent(
+    state: &AppState,
+    lorebook_id: Option<String>,
+    folder_id: Option<&str>,
+    parent_id: &str,
+) -> Result<(), AppError> {
+    if Some(parent_id) == folder_id {
+        return Err(AppError::invalid_input("A folder cannot be its own parent."));
+    }
+    let parent = state
+        .storage
+        .get("lorebook-folders", parent_id)?
+        .ok_or_else(|| AppError::invalid_input(format!("lorebook-folders/{parent_id} was not found")))?;
+    if let Some(lorebook_id) = lorebook_id.as_deref() {
+        if parent.get("lorebookId").and_then(Value::as_str) != Some(lorebook_id) {
+            return Err(AppError::invalid_input(
+                "A folder can only nest under a folder in the same lorebook.",
+            ));
+        }
+    }
+    // Walk up from the target parent; reaching the folder being moved means the
+    // move would nest it inside its own subtree. The `seen` guard keeps a
+    // pre-existing malformed cycle from looping forever.
+    let Some(folder_id) = folder_id else {
+        return Ok(());
+    };
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut cursor = Some(parent_id.to_string());
+    while let Some(current_id) = cursor {
+        if current_id == folder_id {
+            return Err(AppError::invalid_input(
+                "A folder cannot be nested inside one of its own subfolders.",
+            ));
+        }
+        if !seen.insert(current_id.clone()) {
+            break;
+        }
+        cursor = state
+            .storage
+            .get("lorebook-folders", &current_id)?
+            .as_ref()
+            .and_then(|node| node.get("parentFolderId"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|candidate| !candidate.is_empty())
+            .map(str::to_string);
     }
     Ok(())
 }
@@ -3648,6 +3756,76 @@ mod tests {
             .expect("unrelated should read")
             .expect("unrelated should remain");
         assert_eq!(unrelated["parentFolderId"], "other");
+    }
+
+    #[test]
+    fn lorebook_folder_reparent_rejects_cycle_and_cross_lorebook() {
+        let state = test_state("lorebook-folder-reparent-validation");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
+            .expect("lorebook should be created");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "other", "name": "Other" }))
+            .expect("other lorebook should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "a", "lorebookId": "book", "name": "A" }),
+            )
+            .expect("folder a should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "b", "lorebookId": "book", "name": "B", "parentFolderId": "a" }),
+            )
+            .expect("folder b should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "c", "lorebookId": "other", "name": "C" }),
+            )
+            .expect("folder c should be created");
+
+        // Cycle: nest A under its own descendant B.
+        assert!(
+            storage_update_inner(
+                &state,
+                "lorebook-folders".to_string(),
+                "a".to_string(),
+                json!({ "parentFolderId": "b" }),
+            )
+            .is_err(),
+            "nesting a folder under its own descendant should be rejected"
+        );
+
+        // Cross-lorebook: nest A under a folder in another lorebook.
+        assert!(
+            storage_update_inner(
+                &state,
+                "lorebook-folders".to_string(),
+                "a".to_string(),
+                json!({ "parentFolderId": "c" }),
+            )
+            .is_err(),
+            "nesting under a folder in another lorebook should be rejected"
+        );
+
+        // Valid: move B back to the top level.
+        assert!(
+            storage_update_inner(
+                &state,
+                "lorebook-folders".to_string(),
+                "b".to_string(),
+                json!({ "parentFolderId": null }),
+            )
+            .is_ok(),
+            "moving a folder to the root should be allowed"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1209,17 +1209,32 @@ pub(crate) fn validate_lorebook_folder_for_patch(
     let Some(object) = patch.as_object() else {
         return Err(AppError::invalid_input("Patch must be an object"));
     };
-    if !object.contains_key("parentFolderId") {
+    // Validate when EITHER field that defines the ancestry pair changes — a
+    // lorebookId-only patch could otherwise leave a parent that is now in a
+    // different lorebook, evading a check that only watched parentFolderId.
+    if !object.contains_key("parentFolderId") && !object.contains_key("lorebookId") {
         return Ok(());
     }
-    let Some(parent_id) = parse_chat_folder_id(patch.get("parentFolderId"))? else {
-        return Ok(()); // moving to the top level is always allowed
-    };
     let existing = state
         .storage
         .get("lorebook-folders", id)?
         .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
-    validate_lorebook_folder_parent(state, lorebook_folder_lorebook_id(&existing), Some(id), &parent_id)
+    // Resolve the effective post-patch pair: the patched value if present, else
+    // whatever is already stored.
+    let effective_parent = if object.contains_key("parentFolderId") {
+        parse_chat_folder_id(patch.get("parentFolderId"))?
+    } else {
+        parse_chat_folder_id(existing.get("parentFolderId"))?
+    };
+    let Some(parent_id) = effective_parent else {
+        return Ok(()); // a root folder has no ancestry to validate
+    };
+    let effective_lorebook = if object.contains_key("lorebookId") {
+        lorebook_folder_lorebook_id(patch)
+    } else {
+        lorebook_folder_lorebook_id(&existing)
+    };
+    validate_lorebook_folder_parent(state, effective_lorebook, Some(id), &parent_id)
 }
 
 fn lorebook_folder_lorebook_id(value: &Value) -> Option<String> {
@@ -3813,6 +3828,19 @@ mod tests {
             )
             .is_err(),
             "nesting under a folder in another lorebook should be rejected"
+        );
+
+        // Evasion: a lorebookId-only patch must not move B into another lorebook
+        // while it keeps a parent (A) that lives in the original one.
+        assert!(
+            storage_update_inner(
+                &state,
+                "lorebook-folders".to_string(),
+                "b".to_string(),
+                json!({ "lorebookId": "other" }),
+            )
+            .is_err(),
+            "changing only lorebookId while keeping a cross-lorebook parent should be rejected"
         );
 
         // Valid: move B back to the top level.

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -6,7 +6,7 @@ use crate::builtins::is_protected_record;
 use crate::state::AppState;
 use marinara_core::{ensure_object, new_id, now_iso, AppError};
 use serde_json::{json, Map, Value};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use tauri::State;
 
 type LorebookEntryAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
@@ -1223,7 +1223,9 @@ pub(crate) fn validate_lorebook_folder_for_patch(
     // and/or its children across books (a root move leaves the children behind
     // pointing at a parent that left), so reject any change to a different book
     // outright rather than trying to validate ever-more-elaborate move shapes.
-    if changes_lorebook && lorebook_folder_lorebook_id(patch) != lorebook_folder_lorebook_id(&existing) {
+    if changes_lorebook
+        && lorebook_folder_lorebook_id(patch) != lorebook_folder_lorebook_id(&existing)
+    {
         return Err(AppError::invalid_input(
             "A folder cannot be moved to a different lorebook.",
         ));
@@ -1234,7 +1236,12 @@ pub(crate) fn validate_lorebook_folder_for_patch(
     let Some(parent_id) = parse_chat_folder_id(patch.get("parentFolderId"))? else {
         return Ok(()); // moving to the top level is always allowed
     };
-    validate_lorebook_folder_parent(state, lorebook_folder_lorebook_id(&existing), Some(id), &parent_id)
+    validate_lorebook_folder_parent(
+        state,
+        lorebook_folder_lorebook_id(&existing),
+        Some(id),
+        &parent_id,
+    )
 }
 
 fn lorebook_folder_lorebook_id(value: &Value) -> Option<String> {
@@ -1253,12 +1260,16 @@ fn validate_lorebook_folder_parent(
     parent_id: &str,
 ) -> Result<(), AppError> {
     if Some(parent_id) == folder_id {
-        return Err(AppError::invalid_input("A folder cannot be its own parent."));
+        return Err(AppError::invalid_input(
+            "A folder cannot be its own parent.",
+        ));
     }
     let parent = state
         .storage
         .get("lorebook-folders", parent_id)?
-        .ok_or_else(|| AppError::invalid_input(format!("lorebook-folders/{parent_id} was not found")))?;
+        .ok_or_else(|| {
+            AppError::invalid_input(format!("lorebook-folders/{parent_id} was not found"))
+        })?;
     if let Some(lorebook_id) = lorebook_id.as_deref() {
         if parent.get("lorebookId").and_then(Value::as_str) != Some(lorebook_id) {
             return Err(AppError::invalid_input(
@@ -1575,6 +1586,224 @@ fn validate_connection_folder_reorder(
         ));
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn lorebook_folder_reorder(
+    state: State<'_, AppState>,
+    lorebook_id: String,
+    ordered_ids: Vec<String>,
+    parent_folder_id: Option<String>,
+) -> Result<Value, AppError> {
+    lorebook_folder_reorder_inner(&state, &lorebook_id, ordered_ids, parent_folder_id)
+}
+
+pub(crate) fn lorebook_folder_reorder_inner(
+    state: &AppState,
+    lorebook_id: &str,
+    ordered_ids: Vec<String>,
+    parent_folder_id: Option<String>,
+) -> Result<Value, AppError> {
+    let lorebook_id = lorebook_id.trim().to_string();
+    if lorebook_id.is_empty() {
+        return Err(AppError::invalid_input("lorebookId is required"));
+    }
+    let parent_folder_id = normalize_lorebook_reorder_parent_id(parent_folder_id)?;
+    let ordered_ids = normalize_lorebook_reorder_ids(ordered_ids)?;
+
+    state
+        .storage
+        .update_collections_atomically(vec!["lorebook-folders"], move |collections| {
+            let [folders] = collections else {
+                return Err(AppError::new(
+                    "storage_error",
+                    "Lorebook folder reorder expected the lorebook folder collection",
+                ));
+            };
+            if folders.collection() != "lorebook-folders" {
+                return Err(AppError::new(
+                    "storage_error",
+                    "Lorebook folder reorder received an unexpected collection",
+                ));
+            }
+            lorebook_folder_reorder_in_rows(
+                folders.rows_mut(),
+                &lorebook_id,
+                ordered_ids,
+                parent_folder_id,
+            )
+        })
+}
+
+fn lorebook_folder_reorder_in_rows(
+    folder_rows: &mut Vec<Value>,
+    lorebook_id: &str,
+    ordered_ids: Vec<String>,
+    parent_folder_id: Option<String>,
+) -> Result<Value, AppError> {
+    let by_id = folder_rows
+        .iter()
+        .filter_map(|folder| {
+            folder
+                .get("id")
+                .and_then(Value::as_str)
+                .map(|id| (id.to_string(), folder))
+        })
+        .collect::<HashMap<_, _>>();
+    let ordered_id_set = ordered_ids.iter().cloned().collect::<HashSet<_>>();
+
+    if let Some(parent_id) = parent_folder_id.as_deref() {
+        validate_lorebook_folder_parent_in_rows(&by_id, Some(lorebook_id), None, parent_id)?;
+    }
+
+    for id in &ordered_ids {
+        if by_id
+            .get(id)
+            .and_then(|folder| lorebook_folder_lorebook_id(folder))
+            .as_deref()
+            != Some(lorebook_id)
+        {
+            return Err(AppError::invalid_input(format!(
+                "lorebook-folders/{id} does not belong to lorebook {lorebook_id}"
+            )));
+        }
+        if let Some(parent_id) = parent_folder_id.as_deref() {
+            validate_lorebook_folder_parent_in_rows(
+                &by_id,
+                Some(lorebook_id),
+                Some(id),
+                parent_id,
+            )?;
+        }
+    }
+
+    for sibling_id in folder_rows.iter().filter_map(|folder| {
+        let id = folder.get("id").and_then(Value::as_str)?;
+        if lorebook_folder_lorebook_id(folder).as_deref() == Some(lorebook_id)
+            && lorebook_folder_parent_id(folder) == parent_folder_id
+        {
+            Some(id.to_string())
+        } else {
+            None
+        }
+    }) {
+        if !ordered_id_set.contains(&sibling_id) {
+            return Err(AppError::invalid_input(
+                "Lorebook folder reorder must include every existing sibling in the target folder",
+            ));
+        }
+    }
+
+    let parent_patch = parent_folder_id.map(Value::String).unwrap_or(Value::Null);
+    let now = now_iso();
+    for (index, id) in ordered_ids.iter().enumerate() {
+        let row = folder_rows
+            .iter_mut()
+            .find(|row| row.get("id").and_then(Value::as_str) == Some(id.as_str()))
+            .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
+        let Some(object) = row.as_object_mut() else {
+            return Err(AppError::invalid_input("Stored record is not an object"));
+        };
+        object.insert("order".to_string(), json!(index));
+        object.insert("sortOrder".to_string(), json!(index));
+        object.insert("parentFolderId".to_string(), parent_patch.clone());
+        object.insert("updatedAt".to_string(), Value::String(now.clone()));
+    }
+
+    Ok(Value::Array(
+        folder_rows
+            .iter()
+            .filter(|folder| lorebook_folder_lorebook_id(folder).as_deref() == Some(lorebook_id))
+            .cloned()
+            .collect(),
+    ))
+}
+
+fn normalize_lorebook_reorder_parent_id(
+    parent_folder_id: Option<String>,
+) -> Result<Option<String>, AppError> {
+    let Some(parent_folder_id) = parent_folder_id else {
+        return Ok(None);
+    };
+    let parent_folder_id = parent_folder_id.trim();
+    if parent_folder_id.is_empty() {
+        return Err(AppError::invalid_input(
+            "parentFolderId must be a folder id or null",
+        ));
+    }
+    Ok(Some(parent_folder_id.to_string()))
+}
+
+fn normalize_lorebook_reorder_ids(ordered_ids: Vec<String>) -> Result<Vec<String>, AppError> {
+    if ordered_ids.is_empty() {
+        return Err(AppError::invalid_input(
+            "Lorebook folder reorder must include at least one folder",
+        ));
+    }
+    let mut seen = HashSet::with_capacity(ordered_ids.len());
+    let mut normalized = Vec::with_capacity(ordered_ids.len());
+    for raw_id in ordered_ids {
+        let id = raw_id.trim().to_string();
+        if id.is_empty() || !seen.insert(id.clone()) {
+            return Err(AppError::invalid_input(
+                "Lorebook folder reorder must include each folder id exactly once",
+            ));
+        }
+        normalized.push(id);
+    }
+    Ok(normalized)
+}
+
+fn validate_lorebook_folder_parent_in_rows(
+    by_id: &HashMap<String, &Value>,
+    lorebook_id: Option<&str>,
+    folder_id: Option<&str>,
+    parent_id: &str,
+) -> Result<(), AppError> {
+    if Some(parent_id) == folder_id {
+        return Err(AppError::invalid_input(
+            "A folder cannot be its own parent.",
+        ));
+    }
+    let parent = by_id.get(parent_id).ok_or_else(|| {
+        AppError::invalid_input(format!("lorebook-folders/{parent_id} was not found"))
+    })?;
+    if let Some(lorebook_id) = lorebook_id {
+        if parent.get("lorebookId").and_then(Value::as_str) != Some(lorebook_id) {
+            return Err(AppError::invalid_input(
+                "A folder can only nest under a folder in the same lorebook.",
+            ));
+        }
+    }
+
+    let Some(folder_id) = folder_id else {
+        return Ok(());
+    };
+    let mut seen = HashSet::new();
+    let mut cursor = Some(parent_id.to_string());
+    while let Some(current_id) = cursor {
+        if current_id == folder_id {
+            return Err(AppError::invalid_input(
+                "A folder cannot be nested inside one of its own subfolders.",
+            ));
+        }
+        if !seen.insert(current_id.clone()) {
+            break;
+        }
+        cursor = by_id
+            .get(&current_id)
+            .and_then(|node| lorebook_folder_parent_id(node));
+    }
+    Ok(())
+}
+
+fn lorebook_folder_parent_id(folder: &Value) -> Option<String> {
+    folder
+        .get("parentFolderId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 #[tauri::command]
@@ -3752,7 +3981,8 @@ mod tests {
             )
             .expect("unrelated folder should be created");
 
-        delete_entity(&state, "lorebook-folders", "parent", false).expect("folder delete should succeed");
+        delete_entity(&state, "lorebook-folders", "parent", false)
+            .expect("folder delete should succeed");
 
         assert!(state
             .storage
@@ -3867,6 +4097,86 @@ mod tests {
             .is_ok(),
             "moving a folder to the root should be allowed"
         );
+    }
+
+    #[test]
+    fn lorebook_folder_reorder_rejects_invalid_batch_without_partial_writes() {
+        let state = test_state("lorebook-folder-reorder-atomic-validation");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
+            .expect("lorebook should be created");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "other", "name": "Other" }))
+            .expect("other lorebook should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "folder-a", "lorebookId": "book", "name": "A", "order": 0, "sortOrder": 0 }),
+            )
+            .expect("folder a should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "folder-b", "lorebookId": "book", "name": "B", "order": 1, "sortOrder": 1 }),
+            )
+            .expect("folder b should be created");
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "foreign", "lorebookId": "other", "name": "Foreign", "order": 0, "sortOrder": 0 }),
+            )
+            .expect("foreign folder should be created");
+
+        let error = lorebook_folder_reorder_inner(
+            &state,
+            "book",
+            vec![
+                "folder-b".to_string(),
+                "folder-a".to_string(),
+                "foreign".to_string(),
+            ],
+            None,
+        )
+        .expect_err("cross-lorebook batch member should reject the reorder");
+        assert_eq!(error.code, "invalid_input");
+
+        let folder_a = state
+            .storage
+            .get("lorebook-folders", "folder-a")
+            .expect("folder a should read")
+            .expect("folder a should exist");
+        let folder_b = state
+            .storage
+            .get("lorebook-folders", "folder-b")
+            .expect("folder b should read")
+            .expect("folder b should exist");
+        assert_eq!(folder_a["order"], 0);
+        assert_eq!(folder_b["order"], 1);
+
+        lorebook_folder_reorder_inner(
+            &state,
+            "book",
+            vec!["folder-b".to_string(), "folder-a".to_string()],
+            None,
+        )
+        .expect("valid same-lorebook batch should reorder folders");
+        let folder_a = state
+            .storage
+            .get("lorebook-folders", "folder-a")
+            .expect("folder a should read")
+            .expect("folder a should exist");
+        let folder_b = state
+            .storage
+            .get("lorebook-folders", "folder-b")
+            .expect("folder b should read")
+            .expect("folder b should exist");
+        assert_eq!(folder_b["order"], 0);
+        assert_eq!(folder_a["order"], 1);
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -14,6 +14,13 @@ type LorebookFolderDeleteAtomicRows<'a> =
     (&'a mut Vec<Value>, &'a mut Vec<Value>, &'a mut Vec<Value>);
 type ChatFolderDeleteAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
 
+#[derive(Clone)]
+struct LorebookFolderReorderRow {
+    lorebook_id: Option<String>,
+    parent_id: Option<String>,
+    order: i64,
+}
+
 struct StorageWhereIn {
     field: String,
     values: HashSet<String>,
@@ -1636,18 +1643,25 @@ pub(crate) fn lorebook_folder_reorder_inner(
 }
 
 fn lorebook_folder_reorder_in_rows(
-    folder_rows: &mut Vec<Value>,
+    folder_rows: &mut [Value],
     lorebook_id: &str,
     ordered_ids: Vec<String>,
     parent_folder_id: Option<String>,
 ) -> Result<Value, AppError> {
     let by_id = folder_rows
         .iter()
+        .enumerate()
         .filter_map(|folder| {
-            folder
-                .get("id")
-                .and_then(Value::as_str)
-                .map(|id| (id.to_string(), folder))
+            let (index, folder) = folder;
+            let id = folder.get("id").and_then(Value::as_str)?.to_string();
+            Some((
+                id,
+                LorebookFolderReorderRow {
+                    lorebook_id: lorebook_folder_lorebook_id(folder),
+                    parent_id: lorebook_folder_parent_id(folder),
+                    order: lorebook_folder_order(folder, index),
+                },
+            ))
         })
         .collect::<HashMap<_, _>>();
     let ordered_id_set = ordered_ids.iter().cloned().collect::<HashSet<_>>();
@@ -1659,8 +1673,7 @@ fn lorebook_folder_reorder_in_rows(
     for id in &ordered_ids {
         if by_id
             .get(id)
-            .and_then(|folder| lorebook_folder_lorebook_id(folder))
-            .as_deref()
+            .and_then(|folder| folder.lorebook_id.as_deref())
             != Some(lorebook_id)
         {
             return Err(AppError::invalid_input(format!(
@@ -1677,16 +1690,14 @@ fn lorebook_folder_reorder_in_rows(
         }
     }
 
-    for sibling_id in folder_rows.iter().filter_map(|folder| {
-        let id = folder.get("id").and_then(Value::as_str)?;
-        if lorebook_folder_lorebook_id(folder).as_deref() == Some(lorebook_id)
-            && lorebook_folder_parent_id(folder) == parent_folder_id
-        {
-            Some(id.to_string())
-        } else {
-            None
-        }
-    }) {
+    for sibling_id in by_id
+        .iter()
+        .filter(|(_, folder)| {
+            folder.lorebook_id.as_deref() == Some(lorebook_id)
+                && folder.parent_id.as_deref() == parent_folder_id.as_deref()
+        })
+        .map(|(id, _)| id.clone())
+    {
         if !ordered_id_set.contains(&sibling_id) {
             return Err(AppError::invalid_input(
                 "Lorebook folder reorder must include every existing sibling in the target folder",
@@ -1694,20 +1705,45 @@ fn lorebook_folder_reorder_in_rows(
         }
     }
 
+    let affected_source_parents = ordered_ids
+        .iter()
+        .filter_map(|id| by_id.get(id))
+        .filter(|folder| folder.parent_id.as_deref() != parent_folder_id.as_deref())
+        .map(|folder| folder.parent_id.clone())
+        .collect::<HashSet<_>>();
+    let source_reorders = affected_source_parents
+        .into_iter()
+        .map(|source_parent_id| {
+            let mut siblings = by_id
+                .iter()
+                .filter(|(id, folder)| {
+                    folder.lorebook_id.as_deref() == Some(lorebook_id)
+                        && folder.parent_id.as_deref() == source_parent_id.as_deref()
+                        && !ordered_id_set.contains(*id)
+                })
+                .map(|(id, folder)| (folder.order, id.clone()))
+                .collect::<Vec<_>>();
+            siblings.sort_by(|(left_order, left_id), (right_order, right_id)| {
+                left_order
+                    .cmp(right_order)
+                    .then_with(|| left_id.cmp(right_id))
+            });
+            (
+                source_parent_id,
+                siblings.into_iter().map(|(_, id)| id).collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+
     let parent_patch = parent_folder_id.map(Value::String).unwrap_or(Value::Null);
     let now = now_iso();
     for (index, id) in ordered_ids.iter().enumerate() {
-        let row = folder_rows
-            .iter_mut()
-            .find(|row| row.get("id").and_then(Value::as_str) == Some(id.as_str()))
-            .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
-        let Some(object) = row.as_object_mut() else {
-            return Err(AppError::invalid_input("Stored record is not an object"));
-        };
-        object.insert("order".to_string(), json!(index));
-        object.insert("sortOrder".to_string(), json!(index));
-        object.insert("parentFolderId".to_string(), parent_patch.clone());
-        object.insert("updatedAt".to_string(), Value::String(now.clone()));
+        patch_lorebook_folder_reorder_row(folder_rows, id, index, Some(&parent_patch), &now)?;
+    }
+    for (_source_parent_id, sibling_ids) in source_reorders {
+        for (index, id) in sibling_ids.iter().enumerate() {
+            patch_lorebook_folder_reorder_row(folder_rows, id, index, None, &now)?;
+        }
     }
 
     Ok(Value::Array(
@@ -1717,6 +1753,29 @@ fn lorebook_folder_reorder_in_rows(
             .cloned()
             .collect(),
     ))
+}
+
+fn patch_lorebook_folder_reorder_row(
+    folder_rows: &mut [Value],
+    id: &str,
+    index: usize,
+    parent_patch: Option<&Value>,
+    now: &str,
+) -> Result<(), AppError> {
+    let row = folder_rows
+        .iter_mut()
+        .find(|row| row.get("id").and_then(Value::as_str) == Some(id))
+        .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
+    let Some(object) = row.as_object_mut() else {
+        return Err(AppError::invalid_input("Stored record is not an object"));
+    };
+    object.insert("order".to_string(), json!(index));
+    object.insert("sortOrder".to_string(), json!(index));
+    if let Some(parent_patch) = parent_patch {
+        object.insert("parentFolderId".to_string(), parent_patch.clone());
+    }
+    object.insert("updatedAt".to_string(), Value::String(now.to_string()));
+    Ok(())
 }
 
 fn normalize_lorebook_reorder_parent_id(
@@ -1755,7 +1814,7 @@ fn normalize_lorebook_reorder_ids(ordered_ids: Vec<String>) -> Result<Vec<String
 }
 
 fn validate_lorebook_folder_parent_in_rows(
-    by_id: &HashMap<String, &Value>,
+    by_id: &HashMap<String, LorebookFolderReorderRow>,
     lorebook_id: Option<&str>,
     folder_id: Option<&str>,
     parent_id: &str,
@@ -1769,7 +1828,7 @@ fn validate_lorebook_folder_parent_in_rows(
         AppError::invalid_input(format!("lorebook-folders/{parent_id} was not found"))
     })?;
     if let Some(lorebook_id) = lorebook_id {
-        if parent.get("lorebookId").and_then(Value::as_str) != Some(lorebook_id) {
+        if parent.lorebook_id.as_deref() != Some(lorebook_id) {
             return Err(AppError::invalid_input(
                 "A folder can only nest under a folder in the same lorebook.",
             ));
@@ -1792,9 +1851,17 @@ fn validate_lorebook_folder_parent_in_rows(
         }
         cursor = by_id
             .get(&current_id)
-            .and_then(|node| lorebook_folder_parent_id(node));
+            .and_then(|node| node.parent_id.clone());
     }
     Ok(())
+}
+
+fn lorebook_folder_order(folder: &Value, fallback: usize) -> i64 {
+    folder
+        .get("order")
+        .or_else(|| folder.get("sortOrder"))
+        .and_then(Value::as_i64)
+        .unwrap_or(fallback as i64)
 }
 
 fn lorebook_folder_parent_id(folder: &Value) -> Option<String> {
@@ -4177,6 +4244,77 @@ mod tests {
             .expect("folder b should exist");
         assert_eq!(folder_b["order"], 0);
         assert_eq!(folder_a["order"], 1);
+    }
+
+    #[test]
+    fn lorebook_folder_reorder_renumbers_source_and_destination_groups() {
+        let state = test_state("lorebook-folder-reorder-source-destination-groups");
+        state
+            .storage
+            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
+            .expect("lorebook should be created");
+        for (id, order) in [
+            ("folder-a", 0),
+            ("folder-b", 1),
+            ("folder-c", 2),
+            ("parent", 3),
+        ] {
+            state
+                .storage
+                .create(
+                    "lorebook-folders",
+                    json!({ "id": id, "lorebookId": "book", "name": id, "order": order, "sortOrder": order }),
+                )
+                .expect("root folder should be created");
+        }
+        state
+            .storage
+            .create(
+                "lorebook-folders",
+                json!({ "id": "child-a", "lorebookId": "book", "name": "Child A", "parentFolderId": "parent", "order": 0, "sortOrder": 0 }),
+            )
+            .expect("child folder should be created");
+
+        lorebook_folder_reorder_inner(
+            &state,
+            "book",
+            vec!["child-a".to_string(), "folder-b".to_string()],
+            Some("parent".to_string()),
+        )
+        .expect("cross-parent reorder should update both sibling groups");
+
+        let folder_a = state
+            .storage
+            .get("lorebook-folders", "folder-a")
+            .expect("folder a should read")
+            .expect("folder a should exist");
+        let folder_c = state
+            .storage
+            .get("lorebook-folders", "folder-c")
+            .expect("folder c should read")
+            .expect("folder c should exist");
+        let parent = state
+            .storage
+            .get("lorebook-folders", "parent")
+            .expect("parent should read")
+            .expect("parent should exist");
+        let child_a = state
+            .storage
+            .get("lorebook-folders", "child-a")
+            .expect("child a should read")
+            .expect("child a should exist");
+        let folder_b = state
+            .storage
+            .get("lorebook-folders", "folder-b")
+            .expect("folder b should read")
+            .expect("folder b should exist");
+
+        assert_eq!(folder_a["order"], 0);
+        assert_eq!(folder_c["order"], 1);
+        assert_eq!(parent["order"], 2);
+        assert_eq!(child_a["order"], 0);
+        assert_eq!(folder_b["order"], 1);
+        assert_eq!(folder_b["parentFolderId"], "parent");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1182,12 +1182,7 @@ fn validate_chat_folder_assignment(
     Ok(())
 }
 
-/// Reject a lorebook folder whose `parentFolderId` would break the tree: a
-/// missing parent, a parent in a different lorebook, a self-parent, or a move
-/// that nests a folder inside one of its own descendants (a cycle). Mirrors the
-/// editor's `canReparentFolder` guard, but at the storage write path so imports,
-/// remote callers, or any non-editor write can't persist a malformed tree the
-/// scanner would then have to defend against.
+/// Storage-level guard for malformed lorebook folder ancestry.
 pub(crate) fn validate_lorebook_folder_for_create(
     state: &AppState,
     entity: &str,
@@ -1199,8 +1194,7 @@ pub(crate) fn validate_lorebook_folder_for_create(
     let Some(parent_id) = parse_chat_folder_id(value.get("parentFolderId"))? else {
         return Ok(());
     };
-    // A brand-new folder has no descendants yet, so only parent existence and
-    // same-lorebook can be violated on create; the cycle walk matters on reparent.
+    // New folders have no descendants, so create only checks parent existence and ownership.
     validate_lorebook_folder_parent(state, lorebook_folder_lorebook_id(value), None, &parent_id)
 }
 
@@ -1225,11 +1219,7 @@ pub(crate) fn validate_lorebook_folder_for_patch(
         .storage
         .get("lorebook-folders", id)?
         .ok_or_else(|| AppError::not_found(format!("lorebook-folders/{id} was not found")))?;
-    // A folder's lorebook is an immutable ownership key — the app never moves a
-    // folder between lorebooks. Allowing it would strand the folder's parent
-    // and/or its children across books (a root move leaves the children behind
-    // pointing at a parent that left), so reject any change to a different book
-    // outright rather than trying to validate ever-more-elaborate move shapes.
+    // Cross-book folder moves can strand parent/child links, so ownership is immutable.
     if changes_lorebook
         && lorebook_folder_lorebook_id(patch) != lorebook_folder_lorebook_id(&existing)
     {
@@ -1241,7 +1231,8 @@ pub(crate) fn validate_lorebook_folder_for_patch(
         return Ok(());
     }
     let Some(parent_id) = parse_chat_folder_id(patch.get("parentFolderId"))? else {
-        return Ok(()); // moving to the top level is always allowed
+        // Clearing parentFolderId moves the folder to root.
+        return Ok(());
     };
     validate_lorebook_folder_parent(
         state,
@@ -1284,9 +1275,7 @@ fn validate_lorebook_folder_parent(
             ));
         }
     }
-    // Walk up from the target parent; reaching the folder being moved means the
-    // move would nest it inside its own subtree. The `seen` guard keeps a
-    // pre-existing malformed cycle from looping forever.
+    // Walk target ancestors to reject descendant moves; seen handles pre-existing bad cycles.
     let Some(folder_id) = folder_id else {
         return Ok(());
     };
@@ -2092,11 +2081,7 @@ fn delete_lorebook_folder_with_entry_reparent_sync(
             }
 
             let now = now_iso();
-            // Reparent direct child folders to root so they don't keep a stale
-            // parentFolderId pointing at the now-deleted folder. Later reorder/
-            // reparent logic reads that id and would otherwise reject or misplace
-            // moves; buildFolderForest already renders them at root, so this just
-            // makes storage match what the UI shows.
+            // Deleted parents promote direct children to root so stored ancestry matches the UI.
             for folder in folder_rows.iter_mut() {
                 if folder.get("parentFolderId").and_then(Value::as_str) != Some(folder_id) {
                     continue;
@@ -2763,6 +2748,56 @@ mod tests {
             .expect("connection should read")
             .and_then(|row| row.get("defaultForAgents").and_then(Value::as_bool))
             .unwrap_or(false)
+    }
+
+    fn create_record(state: &AppState, collection: &str, value: Value) {
+        state
+            .storage
+            .create(collection, value)
+            .expect("record should be created");
+    }
+
+    fn read_record(state: &AppState, collection: &str, id: &str) -> Value {
+        state
+            .storage
+            .get(collection, id)
+            .expect("record should read")
+            .expect("record should exist")
+    }
+
+    fn create_lorebook(state: &AppState, id: &str) {
+        create_record(state, "lorebooks", json!({ "id": id, "name": id }));
+    }
+
+    fn create_lorebook_folder(
+        state: &AppState,
+        id: &str,
+        lorebook_id: &str,
+        parent_id: Option<&str>,
+        order: Option<i64>,
+    ) {
+        let mut folder = json!({ "id": id, "lorebookId": lorebook_id, "name": id });
+        let folder_object = folder
+            .as_object_mut()
+            .expect("folder fixture should be an object");
+        if let Some(parent_id) = parent_id {
+            folder_object.insert("parentFolderId".to_string(), json!(parent_id));
+        }
+        if let Some(order) = order {
+            folder_object.insert("order".to_string(), json!(order));
+            folder_object.insert("sortOrder".to_string(), json!(order));
+        }
+        create_record(state, "lorebook-folders", folder);
+    }
+
+    fn lorebook_folder(state: &AppState, id: &str) -> Value {
+        read_record(state, "lorebook-folders", id)
+    }
+
+    fn assert_lorebook_folder_order(state: &AppState, id: &str, order: i64) {
+        let folder = lorebook_folder(state, id);
+        assert_eq!(folder["order"], json!(order));
+        assert_eq!(folder["sortOrder"], json!(order));
     }
 
     #[test]
@@ -3938,115 +3973,43 @@ mod tests {
     #[test]
     fn deleting_lorebook_folder_reparents_entries_with_matching_folder_id() {
         let state = test_state("lorebook-folder-delete-reparent");
-        state
-            .storage
-            .create(
-                "lorebooks",
-                json!({ "id": "book-delete", "name": "Delete folder" }),
-            )
-            .expect("lorebook should be created");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "book-keep", "name": "Keep" }))
-            .expect("other lorebook should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "folder-delete", "lorebookId": "book-delete", "name": "Delete" }),
-            )
-            .expect("folder should be created");
-        state
-            .storage
-            .create(
-                "lorebook-entries",
-                json!({
-                    "id": "entry-reparent",
-                    "lorebookId": "book-delete",
-                    "folderId": "folder-delete",
-                    "name": "Reparent",
-                    "content": "x"
-                }),
-            )
-            .expect("entry should be created");
-        state
-            .storage
-            .create(
-                "lorebook-entries",
-                json!({
-                    "id": "entry-stale-cross-lorebook",
-                    "lorebookId": "book-keep",
-                    "folderId": "folder-delete",
-                    "name": "Stale",
-                    "content": "x"
-                }),
-            )
-            .expect("stale cross-lorebook entry should be created");
-        state
-            .storage
-            .create(
-                "lorebook-entries",
-                json!({
-                    "id": "entry-other-folder",
-                    "lorebookId": "book-keep",
-                    "folderId": "folder-keep",
-                    "name": "Other",
-                    "content": "x"
-                }),
-            )
-            .expect("negative-control entry should be created");
+        create_lorebook(&state, "book-delete");
+        create_lorebook(&state, "book-keep");
+        create_lorebook_folder(&state, "folder-delete", "book-delete", None, None);
+        create_record(
+            &state,
+            "lorebook-entries",
+            json!({ "id": "entry-reparent", "lorebookId": "book-delete", "folderId": "folder-delete", "name": "Reparent", "content": "x" }),
+        );
+        create_record(
+            &state,
+            "lorebook-entries",
+            json!({ "id": "entry-stale-cross-lorebook", "lorebookId": "book-keep", "folderId": "folder-delete", "name": "Stale", "content": "x" }),
+        );
+        create_record(
+            &state,
+            "lorebook-entries",
+            json!({ "id": "entry-other-folder", "lorebookId": "book-keep", "folderId": "folder-keep", "name": "Other", "content": "x" }),
+        );
 
         delete_entity(&state, "lorebook-folders", "folder-delete", false)
             .expect("folder delete should succeed");
 
-        let reparented = state
-            .storage
-            .get("lorebook-entries", "entry-reparent")
-            .expect("entry should read")
-            .expect("entry should remain");
+        let reparented = read_record(&state, "lorebook-entries", "entry-reparent");
         assert!(reparented.get("folderId").is_none_or(Value::is_null));
-        let stale = state
-            .storage
-            .get("lorebook-entries", "entry-stale-cross-lorebook")
-            .expect("stale cross-lorebook entry should read")
-            .expect("stale cross-lorebook entry should remain");
+        let stale = read_record(&state, "lorebook-entries", "entry-stale-cross-lorebook");
         assert!(stale.get("folderId").is_none_or(Value::is_null));
-        let other_folder = state
-            .storage
-            .get("lorebook-entries", "entry-other-folder")
-            .expect("negative-control entry should read")
-            .expect("negative-control entry should remain");
+        let other_folder = read_record(&state, "lorebook-entries", "entry-other-folder");
         assert_eq!(other_folder["folderId"], "folder-keep");
     }
 
     #[test]
     fn deleting_lorebook_folder_reparents_child_folders_to_root() {
         let state = test_state("lorebook-folder-delete-reparent-children");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
-            .expect("lorebook should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "parent", "lorebookId": "book", "name": "Parent" }),
-            )
-            .expect("parent folder should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "child", "lorebookId": "book", "name": "Child", "parentFolderId": "parent" }),
-            )
-            .expect("child folder should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "unrelated", "lorebookId": "book", "name": "Unrelated", "parentFolderId": "other" }),
-            )
-            .expect("unrelated folder should be created");
+        create_lorebook(&state, "book");
+        create_lorebook_folder(&state, "parent", "book", None, None);
+        create_lorebook_folder(&state, "child", "book", Some("parent"), None);
+        create_lorebook_folder(&state, "unrelated", "book", Some("other"), None);
 
         delete_entity(&state, "lorebook-folders", "parent", false)
             .expect("folder delete should succeed");
@@ -4056,54 +4019,21 @@ mod tests {
             .get("lorebook-folders", "parent")
             .expect("parent should read")
             .is_none());
-        let child = state
-            .storage
-            .get("lorebook-folders", "child")
-            .expect("child should read")
-            .expect("child should remain");
+        let child = lorebook_folder(&state, "child");
         assert!(child.get("parentFolderId").is_none_or(Value::is_null));
-        let unrelated = state
-            .storage
-            .get("lorebook-folders", "unrelated")
-            .expect("unrelated should read")
-            .expect("unrelated should remain");
+        let unrelated = lorebook_folder(&state, "unrelated");
         assert_eq!(unrelated["parentFolderId"], "other");
     }
 
     #[test]
     fn lorebook_folder_reparent_rejects_cycle_and_cross_lorebook() {
         let state = test_state("lorebook-folder-reparent-validation");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
-            .expect("lorebook should be created");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "other", "name": "Other" }))
-            .expect("other lorebook should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "a", "lorebookId": "book", "name": "A" }),
-            )
-            .expect("folder a should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "b", "lorebookId": "book", "name": "B", "parentFolderId": "a" }),
-            )
-            .expect("folder b should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "c", "lorebookId": "other", "name": "C" }),
-            )
-            .expect("folder c should be created");
+        create_lorebook(&state, "book");
+        create_lorebook(&state, "other");
+        create_lorebook_folder(&state, "a", "book", None, None);
+        create_lorebook_folder(&state, "b", "book", Some("a"), None);
+        create_lorebook_folder(&state, "c", "other", None, None);
 
-        // Cycle: nest A under its own descendant B.
         assert!(
             storage_update_inner(
                 &state,
@@ -4115,7 +4045,6 @@ mod tests {
             "nesting a folder under its own descendant should be rejected"
         );
 
-        // Cross-lorebook: nest A under a folder in another lorebook.
         assert!(
             storage_update_inner(
                 &state,
@@ -4127,8 +4056,6 @@ mod tests {
             "nesting under a folder in another lorebook should be rejected"
         );
 
-        // Immutable lorebook: a child folder can't change lorebookId (it would
-        // keep a parent in the old book).
         assert!(
             storage_update_inner(
                 &state,
@@ -4140,8 +4067,6 @@ mod tests {
             "changing a child folder's lorebookId should be rejected"
         );
 
-        // Immutable lorebook: a ROOT folder can't change lorebookId either — that
-        // would strand its children (B) in the old book under a parent that left.
         assert!(
             storage_update_inner(
                 &state,
@@ -4153,7 +4078,6 @@ mod tests {
             "changing a root folder's lorebookId would strand its children and must be rejected"
         );
 
-        // Valid: move B back to the top level.
         assert!(
             storage_update_inner(
                 &state,
@@ -4169,35 +4093,11 @@ mod tests {
     #[test]
     fn lorebook_folder_reorder_rejects_invalid_batch_without_partial_writes() {
         let state = test_state("lorebook-folder-reorder-atomic-validation");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
-            .expect("lorebook should be created");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "other", "name": "Other" }))
-            .expect("other lorebook should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "folder-a", "lorebookId": "book", "name": "A", "order": 0, "sortOrder": 0 }),
-            )
-            .expect("folder a should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "folder-b", "lorebookId": "book", "name": "B", "order": 1, "sortOrder": 1 }),
-            )
-            .expect("folder b should be created");
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "foreign", "lorebookId": "other", "name": "Foreign", "order": 0, "sortOrder": 0 }),
-            )
-            .expect("foreign folder should be created");
+        create_lorebook(&state, "book");
+        create_lorebook(&state, "other");
+        create_lorebook_folder(&state, "folder-a", "book", None, Some(0));
+        create_lorebook_folder(&state, "folder-b", "book", None, Some(1));
+        create_lorebook_folder(&state, "foreign", "other", None, Some(0));
 
         let error = lorebook_folder_reorder_inner(
             &state,
@@ -4211,19 +4111,8 @@ mod tests {
         )
         .expect_err("cross-lorebook batch member should reject the reorder");
         assert_eq!(error.code, "invalid_input");
-
-        let folder_a = state
-            .storage
-            .get("lorebook-folders", "folder-a")
-            .expect("folder a should read")
-            .expect("folder a should exist");
-        let folder_b = state
-            .storage
-            .get("lorebook-folders", "folder-b")
-            .expect("folder b should read")
-            .expect("folder b should exist");
-        assert_eq!(folder_a["order"], 0);
-        assert_eq!(folder_b["order"], 1);
+        assert_lorebook_folder_order(&state, "folder-a", 0);
+        assert_lorebook_folder_order(&state, "folder-b", 1);
 
         lorebook_folder_reorder_inner(
             &state,
@@ -4232,48 +4121,23 @@ mod tests {
             None,
         )
         .expect("valid same-lorebook batch should reorder folders");
-        let folder_a = state
-            .storage
-            .get("lorebook-folders", "folder-a")
-            .expect("folder a should read")
-            .expect("folder a should exist");
-        let folder_b = state
-            .storage
-            .get("lorebook-folders", "folder-b")
-            .expect("folder b should read")
-            .expect("folder b should exist");
-        assert_eq!(folder_b["order"], 0);
-        assert_eq!(folder_a["order"], 1);
+        assert_lorebook_folder_order(&state, "folder-b", 0);
+        assert_lorebook_folder_order(&state, "folder-a", 1);
     }
 
     #[test]
     fn lorebook_folder_reorder_renumbers_source_and_destination_groups() {
         let state = test_state("lorebook-folder-reorder-source-destination-groups");
-        state
-            .storage
-            .create("lorebooks", json!({ "id": "book", "name": "Book" }))
-            .expect("lorebook should be created");
+        create_lorebook(&state, "book");
         for (id, order) in [
             ("folder-a", 0),
             ("folder-b", 1),
             ("folder-c", 2),
             ("parent", 3),
         ] {
-            state
-                .storage
-                .create(
-                    "lorebook-folders",
-                    json!({ "id": id, "lorebookId": "book", "name": id, "order": order, "sortOrder": order }),
-                )
-                .expect("root folder should be created");
+            create_lorebook_folder(&state, id, "book", None, Some(order));
         }
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "child-a", "lorebookId": "book", "name": "Child A", "parentFolderId": "parent", "order": 0, "sortOrder": 0 }),
-            )
-            .expect("child folder should be created");
+        create_lorebook_folder(&state, "child-a", "book", Some("parent"), Some(0));
 
         lorebook_folder_reorder_inner(
             &state,
@@ -4283,51 +4147,22 @@ mod tests {
         )
         .expect("cross-parent reorder should update both sibling groups");
 
-        let folder_a = state
-            .storage
-            .get("lorebook-folders", "folder-a")
-            .expect("folder a should read")
-            .expect("folder a should exist");
-        let folder_c = state
-            .storage
-            .get("lorebook-folders", "folder-c")
-            .expect("folder c should read")
-            .expect("folder c should exist");
-        let parent = state
-            .storage
-            .get("lorebook-folders", "parent")
-            .expect("parent should read")
-            .expect("parent should exist");
-        let child_a = state
-            .storage
-            .get("lorebook-folders", "child-a")
-            .expect("child a should read")
-            .expect("child a should exist");
-        let folder_b = state
-            .storage
-            .get("lorebook-folders", "folder-b")
-            .expect("folder b should read")
-            .expect("folder b should exist");
-
-        assert_eq!(folder_a["order"], 0);
-        assert_eq!(folder_c["order"], 1);
-        assert_eq!(parent["order"], 2);
-        assert_eq!(child_a["order"], 0);
-        assert_eq!(folder_b["order"], 1);
-        assert_eq!(folder_b["parentFolderId"], "parent");
+        assert_lorebook_folder_order(&state, "folder-a", 0);
+        assert_lorebook_folder_order(&state, "folder-c", 1);
+        assert_lorebook_folder_order(&state, "parent", 2);
+        assert_lorebook_folder_order(&state, "child-a", 0);
+        assert_lorebook_folder_order(&state, "folder-b", 1);
+        assert_eq!(
+            lorebook_folder(&state, "folder-b")["parentFolderId"],
+            "parent"
+        );
     }
 
     #[test]
     fn deleting_lorebook_folder_reparent_rolls_back_when_character_book_sync_fails() {
         let state = test_state("lorebook-folder-delete-reparent-atomic");
         seed_linked_character_book(&state);
-        state
-            .storage
-            .create(
-                "lorebook-folders",
-                json!({ "id": "folder-linked", "lorebookId": "linked-book", "name": "Linked" }),
-            )
-            .expect("folder should be created");
+        create_lorebook_folder(&state, "folder-linked", "linked-book", None, None);
         storage_create_inner(
             &state,
             "lorebook-entries".to_string(),
@@ -4373,11 +4208,7 @@ mod tests {
             .get("lorebook-folders", "folder-linked")
             .expect("folder should read")
             .is_some());
-        let entry = state
-            .storage
-            .get("lorebook-entries", "entry-linked")
-            .expect("entry should read")
-            .expect("entry should remain");
+        let entry = read_record(&state, "lorebook-entries", "entry-linked");
         assert_eq!(entry["folderId"], "folder-linked");
     }
 

--- a/src-tauri/src/http_dispatch.rs
+++ b/src-tauri/src/http_dispatch.rs
@@ -545,6 +545,7 @@ pub async fn dispatch(state: &AppState, request: InvokeRequest) -> AppResult<Val
         "storage_delete" => storage_delete(state, &args),
         "storage_duplicate" => storage_duplicate(state, &args),
         "connection_folder_reorder" => connection_folder_reorder(state, &args),
+        "lorebook_folder_reorder" => lorebook_folder_reorder(state, &args),
         "connection_move" => connection_move(state, &args),
         "chat_message_add_swipe" => chat_message_add_swipe(state, &args),
         "chat_message_update_content_if_unchanged" => {
@@ -991,6 +992,24 @@ fn connection_folder_reorder(state: &AppState, args: &Map<String, Value>) -> App
     entity_commands::connection_folder_reorder_inner(
         state,
         required_string_vec(args, "orderedIds")?,
+    )
+}
+
+fn lorebook_folder_reorder(state: &AppState, args: &Map<String, Value>) -> AppResult<Value> {
+    let parent_folder_id = match args.get("parentFolderId") {
+        Some(Value::Null) | None => None,
+        Some(Value::String(value)) => Some(value.clone()),
+        Some(_) => {
+            return Err(AppError::invalid_input(
+                "parentFolderId must be a folder id or null",
+            ));
+        }
+    };
+    entity_commands::lorebook_folder_reorder_inner(
+        state,
+        required_string(args, "lorebookId")?,
+        required_string_vec(args, "orderedIds")?,
+        parent_folder_id,
     )
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -205,6 +205,7 @@ pub fn run() {
             storage_commands::entity_commands::storage_delete,
             storage_commands::entity_commands::storage_duplicate,
             storage_commands::entity_commands::connection_folder_reorder,
+            storage_commands::entity_commands::lorebook_folder_reorder,
             storage_commands::entity_commands::connection_move,
             storage_commands::game_state_snapshot_commands::tracker_snapshot_latest,
             storage_commands::game_state_snapshot_commands::tracker_snapshot_get,

--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -42,8 +42,9 @@ const lorebookEmbeddingUpdatedAtSchema = z.string().nullable();
 // Folders — collapsible containers for entries
 // `parentFolderId` nests a folder under another folder in the same lorebook
 // (null = top level). Parent validity (same lorebook, no self-parent, no
-// cycle) is checked at write time in the lorebook editor; the activation
-// scanner also gates entries beneath any disabled ancestor.
+// cycle) is checked at the storage write path; the editor mirrors that guard as
+// immediate UI feedback. The activation scanner also gates entries beneath any
+// disabled ancestor.
 // ──────────────────────────────────────────────
 export const createLorebookFolderSchema = z.object({
   lorebookId: z.string(),

--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -40,9 +40,10 @@ const lorebookEmbeddingUpdatedAtSchema = z.string().nullable();
 
 // ──────────────────────────────────────────────
 // Folders — collapsible containers for entries
-// `parentFolderId` is reserved for a future nested-folder PR; v1 enforces
-// `null` at the route layer so the schema accepts the field but the server
-// rejects non-null values.
+// `parentFolderId` nests a folder under another folder in the same lorebook
+// (null = top level). Parent validity (same lorebook, no self-parent, no
+// cycle) is checked at write time in the lorebook editor; the activation
+// scanner also gates entries beneath any disabled ancestor.
 // ──────────────────────────────────────────────
 export const createLorebookFolderSchema = z.object({
   lorebookId: z.string(),

--- a/src/engine/contracts/types/lorebook.ts
+++ b/src/engine/contracts/types/lorebook.ts
@@ -67,13 +67,13 @@ export interface Lorebook {
 
 /**
  * A collapsible container that groups lorebook entries to reduce visual
- * clutter in the editor. Folders are flat in v1 — `parentFolderId` is reserved
- * for future nested-folder support and must currently be null.
+ * clutter in the editor. Folders may nest: `parentFolderId` points at a parent
+ * folder in the same lorebook (null = top level).
  *
- * Folder enable/disable acts as a gate: when `enabled` is false, every entry
- * inside the folder is treated as inactive at activation time, regardless of
- * the entry's own `enabled` flag. The entry's own flag is preserved (the
- * folder toggle does NOT mutate it), so re-enabling the folder restores the
+ * Folder enable/disable acts as a gate: when a folder OR any of its ancestors
+ * is disabled, every entry inside is treated as inactive at activation time,
+ * regardless of the entry's own `enabled` flag. The entry's own flag is
+ * preserved (the folder toggle does NOT mutate it), so re-enabling restores the
  * entries' previous individual settings.
  *
  * Folders sit above root-level entries in the editor display. Folder display
@@ -86,13 +86,15 @@ export interface LorebookFolder {
   /** Display name shown on the folder header row. */
   name: string;
   /**
-   * When false, every entry whose `folderId` matches this folder is skipped
-   * during activation, regardless of the entry's own `enabled` flag.
+   * When false, every entry under this folder is skipped during activation —
+   * including entries in enabled subfolders — regardless of the entry's own
+   * `enabled` flag.
    */
   enabled: boolean;
   /**
-   * Reserved for future nested-folder support. Always null in v1; the server
-   * rejects non-null values.
+   * Parent folder for nesting, or null for a top-level folder. Must reference a
+   * folder in the same lorebook; self-parenting and cycles are rejected at
+   * write time.
    */
   parentFolderId: string | null;
   /** Display order among sibling folders (lower = higher in the list). */

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -444,17 +444,48 @@ async function loadLorebookEntriesForActivation(
   return normalizeLorebookEntriesForActivation(lorebook, rows, folders);
 }
 
+/**
+ * A folder gates its entries when it is disabled OR any ancestor folder is
+ * disabled. Resolve the full set of "effectively disabled" folder ids by
+ * walking each folder's `parentFolderId` chain. A per-walk `seen` guard keeps
+ * a malformed parent cycle from looping forever — storage validation prevents
+ * cycles, but the activation scanner must never hang on bad data.
+ */
+function collectEffectivelyDisabledFolderIds(folders: JsonRecord[]): Set<string> {
+  const foldersById = new Map<string, JsonRecord>();
+  for (const folder of folders) {
+    const id = readString(folder.id);
+    if (id) foldersById.set(id, folder);
+  }
+
+  const disabled = new Set<string>();
+  for (const folder of folders) {
+    const id = readString(folder.id);
+    if (!id) continue;
+    const seen = new Set<string>();
+    let current: JsonRecord | undefined = folder;
+    let currentId: string | undefined = id;
+    while (current && currentId && !seen.has(currentId)) {
+      seen.add(currentId);
+      if (!boolish(current.enabled, true)) {
+        disabled.add(id);
+        break;
+      }
+      const parentId = readString(current.parentFolderId);
+      if (!parentId) break;
+      current = foldersById.get(parentId);
+      currentId = parentId;
+    }
+  }
+  return disabled;
+}
+
 function normalizeLorebookEntriesForActivation(
   lorebook: JsonRecord,
   rows: JsonRecord[],
   folders: JsonRecord[],
 ): LorebookEntry[] {
-  const disabledFolderIds = new Set(
-    folders
-      .filter((folder) => !boolish(folder.enabled, true))
-      .map((folder) => readString(folder.id))
-      .filter(Boolean),
-  );
+  const disabledFolderIds = collectEffectivelyDisabledFolderIds(folders);
   const defaultScanDepth = nonNegativeInteger(lorebook.scanDepth, 0);
   const excludeFromVectorization = boolish(lorebook.excludeFromVectorization, false);
   return rows

--- a/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
@@ -458,6 +458,7 @@ export function LorebookEditor() {
     lorebooks,
     entries,
     filteredEntries,
+    folders,
     showFolderGrouping,
     collapsedFolderIds,
     onTransferEntries: transferEntries.mutateAsync,

--- a/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEditor.tsx
@@ -24,6 +24,7 @@ import {
   useTransferLorebookEntries,
   useBulkUnvectorizeLorebookEntries,
 } from "../../hooks/use-lorebooks";
+import { buildFolderForest } from "../../lib/lorebook-folder-tree";
 import { useCharacterSummaries, useCharacterSummariesByIds } from "../../../characters/index";
 import { usePersonaSummaries } from "../../../personas/index";
 import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
@@ -360,6 +361,9 @@ export function LorebookEditor() {
     return map;
   }, [entries, folders]);
 
+  /** Folders grouped into a render-ready tree (roots + children-by-parent), each sorted by order. */
+  const folderForest = useMemo(() => buildFolderForest(folders), [folders]);
+
   const {
     canReorderEntries,
     canReorderFolders,
@@ -369,9 +373,10 @@ export function LorebookEditor() {
     dragSourceContainer,
     setDragSourceContainer,
     dropTargetContainer,
-    draggingFolderIdx,
+    draggingFolderId,
     folderDragReadyRef,
-    folderDropIdx,
+    folderDropTarget,
+    folderRootDropActive,
     entryListRef,
     resetEntryDragState,
     resetFolderDragState,
@@ -382,12 +387,15 @@ export function LorebookEditor() {
     handleRootListDragOver,
     commitEntryDrop,
     handleFolderDragStart,
-    handleFolderDragOverHeader,
+    handleFolderDragOverRow,
+    handleFolderBodyNestDragOver,
+    handleRootFolderDragOver,
     commitFolderDrop,
   } = useLorebookEditorDragDrop({
     lorebookId,
     entries,
     folders,
+    folderForest,
     entriesByContainer,
     showFolderGrouping,
     reorderEntriesPending: reorderEntries.isPending,
@@ -650,6 +658,7 @@ export function LorebookEditor() {
                 lorebookId={lorebookId}
                 entries={entries}
                 folders={folders}
+                folderForest={folderForest}
                 filteredEntries={filteredEntries}
                 entriesByContainer={entriesByContainer}
                 characters={characters}
@@ -672,8 +681,9 @@ export function LorebookEditor() {
                 canReorderEntries={canReorderEntries}
                 canReorderFolders={canReorderFolders}
                 collapsedFolderIds={collapsedFolderIds}
-                draggingFolderIdx={draggingFolderIdx}
-                folderDropIdx={folderDropIdx}
+                draggingFolderId={draggingFolderId}
+                folderDropTarget={folderDropTarget}
+                folderRootDropActive={folderRootDropActive}
                 draggingEntryIdx={draggingEntryIdx}
                 entryDropIdx={entryDropIdx}
                 dragSourceContainer={dragSourceContainer}
@@ -700,13 +710,15 @@ export function LorebookEditor() {
                 onSetDragSourceContainer={setDragSourceContainer}
                 onFolderDragStart={handleFolderDragStart}
                 onFolderHeaderDragOver={handleFolderHeaderDragOver}
-                onFolderDragOverHeader={handleFolderDragOverHeader}
+                onFolderDragOverRow={handleFolderDragOverRow}
+                onFolderBodyNestDragOver={handleFolderBodyNestDragOver}
                 onCommitEntryDrop={commitEntryDrop}
                 onCommitFolderDrop={commitFolderDrop}
                 onResetFolderDragState={resetFolderDragState}
                 onResetEntryDragState={resetEntryDragState}
                 onFolderBodyDragOver={handleFolderBodyDragOver}
                 onRootListDragOver={handleRootListDragOver}
+                onRootFolderDragOver={handleRootFolderDragOver}
                 onEntryDragStart={handleEntryDragStart}
                 onEntryDragOver={handleEntryDragOver}
                 onToggleEntryExpanded={toggleEntryExpanded}

--- a/src/features/catalog/lorebooks/components/editor/LorebookEntriesTab.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEntriesTab.tsx
@@ -1,6 +1,8 @@
-import { type DragEvent as ReactDragEvent } from "react";
+import { type DragEvent as ReactDragEvent, type ReactNode } from "react";
 import { FileText, Hash } from "lucide-react";
 import type { LorebookEntry, LorebookFolder } from "../../../../../engine/contracts/types/lorebook";
+import type { FolderForest } from "../../lib/lorebook-folder-tree";
+import type { FolderDropTarget } from "./use-lorebook-editor-drag-drop";
 import { cn } from "../../../../../shared/lib/utils";
 import { estimateTokens } from "../shared/LorebookFormFields";
 import { LorebookEntriesToolbar, LorebookEntrySelectionToolbar, type EntrySortKey } from "./LorebookEntriesToolbar";
@@ -14,6 +16,7 @@ export function LorebookEntriesTab({
   lorebookId,
   entries,
   folders,
+  folderForest,
   filteredEntries,
   entriesByContainer,
   characters,
@@ -36,8 +39,9 @@ export function LorebookEntriesTab({
   canReorderEntries,
   canReorderFolders,
   collapsedFolderIds,
-  draggingFolderIdx,
-  folderDropIdx,
+  draggingFolderId,
+  folderDropTarget,
+  folderRootDropActive,
   draggingEntryIdx,
   entryDropIdx,
   dragSourceContainer,
@@ -64,13 +68,15 @@ export function LorebookEntriesTab({
   onSetDragSourceContainer,
   onFolderDragStart,
   onFolderHeaderDragOver,
-  onFolderDragOverHeader,
+  onFolderDragOverRow,
+  onFolderBodyNestDragOver,
   onCommitEntryDrop,
   onCommitFolderDrop,
   onResetFolderDragState,
   onResetEntryDragState,
   onFolderBodyDragOver,
   onRootListDragOver,
+  onRootFolderDragOver,
   onEntryDragStart,
   onEntryDragOver,
   onToggleEntryExpanded,
@@ -79,6 +85,7 @@ export function LorebookEntriesTab({
   lorebookId: string | null;
   entries: LorebookEntry[];
   folders: LorebookFolder[];
+  folderForest: FolderForest<LorebookFolder>;
   filteredEntries: LorebookEntry[];
   entriesByContainer: Map<string | null, LorebookEntry[]>;
   characters: Array<{ id: string; name: string; tags: string[] }>;
@@ -101,8 +108,9 @@ export function LorebookEntriesTab({
   canReorderEntries: boolean;
   canReorderFolders: boolean;
   collapsedFolderIds: Set<string>;
-  draggingFolderIdx: number | null;
-  folderDropIdx: number | null;
+  draggingFolderId: string | null;
+  folderDropTarget: FolderDropTarget | null;
+  folderRootDropActive: boolean;
   draggingEntryIdx: number | null;
   entryDropIdx: number | null;
   dragSourceContainer: string | null | undefined;
@@ -111,7 +119,7 @@ export function LorebookEntriesTab({
   previewMatches: Map<string, PreviewMatch>;
   entryListRef: { current: HTMLDivElement | null };
   entryDragReadyRef: { current: number | null };
-  folderDragReadyRef: { current: number | null };
+  folderDragReadyRef: { current: string | null };
   onEntrySearchChange: (value: string) => void;
   onEntrySortChange: (value: EntrySortKey) => void;
   onToggleSelectionMode: () => void;
@@ -127,15 +135,17 @@ export function LorebookEntriesTab({
   onKeywordPreviewTextChange: (text: string) => void;
   onToggleFolderCollapsed: (folderId: string) => void;
   onSetDragSourceContainer: (containerId: string | null) => void;
-  onFolderDragStart: (folderIndex: number, folderId: string, event: ReactDragEvent<HTMLDivElement>) => void;
+  onFolderDragStart: (folderId: string, event: ReactDragEvent<HTMLDivElement>) => void;
   onFolderHeaderDragOver: (folderId: string, event: ReactDragEvent<HTMLDivElement>) => void;
-  onFolderDragOverHeader: (folderIndex: number, event: ReactDragEvent<HTMLDivElement>) => void;
+  onFolderDragOverRow: (folderId: string, event: ReactDragEvent<HTMLDivElement>) => void;
+  onFolderBodyNestDragOver: (folderId: string, event: ReactDragEvent<HTMLDivElement>) => void;
   onCommitEntryDrop: (event: ReactDragEvent<HTMLDivElement>) => void;
   onCommitFolderDrop: (event: ReactDragEvent<HTMLDivElement>) => void;
   onResetFolderDragState: () => void;
   onResetEntryDragState: () => void;
   onFolderBodyDragOver: (folderId: string, event: ReactDragEvent<HTMLDivElement>) => void;
   onRootListDragOver: (event: ReactDragEvent<HTMLDivElement>) => void;
+  onRootFolderDragOver: (event: ReactDragEvent<HTMLDivElement>) => void;
   onEntryDragStart: (
     containerId: string | null,
     entryIndex: number,
@@ -146,6 +156,145 @@ export function LorebookEntriesTab({
   onToggleEntryExpanded: (entryId: string) => void;
   onToggleEntrySelection: (entryId: string) => void;
 }) {
+  // Render a folder and everything beneath it. Child folders render inside the
+  // parent's indented body, so depth indentation falls out of the DOM nesting.
+  // `renderedFolderIds` ensures each folder is drawn at most once per pass —
+  // a guard against a malformed parent cycle looping the tree (cycles can't be
+  // created through the UI; canReparentFolder blocks them).
+  const renderedFolderIds = new Set<string>();
+  const renderFolder = (folder: LorebookFolder): ReactNode => {
+    // `lorebookId` is non-null wherever this renders (the tree only mounts
+    // inside the `lorebookId &&` guard below); the check also narrows the type
+    // for the row props. The cycle guard keeps each folder to a single draw.
+    if (!lorebookId || renderedFolderIds.has(folder.id)) return null;
+    renderedFolderIds.add(folder.id);
+    const folderEntries = entriesByContainer.get(folder.id) ?? [];
+    const childFolders = folderForest.childrenByParent.get(folder.id) ?? [];
+    const isCollapsed = collapsedFolderIds.has(folder.id);
+    const dropZone = folderDropTarget?.id === folder.id ? folderDropTarget.zone : null;
+    return (
+      <div key={folder.id} className="space-y-1">
+        {dropZone === "before" && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
+        <LorebookFolderRow
+          folder={folder}
+          folders={folders}
+          lorebookId={lorebookId}
+          entryCount={folderEntries.length}
+          isCollapsed={isCollapsed}
+          isNestTarget={dropZone === "inside"}
+          onToggleCollapse={() => onToggleFolderCollapsed(folder.id)}
+          draggable={canReorderFolders}
+          isDragging={draggingFolderId === folder.id}
+          onDragHandleMouseDown={() => {
+            if (canReorderFolders) folderDragReadyRef.current = folder.id;
+          }}
+          onDragStart={(event) => onFolderDragStart(folder.id, event)}
+          onDragOver={(event) => {
+            event.stopPropagation();
+            if (draggingEntryIdx !== null) onFolderHeaderDragOver(folder.id, event);
+            else onFolderDragOverRow(folder.id, event);
+          }}
+          onDrop={(event) => {
+            event.stopPropagation();
+            if (draggingEntryIdx !== null) onCommitEntryDrop(event);
+            else onCommitFolderDrop(event);
+          }}
+          onDragEnd={() => {
+            onResetFolderDragState();
+            onResetEntryDragState();
+          }}
+        />
+        {!isCollapsed && (
+          <div
+            className={cn(
+              "ml-2 space-y-1.5 rounded-lg border-l border-[var(--border)] pl-2 transition-colors sm:ml-3 sm:pl-2.5",
+              ((dropTargetContainer === folder.id && draggingEntryIdx !== null) ||
+                (folderDropTarget?.id === folder.id && folderDropTarget.zone === "inside")) &&
+                "bg-amber-400/5 ring-1 ring-amber-400/40",
+            )}
+            onDragOver={(event) => {
+              // Stop the dragover bubbling to ancestor folder bodies — without
+              // this, a nested target is overwritten by its outermost ancestor,
+              // so the drop lands in the wrong folder. (Hovering the left indent
+              // margin still lands on the shallower ancestor body, by design.)
+              event.stopPropagation();
+              if (draggingFolderId !== null) onFolderBodyNestDragOver(folder.id, event);
+              else onFolderBodyDragOver(folder.id, event);
+            }}
+            onDrop={(event) => {
+              event.stopPropagation();
+              if (draggingFolderId !== null) onCommitFolderDrop(event);
+              else onCommitEntryDrop(event);
+            }}
+          >
+            {folderEntries.length === 0 && childFolders.length === 0 && (
+              <p className="flex min-h-[2.5rem] items-center justify-center rounded-lg border border-dashed border-[var(--border)] px-2 py-2 text-center text-[0.625rem] italic text-[var(--muted-foreground)]">
+                Empty — drag an entry here or pick this folder from an entry's folder selector.
+              </p>
+            )}
+            {folderEntries.map((entry, entryIndex) => {
+              const isDropTarget = dropTargetContainer === folder.id && draggingEntryIdx !== null;
+              const sameContainer = dragSourceContainer === folder.id;
+              const showDropBefore =
+                isDropTarget &&
+                sameContainer &&
+                entryDropIdx === entryIndex &&
+                draggingEntryIdx !== entryIndex &&
+                draggingEntryIdx !== entryIndex - 1;
+              const showDropAfter =
+                isDropTarget &&
+                sameContainer &&
+                entryIndex === folderEntries.length - 1 &&
+                entryDropIdx === folderEntries.length &&
+                draggingEntryIdx !== entryIndex;
+              return (
+                <div key={entry.id}>
+                  {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
+                  <LorebookEntryRow
+                    entry={entry}
+                    lorebookId={lorebookId}
+                    isExpanded={expandedEntryId === entry.id}
+                    onToggleExpand={() => onToggleEntryExpanded(entry.id)}
+                    characters={characters}
+                    characterTags={characterTags}
+                    folders={folders}
+                    draggable={canReorderEntries}
+                    isDragging={sameContainer && draggingEntryIdx === entryIndex}
+                    onDragHandleMouseDown={() => {
+                      if (canReorderEntries) {
+                        entryDragReadyRef.current = entryIndex;
+                        onSetDragSourceContainer(folder.id);
+                      }
+                    }}
+                    onDragStart={(event) => onEntryDragStart(folder.id, entryIndex, entry.id, event)}
+                    onDragOver={(event) => {
+                      if (draggingEntryIdx === null) return;
+                      event.stopPropagation();
+                      onEntryDragOver(folder.id, entryIndex, event);
+                    }}
+                    onDrop={(event) => {
+                      if (draggingEntryIdx === null) return;
+                      event.stopPropagation();
+                      onCommitEntryDrop(event);
+                    }}
+                    onDragEnd={onResetEntryDragState}
+                    selectionMode={entrySelectionMode}
+                    isSelected={selectedEntryIds.has(entry.id)}
+                    onToggleSelected={() => onToggleEntrySelection(entry.id)}
+                    previewMatch={previewMatches.get(entry.id)}
+                  />
+                  {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+                </div>
+              );
+            })}
+            {childFolders.map((child) => renderFolder(child))}
+          </div>
+        )}
+        {dropZone === "after" && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+      </div>
+    );
+  };
+
   return (
     <div className="space-y-3">
       <LorebookKeywordTestPanel
@@ -220,149 +369,35 @@ export function LorebookEntriesTab({
 
       {lorebookId && showFolderGrouping && (entries.length > 0 || folders.length > 0) && (
         <div className="space-y-3">
-          {folders.length > 0 && (
-            <div className="space-y-1.5">
-              {folders.map((folder, folderIndex) => {
-                const folderEntries = entriesByContainer.get(folder.id) ?? [];
-                const isCollapsed = collapsedFolderIds.has(folder.id);
-                const showFolderDropBefore =
-                  folderDropIdx === folderIndex &&
-                  draggingFolderIdx !== null &&
-                  draggingFolderIdx !== folderIndex &&
-                  draggingFolderIdx !== folderIndex - 1;
-                const showFolderDropAfter =
-                  folderIndex === folders.length - 1 &&
-                  folderDropIdx === folders.length &&
-                  draggingFolderIdx !== null &&
-                  draggingFolderIdx !== folderIndex;
-                return (
-                  <div key={folder.id} className="space-y-1">
-                    {showFolderDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
-                    <LorebookFolderRow
-                      folder={folder}
-                      lorebookId={lorebookId}
-                      entryCount={folderEntries.length}
-                      isCollapsed={isCollapsed}
-                      onToggleCollapse={() => onToggleFolderCollapsed(folder.id)}
-                      draggable={canReorderFolders}
-                      isDragging={draggingFolderIdx === folderIndex}
-                      onDragHandleMouseDown={() => {
-                        if (canReorderFolders) folderDragReadyRef.current = folderIndex;
-                      }}
-                      onDragStart={(event) => onFolderDragStart(folderIndex, folder.id, event)}
-                      onDragOver={(event) => {
-                        event.stopPropagation();
-                        if (draggingEntryIdx !== null) onFolderHeaderDragOver(folder.id, event);
-                        else onFolderDragOverHeader(folderIndex, event);
-                      }}
-                      onDrop={(event) => {
-                        event.stopPropagation();
-                        if (draggingEntryIdx !== null) onCommitEntryDrop(event);
-                        else onCommitFolderDrop(event);
-                      }}
-                      onDragEnd={() => {
-                        onResetFolderDragState();
-                        onResetEntryDragState();
-                      }}
-                    />
-                    {!isCollapsed && (
-                      <div
-                        className="ml-2 space-y-1.5 border-l border-[var(--border)] pl-2 sm:ml-3 sm:pl-2.5"
-                        onDragOver={(event) => onFolderBodyDragOver(folder.id, event)}
-                        onDrop={(event) => {
-                          event.stopPropagation();
-                          onCommitEntryDrop(event);
-                        }}
-                      >
-                        {folderEntries.length === 0 && (
-                          <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">
-                            Empty — drag an entry here or pick this folder from an entry's folder selector.
-                          </p>
-                        )}
-                        {folderEntries.map((entry, entryIndex) => {
-                          const isDropTarget = dropTargetContainer === folder.id && draggingEntryIdx !== null;
-                          const sameContainer = dragSourceContainer === folder.id;
-                          const showDropBefore =
-                            isDropTarget &&
-                            sameContainer &&
-                            entryDropIdx === entryIndex &&
-                            draggingEntryIdx !== entryIndex &&
-                            draggingEntryIdx !== entryIndex - 1;
-                          const showDropAfter =
-                            isDropTarget &&
-                            sameContainer &&
-                            entryIndex === folderEntries.length - 1 &&
-                            entryDropIdx === folderEntries.length &&
-                            draggingEntryIdx !== entryIndex;
-                          return (
-                            <div key={entry.id}>
-                              {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
-                              <LorebookEntryRow
-                                entry={entry}
-                                lorebookId={lorebookId}
-                                isExpanded={expandedEntryId === entry.id}
-                                onToggleExpand={() => onToggleEntryExpanded(entry.id)}
-                                characters={characters}
-                                characterTags={characterTags}
-                                folders={folders}
-                                draggable={canReorderEntries}
-                                isDragging={sameContainer && draggingEntryIdx === entryIndex}
-                                onDragHandleMouseDown={() => {
-                                  if (canReorderEntries) {
-                                    entryDragReadyRef.current = entryIndex;
-                                    onSetDragSourceContainer(folder.id);
-                                  }
-                                }}
-                                onDragStart={(event) => onEntryDragStart(folder.id, entryIndex, entry.id, event)}
-                                onDragOver={(event) => {
-                                  event.stopPropagation();
-                                  onEntryDragOver(folder.id, entryIndex, event);
-                                }}
-                                onDrop={(event) => {
-                                  event.stopPropagation();
-                                  onCommitEntryDrop(event);
-                                }}
-                                onDragEnd={onResetEntryDragState}
-                                selectionMode={entrySelectionMode}
-                                isSelected={selectedEntryIds.has(entry.id)}
-                                onToggleSelected={() => onToggleEntrySelection(entry.id)}
-                                previewMatch={previewMatches.get(entry.id)}
-                              />
-                              {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
-                    {showFolderDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
-                  </div>
-                );
-              })}
-            </div>
+          {folderForest.roots.length > 0 && (
+            <div className="space-y-1.5">{folderForest.roots.map((folder) => renderFolder(folder))}</div>
           )}
 
           <div
             ref={entryListRef}
             className={cn(
               "space-y-1.5",
-              draggingEntryIdx !== null &&
-                dragSourceContainer !== null &&
-                dropTargetContainer === null &&
+              ((draggingEntryIdx !== null && dragSourceContainer !== null && dropTargetContainer === null) ||
+                folderRootDropActive) &&
                 "rounded-xl bg-amber-400/5 ring-1 ring-amber-400/40 transition-colors",
             )}
-            onDragOver={onRootListDragOver}
-            onDrop={onCommitEntryDrop}
+            onDragOver={(event) => (draggingFolderId !== null ? onRootFolderDragOver(event) : onRootListDragOver(event))}
+            onDrop={(event) => (draggingFolderId !== null ? onCommitFolderDrop(event) : onCommitEntryDrop(event))}
           >
             {(entriesByContainer.get(null) ?? []).length === 0 && (
               <p
                 className={cn(
                   "py-3 text-center text-[0.625rem] italic text-[var(--muted-foreground)] transition-opacity",
-                  draggingEntryIdx !== null && dragSourceContainer !== null ? "opacity-100" : "opacity-50",
+                  (draggingEntryIdx !== null && dragSourceContainer !== null) || folderRootDropActive
+                    ? "opacity-100"
+                    : "opacity-50",
                 )}
               >
-                {draggingEntryIdx !== null && dragSourceContainer !== null
-                  ? "Drop here to move out of the folder"
-                  : "No entries at the root level"}
+                {draggingFolderId !== null
+                  ? "Drop here to move the folder to the top level"
+                  : draggingEntryIdx !== null && dragSourceContainer !== null
+                    ? "Drop here to move out of the folder"
+                    : "No entries at the root level"}
               </p>
             )}
             {(entriesByContainer.get(null) ?? []).map((entry, entryIndex) => {
@@ -402,10 +437,12 @@ export function LorebookEntriesTab({
                     }}
                     onDragStart={(event) => onEntryDragStart(null, entryIndex, entry.id, event)}
                     onDragOver={(event) => {
+                      if (draggingEntryIdx === null) return;
                       event.stopPropagation();
                       onEntryDragOver(null, entryIndex, event);
                     }}
                     onDrop={(event) => {
+                      if (draggingEntryIdx === null) return;
                       event.stopPropagation();
                       onCommitEntryDrop(event);
                     }}

--- a/src/features/catalog/lorebooks/components/editor/LorebookEntriesTab.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEntriesTab.tsx
@@ -162,7 +162,7 @@ export function LorebookEntriesTab({
   // a guard against a malformed parent cycle looping the tree (cycles can't be
   // created through the UI; canReparentFolder blocks them).
   const renderedFolderIds = new Set<string>();
-  const renderFolder = (folder: LorebookFolder): ReactNode => {
+  const renderFolder = (folder: LorebookFolder, ancestorDisabled = false): ReactNode => {
     // `lorebookId` is non-null wherever this renders (the tree only mounts
     // inside the `lorebookId &&` guard below); the check also narrows the type
     // for the row props. The cycle guard keeps each folder to a single draw.
@@ -182,6 +182,7 @@ export function LorebookEntriesTab({
           entryCount={folderEntries.length}
           isCollapsed={isCollapsed}
           isNestTarget={dropZone === "inside"}
+          inheritedDisabled={ancestorDisabled}
           onToggleCollapse={() => onToggleFolderCollapsed(folder.id)}
           draggable={canReorderFolders}
           isDragging={draggingFolderId === folder.id}
@@ -287,7 +288,7 @@ export function LorebookEntriesTab({
                 </div>
               );
             })}
-            {childFolders.map((child) => renderFolder(child))}
+            {childFolders.map((child) => renderFolder(child, ancestorDisabled || folder.enabled === false))}
           </div>
         )}
         {dropZone === "after" && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}

--- a/src/features/catalog/lorebooks/components/editor/LorebookEntriesTab.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookEntriesTab.tsx
@@ -156,16 +156,9 @@ export function LorebookEntriesTab({
   onToggleEntryExpanded: (entryId: string) => void;
   onToggleEntrySelection: (entryId: string) => void;
 }) {
-  // Render a folder and everything beneath it. Child folders render inside the
-  // parent's indented body, so depth indentation falls out of the DOM nesting.
-  // `renderedFolderIds` ensures each folder is drawn at most once per pass —
-  // a guard against a malformed parent cycle looping the tree (cycles can't be
-  // created through the UI; canReparentFolder blocks them).
+  // Keep malformed cycle data from rendering the same folder more than once.
   const renderedFolderIds = new Set<string>();
   const renderFolder = (folder: LorebookFolder, ancestorDisabled = false): ReactNode => {
-    // `lorebookId` is non-null wherever this renders (the tree only mounts
-    // inside the `lorebookId &&` guard below); the check also narrows the type
-    // for the row props. The cycle guard keeps each folder to a single draw.
     if (!lorebookId || renderedFolderIds.has(folder.id)) return null;
     renderedFolderIds.add(folder.id);
     const folderEntries = entriesByContainer.get(folder.id) ?? [];
@@ -214,10 +207,7 @@ export function LorebookEntriesTab({
                 "bg-amber-400/5 ring-1 ring-amber-400/40",
             )}
             onDragOver={(event) => {
-              // Stop the dragover bubbling to ancestor folder bodies — without
-              // this, a nested target is overwritten by its outermost ancestor,
-              // so the drop lands in the wrong folder. (Hovering the left indent
-              // margin still lands on the shallower ancestor body, by design.)
+              // Prevent ancestor folder bodies from overwriting the intended nested target.
               event.stopPropagation();
               if (draggingFolderId !== null) onFolderBodyNestDragOver(folder.id, event);
               else onFolderBodyDragOver(folder.id, event);

--- a/src/features/catalog/lorebooks/components/editor/use-lorebook-editor-drag-drop.ts
+++ b/src/features/catalog/lorebooks/components/editor/use-lorebook-editor-drag-drop.ts
@@ -11,11 +11,11 @@ type ReorderEntriesInput = {
 type ReorderFoldersInput = {
   lorebookId: string;
   folderIds: string[];
-  /** The listed folders adopt this parent (null un-nests to root). */
+  /** The listed folders adopt this parent; null moves them to root. */
   parentFolderId: string | null;
 };
 
-/** Where a dragged folder will land relative to the folder it's hovering. */
+/** Folder row drop zone relative to the hovered folder. */
 export type FolderDropZone = "before" | "inside" | "after";
 export type FolderDropTarget = { id: string; zone: FolderDropZone };
 
@@ -191,7 +191,7 @@ export function useLorebookEditorDragDrop({
         ids.splice(sourceIdx, 1);
         ids.splice(insertAt, 0, moved.id);
         void Promise.resolve(onReorderEntries({ lorebookId, entryIds: ids, folderId: sourceContainer })).catch(() => {
-          /* mutation surfaces errors through React Query */
+          /* mutation errors surface through React Query */
         });
         return;
       }
@@ -206,7 +206,7 @@ export function useLorebookEditorDragDrop({
         }
         await onReorderEntries({ lorebookId, entryIds: targetIds, folderId: targetContainer });
       })().catch(() => {
-        /* mutation surfaces errors through React Query */
+        /* mutation errors surface through React Query */
       });
     },
     [
@@ -235,11 +235,7 @@ export function useLorebookEditorDragDrop({
     [canReorderFolders],
   );
 
-  // Dragging a folder over another folder's header has three zones: the top
-  // edge reorders it as a sibling *before* the target, the bottom edge *after*,
-  // and the middle nests it *inside*. Each zone validates the move it implies
-  // (nest → under the target; before/after → into the target's parent), so an
-  // invalid hover (self, descendant, cross-lorebook) registers no drop target.
+  // Header hover chooses before/inside/after; each zone validates its resulting parent.
   const handleFolderDragOverRow = useCallback(
     (targetFolderId: string, event: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderFolders || draggingFolderId === null) return;
@@ -269,10 +265,7 @@ export function useLorebookEditorDragDrop({
     [canReorderFolders, draggingFolderId, folders],
   );
 
-  // Dragging a folder into another folder's body (its indented area, including
-  // the empty placeholder) nests it inside — mirroring entry-into-folder. Nested
-  // bodies stop propagation, so hovering the left indent margin lands on the
-  // shallower ancestor body, letting you aim at a more-parent folder.
+  // Body hover nests into the hovered folder.
   const handleFolderBodyNestDragOver = useCallback(
     (targetFolderId: string, event: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderFolders || draggingFolderId === null) return;
@@ -292,8 +285,7 @@ export function useLorebookEditorDragDrop({
     [canReorderFolders, draggingFolderId, folders],
   );
 
-  // Dragging a folder into the open root area (below the tree, where root-level
-  // entries live) un-nests it to the top level. Un-nesting is always valid.
+  // Open root area un-nests the folder to top level.
   const handleRootFolderDragOver = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderFolders || draggingFolderId === null) return;
@@ -315,7 +307,7 @@ export function useLorebookEditorDragDrop({
       if (!lorebookId || !canReorderFolders || !draggedId) return;
 
       if (!drop) {
-        // Dropped in the open root area → un-nest to the end of the top level.
+        // Root drop appends the folder at top level.
         if (!toRoot) return;
         const rootIds = folderForest.roots.map((folder) => folder.id).filter((id) => id !== draggedId);
         rootIds.push(draggedId);
@@ -328,8 +320,7 @@ export function useLorebookEditorDragDrop({
 
       if (drop.zone === "inside") {
         if (!canReparentFolder(folders, draggedId, drop.id).ok) return;
-        // Nest: append to the target's children; each sibling adopts the target
-        // as parent (a no-op for ones already nested there).
+        // Nest drops append to the target's child list.
         const childIds = (folderForest.childrenByParent.get(drop.id) ?? [])
           .map((child) => child.id)
           .filter((id) => id !== draggedId);
@@ -338,8 +329,7 @@ export function useLorebookEditorDragDrop({
         return;
       }
 
-      // before / after: the dragged folder joins the target's sibling group at
-      // that position, adopting the target's parent (null re-homes it to root).
+      // Before/after drops join the target's sibling group.
       const newParentId = target.parentFolderId;
       if (!canReparentFolder(folders, draggedId, newParentId).ok) return;
       const siblings =

--- a/src/features/catalog/lorebooks/components/editor/use-lorebook-editor-drag-drop.ts
+++ b/src/features/catalog/lorebooks/components/editor/use-lorebook-editor-drag-drop.ts
@@ -11,8 +11,8 @@ type ReorderEntriesInput = {
 type ReorderFoldersInput = {
   lorebookId: string;
   folderIds: string[];
-  /** When set, the listed folders also adopt this parent (nest / un-nest). */
-  parentFolderId?: string | null;
+  /** The listed folders adopt this parent (null un-nests to root). */
+  parentFolderId: string | null;
 };
 
 /** Where a dragged folder will land relative to the folder it's hovering. */
@@ -242,15 +242,26 @@ export function useLorebookEditorDragDrop({
   // invalid hover (self, descendant, cross-lorebook) registers no drop target.
   const handleFolderDragOverRow = useCallback(
     (targetFolderId: string, event: ReactDragEvent<HTMLDivElement>) => {
-      if (!canReorderFolders || draggingFolderId === null || draggingFolderId === targetFolderId) return;
+      if (!canReorderFolders || draggingFolderId === null) return;
+      setFolderRootDropActive(false);
+      if (draggingFolderId === targetFolderId) {
+        setFolderDropTarget(null);
+        return;
+      }
       const target = folders.find((folder) => folder.id === targetFolderId);
-      if (!target) return;
+      if (!target) {
+        setFolderDropTarget(null);
+        return;
+      }
       const rect = event.currentTarget.getBoundingClientRect();
       const offset = event.clientY - rect.top;
       const zone: FolderDropZone =
         offset < rect.height * 0.28 ? "before" : offset > rect.height * 0.72 ? "after" : "inside";
       const newParentId = zone === "inside" ? targetFolderId : target.parentFolderId;
-      if (!canReparentFolder(folders, draggingFolderId, newParentId).ok) return;
+      if (!canReparentFolder(folders, draggingFolderId, newParentId).ok) {
+        setFolderDropTarget(null);
+        return;
+      }
       event.preventDefault();
       event.dataTransfer.dropEffect = "move";
       setFolderDropTarget({ id: targetFolderId, zone });
@@ -264,8 +275,16 @@ export function useLorebookEditorDragDrop({
   // shallower ancestor body, letting you aim at a more-parent folder.
   const handleFolderBodyNestDragOver = useCallback(
     (targetFolderId: string, event: ReactDragEvent<HTMLDivElement>) => {
-      if (!canReorderFolders || draggingFolderId === null || draggingFolderId === targetFolderId) return;
-      if (!canReparentFolder(folders, draggingFolderId, targetFolderId).ok) return;
+      if (!canReorderFolders || draggingFolderId === null) return;
+      setFolderRootDropActive(false);
+      if (draggingFolderId === targetFolderId) {
+        setFolderDropTarget(null);
+        return;
+      }
+      if (!canReparentFolder(folders, draggingFolderId, targetFolderId).ok) {
+        setFolderDropTarget(null);
+        return;
+      }
       event.preventDefault();
       event.dataTransfer.dropEffect = "move";
       setFolderDropTarget({ id: targetFolderId, zone: "inside" });
@@ -323,7 +342,8 @@ export function useLorebookEditorDragDrop({
       // that position, adopting the target's parent (null re-homes it to root).
       const newParentId = target.parentFolderId;
       if (!canReparentFolder(folders, draggedId, newParentId).ok) return;
-      const siblings = (newParentId === null ? folderForest.roots : folderForest.childrenByParent.get(newParentId)) ?? [];
+      const siblings =
+        (newParentId === null ? folderForest.roots : folderForest.childrenByParent.get(newParentId)) ?? [];
       const orderedIds = siblings.map((folder) => folder.id).filter((id) => id !== draggedId);
       const targetIndex = orderedIds.indexOf(drop.id);
       if (targetIndex === -1) orderedIds.push(draggedId);

--- a/src/features/catalog/lorebooks/components/editor/use-lorebook-editor-drag-drop.ts
+++ b/src/features/catalog/lorebooks/components/editor/use-lorebook-editor-drag-drop.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, type DragEvent as ReactDragEvent } from "react";
 import type { LorebookEntry, LorebookFolder } from "../../../../../engine/contracts/types/lorebook";
+import { canReparentFolder, type FolderForest } from "../../lib/lorebook-folder-tree";
 
 type ReorderEntriesInput = {
   lorebookId: string;
@@ -10,12 +11,19 @@ type ReorderEntriesInput = {
 type ReorderFoldersInput = {
   lorebookId: string;
   folderIds: string[];
+  /** When set, the listed folders also adopt this parent (nest / un-nest). */
+  parentFolderId?: string | null;
 };
+
+/** Where a dragged folder will land relative to the folder it's hovering. */
+export type FolderDropZone = "before" | "inside" | "after";
+export type FolderDropTarget = { id: string; zone: FolderDropZone };
 
 export function useLorebookEditorDragDrop({
   lorebookId,
   entries,
   folders,
+  folderForest,
   entriesByContainer,
   showFolderGrouping,
   reorderEntriesPending,
@@ -26,6 +34,7 @@ export function useLorebookEditorDragDrop({
   lorebookId: string | null;
   entries: LorebookEntry[];
   folders: LorebookFolder[];
+  folderForest: FolderForest<LorebookFolder>;
   entriesByContainer: Map<string | null, LorebookEntry[]>;
   showFolderGrouping: boolean;
   reorderEntriesPending: boolean;
@@ -38,9 +47,10 @@ export function useLorebookEditorDragDrop({
   const [entryDropIdx, setEntryDropIdx] = useState<number | null>(null);
   const [dragSourceContainer, setDragSourceContainer] = useState<string | null | undefined>(undefined);
   const [dropTargetContainer, setDropTargetContainer] = useState<string | null | undefined>(undefined);
-  const [draggingFolderIdx, setDraggingFolderIdx] = useState<number | null>(null);
-  const folderDragReadyRef = useRef<number | null>(null);
-  const [folderDropIdx, setFolderDropIdx] = useState<number | null>(null);
+  const [draggingFolderId, setDraggingFolderId] = useState<string | null>(null);
+  const folderDragReadyRef = useRef<string | null>(null);
+  const [folderDropTarget, setFolderDropTarget] = useState<FolderDropTarget | null>(null);
+  const [folderRootDropActive, setFolderRootDropActive] = useState(false);
   const entryListRef = useRef<HTMLDivElement | null>(null);
 
   const canReorderEntries = showFolderGrouping && entries.length > 1 && !reorderEntriesPending;
@@ -55,9 +65,10 @@ export function useLorebookEditorDragDrop({
   }, []);
 
   const resetFolderDragState = useCallback(() => {
-    setDraggingFolderIdx(null);
+    setDraggingFolderId(null);
     folderDragReadyRef.current = null;
-    setFolderDropIdx(null);
+    setFolderDropTarget(null);
+    setFolderRootDropActive(false);
   }, []);
 
   const calcEntryDropIdx = useCallback((cardIdx: number, event: ReactDragEvent<HTMLDivElement>) => {
@@ -212,47 +223,124 @@ export function useLorebookEditorDragDrop({
   );
 
   const handleFolderDragStart = useCallback(
-    (idx: number, folderId: string, event: ReactDragEvent<HTMLDivElement>) => {
-      if (!canReorderFolders || folderDragReadyRef.current !== idx) {
+    (folderId: string, event: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || folderDragReadyRef.current !== folderId) {
         event.preventDefault();
         return;
       }
-      setDraggingFolderIdx(idx);
+      setDraggingFolderId(folderId);
       event.dataTransfer.effectAllowed = "move";
       event.dataTransfer.setData("text/plain", folderId);
     },
     [canReorderFolders],
   );
 
-  const handleFolderDragOverHeader = useCallback(
-    (idx: number, event: ReactDragEvent<HTMLDivElement>) => {
-      if (!canReorderFolders || draggingFolderIdx === null) return;
+  // Dragging a folder over another folder's header has three zones: the top
+  // edge reorders it as a sibling *before* the target, the bottom edge *after*,
+  // and the middle nests it *inside*. Each zone validates the move it implies
+  // (nest → under the target; before/after → into the target's parent), so an
+  // invalid hover (self, descendant, cross-lorebook) registers no drop target.
+  const handleFolderDragOverRow = useCallback(
+    (targetFolderId: string, event: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderId === null || draggingFolderId === targetFolderId) return;
+      const target = folders.find((folder) => folder.id === targetFolderId);
+      if (!target) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const offset = event.clientY - rect.top;
+      const zone: FolderDropZone =
+        offset < rect.height * 0.28 ? "before" : offset > rect.height * 0.72 ? "after" : "inside";
+      const newParentId = zone === "inside" ? targetFolderId : target.parentFolderId;
+      if (!canReparentFolder(folders, draggingFolderId, newParentId).ok) return;
       event.preventDefault();
       event.dataTransfer.dropEffect = "move";
-      const rect = event.currentTarget.getBoundingClientRect();
-      const midY = rect.top + rect.height / 2;
-      setFolderDropIdx(event.clientY < midY ? idx : idx + 1);
+      setFolderDropTarget({ id: targetFolderId, zone });
     },
-    [canReorderFolders, draggingFolderIdx],
+    [canReorderFolders, draggingFolderId, folders],
+  );
+
+  // Dragging a folder into another folder's body (its indented area, including
+  // the empty placeholder) nests it inside — mirroring entry-into-folder. Nested
+  // bodies stop propagation, so hovering the left indent margin lands on the
+  // shallower ancestor body, letting you aim at a more-parent folder.
+  const handleFolderBodyNestDragOver = useCallback(
+    (targetFolderId: string, event: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderId === null || draggingFolderId === targetFolderId) return;
+      if (!canReparentFolder(folders, draggingFolderId, targetFolderId).ok) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      setFolderDropTarget({ id: targetFolderId, zone: "inside" });
+    },
+    [canReorderFolders, draggingFolderId, folders],
+  );
+
+  // Dragging a folder into the open root area (below the tree, where root-level
+  // entries live) un-nests it to the top level. Un-nesting is always valid.
+  const handleRootFolderDragOver = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderId === null) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      setFolderRootDropActive(true);
+      setFolderDropTarget(null);
+    },
+    [canReorderFolders, draggingFolderId],
   );
 
   const commitFolderDrop = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
       event.preventDefault();
-      const sourceIdx = draggingFolderIdx;
-      const targetIdx = folderDropIdx;
+      const draggedId = draggingFolderId;
+      const drop = folderDropTarget;
+      const toRoot = folderRootDropActive;
       resetFolderDragState();
-      if (!lorebookId || !canReorderFolders || sourceIdx === null || targetIdx === null) return;
-      let insertAt = targetIdx;
-      if (sourceIdx < insertAt) insertAt--;
-      if (sourceIdx === insertAt) return;
-      const ids = folders.map((folder) => folder.id);
-      const [moved] = ids.splice(sourceIdx, 1);
-      if (!moved) return;
-      ids.splice(insertAt, 0, moved);
-      onReorderFolders({ lorebookId, folderIds: ids });
+      if (!lorebookId || !canReorderFolders || !draggedId) return;
+
+      if (!drop) {
+        // Dropped in the open root area → un-nest to the end of the top level.
+        if (!toRoot) return;
+        const rootIds = folderForest.roots.map((folder) => folder.id).filter((id) => id !== draggedId);
+        rootIds.push(draggedId);
+        onReorderFolders({ lorebookId, folderIds: rootIds, parentFolderId: null });
+        return;
+      }
+
+      const target = folders.find((folder) => folder.id === drop.id);
+      if (!target) return;
+
+      if (drop.zone === "inside") {
+        if (!canReparentFolder(folders, draggedId, drop.id).ok) return;
+        // Nest: append to the target's children; each sibling adopts the target
+        // as parent (a no-op for ones already nested there).
+        const childIds = (folderForest.childrenByParent.get(drop.id) ?? [])
+          .map((child) => child.id)
+          .filter((id) => id !== draggedId);
+        childIds.push(draggedId);
+        onReorderFolders({ lorebookId, folderIds: childIds, parentFolderId: drop.id });
+        return;
+      }
+
+      // before / after: the dragged folder joins the target's sibling group at
+      // that position, adopting the target's parent (null re-homes it to root).
+      const newParentId = target.parentFolderId;
+      if (!canReparentFolder(folders, draggedId, newParentId).ok) return;
+      const siblings = (newParentId === null ? folderForest.roots : folderForest.childrenByParent.get(newParentId)) ?? [];
+      const orderedIds = siblings.map((folder) => folder.id).filter((id) => id !== draggedId);
+      const targetIndex = orderedIds.indexOf(drop.id);
+      if (targetIndex === -1) orderedIds.push(draggedId);
+      else orderedIds.splice(drop.zone === "before" ? targetIndex : targetIndex + 1, 0, draggedId);
+      onReorderFolders({ lorebookId, folderIds: orderedIds, parentFolderId: newParentId });
     },
-    [canReorderFolders, draggingFolderIdx, folderDropIdx, folders, lorebookId, onReorderFolders, resetFolderDragState],
+    [
+      canReorderFolders,
+      draggingFolderId,
+      folderDropTarget,
+      folderRootDropActive,
+      folderForest,
+      folders,
+      lorebookId,
+      onReorderFolders,
+      resetFolderDragState,
+    ],
   );
 
   return {
@@ -264,9 +352,10 @@ export function useLorebookEditorDragDrop({
     dragSourceContainer,
     setDragSourceContainer,
     dropTargetContainer,
-    draggingFolderIdx,
+    draggingFolderId,
     folderDragReadyRef,
-    folderDropIdx,
+    folderDropTarget,
+    folderRootDropActive,
     entryListRef,
     resetEntryDragState,
     resetFolderDragState,
@@ -277,7 +366,9 @@ export function useLorebookEditorDragDrop({
     handleRootListDragOver,
     commitEntryDrop,
     handleFolderDragStart,
-    handleFolderDragOverHeader,
+    handleFolderDragOverRow,
+    handleFolderBodyNestDragOver,
+    handleRootFolderDragOver,
     commitFolderDrop,
   };
 }

--- a/src/features/catalog/lorebooks/components/editor/use-lorebook-entry-selection.ts
+++ b/src/features/catalog/lorebooks/components/editor/use-lorebook-entry-selection.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import type { Lorebook, LorebookEntry } from "../../../../../engine/contracts/types/lorebook";
+import type { Lorebook, LorebookEntry, LorebookFolder } from "../../../../../engine/contracts/types/lorebook";
 import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
+import { collectHiddenFolderIds } from "../../lib/lorebook-folder-tree";
 
 type TransferOperation = "copy" | "move";
 
@@ -19,6 +20,7 @@ export function useLorebookEntrySelection({
   lorebooks,
   entries,
   filteredEntries,
+  folders,
   showFolderGrouping,
   collapsedFolderIds,
   onTransferEntries,
@@ -28,6 +30,7 @@ export function useLorebookEntrySelection({
   lorebooks: Lorebook[];
   entries: LorebookEntry[];
   filteredEntries: LorebookEntry[];
+  folders: LorebookFolder[];
   showFolderGrouping: boolean;
   collapsedFolderIds: Set<string>;
   onTransferEntries: TransferEntries;
@@ -41,13 +44,20 @@ export function useLorebookEntrySelection({
     () => lorebooks.filter((book) => book.id !== lorebookId).sort((a, b) => a.name.localeCompare(b.name)),
     [lorebooks, lorebookId],
   );
+  // Collapsing a folder hides its whole subtree, so an entry is "visible" only
+  // when neither its folder nor any ancestor is collapsed — not just its direct
+  // folder. Otherwise "select all visible" would grab entries the user can't see.
+  const hiddenFolderIds = useMemo(
+    () => collectHiddenFolderIds(folders, collapsedFolderIds),
+    [folders, collapsedFolderIds],
+  );
   const visibleEntryIds = useMemo(
     () =>
       (showFolderGrouping
-        ? entries.filter((entry) => !entry.folderId || !collapsedFolderIds.has(entry.folderId))
+        ? entries.filter((entry) => !entry.folderId || !hiddenFolderIds.has(entry.folderId))
         : filteredEntries
       ).map((entry) => entry.id),
-    [collapsedFolderIds, entries, filteredEntries, showFolderGrouping],
+    [hiddenFolderIds, entries, filteredEntries, showFolderGrouping],
   );
 
   useEffect(() => {

--- a/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
+++ b/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
@@ -280,7 +280,7 @@ export function LorebookFolderRow({
         {/* Parent-folder selector — the dropdown path for nesting (folder-into-folder
             drag lands in a later step). Hidden when there's no other folder to nest under.
             Wrapped so opening the select doesn't toggle the folder's collapse. */}
-        {folders.length > 1 && (
+        {(folders.length > 1 || localParentId !== null) && (
           <span className="shrink-0" onClick={(e) => e.stopPropagation()}>
             <CompactSelect
               value={localParentId ?? ""}

--- a/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
+++ b/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
@@ -43,6 +43,9 @@ interface Props {
   isDragging: boolean;
   /** Highlighted as the folder a dragged folder will nest under. */
   isNestTarget?: boolean;
+  /** True when an ancestor folder is disabled, so this folder's entries are
+   *  gated out at activation even when this folder's own toggle is on. */
+  inheritedDisabled?: boolean;
   onDragHandleMouseDown: () => void;
   onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
   onDragOver: (e: ReactDragEvent<HTMLDivElement>) => void;
@@ -60,6 +63,7 @@ export function LorebookFolderRow({
   draggable,
   isDragging,
   isNestTarget,
+  inheritedDisabled = false,
   onDragHandleMouseDown,
   onDragStart,
   onDragOver,
@@ -175,6 +179,10 @@ export function LorebookFolderRow({
       .map((candidate) => ({ value: candidate.id, label: candidate.name.trim() || "Untitled folder" })),
   ];
 
+  // A disabled ancestor gates this folder's entries regardless of its own
+  // toggle, so reflect that in the icon/toggle styling and copy below.
+  const effectivelyDisabled = inheritedDisabled || !localEnabled;
+
   return (
     <div
       className={cn(
@@ -230,15 +238,20 @@ export function LorebookFolderRow({
           type="button"
           aria-label={localEnabled ? "Disable folder" : "Enable folder"}
           title={
-            localEnabled
-              ? "Folder enabled — entries inside activate normally"
-              : "Folder disabled — entries inside will not activate, regardless of their own toggle"
+            inheritedDisabled
+              ? "A parent folder is disabled, so entries here won't activate even though this folder is on."
+              : localEnabled
+                ? "Folder enabled — entries inside activate normally"
+                : "Folder disabled — entries inside will not activate, regardless of their own toggle"
           }
           onClick={handleEnableToggle}
           className="shrink-0"
         >
           {localEnabled ? (
-            <ToggleRight size="1.125rem" className="text-amber-400" />
+            <ToggleRight
+              size="1.125rem"
+              className={inheritedDisabled ? "text-[var(--muted-foreground)]" : "text-amber-400"}
+            />
           ) : (
             <ToggleLeft size="1.125rem" className="text-[var(--muted-foreground)]" />
           )}
@@ -247,7 +260,7 @@ export function LorebookFolderRow({
         {/* Folder icon + name */}
         <Folder
           size="0.875rem"
-          className={cn("shrink-0", localEnabled ? "text-amber-400" : "text-[var(--muted-foreground)]")}
+          className={cn("shrink-0", effectivelyDisabled ? "text-[var(--muted-foreground)]" : "text-amber-400")}
         />
         <input
           value={localName}
@@ -276,6 +289,16 @@ export function LorebookFolderRow({
               options={parentOptions}
               className="w-[5.5rem] sm:w-[7rem]"
             />
+          </span>
+        )}
+
+        {/* Inherited-disabled cue — entries here are gated by a disabled ancestor */}
+        {inheritedDisabled && (
+          <span
+            className="shrink-0 rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] font-medium text-amber-500/80"
+            title="A parent folder is disabled, so entries in this folder won't activate."
+          >
+            parent off
           </span>
         )}
 

--- a/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
+++ b/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
@@ -1,16 +1,3 @@
-// ──────────────────────────────────────────────
-// Lorebook Folder Row
-// Header for a collapsible folder of lorebook entries. Mirrors the visual
-// language of LorebookEntryRow (compact, drag handle on the left, inline
-// rename, hover-revealed delete) so the two row types feel like one list.
-//
-// Two toggles live on this row:
-//  • Collapse — a UI-only chevron that hides/shows the folder body. Persisted
-//    in localStorage by the parent editor; never sent to native storage.
-//  • Enable  — a native folder.enabled flag. When OFF, every entry
-//    inside the folder is gated out at activation time regardless of the
-//    entry's own enabled flag. Entries' own flags are preserved untouched.
-// ──────────────────────────────────────────────
 import {
   useCallback,
   useEffect,
@@ -29,22 +16,14 @@ import type { LorebookFolder } from "../../../../../engine/contracts/types/loreb
 
 interface Props {
   folder: LorebookFolder;
-  /** All folders in the lorebook — used to build the valid-parent options. */
   folders: LorebookFolder[];
   lorebookId: string;
-  /** Number of entries currently inside this folder (for the count badge). */
   entryCount: number;
-  /** UI-only collapse state — owned by the parent editor and persisted in localStorage. */
   isCollapsed: boolean;
   onToggleCollapse: () => void;
-  // Drag handle wiring — folder rows are draggable to reorder folders, AND
-  // act as drop targets when dragging an entry across containers.
   draggable: boolean;
   isDragging: boolean;
-  /** Highlighted as the folder a dragged folder will nest under. */
   isNestTarget?: boolean;
-  /** True when an ancestor folder is disabled, so this folder's entries are
-   *  gated out at activation even when this folder's own toggle is on. */
   inheritedDisabled?: boolean;
   onDragHandleMouseDown: () => void;
   onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
@@ -73,7 +52,7 @@ export function LorebookFolderRow({
   const updateFolder = useUpdateLorebookFolder();
   const deleteFolder = useDeleteLorebookFolder();
 
-  // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
+  // Optimistic mirrors roll back on mutation errors.
   const [localEnabled, setLocalEnabled] = useState(folder.enabled);
   const [localName, setLocalName] = useState(folder.name);
   const [localParentId, setLocalParentId] = useState(folder.parentFolderId);
@@ -92,11 +71,6 @@ export function LorebookFolderRow({
       e.stopPropagation();
       const previous = localEnabled;
       const next = !previous;
-      // Optimistic flip — but if the PATCH fails, restore the previous value
-      // so the row doesn't lie about persisted state. This matters most for
-      // `enabled`: the activation gate runs through native storage, so a failed flip
-      // would mean the row says "off" while entries still activate (or vice
-      // versa).
       setLocalEnabled(next);
       updateFolder.mutate(
         { lorebookId, folderId: folder.id, enabled: next },
@@ -122,9 +96,6 @@ export function LorebookFolderRow({
         { lorebookId, folderId: folder.id, name: trimmed },
         {
           onError: () => {
-            // Roll the displayed name back to whatever native storage still has
-            // so the row doesn't continue showing a renamed folder that the
-            // save never accepted.
             setLocalName(previous);
           },
         },
@@ -136,8 +107,6 @@ export function LorebookFolderRow({
     (value: string) => {
       const next = value === "" ? null : value;
       const previous = localParentId;
-      // Optimistic so the selector doesn't snap back to the old parent while
-      // the PATCH flushes; restore on error like enable/name above.
       setLocalParentId(next);
       updateFolder.mutate(
         { lorebookId, folderId: folder.id, parentFolderId: next },
@@ -169,9 +138,7 @@ export function LorebookFolderRow({
     [entryCount, lorebookId, folder.id, deleteFolder],
   );
 
-  // Valid parents: any other folder this one may nest under without creating a
-  // cycle or crossing lorebooks (canReparentFolder is the same guard the drag
-  // path will use), plus "(no parent)" to lift it back to the top level.
+  // Valid parents use the same ancestry guard as drag/drop.
   const parentOptions = [
     { value: "", label: "(no parent)" },
     ...folders
@@ -179,8 +146,7 @@ export function LorebookFolderRow({
       .map((candidate) => ({ value: candidate.id, label: candidate.name.trim() || "Untitled folder" })),
   ];
 
-  // A disabled ancestor gates this folder's entries regardless of its own
-  // toggle, so reflect that in the icon/toggle styling and copy below.
+  // Disabled ancestors gate entries even when this folder's own toggle is on.
   const effectivelyDisabled = inheritedDisabled || !localEnabled;
 
   return (
@@ -198,7 +164,6 @@ export function LorebookFolderRow({
       onDragEnd={onDragEnd}
     >
       <div className="group flex cursor-pointer items-center gap-2 px-2 py-1.5" onClick={onToggleCollapse}>
-        {/* Drag handle */}
         <button
           type="button"
           className={cn(
@@ -217,7 +182,6 @@ export function LorebookFolderRow({
           <GripVertical size="0.875rem" />
         </button>
 
-        {/* Collapse chevron */}
         <button
           type="button"
           aria-label={isCollapsed ? "Expand folder" : "Collapse folder"}
@@ -233,7 +197,6 @@ export function LorebookFolderRow({
           />
         </button>
 
-        {/* Enable toggle */}
         <button
           type="button"
           aria-label={localEnabled ? "Disable folder" : "Enable folder"}
@@ -257,7 +220,6 @@ export function LorebookFolderRow({
           )}
         </button>
 
-        {/* Folder icon + name */}
         <Folder
           size="0.875rem"
           className={cn("shrink-0", effectivelyDisabled ? "text-[var(--muted-foreground)]" : "text-amber-400")}
@@ -277,9 +239,6 @@ export function LorebookFolderRow({
           className="min-w-0 flex-1 truncate bg-transparent px-1 text-sm font-semibold outline-none transition-colors hover:bg-[var(--accent)]/40 focus:bg-[var(--accent)]/40 focus:ring-1 focus:ring-[var(--ring)] rounded"
         />
 
-        {/* Parent-folder selector — the dropdown path for nesting (folder-into-folder
-            drag lands in a later step). Hidden when there's no other folder to nest under.
-            Wrapped so opening the select doesn't toggle the folder's collapse. */}
         {(folders.length > 1 || localParentId !== null) && (
           <span className="shrink-0" onClick={(e) => e.stopPropagation()}>
             <CompactSelect
@@ -292,7 +251,6 @@ export function LorebookFolderRow({
           </span>
         )}
 
-        {/* Inherited-disabled cue — entries here are gated by a disabled ancestor */}
         {inheritedDisabled && (
           <span
             className="shrink-0 rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] font-medium text-amber-500/80"
@@ -302,7 +260,6 @@ export function LorebookFolderRow({
           </span>
         )}
 
-        {/* Entry count badge */}
         <span
           className="shrink-0 rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] font-medium text-[var(--muted-foreground)]"
           title={`${entryCount} entr${entryCount === 1 ? "y" : "ies"} in this folder`}
@@ -310,7 +267,6 @@ export function LorebookFolderRow({
           {entryCount}
         </span>
 
-        {/* Delete (hover-revealed on desktop, always visible on mobile per the row-action convention) */}
         <button
           type="button"
           aria-label="Delete folder"

--- a/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
+++ b/src/features/catalog/lorebooks/components/entries/LorebookFolderRow.tsx
@@ -23,10 +23,14 @@ import { ChevronDown, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } fr
 import { cn } from "../../../../../shared/lib/utils";
 import { showConfirmDialog } from "../../../../../shared/lib/app-dialogs";
 import { useUpdateLorebookFolder, useDeleteLorebookFolder } from "../../hooks/use-lorebooks";
+import { canReparentFolder } from "../../lib/lorebook-folder-tree";
+import { CompactSelect } from "./LorebookEntryRowControls";
 import type { LorebookFolder } from "../../../../../engine/contracts/types/lorebook";
 
 interface Props {
   folder: LorebookFolder;
+  /** All folders in the lorebook — used to build the valid-parent options. */
+  folders: LorebookFolder[];
   lorebookId: string;
   /** Number of entries currently inside this folder (for the count badge). */
   entryCount: number;
@@ -37,6 +41,8 @@ interface Props {
   // act as drop targets when dragging an entry across containers.
   draggable: boolean;
   isDragging: boolean;
+  /** Highlighted as the folder a dragged folder will nest under. */
+  isNestTarget?: boolean;
   onDragHandleMouseDown: () => void;
   onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
   onDragOver: (e: ReactDragEvent<HTMLDivElement>) => void;
@@ -46,12 +52,14 @@ interface Props {
 
 export function LorebookFolderRow({
   folder,
+  folders,
   lorebookId,
   entryCount,
   isCollapsed,
   onToggleCollapse,
   draggable,
   isDragging,
+  isNestTarget,
   onDragHandleMouseDown,
   onDragStart,
   onDragOver,
@@ -64,6 +72,7 @@ export function LorebookFolderRow({
   // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
   const [localEnabled, setLocalEnabled] = useState(folder.enabled);
   const [localName, setLocalName] = useState(folder.name);
+  const [localParentId, setLocalParentId] = useState(folder.parentFolderId);
 
   const lastSyncedRef = useRef(folder);
   useEffect(() => {
@@ -71,6 +80,7 @@ export function LorebookFolderRow({
     lastSyncedRef.current = folder;
     setLocalEnabled(folder.enabled);
     setLocalName(folder.name);
+    setLocalParentId(folder.parentFolderId);
   }, [folder]);
 
   const handleEnableToggle = useCallback(
@@ -118,6 +128,25 @@ export function LorebookFolderRow({
     }
   }, [localName, folder.name, lorebookId, folder.id, updateFolder]);
 
+  const handleParentChange = useCallback(
+    (value: string) => {
+      const next = value === "" ? null : value;
+      const previous = localParentId;
+      // Optimistic so the selector doesn't snap back to the old parent while
+      // the PATCH flushes; restore on error like enable/name above.
+      setLocalParentId(next);
+      updateFolder.mutate(
+        { lorebookId, folderId: folder.id, parentFolderId: next },
+        {
+          onError: () => {
+            setLocalParentId(previous);
+          },
+        },
+      );
+    },
+    [localParentId, lorebookId, folder.id, updateFolder],
+  );
+
   const handleDelete = useCallback(
     async (e: ReactMouseEvent) => {
       e.stopPropagation();
@@ -136,11 +165,22 @@ export function LorebookFolderRow({
     [entryCount, lorebookId, folder.id, deleteFolder],
   );
 
+  // Valid parents: any other folder this one may nest under without creating a
+  // cycle or crossing lorebooks (canReparentFolder is the same guard the drag
+  // path will use), plus "(no parent)" to lift it back to the top level.
+  const parentOptions = [
+    { value: "", label: "(no parent)" },
+    ...folders
+      .filter((candidate) => candidate.id !== folder.id && canReparentFolder(folders, folder.id, candidate.id).ok)
+      .map((candidate) => ({ value: candidate.id, label: candidate.name.trim() || "Untitled folder" })),
+  ];
+
   return (
     <div
       className={cn(
         "rounded-xl bg-[var(--secondary)]/60 ring-1 ring-[var(--border)] transition-all",
         !isCollapsed && "ring-amber-400/30",
+        isNestTarget && "ring-2 ring-amber-400",
         isDragging && "opacity-40",
       )}
       draggable={draggable}
@@ -223,6 +263,21 @@ export function LorebookFolderRow({
           placeholder="Untitled folder"
           className="min-w-0 flex-1 truncate bg-transparent px-1 text-sm font-semibold outline-none transition-colors hover:bg-[var(--accent)]/40 focus:bg-[var(--accent)]/40 focus:ring-1 focus:ring-[var(--ring)] rounded"
         />
+
+        {/* Parent-folder selector — the dropdown path for nesting (folder-into-folder
+            drag lands in a later step). Hidden when there's no other folder to nest under.
+            Wrapped so opening the select doesn't toggle the folder's collapse. */}
+        {folders.length > 1 && (
+          <span className="shrink-0" onClick={(e) => e.stopPropagation()}>
+            <CompactSelect
+              value={localParentId ?? ""}
+              onChange={handleParentChange}
+              title="Nest this folder under another folder, or choose (no parent) for the top level."
+              options={parentOptions}
+              className="w-[5.5rem] sm:w-[7rem]"
+            />
+          </span>
+        )}
 
         {/* Entry count badge */}
         <span

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -13,6 +13,7 @@ import {
   updateLorebookFolderSchema,
   updateLorebookSchema,
 } from "../../../../engine/contracts/schemas/lorebook.schema";
+import { lorebookFolderApi } from "../../../../shared/api/lorebook-folder-api";
 import { storageApi } from "../../../../shared/api/storage-api";
 import { ApiError } from "../../../../shared/api/api-errors";
 import { lorebookCommandApi } from "../../../../shared/api/lorebook-command-api";
@@ -89,19 +90,13 @@ async function reorderLorebookEntries(
 async function reorderLorebookFolders(
   lorebookId: string,
   folderIds: string[],
-  parentFolderId?: string | null,
+  parentFolderId: string | null,
 ): Promise<LorebookFolder[]> {
-  await Promise.all(
-    folderIds.map((folderId, index) => {
-      // When `parentFolderId` is provided, this doubles as a re-parent: every id
-      // in the list adopts that parent (a no-op for existing children) and is
-      // renumbered, so nesting/un-nesting + sibling order land in one pass.
-      const patch: Record<string, unknown> = { order: index, sortOrder: index };
-      if (parentFolderId !== undefined) patch.parentFolderId = parentFolderId;
-      return storageApi.update("lorebook-folders", folderId, updateLorebookFolderSchema.parse(patch));
-    }),
-  );
-  return storageApi.list<LorebookFolder>("lorebook-folders", { filters: { lorebookId } });
+  return lorebookFolderApi.reorder({
+    lorebookId,
+    folderIds,
+    parentFolderId,
+  });
 }
 
 async function bulkUnvectorizeLorebookEntries(
@@ -459,7 +454,7 @@ export function useReorderLorebookFolders() {
     }: {
       lorebookId: string;
       folderIds: string[];
-      parentFolderId?: string | null;
+      parentFolderId: string | null;
     }) => reorderLorebookFolders(lorebookId, folderIds, parentFolderId),
     onSuccess: (folders, variables) => {
       qc.setQueryData(lorebookKeys.folders(variables.lorebookId), folders);

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -86,18 +86,20 @@ async function reorderLorebookEntries(
   return storageApi.list<LorebookEntry>("lorebook-entries", { filters: { lorebookId } });
 }
 
-async function reorderLorebookFolders(lorebookId: string, folderIds: string[]): Promise<LorebookFolder[]> {
+async function reorderLorebookFolders(
+  lorebookId: string,
+  folderIds: string[],
+  parentFolderId?: string | null,
+): Promise<LorebookFolder[]> {
   await Promise.all(
-    folderIds.map((folderId, index) =>
-      storageApi.update(
-        "lorebook-folders",
-        folderId,
-        updateLorebookFolderSchema.parse({
-          order: index,
-          sortOrder: index,
-        }),
-      ),
-    ),
+    folderIds.map((folderId, index) => {
+      // When `parentFolderId` is provided, this doubles as a re-parent: every id
+      // in the list adopts that parent (a no-op for existing children) and is
+      // renumbered, so nesting/un-nesting + sibling order land in one pass.
+      const patch: Record<string, unknown> = { order: index, sortOrder: index };
+      if (parentFolderId !== undefined) patch.parentFolderId = parentFolderId;
+      return storageApi.update("lorebook-folders", folderId, updateLorebookFolderSchema.parse(patch));
+    }),
   );
   return storageApi.list<LorebookFolder>("lorebook-folders", { filters: { lorebookId } });
 }
@@ -450,11 +452,20 @@ export function useDeleteLorebookFolder() {
 export function useReorderLorebookFolders() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ lorebookId, folderIds }: { lorebookId: string; folderIds: string[] }) =>
-      reorderLorebookFolders(lorebookId, folderIds),
+    mutationFn: ({
+      lorebookId,
+      folderIds,
+      parentFolderId,
+    }: {
+      lorebookId: string;
+      folderIds: string[];
+      parentFolderId?: string | null;
+    }) => reorderLorebookFolders(lorebookId, folderIds, parentFolderId),
     onSuccess: (folders, variables) => {
       qc.setQueryData(lorebookKeys.folders(variables.lorebookId), folders);
       qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+      // Re-parenting a folder changes the disabled-ancestor gate, so refresh activation.
+      qc.invalidateQueries({ queryKey: lorebookKeys.active() });
     },
   });
 }

--- a/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
@@ -24,15 +24,16 @@ export function canReparentFolder(
   folderId: string,
   newParentId: string | null,
 ): ReparentResult {
+  const byId = new Map(folders.map((folder) => [folder.id, folder]));
+  const folder = byId.get(folderId);
+  if (!folder) return { ok: false, reason: "Folder not found." };
+
   if (newParentId === null) return { ok: true };
   if (newParentId === folderId) {
     return { ok: false, reason: "A folder cannot be its own parent." };
   }
 
-  const byId = new Map(folders.map((folder) => [folder.id, folder]));
-  const folder = byId.get(folderId);
   const newParent = byId.get(newParentId);
-  if (!folder) return { ok: false, reason: "Folder not found." };
   if (!newParent) return { ok: false, reason: "Target parent folder not found." };
   if (newParent.lorebookId !== folder.lorebookId) {
     return { ok: false, reason: "A folder can only nest under a folder in the same lorebook." };

--- a/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
@@ -1,24 +1,10 @@
 import type { LorebookFolder } from "../../../../engine/contracts/types/lorebook";
 
-/** The folder fields the tree logic needs. Callers pass full `LorebookFolder`s. */
 type FolderTreeNode = Pick<LorebookFolder, "id" | "lorebookId" | "parentFolderId">;
 
 type ReparentResult = { ok: true } | { ok: false; reason: string };
 
-/**
- * Decide whether `folderId` may be re-parented under `newParentId`.
- *
- * Rejects self-parenting, a parent in a different lorebook, and any move that
- * would create a cycle (nesting a folder inside one of its own descendants).
- * Moving to the root (`newParentId === null`) is always allowed.
- *
- * This is the write-time guard for nested folders. It runs client-side because
- * the lorebook-folder collection is stored generically with no server-side
- * field validation — matching how every other lorebook edit is validated. The
- * activation scanner additionally resolves disabled ancestors and guards
- * against cycles at read time, so a malformed parent that slips in via import
- * or a direct write can never hang generation.
- */
+// Client-side mirror of the storage ancestry guard for editor affordances.
 export function canReparentFolder(
   folders: FolderTreeNode[],
   folderId: string,
@@ -39,9 +25,7 @@ export function canReparentFolder(
     return { ok: false, reason: "A folder can only nest under a folder in the same lorebook." };
   }
 
-  // Walk up from the target parent; reaching the folder itself means the move
-  // would nest the folder inside its own subtree (a cycle). The `seen` guard
-  // keeps a pre-existing malformed cycle from looping forever.
+  // Reject descendant moves; seen prevents malformed existing cycles from looping.
   const seen = new Set<string>();
   let current: FolderTreeNode | undefined = newParent;
   while (current && !seen.has(current.id)) {
@@ -55,13 +39,7 @@ export function canReparentFolder(
   return { ok: true };
 }
 
-/**
- * Folder ids whose entries are hidden in the tree because the folder is
- * collapsed OR sits inside a collapsed ancestor. Collapsing a folder hides its
- * whole subtree, so a descendant of a collapsed folder counts as hidden even if
- * it is itself expanded. Used so "select all visible" never picks up entries the
- * user cannot actually see.
- */
+// Collapsing a folder hides its whole subtree from "select visible".
 export function collectHiddenFolderIds(
   folders: Pick<LorebookFolder, "id" | "parentFolderId">[],
   collapsedFolderIds: ReadonlySet<string>,
@@ -79,7 +57,7 @@ export function collectHiddenFolderIds(
   const stack = Array.from(collapsedFolderIds);
   while (stack.length > 0) {
     const id = stack.pop()!;
-    if (hidden.has(id)) continue; // also guards against malformed parent cycles
+    if (hidden.has(id)) continue;
     hidden.add(id);
     const children = childrenByParent.get(id);
     if (children) stack.push(...children);
@@ -87,39 +65,21 @@ export function collectHiddenFolderIds(
   return hidden;
 }
 
-/** The folder fields the forest builder needs. Callers pass full `LorebookFolder`s. */
 type ForestNode = { id: string; parentFolderId: string | null; order: number };
 
+// Render shape: sorted roots plus sorted child lists.
 export type FolderForest<T extends ForestNode> = {
-  /** Top-level folders (no parent, or a parent that no longer exists), sorted by `order`. */
   roots: T[];
-  /** Direct children of each folder id, sorted by `order`. */
   childrenByParent: Map<string, T[]>;
 };
 
-/**
- * Group folders into a render-ready forest: top-level `roots` plus a
- * `childrenByParent` lookup, each list sorted by `order`.
- *
- * A folder whose `parentFolderId` is null OR points to a folder that no longer
- * exists is treated as a root. That dangling-parent fallback is what promotes a
- * deleted folder's children back to the top level — mirroring how an entry
- * whose folder is gone falls back to root — so deleting a parent needs no
- * cascade write.
- *
- * Generic over the folder shape so the editor gets full `LorebookFolder`s back.
- * Cycles cannot be created through the UI (`canReparentFolder`) or the storage
- * write path (`validate_lorebook_folder_*`); should malformed import data still
- * introduce one, its members are promoted to `roots` so they stay visible and
- * repairable, and the recursive renderer's visited set keeps a bad parent chain
- * from looping the tree.
- */
 export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderForest<T> {
   const ids = new Set(folders.map((folder) => folder.id));
   const roots: T[] = [];
   const childrenByParent = new Map<string, T[]>();
   for (const folder of folders) {
     const parentId = folder.parentFolderId;
+    // Dangling parents render at root so orphaned folders stay editable.
     if (parentId !== null && ids.has(parentId)) {
       const siblings = childrenByParent.get(parentId);
       if (siblings) siblings.push(folder);
@@ -129,11 +89,7 @@ export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderFor
     }
   }
 
-  // Promote folders unreachable from any root — i.e. trapped in a parent cycle
-  // from malformed data (A→B→A) — up to the roots so they stay visible and
-  // repairable instead of silently vanishing. The write path rejects cycles, so
-  // this only matters for pre-existing or imported bad data; the recursive
-  // renderer's own visited guard keeps the promoted cycle from looping.
+  // Promote unreachable cycle members to roots and remove their cyclic child edge.
   const reachable = new Set<string>();
   const stack = roots.map((folder) => folder.id);
   while (stack.length > 0) {
@@ -145,9 +101,6 @@ export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderFor
   for (const folder of folders) {
     if (reachable.has(folder.id)) continue;
     roots.push(folder);
-    // Sever the cyclic child edge so a promoted node appears ONLY as a root, not
-    // also under its (equally unreachable) parent — keeping the result a forest
-    // rather than emitting the node twice and leaning on the renderer to dedupe.
     const parentId = folder.parentFolderId;
     if (parentId !== null) {
       const siblings = childrenByParent.get(parentId);

--- a/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
@@ -1,0 +1,101 @@
+import type { LorebookFolder } from "../../../../engine/contracts/types/lorebook";
+
+/** The folder fields the tree logic needs. Callers pass full `LorebookFolder`s. */
+type FolderTreeNode = Pick<LorebookFolder, "id" | "lorebookId" | "parentFolderId">;
+
+type ReparentResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Decide whether `folderId` may be re-parented under `newParentId`.
+ *
+ * Rejects self-parenting, a parent in a different lorebook, and any move that
+ * would create a cycle (nesting a folder inside one of its own descendants).
+ * Moving to the root (`newParentId === null`) is always allowed.
+ *
+ * This is the write-time guard for nested folders. It runs client-side because
+ * the lorebook-folder collection is stored generically with no server-side
+ * field validation — matching how every other lorebook edit is validated. The
+ * activation scanner additionally resolves disabled ancestors and guards
+ * against cycles at read time, so a malformed parent that slips in via import
+ * or a direct write can never hang generation.
+ */
+export function canReparentFolder(
+  folders: FolderTreeNode[],
+  folderId: string,
+  newParentId: string | null,
+): ReparentResult {
+  if (newParentId === null) return { ok: true };
+  if (newParentId === folderId) {
+    return { ok: false, reason: "A folder cannot be its own parent." };
+  }
+
+  const byId = new Map(folders.map((folder) => [folder.id, folder]));
+  const folder = byId.get(folderId);
+  const newParent = byId.get(newParentId);
+  if (!folder) return { ok: false, reason: "Folder not found." };
+  if (!newParent) return { ok: false, reason: "Target parent folder not found." };
+  if (newParent.lorebookId !== folder.lorebookId) {
+    return { ok: false, reason: "A folder can only nest under a folder in the same lorebook." };
+  }
+
+  // Walk up from the target parent; reaching the folder itself means the move
+  // would nest the folder inside its own subtree (a cycle). The `seen` guard
+  // keeps a pre-existing malformed cycle from looping forever.
+  const seen = new Set<string>();
+  let current: FolderTreeNode | undefined = newParent;
+  while (current && !seen.has(current.id)) {
+    if (current.id === folderId) {
+      return { ok: false, reason: "A folder cannot be nested inside one of its own subfolders." };
+    }
+    seen.add(current.id);
+    current = current.parentFolderId ? byId.get(current.parentFolderId) : undefined;
+  }
+
+  return { ok: true };
+}
+
+/** The folder fields the forest builder needs. Callers pass full `LorebookFolder`s. */
+type ForestNode = { id: string; parentFolderId: string | null; order: number };
+
+export type FolderForest<T extends ForestNode> = {
+  /** Top-level folders (no parent, or a parent that no longer exists), sorted by `order`. */
+  roots: T[];
+  /** Direct children of each folder id, sorted by `order`. */
+  childrenByParent: Map<string, T[]>;
+};
+
+/**
+ * Group folders into a render-ready forest: top-level `roots` plus a
+ * `childrenByParent` lookup, each list sorted by `order`.
+ *
+ * A folder whose `parentFolderId` is null OR points to a folder that no longer
+ * exists is treated as a root. That dangling-parent fallback is what promotes a
+ * deleted folder's children back to the top level — mirroring how an entry
+ * whose folder is gone falls back to root — so deleting a parent needs no
+ * cascade write.
+ *
+ * Generic over the folder shape so the editor gets full `LorebookFolder`s back.
+ * Cycles cannot be created through the UI (`canReparentFolder` blocks them); a
+ * cycle introduced by malformed import data leaves its members unreachable from
+ * `roots`, and the recursive renderer additionally guards traversal with a
+ * visited set, so a bad parent chain can never loop the tree.
+ */
+export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderForest<T> {
+  const ids = new Set(folders.map((folder) => folder.id));
+  const roots: T[] = [];
+  const childrenByParent = new Map<string, T[]>();
+  for (const folder of folders) {
+    const parentId = folder.parentFolderId;
+    if (parentId !== null && ids.has(parentId)) {
+      const siblings = childrenByParent.get(parentId);
+      if (siblings) siblings.push(folder);
+      else childrenByParent.set(parentId, [folder]);
+    } else {
+      roots.push(folder);
+    }
+  }
+  const byOrder = (a: T, b: T) => a.order - b.order;
+  roots.sort(byOrder);
+  for (const siblings of childrenByParent.values()) siblings.sort(byOrder);
+  return { roots, childrenByParent };
+}

--- a/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
@@ -54,6 +54,38 @@ export function canReparentFolder(
   return { ok: true };
 }
 
+/**
+ * Folder ids whose entries are hidden in the tree because the folder is
+ * collapsed OR sits inside a collapsed ancestor. Collapsing a folder hides its
+ * whole subtree, so a descendant of a collapsed folder counts as hidden even if
+ * it is itself expanded. Used so "select all visible" never picks up entries the
+ * user cannot actually see.
+ */
+export function collectHiddenFolderIds(
+  folders: Pick<LorebookFolder, "id" | "parentFolderId">[],
+  collapsedFolderIds: ReadonlySet<string>,
+): Set<string> {
+  if (collapsedFolderIds.size === 0) return new Set();
+  const childrenByParent = new Map<string, string[]>();
+  for (const folder of folders) {
+    const parentId = folder.parentFolderId;
+    if (!parentId) continue;
+    const siblings = childrenByParent.get(parentId);
+    if (siblings) siblings.push(folder.id);
+    else childrenByParent.set(parentId, [folder.id]);
+  }
+  const hidden = new Set<string>();
+  const stack = Array.from(collapsedFolderIds);
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (hidden.has(id)) continue; // also guards against malformed parent cycles
+    hidden.add(id);
+    const children = childrenByParent.get(id);
+    if (children) stack.push(...children);
+  }
+  return hidden;
+}
+
 /** The folder fields the forest builder needs. Callers pass full `LorebookFolder`s. */
 type ForestNode = { id: string; parentFolderId: string | null; order: number };
 

--- a/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
@@ -107,10 +107,11 @@ export type FolderForest<T extends ForestNode> = {
  * cascade write.
  *
  * Generic over the folder shape so the editor gets full `LorebookFolder`s back.
- * Cycles cannot be created through the UI (`canReparentFolder` blocks them); a
- * cycle introduced by malformed import data leaves its members unreachable from
- * `roots`, and the recursive renderer additionally guards traversal with a
- * visited set, so a bad parent chain can never loop the tree.
+ * Cycles cannot be created through the UI (`canReparentFolder`) or the storage
+ * write path (`validate_lorebook_folder_*`); should malformed import data still
+ * introduce one, its members are promoted to `roots` so they stay visible and
+ * repairable, and the recursive renderer's visited set keeps a bad parent chain
+ * from looping the tree.
  */
 export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderForest<T> {
   const ids = new Set(folders.map((folder) => folder.id));
@@ -126,6 +127,24 @@ export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderFor
       roots.push(folder);
     }
   }
+
+  // Promote folders unreachable from any root — i.e. trapped in a parent cycle
+  // from malformed data (A→B→A) — up to the roots so they stay visible and
+  // repairable instead of silently vanishing. The write path rejects cycles, so
+  // this only matters for pre-existing or imported bad data; the recursive
+  // renderer's own visited guard keeps the promoted cycle from looping.
+  const reachable = new Set<string>();
+  const stack = roots.map((folder) => folder.id);
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (reachable.has(id)) continue;
+    reachable.add(id);
+    for (const child of childrenByParent.get(id) ?? []) stack.push(child.id);
+  }
+  for (const folder of folders) {
+    if (!reachable.has(folder.id)) roots.push(folder);
+  }
+
   const byOrder = (a: T, b: T) => a.order - b.order;
   roots.sort(byOrder);
   for (const siblings of childrenByParent.values()) siblings.sort(byOrder);

--- a/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
+++ b/src/features/catalog/lorebooks/lib/lorebook-folder-tree.ts
@@ -142,7 +142,20 @@ export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderFor
     for (const child of childrenByParent.get(id) ?? []) stack.push(child.id);
   }
   for (const folder of folders) {
-    if (!reachable.has(folder.id)) roots.push(folder);
+    if (reachable.has(folder.id)) continue;
+    roots.push(folder);
+    // Sever the cyclic child edge so a promoted node appears ONLY as a root, not
+    // also under its (equally unreachable) parent — keeping the result a forest
+    // rather than emitting the node twice and leaning on the renderer to dedupe.
+    const parentId = folder.parentFolderId;
+    if (parentId !== null) {
+      const siblings = childrenByParent.get(parentId);
+      if (siblings) {
+        const remaining = siblings.filter((sibling) => sibling.id !== folder.id);
+        if (remaining.length > 0) childrenByParent.set(parentId, remaining);
+        else childrenByParent.delete(parentId);
+      }
+    }
   }
 
   const byOrder = (a: T, b: T) => a.order - b.order;

--- a/src/shared/api/lorebook-folder-api.ts
+++ b/src/shared/api/lorebook-folder-api.ts
@@ -1,0 +1,11 @@
+import type { LorebookFolder } from "../../engine/contracts/types/lorebook";
+import { invokeTauri } from "./tauri-client";
+
+export const lorebookFolderApi = {
+  reorder: (input: { lorebookId: string; folderIds: string[]; parentFolderId: string | null }) =>
+    invokeTauri<LorebookFolder[]>("lorebook_folder_reorder", {
+      lorebookId: input.lorebookId,
+      orderedIds: input.folderIds,
+      parentFolderId: input.parentFolderId,
+    }),
+};

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -105,6 +105,7 @@ const REMOTE_COMMANDS = new Set([
   "storage_delete",
   "storage_duplicate",
   "connection_folder_reorder",
+  "lorebook_folder_reorder",
   "connection_move",
   "chat_message_add_swipe",
   "chat_message_update_content_if_unchanged",


### PR DESCRIPTION
## Linked issue

Closes #2127 — this is the **nested-folders** half. (The intra-lorebook entry-duplication half shipped earlier in #2157.)

## Why this change

- #2127 asked for lorebook sub-folders. Folders were flat — `parentFolderId` existed but was reserved/always-null. This ships nesting end-to-end: organize a lorebook's folders into a tree, set parentage by dropdown or drag, and (the load-bearing part) extend the folder-disabled activation gate to disabled **ancestors**, so nesting can never silently leak gated content into the prompt.

## What changed

- **Scanner gate (`active-lorebook-scanner.ts`)** — activation now resolves "effective disabled" by walking each entry's folder `parentFolderId` chain (with a cycle guard): a folder OR any of its ancestors being disabled gates the entry, regardless of the entry's own flag.
- **Validation + tree model (`lib/lorebook-folder-tree.ts`)** — `canReparentFolder` is the single write-time guard (same lorebook, no self-parent, no cycles, with reasons); `buildFolderForest` groups folders into `{ roots, childrenByParent }` for rendering. A dangling/missing parent falls back to root, which auto-promotes a deleted folder's children to the top level.
- **Storage (`hooks/use-lorebooks.ts`)** — `reorderLorebookFolders` can now also set `parentFolderId`, so nest/un-nest + per-parent ordering happen in one pass; reorder/reparent invalidates the activation cache.
- **Editor UI** — recursive folder-tree render with depth indent + collapse-hides-subtree (`LorebookEntriesTab.tsx`); a per-folder **parent dropdown** filtered to valid parents (`LorebookFolderRow.tsx`); **drag-to-nest** via the header (top = reorder before, middle = nest, bottom = reorder after) and via a folder's **body** including the empty placeholder, with the left-indent margin targeting shallower ancestors; **drag to the root area to un-nest** (`use-lorebook-editor-drag-drop.ts`, `LorebookEditor.tsx`).
- Folder type/schema comments updated to describe real nesting (no longer "reserved / always null").

## Refactor impact

Primary owner: Catalog / Lorebooks editor (frontend), plus the activation scanner (engine generation)

Impact areas reviewed:

- The lorebook editor (recursive render + folder drag-drop), the new folder-tree lib, the activation scanner's disabled-folder gate, and the folder reorder hook. No engine/shared-API/Rust/remote-runtime changes; no storage-contract or `src-tauri/src/lib.rs` change.

Boundary notes:

- Confined to the lorebooks feature UI + its React Query layer + the activation scanner's normalization step. Reuses `canReparentFolder` as the one write-time guard and the existing generic storage gateway; no new storage collection, command, or cross-boundary path.

Pressure points touched:

- The activation scanner (generation path) — specifically the disabled-folder gate, now ancestor-aware. No `ModeSurface`/`GameSurface`/shared mode UI, no `src-tauri/src/lib.rs`, no imports, no version-bearing files.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck` plus `check:architecture` / `check:frontend` / `check:rust` / `check:discovery` / `check:docs` / `check:launcher-safety` / `check:unused` all pass locally. `check:line-endings` fails only on pre-existing CRLF in files this PR doesn't touch (`DESIGN.md`, `custom_components/*.py`); their committed versions are LF, so CI is unaffected.
- Manually verified in the running Tauri build: nesting via the parent dropdown and via drag (header three-zone, folder body, empty placeholder, left-indent targeting); un-nesting via the root area and the dropdown; cycle / self / cross-lorebook moves are never offered as drop targets; collapsing a parent hides its subtree; deleting a parent promotes its children to root; checked light + dark and at ~400px width.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A — sub-folders are an enhancement *within* the already-registered Lorebooks surface (the `lorebooks` discovery entry opens the panel). The registry is surface-level, not per-action, so no new entry is required and `check:discovery` passes unchanged (same call as the entry-duplication PR #2157).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## Proof

Core claim:

- Lorebook folders nest into a tree; a disabled folder or any disabled ancestor gates its entries at activation time; re-parenting is validated at write time (no self-parent / cross-lorebook / cycles) and the scanner can't loop or leak on malformed data.

Verification run:

- The full check suite minus the pre-existing line-endings artifact (see Manual verification notes), plus hands-on testing in the running Tauri build.

Evidence:

- Manual: a disabled parent/grandparent hides entries that live in an enabled child folder at generation time; the parent dropdown and every drag path only offer valid targets; collapse / delete / un-nest behave as described above, in light + dark and at ~400px.
- Local unit tests (uncommitted — the repo gitignores `*.test.ts`, and the template asks not to submit them as proof) cover the scanner's ancestor chain-walk and the `canReparentFolder` / `buildFolderForest` edge cases (self, cross-lorebook, direct + deep cycles, dangling-parent→root). Happy to fold them in if the team wants them tracked.

Design notes (recorded for review):

- **Client-side validation + scanner backstop, by design.** `canReparentFolder` runs client-side because the lorebook-folder collection is stored generically with no server-side field validation — matching how every other lorebook edit is validated. The activation scanner independently resolves disabled ancestors and guards against cycles at read time, so a malformed parent introduced by an import or a direct write can never hang generation or leak gated content. If the lorebook layer later moves into Rust, the same three checks (same lorebook, no self-parent, no cycle) port directly.
- Deleting a parent folder promotes its children to the top level (orphan fallback in `buildFolderForest`) rather than cascade-deleting — consistent with how an entry whose folder is gone falls back to root.

Manual verification requested:

- Reviewers can confirm by nesting a few folders (dropdown + drag), disabling a parent and checking that a nested entry does not inject in a chat, and deleting a parent to watch its children rise to the top level.

## UI evidence

<img width="647" height="346" alt="{FD93A120-C1AF-48A8-BB3C-F10246B0A196}" src="https://github.com/user-attachments/assets/aa292a56-aa2a-40f4-a03d-1859baa5c57c" />

<img width="631" height="327" alt="{0B080A73-73DE-45C6-B1EC-BD85E6AF4E53}" src="https://github.com/user-attachments/assets/1c15fc37-8bbc-47f0-adab-762551659d9c" />

<img width="532" height="388" alt="{A77F01B1-B64E-4715-A0A6-0854A38C40A4}" src="https://github.com/user-attachments/assets/10b3276c-a4fc-4da4-bec5-6aba33ab38c9" />

<img width="631" height="325" alt="{C7CCFAC4-8BF0-4B8A-942A-6F1039F7DD1E}" src="https://github.com/user-attachments/assets/6b074ae0-8ff9-4d75-bf31-80b7d2ecff11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nested folders within loreBooks, allowing hierarchical organization of folder structures.
  * Enhanced drag-and-drop functionality with improved drop-zone targeting ("before," "inside," "after" positions).
  * Added parent folder selector dropdown in the folder editor for easy reparenting.

* **Bug Fixes**
  * Fixed folder disablement logic to cascade down—entries under disabled folders or their ancestors are now properly skipped during activation.

* **Documentation**
  * Updated inline documentation to clarify nested-folder behavior and write-time validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->