### PR TITLE
Fix connection default parameter precedence

### DIFF
--- a/src/engine/generation/generate-route-utils.ts
+++ b/src/engine/generation/generate-route-utils.ts
@@ -314,10 +314,10 @@ export function generationParameterSources(
   const mode = readString(chat?.mode || chat?.chatMode);
   const setupConfig = parseRecord(meta.gameSetupConfig);
   return [
-    connection?.defaultParameters,
     promptPresetParameters,
     mode === "game" ? setupConfig.generationParameters : null,
     mode === "game" ? meta.gameGenerationParameters : null,
+    connection?.defaultParameters,
     meta.chatParameters,
     input?.parameters,
   ];


### PR DESCRIPTION
## Linked issue

Closes #2389

## Why this change

- Connection default generation parameters were saved and loaded, but runtime merge order applied them before prompt preset and mode defaults.
- That let prompt presets override user-set connection defaults, which differs from legacy precedence.

## What changed

- Moves connection `defaultParameters` later in the shared generation parameter source order.
- Keeps prompt preset and game mode defaults below connection defaults.
- Keeps chat metadata parameters and per-request parameters above connection defaults.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- prompt preview parameter assembly
- live generation `llmParameters` path
- prompt assembly parameter reporting
- chat/request override order

Boundary notes:

- React-free engine-only change.
- No feature UI, shared API wrapper, remote-runtime routing, storage, or Rust command changes.

Pressure points touched:

- none

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run --config /tmp/issue-2389-vitest.config.ts`
  - Scratch test imports the real generation helper and verifies prompt preset/game defaults < connection defaults < chat parameters < request parameters.
- `pnpm typecheck`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing generation parameter precedence.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A, engine-only generation parameter precedence fix.
