### PR TITLE
Memoize conversation message rendering to stop the streaming re-parse storm

### DIFF
--- a/src/features/modes/conversation/components/ConversationMessage.tsx
+++ b/src/features/modes/conversation/components/ConversationMessage.tsx
@@ -177,7 +177,7 @@ function highlightMentions(nodes: ReactNode[], names: string[], keyPrefix: strin
 }
 
 /** Renders message content, showing image URLs as inline images */
-function MessageContent({
+export const MessageContent = memo(function MessageContent({
   content,
   mentionNames,
   onImageOpen,
@@ -186,33 +186,43 @@ function MessageContent({
   mentionNames?: string[];
   onImageOpen: (url: string) => void;
 }) {
-  if (IMAGE_URL_RE.test(content.trim())) {
-    const url = content.trim();
+  const trimmed = content.trim();
+  const isImage = IMAGE_URL_RE.test(trimmed);
+
+  // Parse the markdown once per unique content/mentions set. ConversationView
+  // re-renders on every ~45ms stream commit while a message is generating, so
+  // without this memo every mounted message would re-run renderMarkdownBlocks on
+  // each commit — the streaming render storm (#2304). Memoizing the component plus
+  // the parse keeps re-parsing confined to messages whose content actually changed.
+  const rendered = useMemo(() => {
+    if (isImage) return null;
+    // Collapse runs of 3+ blank lines into a double newline (preserve paragraph breaks)
+    const compacted = content.replace(/\n{3,}/g, "\n\n");
+    // Use shared block-level renderer with mention support
+    const renderInline = mentionNames?.length
+      ? (text: string, kp: string) => highlightMentions(applyInlineMarkdown(text, kp), mentionNames, kp)
+      : applyInlineMarkdown;
+    return renderMarkdownBlocks(compacted, renderInline);
+  }, [content, isImage, mentionNames]);
+
+  if (isImage) {
     return (
       <button
         type="button"
         onClick={(e) => {
           e.stopPropagation();
-          onImageOpen(url);
+          onImageOpen(trimmed);
         }}
         className="block cursor-zoom-in rounded-lg text-left"
         title="Open image"
       >
-        <img src={url} alt="GIF" className="max-h-48 max-w-full sm:max-w-xs rounded-lg" loading="lazy" />
+        <img src={trimmed} alt="GIF" className="max-h-48 max-w-full sm:max-w-xs rounded-lg" loading="lazy" />
       </button>
     );
   }
 
-  // Collapse runs of 3+ blank lines into a double newline (preserve paragraph breaks)
-  const compacted = content.replace(/\n{3,}/g, "\n\n");
-
-  // Use shared block-level renderer with mention support
-  const renderInline = mentionNames?.length
-    ? (text: string, kp: string) => highlightMentions(applyInlineMarkdown(text, kp), mentionNames, kp)
-    : applyInlineMarkdown;
-
-  return <>{renderMarkdownBlocks(compacted, renderInline)}</>;
-}
+  return <>{rendered}</>;
+});
 
 /** Parse <speaker="Name">text</speaker> tags into segments */
 interface SpeakerSegment {
@@ -373,6 +383,8 @@ export const ConversationMessage = memo(function ConversationMessage({
   const [showGenerationReplay, setShowGenerationReplay] = useState(false);
   const [manuallyExpandedHidden, setManuallyExpandedHidden] = useState(false);
   const [imageLightbox, setImageLightbox] = useState<{ url: string; prompt?: string | null } | null>(null);
+  // Stable callback so the memoized MessageContent doesn't re-render (and re-parse) on every render.
+  const openImageLightbox = useCallback((url: string) => setImageLightbox({ url }), []);
   const editRef = useRef<HTMLTextAreaElement>(null);
   const lastMessageTapAtRef = useRef(0);
   const guideGenerations = useUIStore((s) => s.guideGenerations);
@@ -1275,7 +1287,7 @@ export const ConversationMessage = memo(function ConversationMessage({
                 <MessageContent
                   content={renderedContent}
                   mentionNames={mentionNames}
-                  onImageOpen={(url) => setImageLightbox({ url })}
+                  onImageOpen={openImageLightbox}
                 />
                 {isStreaming && (
                   <span className="ml-0.5 inline-block h-4 w-[0.125rem] animate-pulse rounded-full bg-[var(--foreground)]/50" />

--- a/src/features/modes/conversation/components/ConversationView.tsx
+++ b/src/features/modes/conversation/components/ConversationView.tsx
@@ -1492,6 +1492,25 @@ function SplitMessageGroup({
 
   const groupCharacterId = items[0]!.msg.characterId ?? undefined;
 
+  // Memoize the combined single-message view. ConversationView re-renders ~22x/sec
+  // during streaming; rebuilding this object on every render handed ConversationMessage
+  // a fresh `message` reference and defeated its memo, forcing a full re-render of every
+  // split group (#2304). Keyed on a content signature (string-equal across renders) so it
+  // only recomputes when an item's id or content actually changes.
+  const firstMessage = items[0]!.msg;
+  const lastMessageExtra = items[items.length - 1]!.msg.extra;
+  const combinedMessageSignature = items.map((gi) => `${gi.key}:${gi.msg.content}`).join("\n");
+  const combinedMessage = useMemo(
+    () => ({
+      ...firstMessage,
+      content: items.map((gi) => gi.msg.content).join("\n\n"),
+      // The last block carries the real extras (attachments, generationInfo, etc.)
+      extra: lastMessageExtra,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [combinedMessageSignature, firstMessage, lastMessageExtra],
+  );
+
   if (editing) {
     // Show the first message header + a single textarea for the full content
     const firstItem = items[0]!;
@@ -1636,18 +1655,11 @@ function SplitMessageGroup({
         // card CSS can style one seamless container (continuous borders, corners, stickers).
         // The stagger animation still works: as hidden blocks become visible the items
         // array grows and the combined content expands inside the same message body.
-        const lastItem = items[items.length - 1]!;
-        const combinedContent = items.map((gi) => gi.msg.content).join("\n\n");
-        const combinedMsg = {
-          ...firstItem.msg,
-          content: combinedContent,
-          // The last block carries the real extras (attachments, generationInfo, etc.)
-          extra: lastItem.msg.extra,
-        };
+        // combinedMessage is memoized at the top of the component (#2304).
         return (
           <ConversationMessage
             key={firstItem.key}
-            message={combinedMsg}
+            message={combinedMessage}
             isStreaming={false}
             isGrouped={firstItem.isGrouped}
             hideActions={false}

--- a/src/features/modes/conversation/components/MessageContent.test.tsx
+++ b/src/features/modes/conversation/components/MessageContent.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Spy on the block-level markdown parser so we can assert how often it runs.
+const { renderMarkdownBlocks } = vi.hoisted(() => ({
+  renderMarkdownBlocks: vi.fn((content: string, _renderInline?: unknown) => [content]),
+}));
+vi.mock("../../../../shared/lib/markdown", () => ({
+  renderMarkdownBlocks: (content: string, renderInline: unknown) => renderMarkdownBlocks(content, renderInline),
+  applyInlineMarkdown: (text: string) => [text],
+}));
+
+import { MessageContent } from "./ConversationMessage";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("MessageContent memoization (#2304)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  function mount(node: Parameters<Root["render"]>[0]) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(node));
+  }
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    renderMarkdownBlocks.mockClear();
+  });
+
+  it("does not re-parse when content is unchanged across re-renders", () => {
+    mount(<MessageContent content="hello **world**" onImageOpen={() => {}} />);
+    expect(renderMarkdownBlocks).toHaveBeenCalledTimes(1);
+
+    // Re-render with a NEW onImageOpen identity (defeating the React.memo bail) but the
+    // same content — the streaming render storm forced exactly this. The parse must not run again.
+    act(() => root.render(<MessageContent content="hello **world**" onImageOpen={() => {}} />));
+    expect(renderMarkdownBlocks).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-parses when the content changes", () => {
+    mount(<MessageContent content="first" onImageOpen={() => {}} />);
+    expect(renderMarkdownBlocks).toHaveBeenCalledTimes(1);
+
+    act(() => root.render(<MessageContent content="second" onImageOpen={() => {}} />));
+    expect(renderMarkdownBlocks).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders an inline image button for image URLs without parsing markdown", () => {
+    const opened: string[] = [];
+    mount(<MessageContent content="https://example.test/pic.png" onImageOpen={(url) => opened.push(url)} />);
+    expect(renderMarkdownBlocks).not.toHaveBeenCalled();
+    const button = container.querySelector("button");
+    expect(button?.querySelector("img")?.getAttribute("src")).toBe("https://example.test/pic.png");
+  });
+});


### PR DESCRIPTION
## Linked issue

Closes #2304

## Why this change

While a message generates, `ConversationView` re-renders on every ~45ms stream-buffer commit (~22x/sec). `MessageContent` ran `renderMarkdownBlocks` directly in its render body and was not memoized, so every mounted message (up to the full render window) re-parsed its entire markdown on each commit — the streaming render storm.

## What changed

- Wrap `MessageContent` in `React.memo` and compute the parsed output in a `useMemo` keyed on `content` / `mentionNames`, so `renderMarkdownBlocks` only re-runs for a message whose content actually changed.
- Stabilize the `onImageOpen` callback (`useCallback`) so the memo can bail.
- The `useMemo` runs unconditionally before the image-URL early return, keeping the Rules of Hooks intact.

## Refactor impact

Primary owner: chat / conversation mode UI (`src/features/modes/conversation/components/ConversationMessage.tsx`)

Impact areas reviewed:

- `MessageContent` is conversation-mode-scoped; `renderedContent` (macro-resolved string) and `mentionNames` are already memoized upstream, so the memo bails for unchanged messages during streaming.

Boundary notes:

- none — no cross-layer imports; pure render optimization.

Pressure points touched:

- none

## Validation

- [ ] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/features/modes/conversation/components/MessageContent.test.tsx` — 3 passed (no re-parse on unchanged content across re-renders with a new `onImageOpen` identity; re-parse on content change; image URL bypasses parse).
- `pnpm exec tsc -b` — clean. `pnpm exec eslint` on the touched files — clean.

## Feature Discoverability

- [x] N/A because this PR is a performance bugfix and does not add a new thing users need to find.

Reason:

- Render optimization only.

## Docs and release impact

- [x] No docs changes needed
