### PR TITLE
Replace atomic-update deep-equality conflict check with cheap file-stamp guard

### DIFF
--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -634,10 +634,13 @@ impl FileStorage {
             loaded
         };
 
-        let original_rows = entries
+        let original_stamps = entries
             .iter()
-            .map(|entry| (entry.collection.clone(), entry.rows.clone()))
-            .collect::<Vec<_>>();
+            .map(|entry| {
+                let path = self.collection_path(&entry.collection)?;
+                Ok((entry.collection.clone(), collection_file_stamp(&path)?))
+            })
+            .collect::<AppResult<Vec<_>>>()?;
 
         let output = update(&mut entries)?;
 
@@ -646,8 +649,9 @@ impl FileStorage {
             .write()
             .map_err(|_| AppError::new("lock_error", "Storage lock poisoned"))?;
         self.flush_dirty_collections_locked()?;
-        for (collection, rows) in &original_rows {
-            if self.read_collection_no_recovery(collection)? != *rows {
+        for (collection, original_stamp) in &original_stamps {
+            let path = self.collection_path(collection)?;
+            if collection_file_stamp(&path)? != *original_stamp {
                 return Err(AppError::new(
                     "storage_conflict",
                     format!("Collection changed during atomic update: {collection}"),

--- a/src-tauri/crates/storage/src/lib.rs
+++ b/src-tauri/crates/storage/src/lib.rs
@@ -610,7 +610,12 @@ impl FileStorage {
         F: FnOnce(&mut [AtomicCollectionRows]) -> AppResult<T>,
     {
         let _atomic_update = self.begin_atomic_update()?;
-        let mut entries = {
+        // Load the rows and capture each collection's file stamp under the SAME
+        // write lock, so the conflict baseline reflects exactly the bytes the rows
+        // were read from. Sampling the stamp after the lock is released would let a
+        // concurrent writer slip in between the read and the stamp, baking its change
+        // into the baseline and hiding it from the commit-time conflict check.
+        let (mut entries, original_stamps) = {
             let _guard = self
                 .lock
                 .write()
@@ -618,10 +623,11 @@ impl FileStorage {
             self.flush_dirty_collections_locked()?;
 
             let mut loaded = Vec::with_capacity(collections.len());
+            let mut original_stamps = Vec::with_capacity(collections.len());
             let mut seen_paths = HashSet::new();
             for collection in collections {
                 let path = self.collection_path(collection)?;
-                if !seen_paths.insert(path) {
+                if !seen_paths.insert(path.clone()) {
                     return Err(AppError::invalid_input(format!(
                         "Duplicate collection update: {collection}"
                     )));
@@ -630,17 +636,10 @@ impl FileStorage {
                     collection: collection.to_string(),
                     rows: self.read_collection_no_recovery(collection)?,
                 });
+                original_stamps.push((collection.to_string(), collection_file_stamp(&path)?));
             }
-            loaded
+            (loaded, original_stamps)
         };
-
-        let original_stamps = entries
-            .iter()
-            .map(|entry| {
-                let path = self.collection_path(&entry.collection)?;
-                Ok((entry.collection.clone(), collection_file_stamp(&path)?))
-            })
-            .collect::<AppResult<Vec<_>>>()?;
 
         let output = update(&mut entries)?;
 


### PR DESCRIPTION
## Linked issue

Closes #2301

## Why this change

- `update_collections_atomically` ran on every message create/edit/swipe. Its concurrent-modification guard cloned the entire global `messages` + `message-swipes` collections and deep-compared them by structural `serde_json::Value` equality (O(n) over the whole corpus) under the storage write lock — pure overhead that scales with chat history size.

## What changed

- `src-tauri/crates/storage/src/lib.rs`: the guard now captures a cheap `CollectionFileStamp` (file length + mtime + content hash) per target collection at load and re-checks it at commit, instead of cloning and deep-comparing all rows. The `CollectionFileStamp`/`collection_file_stamp` primitive already exists in the file and is used by the projected-list cache.
- The pre-load `flush_dirty_collections_locked()` plus the atomic-update mutex mean targets are clean on disk and only an external/concurrent write changes a stamp, so the `storage_conflict` contract is preserved. Public method signature unchanged — callers (message_swipes.rs / chats.rs / entities.rs) untouched.

## Refactor impact

Primary owner: Rust storage

Impact areas reviewed:

- `src-tauri/crates/storage/src/lib.rs` (`update_collections_atomically`)

Boundary notes:

- None. Private method body in the `marinara-storage` crate; no mode-specific logic (shared infra). Per-chat sharding (issue's larger alternative) intentionally out of scope.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-storage` — 45 passed, including all existing conflict/recovery tests (`rejects_duplicate`, `rejects_reentrant_writes`, `reads_targets_without_recovery`, `reentrant_reads_do_not_recover`, `reads_and_replaces_multiple_collections`). Local inline tests confirmed the cheap guard still rejects a genuine out-of-band modification (`storage_conflict`) and does not false-positive on a normal sequential write (kept local per repo convention).
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a performance bugfix in storage internals.

Reason:

- No user-facing surface change.

## Docs and release impact

- [x] No docs changes needed
