### PR TITLE
Restore Cohere compatibility defaults

### DIFF
--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -100,6 +100,9 @@ pub async fn complete_rich(request: LlmRequest) -> AppResult<LlmCompletion> {
                     tool_calls: Vec::new(),
                 })
         }
+        "cohere" if should_use_cohere_compatibility(&request) => {
+            complete_openai_compatible_rich(request).await
+        }
         "cohere" => complete_cohere_rich(request).await,
         _ => complete_openai_compatible_rich(request).await,
     }
@@ -118,6 +121,8 @@ pub async fn stream_events(
         stream_google(request, &mut emit).await?;
     } else if request.connection.provider == "anthropic" {
         stream_anthropic(request, &mut emit).await?;
+    } else if request.connection.provider == "cohere" && should_use_cohere_compatibility(&request) {
+        stream_openai_compatible(request, &mut emit).await?;
     } else if request.connection.provider == "cohere" {
         stream_cohere(request, &mut emit).await?;
     } else if request.connection.provider != "claude_subscription" {
@@ -231,7 +236,7 @@ fn base_url(provider: &str, configured: &str) -> String {
                 .to_string()
         }
         "mistral" => "https://api.mistral.ai/v1".to_string(),
-        "cohere" => "https://api.cohere.com/v2".to_string(),
+        "cohere" => "https://api.cohere.com/compatibility/v1".to_string(),
         "openrouter" => "https://openrouter.ai/api/v1".to_string(),
         "nanogpt" => "https://nano-gpt.com/api/v1".to_string(),
         "xai" => "https://api.x.ai/v1".to_string(),
@@ -241,13 +246,19 @@ fn base_url(provider: &str, configured: &str) -> String {
 
 fn cohere_base_url(configured: &str) -> String {
     let base = base_url("cohere", configured);
-    if base.ends_with("/compatibility/v1") {
-        return format!("{}/v2", base.trim_end_matches("/compatibility/v1"));
-    }
     if base.ends_with("/v1") && base.contains("api.cohere.") {
         return format!("{}/v2", base.trim_end_matches("/v1"));
     }
     base
+}
+
+fn should_use_cohere_compatibility(request: &LlmRequest) -> bool {
+    base_url("cohere", &request.connection.base_url).ends_with("/compatibility/v1")
+}
+
+fn openai_compatible_chat_endpoint(request: &LlmRequest) -> String {
+    let base = base_url(&request.connection.provider, &request.connection.base_url);
+    format!("{base}/chat/completions")
 }
 
 fn cohere_chat_endpoint(configured: &str) -> String {
@@ -1702,8 +1713,7 @@ async fn complete_openai_compatible_rich(request: LlmRequest) -> AppResult<LlmCo
     if should_use_openai_responses(&request) {
         return complete_openai_responses_rich(request).await;
     }
-    let base = base_url(&request.connection.provider, &request.connection.base_url);
-    let url = format!("{base}/chat/completions");
+    let url = openai_compatible_chat_endpoint(&request);
     ensure_url_allowed(&url)?;
     let messages: Vec<Value> = request_messages(&request)
         .iter()
@@ -1752,8 +1762,7 @@ async fn stream_openai_compatible(
     request: LlmRequest,
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
 ) -> AppResult<()> {
-    let base = base_url(&request.connection.provider, &request.connection.base_url);
-    let url = format!("{base}/chat/completions");
+    let url = openai_compatible_chat_endpoint(&request);
     ensure_url_allowed(&url)?;
     let messages: Vec<Value> = request_messages(&request)
         .iter()
@@ -4491,6 +4500,28 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
         assert_eq!(
             base_url("openai_chatgpt", "https://api.example.com/v1"),
             OPENAI_CHATGPT_CODEX_BASE_URL
+        );
+    }
+
+    #[test]
+    fn cohere_default_base_uses_openai_compatible_endpoint() {
+        let mut request = request_for("cohere", "command-a", json!({}));
+
+        assert_eq!(
+            base_url("cohere", ""),
+            "https://api.cohere.com/compatibility/v1"
+        );
+        assert!(should_use_cohere_compatibility(&request));
+        assert_eq!(
+            openai_compatible_chat_endpoint(&request),
+            "https://api.cohere.com/compatibility/v1/chat/completions"
+        );
+
+        request.connection.base_url = "https://api.cohere.com/v2".to_string();
+        assert!(!should_use_cohere_compatibility(&request));
+        assert_eq!(
+            cohere_chat_endpoint(&request.connection.base_url),
+            "https://api.cohere.com/v2/chat"
         );
     }
 

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -1319,9 +1319,7 @@ fn model_endpoint(provider: &str, base: &str, connection: &Value) -> String {
             let base = base.trim_end_matches("/publishers/google/models");
             format!("{base}/publishers/google/models")
         }
-        "cohere" if base.ends_with("/compatibility/v1") => {
-            format!("{}/v1/models", base.trim_end_matches("/compatibility/v1"))
-        }
+        "cohere" if base.ends_with("/compatibility/v1") => format!("{base}/models"),
         "cohere" if base.ends_with("/v2") => {
             format!("{}/v1/models", base.trim_end_matches("/v2"))
         }
@@ -1380,7 +1378,7 @@ fn provider_default_base_url(provider: &str) -> &'static str {
         "nanogpt" => "https://nano-gpt.com/api/v1",
         "ollama" => "http://127.0.0.1:11434",
         "mistral" => "https://api.mistral.ai/v1",
-        "cohere" => "https://api.cohere.com/v2",
+        "cohere" => "https://api.cohere.com/compatibility/v1",
         "togetherai" => "https://api.together.xyz/v1",
         _ => "https://api.openai.com/v1",
     }
@@ -1459,6 +1457,45 @@ mod tests {
         format!("http://{address}/v1")
     }
 
+    async fn serve_models_asserting_request(
+        expected_path: &'static str,
+        expected_auth: &'static str,
+        body: &'static str,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept one request");
+            let mut buffer = [0_u8; 4096];
+            let read = stream
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read request");
+            let request = String::from_utf8_lossy(&buffer[..read]);
+            assert!(request.starts_with(&format!("GET {expected_path} HTTP/1.1")));
+            assert!(request.to_ascii_lowercase().contains(&format!(
+                "\r\nauthorization: {}\r\n",
+                expected_auth.to_ascii_lowercase()
+            )));
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write response");
+        });
+        format!("http://{address}")
+    }
+
     #[test]
     fn google_vertex_model_lookup_uses_aiplatform_endpoint() {
         assert_eq!(
@@ -1481,6 +1518,57 @@ mod tests {
             ),
             "https://us-central1-aiplatform.googleapis.com/v1/projects/demo/locations/us-central1/publishers/google/models"
         );
+    }
+
+    #[test]
+    fn cohere_model_lookup_uses_compatibility_models_path() {
+        assert_eq!(
+            provider_default_base_url("cohere"),
+            "https://api.cohere.com/compatibility/v1"
+        );
+        assert_eq!(
+            model_endpoint(
+                "cohere",
+                "https://api.cohere.com/compatibility/v1",
+                &json!({ "apiKey": "sk-test-key" })
+            ),
+            "https://api.cohere.com/compatibility/v1/models"
+        );
+    }
+
+    #[tokio::test]
+    async fn cohere_connection_models_compatibility_endpoint_sends_authorization() {
+        let state = test_state("cohere-compat-models");
+        let base_url = format!(
+            "{}/compatibility/v1",
+            serve_models_asserting_request(
+                "/compatibility/v1/models",
+                "Bearer sk-test-key",
+                r#"{"data":[{"id":"command-a"}]}"#
+            )
+            .await
+        );
+        state
+            .storage
+            .upsert_with_id(
+                "connections",
+                "cohere-compat",
+                json!({
+                    "provider": "cohere",
+                    "baseUrl": base_url,
+                    "apiKey": "sk-test-key",
+                    "model": "command-a"
+                }),
+            )
+            .expect("connection should be stored");
+
+        let result = connection_models(&state, "cohere-compat")
+            .await
+            .expect("Cohere model lookup should use compatibility endpoint");
+
+        assert_eq!(result["fromProvider"], true);
+        assert_eq!(result["fallback"], false);
+        assert_eq!(result["models"][0]["id"], "command-a");
     }
 
     #[test]

--- a/src/engine/contracts/constants/providers.ts
+++ b/src/engine/contracts/constants/providers.ts
@@ -82,8 +82,8 @@ export const PROVIDERS: Record<APIProvider, ProviderDefinition> = {
   cohere: {
     id: "cohere",
     name: "Cohere",
-    defaultBaseUrl: "https://api.cohere.com/v2",
-    modelsEndpoint: "/v1/models",
+    defaultBaseUrl: "https://api.cohere.com/compatibility/v1",
+    modelsEndpoint: "/models",
     supportsStreaming: true,
     usesAuthHeader: true,
     apiKeyHeader: null,


### PR DESCRIPTION
## Linked issue

Closes #2387

## Why this change

- Cohere connections created from the provider picker were seeded with a host that does not directly match the authenticated OpenAI-compatible API surface Marinara uses.
- Storage model lookup also rewrote Cohere compatibility bases to native `/v1/models`, and generation rewrote compatibility bases to native v2 chat paths.
- That meant new or reset Cohere connections could mix OpenAI-compatible request shapes with native Cohere paths.

## What changed

- Restored Cohere's provider default to `https://api.cohere.com/compatibility/v1`.
- Kept Cohere's provider `modelsEndpoint` as `/models`.
- Made model lookup build `https://api.cohere.com/compatibility/v1/models` for Cohere compatibility bases.
- Routed Cohere compatibility-base streaming and non-streaming generation through the OpenAI-compatible `/chat/completions` path while preserving native v2 behavior for explicit v2 bases.
- Added focused Rust coverage for the model-list URL/auth contract and Cohere generation endpoint routing.

## Refactor impact

Primary owner:

React-free engine provider contracts, Rust storage LLM model lookup, and Rust LLM provider transport.

Impact areas reviewed:

- `CreateConnectionModal` seeds new connections from `PROVIDERS[provider].defaultBaseUrl`.
- `ConnectionEditor` displays and reseeds provider defaults from the same provider catalog.
- `connection_models` now checks Cohere compatibility model listing through `/compatibility/v1/models` with Bearer auth.
- Cohere generation keeps streaming and non-streaming compatibility calls on `/compatibility/v1/chat/completions`.

Boundary notes:

- Engine provider constant changed in `src/engine/contracts/constants/providers.ts`.
- Rust storage model lookup changed in `src-tauri/src/commands/storage/llm.rs`.
- Rust LLM transport changed in `src-tauri/crates/llm/src/lib.rs`.
- No React feature, shared API, HTTP dispatch, or command-registration changes.

Pressure points touched:

- LLM model listing.
- LLM provider transport.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm typecheck`
- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml cohere_ -- --nocapture`
- `cargo test --manifest-path src-tauri/crates/llm/Cargo.toml cohere_ -- --nocapture`
- Mocked model-list smoke verified `GET /compatibility/v1/models` plus `Authorization: Bearer sk-test-key` through `connection_models`.
- Live Cohere provider transport was not exercised.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Provider compatibility fix only; no new user-discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; no visible UI layout or interaction change.
