### PR TITLE
Normalize chat-bulk import entity defaults and message roles

### DIFF
--- a/src-tauri/src/commands/storage/imports/bulk_imports.rs
+++ b/src-tauri/src/commands/storage/imports/bulk_imports.rs
@@ -44,7 +44,7 @@ fn selected_import_total(options: &Value) -> usize {
     .sum()
 }
 
-fn imported_jsonl_message_role(row: &Value) -> &'static str {
+pub(crate) fn imported_jsonl_message_role(row: &Value) -> &'static str {
     match row.get("role").and_then(Value::as_str).map(str::trim) {
         Some("user") => "user",
         Some("assistant") => "assistant",

--- a/src-tauri/src/commands/storage/imports/marinara_chat_bulk.rs
+++ b/src-tauri/src/commands/storage/imports/marinara_chat_bulk.rs
@@ -115,7 +115,8 @@ pub(super) fn import_marinara_chat_bulk(state: &AppState, payload: Value) -> App
                 chat.insert("groupId".to_string(), Value::Null);
             }
             chat.insert("folderId".to_string(), Value::Null);
-            let chat_record = state.storage.create("chats", Value::Object(chat))?;
+            let chat = with_entity_defaults("chats", Value::Object(chat))?;
+            let chat_record = state.storage.create("chats", chat)?;
             let chat_id = created_record_id(&chat_record, "chat")?;
             created_chat_ids.push(chat_id.clone());
 
@@ -128,6 +129,10 @@ pub(super) fn import_marinara_chat_bulk(state: &AppState, payload: Value) -> App
                 message.remove("id");
                 message.remove("rowid");
                 message.insert("chatId".to_string(), Value::String(chat_id.clone()));
+                let role = super::super::bulk_imports::imported_jsonl_message_role(&Value::Object(
+                    message.clone(),
+                ));
+                message.insert("role".to_string(), Value::String(role.to_string()));
                 let created = crate::storage_commands::message_swipes::create_message(
                     state,
                     Value::Object(message),


### PR DESCRIPTION
## Linked issue

Closes #2368

## Why this change

- The native `marinara-chat-bulk` importer created chat records via raw `storage.create` and persisted messages without role validation, unlike every sibling import path. Stringified typed fields (e.g. `characterIds`) stayed strings, and arbitrary message roles persisted unchecked.

## What changed

- `src-tauri/src/commands/storage/imports/marinara_chat_bulk.rs`: chat creation now routes through the shared `with_entity_defaults("chats", ...)` (seeds CHAT_DEFAULTS + normalizes CHAT_FIELDS typed JSON), mirroring `marinara.rs`. Each message role is run through the existing `imported_jsonl_message_role` allowlist before insert.
- `src-tauri/src/commands/storage/imports/bulk_imports.rs`: widened `imported_jsonl_message_role` to `pub(crate)` so the sibling importer can reuse it.
- The allowlist permits `narrator`; only truly-unknown roles coerce to `assistant`, so valid roles pass through unchanged.

## Refactor impact

Primary owner: Rust storage (imports)

Impact areas reviewed:

- `src-tauri/src/commands/storage/imports/marinara_chat_bulk.rs` (chat + message creation)
- `src-tauri/src/commands/storage/imports/bulk_imports.rs` (helper visibility)

Boundary notes:

- None. Confined to the import layer; one helper widened `pub(crate)`, no engine/features/shared crossing, no mode branching. On already-real arrays `with_entity_defaults` is a no-op, so clean exports round-trip unchanged.

Pressure points touched:

- Import modules.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-engine imports::` — 62 passed (no regression). A local-only test confirmed a stringified `characterIds`/`metadata` chat normalizes to a real array/object and that `narrator` is preserved while an unknown role (`banana`) coerces to `assistant`.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is an import-correctness bugfix.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
