### PR TITLE
Honor conversation start marker in generation history

### DIFF
--- a/src/engine/generation/context.ts
+++ b/src/engine/generation/context.ts
@@ -27,6 +27,7 @@ const GENERATION_MESSAGE_EXTRA_FIELDS = [
   "contextInjections",
   "cyoaChoices",
   "spriteExpressions",
+  "isConversationStart",
 ];
 
 function uniqueStrings(values: readonly string[]): string[] {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2507,7 +2507,15 @@ function historyMessageContent(message: JsonRecord, includePastReasoning: boolea
 
 function historyMessages(storedMessages: JsonRecord[], limit: number, includePastReasoning = false): ChatMLMessage[] {
   if (limit <= 0) return [];
-  return storedMessages
+  let conversationStartIndex = 0;
+  for (let index = storedMessages.length - 1; index >= 0; index -= 1) {
+    if (parseRecord(storedMessages[index]!.extra).isConversationStart === true) {
+      conversationStartIndex = index;
+      break;
+    }
+  }
+  const scopedMessages = conversationStartIndex > 0 ? storedMessages.slice(conversationStartIndex) : storedMessages;
+  return scopedMessages
     .filter((message) => !hiddenFromAi(message))
     .slice(-limit)
     .map((message) => ({

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2509,7 +2509,7 @@ function historyMessages(storedMessages: JsonRecord[], limit: number, includePas
   if (limit <= 0) return [];
   let conversationStartIndex = 0;
   for (let index = storedMessages.length - 1; index >= 0; index -= 1) {
-    if (parseRecord(storedMessages[index]!.extra).isConversationStart === true) {
+    if (boolish(parseRecord(storedMessages[index]!.extra).isConversationStart, false)) {
       conversationStartIndex = index;
       break;
     }


### PR DESCRIPTION
## Linked issue

Closes #2281

## Why this change

- "Mark as new start" (`isConversationStart`) was a dead control during generation: the flag was both stripped by the generation message projection and ignored by the history builder, so messages before a user's new-start marker still entered the model context. This restores parity with main's generate.routes.ts and the engine's own auto-summary path.

## What changed

- Added `isConversationStart` to `GENERATION_MESSAGE_EXTRA_FIELDS` in `src/engine/generation/context.ts` so the flag survives the generation projection (previously stripped before prompt assembly ever saw it).
- `historyMessages` in `src/engine/generation/prompt-assembly.ts` now scans `storedMessages` newest-to-oldest for the last `extra.isConversationStart === true` and slices history from that index before the existing hidden-filter + `slice(-limit)` tail. Mirrors the shipping pattern in `auto-summary.service.ts:169`.

## Refactor impact

Primary owner: engine generation

Impact areas reviewed:

- `src/engine/generation/context.ts` (projection allowlist)
- `src/engine/generation/prompt-assembly.ts` (`historyMessages`)

Boundary notes:

- None. Both edits stay inside the engine generation layer; no feature/shared-api/Rust boundary crossed. Mode-agnostic (honors a generic message-level marker, no roleplay/game/chat coupling).

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/generation/prompt-assembly.test.ts` — 11 passed (3 new cases: marker slices pre-marker history, stringified-extra marker form, no-marker passthrough keeps full history).
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a bugfix and does not add a new user-discoverable thing.

Reason:

- Restores an existing control's intended behavior; nothing new to discover.

## Docs and release impact

- [x] No docs changes needed
