### PR TITLE
Fix linked lorebook header sync

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1969,7 +1969,6 @@ fn sync_linked_character_books_for_lorebook_record_in_place(
         .then_with(|| compare_json_values(left.get("createdAt"), right.get("createdAt")))
     });
 
-    let book = linked_character_book(lorebook, &entries);
     for character in character_rows {
         let Some(character_id) = character.get("id").and_then(Value::as_str) else {
             continue;
@@ -1981,15 +1980,17 @@ fn sync_linked_character_books_for_lorebook_record_in_place(
         let Some(data_object) = data.as_object_mut() else {
             continue;
         };
-        match data_object.get("character_book") {
-            Some(Value::Null) | None | Some(Value::Object(_)) => {}
+        let mut book = match data_object.get("character_book") {
+            Some(Value::Null) | None => Map::new(),
+            Some(Value::Object(book)) => book.clone(),
             Some(_) => {
                 return Err(AppError::invalid_input(format!(
                     "Character {character_id} has a malformed embedded lorebook"
                 )));
             }
         };
-        data_object.insert("character_book".to_string(), book.clone());
+        sync_linked_character_book_fields(&mut book, lorebook, &entries);
+        data_object.insert("character_book".to_string(), Value::Object(book));
 
         if let Some(import_metadata) = data
             .pointer_mut("/extensions/importMetadata/embeddedLorebook")
@@ -2009,30 +2010,52 @@ fn sync_linked_character_books_for_lorebook_record_in_place(
     Ok(())
 }
 
-fn linked_character_book(lorebook: &Value, entries: &[Value]) -> Value {
-    json!({
-        "name": lorebook
+fn sync_linked_character_book_fields(
+    book: &mut Map<String, Value>,
+    lorebook: &Value,
+    entries: &[Value],
+) {
+    book.insert(
+        "name".to_string(),
+        json!(lorebook
             .get("name")
             .and_then(Value::as_str)
             .filter(|value| !value.trim().is_empty())
-            .unwrap_or("Character Lorebook"),
-        "description": lorebook
+            .unwrap_or("Character Lorebook")),
+    );
+    book.insert(
+        "description".to_string(),
+        json!(lorebook
             .get("description")
             .and_then(Value::as_str)
-            .unwrap_or(""),
-        "scan_depth": linked_character_book_number(lorebook.get("scanDepth"), 2),
-        "token_budget": linked_character_book_number(lorebook.get("tokenBudget"), 2048),
-        "recursive_scanning": lorebook
+            .unwrap_or("")),
+    );
+    book.insert(
+        "scan_depth".to_string(),
+        linked_character_book_number(lorebook.get("scanDepth"), 2),
+    );
+    book.insert(
+        "token_budget".to_string(),
+        linked_character_book_number(lorebook.get("tokenBudget"), 2048),
+    );
+    book.insert(
+        "recursive_scanning".to_string(),
+        json!(lorebook
             .get("recursiveScanning")
             .and_then(Value::as_bool)
-            .unwrap_or(false),
-        "extensions": {},
-        "entries": entries
+            .unwrap_or(false)),
+    );
+    if !book.contains_key("extensions") {
+        book.insert("extensions".to_string(), json!({}));
+    }
+    book.insert(
+        "entries".to_string(),
+        json!(entries
             .iter()
             .enumerate()
             .map(|(index, entry)| linked_character_book_entry(entry, index))
-            .collect::<Vec<_>>(),
-    })
+            .collect::<Vec<_>>()),
+    );
 }
 
 fn linked_character_book_number(value: Option<&Value>, fallback: i64) -> Value {
@@ -2624,6 +2647,12 @@ mod tests {
                     "data": {
                         "name": "Mira",
                         "character_book": {
+                            "extensions": {
+                                "sillytavern": {
+                                    "source": "card",
+                                    "preserved": true
+                                }
+                            },
                             "entries": [
                                 {
                                     "name": "Old",
@@ -2821,6 +2850,55 @@ mod tests {
     }
 
     #[test]
+    fn linked_lorebook_metadata_update_is_atomic_when_character_book_sync_fails() {
+        let state = test_state("linked-character-book-metadata-update-atomic");
+        seed_linked_character_book(&state);
+        state
+            .storage
+            .patch(
+                "characters",
+                "character-1",
+                json!({
+                    "data": {
+                        "name": "Mira",
+                        "character_book": "malformed",
+                        "extensions": {
+                            "importMetadata": {
+                                "embeddedLorebook": {
+                                    "hasEmbeddedLorebook": true,
+                                    "lorebookId": "linked-book",
+                                    "entriesImported": 1
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("malformed linked character book should seed");
+
+        let error = storage_update_inner(
+            &state,
+            "lorebooks".to_string(),
+            "linked-book".to_string(),
+            json!({
+                "name": "Should Roll Back"
+            }),
+        )
+        .expect_err("malformed linked character book should reject the metadata update");
+
+        assert_eq!(error.code, "invalid_input");
+        let lorebook = state
+            .storage
+            .get("lorebooks", "linked-book")
+            .expect("lorebook should read")
+            .expect("lorebook should still exist");
+        assert_eq!(
+            lorebook.get("name").and_then(Value::as_str),
+            Some("Mira Lorebook")
+        );
+    }
+
+    #[test]
     fn updating_linked_lorebook_entry_syncs_character_book() {
         let state = test_state("linked-character-book-entry-update");
         seed_linked_character_book(&state);
@@ -2926,7 +3004,12 @@ mod tests {
                 "scan_depth": 7,
                 "token_budget": 333,
                 "recursive_scanning": true,
-                "extensions": {}
+                "extensions": {
+                    "sillytavern": {
+                        "source": "card",
+                        "preserved": true
+                    }
+                }
             })
         );
         let entry = first_character_book_entry(&state);

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use tauri::State;
 
 type LorebookEntryAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
+type LorebookMetadataAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>, &'a mut Vec<Value>);
 type LorebookFolderDeleteAtomicRows<'a> =
     (&'a mut Vec<Value>, &'a mut Vec<Value>, &'a mut Vec<Value>);
 type ChatFolderDeleteAtomicRows<'a> = (&'a mut Vec<Value>, &'a mut Vec<Value>);
@@ -748,6 +749,9 @@ pub(crate) fn storage_update_inner(
     }
     if entity == "lorebook-entries" {
         return update_lorebook_entry_with_character_book_sync(state, &id, normalized_patch);
+    }
+    if entity == "lorebooks" {
+        return update_lorebook_with_character_book_sync(state, &id, normalized_patch);
     }
     let updated = if entity == "connections" {
         connection_secrets::patch_connection(state, &id, normalized_patch)?
@@ -1656,6 +1660,39 @@ fn delete_lorebook_entry_with_character_book_sync(
     )
 }
 
+fn update_lorebook_with_character_book_sync(
+    state: &AppState,
+    id: &str,
+    patch: Value,
+) -> Result<Value, AppError> {
+    let patch = ensure_object(patch)?;
+    state.storage.update_collections_atomically(
+        vec!["lorebooks", "lorebook-entries", "characters"],
+        move |collections| {
+            let (lorebook_rows, entry_rows, character_rows) =
+                lorebook_metadata_atomic_rows(collections)?;
+            let row = lorebook_rows
+                .iter_mut()
+                .find(|row| row.get("id").and_then(Value::as_str) == Some(id))
+                .ok_or_else(|| AppError::not_found(format!("lorebooks/{id} was not found")))?;
+            let Some(object) = row.as_object_mut() else {
+                return Err(AppError::invalid_input("Stored record is not an object"));
+            };
+            for (key, value) in patch {
+                object.insert(key, value);
+            }
+            object.insert("updatedAt".to_string(), Value::String(now_iso()));
+            let updated = Value::Object(object.clone());
+            sync_linked_character_books_for_lorebook_record_in_place(
+                character_rows,
+                entry_rows,
+                &updated,
+            )?;
+            Ok(updated)
+        },
+    )
+}
+
 fn delete_lorebook_folder_with_entry_reparent_sync(
     state: &AppState,
     folder_id: &str,
@@ -1772,6 +1809,32 @@ fn lorebook_entry_atomic_rows(
     }
 }
 
+fn lorebook_metadata_atomic_rows(
+    collections: &mut [marinara_storage::AtomicCollectionRows],
+) -> Result<LorebookMetadataAtomicRows<'_>, AppError> {
+    let [lorebooks, entries, characters] = collections else {
+        return Err(AppError::new(
+            "storage_error",
+            "Lorebook metadata sync expected lorebook, entry, and character collections",
+        ));
+    };
+    match (
+        lorebooks.collection(),
+        entries.collection(),
+        characters.collection(),
+    ) {
+        ("lorebooks", "lorebook-entries", "characters") => Ok((
+            lorebooks.rows_mut(),
+            entries.rows_mut(),
+            characters.rows_mut(),
+        )),
+        _ => Err(AppError::new(
+            "storage_error",
+            "Lorebook metadata sync received unexpected collections",
+        )),
+    }
+}
+
 fn lorebook_folder_delete_atomic_rows(
     collections: &mut [marinara_storage::AtomicCollectionRows],
 ) -> Result<LorebookFolderDeleteAtomicRows<'_>, AppError> {
@@ -1883,6 +1946,100 @@ fn sync_linked_character_books_for_lorebook_in_place(
         character_object.insert("updatedAt".to_string(), Value::String(now_iso()));
     }
     Ok(())
+}
+
+fn sync_linked_character_books_for_lorebook_record_in_place(
+    character_rows: &mut [Value],
+    all_entry_rows: &[Value],
+    lorebook: &Value,
+) -> Result<(), AppError> {
+    let Some(lorebook_id) = lorebook.get("id").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let mut entries = all_entry_rows
+        .iter()
+        .filter(|entry| lorebook_entry_lorebook_id(entry) == Some(lorebook_id))
+        .cloned()
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        compare_json_values(
+            left.get("sortOrder").or_else(|| left.get("order")),
+            right.get("sortOrder").or_else(|| right.get("order")),
+        )
+        .then_with(|| compare_json_values(left.get("createdAt"), right.get("createdAt")))
+    });
+
+    let book = linked_character_book(lorebook, &entries);
+    for character in character_rows {
+        let Some(character_id) = character.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let mut data = character.get("data").cloned().unwrap_or_else(|| json!({}));
+        if embedded_lorebook_id(&data) != Some(lorebook_id) {
+            continue;
+        }
+        let Some(data_object) = data.as_object_mut() else {
+            continue;
+        };
+        match data_object.get("character_book") {
+            Some(Value::Null) | None | Some(Value::Object(_)) => {}
+            Some(_) => {
+                return Err(AppError::invalid_input(format!(
+                    "Character {character_id} has a malformed embedded lorebook"
+                )));
+            }
+        };
+        data_object.insert("character_book".to_string(), book.clone());
+
+        if let Some(import_metadata) = data
+            .pointer_mut("/extensions/importMetadata/embeddedLorebook")
+            .and_then(Value::as_object_mut)
+        {
+            import_metadata.insert("entriesImported".to_string(), json!(entries.len()));
+            import_metadata.insert("hasEmbeddedLorebook".to_string(), Value::Bool(true));
+        }
+        let Some(character_object) = character.as_object_mut() else {
+            return Err(AppError::invalid_input(
+                "Stored character record is not an object",
+            ));
+        };
+        character_object.insert("data".to_string(), data);
+        character_object.insert("updatedAt".to_string(), Value::String(now_iso()));
+    }
+    Ok(())
+}
+
+fn linked_character_book(lorebook: &Value, entries: &[Value]) -> Value {
+    json!({
+        "name": lorebook
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("Character Lorebook"),
+        "description": lorebook
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or(""),
+        "scan_depth": linked_character_book_number(lorebook.get("scanDepth"), 2),
+        "token_budget": linked_character_book_number(lorebook.get("tokenBudget"), 2048),
+        "recursive_scanning": lorebook
+            .get("recursiveScanning")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        "extensions": {},
+        "entries": entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| linked_character_book_entry(entry, index))
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn linked_character_book_number(value: Option<&Value>, fallback: i64) -> Value {
+    match value {
+        Some(Value::Number(number)) => Value::Number(number.clone()),
+        _ => json!(fallback),
+    }
 }
 
 fn linked_character_book_entry(entry: &Value, index: usize) -> Value {
@@ -2525,6 +2682,22 @@ mod tests {
             .expect("character book should have an entry")
     }
 
+    fn character_book_header(state: &AppState) -> Value {
+        let mut book = state
+            .storage
+            .get("characters", "character-1")
+            .expect("character should read")
+            .and_then(|character| {
+                character
+                    .pointer("/data/character_book")
+                    .and_then(Value::as_object)
+                    .cloned()
+            })
+            .expect("character book should exist");
+        book.remove("entries");
+        Value::Object(book)
+    }
+
     fn entry_exists(state: &AppState, id: &str) -> bool {
         state
             .storage
@@ -2685,6 +2858,94 @@ mod tests {
         );
         assert_eq!(entry["keys"], json!(["sun"]));
         assert_eq!(entry.get("enabled").and_then(Value::as_bool), Some(false));
+    }
+
+    #[test]
+    fn updating_linked_lorebook_metadata_syncs_character_book_header() {
+        let state = test_state("linked-character-book-metadata-update");
+        seed_linked_character_book(&state);
+        state
+            .storage
+            .create(
+                "lorebook-entries",
+                json!({
+                    "id": "entry-1",
+                    "lorebookId": "linked-book",
+                    "name": "Moon",
+                    "content": "moon text",
+                    "keys": ["moon"]
+                }),
+            )
+            .expect("entry should seed");
+        state
+            .storage
+            .create(
+                "characters",
+                json!({
+                    "id": "character-other",
+                    "name": "Other",
+                    "data": {
+                        "name": "Other",
+                        "character_book": {
+                            "name": "Other Header",
+                            "entries": []
+                        },
+                        "extensions": {
+                            "importMetadata": {
+                                "embeddedLorebook": {
+                                    "hasEmbeddedLorebook": true,
+                                    "lorebookId": "other-book",
+                                    "entriesImported": 0
+                                }
+                            }
+                        }
+                    }
+                }),
+            )
+            .expect("unrelated linked character should seed");
+
+        storage_update_inner(
+            &state,
+            "lorebooks".to_string(),
+            "linked-book".to_string(),
+            json!({
+                "name": "Updated Mira Lorebook",
+                "description": "Fresh linked header",
+                "scanDepth": 7,
+                "tokenBudget": 333,
+                "recursiveScanning": true
+            }),
+        )
+        .expect("lorebook metadata update should sync");
+
+        assert_eq!(
+            character_book_header(&state),
+            json!({
+                "name": "Updated Mira Lorebook",
+                "description": "Fresh linked header",
+                "scan_depth": 7,
+                "token_budget": 333,
+                "recursive_scanning": true,
+                "extensions": {}
+            })
+        );
+        let entry = first_character_book_entry(&state);
+        assert_eq!(entry.get("name").and_then(Value::as_str), Some("Moon"));
+        assert_eq!(
+            entry.get("content").and_then(Value::as_str),
+            Some("moon text")
+        );
+        let other = state
+            .storage
+            .get("characters", "character-other")
+            .expect("other character should read")
+            .expect("other character should exist");
+        assert_eq!(
+            other
+                .pointer("/data/character_book/name")
+                .and_then(Value::as_str),
+            Some("Other Header")
+        );
     }
 
     #[test]

--- a/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
+++ b/src/features/catalog/lorebooks/hooks/use-lorebooks.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // React Query: Lorebook hooks
 // ──────────────────────────────────────────────
-import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueries, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { lorebookKeys } from "../query-keys";
 import { scanActiveLorebookEntries } from "../../../../engine/generation/active-lorebooks";
 import type { LorebookSemanticScanStatus } from "../../../../engine/generation/active-lorebook-scanner";
@@ -130,6 +130,11 @@ async function bulkUnvectorizeLorebookEntries(
   return { lorebookId, requested: requestedIds.length || entries.length, cleared: targets.length };
 }
 
+function invalidateLinkedCharacterBookQueries(qc: Pick<QueryClient, "invalidateQueries">): void {
+  // Linked lorebook writes mirror into character.data.character_book in native storage.
+  qc.invalidateQueries({ queryKey: characterKeys.all });
+}
+
 // ── Lorebooks ──
 
 export function useLorebooks(category?: string) {
@@ -181,6 +186,7 @@ export function useUpdateLorebook() {
       qc.invalidateQueries({ queryKey: lorebookKeys.list() });
       qc.invalidateQueries({ queryKey: lorebookKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -220,7 +226,7 @@ export function useDeleteLorebook() {
       // by this point), so blanket-invalidate character queries —
       // missing this lets the character editor keep rendering stale
       // entries and a broken "Edit Linked Lorebook" button.
-      qc.invalidateQueries({ queryKey: characterKeys.all });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -281,6 +287,7 @@ export function useCreateLorebookEntry() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -304,6 +311,7 @@ export function useDuplicateLorebookEntry() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.entry.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -317,6 +325,7 @@ export function useUpdateLorebookEntry() {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.entry(variables.entryId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -329,6 +338,7 @@ export function useDeleteLorebookEntry() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -341,6 +351,7 @@ export function useBulkUnvectorizeLorebookEntries() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -363,6 +374,7 @@ export function useTransferLorebookEntries() {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.sourceLorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.targetLorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -388,6 +400,7 @@ export function useReorderLorebookEntries() {
       qc.setQueryData(lorebookKeys.entries(variables.lorebookId), entries);
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }
@@ -443,6 +456,7 @@ export function useDeleteLorebookFolder() {
       // Removing a folder reparents its entries to root, so the entry list shape changes.
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      invalidateLinkedCharacterBookQueries(qc);
     },
   });
 }


### PR DESCRIPTION
## Linked issue

Closes #2280

## Why this change

- Linked standalone lorebook metadata edits were patching the `lorebooks` row without re-syncing the linked character's embedded `data.character_book`, so later character card exports could carry a stale ST header.

## What changed

- Route `lorebooks` updates through an atomic lorebook/entries/characters sync path.
- Rebuild the linked character's embedded `character_book` header from the updated lorebook row, including `name`, `description`, `scan_depth`, `token_budget`, and `recursive_scanning`.
- Added regression coverage for the metadata update path, preserving entries and proving an unrelated linked character is not changed.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- `src-tauri/src/commands/storage/commands/entities.rs`
- Character compatible export path, which emits `data.character_book` verbatim after storage sync.

Boundary notes:

- Stays inside `src-tauri`; no React, engine, shared API, remote runtime, schema, dependency, auth, prompt, or release boundary changes.

Pressure points touched:

- Storage entity update command path for `lorebooks`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Codex reproduced the stale-header bug with the new Rust regression test before the production fix: `cargo test --manifest-path src-tauri/Cargo.toml updating_linked_lorebook_metadata_syncs_character_book_header -- --nocapture` failed because the embedded header stayed `{}`.
- After the fix, `cargo test --manifest-path src-tauri/Cargo.toml updating_linked_lorebook_metadata_syncs_character_book_header -- --nocapture` passed.
- Adjacent storage coverage passed: `cargo test --manifest-path src-tauri/Cargo.toml linked_lorebook -- --nocapture` passed, covering linked entry create/update/delete/move, embedded reimport, malformed-book atomic failure, and the metadata sync regression.
- Full baseline passed after the final diff: `pnpm check`.
- Proof gate passed: `node C:\Users\celia\.codex\tools\marinara-proof-gate.mjs scratch\bugfix-verification.json`.
- Bunny review passed before opening this draft: focused Rust storage diff, direct repro, negative control, `pnpm check`, and proof gate clean.
- No human-only verification blocker remains for the core claim.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing linked lorebook export-state behavior; no new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Backend/export-state bug; no meaningful app UI state changes. Evidence is a GitHub-renderable proof card built from the captured Rust repro and `pnpm check` outputs:

![Issue #2280 proof](https://gist.githubusercontent.com/cha1latte/2076e5eaab4fc94164be5093bd59a08c/raw/1fcc0b0075e7bf5cb599acad801ca60f06939a5b/issue-2280-proof.svg)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lorebook metadata updates now automatically synchronize with linked character books, refreshing headers in real-time while maintaining entry syncing.
  * Atomic update mechanism ensures consistent changes across all characters referencing the updated lorebook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->