### PR TITLE
Enforce the SSRF guard in http_binary

### DIFF
--- a/src-tauri/src/commands/storage/http.rs
+++ b/src-tauri/src/commands/storage/http.rs
@@ -1,8 +1,9 @@
 use super::shared::*;
 use super::*;
-use marinara_security::is_allowed_outbound_url;
+use marinara_security::{is_allowed_outbound_url, is_local_or_reserved_ip};
 
 const MAX_BINARY_RESPONSE_BYTES: u64 = 25 * 1024 * 1024;
+const MAX_BINARY_REDIRECTS: usize = 5;
 
 pub(crate) async fn http_json(url: &str) -> AppResult<Value> {
     let client = reqwest::Client::builder()
@@ -31,24 +32,133 @@ pub(crate) async fn http_json(url: &str) -> AppResult<Value> {
 }
 
 pub(crate) async fn http_binary(url: &str, fallback_mime: &str) -> AppResult<Value> {
-    // Enforce the internal-host/IMDS guard: http_binary fetches content-supplied URLs
-    // (avatar/background/image references from imported cards and lorebooks), so local and
-    // reserved hosts must be blocked. Managed local assets are resolved by
-    // load_local_asset_binary (asset://localhost) before this is ever reached.
+    // http_binary fetches content-supplied URLs (avatar/background/image references from
+    // imported cards and lorebooks), so it is an SSRF sink. Three guards apply on every
+    // hop: (1) the host must pass the internal-host/IMDS allow-list, (2) the resolved IPs
+    // must not be local/reserved (defeats DNS rebinding) and are pinned via resolve_to_addrs,
+    // and (3) redirects are followed manually with Policy::none so each Location is
+    // re-validated rather than blindly chased into 169.254.169.254. Managed local assets are
+    // resolved by load_local_asset_binary (asset://localhost) before this is ever reached.
+    let mut current_url = validate_binary_fetch_url(url)?;
+    for redirects_followed in 0..=MAX_BINARY_REDIRECTS {
+        let response = send_binary_fetch_request(&current_url).await?;
+        if response.status().is_redirection()
+            && response.headers().contains_key(reqwest::header::LOCATION)
+        {
+            if redirects_followed == MAX_BINARY_REDIRECTS {
+                return Err(AppError::invalid_input("Remote URL exceeded redirect limit"));
+            }
+            current_url = redirected_binary_fetch_url(&current_url, &response)?;
+            continue;
+        }
+        return finalize_binary_response(response, fallback_mime).await;
+    }
+    Err(AppError::invalid_input("Remote URL exceeded redirect limit"))
+}
+
+/// Parse and SSRF-screen a URL before fetching. Rejects local/reserved hosts (IMDS,
+/// localhost, private ranges) via the security allow-list.
+fn validate_binary_fetch_url(url: &str) -> AppResult<reqwest::Url> {
     if !is_allowed_outbound_url(url, false) {
         return Err(AppError::invalid_input(format!(
             "Outbound URL is not allowed: {url}"
         )));
     }
-    let client = reqwest::Client::builder()
+    reqwest::Url::parse(url)
+        .map_err(|error| AppError::invalid_input(format!("Remote URL is invalid: {error}")))
+}
+
+/// Resolve and re-validate a redirect's Location header (relative or absolute) against the
+/// same SSRF guard, so a public host can't 302 the fetch into a reserved address.
+fn redirected_binary_fetch_url(
+    current_url: &reqwest::Url,
+    response: &reqwest::Response,
+) -> AppResult<reqwest::Url> {
+    let location = response
+        .headers()
+        .get(reqwest::header::LOCATION)
+        .ok_or_else(|| AppError::invalid_input("Remote redirect is missing a Location header"))?
+        .to_str()
+        .map_err(|error| {
+            AppError::invalid_input(format!("Remote redirect Location is invalid: {error}"))
+        })?;
+    validate_redirected_binary_fetch_url(current_url, location)
+}
+
+fn validate_redirected_binary_fetch_url(
+    current_url: &reqwest::Url,
+    location: &str,
+) -> AppResult<reqwest::Url> {
+    let redirected = current_url
+        .join(location)
+        .map_err(|error| AppError::invalid_input(format!("Remote redirect URL is invalid: {error}")))?;
+    validate_binary_fetch_url(redirected.as_str())
+}
+
+async fn send_binary_fetch_request(url: &reqwest::Url) -> AppResult<reqwest::Response> {
+    let resolved_addresses = binary_fetch_resolved_addresses(url).await?;
+    let mut client_builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(60))
+        .redirect(reqwest::redirect::Policy::none());
+    if let (Some(host), Some(addresses)) = (url.host_str(), resolved_addresses.as_deref()) {
+        client_builder = client_builder.resolve_to_addrs(host, addresses);
+    }
+    client_builder
         .build()
-        .map_err(|error| AppError::new("http_client_error", error.to_string()))?;
-    let response = client
-        .get(url)
+        .map_err(|error| AppError::new("http_client_error", error.to_string()))?
+        .get(url.clone())
         .send()
         .await
-        .map_err(|error| AppError::new("upstream_request_failed", error.to_string()))?;
+        .map_err(|error| AppError::new("upstream_request_failed", error.to_string()))
+}
+
+/// Resolve a hostname and reject (then pin) it so a public-looking name can't rebind to a
+/// reserved IP between the allow-list check and the connect. IP-literal hosts are already
+/// screened by validate_binary_fetch_url, so they need no pinning.
+async fn binary_fetch_resolved_addresses(
+    url: &reqwest::Url,
+) -> AppResult<Option<Vec<std::net::SocketAddr>>> {
+    let Some(host) = url.host_str() else {
+        return Err(AppError::invalid_input("Remote URL is missing a hostname"));
+    };
+    if binary_fetch_host_ip(host).is_some() {
+        return Ok(None);
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addresses = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|error| {
+            AppError::invalid_input(format!("Remote host '{host}' did not resolve: {error}"))
+        })?;
+    let mut resolved = Vec::new();
+    for address in addresses {
+        if is_local_or_reserved_ip(address.ip()) {
+            return Err(AppError::invalid_input(format!(
+                "Remote URL resolves to a local, private, or reserved address: {url}"
+            )));
+        }
+        resolved.push(address);
+    }
+    if resolved.is_empty() {
+        return Err(AppError::invalid_input(format!(
+            "Remote host '{host}' did not resolve"
+        )));
+    }
+    Ok(Some(resolved))
+}
+
+fn binary_fetch_host_ip(host: &str) -> Option<std::net::IpAddr> {
+    let unbracketed = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    unbracketed.parse::<std::net::IpAddr>().ok()
+}
+
+async fn finalize_binary_response(
+    response: reqwest::Response,
+    fallback_mime: &str,
+) -> AppResult<Value> {
     let status = response.status();
     if !status.is_success() {
         return Err(AppError::new(
@@ -213,5 +323,30 @@ mod tests {
             assert_eq!(error.code, "invalid_input", "url {url} should be blocked");
             assert!(error.message.contains("Outbound URL is not allowed"));
         }
+    }
+
+    #[test]
+    fn redirect_revalidation_blocks_reserved_locations() {
+        // A public response that 302s to a reserved/internal address must be rejected when the
+        // redirect Location is re-validated, instead of being chased into IMDS/localhost.
+        let current = reqwest::Url::parse("https://cdn.example.com/avatar.png").unwrap();
+        for location in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://127.0.0.1/",
+            "http://localhost/internal",
+            "http://10.0.0.5/",
+        ] {
+            let error = validate_redirected_binary_fetch_url(&current, location)
+                .expect_err("redirect to a reserved host must be rejected");
+            assert_eq!(error.code, "invalid_input", "location {location} should be blocked");
+        }
+    }
+
+    #[test]
+    fn redirect_revalidation_allows_public_relative_locations() {
+        let current = reqwest::Url::parse("https://cdn.example.com/avatar.png").unwrap();
+        let resolved = validate_redirected_binary_fetch_url(&current, "/resized/avatar.png")
+            .expect("public relative redirect should resolve");
+        assert_eq!(resolved.as_str(), "https://cdn.example.com/resized/avatar.png");
     }
 }

--- a/src-tauri/src/commands/storage/http.rs
+++ b/src-tauri/src/commands/storage/http.rs
@@ -349,4 +349,21 @@ mod tests {
             .expect("public relative redirect should resolve");
         assert_eq!(resolved.as_str(), "https://cdn.example.com/resized/avatar.png");
     }
+
+    #[tokio::test]
+    async fn resolved_addresses_skip_pinning_for_ip_literal_hosts() {
+        // IP-literal hosts are screened by the URL guard, so no DNS lookup/pinning is performed.
+        let url = reqwest::Url::parse("http://1.1.1.1/x").unwrap();
+        assert!(binary_fetch_resolved_addresses(&url).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn resolved_addresses_reject_hosts_resolving_to_reserved_ips() {
+        // localhost resolves to a loopback address; the rebinding guard must reject it.
+        let url = reqwest::Url::parse("http://localhost:9/x").unwrap();
+        let error = binary_fetch_resolved_addresses(&url)
+            .await
+            .expect_err("a host that resolves to a reserved IP must be rejected");
+        assert_eq!(error.code, "invalid_input");
+    }
 }

--- a/src-tauri/src/commands/storage/http.rs
+++ b/src-tauri/src/commands/storage/http.rs
@@ -31,7 +31,11 @@ pub(crate) async fn http_json(url: &str) -> AppResult<Value> {
 }
 
 pub(crate) async fn http_binary(url: &str, fallback_mime: &str) -> AppResult<Value> {
-    if !is_allowed_outbound_url(url, true) {
+    // Enforce the internal-host/IMDS guard: http_binary fetches content-supplied URLs
+    // (avatar/background/image references from imported cards and lorebooks), so local and
+    // reserved hosts must be blocked. Managed local assets are resolved by
+    // load_local_asset_binary (asset://localhost) before this is ever reached.
+    if !is_allowed_outbound_url(url, false) {
         return Err(AppError::invalid_input(format!(
             "Outbound URL is not allowed: {url}"
         )));
@@ -186,4 +190,28 @@ pub(crate) async fn gifs_search(route: &ParsedPath) -> AppResult<Value> {
     Ok(
         json!({ "results": results, "next": if next_offset < total { next_offset.to_string() } else { String::new() } }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn http_binary_blocks_local_and_reserved_hosts() {
+        // The internal-host guard runs before any network request, so these all fail fast.
+        for url in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://localhost:3000/secret",
+            "http://127.0.0.1/",
+            "http://10.0.0.5/",
+            "http://192.168.1.1/",
+            "http://[::1]/",
+        ] {
+            let error = http_binary(url, "image/png")
+                .await
+                .expect_err("local/reserved host must be rejected");
+            assert_eq!(error.code, "invalid_input", "url {url} should be blocked");
+            assert!(error.message.contains("Outbound URL is not allowed"));
+        }
+    }
 }


### PR DESCRIPTION
## Linked issue

Closes #2300

## Why this change

`http_binary` resolves content-supplied URLs (avatar/background/image references from imported character cards and lorebooks via `load_url_binary`), so it is an SSRF sink. It passed `allow_local=true` to `is_allowed_outbound_url`, disabling the internal-host guard entirely — and even with the guard enabled, the original one-line flip left two bypasses the issue calls out: redirect-following (a public host can `302` into `169.254.169.254`) and DNS rebinding (a public-looking host resolving to a reserved IP).

## What changed

- Screen the URL with `is_allowed_outbound_url(url, false)` so local/reserved hosts (IMDS, localhost, private ranges) are blocked.
- Follow redirects manually with `redirect::Policy::none` (max 5) and re-validate every `Location` through the same SSRF guard, instead of blindly chasing reqwest's default redirect policy into an internal address.
- Resolve the host and reject local/reserved IPs, pinning the connection via `resolve_to_addrs` so DNS rebinding can't slip a reserved address past the host check. IP-literal hosts are already screened by the URL guard and skip pinning.
- Mirrors the existing `custom_tools.rs` webhook hardening (`redirected_custom_tool_webhook_url` / `custom_tool_webhook_resolved_addresses`).

## Refactor impact

Primary owner: Rust storage (`src-tauri/src/commands/storage/http.rs`)

Impact areas reviewed:

- `load_url_binary_for_state` resolves `asset://localhost` via `load_local_asset_binary` **before** `http_binary`, so managed local-asset loading is unaffected.
- `bot_browser.rs` fetches public card hosts; CDN redirects to public hosts are still followed (now re-validated and pinned).

Boundary notes:

- Reuses `marinara_security::{is_allowed_outbound_url, is_local_or_reserved_ip}`; no new layer boundary crossed.

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green, including:
  - `http_binary_blocks_local_and_reserved_hosts` (IMDS / localhost / 127.0.0.1 / 10.x / 172.16.x / 192.168.x / `[::1]` rejected before any network call),
  - `redirect_revalidation_blocks_reserved_locations` (a `302` to a reserved host is rejected),
  - `redirect_revalidation_allows_public_relative_locations` (a public relative redirect still resolves).

## Feature Discoverability

- [x] N/A because this PR is a security bugfix and does not add a new thing users need to find.

Reason:

- Hardening of an existing fetch path.

## Docs and release impact

- [x] No docs changes needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary file fetching with enhanced URL validation and stricter host verification.
  * Added limits on redirect chains to prevent excessive network hops during downloads.
  * Strengthened network destination validation for more reliable and stable file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->