### PR TITLE
Disable imported extensions so profile import never auto-runs their JS

### DIFF
--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -968,6 +968,9 @@ fn profile_collections_import_plan(
         if collection == "connections" {
             rows = normalize_profile_connection_rows(state, rows, mode)?;
         }
+        if collection == "extensions" {
+            disable_imported_extension_rows(&mut rows);
+        }
         imported.insert(collection.to_string(), json!(rows.len()));
         if mode == ProfileImportMode::Commit {
             progress.advance_counted(
@@ -1096,6 +1099,20 @@ fn normalize_profile_json_fields(collection: &str, rows: &mut [Value]) -> AppRes
         }
     }
     Ok(())
+}
+
+/// Imported extensions must never auto-run their JavaScript. `CustomThemeInjector`
+/// gates CSS/JS execution on the row's `enabled` flag, so an exported extension
+/// carrying `enabled: true` would execute arbitrary JS on the next render with no
+/// user opt-in. Force every imported extension row disabled so the JS/CSS only
+/// runs after the user explicitly re-enables it in settings. Mirrors the
+/// connection-secret redaction special-case in this same import loop (#2366).
+pub(super) fn disable_imported_extension_rows(rows: &mut [Value]) {
+    for row in rows {
+        if let Some(object) = row.as_object_mut() {
+            object.insert("enabled".to_string(), Value::Bool(false));
+        }
+    }
 }
 
 pub(super) fn normalize_profile_prompt_overrides(rows: &mut Vec<Value>) -> usize {

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -509,6 +509,7 @@ fn legacy_profile_import_plan(
             "gallery" | "character-gallery" => {
                 normalize_legacy_gallery_rows(state, staging_root, &mut rows)
             }
+            "extensions" => super::disable_imported_extension_rows(&mut rows),
             _ => {}
         }
         normalize_legacy_profile_json_fields(collection, &mut rows)?;


### PR DESCRIPTION
## Linked issue

Closes #2366

## Why this change

- Profile import wrote imported `extensions` rows verbatim, so an exported extension carrying `enabled: true` (with arbitrary JS) was restored enabled. `CustomThemeInjector` then executed that imported JavaScript on the next render with no user opt-in — arbitrary-JS auto-run on import. (#2382 only sanitized theme/extension CSS; the `enabled: true` passthrough was untouched.)

## What changed

- `src-tauri/src/commands/storage/profile.rs`: added `disable_imported_extension_rows`, a `pub(super)` helper that forces every imported extension row's `enabled` to `false`, and call it in `profile_collections_import_plan` for the `extensions` collection (mirrors the connection-secret redaction special-case in the same loop). The JS/CSS payload and all other fields are preserved — only `enabled` is overwritten.
- `src-tauri/src/commands/storage/profile/legacy.rs`: the legacy SQLite/fileStorage import path gets the same `extensions` arm via `super::disable_imported_extension_rows`, so both import plans stay consistent.
- Imported extensions now require one explicit toggle in Settings to re-activate.

## Refactor impact

Primary owner: Rust storage (imports)

Impact areas reviewed:

- `src-tauri/src/commands/storage/profile.rs` (`profile_collections_import_plan` + new helper)
- `src-tauri/src/commands/storage/profile/legacy.rs` (legacy import per-collection match)

Boundary notes:

- None. Confined to the Rust import normalization layer; no contract/schema change (extensions contract stays `EMPTY_DEFAULTS` — the gate belongs in the import path). No TS touched.

Pressure points touched:

- Import modules (`profile.rs`, `profile/legacy.rs`).

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-engine` (profile import) — a local-only test confirmed an imported extension carrying `enabled: true` comes back `enabled: false` with its `js` payload preserved.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a security hardening fix at the import boundary.

Reason:

- No new discoverable surface; existing extensions UI unchanged (imported ones just start disabled).

## Docs and release impact

- [x] No docs changes needed
