### PR TITLE
Cap TTS provider response while streaming to prevent OOM

### DIFF
--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -422,10 +422,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
         .and_then(|value| value.to_str().ok())
         .unwrap_or(fallback_content_type)
         .to_string();
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|error| AppError::new("tts_response_error", error.to_string()))?;
+    let bytes = read_capped_audio_bytes(response).await?;
     if !status.is_success() {
         let detail = provider_error_detail(&String::from_utf8_lossy(&bytes), 500);
         return Err(AppError::with_details(
@@ -442,13 +439,38 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
             json!({ "contentType": content_type, "detail": detail }),
         ));
     }
-    if bytes.len() > MAX_TTS_AUDIO_BYTES {
-        return Err(AppError::invalid_input("TTS audio response is too large"));
-    }
     Ok(json!({
         "audioBase64": general_purpose::STANDARD.encode(bytes),
         "contentType": if content_type.starts_with("audio/") { content_type } else { fallback_content_type.to_string() }
     }))
+}
+
+/// Streams the TTS provider response body while enforcing `MAX_TTS_AUDIO_BYTES`.
+///
+/// Mirrors `read_limited_webhook_text` in `custom_tools.rs`: a `content_length()`
+/// pre-check rejects oversized bodies before download, then a `.chunk()` loop with
+/// a saturating running counter aborts as soon as the cap is exceeded, so a hostile
+/// or misconfigured endpoint cannot OOM the process by streaming a multi-GB body.
+async fn read_capped_audio_bytes(mut response: reqwest::Response) -> AppResult<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_TTS_AUDIO_BYTES as u64)
+    {
+        return Err(AppError::invalid_input("TTS audio response is too large"));
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| AppError::new("tts_response_error", error.to_string()))?
+    {
+        if body.len().saturating_add(chunk.len()) > MAX_TTS_AUDIO_BYTES {
+            return Err(AppError::invalid_input("TTS audio response is too large"));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 fn normalized_audio_format(config: &Value) -> &'static str {

--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -422,21 +422,7 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
         .and_then(|value| value.to_str().ok())
         .unwrap_or(fallback_content_type)
         .to_string();
-    let bytes = match read_capped_audio_bytes(response).await {
-        Ok(bytes) => bytes,
-        // An oversized body on a failed-status response is a provider failure, not a
-        // user-input error — classify it as a provider error instead of leaking the
-        // cap's "too large" invalid_input message. (A 2xx body over the cap really is
-        // an oversized audio payload, so that case still propagates the cap error.)
-        Err(_) if !status.is_success() => {
-            return Err(AppError::with_details(
-                "tts_provider_error",
-                format!("TTS provider returned HTTP {status}"),
-                json!({ "detail": "Response body exceeded the maximum size" }),
-            ));
-        }
-        Err(error) => return Err(error),
-    };
+    let bytes = read_capped_audio_bytes(response).await?;
     if !status.is_success() {
         let detail = provider_error_detail(&String::from_utf8_lossy(&bytes), 500);
         return Err(AppError::with_details(

--- a/src-tauri/src/commands/storage/integrations/tts.rs
+++ b/src-tauri/src/commands/storage/integrations/tts.rs
@@ -422,7 +422,21 @@ async fn speak(state: &AppState, body: Value) -> AppResult<Value> {
         .and_then(|value| value.to_str().ok())
         .unwrap_or(fallback_content_type)
         .to_string();
-    let bytes = read_capped_audio_bytes(response).await?;
+    let bytes = match read_capped_audio_bytes(response).await {
+        Ok(bytes) => bytes,
+        // An oversized body on a failed-status response is a provider failure, not a
+        // user-input error — classify it as a provider error instead of leaking the
+        // cap's "too large" invalid_input message. (A 2xx body over the cap really is
+        // an oversized audio payload, so that case still propagates the cap error.)
+        Err(_) if !status.is_success() => {
+            return Err(AppError::with_details(
+                "tts_provider_error",
+                format!("TTS provider returned HTTP {status}"),
+                json!({ "detail": "Response body exceeded the maximum size" }),
+            ));
+        }
+        Err(error) => return Err(error),
+    };
     if !status.is_success() {
         let detail = provider_error_detail(&String::from_utf8_lossy(&bytes), 500);
         return Err(AppError::with_details(


### PR DESCRIPTION
## Linked issue

Closes #2324

## Why this change

- TTS `speak()` fully buffered the provider response into memory via `response.bytes().await` and only enforced the 20MB cap afterward. A hostile or misconfigured endpoint could stream a multi-GB body (with the request timeout up to 30 min) and OOM the process before the cap ever ran.

## What changed

- `src-tauri/src/commands/storage/integrations/tts.rs`: replaced `bytes().await` with a new `read_capped_audio_bytes` helper that does a `content_length()` pre-check against `MAX_TTS_AUDIO_BYTES` and then streams via a `.chunk()` loop with a saturating running counter, aborting the moment the cap is exceeded. Mirrors the in-repo `read_limited_webhook_text` pattern in `custom_tools.rs`. The post-buffer size check is removed (now enforced during streaming); the same `invalid_input` "TTS audio response is too large" message is preserved on both reject paths.

## Refactor impact

Primary owner: Rust storage (integrations)

Impact areas reviewed:

- `src-tauri/src/commands/storage/integrations/tts.rs` (`speak`, new `read_capped_audio_bytes`)

Boundary notes:

- None. Same-file integration change; no IPC/command-signature/return-shape change. Valid (<20MB) responses behave identically. Sibling call sites sharing the same anti-pattern (http.rs, images/providers.rs) are intentionally left out of scope (no drive-by refactor) and can be addressed separately.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-engine tts` — 13 passed, including local-only tests for the `content_length` pre-check (declared-41MB body rejected before download) and the streamed-overflow abort (no Content-Length, >20MB stream aborts); happy path unchanged.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a resource-safety bugfix.

Reason:

- No user-facing surface change.

## Docs and release impact

- [x] No docs changes needed
