### PR TITLE
Batch lorebook entry embedding requests

### DIFF
--- a/src-tauri/src/commands/storage/prompts.rs
+++ b/src-tauri/src/commands/storage/prompts.rs
@@ -230,6 +230,9 @@ pub(crate) async fn vectorize_lorebook(
     }
     let mut vectorized = 0usize;
     let mut skipped = 0usize;
+    // Collect the entries that actually need embedding so we can batch the
+    // provider calls instead of firing one HTTP round-trip per entry (#2285).
+    let mut pending: Vec<(String, String)> = Vec::new();
     for entry in entries {
         if is_excluded_from_vectorization(&entry) {
             skipped += 1;
@@ -253,18 +256,27 @@ pub(crate) async fn vectorize_lorebook(
             skipped += 1;
             continue;
         }
-        let embedding = embed_text(&connection, &model, &text).await?;
-        state.storage.patch(
-            "lorebook-entries",
-            entry_id,
-            json!({
-                "embedding": embedding,
-                "embeddingModel": model,
-                "embeddingConnectionId": embedding_connection_id,
-                "embeddingUpdatedAt": now_iso()
-            }),
-        )?;
-        vectorized += 1;
+        pending.push((entry_id.to_string(), text));
+    }
+    for chunk in pending.chunks(EMBEDDING_BATCH_SIZE) {
+        let texts = chunk
+            .iter()
+            .map(|(_, text)| text.as_str())
+            .collect::<Vec<_>>();
+        let embeddings = embed_texts(&connection, &model, &texts).await?;
+        for ((entry_id, _), embedding) in chunk.iter().zip(embeddings) {
+            state.storage.patch(
+                "lorebook-entries",
+                entry_id,
+                json!({
+                    "embedding": embedding,
+                    "embeddingModel": model,
+                    "embeddingConnectionId": embedding_connection_id,
+                    "embeddingUpdatedAt": now_iso()
+                }),
+            )?;
+            vectorized += 1;
+        }
     }
     Ok(json!({
         "success": true,
@@ -522,6 +534,39 @@ pub(crate) async fn embed_text(connection: &Value, model: &str, text: &str) -> A
     }
 }
 
+/// Maximum number of texts sent in a single embeddings request, mirroring the
+/// web build's batch size so a large lorebook needs one HTTP round-trip per 50
+/// entries instead of one per entry (#2285).
+const EMBEDDING_BATCH_SIZE: usize = 50;
+
+/// Embed a batch of texts, returning one embedding per input in the same order.
+///
+/// OpenAI-compatible providers accept an `input` array and return `data[]`
+/// ordered by `index`, so they are batched in a single request. Google and
+/// Ollama embedding endpoints are single-input by protocol, so they fall back
+/// to one call per text.
+pub(crate) async fn embed_texts(
+    connection: &Value,
+    model: &str,
+    texts: &[&str],
+) -> AppResult<Vec<Vec<f64>>> {
+    let provider = connection
+        .get("provider")
+        .and_then(Value::as_str)
+        .unwrap_or("openai");
+    match provider {
+        "openai_chatgpt" => Err(openai_chatgpt_embedding_error()),
+        "google" | "google_vertex" | "ollama" => {
+            let mut out = Vec::with_capacity(texts.len());
+            for text in texts {
+                out.push(embed_text(connection, model, text).await?);
+            }
+            Ok(out)
+        }
+        _ => embed_openai_compatible_batch(connection, model, texts).await,
+    }
+}
+
 fn openai_chatgpt_embedding_error() -> AppError {
     AppError::invalid_input(
         "OpenAI (ChatGPT) does not support embeddings through Codex auth. Configure a separate embedding connection.",
@@ -539,12 +584,26 @@ async fn embed_openai_compatible(
     model: &str,
     text: &str,
 ) -> AppResult<Vec<f64>> {
+    let mut embeddings = embed_openai_compatible_batch(connection, model, &[text]).await?;
+    embeddings.pop().ok_or_else(|| {
+        AppError::new(
+            "embedding_response_error",
+            "Embedding response did not contain a numeric embedding",
+        )
+    })
+}
+
+async fn embed_openai_compatible_batch(
+    connection: &Value,
+    model: &str,
+    texts: &[&str],
+) -> AppResult<Vec<Vec<f64>>> {
     let base = embedding_base_url(connection, "https://api.openai.com/v1");
     let url = format!("{base}/embeddings");
     ensure_embedding_url_allowed(&url)?;
     let mut request = reqwest::Client::new()
         .post(url)
-        .json(&json!({ "model": model, "input": text }));
+        .json(&json!({ "model": model, "input": texts }));
     if let Some(api_key) = connection
         .get("apiKey")
         .and_then(Value::as_str)
@@ -556,14 +615,8 @@ async fn embed_openai_compatible(
         .send()
         .await
         .map_err(|error| AppError::new("embedding_network_error", error.to_string()))?;
-    parse_embedding_response(response, |json| {
-        json.get("data")
-            .and_then(Value::as_array)
-            .and_then(|items| items.first())
-            .and_then(|item| item.get("embedding"))
-            .and_then(json_embedding_array)
-    })
-    .await
+    let expected = texts.len();
+    parse_embedding_batch_response(response, expected).await
 }
 
 async fn embed_google(connection: &Value, model: &str, text: &str) -> AppResult<Vec<f64>> {
@@ -630,6 +683,83 @@ where
                 "embedding_response_error",
                 "Embedding response did not contain a numeric embedding",
                 json,
+            )
+        })
+}
+
+/// Parse an OpenAI-compatible batch embeddings response, returning embeddings
+/// ordered by each item's `index` (the API does not guarantee response order).
+async fn parse_embedding_batch_response(
+    response: reqwest::Response,
+    expected: usize,
+) -> AppResult<Vec<Vec<f64>>> {
+    let status = response.status();
+    let json: Value = response
+        .json()
+        .await
+        .map_err(|error| AppError::new("embedding_response_error", error.to_string()))?;
+    if !status.is_success() {
+        return Err(AppError::with_details(
+            "embedding_provider_error",
+            format!("Embedding provider returned HTTP {status}"),
+            json,
+        ));
+    }
+    order_embeddings_by_index(&json, expected)
+}
+
+/// Order the `data[]` embeddings of an OpenAI-compatible response by each
+/// item's `index` field, falling back to array position when `index` is
+/// absent. Errors loudly if any input slot ends up unfilled, so a misordered
+/// or truncated provider response can never silently write the wrong vector to
+/// an entry.
+fn order_embeddings_by_index(json: &Value, expected: usize) -> AppResult<Vec<Vec<f64>>> {
+    let items = json
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            AppError::with_details(
+                "embedding_response_error",
+                "Embedding response did not contain a data array",
+                json.clone(),
+            )
+        })?;
+    let mut ordered: Vec<Option<Vec<f64>>> = vec![None; expected];
+    let mut fallback = Vec::with_capacity(items.len());
+    for (position, item) in items.iter().enumerate() {
+        let embedding = item
+            .get("embedding")
+            .and_then(json_embedding_array)
+            .filter(|embedding| !embedding.is_empty())
+            .ok_or_else(|| {
+                AppError::with_details(
+                    "embedding_response_error",
+                    "Embedding response did not contain a numeric embedding",
+                    json.clone(),
+                )
+            })?;
+        let index = item.get("index").and_then(Value::as_u64).map(|n| n as usize);
+        match index {
+            Some(index) if index < expected => ordered[index] = Some(embedding),
+            _ => fallback.push((position, embedding)),
+        }
+    }
+    for (position, embedding) in fallback {
+        if position < expected {
+            ordered[position].get_or_insert(embedding);
+        }
+    }
+    ordered
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .filter(|all| all.len() == expected)
+        .ok_or_else(|| {
+            AppError::with_details(
+                "embedding_response_error",
+                format!(
+                    "Embedding response returned fewer embeddings than the {expected} requested inputs"
+                ),
+                json.clone(),
             )
         })
 }

--- a/src-tauri/src/commands/storage/prompts.rs
+++ b/src-tauri/src/commands/storage/prompts.rs
@@ -740,8 +740,27 @@ fn order_embeddings_by_index(json: &Value, expected: usize) -> AppResult<Vec<Vec
             })?;
         let index = item.get("index").and_then(Value::as_u64).map(|n| n as usize);
         match index {
-            Some(index) if index < expected => ordered[index] = Some(embedding),
-            _ => fallback.push((position, embedding)),
+            // An explicit index is authoritative: an out-of-range or duplicate
+            // index is a malformed response, not a positional fallback. Treating
+            // it as positional would write the wrong input's vector to an entry,
+            // so fail loudly instead.
+            Some(index) if index >= expected => {
+                return Err(AppError::with_details(
+                    "embedding_response_error",
+                    format!("Embedding response returned an out-of-range index {index} for {expected} inputs"),
+                    json.clone(),
+                ));
+            }
+            Some(index) if ordered[index].is_some() => {
+                return Err(AppError::with_details(
+                    "embedding_response_error",
+                    format!("Embedding response returned a duplicate index {index}"),
+                    json.clone(),
+                ));
+            }
+            Some(index) => ordered[index] = Some(embedding),
+            // Only wholly-unindexed items fall back to array position.
+            None => fallback.push((position, embedding)),
         }
     }
     for (position, embedding) in fallback {


### PR DESCRIPTION
## Linked issue

Closes #2285

## Why this change

- `vectorize_lorebook` fired one `/embeddings` HTTP round-trip per entry, so a large lorebook meant N serial requests (slow and rate-limit-prone). OpenAI-compatible embedding endpoints accept an `input` array, so the same work can be done in batches.

## What changed

- `src-tauri/src/commands/storage/prompts.rs`: added `embed_texts()` which, for OpenAI-compatible providers, POSTs `input` as an array and parses every `data[].embedding` ordered strictly by each item's `index` (array-position fallback when `index` is absent; fails closed if any slot is unfilled, so a misordered/truncated response can never write the wrong vector). Google/Ollama remain single-input per protocol (per-item fallback).
- `vectorize_lorebook` now collects entries needing embedding and embeds in chunks of `EMBEDDING_BATCH_SIZE = 50` (mirrors the web build's BATCH_SIZE). An N-entry lorebook drops from N round-trips to ceil(N/50).
- `embed_text`/`embed_openai_compatible` are preserved as thin wrappers over the batch path, so single-call sites (chat memory, query embedding), the `openai_chatgpt` rejection, and the SSRF `ensure_embedding_url_allowed` guard are unchanged.

## Refactor impact

Primary owner: Rust storage

Impact areas reviewed:

- `src-tauri/src/commands/storage/prompts.rs` (`vectorize_lorebook`, embedding request/parse path)

Boundary notes:

- None. Confined to the embeddings helpers in one Rust module. Failure semantics unchanged except now at chunk granularity (entries patched in prior chunks stay vectorized — same partial-progress behavior as before).

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-engine` (embed/vectorize filters) — pass; the 5 existing `vectorize_lorebook_*` tests still green. Order-by-index and batch-size behavior were verified with local inline tests (kept local per repo convention).
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.
- (`cargo nextest` is the CI runner; `cargo test` used locally as nextest is not installed here.)

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a performance bugfix with no user-facing surface change.

Reason:

- Same vectorization result, fewer requests.

## Docs and release impact

- [x] No docs changes needed
