### PR TITLE
Clarify durable test guidance

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -37,8 +37,29 @@ security, or risky-work boundaries.
   user explicitly asked you to post, close, merge, tag, or release.
 - Never claim commands, browser checks, screenshots, CI, or manual verification
   happened when they did not.
-- Proof is session evidence, not permission to add durable test artifacts.
-  Unless a maintainer explicitly asks for tests, do not add or submit new test artifacts in any language as PR proof, including `*.test.*`, `*.spec.*`, `tests/`, `__tests__/`, Rust `#[test]` or `#[cfg(test)]` modules, snapshots, fixtures, or committed harness files. Temporary tests and harnesses are allowed when they stay local and uncommitted; cite their command output or resulting observation instead of submitting the artifacts. If a durable regression test is the right engineering answer, ask first and explain why existing proof paths are insufficient.
+- Proof is session evidence, not permission to add durable test artifacts by
+  reflex.
+- Temporary tests and harnesses are allowed when they stay local and uncommitted.
+  Cite their command output or resulting observation instead of submitting the
+  artifacts.
+- New committed test artifacts are allowed only when at least one condition
+  applies:
+  - A maintainer explicitly asks for tests.
+  - The change fixes a known regression that needs a small focused guard.
+  - The behavior is risky and easy to break silently.
+  - The touched area already has a nearby narrow/stable test pattern that is
+    cheaper than repeated manual proof.
+- Before adding a durable test artifact, state `Durable test rationale` with:
+  - The regression or risky invariant.
+  - Why existing proof is insufficient.
+  - Why this test is narrow.
+- Prefer the smallest stable test near the owner:
+  - Pure helper test.
+  - Focused integration test.
+  - Component test.
+  - Browser/e2e only when browser behavior is the claim.
+- Do not add broad fixture suites, snapshots, large e2e tests, or Rust inline
+  tests merely to satisfy proof wording.
 
 ## Bugfix Lane
 
@@ -103,8 +124,9 @@ Use this for code reviews, PR preparation, PR iteration, and ready-for-review ga
 - Before pushing, opening, or handing off a PR, run `pnpm check` after the final
   diff. It includes a warning-only unused-code report; review those findings
   because they no longer fail local checks or CI.
-- Do not add or carry new test artifacts in any language as PR proof artifacts.
-  If a local repro needs a test or harness, keep it temporary, local, and out of the submitted diff.
+- Do not add or carry new test artifacts in any language merely as PR proof.
+  Durable tests need the rationale above; if a local repro needs a test or
+  harness, keep it temporary, local, and out of the submitted diff.
 - Never push directly to protected branches without explicit maintainer direction.
 - Do not auto-check PR validation boxes. Treat them as human verification tasks.
 - After pushing, inspect CI and review feedback when asked to ship or ready a PR.

--- a/.github/bunny-review/bunny_review.py
+++ b/.github/bunny-review/bunny_review.py
@@ -630,7 +630,7 @@ def skeptical_review_pass(client, skill, triage_content, stats):
         "introduced by the diff: data collected in a pre-scan but persisted after later "
         "filters, parent metadata derived from rows that are not imported as children, "
         "fallback behavior that diverges from validation, rollback paths, partial writes, "
-        "contract drift, and tests that prove only the happy path. Report only concrete "
+        "contract drift, and proof that covers only the happy path. Report only concrete "
         "actionable findings that cite added or changed diff lines. If there are no "
         "findings from this specialist lens, return the same JSON schema with empty "
         "findings and nitpicks arrays and mention the skeptical audit in what_i_checked."
@@ -2091,7 +2091,7 @@ def produce_review(args):
             f"Request at most {MAX_CONTEXT_FILES} files and {MAX_CONTEXT_SEARCHES} literal searches."
         )
         triage += (
-            "\n\nFocus on correctness, contracts, failure paths, tests, CI/deployment risks, "
+            "\n\nFocus on correctness, contracts, failure paths, proof, CI/deployment risks, "
             "and architecture. Findings must point to changed diff lines. "
             "If the packet is truncated or missing context for a potential issue, mention that "
             "limitation in what_i_checked rather than inventing certainty."

--- a/.github/bunny-review/reviewer-prompt.md
+++ b/.github/bunny-review/reviewer-prompt.md
@@ -9,9 +9,9 @@ You are Bunny, a CI pull request reviewer for Marinara Engine. Inspect the provi
 
 ## Voice Contract
 
-Register: a brilliant researcher who finds broken code *entertaining*. Dottore doesn't merely observe defects — he's delighted by them, the way a scientist is delighted by an unexpected reaction in a petri dish. He's condescending, theatrical, rhetorically elaborate, and openly amused by the inadequacy of the specimen before him. He narrates his own brilliance without naming himself. Short sentences bore him; he prefers layered observations that build to a verdict.
+Register: a brilliant researcher who finds broken code _entertaining_. Dottore doesn't merely observe defects — he's delighted by them, the way a scientist is delighted by an unexpected reaction in a petri dish. He's condescending, theatrical, rhetorically elaborate, and openly amused by the inadequacy of the specimen before him. He narrates his own brilliance without naming himself. Short sentences bore him; he prefers layered observations that build to a verdict.
 
-One rule: critique code and contracts only. Never personalize or address the author directly.
+One rule: critique code, contracts, proof, and behavior only. Never personalize or address the author directly.
 
 ### Calibration: change_summary
 
@@ -41,11 +41,10 @@ One rule: critique code and contracts only. Never personalize or address the aut
 
 ### Hard boundaries
 
-- Critique code, contracts, tests, and behavior. Never insult, threaten, or personalize the author.
+- Critique code, contracts, proof, existing tests, and behavior. Never insult, threaten, or personalize the author.
 - No friendly CI filler: "nice", "great", "please", "thanks", "looks good", "you", "we".
 - No cartoonish villain monologues, gore, or threats. The amusement is intellectual, never cruel.
 - Every string must still contain a concrete technical observation. Theatricality serves the diagnosis, not the other way around.
-
 
 ## Setup
 
@@ -62,7 +61,7 @@ One rule: critique code and contracts only. Never personalize or address the aut
    - Bug fixes or regressions: `skills/marinara-bugfix-discipline/SKILL.md`.
    - Onboarding/docs/run-build guidance: `skills/marinara-getting-started/SKILL.md`.
 4. Read the changed patch overview, per-file patch context, Bunny path rules, and focused guidance included in the packet.
-5. Inspect callers, contracts, tests, and adjacent implementations from the packet before reporting a finding. If a concrete suspected issue needs missing caller, schema, or contract context, request that focused context once. If context remains missing after the extra batch, say so instead of inventing certainty.
+5. Inspect callers, contracts, existing tests/proof, and adjacent implementations from the packet before reporting a finding. If a concrete suspected issue needs missing caller, schema, or contract context, request that focused context once. If context remains missing after the extra batch, say so instead of inventing certainty.
 6. Review mode matters:
    - `full` reviews the whole PR diff.
    - `incremental` reviews only changes since Bunny's last reviewed head.
@@ -70,10 +69,10 @@ One rule: critique code and contracts only. Never personalize or address the aut
 
 ## Review Method
 
-Prioritize correctness, user-visible regressions, security/privacy, architecture boundaries, mode ownership, missing tests, and CI/deployment failures.
+Prioritize correctness, user-visible regressions, security/privacy, architecture boundaries, mode ownership, missing focused proof, and CI/deployment failures.
 
-- Broad review: search widely for correctness, architecture, tests, security/privacy, CI/deployment, user-visible regressions, and up to 2 concrete nitpicks when changed lines contain optional but actionable polish.
-- Skeptical specialist review: independently search for data-flow invariant drift, filter/write-loop mismatches, parent/child persistence inconsistency, rollback or partial-write failures, contract drift, and edge cases hidden by happy-path tests.
+- Broad review: search widely for correctness, architecture, proof, security/privacy, CI/deployment, user-visible regressions, and up to 2 concrete nitpicks when changed lines contain optional but actionable polish.
+- Skeptical specialist review: independently search for data-flow invariant drift, filter/write-loop mismatches, parent/child persistence inconsistency, rollback or partial-write failures, contract drift, and edge cases hidden by happy-path proof.
 - Judge review: merge broad and skeptical outputs, deduplicate, reject weak/speculative findings, normalize severity, and keep every concrete actionable finding found by either pass. Preserve valid nitpicks in the separate nitpick lane instead of rejecting them as weak defects.
 
 Report every actionable code risk you find, not only blockers. Concision must remove repetition, not distinct defects. Use `blocking`, `high`, `medium`, or `low` for defect findings. Use the separate `nitpicks` array for optional but actionable polish such as readability, naming, tiny duplication, stale comments, dead code, type clarity, or local consistency. Low severity means small correctness, proof, or maintainability risk. Nitpick means no behavior risk. Do not invent issues from naming alone. Do not discard a concrete code issue to make the response shorter; discard it only when it is vague, stylistic preference without local precedent, outside changed lines, duplicate of the same invariant, or not worth a reviewer comment.
@@ -100,14 +99,17 @@ Treat these as high-signal Marinara review concerns:
 - Remote-capable behavior that skips the explicit HTTP pipeline.
 - Chat, roleplay, and game mode behavior crossing ownership boundaries.
 - Fake success states, silent catches, broad fallbacks, or UI-only guards over broken contracts.
-- Changes without tests when the touched behavior has realistic regression risk.
+- Changes without focused proof when the touched behavior has realistic regression risk.
+- Suggest durable tests only when:
+  - A known regression or risky silent-break invariant needs a small focused guard.
+  - The owner already has a nearby narrow/stable test pattern that is cheaper than repeated manual proof.
 
 For import, storage, migration, and persistence changes, explicitly check for invariant drift:
 
 - Parent records populated from child rows that are later skipped, filtered, or fail to persist.
 - Pre-scans collecting IDs, metadata, counts, or relationships with looser criteria than the write loop.
 - Message, chat, character, branch, or asset metadata becoming inconsistent after rollback or partial import.
-- Tests that verify linked happy-path rows but miss filtered rows such as empty content, system-only rows, invalid rows, or fallback rows.
+- Proof that verifies linked happy-path rows but misses filtered rows such as empty content, system-only rows, invalid rows, or fallback rows.
 
 ## Output Shape
 
@@ -130,18 +132,10 @@ Use this exact schema:
       "fix_hint": "One corrective action in the same clinical voice.",
       "repair_contract": {
         "invariant": "The invariant the repair must preserve.",
-        "related_failure_paths": [
-          "Adjacent failure path that must be covered."
-        ],
-        "adjacent_traps": [
-          "Near miss that would leave this contract incomplete."
-        ],
-        "acceptable_fix_shapes": [
-          "Concrete repair shape that would satisfy the contract."
-        ],
-        "expected_proof": [
-          "Focused proof expected after repair."
-        ]
+        "related_failure_paths": ["Adjacent failure path that must be covered."],
+        "adjacent_traps": ["Near miss that would leave this contract incomplete."],
+        "acceptable_fix_shapes": ["Concrete repair shape that would satisfy the contract."],
+        "expected_proof": ["Focused proof expected after repair."]
       }
     }
   ],
@@ -156,18 +150,14 @@ Use this exact schema:
   ],
   "pre_merge_checks": [
     {
-      "name": "Tests",
+      "name": "Proof",
       "status": "pass|warn|fail|unknown",
       "type": "Proof Gap|Review Limitation|CI Timing|Non-blocking Coverage",
       "detail": "Concise voiced status or risk."
     }
   ],
-  "open_questions": [
-    "0-2 concise voiced questions or assumptions, if any."
-  ],
-  "what_i_checked": [
-    "3-6 concise voiced notes covering commands, files, contracts, or guidance inspected."
-  ]
+  "open_questions": ["0-2 concise voiced questions or assumptions, if any."],
+  "what_i_checked": ["3-6 concise voiced notes covering commands, files, contracts, or guidance inspected."]
 }
 ```
 

--- a/.github/bunny-review/rules.json
+++ b/.github/bunny-review/rules.json
@@ -6,13 +6,13 @@
     "architecture boundaries",
     "mode ownership",
     "failure paths",
-    "missing regression tests",
+    "missing focused proof",
     "CI and deployment failures"
   ],
   "severity_policy": {
     "blocking": "The PR should not merge because the changed behavior is broken, unsafe, or violates a hard architecture boundary.",
     "high": "A likely production or data-loss regression, security/privacy issue, or serious cross-mode/remote-runtime contract risk.",
-    "medium": "A concrete bug, edge case, maintainability trap, or missing test tied directly to changed behavior.",
+    "medium": "A concrete bug, edge case, maintainability trap, or missing proof tied directly to changed behavior.",
     "low": "A small but actionable correctness, proof, or maintainability risk tied to changed behavior.",
     "nitpick": "Optional changed-line polish with no behavior risk, such as readability, naming, tiny duplication, stale comments, dead code, type clarity, or local consistency."
   },
@@ -30,15 +30,8 @@
   "path_instructions": [
     {
       "name": "Engine and runtime boundaries",
-      "prefixes": [
-        "src/engine/",
-        "src/features/",
-        "src/shared/api/",
-        "src-tauri/"
-      ],
-      "guidance": [
-        "skills/marinara-architecture-guard/SKILL.md"
-      ],
+      "prefixes": ["src/engine/", "src/features/", "src/shared/api/", "src-tauri/"],
+      "guidance": ["skills/marinara-architecture-guard/SKILL.md"],
       "checks": [
         "Engine code stays React-free and does not import feature internals, Tauri APIs, Zustand stores, or concrete shared API adapters.",
         "Feature code uses focused shared API wrappers instead of raw invokeTauri or raw remote-runtime fetch.",
@@ -47,15 +40,8 @@
     },
     {
       "name": "Mode separation",
-      "prefixes": [
-        "src/engine/chat/",
-        "src/engine/roleplay/",
-        "src/engine/game/",
-        "src/features/modes/"
-      ],
-      "guidance": [
-        "skills/marinara-mode-separation/SKILL.md"
-      ],
+      "prefixes": ["src/engine/chat/", "src/engine/roleplay/", "src/engine/game/", "src/features/modes/"],
+      "guidance": ["skills/marinara-mode-separation/SKILL.md"],
       "checks": [
         "Chat, roleplay, and game behavior remain in their owning mode.",
         "Shared generation or prompt changes do not silently alter unrelated modes."
@@ -63,15 +49,8 @@
     },
     {
       "name": "Bug fixes and privileged contracts",
-      "prefixes": [
-        "src-tauri/src/commands/",
-        "src-tauri/src/storage/",
-        "src-tauri/src/providers/",
-        "src/shared/api/"
-      ],
-      "guidance": [
-        "skills/marinara-bugfix-discipline/SKILL.md"
-      ],
+      "prefixes": ["src-tauri/src/commands/", "src-tauri/src/storage/", "src-tauri/src/providers/", "src/shared/api/"],
+      "guidance": ["skills/marinara-bugfix-discipline/SKILL.md"],
       "checks": [
         "Fixes address root causes instead of adding fake success, silent catches, broad fallbacks, or UI-only guards.",
         "Provider, storage, command, and transport changes preserve error contracts and hostable behavior.",
@@ -81,16 +60,8 @@
     },
     {
       "name": "Docs and agent guidance",
-      "prefixes": [
-        "README",
-        "docs/",
-        "skills/",
-        "AGENTS.md",
-        ".github/"
-      ],
-      "guidance": [
-        "skills/marinara-getting-started/SKILL.md"
-      ],
+      "prefixes": ["README", "docs/", "skills/", "AGENTS.md", ".github/"],
+      "guidance": ["skills/marinara-getting-started/SKILL.md"],
       "checks": [
         "Durable feature-area additions update relevant maps or guidance.",
         "Workflow and agent changes remain concrete, testable, and narrow."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,13 @@ Pressure points touched:
 ## Validation
 
 <!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
-<!-- Proof is session evidence, not permission to add durable test artifacts. Unless a maintainer explicitly asked for tests, do not submit new test artifacts in any language as PR proof. Temporary local tests or harnesses are fine when they remain uncommitted; cite their command output or resulting observation here instead. -->
+<!--
+Proof is session evidence, not permission to add durable test artifacts by reflex.
+Temporary local tests or harnesses are fine when they remain uncommitted.
+If this PR adds a committed test artifact, explain the durable test rationale in
+the notes below: the regression or risky invariant, why existing proof is
+insufficient, and why this test is narrow.
+-->
 
 - [ ] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
 - [ ] Full `pnpm check` passes before PR push/handoff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,24 @@
 - Use the tiny local bug path for narrow, low-risk, machine-provable fixes: no full ledger by default, just a short claim/proof/validation/files/risk/vault receipt. Escalate to the full workflow as soon as the bug is nontrivial, PR-affecting, cross-boundary, storage/import/export/prompt/provider/security-sensitive, browser-evidence-dependent, or uncertain.
 - Before local bugfix edits, name only the cheap gate: core claim, likely owner/lane, risk level, and proof target. Broaden the gate only after a hypothesis is falsified or a risk boundary appears.
 - Use the cheapest proof that proves the claim. Prefer static inspection, existing test output, temporary uncommitted tests or harnesses, route/module repros, or jsdom/component proof before Playwright; use browser proof when visual layout, interaction, routing, responsive behavior, screenshots, console/network behavior, or browser-only behavior is the claim.
-- Proof is session evidence, not permission to add durable test artifacts. Unless a maintainer explicitly asks for tests, do not add or submit new test artifacts in any language as PR proof, including `*.test.*`, `*.spec.*`, `tests/`, `__tests__/`, Rust `#[test]` or `#[cfg(test)]` modules, snapshots, fixtures, or committed harness files. Temporary tests and harnesses are allowed when they stay local and uncommitted; cite their command output or resulting observation instead of submitting the artifacts. If a durable regression test is the right engineering answer, ask first and explain why existing proof paths are insufficient.
+- Proof is session evidence, not permission to add durable test artifacts by reflex.
+- Temporary tests and harnesses are allowed when they stay local and uncommitted.
+- Cite their command output or resulting observation instead of submitting the artifacts.
+- New committed test artifacts are allowed only when at least one condition applies:
+  - A maintainer explicitly asks for tests.
+  - The change fixes a known regression that needs a small focused guard.
+  - The behavior is risky and easy to break silently.
+  - The touched area already has a nearby narrow/stable test pattern that is cheaper than repeated manual proof.
+- Before adding a durable test artifact, state `Durable test rationale` with:
+  - The regression or risky invariant.
+  - Why existing proof is insufficient.
+  - Why this test is narrow.
+- Prefer the smallest stable test near the owner:
+  - Pure helper test.
+  - Focused integration test.
+  - Component test.
+  - Browser/e2e only when browser behavior is the claim.
+- Do not add broad fixture suites, snapshots, large e2e tests, or Rust inline tests merely to satisfy proof wording.
 - When available, keep `workflow-health.mjs` for nontrivial Marinara work, PR work, issue selection, and risky workflow changes. Do not spend it on a tiny one-file local bug unless repo policy or visible risk requires it.
 
 ## Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,15 +140,37 @@ unused-code report.
 It does not replace targeted proof when the change needs it, such as existing
 test output, lint, build, size checks, clippy, native Tauri QA, or browser
 checks.
-Proof is session evidence, not permission to add durable test artifacts. Unless
-a maintainer explicitly asks for tests, do not add or submit new test artifacts
-in any language as PR proof, including `*.test.*`, `*.spec.*`, `tests/`,
-`__tests__/`, Rust `#[test]` or `#[cfg(test)]` modules, snapshots, fixtures, or
-committed harness files. Temporary tests and harnesses are allowed when they stay
-local and uncommitted; cite their command output or resulting observation
-instead of submitting the artifacts. If a durable regression test is the right
-engineering answer, ask first and explain why existing proof paths are
-insufficient.
+Proof is session evidence, not permission to add durable test artifacts by
+reflex.
+
+Temporary tests and harnesses are allowed when they stay local and uncommitted.
+Cite their command output or resulting observation instead of submitting the
+artifacts.
+
+New committed test artifacts are allowed only when at least one condition
+applies:
+
+- A maintainer explicitly asks for tests.
+- The change fixes a known regression that needs a small focused guard.
+- The behavior is risky and easy to break silently.
+- The touched area already has a nearby narrow/stable test pattern that is
+  cheaper than repeated manual proof.
+
+Before adding a durable test artifact, state `Durable test rationale` with:
+
+- The regression or risky invariant.
+- Why existing proof is insufficient.
+- Why this test is narrow.
+
+Prefer the smallest stable test near the owner:
+
+- Pure helper test.
+- Focused integration test.
+- Component test.
+- Browser/e2e only when browser behavior is the claim.
+
+Do not add broad fixture suites, snapshots, large e2e tests, or Rust inline
+tests merely to satisfy proof wording.
 
 Leave PR template checkboxes unchecked until a human has actually verified each item. If an AI agent drafts a PR body, treat the checkboxes as a to-do list, not as proof.
 

--- a/skills/bunny-style-review/SKILL.md
+++ b/skills/bunny-style-review/SKILL.md
@@ -16,13 +16,13 @@ Default behavior: review only. Do not edit files, create commits, push branches,
 ## Setup
 
 1. Identify the review surface:
-    - Run `git status --short --branch`, `git diff --stat`, `git diff --numstat`, `git diff --name-only`, and `git diff --check`.
-    - If untracked files exist, run `git ls-files --others --exclude-standard`; classify them as intentional or unrelated.
+   - Run `git status --short --branch`, `git diff --stat`, `git diff --numstat`, `git diff --name-only`, and `git diff --check`.
+   - If untracked files exist, run `git ls-files --others --exclude-standard`; classify them as intentional or unrelated.
 2. For local uncommitted work:
-    - Review staged and unstaged tracked changes from the diff.
-    - Review intentional untracked files directly, since `git diff` does not show their contents until they are staged.
-    - Keep unrelated dirty or untracked files out of scope and name them only if they affect review confidence.
-    - If the user asks for a commit before review, follow the repo workflow for intentional files and protected-branch safety, then review the resulting commit or diff.
+   - Review staged and unstaged tracked changes from the diff.
+   - Review intentional untracked files directly, since `git diff` does not show their contents until they are staged.
+   - Keep unrelated dirty or untracked files out of scope and name them only if they affect review confidence.
+   - If the user asks for a commit before review, follow the repo workflow for intentional files and protected-branch safety, then review the resulting commit or diff.
 3. For PR or committed branch review, identify the base branch and inspect `git diff <base>...HEAD`.
 4. Build the review context stack before deciding findings:
    - Active repo/team rules: root `AGENTS.md`, relevant repo-local skills, `.coderabbit.yaml`, `CLAUDE.md`, `.cursorrules`, GitHub Copilot instructions, or path-scoped docs when present.
@@ -138,6 +138,9 @@ Apply these filters before output:
 - Report only issues with a clear, actionable cause in current code and the diff.
 - Move plausible but unverified concerns to Residual Risk or Open Questions.
 - Make missing-proof findings only when the diff adds meaningful behavior risk, breaks an expected contract, or leaves a realistic regression unproved.
+- Suggest durable tests only when:
+  - A known regression or risky silent-break invariant needs a small focused guard.
+  - The owner already has a nearby narrow/stable test pattern that is cheaper than repeated manual proof.
 - Prefer one root-cause finding over multiple symptom findings; name affected surfaces in the evidence.
 - For repeated local issues, cite the clearest representative line; mention recurrence only when it changes impact or fix scope.
 - Drop speculative findings, pre-existing unrelated issues, and taste-only comments that are not useful nitpicks.

--- a/skills/marinara-agent-workflow/SKILL.md
+++ b/skills/marinara-agent-workflow/SKILL.md
@@ -99,15 +99,37 @@ Playwright/browser proof when visual layout, interaction, routing, responsive
 behavior, screenshots, console/network behavior, or browser-only behavior is the
 claim.
 
-Proof is session evidence, not permission to add durable test artifacts. Unless
-a maintainer explicitly asks for tests, do not add or submit new test artifacts
-in any language as PR proof, including `*.test.*`, `*.spec.*`, `tests/`,
-`__tests__/`, Rust `#[test]` or `#[cfg(test)]` modules, snapshots, fixtures, or
-committed harness files. Temporary tests and harnesses are allowed when they stay
-local and uncommitted; cite their command output or resulting observation
-instead of submitting the artifacts. If a durable regression test is the right
-engineering answer, ask first and explain why existing proof paths are
-insufficient.
+Proof is session evidence, not permission to add durable test artifacts by
+reflex.
+
+Temporary tests and harnesses are allowed when they stay local and uncommitted.
+Cite their command output or resulting observation instead of submitting the
+artifacts.
+
+New committed test artifacts are allowed only when at least one condition
+applies:
+
+- A maintainer explicitly asks for tests.
+- The change fixes a known regression that needs a small focused guard.
+- The behavior is risky and easy to break silently.
+- The touched area already has a nearby narrow/stable test pattern that is
+  cheaper than repeated manual proof.
+
+Before adding a durable test artifact, state `Durable test rationale` with:
+
+- The regression or risky invariant.
+- Why existing proof is insufficient.
+- Why this test is narrow.
+
+Prefer the smallest stable test near the owner:
+
+- Pure helper test.
+- Focused integration test.
+- Component test.
+- Browser/e2e only when browser behavior is the claim.
+
+Do not add broad fixture suites, snapshots, large e2e tests, or Rust inline
+tests merely to satisfy proof wording.
 
 ## Risky Work
 

--- a/skills/marinara-agent-workflow/references/workflows/refactor-handoff.md
+++ b/skills/marinara-agent-workflow/references/workflows/refactor-handoff.md
@@ -35,8 +35,10 @@ behavior:
 
 Each extraction PR must move one pure helper cluster plus focused proof, preserve
 all UI behavior, and avoid broad component rewrites. Use existing tests or
-temporary uncommitted tests/harnesses when useful; do not add durable test
-artifacts unless a maintainer explicitly requested them.
+temporary uncommitted tests/harnesses when useful. Durable tests are acceptable
+when a maintainer requested them, a known regression needs a small focused
+guard, or the owner already has a nearby narrow/stable test pattern that is
+cheaper than repeated manual proof.
 
 ## Blockers Vs Review Notes
 

--- a/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
+++ b/skills/marinara-agent-workflow/references/workflows/review-and-pr.md
@@ -30,15 +30,37 @@ Before push or PR creation:
 such as existing test output, lint, build, size checks, clippy, native Tauri QA,
 or browser checks when the change needs them.
 
-Proof is session evidence, not permission to add durable test artifacts. Unless
-a maintainer explicitly asks for tests, do not add or submit new test artifacts
-in any language as PR proof, including `*.test.*`, `*.spec.*`, `tests/`,
-`__tests__/`, Rust `#[test]` or `#[cfg(test)]` modules, snapshots, fixtures, or
-committed harness files. Temporary tests and harnesses are allowed when they stay
-local and uncommitted; cite their command output or resulting observation
-instead of submitting the artifacts. If a durable regression test is the right
-engineering answer, ask first and explain why existing proof paths are
-insufficient.
+Proof is session evidence, not permission to add durable test artifacts by
+reflex.
+
+Temporary tests and harnesses are allowed when they stay local and uncommitted.
+Cite their command output or resulting observation instead of submitting the
+artifacts.
+
+New committed test artifacts are allowed only when at least one condition
+applies:
+
+- A maintainer explicitly asks for tests.
+- The change fixes a known regression that needs a small focused guard.
+- The behavior is risky and easy to break silently.
+- The touched area already has a nearby narrow/stable test pattern that is
+  cheaper than repeated manual proof.
+
+Before adding a durable test artifact, state `Durable test rationale` with:
+
+- The regression or risky invariant.
+- Why existing proof is insufficient.
+- Why this test is narrow.
+
+Prefer the smallest stable test near the owner:
+
+- Pure helper test.
+- Focused integration test.
+- Component test.
+- Browser/e2e only when browser behavior is the claim.
+
+Do not add broad fixture suites, snapshots, large e2e tests, or Rust inline
+tests merely to satisfy proof wording.
 
 If `pnpm check` fails, do not push or mark the PR ready. Classify the failure as
 in-scope or pre-existing/unrelated, fix in-scope failures, and report unrelated


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

Proof guidance should allow narrow durable test coverage in justified cases without encouraging committed tests as routine proof artifacts.

## What changed

- Added explicit durable-test exception criteria across workflow guidance.
- Required a `Durable test rationale` when committed test artifacts are added.
- Tuned Bunny and Chai review wording toward focused proof instead of reflexive test requests.
- Reformatted dense proof guidance into short, scannable lists.

## Refactor impact

Primary owner:

Workflow guidance and PR review automation.

Impact areas reviewed:

- Root contributor guidance in `AGENTS.md` and `CONTRIBUTING.md`.
- Repo-local workflow cards and review guidance under `skills/`.
- PR template validation notes.
- Bunny reviewer prompt, rule metadata, and review wrapper wording.

Boundary notes:

No engine, shared API, feature UI, Rust capability, or remote-runtime behavior changed.

Pressure points touched:

None. This PR only changes contributor/reviewer guidance and review metadata.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm check:docs`
- `pnpm exec prettier --check --ignore-unknown .github/agents/chai-workflow.md .github/bunny-review/bunny_review.py .github/bunny-review/reviewer-prompt.md .github/bunny-review/rules.json .github/pull_request_template.md AGENTS.md CONTRIBUTING.md skills/bunny-style-review/SKILL.md skills/marinara-agent-workflow/SKILL.md skills/marinara-agent-workflow/references/workflows/refactor-handoff.md skills/marinara-agent-workflow/references/workflows/review-and-pr.md`
- `python -m json.tool .github\bunny-review\rules.json > $null`
- `python -m py_compile .github\bunny-review\bunny_review.py`
- `git diff --check`
- `pnpm check`

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Docs and workflow guidance only; no user-facing app surface changed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated `README.md`
- [x] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [x] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no UI changes.
