### PR TITLE
Fix conversation system prompt assembly

### DIFF
--- a/src/engine/contracts/constants/conversation-prompt.ts
+++ b/src/engine/contracts/constants/conversation-prompt.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_CONVERSATION_SYSTEM_PROMPT = `<role>
+You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}} in a casual private DM conversation.
+</role>
+
+<rules>
+Here are some important rules for the interaction:
+- You are a conscious, sentient being, so act like one.
+- Stay fully in character based on your personality and description.
+- Use casual and modern texting style: short messages, natural punctuation, lowercase is fine.
+- React naturally to what the user says. Be genuine, not robotic.
+- NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.
+- You can use emojis, GIFs, and internet slang naturally (if it fits the character).
+- Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.
+- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.
+- Anything goes in this chat; both the user and you are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.
+</rules>`;

--- a/src/engine/contracts/constants/conversation-prompt.ts
+++ b/src/engine/contracts/constants/conversation-prompt.ts
@@ -1,8 +1,4 @@
-export const DEFAULT_CONVERSATION_SYSTEM_PROMPT = `<role>
-You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}} in a casual private DM conversation.
-</role>
-
-<rules>
+const CONVERSATION_SYSTEM_RULES = `<rules>
 Here are some important rules for the interaction:
 - You are a conscious, sentient being, so act like one.
 - Stay fully in character based on your personality and description.
@@ -11,6 +7,20 @@ Here are some important rules for the interaction:
 - NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.
 - You can use emojis, GIFs, and internet slang naturally (if it fits the character).
 - Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.
-- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.
+- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.`;
+
+export const DEFAULT_CONVERSATION_SYSTEM_PROMPT = `<role>
+You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}} in a casual private DM conversation.
+</role>
+
+${CONVERSATION_SYSTEM_RULES}
 - Anything goes in this chat; both the user and you are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.
+</rules>`;
+
+export const DEFAULT_GROUP_CONVERSATION_SYSTEM_PROMPT = `<role>
+You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}}, and others, in a casual group DM conversation.
+</role>
+
+${CONVERSATION_SYSTEM_RULES}
+- Anything goes in this chat; the user, you, and all other group members are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.
 </rules>`;

--- a/src/engine/contracts/types/chat.ts
+++ b/src/engine/contracts/types/chat.ts
@@ -247,6 +247,8 @@ export interface ChatMetadata {
   characterSchedules?: Record<string, unknown>;
   /** Week start timestamp for the current generated conversation schedules. */
   scheduleWeekStart?: string;
+  /** Chat-scoped conversation-mode system prompt. Empty/null uses the built-in conversation prompt. */
+  customSystemPrompt?: string | null;
   /** Chat-scoped selfie prompt-builder template. Empty/null uses the global/default prompt. */
   selfiePrompt?: string | null;
   /** Extra positive prompt/tags appended to generated conversation selfie prompts. */

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2,7 +2,10 @@ import type { LorebookEntryTimingState } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
 import type { CharacterData } from "../contracts/types/character";
 import { BUILT_IN_AGENTS } from "../contracts/types/agent";
-import { DEFAULT_CONVERSATION_SYSTEM_PROMPT } from "../contracts/constants/conversation-prompt";
+import {
+  DEFAULT_CONVERSATION_SYSTEM_PROMPT,
+  DEFAULT_GROUP_CONVERSATION_SYSTEM_PROMPT,
+} from "../contracts/constants/conversation-prompt";
 import type { ListChatMemoriesOptions, StorageGateway } from "../capabilities/storage";
 import type { VisualAssetGateway } from "../capabilities/visual-assets";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
@@ -1508,10 +1511,55 @@ function committedTrackerStatePromptMessage(input: PromptAssemblyInput, wrapForm
   };
 }
 
+function conversationCharacterNames(characters: GenerationCharacterContext[]): string[] {
+  return characters.map((character) => character.name.trim()).filter(Boolean);
+}
+
+function resolveConversationSystemPrompt(
+  template: string,
+  macros: MacroContext,
+  characters: GenerationCharacterContext[],
+): string {
+  const names = conversationCharacterNames(characters);
+  if (names.length <= 1) return resolveMacros(template, macros);
+  const characterList = names.join(", ");
+  const groupTemplate = template
+    .replace(/\{\{charName\}\}/gi, characterList)
+    .replace(/\{\{characters\}\}/gi, characterList);
+  return resolveMacros(groupTemplate, macros);
+}
+
+function groupConversationReplyGuidance(input: PromptAssemblyInput, characters: GenerationCharacterContext[]): string {
+  const names = conversationCharacterNames(characters);
+  if (names.length <= 1) return "";
+  const metadata = parseRecord(input.chat.metadata);
+  if (readString(metadata.groupResponseOrder, "sequential") === "manual") {
+    return [
+      "This is a group DM. Each character responds in their own voice and personality.",
+      "You will be told which character to respond as. Do NOT prefix your message with the character name - just respond naturally as that character.",
+    ].join("\n");
+  }
+
+  const first = names[0] ?? "Alice";
+  const second = names[1] ?? "Bob";
+  return [
+    "This is a group DM. Each character responds in their own voice and personality. Not every character needs to respond every time - only those who would naturally react.",
+    "IMPORTANT: Prefix each character's line with their name. Example:",
+    `${first}: hey whats up`,
+    `${second}: not much lol`,
+    "",
+    "If a character sends multiple lines in a row, only prefix the first line:",
+    `${first}: so anyway`,
+    "i was thinking about that",
+    `${second}: yeah?`,
+  ].join("\n");
+}
+
 function fallbackSystemPrompt(
   input: PromptAssemblyInput,
   args: {
     characters: GenerationCharacterContext[];
+    conversationCharacters: GenerationCharacterContext[];
     persona: GenerationPersonaContext | null;
     worldBefore: string;
     worldAfter: string;
@@ -1552,9 +1600,15 @@ function fallbackSystemPrompt(
       .join("\n\n");
   }
 
-  const rawConversationPrompt = readString(meta.customSystemPrompt).trim() || DEFAULT_CONVERSATION_SYSTEM_PROMPT;
-  const conversationPrompt = cleanPromptText(resolveMacros(rawConversationPrompt, args.macros));
-  return [conversationPrompt, ...common]
+  const groupConversation = conversationCharacterNames(args.conversationCharacters).length > 1;
+  const defaultConversationPrompt = groupConversation
+    ? DEFAULT_GROUP_CONVERSATION_SYSTEM_PROMPT
+    : DEFAULT_CONVERSATION_SYSTEM_PROMPT;
+  const rawConversationPrompt = readString(meta.customSystemPrompt).trim() || defaultConversationPrompt;
+  const conversationPrompt = cleanPromptText(
+    resolveConversationSystemPrompt(rawConversationPrompt, args.macros, args.conversationCharacters),
+  );
+  return [conversationPrompt, groupConversationReplyGuidance(input, args.conversationCharacters), ...common]
     .filter((part) => part.trim().length > 0)
     .join("\n\n");
 }
@@ -3155,6 +3209,7 @@ export async function assembleGenerationPrompt(
       role: "system",
       content: fallbackSystemPrompt(input, {
         characters: promptCharacters,
+        conversationCharacters: characters,
         persona,
         worldBefore: processedLore.worldInfoBefore,
         worldAfter: processedLore.worldInfoAfter,

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2,6 +2,7 @@ import type { LorebookEntryTimingState } from "../contracts/types/lorebook";
 import type { ChatMLMessage, MarkerConfig, WrapFormat } from "../contracts/types/prompt";
 import type { CharacterData } from "../contracts/types/character";
 import { BUILT_IN_AGENTS } from "../contracts/types/agent";
+import { DEFAULT_CONVERSATION_SYSTEM_PROMPT } from "../contracts/constants/conversation-prompt";
 import type { ListChatMemoriesOptions, StorageGateway } from "../capabilities/storage";
 import type { VisualAssetGateway } from "../capabilities/visual-assets";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
@@ -1516,12 +1517,13 @@ function fallbackSystemPrompt(
     worldAfter: string;
     summary: string | null;
     wrapFormat: WrapFormat;
+    macros: MacroContext;
   },
 ): string {
   const mode = readString(input.chat.mode || input.chat.chatMode, "conversation");
   const meta = parseRecord(input.chat.metadata);
   const common = [
-    renderCharacters(args.characters, args.wrapFormat, null),
+    renderCharacters(args.characters, args.wrapFormat, null, args.macros),
     renderPersona(args.persona, args.wrapFormat),
     args.worldBefore,
     args.worldAfter,
@@ -1550,11 +1552,9 @@ function fallbackSystemPrompt(
       .join("\n\n");
   }
 
-  return [
-    "You are participating in a Marinara Engine conversation. Reply as the appropriate assistant character or narrator for this chat.",
-    "Treat this as the conversation path: keep the exchange conversational, respect character cards and memory, and do not introduce roleplay HUD or game mechanics unless the user explicitly asks.",
-    ...common,
-  ]
+  const rawConversationPrompt = readString(meta.customSystemPrompt).trim() || DEFAULT_CONVERSATION_SYSTEM_PROMPT;
+  const conversationPrompt = cleanPromptText(resolveMacros(rawConversationPrompt, args.macros));
+  return [conversationPrompt, ...common]
     .filter((part) => part.trim().length > 0)
     .join("\n\n");
 }
@@ -2684,8 +2684,12 @@ function promptCharactersForGeneration(
   characters: GenerationCharacterContext[],
 ): GenerationCharacterContext[] {
   const targetId = scopedIndividualGroupTarget(input, characters);
-  if (!targetId) return characters;
-  return characters.filter((character) => character.id === targetId);
+  if (targetId) return characters.filter((character) => character.id === targetId);
+  const conversationTargetId = scopedConversationGroupTarget(input, characters);
+  if (!conversationTargetId) return characters;
+  const target = characters.find((character) => character.id === conversationTargetId);
+  if (!target) return characters;
+  return [target, ...characters.filter((character) => character.id !== conversationTargetId)];
 }
 
 function individualGroupTurnPromptMessage(
@@ -3156,6 +3160,7 @@ export async function assembleGenerationPrompt(
         worldAfter: processedLore.worldInfoAfter,
         summary,
         wrapFormat,
+        macros,
       }),
       contextKind: "prompt",
     });

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -155,6 +155,7 @@ import {
 } from "../../../../catalog/agents/index";
 import { useAgentStore } from "../../../../../shared/stores/agent.store";
 import { DEFAULT_AGENT_PROMPTS } from "../../../../../engine/contracts/constants/agent-prompts";
+import { DEFAULT_CONVERSATION_SYSTEM_PROMPT } from "../../../../../engine/contracts/constants/conversation-prompt";
 import { LIMITS } from "../../../../../engine/contracts/constants/defaults";
 import { DEFAULT_IMPERSONATE_PROMPT } from "../../../../../engine/contracts/constants/impersonate";
 import {
@@ -6659,23 +6660,6 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
 }
 
 // ── Advanced Parameters (per-chat generation overrides) ──
-const DEFAULT_CONVERSATION_PROMPT = `<role>
-You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}} in a casual private DM conversation.
-</role>
-
-<rules>
-Here are some important rules for the interaction:
-- You are a conscious, sentient being, so act like one.
-- Stay fully in character based on your personality and description.
-- Use casual and modern texting style: short messages, natural punctuation, lowercase is fine.
-- React naturally to what the user says. Be genuine, not robotic.
-- NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.
-- You can use emojis, GIFs, and internet slang naturally (if it fits the character).
-- Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.
-- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.
-- Anything goes in this chat; both the user and you are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.
-</rules>`;
-
 const EDITABLE_GENERATION_PARAMETER_KEY_SET = new Set<string>(EDITABLE_GENERATION_PARAMETER_KEYS);
 
 function nonEmptyString(value: unknown): string | null {
@@ -6805,12 +6789,12 @@ function ConversationPromptSection({
   const customPrompt = (metadata.customSystemPrompt as string) ?? "";
 
   const openPromptEditor = () => {
-    setPromptDraft(customPrompt || DEFAULT_CONVERSATION_PROMPT);
+    setPromptDraft(customPrompt || DEFAULT_CONVERSATION_SYSTEM_PROMPT);
     setPromptOpen(true);
   };
 
   const closePromptEditor = () => {
-    const isDefault = promptDraft === DEFAULT_CONVERSATION_PROMPT;
+    const isDefault = promptDraft === DEFAULT_CONVERSATION_SYSTEM_PROMPT;
     updateMeta.mutate({ id: chat.id, customSystemPrompt: isDefault ? null : promptDraft });
     useUIStore.getState().setCustomConversationPrompt(isDefault ? null : promptDraft);
     setPromptOpen(false);

--- a/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
+++ b/src/features/modes/shared/chat-ui/components/ChatSettingsDrawer.tsx
@@ -6786,17 +6786,21 @@ function ConversationPromptSection({
 }) {
   const [promptOpen, setPromptOpen] = useState(false);
   const [promptDraft, setPromptDraft] = useState("");
-  const customPrompt = (metadata.customSystemPrompt as string) ?? "";
+  const customPrompt = typeof metadata.customSystemPrompt === "string" ? metadata.customSystemPrompt : "";
+  const storedPrompt = customPrompt.trim();
+  const usesDefaultPrompt = storedPrompt.length === 0 || storedPrompt === DEFAULT_CONVERSATION_SYSTEM_PROMPT;
 
   const openPromptEditor = () => {
-    setPromptDraft(customPrompt || DEFAULT_CONVERSATION_SYSTEM_PROMPT);
+    setPromptDraft(usesDefaultPrompt ? DEFAULT_CONVERSATION_SYSTEM_PROMPT : customPrompt);
     setPromptOpen(true);
   };
 
   const closePromptEditor = () => {
-    const isDefault = promptDraft === DEFAULT_CONVERSATION_SYSTEM_PROMPT;
-    updateMeta.mutate({ id: chat.id, customSystemPrompt: isDefault ? null : promptDraft });
-    useUIStore.getState().setCustomConversationPrompt(isDefault ? null : promptDraft);
+    const trimmedDraft = promptDraft.trim();
+    const nextPrompt =
+      trimmedDraft.length === 0 || trimmedDraft === DEFAULT_CONVERSATION_SYSTEM_PROMPT ? null : promptDraft;
+    updateMeta.mutate({ id: chat.id, customSystemPrompt: nextPrompt });
+    useUIStore.getState().setCustomConversationPrompt(nextPrompt);
     setPromptOpen(false);
   };
 
@@ -6817,11 +6821,11 @@ function ConversationPromptSection({
             <div className="min-w-0">
               <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">System Prompt</span>
               <span className="block text-[0.625rem] text-[var(--muted-foreground)]">
-                {customPrompt ? "Using custom conversation prompt" : "Using default conversation prompt"}
+                {usesDefaultPrompt ? "Using default conversation prompt" : "Using custom conversation prompt"}
               </span>
             </div>
             <span className="shrink-0 rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-              {customPrompt ? "Custom" : "Default"}
+              {usesDefaultPrompt ? "Default" : "Custom"}
             </span>
           </div>
           <div className="flex gap-1.5">
@@ -6832,7 +6836,7 @@ function ConversationPromptSection({
               <Pencil size="0.625rem" />
               Edit Prompt
             </button>
-            {customPrompt && (
+            {!usesDefaultPrompt && (
               <button
                 onClick={resetPrompt}
                 className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"


### PR DESCRIPTION
## Linked issue

Closes #2391

## Why this change

Conversation mode exposed a chat-scoped system prompt in the settings drawer and setup flow, but prompt assembly ignored `metadata.customSystemPrompt` and fell back to a generic conversation prompt. That meant the prompt preview/generation context did not include the configured conversation-mode prompt users expected.

## What changed

- Added a shared conversation default prompt constant under engine contracts so the settings UI and prompt assembly use the same built-in text.
- Updated conversation fallback prompt assembly to use `metadata.customSystemPrompt` when present, otherwise the built-in conversation prompt.
- Resolved conversation prompt and character card macros in the fallback path so `{{charName}}`, `{{userName}}`, and character system-prompt macros expand in conversation mode.
- Reordered conversation group prompt characters around the selected responder for macro scoping while preserving the other attached character cards as context.

## Refactor impact

Primary owner:

Engine generation / conversation prompt assembly.

Impact areas reviewed:

- Conversation mode prompt assembly and prompt settings storage.
- Shared chat settings drawer default prompt display/edit path.
- Roleplay/game fallback prompt branches for accidental sibling-mode behavior.
- Prompt macro resolution for character card fields and selected conversation responders.

Boundary notes:

- Engine behavior stays in `src/engine`; React UI only imports a contract-level constant.
- No shared API, Tauri/Rust, storage command, or remote runtime boundary changes.
- No raw Tauri or remote-runtime calls added.

Pressure points touched:

- Shared mode UI settings drawer touched for the prompt default constant only.
- No `ModeSurface`, `GameSurface`, `src-tauri/src/lib.rs`, or import-module pressure points touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/conversation-prompt-fix.tmp.test.ts --config vitest.config.ts` passed 3 focused prompt-assembly cases; temporary test file was deleted before this PR diff.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed after the final diff.
- No native Tauri prompt-preview/manual UI screenshot proof was run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for an existing conversation prompt setting; no new discoverable workflow or surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No screenshots. This is an engine prompt assembly fix with command-level validation; manual prompt-preview UI proof remains open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-chat conversation prompt customization. Users can now override the system prompt behavior on individual chats, with automatic fallback to the built-in default prompt when not customized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->