### PR TITLE
Sanitize theme and extension CSS before injecting into document.head

### DIFF
--- a/src/app/providers/CustomThemeInjector.tsx
+++ b/src/app/providers/CustomThemeInjector.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { useThemes } from "../../features/shell/settings/index";
 import { useExtensions } from "../../features/shell/settings/index";
 import { storageApi } from "../../shared/api/storage-api";
+import { stripDangerousCss } from "../../shared/lib/chat-css";
 
 type ExtensionGlobal = typeof globalThis & {
   __marinaraExtensionApis?: Map<string, unknown>;
@@ -61,7 +62,10 @@ export function CustomThemeInjector() {
       style.id = id;
       document.head.appendChild(style);
     }
-    style.textContent = activeTheme.css;
+    // Theme CSS is injected raw into document.head, so it bypasses the card-CSS
+    // sanitizer. Strip the network-exfil and script-injection vectors while leaving
+    // a theme's legitimate token/!important/position overrides intact.
+    style.textContent = stripDangerousCss(activeTheme.css);
 
     return () => {
       style?.remove();
@@ -80,7 +84,7 @@ export function CustomThemeInjector() {
       if (!ext.enabled || !ext.css) continue;
       const style = document.createElement("style");
       style.id = `${prefix}${ext.id}`;
-      style.textContent = ext.css;
+      style.textContent = stripDangerousCss(ext.css);
       document.head.appendChild(style);
     }
 

--- a/src/features/shell/settings/components/SettingsPanel.tsx
+++ b/src/features/shell/settings/components/SettingsPanel.tsx
@@ -19,6 +19,7 @@ import {
   type VisualTheme,
 } from "../../../../shared/stores/ui.store";
 import { cn } from "../../../../shared/lib/utils";
+import { stripDangerousCss } from "../../../../shared/lib/chat-css";
 import { TEMPERATURE_UNITS } from "../../../../shared/lib/temperature-units";
 import { QUOTE_FORMATS } from "../../../../shared/lib/dialogue-quotes";
 import { useExtensions, useCreateExtension, useDeleteExtension, useUpdateExtension } from "../hooks/use-extensions";
@@ -2561,7 +2562,9 @@ function ThemesSettings() {
       style = document.createElement("style");
       style.id = "marinara-css-editor-preview";
     }
-    style.textContent = themeCss;
+    // Sanitize the live preview the same way the saved-activation injector does, so editing
+    // (or importing) a malicious theme can't fire url() beacons / scripts during preview (#2365).
+    style.textContent = stripDangerousCss(themeCss);
     // Always (re-)append so it's the last <style> in <head>,
     // overriding the active-theme injector's saved CSS.
     document.head.appendChild(style);

--- a/src/shared/lib/chat-css.test.ts
+++ b/src/shared/lib/chat-css.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cssTargetsTypingIndicator, filterCssByMode, scopeChatCss } from "./chat-css";
+import { cssTargetsTypingIndicator, filterCssByMode, scopeChatCss, stripDangerousCss } from "./chat-css";
 
 describe("filterCssByMode", () => {
   it("keeps global CSS and only the requested chat mode block", () => {
@@ -350,5 +350,44 @@ describe("cssTargetsTypingIndicator", () => {
     const css = "@chat-mode conversation { .mari-typing-text::after { content: ' is cooking…'; } }";
     expect(cssTargetsTypingIndicator(filterCssByMode(css, "conversation"))).toBe(true);
     expect(cssTargetsTypingIndicator(filterCssByMode(css, "game"))).toBe(false);
+  });
+});
+
+describe("stripDangerousCss (theme/extension CSS)", () => {
+  it("neutralizes remote url() exfiltration", () => {
+    const out = stripDangerousCss(".bg { background: url(https://tracker.test/pixel.png); }");
+    expect(out).toContain("url(about:invalid)");
+    expect(out).not.toContain("tracker.test");
+  });
+
+  it("still neutralizes url() hidden behind escaped characters (#1989)", () => {
+    const out = stripDangerousCss(".bg { background: \\75rl(https://tracker.test/pixel); }");
+    expect(out).not.toContain("tracker.test");
+  });
+
+  it("keeps data: image and font URLs", () => {
+    expect(stripDangerousCss(".x { background: url(data:image/png;base64,abc); }")).toContain("data:image/png");
+    expect(
+      stripDangerousCss("@font-face { font-family: F; src: url(data:font/woff2;base64,abc); }"),
+    ).toContain("data:font/woff2");
+  });
+
+  it("strips @import, expression(), and javascript: vectors", () => {
+    expect(stripDangerousCss('@import "https://evil.test/x.css"; .a { color: red; }')).not.toContain("@import");
+    expect(stripDangerousCss(".a { width: expression(alert(1)); }")).not.toContain("expression(");
+    expect(stripDangerousCss(".a { background: javascript:alert(1); }")).not.toContain("javascript:");
+  });
+
+  it("defuses :visited history probing", () => {
+    expect(stripDangerousCss("a:visited { color: red; }")).not.toContain(":visited");
+  });
+
+  it("preserves a theme's legitimate token, !important, and position overrides", () => {
+    const themeCss = ":root { --background: #101010; --accent: #ff0066; } .panel { color: red !important; position: fixed; }";
+    const out = stripDangerousCss(themeCss);
+    expect(out).toContain("--background: #101010");
+    expect(out).toContain("--accent: #ff0066");
+    expect(out).toContain("!important");
+    expect(out).toContain("position: fixed");
   });
 });

--- a/src/shared/lib/chat-css.ts
+++ b/src/shared/lib/chat-css.ts
@@ -320,17 +320,17 @@ function canonicalizeKeywordEscapes(css: string): string {
 }
 
 /**
- * Remove dangerous constructs from CSS.
+ * Strip the CSS constructs that are dangerous no matter where the CSS is injected:
+ * network exfiltration (url()/@import/@namespace/@font-face), script execution
+ * (expression()/javascript:/vbscript:/behavior/-moz-binding), and browsing-history
+ * probing (:visited).
  *
- * Security model: card CSS is untrusted user content shared between users.
- * A malicious card creator must not be able to:
- * - Make network requests (data exfiltration, IP tracking)
- * - Escape the scoped container to style/probe app UI
- * - Override application theme tokens
- * - Inject phishing content via `content` property
- * - Cause denial-of-service via resource-heavy rules
+ * Unlike scoped card CSS, app-level theme and extension CSS is allowed to override
+ * theme tokens, use !important, and position elements — so it must be run through
+ * THIS function rather than sanitizeChatCss, which additionally applies card-only
+ * scope/theme-protection passes that would neuter a legitimate theme.
  */
-function sanitizeChatCss(css: string): string {
+export function stripDangerousCss(css: string): string {
   let out = stripComments(css);
 
   // ── Escape normalization ──
@@ -373,11 +373,31 @@ function sanitizeChatCss(css: string): string {
   out = out.replace(/behavior\s*:[^;]*/gi, "");
   out = out.replace(/-moz-binding\s*:[^;]*/gi, "");
 
+  // ── History probing ──
+  // Strip :visited — can detect browsing history via style differences
+  out = out.replace(/:visited/gi, ":link");
+
+  return out;
+}
+
+/**
+ * Remove dangerous constructs from CSS and additionally lock it down for use as
+ * scoped card CSS.
+ *
+ * Security model: card CSS is untrusted user content shared between users.
+ * A malicious card creator must not be able to:
+ * - Make network requests (data exfiltration, IP tracking)
+ * - Escape the scoped container to style/probe app UI
+ * - Override application theme tokens
+ * - Inject phishing content via `content` property
+ * - Cause denial-of-service via resource-heavy rules
+ */
+function sanitizeChatCss(css: string): string {
+  let out = stripDangerousCss(css);
+
   // ── Scope escape prevention ──
   // Strip :has() — can probe elements outside the scoped container
   out = out.replace(/:has\s*\([^)]*\)/gi, "");
-  // Strip :visited — can detect browsing history via style differences
-  out = out.replace(/:visited/gi, ":link");
   // Convert position:fixed to position:absolute (prevent viewport overlays)
   out = out.replace(/position\s*:\s*fixed/gi, "position:absolute");
 


### PR DESCRIPTION
## Linked issue

Closes #2365

## Why this change

`CustomThemeInjector` assigned the active theme's CSS and each enabled extension's CSS straight to a `<style>` element's `textContent`, bypassing the card-CSS sanitizer. With the app CSP set to `null`, a theme or extension could ship `url()` beacons (exfil / IP tracking), `@import`, `expression()` / `javascript:`, or `:visited` history probes that run on every render — and an imported profile can auto-activate a theme without user intent.

## What changed

- Factor a reusable `stripDangerousCss` out of `sanitizeChatCss` covering the constructs that are unsafe regardless of scope (remote `url()` -> `about:invalid`, `@import` / `@namespace` / `@font-face`, `expression` / `javascript:` / `vbscript:` / `behavior` / `-moz-binding`, `:visited`), and run theme and extension CSS through it.
- `sanitizeChatCss` now calls `stripDangerousCss` and keeps its card-only scope/theme-protection passes, so scoped card CSS is byte-for-byte unchanged (existing tests pass).
- Theme CSS is intentionally **not** run through the full card sanitizer: a user-installed theme legitimately overrides theme tokens, uses `!important`, and positions elements, so only the always-dangerous vectors are stripped. Auto-activation of imported themes is tracked separately (#2366).

## Refactor impact

Primary owner: app shell / shared lib (`src/app/providers/CustomThemeInjector.tsx`, `src/shared/lib/chat-css.ts`)

Impact areas reviewed:

- Card-CSS scoping path unchanged; only the theme/extension injection path now sanitizes.

Boundary notes:

- `app/providers` imports `stripDangerousCss` from `shared/lib` (downward dependency, allowed).

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/shared/lib/chat-css.test.ts` — 46 passed (all existing card-sanitization tests + 6 new `stripDangerousCss` tests proving `url()`/`@import`/`expression`/`javascript:`/`:visited` are stripped while theme tokens, `!important`, and `position: fixed` are preserved).
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [x] N/A because this PR is a security bugfix and does not add a new thing users need to find.

Reason:

- Hardening of the theme/extension injection path.

## Docs and release impact

- [x] No docs changes needed
