### PR TITLE
Fix cross-lorebook recursive frontier seeding

### DIFF
--- a/src/engine/contracts/schemas/lorebook.schema.ts
+++ b/src/engine/contracts/schemas/lorebook.schema.ts
@@ -70,7 +70,9 @@ export const createLorebookSchema = z.object({
   imagePath: z.string().nullable().default(null),
   scanDepth: z.number().int().min(0).default(2),
   tokenBudget: z.number().int().min(0).default(2048),
+  // Scan-level enabler: any active lorebook with this enabled starts recursion.
   recursiveScanning: z.boolean().default(false),
+  // When multiple active lorebooks enable recursion, the scanner uses the highest active depth.
   maxRecursionDepth: z.number().int().min(1).max(10).default(3),
   characterId: z.string().nullable().default(null),
   characterIds: z.array(z.string()).default([]),
@@ -93,7 +95,9 @@ export const updateLorebookSchema = z
     imagePath: z.string().nullable().optional(),
     scanDepth: z.number().int().min(0).optional(),
     tokenBudget: z.number().int().min(0).optional(),
+    // Scan-level enabler: any active lorebook with this enabled starts recursion.
     recursiveScanning: z.boolean().optional(),
+    // When multiple active lorebooks enable recursion, the scanner uses the highest active depth.
     maxRecursionDepth: z.number().int().min(1).max(10).optional(),
     characterId: z.string().nullable().optional(),
     characterIds: z.array(z.string()).optional(),

--- a/src/engine/contracts/types/lorebook.ts
+++ b/src/engine/contracts/types/lorebook.ts
@@ -37,8 +37,13 @@ export interface Lorebook {
   scanDepth: number;
   /** Max output tokens allocated to this lorebook */
   tokenBudget: number;
+  /**
+   * Enables recursive scanning for the active lorebook set. Once any active
+   * lorebook enables recursion, selected entries from all active lorebooks can
+   * seed later passes unless the entry has preventRecursion.
+   */
   recursiveScanning: boolean;
-  /** Maximum recursion depth for recursive scanning (default 3) */
+  /** Maximum recursion depth this lorebook contributes when it enables recursive scanning. */
   maxRecursionDepth: number;
   /** ID of the character this lorebook is linked to (character books) */
   characterId: string | null;
@@ -177,7 +182,7 @@ export interface LorebookEntry {
   // ── Engine extensions (beyond ST) ──
   /** When true, the Lorebook Keeper agent cannot modify or overwrite this entry */
   locked: boolean;
-  /** When true, this entry's content won't trigger further entries during recursive scanning */
+  /** When true, this entry's content won't seed later recursive scanning passes. */
   preventRecursion: boolean;
   /** Sub-category tag for the entry (e.g. "location", "item", "lore", "quest") */
   tag: string;

--- a/src/engine/generation/active-lorebook-scanner.test.ts
+++ b/src/engine/generation/active-lorebook-scanner.test.ts
@@ -300,7 +300,7 @@ describe("scanActiveLorebooks", () => {
     expect(includedIds).toEqual(["entry-a", "entry-prevent", "entry-b"]);
   });
 
-  it("does not use non-recursive lorebook entries as recursive frontier content", async () => {
+  it("uses selected non-recursive lorebook entries as frontier content when recursion is enabled globally", async () => {
     const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
     const storage = storageWithRows(
       {
@@ -359,7 +359,53 @@ describe("scanActiveLorebooks", () => {
     });
 
     const includedIds = result.processedLore.includedEntries.map((entry) => entry.entry.id);
-    expect(includedIds).toEqual(["entry-a", "entry-b"]);
+    expect(includedIds).toEqual(["entry-a", "entry-b", "entry-c"]);
+  });
+
+  it("does not recursively activate entries when every active lorebook disables recursion", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const storage = storageWithRows(
+      {
+        lorebooks: [
+          { id: "book-a", name: "Book A", enabled: true, isGlobal: true, recursiveScanning: false },
+          { id: "book-b", name: "Book B", enabled: true, isGlobal: true, recursiveScanning: false },
+        ],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-a",
+            lorebookId: "book-a",
+            name: "Entry A",
+            content: "beta-key",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 10,
+          },
+          {
+            id: "entry-b",
+            lorebookId: "book-b",
+            name: "Entry B",
+            content: "should not activate",
+            keys: ["beta-key"],
+            enabled: true,
+            order: 20,
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
+      embeddingSource: null,
+    });
+
+    const includedIds = result.processedLore.includedEntries.map((entry) => entry.entry.id);
+    expect(includedIds).toEqual(["entry-a"]);
   });
 
   it("does not recursively activate from entries excluded by the chat lorebook budget", async () => {

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -673,10 +673,7 @@ async function scanActiveLorebookEntrySet(
     budgetSkippedEntries.push(...selectedBatch.budgetSkippedEntries);
 
     const recursiveContent = selectedBatch.selectedFromCandidates
-      .filter(
-        (selected) =>
-          lorebooksById.get(selected.entry.lorebookId)?.recursiveScanning && !selected.entry.preventRecursion,
-      )
+      .filter((selected) => !selected.entry.preventRecursion)
       .map((selected) => selected.entry.content)
       .join("\n");
 

--- a/src/features/catalog/lorebooks/components/editor/LorebookOverviewTab.tsx
+++ b/src/features/catalog/lorebooks/components/editor/LorebookOverviewTab.tsx
@@ -431,7 +431,10 @@ export function LorebookOverviewTab({
         </div>
         <div className="flex items-end gap-2">
           <div className="flex items-center justify-between rounded-xl bg-[var(--secondary)] px-3 py-2.5 ring-1 ring-[var(--border)]">
-            <span className="mr-2 text-xs">Recursive</span>
+            <span className="mr-2 inline-flex items-center gap-1 text-xs">
+              Recursive
+              <HelpTooltip text="When enabled on any active lorebook, recursive scanning runs for the whole active lore set. Selected entries from any active book can seed later passes unless that entry has No Recursion enabled." />
+            </span>
             <button
               onClick={() => {
                 onRecursiveChange(!recursive);
@@ -451,7 +454,7 @@ export function LorebookOverviewTab({
             <div>
               <label className="mb-1.5 flex items-center gap-1 text-xs font-medium">
                 Max Depth{" "}
-                <HelpTooltip text="Maximum number of recursive passes. Each pass scans activated entry content for additional keyword matches. Higher values find more connections but use more processing." />
+                <HelpTooltip text="Maximum recursive passes this lorebook contributes when it enables recursion. If multiple active lorebooks enable recursion, Marinara uses the highest active depth." />
               </label>
               <input
                 type="number"
@@ -478,9 +481,7 @@ export function LorebookOverviewTab({
                 onExcludeFromVectorizationChange(!excludeFromVectorization);
                 onDirty();
               }}
-              aria-label={
-                excludeFromVectorization ? "Enable semantic vectorization" : "Disable semantic vectorization"
-              }
+              aria-label={excludeFromVectorization ? "Enable semantic vectorization" : "Disable semantic vectorization"}
               aria-pressed={excludeFromVectorization}
             >
               {excludeFromVectorization ? (


### PR DESCRIPTION
<!-- Target branch: `refactor`. Change the base to `refactor` before submitting unless a maintainer explicitly asked for another base. -->
<!-- Keep all checkboxes unchecked until a human has actually verified them. -->

## Linked issue

<!-- Every user-facing PR should reference a feature request or issue report when practical. -->

Closes #2279

## Why this change

<!-- What user problem, bug, refactor goal, or maintenance need does this solve? -->

- Refactor still seeded recursive lorebook passes only from entries whose own lorebook had `recursiveScanning` enabled.
- Main treats recursion as globally enabled for the scan once any active lorebook enables it, so selected non-`preventRecursion` entries from character/persona or other non-recursive books can chain-trigger related lore in recursive books.

## What changed

<!-- List the key changes in this PR. -->

- Changed active lorebook recursive frontier seeding to use every selected, budgeted entry unless that entry has `preventRecursion`.
- Updated the cross-lorebook regression row so a selected entry from a non-recursive book can seed the next recursive pass when recursion is enabled elsewhere.
- Added a negative-control regression row proving recursion still does not run when every active lorebook disables `recursiveScanning`.

## Refactor impact

Primary owner:

<!-- Examples: app shell, catalog, chat mode, roleplay mode, game mode, runtime generation, world-state, shared API, engine generation, Rust storage, imports, remote runtime. -->

engine generation

Impact areas reviewed:

- Chat, roleplay, and game prompt assembly share `scanActiveLorebooks`.
- Recursive scanning, `preventRecursion`, recursion depth, chat lorebook budget skipping, and selected-entry frontier behavior.

Boundary notes:

<!-- Note engine/shared-api/feature/Rust/remote-runtime boundaries. Say "none" only if you checked. -->

- React-free engine change only. No feature UI, shared API wrapper, Tauri/Rust storage, remote runtime, schema, dependency, auth, or release metadata changes.

Pressure points touched:

<!-- Mention ModeSurface, GameSurface, shared mode UI, src-tauri/src/lib.rs command registration, or import modules if touched. -->

- Shared engine lorebook activation in `src/engine/generation/active-lorebook-scanner.ts`.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!-- Do not submit *.test.ts or *.test.tsx files as PR proof; cite existing checks, command output, app/browser/Tauri verification, or manual notes instead. -->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

<!-- Describe exact commands and manual steps, including typecheck/build/docs/architecture/Rust/browser/remote-runtime checks when they apply. If an AI agent filled this out, verify it yourself before ticking boxes. -->

- Codex proof before production fix: `pnpm test src/engine/generation/active-lorebook-scanner.test.ts` failed on the new #2279 regression row. Expected `[entry-a, entry-b, entry-c]`, received `[entry-a, entry-b]`.
- Codex proof after fix: `pnpm test src/engine/generation/active-lorebook-scanner.test.ts` passed with 9 tests.
- Codex lane validation: `pnpm typecheck` passed.
- Codex full gate: `pnpm check` passed.
- Codex proof gate: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json` passed.
- Bunny review: pass. No blocking manual verification remains for the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing lorebook runtime behavior; no new user-discoverable product surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

<!-- Add before/after screenshots or recordings for visible UI changes. -->

N/A. This is React-free engine prompt assembly logic with focused command proof; there is no meaningful visible UI state to screenshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lorebook recursion behavior to correctly include selected entries when global recursion is enabled, regardless of individual entry recursion settings.
  * Fixed recursive content propagation to properly stop when all active lorebooks have recursion disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->