### PR TITLE
Delete sprite directories when a character or persona is deleted

### DIFF
--- a/src-tauri/src/commands/storage/admin.rs
+++ b/src-tauri/src/commands/storage/admin.rs
@@ -129,6 +129,7 @@ fn clear_runtime_media(state: &AppState) -> AppResult<()> {
         state.data_dir.join("avatars"),
         state.data_dir.join("fonts"),
         state.data_dir.join("knowledge-sources"),
+        state.data_dir.join("sprites"),
         state.game_assets.root().to_path_buf(),
         state.backgrounds.root().to_path_buf(),
     ] {

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -1,6 +1,6 @@
 use super::{
     avatars, characters, chats, connection_secrets, contracts, game_state_snapshots, integrations,
-    lorebook_images, media_uploads, message_swipes, personas, prompts, shared,
+    lorebook_images, media_uploads, message_swipes, personas, prompts, shared, sprites,
 };
 use crate::builtins::is_protected_record;
 use crate::state::AppState;
@@ -2057,10 +2057,18 @@ fn delete_cleanup_needs_existing_record(cleanup: &contracts::DeleteCleanup) -> b
 
 fn remove_owned_media(state: &AppState, entity: &str, record: &Value) {
     match entity {
-        "characters" => avatars::remove_avatar_file(state, entity, record),
+        "characters" => {
+            avatars::remove_avatar_file(state, entity, record);
+            if let Some(id) = record.get("id").and_then(Value::as_str) {
+                sprites::remove_owned_sprite_dir(state, sprites::SpriteOwnerKind::Character, id);
+            }
+        }
         "character-versions" => characters::remove_character_version_avatar_file(state, record),
         "personas" => {
-            avatars::remove_avatar_file_preserving_persona_snapshots(state, entity, record)
+            avatars::remove_avatar_file_preserving_persona_snapshots(state, entity, record);
+            if let Some(id) = record.get("id").and_then(Value::as_str) {
+                sprites::remove_owned_sprite_dir(state, sprites::SpriteOwnerKind::Persona, id);
+            }
         }
         "lorebooks" => lorebook_images::remove_lorebook_image_file(state, record),
         "gallery" | "character-gallery" => remove_gallery_file(state, record),
@@ -4103,6 +4111,44 @@ mod tests {
         assert!(
             !avatar_path.exists(),
             "deleted version should remove its owned avatar copy"
+        );
+    }
+
+    #[test]
+    fn deleting_character_removes_its_sprite_directory() {
+        let state = test_state("character-delete-sprites");
+        let sprite_dir = state.data_dir.join("sprites").join("char-1");
+        std::fs::create_dir_all(&sprite_dir).expect("sprite dir should be created");
+        std::fs::write(sprite_dir.join("neutral.png"), b"sprite").expect("sprite should be written");
+        state
+            .storage
+            .create("characters", json!({ "id": "char-1" }))
+            .expect("character row should be created");
+
+        delete_entity(&state, "characters", "char-1", false).expect("character delete should succeed");
+
+        assert!(
+            !sprite_dir.exists(),
+            "deleted character should remove its sprite directory"
+        );
+    }
+
+    #[test]
+    fn deleting_persona_removes_its_sprite_directory() {
+        let state = test_state("persona-delete-sprites");
+        let sprite_dir = state.data_dir.join("sprites").join("personas").join("persona-1");
+        std::fs::create_dir_all(&sprite_dir).expect("persona sprite dir should be created");
+        std::fs::write(sprite_dir.join("happy.png"), b"sprite").expect("sprite should be written");
+        state
+            .storage
+            .create("personas", json!({ "id": "persona-1" }))
+            .expect("persona row should be created");
+
+        delete_entity(&state, "personas", "persona-1", false).expect("persona delete should succeed");
+
+        assert!(
+            !sprite_dir.exists(),
+            "deleted persona should remove its sprite directory"
         );
     }
 

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -4153,6 +4153,35 @@ mod tests {
     }
 
     #[test]
+    fn deleting_persona_removes_namespaced_sprites_and_leaves_legacy_dir() {
+        // When both a legacy sprites/<id> and the namespaced sprites/personas/<id> exist, deleting
+        // the persona must still remove the namespaced dir (no dependence on legacy migration) and
+        // must NOT touch the legacy path, which can belong to a same-id character.
+        let state = test_state("persona-delete-sprites-conflict");
+        let legacy_dir = state.data_dir.join("sprites").join("persona-1");
+        let namespaced_dir = state.data_dir.join("sprites").join("personas").join("persona-1");
+        std::fs::create_dir_all(&legacy_dir).expect("legacy sprite dir should be created");
+        std::fs::write(legacy_dir.join("happy.png"), b"legacy").expect("legacy sprite should write");
+        std::fs::create_dir_all(&namespaced_dir).expect("namespaced sprite dir should be created");
+        std::fs::write(namespaced_dir.join("happy.png"), b"namespaced").expect("sprite should write");
+        state
+            .storage
+            .create("personas", json!({ "id": "persona-1" }))
+            .expect("persona row should be created");
+
+        delete_entity(&state, "personas", "persona-1", false).expect("persona delete should succeed");
+
+        assert!(
+            !namespaced_dir.exists(),
+            "deleted persona should remove its namespaced sprite directory even with a legacy dir present"
+        );
+        assert!(
+            legacy_dir.exists(),
+            "deleted persona must not remove the legacy sprite path (it can belong to a same-id character)"
+        );
+    }
+
+    #[test]
     fn deleting_character_version_preserves_avatar_still_used_by_character() {
         let state = test_state("character-version-delete-live-avatar");
         let avatar_dir = state.data_dir.join("avatars").join("characters");

--- a/src-tauri/src/commands/storage/sprites.rs
+++ b/src-tauri/src/commands/storage/sprites.rs
@@ -1814,12 +1814,20 @@ fn persona_sprites_dir(state: &AppState, persona_id: &str) -> PathBuf {
 
 /// Best-effort removal of an owner's entire sprite directory on entity delete.
 /// Mirrors the avatar-cleanup pattern: failures are logged, never propagated, so a
-/// missing or locked sprite dir can't block the delete. The owner id is validated
-/// via sprites_dir before any filesystem touch.
+/// missing or locked sprite dir can't block the delete.
+///
+/// Resolves the canonical sprite directory WITHOUT running legacy migration: destructive
+/// cleanup must not depend on migration succeeding (a migration error would otherwise leak the
+/// namespaced dir), and it must never remove the legacy `sprites/<id>` path for a persona, since
+/// that path can belong to a character that shares the id. The owner id is validated first so a
+/// malformed value can't escape the sprites tree.
 pub(crate) fn remove_owned_sprite_dir(state: &AppState, owner_kind: SpriteOwnerKind, owner_id: &str) {
-    let dir = match sprites_dir(state, owner_kind, owner_id) {
-        Ok(dir) => dir,
-        Err(_) => return,
+    if validate_safe_segment(owner_id, owner_kind.owner_label()).is_err() {
+        return;
+    }
+    let dir = match owner_kind {
+        SpriteOwnerKind::Character => state.data_dir.join("sprites").join(owner_id),
+        SpriteOwnerKind::Persona => persona_sprites_dir(state, owner_id),
     };
     if dir.exists() {
         if let Err(error) = fs::remove_dir_all(&dir) {

--- a/src-tauri/src/commands/storage/sprites.rs
+++ b/src-tauri/src/commands/storage/sprites.rs
@@ -1812,6 +1812,26 @@ fn persona_sprites_dir(state: &AppState, persona_id: &str) -> PathBuf {
         .join(persona_id)
 }
 
+/// Best-effort removal of an owner's entire sprite directory on entity delete.
+/// Mirrors the avatar-cleanup pattern: failures are logged, never propagated, so a
+/// missing or locked sprite dir can't block the delete. The owner id is validated
+/// via sprites_dir before any filesystem touch.
+pub(crate) fn remove_owned_sprite_dir(state: &AppState, owner_kind: SpriteOwnerKind, owner_id: &str) {
+    let dir = match sprites_dir(state, owner_kind, owner_id) {
+        Ok(dir) => dir,
+        Err(_) => return,
+    };
+    if dir.exists() {
+        if let Err(error) = fs::remove_dir_all(&dir) {
+            log::warn!(
+                "could not remove {} sprite directory at {}: {error}",
+                owner_kind.as_str(),
+                dir.display()
+            );
+        }
+    }
+}
+
 fn legacy_persona_sprites_dir(state: &AppState, persona_id: &str) -> PathBuf {
     state.data_dir.join("sprites").join(persona_id)
 }


### PR DESCRIPTION
## Linked issue

Closes #2328

## Why this change

Sprite packs are written under `sprites/<characterId>` and `sprites/personas/<personaId>`, but `remove_owned_media` only cleaned up avatars, so the whole sprite directory leaked on entity delete. `clear_runtime_media` (admin reset) also skipped sprites.

## What changed

- Add a best-effort `remove_owned_sprite_dir` helper (mirrors the avatar-cleanup pattern, reuses the validated `sprites_dir` path resolver, logs and swallows errors) and call it from the `characters` and `personas` branches of `remove_owned_media`.
- Wipe the `sprites` directory in `clear_runtime_media`.

## Refactor impact

Primary owner: Rust storage (`src-tauri/src/commands/storage/`)

Impact areas reviewed:

- `entities.rs` (`remove_owned_media`), `sprites.rs` (helper), `admin.rs` (`clear_runtime_media`). No new `DeleteCleanup` variant — reuses the existing `RemoveOwnedMedia` path.

Boundary notes:

- none

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green, including new `deleting_character_removes_its_sprite_directory` and `deleting_persona_removes_its_sprite_directory`.

## Feature Discoverability

- [x] N/A because this PR is a disk-leak bugfix and does not add a new thing users need to find.

Reason:

- Cleanup of an existing delete path.

## Docs and release impact

- [x] No docs changes needed
