### PR TITLE
Guard debounced manual world-state patch against stale chat.gameState write

### DIFF
--- a/src/features/runtime/world-state/api/world-state-api.ts
+++ b/src/features/runtime/world-state/api/world-state-api.ts
@@ -201,6 +201,25 @@ async function resolveVisibleTarget(chatId: string, fallback: unknown): Promise<
   return (await latestAssistantTarget(chatId).catch(() => null)) ?? readTarget(fallback);
 }
 
+// Determines whether a patch may persist chat.gameState. Patches without an explicit
+// requestedTarget (per-turn snapshot writes, clearManualState) always own chat.gameState.
+// A patch that pinned a specific message target at edit time (debounced manual edits) may
+// only write chat.gameState when that target is still the current visible assistant target;
+// if a newer turn has advanced the visible target during the debounce window the stale write
+// is skipped so it cannot clobber the current turn's persisted state.
+async function canPersistChatGameState(
+  chatId: string,
+  requestedTarget: ResolvedWorldStateTarget | null,
+): Promise<boolean> {
+  if (!requestedTarget) return true;
+  const visibleTarget = await latestAssistantTarget(chatId).catch(() => null);
+  if (!visibleTarget?.messageId) return true;
+  return (
+    visibleTarget.messageId === requestedTarget.messageId &&
+    visibleTarget.swipeIndex === requestedTarget.swipeIndex
+  );
+}
+
 async function getWorldState(chatId: string, target: WorldStateTarget, init?: RequestInit): Promise<WorldState | null>;
 async function getWorldState(chatId: string, init?: RequestInit): Promise<WorldState | null>;
 async function getWorldState(
@@ -276,7 +295,17 @@ export const worldStateApi: WorldStateApi = {
     );
     const saved = target ? await trackerSnapshotApi.save(chatId, next) : null;
     throwIfAborted(init);
-    await storageApi.update("chats", chatId, { gameState: saved ?? next });
+    // Guard against a stale debounced manual patch clobbering chat.gameState. When an
+    // explicit requestedTarget was captured at edit time (only use-world-state-patcher does
+    // this), a concurrent assistant turn may have advanced the visible target during the
+    // debounce window. Re-resolve the current visible target at flush time and only persist
+    // chat.gameState when the requested target is still visible; otherwise keep the
+    // per-message snapshot only and let the visible-read path own chat.gameState.
+    const shouldWriteChatGameState = await canPersistChatGameState(chatId, requestedTarget);
+    throwIfAborted(init);
+    if (shouldWriteChatGameState) {
+      await storageApi.update("chats", chatId, { gameState: saved ?? next });
+    }
     return applyManualOverrides(saved ?? next);
   },
 };


### PR DESCRIPTION
## Linked issue

Closes #2327

## Why this change

- A 500ms-debounced manual tracker edit pins its target message at edit time. If an assistant turn completes inside that debounce window, the queued flush wrote the OLD message's snapshot into `chat.gameState`, clobbering the current turn's persisted state (notably breaks `gameStateCarryoverPatch` seeding a new session).

## What changed

- `src/features/runtime/world-state/api/world-state-api.ts`: the `chat.gameState` write in `worldStateApi.patch` is now gated by a new `canPersistChatGameState` helper. Patches without an explicit `requestedTarget` (per-turn snapshot writes, `clearManualState`) still always write. A patch that pinned a specific target (debounced manual edits) re-resolves the current visible assistant target at flush time and only writes `chat.gameState` when the pinned target is still visible; otherwise it keeps the per-message snapshot and lets the visible-read path own `chat.gameState`.
- The per-message snapshot `trackerSnapshotApi.save` stays unconditional. Fail-open on error preserves current behavior.

## Refactor impact

Primary owner: world-state

Impact areas reviewed:

- `src/features/runtime/world-state/api/world-state-api.ts` (`patch`, new `canPersistChatGameState`)

Boundary notes:

- None. Single feature-layer file. Extra `latestAssistantTarget` (one `listChatMessages`) call only on the low-frequency manual-edit path; the per-turn hot path returns immediately. No Rust/DB/schema change.

Pressure points touched:

- None.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run` (world-state-api) — a local-only test drove the race: a stale `requestedTarget` (pinned `msg-OLD`, visible advanced to `msg-NEW`) saves the per-message snapshot but performs ZERO `storageApi.update("chats", …)` writes; a still-visible target writes `chat.gameState` once; both no-`requestedTarget` paths still write (no per-turn regression).
- `pnpm exec tsc -b` — clean (with and without the local test).

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a data-loss race bugfix.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
