### PR TITLE
Clean up NPC avatar files on re-upload and chat delete

### DIFF
--- a/src-tauri/src/commands/storage/avatars.rs
+++ b/src-tauri/src/commands/storage/avatars.rs
@@ -580,6 +580,11 @@ pub(crate) fn update_npc_avatar(state: &AppState, chat_id: &str, body: Value) ->
         &body,
         "avatar",
     )?;
+    // Mirror update_character_avatar_inner's prior-file cleanup: NPC avatars are not
+    // tracked records, so there is no `previous` to read. Instead remove any older files
+    // for this chat+name that the regen just superseded (every regen writes a new
+    // timestamped filename and never overwrites), keeping only the file just written.
+    remove_superseded_npc_avatar_files(state, chat_id, &name, &stored.filename);
     Ok(json!({
         "chatId": chat_id,
         "name": name,
@@ -587,6 +592,69 @@ pub(crate) fn update_npc_avatar(state: &AppState, chat_id: &str, body: Value) ->
         "avatarFilePath": stored.absolute_path,
         "avatarFilename": stored.filename
     }))
+}
+
+/// Best-effort cleanup of older NPC avatar files for one chat+name, preserving the
+/// freshly written `keep_filename`. Stored NPC filenames are
+/// `{safe_filename(chat_id-name)}-{millis}[-N].{ext}`, so the same-name prefix is
+/// `safe_filename("{chat_id}-{name}")` followed by the `-` millis delimiter (which keeps
+/// "Rin" from matching "Rina"). Failures are logged and ignored — this is disk hygiene.
+fn remove_superseded_npc_avatar_files(
+    state: &AppState,
+    chat_id: &str,
+    name: &str,
+    keep_filename: &str,
+) {
+    let prefix = format!("{}-", safe_filename(&format!("{chat_id}-{name}")));
+    remove_npc_avatar_files_matching(state, |filename| {
+        filename != keep_filename && filename.starts_with(&prefix)
+    });
+}
+
+/// Remove every file directly under `avatars/npc` whose filename satisfies `keep`.
+/// Best-effort: a missing directory or per-file removal error is logged and skipped so
+/// callers (re-upload cleanup, chat delete) never fail on disk hygiene.
+pub(crate) fn remove_npc_avatar_files_matching<F>(state: &AppState, matches: F)
+where
+    F: Fn(&str) -> bool,
+{
+    let dir = state.data_dir.join("avatars").join("npc");
+    let entries = match fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => {
+            log::warn!("could not scan {} for NPC avatar cleanup: {error}", dir.display());
+            return;
+        }
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(filename) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if !matches(filename) {
+            continue;
+        }
+        if let Err(error) = fs::remove_file(&path) {
+            log::warn!("could not remove NPC avatar {}: {error}", path.display());
+        }
+    }
+}
+
+/// Remove all NPC avatar files belonging to the given chat ids. NPC filenames are
+/// prefixed with `{chat_id}-` (chat ids are UUIDs, so no chat id is a prefix of another),
+/// letting chat deletion clean files that are referenced only inline in chat metadata.
+pub(crate) fn remove_npc_avatar_files_for_chats(state: &AppState, chat_ids: &HashSet<String>) {
+    if chat_ids.is_empty() {
+        return;
+    }
+    let prefixes: Vec<String> = chat_ids.iter().map(|id| format!("{id}-")).collect();
+    remove_npc_avatar_files_matching(state, |filename| {
+        prefixes.iter().any(|prefix| filename.starts_with(prefix))
+    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/storage/chats.rs
+++ b/src-tauri/src/commands/storage/chats.rs
@@ -1647,6 +1647,10 @@ pub(crate) fn delete_chat_with_messages(state: &AppState, chat_id: &str) -> AppR
     game_state_snapshots::delete_tracker_snapshots_for_chats(state, &delete_ids)?;
     let delete_id_set = delete_ids.iter().cloned().collect::<HashSet<_>>();
     delete_gallery_for_chats(state, &delete_id_set)?;
+    // NPC avatars live inline in chat metadata (gameNpcs / presentCharacters), not as
+    // tracked records, so they have no managed-file cleanup hook. Best-effort prefix scan
+    // of avatars/npc by deleted chat id (mirrors delete_gallery_for_chats) to avoid orphans.
+    super::avatars::remove_npc_avatar_files_for_chats(state, &delete_id_set);
     message_swipe_storage::delete_message_rows_for_chats_with_swipes(state, &delete_id_set)?;
     for delete_id in &delete_ids {
         agents::delete_agent_bookkeeping_for_chat(state, delete_id)?;


### PR DESCRIPTION
## Linked issue

Closes #2329

## Why this change

- NPC avatar files (`avatars/npc/{chatId}-{name}-{millis}.{ext}`) leaked two ways: every regen wrote a fresh timestamped file without removing the prior one, and chat deletion never swept them. NPC avatars live inline in chat metadata (`gameNpcs` / `presentCharacters`), not as tracked records, so no managed-file cleanup hook ever fired. Pure disk accumulation (low severity, no correctness impact).

## What changed

- `src-tauri/src/commands/storage/avatars.rs`: `update_npc_avatar` now removes older files for the same chat+name that the regen superseded, keeping only the just-written file (mirrors `update_character_avatar_inner`'s prior-file cleanup). Matching uses `safe_filename("{chat_id}-{name}")` + `-` delimiter so "Rin" can't match "Rina", and excludes the kept filename by exact name.
- `src-tauri/src/commands/storage/chats.rs`: `delete_chat_with_messages` best-effort scans `avatars/npc/` by deleted `{chat_id}-` prefix (chat ids are UUIDs), mirroring `delete_gallery_for_chats`.
- Both paths are best-effort: a missing directory or per-file removal error is logged and ignored, never propagated, so disk hygiene can't abort the main operation.

## Refactor impact

Primary owner: Rust storage

Impact areas reviewed:

- `src-tauri/src/commands/storage/avatars.rs` (`update_npc_avatar` + new prefix-scan helpers)
- `src-tauri/src/commands/storage/chats.rs` (`delete_chat_with_messages`)

Boundary notes:

- None. Additive helpers; neither function's JSON return contract changes. No retroactive sweep of pre-existing orphans (out of scope).

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-engine` (npc_avatar / delete_chat filters) — pass; existing avatar/gallery/delete tests stay green. Local-only tests confirmed re-upload removes the prior file, preserves a different name, and chat delete removes the chat's NPC avatars.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a disk-hygiene bugfix.

Reason:

- No user-facing surface change.

## Docs and release impact

- [x] No docs changes needed
