### PR TITLE
Preserve player stats on empty persona-stats agent output

### DIFF
--- a/src/engine/generation/tracker-snapshots.test.ts
+++ b/src/engine/generation/tracker-snapshots.test.ts
@@ -90,6 +90,19 @@ function worldStateResult(data: unknown): AgentResult {
   };
 }
 
+function personaStatsResult(data: unknown): AgentResult {
+  return {
+    agentId: "persona-stats",
+    agentType: "persona-stats",
+    type: "persona_stats_update",
+    data,
+    tokensUsed: 0,
+    durationMs: 0,
+    success: true,
+    error: null,
+  };
+}
+
 describe("tracker snapshots", () => {
   it("does not persist player persona rows from character tracker output", async () => {
     const chat = {
@@ -165,5 +178,62 @@ describe("tracker snapshots", () => {
       time: "7:30 PM",
       temperature: "68\u00b0F",
     });
+  });
+
+  it("does not clobber player inventory, status, or persona stats on empty persona-stats output", async () => {
+    const baseline = gameState({
+      playerStats: {
+        stats: [],
+        inventory: [{ name: "Iron Sword", quantity: 1 }],
+        status: "Wounded",
+      },
+      personaStats: [{ name: "Health", value: 40, max: 100 }],
+    } as unknown as Partial<GameState>);
+    const { storage } = storageWithRows({}, []);
+
+    const saved = await persistTrackerSnapshotForTurn(
+      storage,
+      "chat-1",
+      { messageId: "assistant-1", swipeIndex: 0 },
+      [personaStatsResult({ status: "", inventory: [], stats: [] })],
+      { baseSnapshot: baseline },
+    );
+
+    expect(saved?.playerStats?.inventory).toHaveLength(1);
+    expect(saved?.playerStats?.inventory?.[0]).toMatchObject({ name: "Iron Sword" });
+    expect(saved?.playerStats?.status).toBe("Wounded");
+    expect(saved?.personaStats).toHaveLength(1);
+    expect(saved?.personaStats?.[0]).toMatchObject({ name: "Health", value: 40 });
+  });
+
+  it("applies persona-stats updates when the agent returns non-empty values", async () => {
+    const baseline = gameState({
+      playerStats: {
+        stats: [],
+        inventory: [{ name: "Iron Sword", quantity: 1 }],
+        status: "Wounded",
+      },
+      personaStats: [{ name: "Health", value: 40, max: 100 }],
+    } as unknown as Partial<GameState>);
+    const { storage } = storageWithRows({}, []);
+
+    const saved = await persistTrackerSnapshotForTurn(
+      storage,
+      "chat-1",
+      { messageId: "assistant-1", swipeIndex: 0 },
+      [
+        personaStatsResult({
+          status: "Healthy",
+          inventory: [{ name: "Health Potion", quantity: 3 }],
+          stats: [{ name: "Health", value: 90, max: 100 }],
+        }),
+      ],
+      { baseSnapshot: baseline },
+    );
+
+    expect(saved?.playerStats?.status).toBe("Healthy");
+    expect(saved?.playerStats?.inventory).toHaveLength(1);
+    expect(saved?.playerStats?.inventory?.[0]).toMatchObject({ name: "Health Potion", quantity: 3 });
+    expect(saved?.personaStats?.[0]).toMatchObject({ name: "Health", value: 90 });
   });
 });

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -451,13 +451,20 @@ function gameStatePatchFromAgentResult(
 
   if (result.agentType === "persona-stats" || result.type === "persona_stats_update") {
     const playerStats = clonePlayerStats(snapshot.playerStats);
-    if (Object.prototype.hasOwnProperty.call(data, "status")) playerStats.status = readString(data.status).trim();
+    if (Object.prototype.hasOwnProperty.call(data, "status")) {
+      const status = readString(data.status).trim();
+      if (status) playerStats.status = status;
+    }
     if (Array.isArray(data.inventory)) {
-      playerStats.inventory = data.inventory.map(parseInventoryItem).filter((item): item is InventoryItem => !!item);
+      const inventory = data.inventory
+        .map(parseInventoryItem)
+        .filter((item): item is InventoryItem => !!item);
+      if (inventory.length > 0) playerStats.inventory = inventory;
     }
     const patch: TrackerStatePatch = { playerStats };
     if (Array.isArray(data.stats)) {
-      patch.personaStats = data.stats.map(parseStat).filter((stat): stat is CharacterStat => !!stat);
+      const stats = data.stats.map(parseStat).filter((stat): stat is CharacterStat => !!stat);
+      if (stats.length > 0) patch.personaStats = stats;
     }
     return patch;
   }


### PR DESCRIPTION
## Linked issue

Closes #2370

## Why this change

The persona-stats tracker branch in `gameStatePatchFromAgentResult` assigned `inventory`, `status`, and `personaStats` unconditionally, so a truncated or empty agent payload wiped the player's existing inventory, stat bars, and status. The clobbered values persist to `chat.gameState` and become the next-turn baseline, making the loss permanent (high-severity roleplay data loss).

## What changed

- Guard each field so an empty array or blank string is treated as "no update" rather than a clear, mirroring the `mergeCustomTrackerFieldsFromAgent` `length > 0` guard already used by the custom-tracker branch.

## Refactor impact

Primary owner: engine generation (`src/engine/generation/tracker-snapshots.ts`)

Impact areas reviewed:

- Only the `persona-stats` branch; the patch is spread over the snapshot, so omitting a key preserves the baseline value.

Boundary notes:

- none — engine-layer pure logic.

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/generation/tracker-snapshots.test.ts` — 4 passed (2 existing + 2 new: empty payload preserves inventory/status/persona-stats; non-empty payload still applies).
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [x] N/A because this PR is a data-loss bugfix and does not add a new thing users need to find.

Reason:

- Corrects an existing merge path.

## Docs and release impact

- [x] No docs changes needed
