### PR TITLE
Keep AM/PM suffix on spaced 12-hour world times

### DIFF
--- a/src/features/runtime/world-state/lib/world-state-display.test.ts
+++ b/src/features/runtime/world-state/lib/world-state-display.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { getWorldTimeDisplay } from "./world-state-display";
+
+describe("getWorldTimeDisplay", () => {
+  it("keeps the PM suffix on spaced 12-hour times", () => {
+    const result = getWorldTimeDisplay("6:00 PM");
+    expect(result.suffix).toBe("PM");
+    expect(result.main).toBe("06:00");
+    expect(result.hour).toBe(18);
+    expect(result.minute).toBe(0);
+  });
+
+  it("keeps the AM suffix on spaced 12-hour times", () => {
+    const result = getWorldTimeDisplay("3:30 am");
+    expect(result.suffix).toBe("AM");
+    expect(result.main).toBe("03:30");
+    expect(result.hour).toBe(3);
+    expect(result.minute).toBe(30);
+  });
+
+  it("parses dotted meridiem markers", () => {
+    const result = getWorldTimeDisplay("8:15 p.m.");
+    expect(result.suffix).toBe("PM");
+    expect(result.hour).toBe(20);
+  });
+
+  it("maps 12 AM to midnight and 12 PM to noon", () => {
+    expect(getWorldTimeDisplay("12:00 AM").hour).toBe(0);
+    expect(getWorldTimeDisplay("12:00 PM").hour).toBe(12);
+  });
+
+  it("still parses meridiem times without a space", () => {
+    const result = getWorldTimeDisplay("6pm");
+    expect(result.suffix).toBe("PM");
+    expect(result.hour).toBe(18);
+  });
+
+  it("parses 24-hour times with no suffix", () => {
+    const result = getWorldTimeDisplay("18:00");
+    expect(result.suffix).toBe("");
+    expect(result.main).toBe("18:00");
+    expect(result.hour).toBe(18);
+  });
+
+  it("preserves the refactor-only h separator for 24-hour times", () => {
+    const result = getWorldTimeDisplay("6h30");
+    expect(result.suffix).toBe("");
+    expect(result.main).toBe("06:30");
+    expect(result.hour).toBe(6);
+    expect(result.minute).toBe(30);
+  });
+
+  it("falls back to keyword hours", () => {
+    const result = getWorldTimeDisplay("morning");
+    expect(result.hour).toBe(9);
+    expect(result.suffix).toBe("");
+    expect(result.main).toBe("morning");
+  });
+
+  it("returns a placeholder for empty or missing input", () => {
+    expect(getWorldTimeDisplay("").main).toBe("--:--");
+    expect(getWorldTimeDisplay(null).hour).toBeNull();
+    expect(getWorldTimeDisplay(undefined).hour).toBeNull();
+  });
+});

--- a/src/features/runtime/world-state/lib/world-state-display.ts
+++ b/src/features/runtime/world-state/lib/world-state-display.ts
@@ -178,19 +178,8 @@ export function getWorldTimeDisplay(time: string | null | undefined) {
   const text = (time ?? "").trim();
   if (!text) return { main: "--:--", suffix: "", raw: "", hour: null as number | null, minute: null as number | null };
 
-  const twentyFourHour = text.match(/\b([01]?\d|2[0-3])[:.h]([0-5]\d)\b/i);
-  if (twentyFourHour) {
-    const hour = Number(twentyFourHour[1]);
-    const minute = Number(twentyFourHour[2]);
-    return {
-      main: `${twentyFourHour[1]!.padStart(2, "0")}:${twentyFourHour[2]}`,
-      suffix: "",
-      hour,
-      minute,
-      raw: text,
-    };
-  }
-
+  // Try meridiem (12-hour with AM/PM) before the 24-hour pattern: a spaced time like
+  // "6:00 PM" would otherwise match the 24-hour regex on "6:00" and drop the PM suffix.
   const meridiem = text.match(/\b(1[0-2]|0?\d)(?::([0-5]\d))?\s*([ap])\.?m?\.?\b/i);
   if (meridiem) {
     const displayHour = Number(meridiem[1]);
@@ -200,6 +189,19 @@ export function getWorldTimeDisplay(time: string | null | undefined) {
     return {
       main: `${meridiem[1]!.padStart(2, "0")}:${meridiem[2] ?? "00"}`,
       suffix: `${meridiem[3]!.toUpperCase()}M`,
+      hour,
+      minute,
+      raw: text,
+    };
+  }
+
+  const twentyFourHour = text.match(/\b([01]?\d|2[0-3])[:.h]([0-5]\d)\b/i);
+  if (twentyFourHour) {
+    const hour = Number(twentyFourHour[1]);
+    const minute = Number(twentyFourHour[2]);
+    return {
+      main: `${twentyFourHour[1]!.padStart(2, "0")}:${twentyFourHour[2]}`,
+      suffix: "",
       hour,
       minute,
       raw: text,


### PR DESCRIPTION
## Linked issue

Closes #2372

## Why this change

`getWorldTimeDisplay` tried the 24-hour regex before the meridiem regex, so a spaced 12-hour time like `6:00 PM` matched the 24-hour pattern on `6:00` (the trailing space acts as a word boundary) and returned an empty suffix, dropping the AM/PM badge on the roleplay World tile. This worked on `main`, where meridiem is tried first — a regression.

## What changed

- Run the meridiem match before the 24-hour match, matching `main`'s ordering. The refactor-only `[:.h]` separator and `keywordHour` fallback are preserved.

## Refactor impact

Primary owner: runtime / world-state (`src/features/runtime/world-state/lib/world-state-display.ts`)

Impact areas reviewed:

- Pure `string -> object` helper used by both the roleplay HUD World widget and the tracker World tile; reordering two disjoint regex branches.

Boundary notes:

- none

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/features/runtime/world-state/lib/world-state-display.test.ts` — 9 passed (spaced PM/AM keep suffix, dotted `p.m.`, 12AM->0 / 12PM->12, no-space `6pm`, 24h `18:00`, `6h30` separator, keyword `morning`, empty/null).
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [x] N/A because this PR is a regression bugfix and does not add a new thing users need to find.

Reason:

- Restores correct AM/PM display.

## Docs and release impact

- [x] No docs changes needed
