### PR TITLE
Merge all chunk extractions when knowledge consolidation under-merges

### DIFF
--- a/src/engine/agents-runtime/knowledge/knowledge-retrieval.ts
+++ b/src/engine/agents-runtime/knowledge/knowledge-retrieval.ts
@@ -158,14 +158,17 @@ export async function executeKnowledgeRetrieval(
     const priorExtractions = extractions.slice(0, -1);
     const consolidatedLower = consolidated.toLowerCase();
     const isSuperset = priorExtractions.every((prior) => {
-      // A prior extraction is considered preserved if its first non-trivial line
-      // (a stable, content-bearing signature) survived into the consolidation.
-      const signature = prior
+      // A prior extraction is considered preserved only when EVERY one of its
+      // content-bearing lines survived into the consolidation. Sampling just the
+      // first line would let a model keep a heading while dropping later facts and
+      // still pass as a superset; requiring all lines means any dropped fact routes
+      // to the merge fallback below instead of being silently lost.
+      const lines = prior
         .split("\n")
         .map((line) => line.trim())
-        .find((line) => line.length >= 12);
-      if (!signature) return true; // nothing meaningful to preserve
-      return consolidatedLower.includes(signature.toLowerCase());
+        .filter((line) => line.length >= 12);
+      if (lines.length === 0) return true; // nothing meaningful to preserve
+      return lines.every((line) => consolidatedLower.includes(line.toLowerCase()));
     });
 
     if (isSuperset) {

--- a/src/engine/agents-runtime/knowledge/knowledge-retrieval.ts
+++ b/src/engine/agents-runtime/knowledge/knowledge-retrieval.ts
@@ -148,13 +148,54 @@ export async function executeKnowledgeRetrieval(
       };
     }
 
-    // The last extraction is the consolidated result
+    // The last extraction is the LLM-consolidated result. Trust it ONLY when it
+    // is actually a superset of every prior extraction. The consolidation prompt
+    // asks the model to fold all `_previousExtractions` into the final pass, but a
+    // weak model (or many chunks) can under-merge and silently drop earlier
+    // excerpts. If that happens, fall back to joining every extraction so we never
+    // lose knowledge from earlier chunks (mirrors the partial-failure branch above).
     const consolidated = extractions[extractions.length - 1]!;
+    const priorExtractions = extractions.slice(0, -1);
+    const consolidatedLower = consolidated.toLowerCase();
+    const isSuperset = priorExtractions.every((prior) => {
+      // A prior extraction is considered preserved if its first non-trivial line
+      // (a stable, content-bearing signature) survived into the consolidation.
+      const signature = prior
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length >= 12);
+      if (!signature) return true; // nothing meaningful to preserve
+      return consolidatedLower.includes(signature.toLowerCase());
+    });
+
+    if (isSuperset) {
+      return {
+        agentId: config.id,
+        agentType: config.type,
+        type: "context_injection",
+        data: { text: consolidated },
+        tokensUsed: totalTokens,
+        durationMs: totalDuration,
+        success: true,
+        error: null,
+      };
+    }
+
+    // Under-merged consolidation: keep the consolidated pass (it carries the last
+    // chunk's new info) plus every dropped prior extraction, de-duplicated.
+    const seen = new Set<string>();
+    const mergedParts: string[] = [];
+    for (const part of [consolidated, ...priorExtractions]) {
+      const key = part.trim();
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      mergedParts.push(key);
+    }
     return {
       agentId: config.id,
       agentType: config.type,
       type: "context_injection",
-      data: { text: consolidated },
+      data: { text: mergedParts.join("\n\n") },
       tokensUsed: totalTokens,
       durationMs: totalDuration,
       success: true,


### PR DESCRIPTION
## Linked issue

Closes #2326

## Why this change

- In multi-chunk knowledge retrieval, when every chunk extracts successfully the code returned ONLY the final LLM-consolidated extraction and discarded all earlier chunks' extractions. That is correct only if the consolidation pass is a true superset of every prior excerpt. A weak model (or many chunks) can under-merge and silently drop earlier chunks' facts, losing retrieved knowledge from the injected context.

## What changed

- In `executeKnowledgeRetrieval` (`src/engine/agents-runtime/knowledge/knowledge-retrieval.ts`), the all-chunks-succeeded branch now checks whether the consolidation actually preserved each prior extraction (first content-bearing line survives, case-insensitive). If it did, the consolidated text is returned verbatim (happy path unchanged). If it under-merged, it falls back to joining the consolidated pass plus every dropped prior extraction, de-duplicated — mirroring the existing partial-failure branch's "never drop" behavior.

## Refactor impact

Primary owner: engine generation (agents-runtime)

Impact areas reviewed:

- `src/engine/agents-runtime/knowledge/knowledge-retrieval.ts` (multi-pass consolidation branch only)

Boundary notes:

- None. Engine-only, no new imports; single-pass / zero-extraction / single-extraction / partial-failure branches untouched.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/agents-runtime/knowledge/knowledge-retrieval.test.ts` — 2 passed (new file): under-merged consolidation now preserves FACT_1/FACT_2/FACT_3; a true-superset consolidation returns verbatim with no duplicated blocks.
- `pnpm exec tsc -b` — clean. ESLint — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a data-loss bugfix in existing plumbing.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
