### PR TITLE
Apply strict role formatting in all chat modes

### DIFF
--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -3265,7 +3265,7 @@ export async function assembleGenerationPrompt(
   }
   const previewMessages = previewMessagesForPrompt(messages);
   const shouldEnforceStrictRoles =
-    boolish(promptParameters?.strictRoleFormatting, true) && chatMode === "roleplay" && !individualGroupTarget;
+    boolish(promptParameters?.strictRoleFormatting, true) && !individualGroupTarget;
   messages = shouldEnforceStrictRoles ? enforceStrictRoles(messages) : mergeAdjacentMessages(messages);
   if (!shouldEnforceStrictRoles && boolish(promptParameters?.squashSystemMessages, false)) {
     messages = squashLeadingSystemMessages(messages);


### PR DESCRIPTION
## Linked issue

Closes #2289

## Why this change

- `strictRoleFormatting` ships enabled by default, but the strict-role gate in `assembleGenerationPrompt` additionally required `chatMode === "roleplay"`. In conversation/game/visual_novel modes the assembler fell back to `mergeAdjacentMessages`, which never coerces a leading assistant turn or alternates roles. Combined with the Rust Anthropic/Google builders (which hoist/strip system messages without merging), this produced malformed "roles must alternate" / leading-assistant requests in non-roleplay modes. Main runs `enforceStrictRoles` whenever `strictRoleFormatting` is true with no mode condition; this restores that parity.

## What changed

- Removed the `chatMode === "roleplay"` conjunct from `shouldEnforceStrictRoles` in `src/engine/generation/prompt-assembly.ts`. The `!individualGroupTarget` guard (per-character group targeting) is preserved, so only the over-narrow mode discrimination is dropped.
- Exported `enforceStrictRoles` so the behavioral difference vs `mergeAdjacentMessages` can be unit-tested directly.

## Refactor impact

Primary owner: engine generation

Impact areas reviewed:

- `src/engine/generation/prompt-assembly.ts` (`shouldEnforceStrictRoles` gate)

Boundary notes:

- None. Engine-only; one boolean conjunct removed plus a test-motivated export. No feature/shared/Rust changes.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/generation/prompt-assembly.test.ts` — 10 passed (2 new: `enforceStrictRoles` coerces the leading turn to `user` and keeps alternation; the merge-only branch leaves a leading assistant turn that Anthropic/Google reject).
- `pnpm vitest run src/engine/generation` — 69 passed (no regression; existing assertions read `previewMessages`, computed before this branch).
- `pnpm exec tsc -b` — clean.
- TODO (human): smoke a default-preset conversation chat with an author's note against an Anthropic and a Google connection to confirm the prior alternation rejection is gone.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a bugfix restoring provider-safe prompt formatting.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
