### PR TITLE
Fix lorebook macro rollback on budget skips

### DIFF
--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -126,6 +126,7 @@ export interface BudgetSkippedActivatedEntry {
 
 export interface LorebookContentResolver {
   resolve(content: string): string;
+  snapshotVariables?(): () => void;
 }
 
 function withResolvedContent(entry: ActivatedEntry, resolver?: LorebookContentResolver): ActivatedEntry {

--- a/src/engine/generation-core/lorebooks/prompt-injector.ts
+++ b/src/engine/generation-core/lorebooks/prompt-injector.ts
@@ -131,10 +131,11 @@ export interface LorebookContentResolver {
 
 function withResolvedContent(entry: ActivatedEntry, resolver?: LorebookContentResolver): ActivatedEntry {
   if (!resolver) return entry;
-  const content = resolver.resolve(entry.entry.content);
+  const rawContent = entry.rawContent ?? entry.entry.content;
+  const content = resolver.resolve(rawContent);
   return {
     ...entry,
-    rawContent: entry.rawContent ?? entry.entry.content,
+    rawContent,
     entry: {
       ...entry.entry,
       content,

--- a/src/engine/generation/active-lorebook-scanner.test.ts
+++ b/src/engine/generation/active-lorebook-scanner.test.ts
@@ -39,6 +39,21 @@ function storageWithRows(rows: RowMap, calls: { batchedEntryReads: number; singl
   };
 }
 
+function macroContentResolver(macros: MacroContext) {
+  return {
+    resolve: (content: string) => resolveMacros(content, macros),
+    snapshotVariables: () => {
+      const before = { ...macros.variables };
+      return () => {
+        for (const name of Object.keys(macros.variables)) {
+          if (before[name] === undefined) delete macros.variables[name];
+        }
+        Object.assign(macros.variables, before);
+      };
+    },
+  };
+}
+
 describe("scanActiveLorebooks", () => {
   it("reads entries for active lorebooks in one batched storage call", async () => {
     const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
@@ -530,18 +545,7 @@ describe("scanActiveLorebooks", () => {
       persona: null,
       storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
       embeddingSource: null,
-      contentResolver: {
-        resolve: (content) => resolveMacros(content, macros),
-        snapshotVariables: () => {
-          const before = { ...macros.variables };
-          return () => {
-            for (const name of Object.keys(macros.variables)) {
-              if (before[name] === undefined) delete macros.variables[name];
-            }
-            Object.assign(macros.variables, before);
-          };
-        },
-      },
+      contentResolver: macroContentResolver(macros),
     });
 
     expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-budget-skipped-setvar"]);
@@ -551,6 +555,179 @@ describe("scanActiveLorebooks", () => {
       "flag=selected",
     ]);
     expect(macros.variables.flag).toBe("selected");
+  });
+
+  it("keeps lorebook exhaustion active for recursive frontiers after macro-stable replay", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const storage = storageWithRows(
+      {
+        lorebooks: [
+          { id: "book-a", name: "Book A", enabled: true, isGlobal: true, tokenBudget: 1, recursiveScanning: true },
+          { id: "book-b", name: "Book B", enabled: true, isGlobal: true, tokenBudget: 0, recursiveScanning: true },
+        ],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-a-large",
+            lorebookId: "book-a",
+            name: "Large A",
+            content: "This entry is too large for the lorebook budget.",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 0,
+          },
+          {
+            id: "entry-b-recursive",
+            lorebookId: "book-b",
+            name: "Recursive B",
+            content: "beta-key",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 10,
+          },
+          {
+            id: "entry-a-recursive",
+            lorebookId: "book-a",
+            name: "Recursive A",
+            content: "x",
+            keys: ["beta-key"],
+            enabled: true,
+            order: 20,
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
+      embeddingSource: null,
+    });
+
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual(["entry-b-recursive"]);
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual([
+      "entry-a-large",
+      "entry-a-recursive",
+    ]);
+  });
+
+  it("keeps chat budget exhaustion active for recursive frontiers after macro-stable replay", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const storage = storageWithRows(
+      {
+        lorebooks: [{ id: "book-a", name: "Book A", enabled: true, isGlobal: true, recursiveScanning: true }],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-selected-recursive",
+            lorebookId: "book-a",
+            name: "Selected recursive",
+            content: "beta-key",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 0,
+          },
+          {
+            id: "entry-chat-large",
+            lorebookId: "book-a",
+            name: "Large chat entry",
+            content: "This entry is too large for the chat lorebook budget.",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 10,
+          },
+          {
+            id: "entry-recursive-after-chat-exhaustion",
+            lorebookId: "book-a",
+            name: "Recursive after exhaustion",
+            content: "x",
+            keys: ["beta-key"],
+            enabled: true,
+            order: 20,
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
+      request: { lorebookTokenBudget: 3 },
+      embeddingSource: null,
+    });
+
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual([
+      "entry-selected-recursive",
+    ]);
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual([
+      "entry-chat-large",
+      "entry-recursive-after-chat-exhaustion",
+    ]);
+  });
+
+  it("keeps earlier skipped diagnostics when later replay passes skip another survivor", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const macros: MacroContext = {
+      char: "Ari",
+      user: "User",
+      characters: ["Ari"],
+      variables: { payload: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" },
+    };
+    const storage = storageWithRows(
+      {
+        lorebooks: [
+          { id: "book-a", name: "Book A", enabled: true, isGlobal: true, tokenBudget: 1 },
+          { id: "book-b", name: "Book B", enabled: true, isGlobal: true, tokenBudget: 1 },
+        ],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-a-skipped-mutator",
+            lorebookId: "book-a",
+            name: "Skipped mutator",
+            content: "{{setvar::payload::x}}This entry is too large.",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 0,
+          },
+          {
+            id: "entry-b-survivor-then-skip",
+            lorebookId: "book-b",
+            name: "Replay skip",
+            content: "{{getvar::payload}}",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 10,
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
+      embeddingSource: null,
+      contentResolver: macroContentResolver(macros),
+    });
+
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual([]);
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual([
+      "entry-a-skipped-mutator",
+      "entry-b-survivor-then-skip",
+    ]);
+    expect(macros.variables.payload).toBe("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
   });
 
   it("keeps lower-priority entries skipped after the chat lorebook budget is exhausted", async () => {

--- a/src/engine/generation/active-lorebook-scanner.test.ts
+++ b/src/engine/generation/active-lorebook-scanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { StorageGateway } from "../capabilities/storage";
 import { LIMITS } from "../contracts/constants/defaults";
+import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine";
 import { scanActiveLorebooks } from "./active-lorebook-scanner";
 
 type RowMap = Record<string, Array<Record<string, unknown>>>;
@@ -463,6 +464,93 @@ describe("scanActiveLorebooks", () => {
 
     expect(result.processedLore.includedEntries).toEqual([]);
     expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-budget-skipped-frontier"]);
+  });
+
+  it("rolls back macro variable mutations from budget-skipped entries", async () => {
+    const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
+    const macros: MacroContext = {
+      char: "Ari",
+      user: "User",
+      characters: ["Ari"],
+      variables: { flag: "prior" },
+    };
+    const storage = storageWithRows(
+      {
+        lorebooks: [
+          { id: "book-a", name: "Budgeted Book", enabled: true, isGlobal: true, tokenBudget: 1 },
+          { id: "book-b", name: "Kept Book", enabled: true, isGlobal: true, tokenBudget: 0 },
+        ],
+        "lorebook-folders": [],
+        "lorebook-entries": [
+          {
+            id: "entry-budget-skipped-setvar",
+            lorebookId: "book-a",
+            name: "Budget skipped setvar",
+            content: "{{setvar::flag::leaked}}This entry is too large for the lorebook budget.",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 0,
+          },
+          {
+            id: "entry-kept-getvar",
+            lorebookId: "book-b",
+            name: "Kept getvar before selected setvar",
+            content: "flag={{getvar::flag}}",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 10,
+          },
+          {
+            id: "entry-kept-setvar",
+            lorebookId: "book-b",
+            name: "Kept setvar",
+            content: "{{setvar::flag::selected}}selected",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 20,
+          },
+          {
+            id: "entry-later-getvar",
+            lorebookId: "book-b",
+            name: "Later getvar",
+            content: "flag={{getvar::flag}}",
+            keys: ["alpha-key"],
+            enabled: true,
+            order: 30,
+          },
+        ],
+      },
+      calls,
+    );
+
+    const result = await scanActiveLorebooks({
+      storage,
+      chat: { id: "chat-1", mode: "roleplay", metadata: {} },
+      characters: [],
+      persona: null,
+      storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
+      embeddingSource: null,
+      contentResolver: {
+        resolve: (content) => resolveMacros(content, macros),
+        snapshotVariables: () => {
+          const before = { ...macros.variables };
+          return () => {
+            for (const name of Object.keys(macros.variables)) {
+              if (before[name] === undefined) delete macros.variables[name];
+            }
+            Object.assign(macros.variables, before);
+          };
+        },
+      },
+    });
+
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-budget-skipped-setvar"]);
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.content)).toEqual([
+      "flag=prior",
+      "selected",
+      "flag=selected",
+    ]);
+    expect(macros.variables.flag).toBe("selected");
   });
 
   it("keeps lower-priority entries skipped after the chat lorebook budget is exhausted", async () => {

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -637,6 +637,39 @@ function sameActivatedEntrySet(a: ActivatedEntry[], b: ActivatedEntry[]): boolea
   return a.every((entry) => bIds.has(entry.entry.id));
 }
 
+function recordBudgetSelectionPass(
+  skippedById: Map<string, BudgetSkippedLorebookEntry>,
+  selectedEntries: ActivatedEntry[],
+  skippedEntries: BudgetSkippedLorebookEntry[],
+): void {
+  for (const selected of selectedEntries) {
+    skippedById.delete(selected.entry.id);
+  }
+  for (const skipped of skippedEntries) {
+    skippedById.set(skipped.id, skipped);
+  }
+}
+
+function applySkippedBudgetExhaustion(
+  state: LorebookBudgetSelectionState,
+  skippedEntries: Iterable<BudgetSkippedLorebookEntry>,
+): void {
+  for (const skipped of skippedEntries) {
+    if (skipped.blockedBy === "lorebook" || skipped.blockedBy === "both") {
+      state.exhaustedLorebookIds.add(skipped.lorebookId);
+    }
+    if (skipped.blockedBy === "chat" || skipped.blockedBy === "both") {
+      state.chatBudgetExhausted = true;
+    }
+  }
+}
+
+function sortedBudgetSkippedEntries(
+  skippedById: ReadonlyMap<string, BudgetSkippedLorebookEntry>,
+): BudgetSkippedLorebookEntry[] {
+  return [...skippedById.values()].sort((a, b) => a.id.localeCompare(b.id));
+}
+
 function budgetSkipReason(exceedsLorebookBudget: boolean, exceedsChatBudget: boolean): "lorebook" | "chat" | "both" {
   if (exceedsLorebookBudget && exceedsChatBudget) return "both";
   if (exceedsLorebookBudget) return "lorebook";
@@ -703,7 +736,7 @@ function selectBudgetedLorebookEntries(
   if (candidates.length === 0) return { selectedFromCandidates: [], budgetSkippedEntries: [] };
 
   let pool = candidates;
-  let lastSkippedBudgetEntries: BudgetSkippedLorebookEntry[] = [];
+  const skippedById = new Map<string, BudgetSkippedLorebookEntry>();
   const maxPasses = Math.max(1, candidates.length + 1);
 
   for (let passIndex = 0; passIndex < maxPasses; passIndex += 1) {
@@ -722,23 +755,25 @@ function selectBudgetedLorebookEntries(
     }
 
     selectedFromCandidates.sort(lorebookInjectionOrder);
+    recordBudgetSelectionPass(skippedById, selectedFromCandidates, skippedFromCandidates);
 
     if (sameActivatedEntrySet(pool, selectedFromCandidates)) {
+      applySkippedBudgetExhaustion(nextState, skippedById.values());
       applyLorebookBudgetSelectionState(state, nextState);
       return {
         selectedFromCandidates,
-        budgetSkippedEntries: lastSkippedBudgetEntries.sort((a, b) => a.id.localeCompare(b.id)),
+        budgetSkippedEntries: sortedBudgetSkippedEntries(skippedById),
       };
     }
 
     rollbackLorebookCandidatePass(pass);
-    lastSkippedBudgetEntries = skippedFromCandidates;
     pool = selectedFromCandidates;
   }
 
+  applySkippedBudgetExhaustion(state, skippedById.values());
   return {
     selectedFromCandidates: [],
-    budgetSkippedEntries: lastSkippedBudgetEntries.sort((a, b) => a.id.localeCompare(b.id)),
+    budgetSkippedEntries: sortedBudgetSkippedEntries(skippedById),
   };
 }
 

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -152,6 +152,15 @@ interface LorebookBudgetSelectionState {
   chatBudgetExhausted: boolean;
 }
 
+interface LorebookResolvedCandidatePass {
+  entries: ActivatedEntry[];
+  restoreVariables: Array<() => void>;
+}
+
+type BudgetedLorebookEntrySelection =
+  | { selected: true; entry: ActivatedEntry }
+  | { selected: false; skipped?: BudgetSkippedLorebookEntry };
+
 const MAX_LOREBOOK_RECURSION_DEPTH = 10;
 
 function nonNegativeInteger(value: unknown, fallback = 0): number {
@@ -559,15 +568,39 @@ function createLorebookBudgetSelectionState(): LorebookBudgetSelectionState {
   };
 }
 
+function cloneLorebookBudgetSelectionState(state: LorebookBudgetSelectionState): LorebookBudgetSelectionState {
+  return {
+    selected: [...state.selected],
+    selectedIds: new Set(state.selectedIds),
+    perLorebookTokens: new Map(state.perLorebookTokens),
+    exhaustedLorebookIds: new Set(state.exhaustedLorebookIds),
+    totalTokens: state.totalTokens,
+    chatBudgetExhausted: state.chatBudgetExhausted,
+  };
+}
+
+function applyLorebookBudgetSelectionState(
+  target: LorebookBudgetSelectionState,
+  source: LorebookBudgetSelectionState,
+): void {
+  target.selected = source.selected;
+  target.selectedIds = source.selectedIds;
+  target.perLorebookTokens = source.perLorebookTokens;
+  target.exhaustedLorebookIds = source.exhaustedLorebookIds;
+  target.totalTokens = source.totalTokens;
+  target.chatBudgetExhausted = source.chatBudgetExhausted;
+}
+
 function activatedEntryWithResolvedContent(
   activatedEntry: ActivatedEntry,
   contentResolver?: LorebookContentResolver,
 ): ActivatedEntry {
   if (!contentResolver) return activatedEntry;
-  const resolvedContent = contentResolver.resolve(activatedEntry.entry.content);
+  const rawContent = activatedEntry.rawContent ?? activatedEntry.entry.content;
+  const resolvedContent = contentResolver.resolve(rawContent);
   return {
     ...activatedEntry,
-    rawContent: activatedEntry.rawContent ?? activatedEntry.entry.content,
+    rawContent,
     entry: {
       ...activatedEntry.entry,
       content: resolvedContent,
@@ -575,10 +608,88 @@ function activatedEntryWithResolvedContent(
   };
 }
 
+function resolveLorebookCandidatePass(
+  candidates: ActivatedEntry[],
+  contentResolver?: LorebookContentResolver,
+): LorebookResolvedCandidatePass {
+  const entries: ActivatedEntry[] = [];
+  const restoreVariables: Array<() => void> = [];
+
+  for (const candidate of [...candidates].sort(lorebookInjectionOrder)) {
+    const restore = contentResolver?.snapshotVariables?.();
+    const resolvedCandidate = activatedEntryWithResolvedContent(candidate, contentResolver);
+    if (restore) restoreVariables.push(restore);
+    entries.push(resolvedCandidate);
+  }
+
+  return { entries, restoreVariables };
+}
+
+function rollbackLorebookCandidatePass(pass: LorebookResolvedCandidatePass): void {
+  for (const restore of [...pass.restoreVariables].reverse()) {
+    restore();
+  }
+}
+
+function sameActivatedEntrySet(a: ActivatedEntry[], b: ActivatedEntry[]): boolean {
+  if (a.length !== b.length) return false;
+  const bIds = new Set(b.map((entry) => entry.entry.id));
+  return a.every((entry) => bIds.has(entry.entry.id));
+}
+
 function budgetSkipReason(exceedsLorebookBudget: boolean, exceedsChatBudget: boolean): "lorebook" | "chat" | "both" {
   if (exceedsLorebookBudget && exceedsChatBudget) return "both";
   if (exceedsLorebookBudget) return "lorebook";
   return "chat";
+}
+
+function trySelectBudgetedLorebookEntry(
+  candidate: ActivatedEntry,
+  state: LorebookBudgetSelectionState,
+  lorebooksById: ReadonlyMap<string, ActiveLorebookBudgetMetadata>,
+  chatBudget: number,
+  maxEntries: number,
+): BudgetedLorebookEntrySelection {
+  if (state.selectedIds.has(candidate.entry.id)) return { selected: false };
+  if (maxEntries > 0 && state.selected.length >= maxEntries) return { selected: false };
+
+  const entryTokens = estimateLorebookTokens(candidate.entry.content);
+  const lorebookMeta = lorebooksById.get(candidate.entry.lorebookId);
+  const lorebookBudget = lorebookMeta?.lorebookBudget ?? 0;
+  const lorebookUsedTokens = state.perLorebookTokens.get(candidate.entry.lorebookId) ?? 0;
+  const exceedsLorebookBudget =
+    state.exhaustedLorebookIds.has(candidate.entry.lorebookId) ||
+    (lorebookBudget > 0 && lorebookUsedTokens + entryTokens > lorebookBudget);
+  const exceedsChatBudget =
+    state.chatBudgetExhausted || (chatBudget > 0 && state.totalTokens + entryTokens > chatBudget);
+
+  if (exceedsLorebookBudget || exceedsChatBudget) {
+    if (exceedsLorebookBudget) state.exhaustedLorebookIds.add(candidate.entry.lorebookId);
+    if (exceedsChatBudget) state.chatBudgetExhausted = true;
+    return {
+      selected: false,
+      skipped: {
+        id: candidate.entry.id,
+        name: candidate.entry.name,
+        lorebookId: candidate.entry.lorebookId,
+        lorebookName: lorebookMeta?.lorebookName ?? candidate.entry.lorebookId,
+        matchedKeys: candidate.matchedKeys,
+        estimatedTokens: entryTokens,
+        lorebookBudget,
+        lorebookUsedTokens,
+        chatBudget,
+        chatUsedTokens: state.totalTokens,
+        blockedBy: budgetSkipReason(exceedsLorebookBudget, exceedsChatBudget),
+      },
+    };
+  }
+
+  state.selected.push(candidate);
+  state.selectedIds.add(candidate.entry.id);
+  state.perLorebookTokens.set(candidate.entry.lorebookId, lorebookUsedTokens + entryTokens);
+  state.totalTokens += entryTokens;
+
+  return { selected: true, entry: candidate };
 }
 
 function selectBudgetedLorebookEntries(
@@ -589,55 +700,45 @@ function selectBudgetedLorebookEntries(
   maxEntries: number,
   contentResolver?: LorebookContentResolver,
 ): { selectedFromCandidates: ActivatedEntry[]; budgetSkippedEntries: BudgetSkippedLorebookEntry[] } {
-  const selectedFromCandidates: ActivatedEntry[] = [];
-  const budgetSkippedEntries: BudgetSkippedLorebookEntry[] = [];
+  if (candidates.length === 0) return { selectedFromCandidates: [], budgetSkippedEntries: [] };
 
-  for (const candidate of [...candidates].sort(lorebookBudgetSelectionOrder)) {
-    if (state.selectedIds.has(candidate.entry.id)) continue;
-    if (maxEntries > 0 && state.selected.length >= maxEntries) break;
+  let pool = candidates;
+  let lastSkippedBudgetEntries: BudgetSkippedLorebookEntry[] = [];
+  const maxPasses = Math.max(1, candidates.length + 1);
 
-    const restoreVariables = contentResolver?.snapshotVariables?.();
-    const resolvedCandidate = activatedEntryWithResolvedContent(candidate, contentResolver);
-    const entryTokens = estimateLorebookTokens(resolvedCandidate.entry.content);
-    const lorebookMeta = lorebooksById.get(resolvedCandidate.entry.lorebookId);
-    const lorebookBudget = lorebookMeta?.lorebookBudget ?? 0;
-    const lorebookUsedTokens = state.perLorebookTokens.get(resolvedCandidate.entry.lorebookId) ?? 0;
-    const exceedsLorebookBudget =
-      state.exhaustedLorebookIds.has(resolvedCandidate.entry.lorebookId) ||
-      (lorebookBudget > 0 && lorebookUsedTokens + entryTokens > lorebookBudget);
-    const exceedsChatBudget =
-      state.chatBudgetExhausted || (chatBudget > 0 && state.totalTokens + entryTokens > chatBudget);
+  for (let passIndex = 0; passIndex < maxPasses; passIndex += 1) {
+    const pass = resolveLorebookCandidatePass(pool, contentResolver);
+    const nextState = cloneLorebookBudgetSelectionState(state);
+    const selectedFromCandidates: ActivatedEntry[] = [];
+    const skippedFromCandidates: BudgetSkippedLorebookEntry[] = [];
 
-    if (exceedsLorebookBudget || exceedsChatBudget) {
-      restoreVariables?.();
-      if (exceedsLorebookBudget) state.exhaustedLorebookIds.add(resolvedCandidate.entry.lorebookId);
-      if (exceedsChatBudget) state.chatBudgetExhausted = true;
-      budgetSkippedEntries.push({
-        id: resolvedCandidate.entry.id,
-        name: resolvedCandidate.entry.name,
-        lorebookId: resolvedCandidate.entry.lorebookId,
-        lorebookName: lorebookMeta?.lorebookName ?? resolvedCandidate.entry.lorebookId,
-        matchedKeys: resolvedCandidate.matchedKeys,
-        estimatedTokens: entryTokens,
-        lorebookBudget,
-        lorebookUsedTokens,
-        chatBudget,
-        chatUsedTokens: state.totalTokens,
-        blockedBy: budgetSkipReason(exceedsLorebookBudget, exceedsChatBudget),
-      });
-      continue;
+    for (const candidate of [...pass.entries].sort(lorebookBudgetSelectionOrder)) {
+      const selected = trySelectBudgetedLorebookEntry(candidate, nextState, lorebooksById, chatBudget, maxEntries);
+      if (selected.selected) {
+        selectedFromCandidates.push(selected.entry);
+      } else if (selected.skipped) {
+        skippedFromCandidates.push(selected.skipped);
+      }
     }
 
-    state.selected.push(resolvedCandidate);
-    state.selectedIds.add(resolvedCandidate.entry.id);
-    state.perLorebookTokens.set(resolvedCandidate.entry.lorebookId, lorebookUsedTokens + entryTokens);
-    state.totalTokens += entryTokens;
-    selectedFromCandidates.push(resolvedCandidate);
+    selectedFromCandidates.sort(lorebookInjectionOrder);
+
+    if (sameActivatedEntrySet(pool, selectedFromCandidates)) {
+      applyLorebookBudgetSelectionState(state, nextState);
+      return {
+        selectedFromCandidates,
+        budgetSkippedEntries: lastSkippedBudgetEntries.sort((a, b) => a.id.localeCompare(b.id)),
+      };
+    }
+
+    rollbackLorebookCandidatePass(pass);
+    lastSkippedBudgetEntries = skippedFromCandidates;
+    pool = selectedFromCandidates;
   }
 
   return {
-    selectedFromCandidates: selectedFromCandidates.sort(lorebookInjectionOrder),
-    budgetSkippedEntries: budgetSkippedEntries.sort((a, b) => a.id.localeCompare(b.id)),
+    selectedFromCandidates: [],
+    budgetSkippedEntries: lastSkippedBudgetEntries.sort((a, b) => a.id.localeCompare(b.id)),
   };
 }
 

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -596,6 +596,7 @@ function selectBudgetedLorebookEntries(
     if (state.selectedIds.has(candidate.entry.id)) continue;
     if (maxEntries > 0 && state.selected.length >= maxEntries) break;
 
+    const restoreVariables = contentResolver?.snapshotVariables?.();
     const resolvedCandidate = activatedEntryWithResolvedContent(candidate, contentResolver);
     const entryTokens = estimateLorebookTokens(resolvedCandidate.entry.content);
     const lorebookMeta = lorebooksById.get(resolvedCandidate.entry.lorebookId);
@@ -608,6 +609,7 @@ function selectBudgetedLorebookEntries(
       state.chatBudgetExhausted || (chatBudget > 0 && state.totalTokens + entryTokens > chatBudget);
 
     if (exceedsLorebookBudget || exceedsChatBudget) {
+      restoreVariables?.();
       if (exceedsLorebookBudget) state.exhaustedLorebookIds.add(resolvedCandidate.entry.lorebookId);
       if (exceedsChatBudget) state.chatBudgetExhausted = true;
       budgetSkippedEntries.push({

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2998,6 +2998,16 @@ function chatHistoryDepthInjectionBounds(
   return { minIndex, anchorIndex: lastHistoryIndex + 1 };
 }
 
+function snapshotMacroVariables(macros: MacroContext): () => void {
+  const before = { ...macros.variables };
+  return () => {
+    for (const name of Object.keys(macros.variables)) {
+      if (before[name] === undefined) delete macros.variables[name];
+    }
+    Object.assign(macros.variables, before);
+  };
+}
+
 export async function assembleGenerationPrompt(
   storage: StorageGateway,
   rawInput: PromptAssemblyInput,
@@ -3053,6 +3063,7 @@ export async function assembleGenerationPrompt(
       includedPositions,
       contentResolver: {
         resolve: (content) => cleanPromptText(resolveMacros(content, macros)),
+        snapshotVariables: () => snapshotMacroVariables(macros),
       },
     });
   let loreScan = await scanLorebooksForPositions(baseLorebookIncludedPositions);


### PR DESCRIPTION
## Linked issue

Closes #2278

## Why this change

- Budget-dropped lorebook entries resolved macros before their budget check, so `{{setvar}}`/`{{addvar}}` mutations from entries that were never injected could leak into later kept entries and prompt sections.

## What changed

- Added an optional variable snapshot hook to lorebook content resolution.
- Restored the macro-variable snapshot only when an activated lorebook entry is skipped by lorebook/chat budget.
- Wired prompt assembly's macro resolver to provide that snapshot.
- Added regression coverage proving skipped `setvar` rolls back while selected `setvar` still commits for later kept entries.

## Refactor impact

Primary owner:

- engine generation

Impact areas reviewed:

- Active lorebook budget selection
- Prompt assembly macro resolution
- Lorebook content resolver contract

Boundary notes:

- The fix stays in React-free engine code and prompt assembly wiring.
- No shared API, feature UI, Rust, remote runtime, schema, storage, dependency, or release metadata changes.

Pressure points touched:

- `scanActiveLorebooks` budget selection
- `assembleGenerationPrompt` lorebook content resolver

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the regression with `pnpm test src\engine\generation\active-lorebook-scanner.test.ts`: before the fix, the kept entry resolved to `flag=leaked` instead of the prior value.
- Codex verified the fix with `pnpm test src\engine\generation\active-lorebook-scanner.test.ts`: 9 tests passed, including the rollback regression and the selected-entry commit edge case.
- Codex ran `pnpm typecheck`: passed.
- Codex ran `pnpm check`: passed.
- Codex ran the Marinara proof gate against `scratch/bugfix-verification.json`: passed.
- Bunny review pass: passed before opening this draft.
- Manual UI verification: N/A, this is a React-free engine logic regression with no visible UI state.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- N/A; this fixes internal lorebook macro behavior and does not add a user-discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs or release-note changes needed for this narrow engine regression fix.

## UI evidence

N/A. This is a React-free engine logic fix; command proof is listed above.
