### PR TITLE
Fix connection folder top insertion

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -690,6 +690,9 @@ pub(crate) fn storage_create_inner(
     if entity == "chat-folders" {
         return create_chat_folder(state, value);
     }
+    if entity == "connection-folders" {
+        return create_connection_folder(state, value);
+    }
     let should_remove_prepared_gallery_file = gallery_create_persists_inline_image(&entity, &value);
     let prepared = prepare_entity_for_create(state, &entity, value)?;
     if entity == "lorebook-entries" {
@@ -1101,6 +1104,99 @@ fn connection_folder_defaults_for_create(
         object.insert("order".to_string(), json!(next_order));
     }
     Ok(Value::Object(object))
+}
+
+fn create_connection_folder(state: &AppState, value: Value) -> Result<Value, AppError> {
+    let explicit_order = explicit_positive_connection_folder_order(&value);
+    let mut prepared = prepare_entity_for_create(state, "connection-folders", value)?;
+    if let Some(order) = explicit_order {
+        let Some(object) = prepared.as_object_mut() else {
+            return Err(AppError::invalid_input(
+                "Connection folder must be an object",
+            ));
+        };
+        object.insert("sortOrder".to_string(), json!(order));
+        object.insert("order".to_string(), json!(order));
+        return state.storage.create("connection-folders", prepared);
+    }
+
+    state
+        .storage
+        .update_collections_atomically(vec!["connection-folders"], move |collections| {
+            let [folders] = collections else {
+                return Err(AppError::new(
+                    "storage_error",
+                    "Connection folder create expected connection-folder collection",
+                ));
+            };
+            if folders.collection() != "connection-folders" {
+                return Err(AppError::new(
+                    "storage_error",
+                    "Connection folder create received unexpected collection",
+                ));
+            }
+            create_connection_folder_in_rows(folders.rows_mut(), prepared)
+        })
+}
+
+fn explicit_positive_connection_folder_order(value: &Value) -> Option<i64> {
+    ["sortOrder", "order"].into_iter().find_map(|field| {
+        value
+            .get(field)
+            .and_then(Value::as_i64)
+            .filter(|order| *order > 0)
+    })
+}
+
+fn create_connection_folder_in_rows(
+    rows: &mut Vec<Value>,
+    value: Value,
+) -> Result<Value, AppError> {
+    let mut object = ensure_object(value)?;
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(new_id);
+    if rows
+        .iter()
+        .any(|row| row.get("id").and_then(Value::as_str) == Some(id.as_str()))
+    {
+        return Err(AppError::invalid_input(format!(
+            "connection-folders/{id} already exists"
+        )));
+    }
+
+    let now = now_iso();
+    object.insert("id".to_string(), Value::String(id));
+    object
+        .entry("createdAt".to_string())
+        .or_insert_with(|| Value::String(now.clone()));
+    object
+        .entry("updatedAt".to_string())
+        .or_insert_with(|| Value::String(now.clone()));
+    object.insert("sortOrder".to_string(), json!(0));
+    object.insert("order".to_string(), json!(0));
+
+    for folder in rows.iter_mut() {
+        let Some(folder) = folder.as_object_mut() else {
+            return Err(AppError::invalid_input("Stored record is not an object"));
+        };
+        let next_order = folder
+            .get("sortOrder")
+            .or_else(|| folder.get("order"))
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            + 1;
+        folder.insert("sortOrder".to_string(), json!(next_order));
+        folder.insert("order".to_string(), json!(next_order));
+        folder.insert("updatedAt".to_string(), Value::String(now.clone()));
+    }
+
+    let record = Value::Object(object);
+    rows.push(record.clone());
+    Ok(record)
 }
 
 pub(crate) fn validate_connection_folder_for_create(
@@ -5390,6 +5486,118 @@ mod tests {
     }
 
     #[test]
+    fn creating_connection_folder_defaults_and_shifts_existing_folders() {
+        let state = test_state("connection-folder-create-defaults");
+        storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({
+                "id": "folder-old",
+                "name": "Old"
+            }),
+        )
+        .expect("existing folder should be created");
+
+        let created = storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({
+                "id": "folder-new",
+                "name": "New folder"
+            }),
+        )
+        .expect("new folder should be created");
+
+        assert_eq!(created["color"], "#38bdf8");
+        assert_eq!(created["collapsed"], false);
+        assert_eq!(created["sortOrder"], 0);
+        assert_eq!(created["order"], 0);
+        assert!(created.get("createdAt").is_some());
+        assert!(created.get("updatedAt").is_some());
+
+        let shifted = state
+            .storage
+            .get("connection-folders", "folder-old")
+            .expect("folder should read")
+            .expect("folder should remain");
+        assert_eq!(shifted["sortOrder"], 1);
+        assert_eq!(shifted["order"], 1);
+    }
+
+    #[test]
+    fn creating_connection_folder_with_explicit_order_does_not_shift_existing_folders() {
+        let state = test_state("connection-folder-create-explicit-order");
+        storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({
+                "id": "folder-old",
+                "name": "Old"
+            }),
+        )
+        .expect("existing folder should be created");
+
+        let created = storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({
+                "id": "folder-new",
+                "name": "New folder",
+                "sortOrder": 4,
+                "order": 4
+            }),
+        )
+        .expect("new folder should be created");
+
+        assert_eq!(created["sortOrder"], 4);
+        assert_eq!(created["order"], 4);
+
+        let existing = state
+            .storage
+            .get("connection-folders", "folder-old")
+            .expect("folder should read")
+            .expect("folder should remain");
+        assert_eq!(existing["sortOrder"], 0);
+        assert_eq!(existing["order"], 0);
+    }
+
+    #[test]
+    fn creating_connection_folder_with_explicit_legacy_order_preserves_order() {
+        let state = test_state("connection-folder-create-legacy-order");
+        storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({
+                "id": "folder-old",
+                "name": "Old"
+            }),
+        )
+        .expect("existing folder should be created");
+
+        let created = storage_create_inner(
+            &state,
+            "connection-folders".to_string(),
+            json!({
+                "id": "folder-new",
+                "name": "New folder",
+                "order": 3
+            }),
+        )
+        .expect("new folder should be created");
+
+        assert_eq!(created["sortOrder"], 3);
+        assert_eq!(created["order"], 3);
+
+        let existing = state
+            .storage
+            .get("connection-folders", "folder-old")
+            .expect("folder should read")
+            .expect("folder should remain");
+        assert_eq!(existing["sortOrder"], 0);
+        assert_eq!(existing["order"], 0);
+    }
+
+    #[test]
     fn creating_chat_folder_defaults_and_shifts_existing_folders() {
         let state = test_state("chat-folder-create-defaults");
         storage_create_inner(
@@ -6147,6 +6355,7 @@ mod tests {
             .get("connection-folders", "folder-b")
             .expect("folder should read")
             .expect("folder should exist");
-        assert_eq!(folder_b["sortOrder"], 1);
+        assert_eq!(folder_b["sortOrder"], 0);
+        assert_eq!(folder_b["order"], 0);
     }
 }


### PR DESCRIPTION
## Linked issue

Closes #2388

## Why this change

- Connection folder creation in the refactor branch appended new folders by default, while legacy storage inserted new folders at the top and shifted existing folder order down.

## What changed

- Route `connection-folders` creation through a focused storage helper.
- Insert default connection folders atomically at `sortOrder`/`order` `0`.
- Shift existing connection folders down during default create.
- Preserve explicit positive `sortOrder` or legacy `order` values without shifting existing rows.
- Add focused Rust coverage for default top insertion, explicit order, legacy `order`, and reorder validation expectations.

## Refactor impact

Primary owner:

Rust storage

Impact areas reviewed:

- Connection folder create defaults
- Connection folder reorder validation
- Connection folder delete/unfile behavior
- Profile export/import preservation for connection folders

Boundary notes:

- No React, engine, shared API, or remote-runtime boundary changes.
- Change stays inside the Rust storage command owner.

Pressure points touched:

- None.

## Validation

- [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml connection_folder` passed: 7 tests.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `pnpm check` passed, including line endings, scratch, architecture, frontend typecheck, Rust workspace check, docs, discovery metadata, launcher safety, and warning-only unused-code scan.
- `git diff --check` passed.
- No browser/manual UI verification performed; change is storage-only.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [ ] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix only; no new discoverable feature or workflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: storage-only behavior fix.
