### PR TITLE
Flush pending storage writes on app quit

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -4567,6 +4567,32 @@ mod tests {
     }
 
     #[test]
+    fn flush_persists_pending_debounced_writes_to_disk() {
+        // The on-quit RunEvent handler calls storage.flush() to drain writes that are
+        // still sitting in the debounce window (#2319). Verify flush() actually lands a
+        // pending (dirty, not-yet-written) collection on disk and clears the dirty flag.
+        let root = temp_storage_root("flush-persists-pending");
+        let storage = FileStorage::new(&root).unwrap();
+        storage
+            .cache_collection("characters", &[json!({ "id": "pending" })], true)
+            .unwrap();
+        assert!(storage.dirty_collection_count() > 0, "write should be pending");
+
+        storage.flush().unwrap();
+
+        assert_eq!(
+            storage.dirty_collection_count(),
+            0,
+            "flush should clear the dirty collections"
+        );
+        // A fresh instance reads from disk, proving the pending write was persisted.
+        let reopened = FileStorage::new(&root).unwrap();
+        assert_eq!(reopened.list("characters").unwrap()[0]["id"], "pending");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn list_projected_caches_clean_projection_shapes_until_file_changes() {
         let root = temp_storage_root("list-projected-caches-clean-shapes");
         let storage = FileStorage::new(&root).unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -288,7 +288,11 @@ pub fn run() {
                 tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
             ) {
                 if let Some(state) = app_handle.try_state::<crate::state::AppState>() {
-                    let _ = state.storage.flush();
+                    if let Err(error) = state.storage.flush() {
+                        // Best-effort: a failed quit-time flush must not block shutdown, but it
+                        // must not be silent either, so a dropped write is diagnosable.
+                        log::error!("failed to flush pending storage writes on quit: {error}");
+                    }
                 }
             }
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,18 @@ pub fn run() {
             storage_commands::update_commands::update_check,
             storage_commands::update_commands::update_apply,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Flush pending debounced storage writes on quit so writes made inside the
+            // 750ms debounce window aren't lost when the app closes (#2319).
+            if matches!(
+                event,
+                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
+            ) {
+                if let Some(state) = app_handle.try_state::<crate::state::AppState>() {
+                    let _ = state.storage.flush();
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Linked issue

Closes #2319

## Why this change

Storage writes are debounced ~750ms before hitting disk. The Tauri app exited via `.run(generate_context!())` with no exit handler, so any write still inside the debounce window when the user closed the app was lost. The `Drop` backstop on `FileStorage` is gated on being the sole cache owner, which the in-flight debounce thread defeats during exactly that window.

## What changed

- Build the app and drive it with `.build(ctx).expect(...).run(|handle, event| ...)`, flushing storage on `RunEvent::ExitRequested` / `RunEvent::Exit` so pending writes are persisted before the process exits.
- The `FileStorage` `Drop` guard is intentionally left **unchanged**: dropping a still-shared, dirty storage (e.g. during a read-only health probe) must not eagerly persist seeded defaults; the explicit on-quit flush is the correct, scoped fix.

## Refactor impact

Primary owner: app shell + Rust storage (`src-tauri/src/lib.rs`, `src-tauri/crates/storage/src/lib.rs`)

Impact areas reviewed:

- `run()` keeps its `()` signature, so `main.rs` is untouched. `flush()` drains the dirty cache synchronously and is already used on other paths.

Boundary notes:

- The exit handler (app layer) calls `storage.flush()` (public storage-crate API). No new cross-layer coupling.

Pressure points touched:

- `src-tauri/src/lib.rs` (run loop only — command registration unchanged)

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green, including new `flush_persists_pending_debounced_writes_to_disk` (a dirty, not-yet-written collection lands on disk after `flush()` and the dirty flag clears). Existing `health_liveness_skips_writable_probe_by_default` still passes (Drop semantics unchanged).

## Feature Discoverability

- [x] N/A because this PR is a durability bugfix and does not add a new thing users need to find.

Reason:

- Persists existing writes on quit.

## Docs and release impact

- [x] No docs changes needed
