### PR TITLE
generation: honor model context window

### DIFF
--- a/src/engine/generation/context-window.test.ts
+++ b/src/engine/generation/context-window.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { effectiveMaxContext } from "./context-window";
+
+describe("effectiveMaxContext", () => {
+  it("uses known model context when useMaxContext is enabled", () => {
+    expect(
+      effectiveMaxContext(
+        { provider: "openai", model: "gpt-4.1", maxContext: 2_000_000 },
+        { maxContext: 128_000, useMaxContext: true },
+      ),
+    ).toBe(1_047_576);
+  });
+
+  it("falls back to connection context when useMaxContext is enabled for an unknown model", () => {
+    expect(
+      effectiveMaxContext(
+        { provider: "nanogpt", model: "external-model", maxContext: 256_000 },
+        { maxContext: 128_000, useMaxContext: true },
+      ),
+    ).toBe(256_000);
+  });
+
+  it("clamps to the smallest positive context limit", () => {
+    expect(
+      effectiveMaxContext(
+        { provider: "openai", model: "gpt-4.1", maxContext: 80_000 },
+        { maxContext: 128_000, useMaxContext: true },
+      ),
+    ).toBe(80_000);
+
+    expect(
+      effectiveMaxContext(
+        { provider: "openai", model: "gpt-4.1", maxContext: 2_000_000 },
+        { maxContext: 64_000, useMaxContext: false },
+      ),
+    ).toBe(64_000);
+  });
+
+  it("ignores null, undefined, zero, and negative limits", () => {
+    expect(effectiveMaxContext(null, { maxContext: 0, useMaxContext: false })).toBe(0);
+    expect(effectiveMaxContext(undefined, { maxContext: -1, useMaxContext: false })).toBe(0);
+    expect(
+      effectiveMaxContext(
+        { provider: "openai", model: "gpt-4.1", maxContext: null },
+        { maxContext: undefined, useMaxContext: true },
+      ),
+    ).toBe(1_047_576);
+  });
+});

--- a/src/engine/generation/context-window.ts
+++ b/src/engine/generation/context-window.ts
@@ -1,9 +1,51 @@
 import type { LlmMessage } from "../capabilities/llm";
-import { readNumber } from "./runtime-records";
+import { MODEL_LISTS } from "../contracts/constants/model-lists";
+import { boolish, readNumber, readString } from "./runtime-records";
 
 const DEFAULT_RESPONSE_TOKENS = 4096;
 const CONTEXT_SAFETY_TOKENS = 256;
 const CHARS_PER_TOKEN = 4;
+
+type ContextConnection = Record<string, unknown> | null | undefined;
+type ContextParameters = Record<string, unknown> | null | undefined;
+
+function readPositiveContext(value: unknown): number {
+  const parsed = readNumber(value, 0);
+  return parsed > 0 ? Math.trunc(parsed) : 0;
+}
+
+function normalizedKey(value: unknown): string {
+  return readString(value).trim().toLowerCase();
+}
+
+function knownModelContext(connection: ContextConnection): number {
+  const provider = normalizedKey(connection?.provider);
+  const model = normalizedKey(connection?.model);
+  if (!provider || !model) return 0;
+
+  const modelLists = MODEL_LISTS as Partial<Record<string, Array<{ id: string; name: string; context: number }>>>;
+  const known = modelLists[provider]?.find(
+    (entry) => normalizedKey(entry.id) === model || normalizedKey(entry.name) === model,
+  );
+  return readPositiveContext(known?.context);
+}
+
+function minPositiveContext(...limits: number[]): number {
+  let resolved = 0;
+  for (const limit of limits) {
+    if (limit <= 0) continue;
+    resolved = resolved > 0 ? Math.min(resolved, limit) : limit;
+  }
+  return resolved;
+}
+
+export function effectiveMaxContext(connection: ContextConnection, parameters: ContextParameters): number {
+  const knownContext = knownModelContext(connection);
+  const parameterContext = boolish(parameters?.useMaxContext, false)
+    ? knownContext
+    : readPositiveContext(parameters?.maxContext);
+  return minPositiveContext(readPositiveContext(connection?.maxContext), knownContext, parameterContext);
+}
 
 function estimatedMessageTokens(message: LlmMessage): number {
   const contentTokens = Math.ceil((message.content?.length ?? 0) / CHARS_PER_TOKEN);
@@ -61,8 +103,12 @@ function truncateOldestHistory(messages: LlmMessage[], tokenBudget: number): Llm
   return next;
 }
 
-export function fitMessagesToContextWindow(messages: LlmMessage[], parameters: Record<string, unknown>): LlmMessage[] {
-  const maxContext = readNumber(parameters.maxContext, 0);
+export function fitMessagesToContextWindow(
+  messages: LlmMessage[],
+  parameters: Record<string, unknown>,
+  connection?: Record<string, unknown> | null,
+): LlmMessage[] {
+  const maxContext = effectiveMaxContext(connection, parameters);
   if (maxContext <= 0) return messages;
 
   const maxTokens = Math.max(1, readNumber(parameters.maxTokens, DEFAULT_RESPONSE_TOKENS));

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -39,6 +39,7 @@ import {
   mergeStoredGenerationParameters,
   type StoredGenerationParameters,
 } from "./generate-route-utils";
+import { effectiveMaxContext } from "./context-window";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection";
 import {
   bySortOrder,
@@ -3089,6 +3090,7 @@ export async function assembleGenerationPrompt(
   const promptParameters = mergeStoredGenerationParameters(
     ...generationParameterSources(input.connection, input.request, input.chat, selectedPreset?.parameters),
   );
+  const maxContext = effectiveMaxContext(input.connection, promptParameters);
   const wrapFormat =
     selectedPreset?.wrapFormat ??
     normalizeWrapFormat(input.chat.wrapFormat) ??
@@ -3132,7 +3134,7 @@ export async function assembleGenerationPrompt(
     input.chat,
     input.storedMessages,
     input.latestUserInput,
-    readNumber(input.connection.maxContext, 0) || undefined,
+    maxContext || undefined,
     embeddingSource,
   );
   const metadataHistoryLimit = readNumber(chatMeta.contextMessageLimit, 0);

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -3413,9 +3413,9 @@ async function* streamMainGenerationLoop(args: {
       }
     };
 
-    const requestMessages = fitMessagesToContextWindow(conversation, parameters);
+    const requestMessages = fitMessagesToContextWindow(conversation, parameters, connection);
     const requestPreviewMessages = previewMessages?.length
-      ? fitMessagesToContextWindow(previewMessages, parameters)
+      ? fitMessagesToContextWindow(previewMessages, parameters, connection)
       : null;
     const requestParameters = runtimeLlmParameters(connection, input, chat, parameters);
     const requestTools = mainTools?.toolDefs;


### PR DESCRIPTION
## Linked issue

Closes #2288

## Why this change

- Presets with `useMaxContext` enabled still sized prompt fitting and memory recall against the manual `maxContext`, so known models with different context windows could be under-budgeted or over-budgeted.

## What changed

- Added shared engine logic to resolve the effective context window from connection limits, known model metadata, and preset/manual parameters.
- Updated final request prompt fitting to use the effective context window.
- Updated memory recall packing to use the same effective context window instead of raw `connection.maxContext`.
- Added a focused regression test for effective context precedence, unknown-model fallback, smallest-limit clamping, and invalid limit handling.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Shared generation prompt fitting for chat, roleplay, and game mode sends.
- Memory recall prompt packing in shared prompt assembly.
- Legacy `origin/main` context-window parity for `useMaxContext` and smallest-limit clamping.

Boundary notes:

- React-free engine change only.
- No feature UI, shared API wrapper, Tauri command, Rust capability, or remote-runtime route changes.
- Engine imports engine contract model metadata; no React, Zustand, Tauri, or feature imports added.

Pressure points touched:

- None. `ModeSurface`, `GameSurface`, shared mode UI, command registration, and import modules were not touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused local `jiti` harness verified effective context selection for known model, manual max context, connection clamping, unknown model fallback, and prompt-trim behavior.
- `pnpm test -- src/engine/generation/context-window.test.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check`
- No native Tauri/manual generation run; this is a shared engine sizing fix with command-level proof.

Durable test rationale:

- Regression/risky invariant: `effectiveMaxContext` now controls both prompt trimming and memory recall sizing for `useMaxContext`.
- Existing proof gap: command output proved the current behavior, but reviewer feedback requested a committed guard for precedence and fallback cases.
- Test scope: one narrow engine helper test file covering known-model lookup, unknown-model fallback, smallest-limit clamping, and invalid limit handling.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing `useMaxContext` behavior; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No UI evidence. This change affects engine prompt sizing, not visible UI layout.
