### PR TITLE
Suppress mentions in Discord webhook mirror payloads

### DIFF
--- a/src-tauri/src/commands/storage/integrations/discord.rs
+++ b/src-tauri/src/commands/storage/integrations/discord.rs
@@ -13,25 +13,7 @@ pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
         return Err(AppError::invalid_input("Invalid Discord webhook URL"));
     }
 
-    let content = required_string(&body, "content")?.trim();
-    let mut payload = Map::new();
-    payload.insert(
-        "content".to_string(),
-        Value::String(truncate_for_discord(content, DISCORD_CONTENT_LIMIT)),
-    );
-
-    if let Some(username) = optional_trimmed_string(&body, "username") {
-        payload.insert(
-            "username".to_string(),
-            Value::String(truncate_chars(&username, DISCORD_USERNAME_LIMIT)),
-        );
-    }
-    if let Some(avatar_url) = optional_trimmed_string(&body, "avatarUrl") {
-        if !is_allowed_outbound_url(&avatar_url, false) {
-            return Err(AppError::invalid_input("Invalid Discord avatar URL"));
-        }
-        payload.insert("avatar_url".to_string(), Value::String(avatar_url));
-    }
+    let payload = build_discord_payload(&body)?;
 
     let response = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
@@ -59,6 +41,37 @@ pub(crate) async fn discord_webhook_send(body: Value) -> AppResult<Value> {
     }
 
     Ok(json!({ "success": true }))
+}
+
+/// Build the Discord webhook JSON payload from a mirror request.
+///
+/// `allowed_mentions` is always set to `{ "parse": [] }` so mention syntax in the
+/// mirrored content (which is model/card output) can never resolve real @everyone /
+/// @here / role / user pings on the target server.
+fn build_discord_payload(body: &Value) -> AppResult<Map<String, Value>> {
+    let content = required_string(body, "content")?.trim();
+    let mut payload = Map::new();
+    payload.insert(
+        "content".to_string(),
+        Value::String(truncate_for_discord(content, DISCORD_CONTENT_LIMIT)),
+    );
+
+    if let Some(username) = optional_trimmed_string(body, "username") {
+        payload.insert(
+            "username".to_string(),
+            Value::String(truncate_chars(&username, DISCORD_USERNAME_LIMIT)),
+        );
+    }
+    if let Some(avatar_url) = optional_trimmed_string(body, "avatarUrl") {
+        if !is_allowed_outbound_url(&avatar_url, false) {
+            return Err(AppError::invalid_input("Invalid Discord avatar URL"));
+        }
+        payload.insert("avatar_url".to_string(), Value::String(avatar_url));
+    }
+
+    payload.insert("allowed_mentions".to_string(), json!({ "parse": [] }));
+
+    Ok(payload)
 }
 
 fn optional_trimmed_string(body: &Value, key: &str) -> Option<String> {
@@ -135,5 +148,32 @@ mod tests {
         let truncated = truncate_for_discord(&value, DISCORD_CONTENT_LIMIT);
         assert_eq!(truncated.chars().count(), DISCORD_CONTENT_LIMIT);
         assert!(truncated.ends_with("..."));
+    }
+
+    #[test]
+    fn payload_always_suppresses_mentions() {
+        let payload = build_discord_payload(&json!({ "content": "hey @everyone @here <@&123>" }))
+            .expect("payload should build");
+        let parse = payload
+            .get("allowed_mentions")
+            .and_then(|value| value.get("parse"))
+            .and_then(Value::as_array)
+            .expect("allowed_mentions.parse must be present");
+        assert!(parse.is_empty(), "no mention types may be parsed");
+        // Suppression is via allowed_mentions, not by mangling the visible text.
+        assert_eq!(
+            payload.get("content").and_then(Value::as_str),
+            Some("hey @everyone @here <@&123>")
+        );
+    }
+
+    #[test]
+    fn payload_rejects_reserved_avatar_url() {
+        let error = build_discord_payload(&json!({
+            "content": "hi",
+            "avatarUrl": "http://169.254.169.254/latest/meta-data/"
+        }))
+        .expect_err("reserved avatar URL must be rejected");
+        assert_eq!(error.code, "invalid_input");
     }
 }


### PR DESCRIPTION
## Linked issue

Closes #2369

## Why this change

The Discord mirror built its webhook payload with no `allowed_mentions` field. Discord parses mentions in `content` by default when the field is absent, so any `@everyone` / `@here` / role / user mention in the mirrored model or card output fired real notifications on the target server.

## What changed

- Factor payload construction into `build_discord_payload` and always set `allowed_mentions` to `{ "parse": [] }`, disabling all mention resolution while leaving the visible text intact (suppression at the API level, not by mangling content).

## Refactor impact

Primary owner: Rust integrations (`src-tauri/src/commands/storage/integrations/discord.rs`)

Impact areas reviewed:

- Only the webhook send path; the existing webhook-URL and outbound-URL (SSRF) guards are unchanged.

Boundary notes:

- none

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green, including new `payload_always_suppresses_mentions` and `payload_rejects_reserved_avatar_url`.

## Feature Discoverability

- [x] N/A because this PR is a security bugfix and does not add a new thing users need to find.

Reason:

- Hardening of an existing integration path.

## Docs and release impact

- [x] No docs changes needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord webhook security by preventing unintended mention resolution in messages.
  * Added validation for avatar URLs to reject unsafe or reserved addresses.
  * Content and usernames are now automatically truncated to Discord's character limits for proper delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->