### PR TITLE
Guard profile-import regex scripts against ReDoS patterns

### DIFF
--- a/src-tauri/src/commands/storage/profile.rs
+++ b/src-tauri/src/commands/storage/profile.rs
@@ -971,6 +971,9 @@ fn profile_collections_import_plan(
         if collection == "extensions" {
             disable_imported_extension_rows(&mut rows);
         }
+        if collection == "regex-scripts" {
+            drop_unsafe_regex_scripts(&mut rows);
+        }
         imported.insert(collection.to_string(), json!(rows.len()));
         if mode == ProfileImportMode::Commit {
             progress.advance_counted(
@@ -1113,6 +1116,267 @@ pub(super) fn disable_imported_extension_rows(rows: &mut [Value]) {
             object.insert("enabled".to_string(), Value::Bool(false));
         }
     }
+}
+
+/// Drop regex-script rows whose `findRegex` is prone to catastrophic backtracking
+/// (ReDoS). The profile-import path (modern `.marinara` envelopes and the legacy
+/// SQLite path) writes rows verbatim, so this is the only guard before they reach
+/// the runtime executors. Mirrors the TypeScript `isPatternSafe` chokepoint in
+/// `regex-script-import.ts` (which already protects the ST character-card path).
+pub(super) fn drop_unsafe_regex_scripts(rows: &mut Vec<Value>) {
+    rows.retain(|row| match row.get("findRegex") {
+        // Non-string or absent findRegex: leave the row alone; downstream
+        // normalization / the editor handles malformed scripts. Only reject
+        // string patterns that fail the safety heuristic.
+        Some(Value::String(pattern)) => is_pattern_safe(pattern),
+        _ => true,
+    });
+}
+
+// Static ReDoS safety heuristic for user-supplied regex sources, ported from
+// `src/engine/shared/regex/regex-safety.ts`. Catches the common catastrophic
+// backtracking shapes — nested quantifiers like `(a+)+`, pathological `{n,m}`
+// counts, and oversized sources — before the pattern is ever compiled.
+const REGEX_SAFETY_MAX_LENGTH: usize = 1000;
+const REGEX_SAFETY_MAX_STAR_HEIGHT: u32 = 1;
+const REGEX_SAFETY_MAX_REPETITION: f64 = 100.0;
+
+fn is_pattern_safe(source: &str) -> bool {
+    if source.is_empty() {
+        return true;
+    }
+    let chars: Vec<char> = source.chars().collect();
+    if chars.len() > REGEX_SAFETY_MAX_LENGTH {
+        return false;
+    }
+
+    let mut i = 0usize;
+    let mut group_depth = 0i32;
+    let mut group_inner_height: Vec<u32> = Vec::new();
+    let mut top_level_height = 0u32;
+
+    let record_atom_height = |height: u32,
+                              group_depth: i32,
+                              group_inner_height: &mut Vec<u32>,
+                              top_level_height: &mut u32| {
+        if group_depth > 0 {
+            if let Some(last) = group_inner_height.last_mut() {
+                if height > *last {
+                    *last = height;
+                }
+            }
+        } else if height > *top_level_height {
+            *top_level_height = height;
+        }
+    };
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == '\\' {
+            // Escape: skip the next char (counts as one atom).
+            if i + 1 >= chars.len() {
+                return false; // Trailing backslash.
+            }
+            let after = chars.get(i + 2).copied();
+            let quant_height = if is_quantifier_start(after) { 1 } else { 0 };
+            record_atom_height(
+                quant_height,
+                group_depth,
+                &mut group_inner_height,
+                &mut top_level_height,
+            );
+            i += 2;
+            if quant_height > 0 {
+                match consume_quantifier(&chars, i) {
+                    Some(next) => i = next,
+                    None => return false,
+                }
+            }
+            continue;
+        }
+
+        if c == '[' {
+            let close_idx = match find_char_class_close(&chars, i) {
+                Some(idx) => idx,
+                None => return false,
+            };
+            let after = chars.get(close_idx + 1).copied();
+            let quant_height = if is_quantifier_start(after) { 1 } else { 0 };
+            record_atom_height(
+                quant_height,
+                group_depth,
+                &mut group_inner_height,
+                &mut top_level_height,
+            );
+            i = close_idx + 1;
+            if quant_height > 0 {
+                match consume_quantifier(&chars, i) {
+                    Some(next) => i = next,
+                    None => return false,
+                }
+            }
+            continue;
+        }
+
+        if c == '(' {
+            group_depth += 1;
+            group_inner_height.push(0);
+            if chars.get(i + 1).copied() == Some('?') {
+                if chars.get(i + 2).copied() == Some('<')
+                    && chars.get(i + 3).copied() != Some('=')
+                    && chars.get(i + 3).copied() != Some('!')
+                {
+                    // Named capture (?<name>...).
+                    match char_index_of(&chars, '>', i + 3) {
+                        Some(close) => i = close + 1,
+                        None => return false,
+                    }
+                } else {
+                    i += 3; // (?: (?= (?! (?<= (?<!
+                    if chars.get(i.wrapping_sub(1)).copied() == Some('<') {
+                        i += 1;
+                    }
+                }
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+
+        if c == ')' {
+            let inner_height = group_inner_height.pop().unwrap_or(0);
+            group_depth -= 1;
+            let after = chars.get(i + 1).copied();
+            let quantified = is_quantifier_start(after);
+            let group_height = inner_height + if quantified { 1 } else { 0 };
+            if group_height > REGEX_SAFETY_MAX_STAR_HEIGHT {
+                return false;
+            }
+            record_atom_height(
+                group_height,
+                group_depth,
+                &mut group_inner_height,
+                &mut top_level_height,
+            );
+            i += 1;
+            if quantified {
+                match consume_quantifier(&chars, i) {
+                    Some(next) => i = next,
+                    None => return false,
+                }
+            }
+            continue;
+        }
+
+        // Plain literal character: atom of height 0 unless quantified, then 1.
+        let after = chars.get(i + 1).copied();
+        let quant_height = if is_quantifier_start(after) { 1 } else { 0 };
+        record_atom_height(
+            quant_height,
+            group_depth,
+            &mut group_inner_height,
+            &mut top_level_height,
+        );
+        i += 1;
+        if quant_height > 0 {
+            match consume_quantifier(&chars, i) {
+                Some(next) => i = next,
+                None => return false,
+            }
+        }
+    }
+
+    if group_depth != 0 {
+        return false; // Unbalanced.
+    }
+    if top_level_height > REGEX_SAFETY_MAX_STAR_HEIGHT {
+        return false;
+    }
+    true
+}
+
+fn is_quantifier_start(ch: Option<char>) -> bool {
+    matches!(ch, Some('*') | Some('+') | Some('?') | Some('{'))
+}
+
+fn char_index_of(chars: &[char], needle: char, from: usize) -> Option<usize> {
+    chars
+        .iter()
+        .enumerate()
+        .skip(from)
+        .find(|(_, c)| **c == needle)
+        .map(|(idx, _)| idx)
+}
+
+/// Advance past a quantifier starting at `i`, validating `{n,m}` bounds.
+/// Returns the new index, or `None` if invalid / over budget.
+fn consume_quantifier(chars: &[char], i: usize) -> Option<usize> {
+    match chars.get(i).copied() {
+        Some('*') | Some('+') | Some('?') => {
+            let next = chars.get(i + 1).copied();
+            if next == Some('?') || next == Some('+') {
+                Some(i + 2)
+            } else {
+                Some(i + 1)
+            }
+        }
+        Some('{') => {
+            let close = char_index_of(chars, '}', i + 1)?;
+            let body: String = chars[i + 1..close].iter().collect();
+            let (lo_str, upper_part) = match body.split_once(',') {
+                Some((lo, hi)) => (lo, Some(hi)),
+                None => (body.as_str(), None),
+            };
+            if lo_str.is_empty() || !lo_str.chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
+            let lo: f64 = lo_str.parse().ok()?;
+            let hi: f64 = match upper_part {
+                None => lo,
+                Some("") => f64::INFINITY,
+                Some(upper) => {
+                    if !upper.chars().all(|c| c.is_ascii_digit()) {
+                        return None;
+                    }
+                    upper.parse().ok()?
+                }
+            };
+            if !lo.is_finite() || lo > REGEX_SAFETY_MAX_REPETITION {
+                return None;
+            }
+            if !hi.is_finite() || hi > REGEX_SAFETY_MAX_REPETITION {
+                return None;
+            }
+            let mut next = close + 1;
+            if matches!(chars.get(next).copied(), Some('?') | Some('+')) {
+                next += 1;
+            }
+            Some(next)
+        }
+        _ => Some(i),
+    }
+}
+
+fn find_char_class_close(chars: &[char], open_idx: usize) -> Option<usize> {
+    let mut j = open_idx + 1;
+    if chars.get(j).copied() == Some('^') {
+        j += 1;
+    }
+    if chars.get(j).copied() == Some(']') {
+        j += 1; // Leading ] is literal.
+    }
+    while j < chars.len() {
+        match chars[j] {
+            '\\' => {
+                j += 2;
+                continue;
+            }
+            ']' => return Some(j),
+            _ => j += 1,
+        }
+    }
+    None
 }
 
 pub(super) fn normalize_profile_prompt_overrides(rows: &mut Vec<Value>) -> usize {

--- a/src-tauri/src/commands/storage/profile/legacy.rs
+++ b/src-tauri/src/commands/storage/profile/legacy.rs
@@ -491,6 +491,7 @@ fn legacy_profile_import_plan(
         let processed_rows = rows.len();
         match *collection {
             "app-settings" => normalize_legacy_app_settings(&mut rows),
+            "regex-scripts" => super::drop_unsafe_regex_scripts(&mut rows),
             "characters" => normalize_legacy_character_data(&mut rows),
             "prompt-overrides" => {
                 unsupported_prompt_overrides = normalize_profile_prompt_overrides(&mut rows)


### PR DESCRIPTION
## Linked issue

Closes #2364

## Why this change

- Regex scripts run a content-supplied `findRegex` against the full transcript on every generation turn. Only the ST character-card import path was guarded by `isPatternSafe`; the profile/preset bundle import wrote `regex-scripts` rows verbatim with no ReDoS check (the issue's repro: import a `.marinara` profile whose `regex-scripts` contains `(a+)+$`, then send a turn with a long run of `a` → the single-threaded renderer freezes on catastrophic backtracking).

## What changed

- `src-tauri/src/commands/storage/profile.rs`: added `drop_unsafe_regex_scripts` plus a faithful Rust port of the TypeScript `isPatternSafe` heuristic (`src/engine/shared/regex/regex-safety.ts` — star-height, `{n,m}` bounds, length cap). The modern profile import (`profile_collections_import_plan`) now drops `regex-scripts` rows whose `findRegex` fails the heuristic, mirroring the existing ST-card import behavior of skipping unsafe patterns at the storage boundary.
- `src-tauri/src/commands/storage/profile/legacy.rs`: the legacy SQLite profile import calls the same `super::drop_unsafe_regex_scripts`, so both import paths share one source of truth.

## Scope note (deliberate)

This PR guards the **import boundary** — the issue's demonstrated vector. I intentionally did **not** add the `isPatternSafe` heuristic to the in-app editor schema or the three runtime script executors, because the existing heuristic rejects common safe patterns (`\n{3,}`, `\s{2,}`) and both shipped default regex scripts (the HTML-stripper and the blank-line collapser seeded in `seed_defaults.rs`). A schema refine would block users from saving those patterns, and a runtime skip would silently break the seeded defaults. The issue's preferred runtime hardening is the lorebook scanner's interruptible-worker timeout (`vmRegexExecutor`, `regex-timeout.ts`); routing the script executors through that timeout (so a catastrophic pattern is interrupted without dropping safe-but-heuristic-failing patterns) is a larger follow-up worth its own PR.

## Refactor impact

Primary owner: Rust storage (imports)

Impact areas reviewed:

- `src-tauri/src/commands/storage/profile.rs` (`profile_collections_import_plan` + new helper)
- `src-tauri/src/commands/storage/profile/legacy.rs` (legacy import per-collection match)

Boundary notes:

- None. Confined to the Rust import normalization layer; the safety helper lives in `profile.rs` and is shared with the `legacy` submodule via `super::`. No TS, engine, or runtime path touched, so seeded defaults and the editor are unaffected.

Pressure points touched:

- Import modules.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml -p marinara-engine` (profile import) — a local-only test confirmed a profile importing `findRegex: "(a+)+$"` drops that script while a safe `a+` script imports. The Rust heuristic was cross-checked against the TS `isPatternSafe` for parity.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a security hardening fix at the import boundary.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
