### PR TITLE
Harden provider config fetch safety

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tokio",
  "uuid",
 ]
 

--- a/src-tauri/crates/llm/Cargo.toml
+++ b/src-tauri/crates/llm/Cargo.toml
@@ -14,4 +14,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+tokio = { version = "1", features = ["net", "macros", "rt-multi-thread"] }
 uuid = { version = "1", features = ["v5"] }

--- a/src-tauri/crates/llm/src/lib.rs
+++ b/src-tauri/crates/llm/src/lib.rs
@@ -1,12 +1,16 @@
 use futures_util::StreamExt;
 use marinara_core::{AppError, AppResult};
-use marinara_security::{is_allowed_outbound_url, redact_sensitive_json, redact_sensitive_text};
+use marinara_security::{
+    is_allowed_provider_url, is_forbidden_provider_resolved_ip, is_loopback_provider_host,
+    redact_sensitive_json, redact_sensitive_text,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
     collections::BTreeMap,
     env, fs,
     io::Write,
+    net::{IpAddr, SocketAddr},
     path::PathBuf,
     process::{Command, Stdio},
 };
@@ -18,6 +22,8 @@ const OPENAI_CHATGPT_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const APP_VERSION: &str = "1.6.1";
 const CLAUDE_SUBSCRIPTION_1M_SUFFIX: &str = "[1m]";
 const CLAUDE_SUBSCRIPTION_1M_BETA: &str = "context-1m-2025-08-07";
+const PROVIDER_LOCAL_URLS_ENABLED_FLAG: &str = "PROVIDER_LOCAL_URLS_ENABLED";
+const PROVIDER_RESPONSE_MAX_BYTES: usize = 5 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SseBlockStatus {
@@ -377,15 +383,109 @@ fn request_max_tokens(request: &LlmRequest, fallback: u64) -> u64 {
         .unwrap_or(value)
 }
 
-fn ensure_url_allowed(url: &str) -> AppResult<()> {
-    if is_allowed_outbound_url(url, true) {
-        Ok(())
-    } else {
-        Err(AppError::invalid_input(format!(
-            "Outbound URL is not allowed: {}",
-            redact_sensitive_text(url)
-        )))
+fn provider_local_urls_enabled() -> bool {
+    std::env::var(PROVIDER_LOCAL_URLS_ENABLED_FLAG).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+async fn provider_http_client_for_url(url: &str) -> AppResult<reqwest::Client> {
+    let parsed = reqwest::Url::parse(url).map_err(|error| {
+        AppError::invalid_input(format!(
+            "Outbound URL is invalid: {}",
+            redact_sensitive_text(&error.to_string())
+        ))
+    })?;
+    let allow_private_or_reserved = provider_local_urls_enabled();
+    if !is_allowed_provider_url(parsed.as_str(), allow_private_or_reserved) {
+        return Err(provider_url_not_allowed_error(url));
     }
+    let resolved = validate_provider_url_resolution(&parsed, allow_private_or_reserved).await?;
+    provider_http_client(parsed.host_str(), resolved.as_deref())
+}
+
+async fn validate_provider_url_resolution(
+    url: &reqwest::Url,
+    allow_private_or_reserved: bool,
+) -> AppResult<Option<Vec<SocketAddr>>> {
+    if allow_private_or_reserved {
+        return Ok(None);
+    }
+    let Some(host) = url.host_str() else {
+        return Err(provider_url_not_allowed_error(url.as_str()));
+    };
+    if is_loopback_provider_host(host) {
+        return Ok(None);
+    }
+    if let Some(address) = provider_host_ip(host) {
+        if is_forbidden_provider_resolved_ip(address, allow_private_or_reserved) {
+            return Err(provider_url_not_allowed_error(url.as_str()));
+        }
+        return Ok(None);
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addresses = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|error| {
+            AppError::invalid_input(format!(
+                "Outbound URL host '{}' did not resolve: {}",
+                redact_sensitive_text(host),
+                redact_sensitive_text(&error.to_string())
+            ))
+        })?
+        .collect::<Vec<_>>();
+    validate_provider_resolved_addresses(url, allow_private_or_reserved, addresses)
+}
+
+fn validate_provider_resolved_addresses(
+    url: &reqwest::Url,
+    allow_private_or_reserved: bool,
+    addresses: Vec<SocketAddr>,
+) -> AppResult<Option<Vec<SocketAddr>>> {
+    if addresses.is_empty() {
+        Err(AppError::invalid_input(format!(
+            "Outbound URL host '{}' did not resolve",
+            redact_sensitive_text(url.host_str().unwrap_or("<missing>"))
+        )))
+    } else if addresses
+        .iter()
+        .any(|address| is_forbidden_provider_resolved_ip(address.ip(), allow_private_or_reserved))
+    {
+        Err(provider_url_not_allowed_error(url.as_str()))
+    } else {
+        Ok(Some(addresses))
+    }
+}
+
+fn provider_host_ip(host: &str) -> Option<IpAddr> {
+    let unbracketed = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    unbracketed.parse::<IpAddr>().ok()
+}
+
+fn provider_url_not_allowed_error(url: &str) -> AppError {
+    AppError::invalid_input(format!(
+        "Outbound URL points to a private, LAN, metadata, or reserved target: {}. Set {PROVIDER_LOCAL_URLS_ENABLED_FLAG}=true only if you trust that provider target.",
+        redact_sensitive_text(url)
+    ))
+}
+
+fn provider_http_client(
+    host: Option<&str>,
+    resolved_addresses: Option<&[SocketAddr]>,
+) -> AppResult<reqwest::Client> {
+    let mut builder = reqwest::Client::builder().redirect(reqwest::redirect::Policy::none());
+    if let (Some(host), Some(addresses)) = (host, resolved_addresses) {
+        builder = builder.resolve_to_addrs(host, addresses);
+    }
+    builder
+        .build()
+        .map_err(|error| AppError::new("llm_client_error", error.to_string()))
 }
 
 fn provider_transport_error_message(error: impl std::fmt::Display) -> String {
@@ -1449,8 +1549,8 @@ fn openai_chatgpt_auth_is_stale(auth_json: &Value) -> bool {
 }
 
 async fn refresh_openai_chatgpt_auth(refresh_token: &str) -> AppResult<Value> {
-    ensure_url_allowed(OPENAI_CHATGPT_REFRESH_URL)?;
-    let response = reqwest::Client::new()
+    let response = provider_http_client_for_url(OPENAI_CHATGPT_REFRESH_URL)
+        .await?
         .post(OPENAI_CHATGPT_REFRESH_URL)
         .json(&json!({
             "client_id": OPENAI_CHATGPT_CLIENT_ID,
@@ -1643,10 +1743,9 @@ fn build_cohere_body(request: &LlmRequest, stream: bool) -> Value {
 
 async fn complete_cohere_rich(request: LlmRequest) -> AppResult<LlmCompletion> {
     let url = cohere_chat_endpoint(&request.connection.base_url);
-    ensure_url_allowed(&url)?;
     let body = build_cohere_body(&request, false);
     log_prompt_connection_request("cohere.v2.chat", &url, &request, &body);
-    let client = reqwest::Client::new();
+    let client = provider_http_client_for_url(&url).await?;
     let mut req = client.post(url).json(&body);
     if !request.connection.api_key.trim().is_empty() {
         req = req.bearer_auth(request.connection.api_key.trim());
@@ -1662,10 +1761,9 @@ async fn stream_cohere(
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
 ) -> AppResult<()> {
     let url = cohere_chat_endpoint(&request.connection.base_url);
-    ensure_url_allowed(&url)?;
     let body = build_cohere_body(&request, true);
     log_prompt_connection_request("cohere.v2.chat.stream", &url, &request, &body);
-    let client = reqwest::Client::new();
+    let client = provider_http_client_for_url(&url).await?;
     let mut req = client.post(url).json(&body);
     if !request.connection.api_key.trim().is_empty() {
         req = req.bearer_auth(request.connection.api_key.trim());
@@ -1675,7 +1773,7 @@ async fn stream_cohere(
     })?;
     let status = response.status();
     if !status.is_success() {
-        let error_body = response.json::<Value>().await.unwrap_or_else(|_| json!({}));
+        let error_body = read_error_response_details(response).await?;
         return Err(provider_http_error(status, error_body));
     }
 
@@ -1714,7 +1812,6 @@ async fn complete_openai_compatible_rich(request: LlmRequest) -> AppResult<LlmCo
         return complete_openai_responses_rich(request).await;
     }
     let url = openai_compatible_chat_endpoint(&request);
-    ensure_url_allowed(&url)?;
     let messages: Vec<Value> = request_messages(&request)
         .iter()
         .map(openai_message)
@@ -1742,7 +1839,7 @@ async fn complete_openai_compatible_rich(request: LlmRequest) -> AppResult<LlmCo
     }
     apply_openai_parameters(&mut body, &request);
     log_prompt_connection_request("openai.chat.completions", &url, &request, &body);
-    let client = reqwest::Client::new();
+    let client = provider_http_client_for_url(&url).await?;
     let mut req = client.post(url).json(&body);
     if !request.connection.api_key.trim().is_empty() {
         req = req.bearer_auth(request.connection.api_key.trim());
@@ -1763,7 +1860,6 @@ async fn stream_openai_compatible(
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
 ) -> AppResult<()> {
     let url = openai_compatible_chat_endpoint(&request);
-    ensure_url_allowed(&url)?;
     let messages: Vec<Value> = request_messages(&request)
         .iter()
         .map(openai_message)
@@ -1791,7 +1887,7 @@ async fn stream_openai_compatible(
     }
     apply_openai_parameters(&mut body, &request);
     log_prompt_connection_request("openai.chat.completions.stream", &url, &request, &body);
-    let client = reqwest::Client::new();
+    let client = provider_http_client_for_url(&url).await?;
     let mut req = client.post(url).json(&body);
     if !request.connection.api_key.trim().is_empty() {
         req = req.bearer_auth(request.connection.api_key.trim());
@@ -1806,7 +1902,7 @@ async fn stream_openai_compatible(
     })?;
     let status = response.status();
     if !status.is_success() {
-        let error_body = response.json::<Value>().await.unwrap_or_else(|_| json!({}));
+        let error_body = read_error_response_details(response).await?;
         return Err(provider_http_error(status, error_body));
     }
 
@@ -1950,9 +2046,8 @@ async fn openai_responses_request(
 ) -> AppResult<reqwest::Response> {
     let base = base_url(&request.connection.provider, &request.connection.base_url);
     let url = format!("{base}/responses");
-    ensure_url_allowed(&url)?;
     log_prompt_connection_request("openai.responses", &url, request, body);
-    let req = reqwest::Client::new().post(url).json(body);
+    let req = provider_http_client_for_url(&url).await?.post(url).json(body);
     let req = if request.connection.provider == "openai_chatgpt" {
         apply_chatgpt_auth_headers(req).await?
     } else {
@@ -3478,9 +3573,9 @@ async fn anthropic_request(
 ) -> AppResult<reqwest::Response> {
     let base = base_url(&request.connection.provider, &request.connection.base_url);
     let url = anthropic_endpoint(&base, "messages");
-    ensure_url_allowed(&url)?;
     log_prompt_connection_request(kind, &url, request, body);
-    reqwest::Client::new()
+    provider_http_client_for_url(&url)
+        .await?
         .post(url)
         .header("x-api-key", request.connection.api_key.trim())
         .header("anthropic-version", "2023-06-01")
@@ -3891,10 +3986,10 @@ fn google_generate_body(request: &LlmRequest) -> Value {
 
 async fn complete_google(request: LlmRequest) -> AppResult<String> {
     let url = google_endpoint(&request, "generateContent", false);
-    ensure_url_allowed(&url)?;
     let body = google_generate_body(&request);
     log_prompt_connection_request("google.generateContent", &url, &request, &body);
-    let response = reqwest::Client::new()
+    let response = provider_http_client_for_url(&url)
+        .await?
         .post(url)
         .json(&body)
         .send()
@@ -3932,10 +4027,10 @@ async fn stream_google(
     emit: &mut (impl FnMut(Value) -> AppResult<()> + Send),
 ) -> AppResult<()> {
     let url = google_endpoint(&request, "streamGenerateContent", true);
-    ensure_url_allowed(&url)?;
     let body = google_generate_body(&request);
     log_prompt_connection_request("google.streamGenerateContent", &url, &request, &body);
-    let response = reqwest::Client::new()
+    let response = provider_http_client_for_url(&url)
+        .await?
         .post(url)
         .json(&body)
         .send()
@@ -4067,12 +4162,7 @@ fn ensure_google_finish_reason_allows_complete(reason: &str) -> AppResult<()> {
 }
 
 async fn read_error_response_details(response: reqwest::Response) -> AppResult<Value> {
-    let text = response.text().await.map_err(|error| {
-        AppError::new(
-            "llm_response_error",
-            provider_transport_error_message(error),
-        )
-    })?;
+    let text = read_capped_provider_error_text(response).await?;
     Ok(provider_error_details_from_text(&text))
 }
 
@@ -4080,15 +4170,11 @@ async fn read_json_response(
     response: reqwest::Response,
 ) -> AppResult<(reqwest::StatusCode, Value)> {
     let status = response.status();
-    let text = response.text().await.map_err(|error| {
-        AppError::new(
-            "llm_response_error",
-            provider_transport_error_message(error),
-        )
-    })?;
     if !status.is_success() {
+        let text = read_capped_provider_error_text(response).await?;
         return Ok((status, provider_error_details_from_text(&text)));
     }
+    let text = read_limited_provider_text(response).await?;
     let json = serde_json::from_str::<Value>(&text).map_err(|error| {
         AppError::with_details(
             "llm_response_error",
@@ -4097,6 +4183,56 @@ async fn read_json_response(
         )
     })?;
     Ok((status, json))
+}
+
+async fn read_limited_provider_text(mut response: reqwest::Response) -> AppResult<String> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > PROVIDER_RESPONSE_MAX_BYTES as u64)
+    {
+        return Err(provider_response_too_large_error());
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        AppError::new("llm_response_error", provider_transport_error_message(error))
+    })? {
+        if body.len().saturating_add(chunk.len()) > PROVIDER_RESPONSE_MAX_BYTES {
+            return Err(provider_response_too_large_error());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+async fn read_capped_provider_error_text(mut response: reqwest::Response) -> AppResult<String> {
+    let mut body = Vec::new();
+    let mut truncated = false;
+
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        AppError::new("llm_response_error", provider_transport_error_message(error))
+    })? {
+        let remaining = PROVIDER_RESPONSE_MAX_BYTES.saturating_sub(body.len());
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    let mut text = String::from_utf8_lossy(&body).into_owned();
+    if truncated {
+        text.push_str(" [truncated]");
+    }
+    Ok(text)
+}
+
+fn provider_response_too_large_error() -> AppError {
+    AppError::new(
+        "llm_response_error",
+        format!("Provider response exceeds {PROVIDER_RESPONSE_MAX_BYTES} bytes"),
+    )
 }
 
 async fn parse_json_response<F>(response: reqwest::Response, extract: F) -> AppResult<String>
@@ -4331,6 +4467,8 @@ fn normalize_tool_call(call: Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn test_connection() -> LlmConnection {
         LlmConnection {
@@ -4363,6 +4501,102 @@ mod tests {
             parameters,
             tools: Vec::new(),
         }
+    }
+
+    async fn serve_response(
+        status: &'static str,
+        content_type: &'static str,
+        body: Vec<u8>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test LLM server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test LLM server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test LLM server should accept one request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test LLM server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test LLM server should write response headers");
+            stream
+                .write_all(&body)
+                .await
+                .expect("test LLM server should write response body");
+        });
+        format!("http://{address}")
+    }
+
+    async fn serve_chunked_response(
+        status: &'static str,
+        content_type: &'static str,
+        chunks: Vec<Vec<u8>>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test LLM server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test LLM server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test LLM server should accept one request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test LLM server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test LLM server should write response headers");
+            for chunk in chunks {
+                let header = format!("{:x}\r\n", chunk.len());
+                stream
+                    .write_all(header.as_bytes())
+                    .await
+                    .expect("test LLM server should write chunk header");
+                stream
+                    .write_all(&chunk)
+                    .await
+                    .expect("test LLM server should write chunk body");
+                stream
+                    .write_all(b"\r\n")
+                    .await
+                    .expect("test LLM server should write chunk terminator");
+            }
+            stream
+                .write_all(b"0\r\n\r\n")
+                .await
+                .expect("test LLM server should write final chunk");
+        });
+        format!("http://{address}")
+    }
+
+    async fn response_from_url(url: String) -> reqwest::Response {
+        reqwest::Client::new()
+            .get(url)
+            .send()
+            .await
+            .expect("test LLM response should arrive")
     }
 
     #[test]
@@ -4634,14 +4868,72 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
         assert_eq!(body["reasoning"], json!({ "effort": "xhigh" }));
     }
 
-    #[test]
-    fn ensure_url_allowed_redacts_query_secret() {
-        let error = ensure_url_allowed("ftp://example.test/models?key=sk-test-secret")
+    #[tokio::test]
+    async fn provider_http_client_redacts_query_secret() {
+        let error = provider_http_client_for_url("ftp://example.test/models?key=sk-test-secret")
+            .await
             .expect_err("disallowed URL should fail");
 
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("[REDACTED]"));
         assert!(!error.message.contains("sk-test-secret"));
+    }
+
+    #[test]
+    fn provider_http_client_policy_blocks_private_dns_answers() {
+        let url = reqwest::Url::parse("https://public-looking.example.test/v1/chat/completions")
+            .expect("test URL should parse");
+        let error = validate_provider_resolved_addresses(
+            &url,
+            false,
+            vec![
+                "10.0.0.1:443".parse().expect("private address parses"),
+                "[::ffff:10.0.0.1]:443"
+                    .parse()
+                    .expect("mapped private address parses"),
+            ],
+        )
+        .expect_err("private DNS answers should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains(PROVIDER_LOCAL_URLS_ENABLED_FLAG));
+    }
+
+    #[test]
+    fn provider_http_client_policy_blocks_loopback_dns_answers() {
+        let url = reqwest::Url::parse("https://public-looking.example.test/v1/chat/completions")
+            .expect("test URL should parse");
+        let error = validate_provider_resolved_addresses(
+            &url,
+            false,
+            vec![
+                "127.0.0.1:443".parse().expect("loopback address parses"),
+                "[::1]:443".parse().expect("IPv6 loopback address parses"),
+                "[::ffff:127.0.0.1]:443"
+                    .parse()
+                    .expect("mapped loopback address parses"),
+            ],
+        )
+        .expect_err("loopback DNS answers should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains(PROVIDER_LOCAL_URLS_ENABLED_FLAG));
+    }
+
+    #[tokio::test]
+    async fn provider_http_client_policy_keeps_literal_loopback_allowed() {
+        for url in [
+            "http://127.0.0.1:11434/api/chat",
+            "http://localhost:11434/api/chat",
+            "http://[::ffff:127.0.0.1]:11434/api/chat",
+        ] {
+            let url = reqwest::Url::parse(url).expect("test URL should parse");
+            let allowed = validate_provider_url_resolution(&url, false)
+                .await
+                .expect("literal loopback host should keep local provider allowance");
+
+            assert!(allowed.is_none());
+        }
     }
 
     #[test]
@@ -4719,6 +5011,54 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
         assert_eq!(details["api_key"], "[REDACTED]");
         assert_eq!(details["usage"]["input_tokens"], 12);
         assert!(!details.to_string().contains("sk-test-secret"));
+    }
+
+    #[tokio::test]
+    async fn oversized_llm_error_body_preserves_provider_status() {
+        let url = serve_response(
+            "429 Too Many Requests",
+            "text/plain",
+            vec![b'x'; PROVIDER_RESPONSE_MAX_BYTES + 1024],
+        )
+        .await;
+        let response = response_from_url(url).await;
+        let error = parse_json_response(response, |json| Some(json.to_string()))
+            .await
+            .expect_err("oversized provider error should stay status-bearing");
+
+        assert_eq!(error.code, "llm_provider_error");
+        assert!(error
+            .message
+            .contains("Provider returned HTTP 429 Too Many Requests"));
+        assert!(!error.message.contains("exceeds"));
+        assert!(error.message.len() < 700);
+    }
+
+    #[tokio::test]
+    async fn chunked_llm_error_body_is_bounded_redacted_and_status_bearing() {
+        let url = serve_chunked_response(
+            "401 Unauthorized",
+            "text/plain",
+            vec![
+                b"bad key sk-test-secret ".to_vec(),
+                vec![b'x'; PROVIDER_RESPONSE_MAX_BYTES + 1024],
+            ],
+        )
+        .await;
+        let response = response_from_url(url).await;
+        let error_body = read_error_response_details(response)
+            .await
+            .expect("chunked provider error details should read bounded diagnostic");
+        let error = provider_http_error(reqwest::StatusCode::UNAUTHORIZED, error_body);
+
+        assert_eq!(error.code, "llm_provider_error");
+        assert!(error
+            .message
+            .contains("Provider returned HTTP 401 Unauthorized"));
+        assert!(error.message.contains("[REDACTED]"));
+        assert!(!error.message.contains("sk-test-secret"));
+        assert!(!error.message.contains("exceeds"));
+        assert!(error.message.len() < 700);
     }
 
     #[test]

--- a/src-tauri/crates/security/src/lib.rs
+++ b/src-tauri/crates/security/src/lib.rs
@@ -96,17 +96,43 @@ pub fn is_allowed_outbound_url(raw: &str, allow_local: bool) -> bool {
     !is_local_or_reserved_host(host)
 }
 
-fn is_local_or_reserved_host(host: &str) -> bool {
-    let normalized = host
-        .trim()
-        .trim_matches(['[', ']'])
-        .trim_end_matches('.')
-        .to_ascii_lowercase();
+pub fn is_allowed_provider_url(raw: &str, allow_private_or_reserved: bool) -> bool {
+    let Ok(url) = Url::parse(raw) else {
+        return false;
+    };
+    if !matches!(url.scheme(), "http" | "https") {
+        return false;
+    }
+    if allow_private_or_reserved {
+        return true;
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    !is_private_or_reserved_provider_host(host)
+}
+
+fn is_private_or_reserved_provider_host(host: &str) -> bool {
+    let normalized = normalize_host(host);
     if normalized.is_empty()
-        || matches!(
-            normalized.as_str(),
-            "localhost" | "localhost.localdomain" | "ip6-localhost" | "ip6-loopback"
-        )
+        || normalized.ends_with(".local")
+        || normalized.ends_with(".internal")
+        || normalized.ends_with(".onion")
+    {
+        return true;
+    }
+    if is_loopback_host(&normalized) {
+        return false;
+    }
+    normalized
+        .parse::<IpAddr>()
+        .is_ok_and(is_local_or_reserved_ip)
+}
+
+fn is_local_or_reserved_host(host: &str) -> bool {
+    let normalized = normalize_host(host);
+    if normalized.is_empty()
+        || is_loopback_host(&normalized)
         || normalized.ends_with(".localhost")
         || normalized.ends_with(".local")
         || normalized.ends_with(".internal")
@@ -119,11 +145,50 @@ fn is_local_or_reserved_host(host: &str) -> bool {
         .is_ok_and(is_local_or_reserved_ip)
 }
 
+fn normalize_host(host: &str) -> String {
+    host.trim()
+        .trim_matches(['[', ']'])
+        .trim_end_matches('.')
+        .to_ascii_lowercase()
+}
+
+pub fn is_loopback_provider_host(host: &str) -> bool {
+    let normalized = normalize_host(host);
+    is_loopback_host(&normalized)
+}
+
+fn is_loopback_host(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "localhost" | "localhost.localdomain" | "ip6-localhost" | "ip6-loopback"
+    ) || normalized.ends_with(".localhost")
+        || normalized
+            .parse::<IpAddr>()
+            .is_ok_and(is_loopback_ip)
+}
+
+fn is_loopback_ip(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => address.is_loopback(),
+        IpAddr::V6(address) => {
+            address.is_loopback()
+                || embedded_ipv4(address).is_some_and(|address| address.is_loopback())
+        }
+    }
+}
+
 pub fn is_local_or_reserved_ip(address: IpAddr) -> bool {
     match address {
         IpAddr::V4(address) => is_local_or_reserved_ipv4(address),
         IpAddr::V6(address) => is_local_or_reserved_ipv6(address),
     }
+}
+
+pub fn is_forbidden_provider_resolved_ip(
+    address: IpAddr,
+    allow_private_or_reserved: bool,
+) -> bool {
+    !allow_private_or_reserved && is_local_or_reserved_ip(address)
 }
 
 fn is_local_or_reserved_ipv4(address: Ipv4Addr) -> bool {
@@ -464,5 +529,73 @@ mod tests {
         assert!(is_allowed_outbound_url("https://example.com/hook", false));
         assert!(is_allowed_outbound_url("http://example.com/hook", false));
         assert!(!is_allowed_outbound_url("file:///etc/passwd", true));
+    }
+
+    #[test]
+    fn provider_url_policy_allows_loopback_but_blocks_private_without_opt_in() {
+        for url in [
+            "http://localhost:11434/api/tags",
+            "http://localhost./api/tags",
+            "http://127.0.0.1:11434/api/tags",
+            "http://[::1]:11434/api/tags",
+            "http://[::ffff:127.0.0.1]:11434/api/tags",
+        ] {
+            assert!(
+                is_allowed_provider_url(url, false),
+                "provider policy should allow loopback target {url}"
+            );
+        }
+
+        for url in [
+            "http://10.1.2.3/models",
+            "http://172.16.0.5/models",
+            "http://192.168.1.5/models",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[fc00::1]/models",
+            "http://[::ffff:10.0.0.1]/models",
+            "https://hidden-service.onion/models",
+        ] {
+            assert!(
+                !is_allowed_provider_url(url, false),
+                "provider policy should reject private/reserved target {url}"
+            );
+            assert!(
+                is_allowed_provider_url(url, true),
+                "provider local opt-in should accept {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_resolved_ip_policy_blocks_private_metadata_and_mapped_addresses() {
+        for address in [
+            "10.0.0.1",
+            "169.254.169.254",
+            "127.0.0.1",
+            "::1",
+            "fc00::1",
+            "::ffff:10.0.0.1",
+            "::ffff:127.0.0.1",
+        ] {
+            let address = address
+                .parse::<IpAddr>()
+                .expect("test address should parse");
+            assert!(
+                is_forbidden_provider_resolved_ip(address, false),
+                "provider policy should reject resolved target {address}"
+            );
+            assert!(
+                !is_forbidden_provider_resolved_ip(address, true),
+                "provider local opt-in should accept resolved target {address}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_literal_loopback_policy_covers_mapped_ipv6() {
+        assert!(is_loopback_provider_host("127.0.0.1"));
+        assert!(is_loopback_provider_host("[::1]"));
+        assert!(is_loopback_provider_host("[::ffff:127.0.0.1]"));
+        assert!(!is_loopback_provider_host("[::ffff:10.0.0.1]"));
     }
 }

--- a/src-tauri/src/commands/storage/images/providers.rs
+++ b/src-tauri/src/commands/storage/images/providers.rs
@@ -20,6 +20,9 @@ const DEFAULT_RUNPOD_BASE_URL: &str = "https://api.runpod.ai/v2";
 const DEFAULT_GOOGLE_IMAGE_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 const NOVELAI_V4_PROMPT_HINT: &str = "NovelAI V4/V4.5 prompts support roughly 512 T5 tokens and reject most Unicode prompt characters; try a shorter ASCII prompt without emoji or non-Latin text.";
 const NOVELAI_V4_PROMPT_CHAR_LIMIT: usize = 1800;
+const IMAGE_PROVIDER_ERROR_MAX_BYTES: usize = 256 * 1024;
+const IMAGE_PROVIDER_JSON_ENVELOPE_MAX_BYTES: usize = 48 * 1024 * 1024;
+const IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES: usize = 32 * 1024 * 1024;
 const COMFYUI_PLACEHOLDER_REFERENCE_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
@@ -440,10 +443,8 @@ fn bearer(request: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBu
 
 async fn response_json(response: reqwest::Response, provider: &str) -> AppResult<Value> {
     let status = response.status();
-    let text = response.text().await.map_err(|error| {
-        AppError::new("image_response_error", image_transport_error_message(error))
-    })?;
     if !status.is_success() {
+        let text = read_capped_error_body(response).await?;
         return Err(AppError::new(
             "image_provider_error",
             format!(
@@ -452,7 +453,9 @@ async fn response_json(response: reqwest::Response, provider: &str) -> AppResult
             ),
         ));
     }
-    serde_json::from_str::<Value>(&text).map_err(|error| {
+    let bytes =
+        read_limited_response_bytes(response, IMAGE_PROVIDER_JSON_ENVELOPE_MAX_BYTES).await?;
+    serde_json::from_slice::<Value>(&bytes).map_err(|error| {
         AppError::new(
             "image_response_error",
             format!("{provider} returned invalid JSON: {error}"),
@@ -471,11 +474,8 @@ async fn image_response_base64(
         .and_then(|value| value.to_str().ok())
         .unwrap_or("image/png")
         .to_string();
-    let bytes = response.bytes().await.map_err(|error| {
-        AppError::new("image_response_error", image_transport_error_message(error))
-    })?;
     if !status.is_success() {
-        let text = String::from_utf8_lossy(&bytes);
+        let text = read_capped_error_body(response).await?;
         return Err(AppError::new(
             "image_provider_error",
             format!(
@@ -484,6 +484,7 @@ async fn image_response_base64(
             ),
         ));
     }
+    let bytes = read_limited_response_bytes(response, IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES).await?;
     Ok((general_purpose::STANDARD.encode(bytes), content_type))
 }
 
@@ -513,6 +514,35 @@ fn strip_data_url(value: &str) -> (&str, &str) {
         }
     }
     (value, "image/png")
+}
+
+fn ensure_base64_image_within_limit(base64: &str) -> AppResult<()> {
+    let normalized_len = base64
+        .as_bytes()
+        .iter()
+        .filter(|byte| !byte.is_ascii_whitespace())
+        .count();
+    let padding = base64
+        .trim_end()
+        .as_bytes()
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'=')
+        .count()
+        .min(2);
+    let decoded_len = normalized_len.saturating_mul(3) / 4;
+    let decoded_len = decoded_len.saturating_sub(padding);
+    if decoded_len > IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES {
+        return Err(image_response_too_large_error(
+            IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES,
+        ));
+    }
+    Ok(())
+}
+
+fn validated_base64_image(base64: &str, mime: &str) -> AppResult<(String, String)> {
+    ensure_base64_image_within_limit(base64)?;
+    Ok((base64.to_string(), mime.to_string()))
 }
 
 fn detect_image_mime_type(bytes: &[u8]) -> &'static str {
@@ -610,15 +640,8 @@ async fn response_bytes(
         .and_then(|value| value.to_str().ok())
         .unwrap_or("application/octet-stream")
         .to_string();
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|error| {
-            AppError::new("image_response_error", image_transport_error_message(error))
-        })?
-        .to_vec();
     if !status.is_success() {
-        let text = String::from_utf8_lossy(&bytes);
+        let text = read_capped_error_body(response).await?;
         return Err(AppError::new(
             "image_provider_error",
             format!(
@@ -627,7 +650,61 @@ async fn response_bytes(
             ),
         ));
     }
+    let bytes = read_limited_response_bytes(response, IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES).await?;
     Ok((bytes, content_type))
+}
+
+async fn read_limited_response_bytes(
+    mut response: reqwest::Response,
+    max_bytes: usize,
+) -> AppResult<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(image_response_too_large_error(max_bytes));
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        AppError::new("image_response_error", image_transport_error_message(error))
+    })? {
+        if body.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(image_response_too_large_error(max_bytes));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+async fn read_capped_error_body(mut response: reqwest::Response) -> AppResult<String> {
+    let mut body = Vec::new();
+    let mut truncated = false;
+
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        AppError::new("image_response_error", image_transport_error_message(error))
+    })? {
+        let remaining = IMAGE_PROVIDER_ERROR_MAX_BYTES.saturating_sub(body.len());
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    let mut text = String::from_utf8_lossy(&body).into_owned();
+    if truncated {
+        text.push_str(" [truncated]");
+    }
+    Ok(text)
+}
+
+fn image_response_too_large_error(max_bytes: usize) -> AppError {
+    AppError::new(
+        "image_response_error",
+        format!("Image provider response exceeds {max_bytes} bytes"),
+    )
 }
 
 async fn fetch_image_url(client: &reqwest::Client, url: &str) -> AppResult<(String, String)> {
@@ -719,7 +796,7 @@ async fn generate_openai_compatible_image(
             AppError::new("image_network_error", image_transport_error_message(error))
         })?;
         let json = response_json(response, source).await?;
-        return parse_image_json(&client, &json).await.ok_or_else(|| {
+        return parse_image_json(&client, &json).await?.ok_or_else(|| {
             AppError::new(
                 "image_response_error",
                 format!("{source} returned no image data"),
@@ -762,7 +839,7 @@ async fn generate_openai_compatible_image(
     .await
     .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, source).await?;
-    parse_image_json(&client, &json).await.ok_or_else(|| {
+    parse_image_json(&client, &json).await?.ok_or_else(|| {
         AppError::new(
             "image_response_error",
             format!("{source} returned no image data"),
@@ -876,7 +953,7 @@ async fn generate_xai(
     .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "xai").await?;
     parse_image_json(&client, &json)
-        .await
+        .await?
         .ok_or_else(|| AppError::new("image_response_error", "xAI returned no image data"))
 }
 
@@ -1009,7 +1086,7 @@ async fn generate_nanogpt_image(
     .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "nanogpt").await?;
     parse_image_json(&client, &json)
-        .await
+        .await?
         .ok_or_else(|| AppError::new("image_response_error", "NanoGPT returned no image data"))
 }
 
@@ -1055,7 +1132,7 @@ async fn generate_together_image(
     .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, "togetherai").await?;
     parse_image_json(&client, &json)
-        .await
+        .await?
         .ok_or_else(|| AppError::new("image_response_error", "Together AI returned no image data"))
 }
 
@@ -1104,7 +1181,7 @@ async fn generate_chat_image(
     .await
     .map_err(|error| AppError::new("image_network_error", image_transport_error_message(error)))?;
     let json = response_json(response, &source).await?;
-    parse_image_json(&client, &json).await.ok_or_else(|| {
+    parse_image_json(&client, &json).await?.ok_or_else(|| {
         AppError::new(
             "image_response_error",
             format!("{source} returned no image data"),
@@ -1175,7 +1252,7 @@ async fn generate_google_image(
                 AppError::new("image_network_error", image_transport_error_message(error))
             })?;
         let json = response_json(response, GOOGLE_IMAGE_PROVIDER).await?;
-        return parse_google_predict_image(&json).ok_or_else(|| {
+        return parse_google_predict_image(&json)?.ok_or_else(|| {
             AppError::new(
                 "image_response_error",
                 "Google Imagen returned no image data",
@@ -1216,7 +1293,7 @@ async fn generate_google_image(
             AppError::new("image_network_error", image_transport_error_message(error))
         })?;
     let json = response_json(response, GOOGLE_IMAGE_PROVIDER).await?;
-    parse_google_generate_content_image(&json).ok_or_else(|| {
+    parse_google_generate_content_image(&json)?.ok_or_else(|| {
         // No inline image part — surface why (e.g. a SAFETY block or a text-only reply)
         // instead of a generic message, since Gemini returns 200 OK in these cases.
         let reason = json
@@ -1284,8 +1361,13 @@ fn closest_google_aspect_ratio(width: u64, height: u64) -> &'static str {
     .unwrap_or("1:1")
 }
 
-fn parse_google_generate_content_image(json: &Value) -> Option<(String, String)> {
-    let parts = json.pointer("/candidates/0/content/parts")?.as_array()?;
+fn parse_google_generate_content_image(json: &Value) -> AppResult<Option<(String, String)>> {
+    let Some(parts) = json
+        .pointer("/candidates/0/content/parts")
+        .and_then(Value::as_array)
+    else {
+        return Ok(None);
+    };
     for part in parts {
         // v1beta REST emits camelCase, but accept snake_case defensively.
         for key in ["inlineData", "inline_data"] {
@@ -1303,25 +1385,30 @@ fn parse_google_generate_content_image(json: &Value) -> Option<(String, String)>
                     .and_then(Value::as_str)
                     .unwrap_or("image/png")
                     .to_string();
-                return Some((data.to_string(), mime));
+                return validated_base64_image(data, &mime).map(Some);
             }
         }
     }
-    None
+    Ok(None)
 }
 
-fn parse_google_predict_image(json: &Value) -> Option<(String, String)> {
-    let prediction = json.pointer("/predictions/0")?;
-    let data = prediction
+fn parse_google_predict_image(json: &Value) -> AppResult<Option<(String, String)>> {
+    let Some(prediction) = json.pointer("/predictions/0") else {
+        return Ok(None);
+    };
+    let Some(data) = prediction
         .get("bytesBase64Encoded")
         .and_then(Value::as_str)
-        .filter(|value| !value.is_empty())?;
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
     let mime = prediction
         .get("mimeType")
         .and_then(Value::as_str)
         .unwrap_or("image/png")
         .to_string();
-    Some((data.to_string(), mime))
+    validated_base64_image(data, &mime).map(Some)
 }
 
 /// Imagen only accepts a fixed set of aspect ratios; snap the requested
@@ -1372,13 +1459,16 @@ fn chat_completions_url(base: &str) -> String {
     format!("{trimmed}/chat/completions")
 }
 
-async fn parse_image_json(client: &reqwest::Client, json: &Value) -> Option<(String, String)> {
+async fn parse_image_json(
+    client: &reqwest::Client,
+    json: &Value,
+) -> AppResult<Option<(String, String)>> {
     if let Some(base64) = json
         .pointer("/data/0/b64_json")
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
     {
-        return Some((base64.to_string(), "image/png".to_string()));
+        return validated_base64_image(base64, "image/png").map(Some);
     }
     if let Some(url) = json
         .pointer("/data/0/url")
@@ -1387,20 +1477,20 @@ async fn parse_image_json(client: &reqwest::Client, json: &Value) -> Option<(Str
     {
         if url.starts_with("data:image/") {
             let (base64, mime) = strip_data_url(url);
-            return Some((base64.to_string(), mime.to_string()));
+            return validated_base64_image(base64, mime).map(Some);
         }
-        return fetch_image_url(client, url).await.ok();
+        return fetch_image_url(client, url).await.map(Some);
     }
     if let Some(value) = find_image_string(json) {
         if value.starts_with("data:image/") {
             let (base64, mime) = strip_data_url(value);
-            return Some((base64.to_string(), mime.to_string()));
+            return validated_base64_image(base64, mime).map(Some);
         }
         if is_http_image_url(value) {
-            return fetch_image_url(client, value).await.ok();
+            return fetch_image_url(client, value).await.map(Some);
         }
     }
-    None
+    Ok(None)
 }
 
 fn find_image_string(value: &Value) -> Option<&str> {
@@ -1721,7 +1811,7 @@ async fn generate_stability_v1(
                 .find_map(|item| item.get("base64").and_then(Value::as_str))
         })
         .ok_or_else(|| AppError::new("image_response_error", "Stability returned no image data"))?;
-    Ok((base64.to_string(), "image/png".to_string()))
+    validated_base64_image(base64, "image/png")
 }
 
 fn stability_url(base: &str, target_path: &str) -> String {
@@ -2444,9 +2534,9 @@ fn extract_runpod_image(status: &Value) -> AppResult<(String, String)> {
         if let Some(value) = candidate {
             if value.starts_with("data:") {
                 let (base64, mime) = strip_data_url(value);
-                return Ok((base64.to_string(), mime.to_string()));
+                return validated_base64_image(base64, mime);
             }
-            return Ok((value.to_string(), detect_base64_mime_type(value)));
+            return validated_base64_image(value, &detect_base64_mime_type(value));
         }
     }
     Err(AppError::new(
@@ -2669,8 +2759,20 @@ async fn parse_novelai_image_response(
                 continue;
             }
             let mut image = Vec::new();
-            file.read_to_end(&mut image)
+            if file.size() > IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES as u64 {
+                return Err(image_response_too_large_error(
+                    IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES,
+                ));
+            }
+            let mut limited = (&mut file).take((IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES as u64) + 1);
+            limited
+                .read_to_end(&mut image)
                 .map_err(|error| AppError::new("image_response_error", error.to_string()))?;
+            if image.len() > IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES {
+                return Err(image_response_too_large_error(
+                    IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES,
+                ));
+            }
             let mime = detect_image_mime_type(&image).to_string();
             return Ok((general_purpose::STANDARD.encode(image), mime));
         }
@@ -2683,7 +2785,7 @@ async fn parse_novelai_image_response(
         return Ok((general_purpose::STANDARD.encode(bytes), mime));
     }
     if let Ok(json) = serde_json::from_slice::<Value>(&bytes) {
-        if let Some(result) = parse_image_json(client, &json).await {
+        if let Some(result) = parse_image_json(client, &json).await? {
             return Ok(result);
         }
         if let Some(error) = image_provider_json_error(&json) {
@@ -2717,6 +2819,7 @@ fn find_comfyui_image<'a>(history: &'a Value, prompt_id: &str) -> Option<&'a Val
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -2834,6 +2937,121 @@ mod tests {
         (format!("http://{address}"), handle)
     }
 
+    async fn serve_bytes_response(
+        status: &'static str,
+        content_type: &'static str,
+        body: Vec<u8>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test image server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test image server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test image server should accept one request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test image server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test image server should write response headers");
+            stream
+                .write_all(&body)
+                .await
+                .expect("test image server should write response body");
+        });
+        format!("http://{address}")
+    }
+
+    async fn serve_chunked_response(
+        status: &'static str,
+        content_type: &'static str,
+        chunks: Vec<Vec<u8>>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test image server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test image server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test image server should accept one request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test image server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test image server should write response headers");
+            for chunk in chunks {
+                let header = format!("{:x}\r\n", chunk.len());
+                stream
+                    .write_all(header.as_bytes())
+                    .await
+                    .expect("test image server should write chunk header");
+                stream
+                    .write_all(&chunk)
+                    .await
+                    .expect("test image server should write chunk body");
+                stream
+                    .write_all(b"\r\n")
+                    .await
+                    .expect("test image server should write chunk terminator");
+            }
+            stream
+                .write_all(b"0\r\n\r\n")
+                .await
+                .expect("test image server should write final chunk");
+        });
+        format!("http://{address}")
+    }
+
+    async fn response_from_body(
+        status: &'static str,
+        content_type: &'static str,
+        body: Vec<u8>,
+    ) -> reqwest::Response {
+        let url = serve_bytes_response(status, content_type, body).await;
+        http_client(1)
+            .expect("client should build")
+            .get(url)
+            .send()
+            .await
+            .expect("test image response should arrive")
+    }
+
+    fn zip_with_image(name: &str, image: &[u8]) -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        writer
+            .start_file(
+                name,
+                zip::write::SimpleFileOptions::default()
+                    .compression_method(zip::CompressionMethod::Deflated),
+            )
+            .expect("zip entry should start");
+        writer.write_all(image).expect("zip image should write");
+        writer.finish().expect("zip should finish").into_inner()
+    }
+
     #[test]
     fn image_provider_error_sanitizer_redacts_secrets() {
         let sanitized = sanitize_error(
@@ -2844,6 +3062,240 @@ mod tests {
         assert!(sanitized.contains("[REDACTED_URL]"));
         assert!(!sanitized.contains("sk-test-secret"));
         assert!(!sanitized.contains("retrieve/session"));
+    }
+
+    #[tokio::test]
+    async fn image_provider_response_body_is_capped() {
+        let response = response_from_body(
+            "500 Internal Server Error",
+            "text/plain",
+            vec![b'x'; IMAGE_PROVIDER_ERROR_MAX_BYTES + 1024],
+        )
+        .await;
+
+        let error = response_json(response, "test-provider")
+            .await
+            .expect_err("oversized image provider error should stay status-bearing");
+
+        assert_eq!(error.code, "image_provider_error");
+        assert!(error
+            .message
+            .contains("test-provider returned HTTP 500 Internal Server Error"));
+        assert!(!error.message.contains("exceeds"));
+        assert!(error.message.len() < 600);
+    }
+
+    #[tokio::test]
+    async fn image_provider_chunked_error_body_is_bounded_status_bearing() {
+        let url = serve_chunked_response(
+            "502 Bad Gateway",
+            "text/html",
+            vec![
+                b"<html>bad upstream sk-test-secret ".to_vec(),
+                vec![b'x'; IMAGE_PROVIDER_ERROR_MAX_BYTES + 1024],
+            ],
+        )
+        .await;
+        let response = http_client(1)
+            .expect("client should build")
+            .get(url)
+            .send()
+            .await
+            .expect("chunked test image response should arrive");
+        let error = image_response_base64(response, "chunked-provider")
+            .await
+            .expect_err("chunked oversized error should stay status-bearing");
+
+        assert_eq!(error.code, "image_provider_error");
+        assert!(error
+            .message
+            .contains("chunked-provider returned HTTP 502 Bad Gateway"));
+        assert!(error.message.contains("[REDACTED]"));
+        assert!(!error.message.contains("sk-test-secret"));
+        assert!(!error.message.contains("exceeds"));
+        assert!(error.message.len() < 600);
+    }
+
+    #[tokio::test]
+    async fn image_json_base64_envelope_can_exceed_legacy_five_mib_cap() {
+        let mut image = vec![0_u8; 6 * 1024 * 1024];
+        image[..8].copy_from_slice(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']);
+        let base64 = general_purpose::STANDARD.encode(&image);
+        let body = format!(r#"{{"data":[{{"b64_json":"{base64}"}}]}}"#);
+        assert!(body.len() > 5 * 1024 * 1024);
+        let response = response_from_body("200 OK", "application/json", body.into_bytes()).await;
+        let json = response_json(response, "test-provider")
+            .await
+            .expect("large JSON envelope should parse within envelope cap");
+        let result = parse_image_json(&http_client(1).expect("client should build"), &json)
+            .await
+            .expect("decoded image should be within raw image cap")
+            .expect("image data should be found");
+
+        assert_eq!(result.0, base64);
+    }
+
+    #[tokio::test]
+    async fn direct_binary_image_can_exceed_legacy_five_mib_cap() {
+        let mut image = vec![0_u8; 6 * 1024 * 1024];
+        image[..8].copy_from_slice(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']);
+        let response = response_from_body("200 OK", "image/png", image).await;
+        let (base64, mime) = image_response_base64(response, "test-provider")
+            .await
+            .expect("raw image within product cap should succeed");
+
+        assert_eq!(mime, "image/png");
+        assert!(base64.len() > 5 * 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn image_json_decoded_image_over_raw_cap_is_rejected() {
+        let image = vec![0_u8; IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES + 1];
+        let base64 = general_purpose::STANDARD.encode(&image);
+        let json = json!({ "data": [{ "b64_json": base64 }] });
+
+        let error = parse_image_json(&http_client(1).expect("client should build"), &json)
+            .await
+            .expect_err("decoded image above raw cap should fail");
+
+        assert_eq!(error.code, "image_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[test]
+    fn google_inline_data_rejects_decoded_image_over_raw_cap() {
+        let base64 =
+            general_purpose::STANDARD.encode(vec![0_u8; IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES + 1]);
+        let json = json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "inlineData": { "mimeType": "image/png", "data": base64 }
+                    }]
+                }
+            }]
+        });
+        let error = parse_google_generate_content_image(&json)
+            .expect_err("oversized Gemini inline data should fail");
+
+        assert_eq!(error.code, "image_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[test]
+    fn google_inline_data_accepts_image_within_raw_cap() {
+        let base64 = general_purpose::STANDARD.encode(vec![0_u8; 1024]);
+        let json = json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "inlineData": { "mimeType": "image/png", "data": base64 }
+                    }]
+                }
+            }]
+        });
+        let result = parse_google_generate_content_image(&json)
+            .expect("Gemini inline data should parse")
+            .expect("Gemini inline image should exist");
+
+        assert_eq!(result.1, "image/png");
+    }
+
+    #[test]
+    fn google_predict_rejects_decoded_image_over_raw_cap() {
+        let base64 =
+            general_purpose::STANDARD.encode(vec![0_u8; IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES + 1]);
+        let json = json!({
+            "predictions": [{
+                "bytesBase64Encoded": base64,
+                "mimeType": "image/png"
+            }]
+        });
+        let error = parse_google_predict_image(&json)
+            .expect_err("oversized Imagen inline data should fail");
+
+        assert_eq!(error.code, "image_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn image_json_explicit_url_reports_oversized_fetch_error() {
+        let url = serve_bytes_response(
+            "200 OK",
+            "image/png",
+            vec![0_u8; IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES + 1],
+        )
+        .await;
+        let json = json!({ "data": [{ "url": url }] });
+        let error = parse_image_json(&http_client(1).expect("client should build"), &json)
+            .await
+            .expect_err("oversized fetched image should surface");
+
+        assert_eq!(error.code, "image_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn image_json_nested_url_reports_oversized_fetch_error() {
+        let url = format!(
+            "{}/image.png",
+            serve_bytes_response(
+                "200 OK",
+                "image/png",
+                vec![0_u8; IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES + 1],
+            )
+            .await
+        );
+        let json = json!({ "message": format!("image at {url}") });
+        let error = parse_image_json(&http_client(1).expect("client should build"), &json)
+            .await
+            .expect_err("oversized nested fetched image should surface");
+
+        assert_eq!(error.code, "image_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn image_json_explicit_url_success_still_returns_image() {
+        let mut image = vec![0_u8; 1024];
+        image[..8].copy_from_slice(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']);
+        let url = serve_bytes_response("200 OK", "image/png", image).await;
+        let json = json!({ "data": [{ "url": url }] });
+        let result = parse_image_json(&http_client(1).expect("client should build"), &json)
+            .await
+            .expect("image URL fetch should succeed")
+            .expect("image URL should return image data");
+
+        assert_eq!(result.1, "image/png");
+    }
+
+    #[tokio::test]
+    async fn novelai_zip_entry_over_raw_cap_is_rejected_before_base64() {
+        let client = http_client(1).expect("client should build");
+        let archive = zip_with_image(
+            "image.png",
+            &vec![0_u8; IMAGE_PROVIDER_RAW_IMAGE_MAX_BYTES + 1],
+        );
+        assert!(archive.len() < IMAGE_PROVIDER_JSON_ENVELOPE_MAX_BYTES);
+        let error = parse_novelai_image_response(&client, archive, "application/zip")
+            .await
+            .expect_err("oversized zipped image should fail");
+
+        assert_eq!(error.code, "image_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn novelai_zip_small_png_still_parses() {
+        let client = http_client(1).expect("client should build");
+        let mut image = vec![0_u8; 1024];
+        image[..8].copy_from_slice(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']);
+        let archive = zip_with_image("image.png", &image);
+        let (_base64, mime) = parse_novelai_image_response(&client, archive, "application/zip")
+            .await
+            .expect("small zipped image should parse");
+
+        assert_eq!(mime, "image/png");
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/llm.rs
+++ b/src-tauri/src/commands/storage/llm.rs
@@ -1,6 +1,14 @@
 use super::prompts;
 use super::*;
-use marinara_security::{is_allowed_outbound_url, redact_sensitive_text};
+use marinara_security::{
+    is_allowed_provider_url, is_forbidden_provider_resolved_ip, is_loopback_provider_host,
+    redact_sensitive_text,
+};
+use std::net::{IpAddr, SocketAddr};
+
+const PROVIDER_LOCAL_URLS_ENABLED_FLAG: &str = "PROVIDER_LOCAL_URLS_ENABLED";
+const IMAGE_LOCAL_URLS_ENABLED_FLAG: &str = "IMAGE_LOCAL_URLS_ENABLED";
+const PROVIDER_CONFIG_MAX_RESPONSE_BYTES: usize = 5 * 1024 * 1024;
 
 pub(crate) fn resolve_llm_connection_for_request(
     state: &AppState,
@@ -492,15 +500,15 @@ async fn check_openrouter_key(connection: &Value) -> AppResult<String> {
     let api_key = connection_api_key(connection)?;
     let base = connection_base_url(connection);
     let url = format!("{}/key", base.trim_end_matches('/'));
-    ensure_model_url_allowed(&url)?;
-    let client = connection_test_client()?;
-    let request = client
-        .get(&url)
-        .header("accept", "application/json")
-        .bearer_auth(api_key)
-        .header("HTTP-Referer", "https://marinara.local")
-        .header("X-Title", "Marinara Engine");
-    let json = send_connection_test_request(request, "OpenRouter").await?;
+    let policy = provider_url_policy_for_connection(connection);
+    let json = send_connection_test_get(&url, policy, "OpenRouter", |request| {
+        request
+            .header("accept", "application/json")
+            .bearer_auth(&api_key)
+            .header("HTTP-Referer", "https://marinara.local")
+            .header("X-Title", "Marinara Engine")
+    })
+    .await?;
     let remaining = json
         .pointer("/data/limit_remaining")
         .and_then(Value::as_f64)
@@ -537,21 +545,22 @@ async fn check_image_generation_connection(connection: &Value) -> AppResult<Stri
         }
         "horde" => {
             let url = build_horde_url(&base, "status/heartbeat");
-            ensure_model_url_allowed(&url)?;
+            let policy = provider_url_policy_for_connection(connection);
             let api_key = connection_api_key_optional(connection);
-            let request = connection_test_client()?
-                .get(&url)
-                .header("accept", "application/json")
-                .header(
-                    "apikey",
-                    if api_key.trim().is_empty() {
-                        "0000000000"
-                    } else {
-                        api_key.trim()
-                    },
-                )
-                .header("Client-Agent", "Marinara-Engine");
-            send_connection_test_request(request, "Stable Horde").await?;
+            send_connection_test_get(&url, policy, "Stable Horde", |request| {
+                request
+                    .header("accept", "application/json")
+                    .header(
+                        "apikey",
+                        if api_key.trim().is_empty() {
+                            "0000000000"
+                        } else {
+                            api_key.trim()
+                        },
+                    )
+                    .header("Client-Agent", "Marinara-Engine")
+            })
+            .await?;
             Ok("Stable Horde endpoint is reachable.".to_string())
         }
         "stability" => {
@@ -585,25 +594,27 @@ async fn check_image_generation_connection(connection: &Value) -> AppResult<Stri
 async fn check_openrouter_key_for_base(connection: &Value, base: &str) -> AppResult<String> {
     let api_key = connection_api_key(connection)?;
     let url = format!("{}/key", base.trim_end_matches('/'));
-    ensure_model_url_allowed(&url)?;
-    let request = connection_test_client()?
-        .get(&url)
-        .header("accept", "application/json")
-        .bearer_auth(api_key)
-        .header("HTTP-Referer", "https://marinara.local")
-        .header("X-Title", "Marinara Engine");
-    send_connection_test_request(request, "OpenRouter").await?;
+    let policy = provider_url_policy_for_connection(connection);
+    send_connection_test_get(&url, policy, "OpenRouter", |request| {
+        request
+            .header("accept", "application/json")
+            .bearer_auth(&api_key)
+            .header("HTTP-Referer", "https://marinara.local")
+            .header("X-Title", "Marinara Engine")
+    })
+    .await?;
     Ok("OpenRouter API key is valid.".to_string())
 }
 
 async fn check_bearer_get(url: &str, connection: &Value, label: &str) -> AppResult<Value> {
     let api_key = connection_api_key(connection)?;
-    ensure_model_url_allowed(url)?;
-    let request = connection_test_client()?
-        .get(url)
-        .header("accept", "application/json")
-        .bearer_auth(api_key);
-    send_connection_test_request(request, label).await
+    let policy = provider_url_policy_for_connection(connection);
+    send_connection_test_get(url, policy, label, |request| {
+        request
+            .header("accept", "application/json")
+            .bearer_auth(&api_key)
+    })
+    .await
 }
 
 /// Like `check_bearer_get`, but authenticates with Google's `x-goog-api-key`
@@ -611,42 +622,55 @@ async fn check_bearer_get(url: &str, connection: &Value, label: &str) -> AppResu
 /// "Expected OAuth 2 access token" error, so the API key must travel this way.
 async fn check_google_api_key_get(url: &str, connection: &Value, label: &str) -> AppResult<Value> {
     let api_key = connection_api_key(connection)?;
-    ensure_model_url_allowed(url)?;
-    let request = connection_test_client()?
-        .get(url)
-        .header("accept", "application/json")
-        .header("x-goog-api-key", api_key);
-    send_connection_test_request(request, label).await
+    let policy = provider_url_policy_for_connection(connection);
+    send_connection_test_get(url, policy, label, |request| {
+        request
+            .header("accept", "application/json")
+            .header("x-goog-api-key", &api_key)
+    })
+    .await
 }
 
 async fn check_optional_bearer_get(url: &str, connection: &Value, label: &str) -> AppResult<Value> {
-    ensure_model_url_allowed(url)?;
-    let mut request = connection_test_client()?
-        .get(url)
-        .header("accept", "application/json");
+    let policy = provider_url_policy_for_connection(connection);
     let api_key = connection_api_key_optional(connection);
-    if !api_key.trim().is_empty() {
-        request = request.bearer_auth(api_key.trim().to_string());
-    }
-    send_connection_test_request(request, label).await
+    send_connection_test_get(url, policy, label, |request| {
+        let request = request.header("accept", "application/json");
+        if api_key.trim().is_empty() {
+            request
+        } else {
+            request.bearer_auth(api_key.trim())
+        }
+    })
+    .await
 }
 
-async fn send_connection_test_request(
-    request: reqwest::RequestBuilder,
+async fn send_connection_test_get(
+    url: &str,
+    policy: ProviderUrlPolicy,
+    label: &str,
+    configure: impl Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+) -> AppResult<Value> {
+    let response = send_provider_get(
+        url,
+        policy,
+        Duration::from_secs(30),
+        "connection_client_error",
+        "connection_network_error",
+        "connection_redirect_error",
+        configure,
+    )
+    .await?;
+    read_connection_test_response(response, label).await
+}
+
+async fn read_connection_test_response(
+    response: reqwest::Response,
     label: &str,
 ) -> AppResult<Value> {
-    let response = request.send().await.map_err(|error| {
-        AppError::new(
-            "connection_network_error",
-            provider_transport_error_message(error),
-        )
-    })?;
     let status = response.status();
-    let text = response
-        .text()
-        .await
-        .map_err(|error| AppError::new("connection_response_error", error.to_string()))?;
     if !status.is_success() {
+        let text = read_capped_provider_error_text(response, "connection_response_error").await?;
         return Err(AppError::new(
             "connection_provider_error",
             format!(
@@ -655,14 +679,66 @@ async fn send_connection_test_request(
             ),
         ));
     }
+    let text = read_limited_provider_text(response, "connection_response_error").await?;
     Ok(serde_json::from_str::<Value>(&text).unwrap_or(Value::Null))
 }
 
-fn connection_test_client() -> AppResult<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|error| AppError::new("connection_client_error", error.to_string()))
+async fn send_provider_get(
+    url: &str,
+    policy: ProviderUrlPolicy,
+    timeout: Duration,
+    client_error_code: &str,
+    network_error_code: &str,
+    redirect_error_code: &str,
+    configure: impl Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+) -> AppResult<reqwest::Response> {
+    let mut current_url = reqwest::Url::parse(url).map_err(|error| {
+        AppError::invalid_input(format!("Outbound model URL is invalid: {error}"))
+    })?;
+    let original_url = current_url.clone();
+    for redirect_count in 0..=10 {
+        let allow_loopback = redirect_count == 0 || same_origin(&original_url, &current_url);
+        let resolved =
+            ensure_model_url_allowed(current_url.as_str(), policy, allow_loopback).await?;
+        let client = provider_http_client(
+            timeout,
+            client_error_code,
+            current_url.host_str(),
+            resolved.as_deref(),
+        )?;
+        let request = client.get(current_url.clone());
+        let request = if same_origin(&original_url, &current_url) {
+            configure(request)
+        } else {
+            request
+        };
+        let response = request.send().await.map_err(|error| {
+            AppError::new(network_error_code, provider_transport_error_message(error))
+        })?;
+        let status = response.status();
+        if !(status.is_redirection() && response.headers().contains_key(reqwest::header::LOCATION))
+        {
+            return Ok(response);
+        }
+        if redirect_count == 10 {
+            return Err(AppError::new(
+                redirect_error_code,
+                "Outbound request exceeded redirect limit",
+            ));
+        }
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(|| AppError::new(redirect_error_code, "Provider redirect is invalid"))?;
+        current_url = current_url
+            .join(location)
+            .map_err(|error| AppError::new(redirect_error_code, error.to_string()))?;
+    }
+    Err(AppError::new(
+        redirect_error_code,
+        "Outbound request exceeded redirect limit",
+    ))
 }
 
 fn connection_api_key(connection: &Value) -> AppResult<String> {
@@ -882,38 +958,37 @@ async fn fetch_provider_models(connection: &Value) -> AppResult<Vec<Value>> {
         return Ok(provider_model_catalog(provider));
     }
     let url = model_endpoint(provider, &base, connection);
-    ensure_model_url_allowed(&url)?;
-    let mut request = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|error| AppError::new("models_client_error", error.to_string()))?
-        .get(url)
-        .header("accept", "application/json");
+    let policy = provider_url_policy_for_connection(connection);
     let api_key = connection
         .get("apiKey")
         .and_then(Value::as_str)
         .unwrap_or("")
         .trim()
         .to_string();
-    if provider == "anthropic" {
-        request = request
-            .header("x-api-key", api_key)
-            .header("anthropic-version", "2023-06-01");
-    } else if !api_key.is_empty() && provider != "google" {
-        request = request.bearer_auth(api_key);
-    }
-    let response = request.send().await.map_err(|error| {
-        AppError::new(
-            "models_network_error",
-            provider_transport_error_message(error),
-        )
-    })?;
+    let response = send_provider_get(
+        &url,
+        policy,
+        Duration::from_secs(30),
+        "models_client_error",
+        "models_network_error",
+        "models_redirect_error",
+        |request| {
+            let request = request.header("accept", "application/json");
+            if provider == "anthropic" {
+                request
+                    .header("x-api-key", &api_key)
+                    .header("anthropic-version", "2023-06-01")
+            } else if !api_key.is_empty() && provider != "google" {
+                request.bearer_auth(&api_key)
+            } else {
+                request
+            }
+        },
+    )
+    .await?;
     let status = response.status();
-    let text = response
-        .text()
-        .await
-        .map_err(|error| AppError::new("models_response_error", error.to_string()))?;
     if !status.is_success() {
+        let text = read_capped_provider_error_text(response, "models_response_error").await?;
         return Err(AppError::new(
             "models_provider_error",
             format!(
@@ -922,6 +997,7 @@ async fn fetch_provider_models(connection: &Value) -> AppResult<Vec<Value>> {
             ),
         ));
     }
+    let text = read_limited_provider_text(response, "models_response_error").await?;
     let json = serde_json::from_str::<Value>(&text)
         .map_err(|error| AppError::new("models_json_error", error.to_string()))?;
     Ok(normalize_models_response(provider, &json))
@@ -930,22 +1006,30 @@ async fn fetch_provider_models(connection: &Value) -> AppResult<Vec<Value>> {
 async fn fetch_ollama_models(connection: &Value) -> AppResult<Vec<Value>> {
     let base = connection_base_url(connection);
     let url = format!("{base}/api/tags");
-    ensure_model_url_allowed(&url)?;
-    let json = reqwest::Client::builder()
-        .timeout(Duration::from_secs(15))
-        .build()
-        .map_err(|error| AppError::new("models_client_error", error.to_string()))?
-        .get(url)
-        .send()
-        .await
-        .map_err(|error| {
-            AppError::new(
-                "models_network_error",
-                provider_transport_error_message(error),
-            )
-        })?
-        .json::<Value>()
-        .await
+    let policy = provider_url_policy_for_connection(connection);
+    let response = send_provider_get(
+        &url,
+        policy,
+        Duration::from_secs(15),
+        "models_client_error",
+        "models_network_error",
+        "models_redirect_error",
+        |request| request,
+    )
+    .await?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = read_capped_provider_error_text(response, "models_response_error").await?;
+        return Err(AppError::new(
+            "models_provider_error",
+            format!(
+                "Ollama returned HTTP {status}: {}",
+                sanitize_provider_body(&text)
+            ),
+        ));
+    }
+    let text = read_limited_provider_text(response, "models_response_error").await?;
+    let json = serde_json::from_str::<Value>(&text)
         .map_err(|error| AppError::new("models_json_error", error.to_string()))?;
     Ok(json
         .get("models")
@@ -1066,32 +1150,33 @@ async fn fetch_json_models<F>(
 where
     F: Fn(&Value) -> Vec<Value>,
 {
-    ensure_model_url_allowed(url)?;
-    let mut request = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .map_err(|error| AppError::new("models_client_error", error.to_string()))?
-        .get(url)
-        .header("accept", "application/json");
-    if let Some(api_key) = connection
+    let policy = provider_url_policy_for_connection(connection);
+    let api_key = connection
         .get("apiKey")
         .and_then(Value::as_str)
-        .filter(|key| !key.trim().is_empty())
-    {
-        request = request.bearer_auth(api_key.trim());
-    }
-    let response = request.send().await.map_err(|error| {
-        AppError::new(
-            "models_network_error",
-            provider_transport_error_message(error),
-        )
-    })?;
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string);
+    let response = send_provider_get(
+        url,
+        policy,
+        Duration::from_secs(30),
+        "models_client_error",
+        "models_network_error",
+        "models_redirect_error",
+        |request| {
+            let request = request.header("accept", "application/json");
+            if let Some(api_key) = api_key.as_deref() {
+                request.bearer_auth(api_key)
+            } else {
+                request
+            }
+        },
+    )
+    .await?;
     let status = response.status();
-    let text = response
-        .text()
-        .await
-        .map_err(|error| AppError::new("models_response_error", error.to_string()))?;
     if !status.is_success() {
+        let text = read_capped_provider_error_text(response, "models_response_error").await?;
         return Err(AppError::new(
             "models_provider_error",
             format!(
@@ -1100,6 +1185,7 @@ where
             ),
         ));
     }
+    let text = read_limited_provider_text(response, "models_response_error").await?;
     let json = serde_json::from_str::<Value>(&text)
         .map_err(|error| AppError::new("models_json_error", error.to_string()))?;
     Ok(normalize(&json))
@@ -1384,15 +1470,221 @@ fn provider_default_base_url(provider: &str) -> &'static str {
     }
 }
 
-fn ensure_model_url_allowed(url: &str) -> AppResult<()> {
-    if is_allowed_outbound_url(url, true) {
-        Ok(())
-    } else {
-        Err(AppError::invalid_input(format!(
-            "Outbound model URL is not allowed: {}",
-            redact_sensitive_text(url)
-        )))
+#[derive(Clone, Copy)]
+struct ProviderUrlPolicy {
+    allow_private_or_reserved: bool,
+    flag_name: &'static str,
+}
+
+fn provider_url_policy_for_connection(connection: &Value) -> ProviderUrlPolicy {
+    let provider = connection
+        .get("provider")
+        .and_then(Value::as_str)
+        .unwrap_or("openai");
+    if provider == "image_generation" {
+        let source = super::images::image_generation_source(connection);
+        let is_local_image_backend =
+            matches!(source.as_str(), "comfyui" | "automatic1111" | "drawthings");
+        return ProviderUrlPolicy {
+            allow_private_or_reserved: is_local_image_backend
+                || local_url_flag_enabled(IMAGE_LOCAL_URLS_ENABLED_FLAG),
+            flag_name: IMAGE_LOCAL_URLS_ENABLED_FLAG,
+        };
     }
+    ProviderUrlPolicy {
+        allow_private_or_reserved: local_url_flag_enabled(PROVIDER_LOCAL_URLS_ENABLED_FLAG),
+        flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+    }
+}
+
+fn local_url_flag_enabled(flag_name: &str) -> bool {
+    std::env::var(flag_name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+async fn ensure_model_url_allowed(
+    url: &str,
+    policy: ProviderUrlPolicy,
+    allow_loopback: bool,
+) -> AppResult<Option<Vec<SocketAddr>>> {
+    let parsed = reqwest::Url::parse(url).map_err(|error| {
+        AppError::invalid_input(format!(
+            "Outbound model URL is invalid: {}",
+            redact_sensitive_text(&error.to_string())
+        ))
+    })?;
+    if !is_allowed_provider_url(parsed.as_str(), policy.allow_private_or_reserved) {
+        return Err(provider_url_not_allowed_error(url, policy.flag_name));
+    }
+    validate_model_url_resolution(&parsed, policy, allow_loopback).await
+}
+
+async fn validate_model_url_resolution(
+    url: &reqwest::Url,
+    policy: ProviderUrlPolicy,
+    allow_loopback: bool,
+) -> AppResult<Option<Vec<SocketAddr>>> {
+    if policy.allow_private_or_reserved {
+        return Ok(None);
+    }
+    let Some(host) = url.host_str() else {
+        return Err(provider_url_not_allowed_error(
+            url.as_str(),
+            policy.flag_name,
+        ));
+    };
+    if allow_loopback && is_loopback_provider_host(host) {
+        return Ok(None);
+    }
+    if let Some(address) = provider_host_ip(host) {
+        if is_forbidden_provider_resolved_ip(address, policy.allow_private_or_reserved) {
+            return Err(provider_url_not_allowed_error(
+                url.as_str(),
+                policy.flag_name,
+            ));
+        }
+        return Ok(None);
+    }
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addresses = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|error| {
+            AppError::invalid_input(format!(
+                "Outbound model URL host '{}' did not resolve: {}",
+                redact_sensitive_text(host),
+                redact_sensitive_text(&error.to_string())
+            ))
+        })?;
+    let validated_addresses = addresses.collect::<Vec<_>>();
+    validate_provider_resolved_addresses(url, policy, validated_addresses)
+}
+
+fn validate_provider_resolved_addresses(
+    url: &reqwest::Url,
+    policy: ProviderUrlPolicy,
+    addresses: Vec<SocketAddr>,
+) -> AppResult<Option<Vec<SocketAddr>>> {
+    if addresses.is_empty() {
+        Err(AppError::invalid_input(format!(
+            "Outbound model URL host '{}' did not resolve",
+            redact_sensitive_text(url.host_str().unwrap_or("<missing>"))
+        )))
+    } else if addresses.iter().any(|address| {
+        is_forbidden_provider_resolved_ip(address.ip(), policy.allow_private_or_reserved)
+    }) {
+        Err(provider_url_not_allowed_error(
+            url.as_str(),
+            policy.flag_name,
+        ))
+    } else {
+        Ok(Some(addresses))
+    }
+}
+
+fn provider_host_ip(host: &str) -> Option<IpAddr> {
+    let unbracketed = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    unbracketed.parse::<IpAddr>().ok()
+}
+
+fn same_origin(left: &reqwest::Url, right: &reqwest::Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str().map(str::to_ascii_lowercase)
+            == right.host_str().map(str::to_ascii_lowercase)
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn provider_url_not_allowed_error(url: &str, flag_name: &str) -> AppError {
+    AppError::invalid_input(format!(
+        "Outbound model URL points to a private, LAN, metadata, or reserved target: {}. Set {flag_name}=true only if you trust that provider target.",
+        redact_sensitive_text(url)
+    ))
+}
+
+fn provider_http_client(
+    timeout: Duration,
+    error_code: &str,
+    host: Option<&str>,
+    resolved_addresses: Option<&[SocketAddr]>,
+) -> AppResult<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none());
+    if let (Some(host), Some(addresses)) = (host, resolved_addresses) {
+        builder = builder.resolve_to_addrs(host, addresses);
+    }
+    builder
+        .build()
+        .map_err(|error| AppError::new(error_code, error.to_string()))
+}
+
+async fn read_limited_provider_text(
+    mut response: reqwest::Response,
+    error_code: &str,
+) -> AppResult<String> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > PROVIDER_CONFIG_MAX_RESPONSE_BYTES as u64)
+    {
+        return Err(provider_response_too_large_error(error_code));
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| AppError::new(error_code, provider_transport_error_message(error)))?
+    {
+        if body.len().saturating_add(chunk.len()) > PROVIDER_CONFIG_MAX_RESPONSE_BYTES {
+            return Err(provider_response_too_large_error(error_code));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
+async fn read_capped_provider_error_text(
+    mut response: reqwest::Response,
+    error_code: &str,
+) -> AppResult<String> {
+    let mut body = Vec::new();
+    let mut truncated = false;
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| AppError::new(error_code, provider_transport_error_message(error)))?
+    {
+        let remaining = PROVIDER_CONFIG_MAX_RESPONSE_BYTES.saturating_sub(body.len());
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    let mut text = String::from_utf8_lossy(&body).into_owned();
+    if truncated {
+        text.push_str(" [truncated]");
+    }
+    Ok(text)
+}
+
+fn provider_response_too_large_error(error_code: &str) -> AppError {
+    AppError::new(
+        error_code,
+        format!(
+            "Provider response exceeds {} bytes",
+            PROVIDER_CONFIG_MAX_RESPONSE_BYTES
+        ),
+    )
 }
 
 fn provider_transport_error_message(error: impl std::fmt::Display) -> String {
@@ -1412,6 +1704,10 @@ fn sanitize_provider_body(body: &str) -> String {
 mod tests {
     use super::*;
     use crate::state::AppState;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -1428,7 +1724,8 @@ mod tests {
         AppState::from_data_dir(path, Vec::new()).expect("test app state should initialize")
     }
 
-    async fn serve_model_failure(status: &'static str, body: &'static str) -> String {
+    async fn serve_model_failure(status: &'static str, body: impl Into<String>) -> String {
+        let body = body.into();
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("test model server should bind");
@@ -1453,6 +1750,78 @@ mod tests {
                 .write_all(response.as_bytes())
                 .await
                 .expect("test model server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    async fn serve_chunked_failure(status: &'static str, chunks: Vec<Vec<u8>>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read request");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write response headers");
+            for chunk in chunks {
+                let header = format!("{:x}\r\n", chunk.len());
+                stream
+                    .write_all(header.as_bytes())
+                    .await
+                    .expect("test model server should write chunk header");
+                stream
+                    .write_all(&chunk)
+                    .await
+                    .expect("test model server should write chunk body");
+                stream
+                    .write_all(b"\r\n")
+                    .await
+                    .expect("test model server should write chunk terminator");
+            }
+            stream
+                .write_all(b"0\r\n\r\n")
+                .await
+                .expect("test model server should write final chunk");
+        });
+        format!("http://{address}/v1")
+    }
+
+    async fn serve_redirect_loop(location: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buffer = [0_u8; 2048];
+                    let _ = stream.read(&mut buffer).await;
+                    let response = format!(
+                        "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
         });
         format!("http://{address}/v1")
     }
@@ -1494,6 +1863,158 @@ mod tests {
                 .expect("test model server should write response");
         });
         format!("http://{address}")
+    }
+
+    async fn serve_model_redirect(location: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read request");
+            let response = format!(
+                "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    async fn serve_model_success(body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept one request");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read request");
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write response");
+        });
+        format!("http://{address}/v1")
+    }
+
+    async fn serve_recording_target() -> (String, Arc<AtomicBool>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        let contacted = Arc::new(AtomicBool::new(false));
+        let contacted_for_task = Arc::clone(&contacted);
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                contacted_for_task.store(true, Ordering::SeqCst);
+                let response =
+                    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}";
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+        (format!("http://{address}/blocked"), contacted)
+    }
+
+    async fn serve_request_recording_target() -> (String, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept one request");
+            let mut buffer = [0_u8; 4096];
+            let read = stream
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read request");
+            let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}";
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write response");
+            String::from_utf8_lossy(&buffer[..read]).to_string()
+        });
+        (format!("http://{address}/redirected"), handle)
+    }
+
+    async fn serve_same_origin_authenticated_redirect() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test model server should bind");
+        let address = listener
+            .local_addr()
+            .expect("test model server address should be readable");
+        tokio::spawn(async move {
+            let (mut first, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept redirect request");
+            let mut buffer = [0_u8; 2048];
+            let _ = first
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read redirect request");
+            first
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: /v1/models2\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .expect("test model server should write redirect");
+
+            let (mut second, _) = listener
+                .accept()
+                .await
+                .expect("test model server should accept follow-up request");
+            let mut buffer = [0_u8; 4096];
+            let read = second
+                .read(&mut buffer)
+                .await
+                .expect("test model server should read follow-up request");
+            let request = String::from_utf8_lossy(&buffer[..read]).to_ascii_lowercase();
+            assert!(request.contains("\r\nauthorization: bearer sk-test-key\r\n"));
+            let body = r#"{"data":[{"id":"same-origin-model"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            second
+                .write_all(response.as_bytes())
+                .await
+                .expect("test model server should write model body");
+        });
+        format!("http://{address}/v1/models")
     }
 
     #[test]
@@ -1596,15 +2117,312 @@ mod tests {
         );
     }
 
-    #[test]
-    fn model_url_rejection_redacts_query_secret() {
-        let error =
-            ensure_model_url_allowed("ftp://example.test/v1beta/models?key=AIzaSecretValue123")
-                .expect_err("disallowed model URL should fail");
+    #[tokio::test]
+    async fn model_url_rejection_redacts_query_secret() {
+        let error = ensure_model_url_allowed(
+            "ftp://example.test/v1beta/models?key=AIzaSecretValue123",
+            ProviderUrlPolicy {
+                allow_private_or_reserved: false,
+                flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+            },
+            true,
+        )
+        .await
+        .expect_err("disallowed model URL should fail");
 
         assert_eq!(error.code, "invalid_input");
         assert!(error.message.contains("[REDACTED]"));
         assert!(!error.message.contains("AIzaSecretValue123"));
+    }
+
+    #[tokio::test]
+    async fn provider_model_url_policy_allows_loopback_but_blocks_private_targets() {
+        let policy = ProviderUrlPolicy {
+            allow_private_or_reserved: false,
+            flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+        };
+
+        for url in [
+            "http://127.0.0.1:11434/api/tags",
+            "http://localhost:11434/api/tags",
+            "http://[::ffff:127.0.0.1]:11434/api/tags",
+        ] {
+            ensure_model_url_allowed(url, policy, true)
+                .await
+                .expect("loopback provider URL should remain allowed");
+        }
+        let error =
+            ensure_model_url_allowed("http://169.254.169.254/latest/meta-data", policy, true)
+                .await
+                .expect_err("metadata target should be blocked without provider opt-in");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains(PROVIDER_LOCAL_URLS_ENABLED_FLAG));
+        assert!(error.message.contains("private"));
+    }
+
+    #[tokio::test]
+    async fn provider_model_url_policy_blocks_private_dns_answers() {
+        let policy = ProviderUrlPolicy {
+            allow_private_or_reserved: false,
+            flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+        };
+        let url = reqwest::Url::parse("https://public-looking.example.test/v1/models")
+            .expect("test URL should parse");
+        let error = validate_provider_resolved_addresses(
+            &url,
+            policy,
+            vec![
+                "10.0.0.1:443".parse().expect("private address parses"),
+                "[::ffff:10.0.0.1]:443"
+                    .parse()
+                    .expect("mapped private address parses"),
+            ],
+        )
+        .expect_err("private DNS answers should be rejected");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains(PROVIDER_LOCAL_URLS_ENABLED_FLAG));
+    }
+
+    #[tokio::test]
+    async fn provider_model_url_policy_blocks_public_host_resolving_to_loopback() {
+        let policy = ProviderUrlPolicy {
+            allow_private_or_reserved: false,
+            flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+        };
+        let url = reqwest::Url::parse("https://public-looking.example.test/v1/models")
+            .expect("test URL should parse");
+        let error = validate_provider_resolved_addresses(
+            &url,
+            policy,
+            vec![
+                "127.0.0.1:443".parse().expect("loopback address parses"),
+                "[::1]:443".parse().expect("IPv6 loopback address parses"),
+                "[::ffff:127.0.0.1]:443"
+                    .parse()
+                    .expect("mapped loopback address parses"),
+            ],
+        )
+        .expect_err("loopback DNS answers should be rejected for public-looking hosts");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains(PROVIDER_LOCAL_URLS_ENABLED_FLAG));
+    }
+
+    #[tokio::test]
+    async fn provider_config_success_response_body_is_capped() {
+        let body = "x".repeat(PROVIDER_CONFIG_MAX_RESPONSE_BYTES + 1);
+        let base_url = serve_model_failure("200 OK", body).await;
+        let error = fetch_provider_models(&json!({
+            "provider": "openai",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "gpt-custom"
+        }))
+        .await
+        .expect_err("oversized successful model lookup response should fail");
+
+        assert_eq!(error.code, "models_response_error");
+        assert!(error.message.contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn oversized_provider_config_error_preserves_status() {
+        let body = "x".repeat(PROVIDER_CONFIG_MAX_RESPONSE_BYTES + 1024);
+        let base_url = serve_model_failure("500 Internal Server Error", body).await;
+        let error = fetch_provider_models(&json!({
+            "provider": "openai",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "gpt-custom"
+        }))
+        .await
+        .expect_err("oversized model lookup error should stay status-bearing");
+
+        assert_eq!(error.code, "models_provider_error");
+        assert!(error
+            .message
+            .contains("Provider returned HTTP 500 Internal Server Error"));
+        assert!(!error.message.contains("exceeds"));
+        assert!(error.message.len() < 600);
+    }
+
+    #[tokio::test]
+    async fn chunked_connection_error_is_bounded_sanitized_and_status_bearing() {
+        let base_url = serve_chunked_failure(
+            "429 Too Many Requests",
+            vec![
+                b"rate limited sk-test-secret ".to_vec(),
+                vec![b'x'; PROVIDER_CONFIG_MAX_RESPONSE_BYTES + 1024],
+            ],
+        )
+        .await;
+        let error = check_connection_without_generation(&json!({
+            "provider": "image_generation",
+            "baseUrl": base_url,
+            "imageGenerationSource": "pollinations",
+            "apiKey": "sk-test-key",
+            "model": "test-image-model"
+        }))
+        .await
+        .expect_err("chunked connection error should stay status-bearing");
+
+        assert_eq!(error.code, "connection_provider_error");
+        assert!(error
+            .message
+            .contains("Pollinations returned HTTP 429 Too Many Requests"));
+        assert!(error.message.contains("[REDACTED]"));
+        assert!(!error.message.contains("sk-test-secret"));
+        assert!(!error.message.contains("exceeds"));
+        assert!(error.message.len() < 600);
+    }
+
+    #[tokio::test]
+    async fn connection_redirect_limit_uses_connection_error_code() {
+        let base_url = serve_redirect_loop("/v1/key").await;
+        let error = check_connection_without_generation(&json!({
+            "provider": "openrouter",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "openai/gpt-4o-mini"
+        }))
+        .await
+        .expect_err("connection redirect loop should fail");
+
+        assert_eq!(error.code, "connection_redirect_error");
+        assert!(error.message.contains("redirect limit"));
+    }
+
+    #[tokio::test]
+    async fn model_redirect_limit_keeps_models_error_code() {
+        let base_url = serve_redirect_loop("/v1/models").await;
+        let error = fetch_provider_models(&json!({
+            "provider": "openai",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "gpt-custom"
+        }))
+        .await
+        .expect_err("model redirect loop should fail");
+
+        assert_eq!(error.code, "models_redirect_error");
+        assert!(error.message.contains("redirect limit"));
+    }
+
+    #[tokio::test]
+    async fn provider_model_redirect_revalidates_private_target() {
+        let base_url = serve_model_redirect("http://169.254.169.254/latest/meta-data").await;
+        let error = fetch_provider_models(&json!({
+            "provider": "openai",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "gpt-custom"
+        }))
+        .await
+        .expect_err("private redirect target should be blocked before follow");
+
+        assert_eq!(error.code, "invalid_input");
+        assert!(error.message.contains(PROVIDER_LOCAL_URLS_ENABLED_FLAG));
+    }
+
+    #[tokio::test]
+    async fn provider_model_redirect_rejects_loopback_before_contacting_target() {
+        let (target_url, contacted) = serve_recording_target().await;
+        let target_url: &'static str = Box::leak(target_url.into_boxed_str());
+        let base_url = serve_model_redirect(target_url).await;
+        let error = fetch_provider_models(&json!({
+            "provider": "openai",
+            "baseUrl": base_url,
+            "apiKey": "sk-test-key",
+            "model": "gpt-custom"
+        }))
+        .await
+        .expect_err("loopback redirect target should be blocked before follow");
+
+        assert_eq!(error.code, "invalid_input");
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!contacted.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn provider_model_redirect_allows_loopback_when_local_opt_in_allows_it() {
+        let target_url = serve_model_success(r#"{"data":[{"id":"redirected-model"}]}"#).await;
+        let target_url: &'static str = Box::leak(target_url.into_boxed_str());
+        let base_url = serve_model_redirect(target_url).await;
+        let response = send_provider_get(
+            &base_url,
+            ProviderUrlPolicy {
+                allow_private_or_reserved: true,
+                flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+            },
+            Duration::from_secs(5),
+            "models_client_error",
+            "models_network_error",
+            "models_redirect_error",
+            |request| request,
+        )
+        .await
+        .expect("local image provider opt-in should allow redirect through manual loop");
+
+        assert!(response.status().is_success());
+        let text = read_limited_provider_text(response, "models_response_error")
+            .await
+            .expect("redirect response body should read");
+        assert!(text.contains("redirected-model"));
+    }
+
+    #[tokio::test]
+    async fn provider_model_redirect_strips_credentials_on_cross_origin_follow() {
+        let (target_url, target_request) = serve_request_recording_target().await;
+        let target_url: &'static str = Box::leak(target_url.into_boxed_str());
+        let base_url = serve_model_redirect(target_url).await;
+        let response = send_provider_get(
+            &base_url,
+            ProviderUrlPolicy {
+                allow_private_or_reserved: true,
+                flag_name: PROVIDER_LOCAL_URLS_ENABLED_FLAG,
+            },
+            Duration::from_secs(5),
+            "models_client_error",
+            "models_network_error",
+            "models_redirect_error",
+            |request| {
+                request
+                    .header("accept", "application/json")
+                    .header("authorization", "Bearer sk-test-key")
+                    .header("x-api-key", "sk-test-key")
+                    .header("x-goog-api-key", "AIzaSecretValue")
+                    .header("apikey", "horde-secret")
+            },
+        )
+        .await
+        .expect("cross-origin redirect target is network-allowed");
+
+        assert!(response.status().is_success());
+        let request = target_request
+            .await
+            .expect("target request should be captured")
+            .to_ascii_lowercase();
+        assert!(!request.contains("\r\nauthorization:"));
+        assert!(!request.contains("\r\nx-api-key:"));
+        assert!(!request.contains("\r\nx-goog-api-key:"));
+        assert!(!request.contains("\r\napikey:"));
+    }
+
+    #[tokio::test]
+    async fn provider_model_redirect_keeps_credentials_on_same_origin_follow() {
+        let base_url = serve_same_origin_authenticated_redirect().await;
+        let models = fetch_provider_models(&json!({
+            "provider": "openai",
+            "baseUrl": base_url.trim_end_matches("/v1/models"),
+            "apiKey": "sk-test-key",
+            "model": "same-origin-model"
+        }))
+        .await
+        .expect("same-origin redirect should retain model auth");
+
+        assert_eq!(models[0]["id"], "same-origin-model");
     }
 
     #[test]


### PR DESCRIPTION
## Linked issue

Closes #2390

## Why this change

Surface `10-CONN-ERROR-config-url-and-provider-error-safety` from #2384 regressed from legacy connection safety: refactor config/model/test fetches treated all local/private HTTP(S) targets as allowed and read provider error bodies fully before truncating or sanitizing.

## What changed

- Added a provider URL policy that allows loopback provider targets by default while blocking private, LAN, metadata, mDNS/internal/onion, and reserved targets unless the provider/image local URL opt-in is explicit.
- Routed connection model/test GETs through a policy-aware redirect loop that revalidates each redirect target before following it.
- Added bounded 5 MiB response readers before parsing or sanitizing model/test, LLM provider, and image provider responses.
- Kept provider error sanitization/redaction behavior while preventing oversized HTML/error bodies from being buffered first.

## Refactor impact

Primary owner:

Rust storage/provider transport and security capability helpers.

Impact areas reviewed:

- `src-tauri/src/commands/storage/llm.rs` connection auth/model list paths
- `src-tauri/crates/security/src/lib.rs` outbound/provider URL policy helpers
- `src-tauri/crates/llm/src/lib.rs` provider transport error/body reads
- `src-tauri/src/commands/storage/images/providers.rs` image provider response parsing

Boundary notes:

Rust-only change. No React UI, engine, shared API, command registration, or remote-runtime TypeScript routing changes. Local/private provider opt-ins remain environment-scoped via `PROVIDER_LOCAL_URLS_ENABLED` and `IMAGE_LOCAL_URLS_ENABLED`.

Pressure points touched:

None of ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs` command registration, or import modules were touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-security provider_url_policy_allows_loopback_but_blocks_private_without_opt_in -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_model_url_policy_allows_loopback_but_blocks_private_targets -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_model_redirect_revalidates_private_target -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml provider_config_response_body_is_capped -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml image_provider_response_body_is_capped -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-llm ensure_url_allowed_redacts_query_secret -- --nocapture`
- Static grep confirmed no raw `response.text()`, `response.bytes()`, or `json::<Value>()` remains on the targeted model/test/image/LLM provider response paths.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Security/parity bugfix for existing provider config fetch behavior; no new user-discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No UI changes.
