### PR TITLE
Reply as all characters in sequential individual group chat

### DIFF
--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1122,6 +1122,14 @@ function sequentialGroupTarget(messages: JsonRecord[], activeIds: string[]): str
   return activeIds[(index + 1) % activeIds.length] ?? activeIds[0] ?? null;
 }
 
+function sequentialGroupTurnOrder(messages: JsonRecord[], activeIds: string[]): string[] {
+  if (activeIds.length === 0) return [];
+  const lastCharacterId = lastVisibleAssistantCharacterId(messages, activeIds);
+  const lastIndex = lastCharacterId ? activeIds.indexOf(lastCharacterId) : -1;
+  const start = lastIndex >= 0 ? (lastIndex + 1) % activeIds.length : 0;
+  return activeIds.map((_, offset) => activeIds[(start + offset) % activeIds.length]!);
+}
+
 function activeSwipeCharacterId(message: JsonRecord | undefined): string | null {
   if (!message) return null;
   const rawSwipes = Array.isArray(message.swipes)
@@ -1420,8 +1428,7 @@ async function resolveIndividualGroupTurnIds(args: {
       selectionMode: "multi",
     });
   }
-  const sequential = sequentialGroupTarget(args.storedMessages, activeIds);
-  return sequential ? [sequential] : [];
+  return sequentialGroupTurnOrder(args.storedMessages, activeIds);
 }
 
 async function* runIndividualGroupTurnLoop(args: {


### PR DESCRIPTION
## Linked issue

Closes #2282

## Why this change

- In roleplay group chat with `groupChatMode: "individual"` and `groupResponseOrder: "sequential"`, only one character replied per user send instead of all active characters taking a turn. The sequential branch of `resolveIndividualGroupTurnIds` returned a single next-in-rotation id while the "smart" branch already returned the full multi-selection. The turn loop, `group_turn` total, and client `index`/`total` handling already support N>1, so only the sequential branch under-filled the array.

## What changed

- Added `sequentialGroupTurnOrder` in `src/engine/generation/start-generation.ts` returning the full active-character rotation in turn order, starting at the character after the last visible assistant.
- The sequential branch of `resolveIndividualGroupTurnIds` now returns that full rotation instead of `[singleTarget]`.
- The single-target `sequentialGroupTarget` helper is unchanged and still used by the merged-mode single-responder and smart-fallback paths.

## Refactor impact

Primary owner: engine generation

Impact areas reviewed:

- `src/engine/generation/start-generation.ts` (`resolveIndividualGroupTurnIds`, new `sequentialGroupTurnOrder`)

Boundary notes:

- None. Engine-only; reuses engine-local `lastVisibleAssistantCharacterId` and `activeCharacterIds`. No feature/shared/Rust crossing.

Pressure points touched:

- None. Consumed only by the pre-existing `runIndividualGroupTurnLoop`.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/generation/start-generation.test.ts` — 19 passed (3 new: full rotation emits one `group_turn` per active character with `total: 3`; round starts after the last visible assistant; `manual` order still emits zero turns).
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a bugfix restoring intended group-turn behavior.

Reason:

- No new discoverable surface; the control already exists.

## Docs and release impact

- [x] No docs changes needed
