### PR TITLE
Strip style attribute from game AnimatedText sanitizer

### DIFF
--- a/src/features/modes/game/components/AnimatedText.tsx
+++ b/src/features/modes/game/components/AnimatedText.tsx
@@ -201,7 +201,9 @@ function wrapCharactersForWave(html: string): string {
     const chars = [...text];
     const wrapped = chars
       .map((ch, i) =>
-        ch === " " ? " " : `<span class="anim-text-wave-char" style="animation-delay:${i * 60}ms">${ch}</span>`,
+        ch === " "
+          ? " "
+          : `<span class="anim-text-wave-char anim-text-wave-char-${i % 10}">${ch}</span>`,
       )
       .join("");
     return `<span class="anim-text-wave">${wrapped}</span>`;
@@ -226,7 +228,7 @@ export function AnimatedText({ html, className, style }: AnimatedTextProps) {
     // Re-sanitize after our additions
     return DOMPurify.sanitize(result, {
       ALLOWED_TAGS: ["strong", "em", "br", "span"],
-      ALLOWED_ATTR: ["class", "style"],
+      ALLOWED_ATTR: ["class"],
     });
   }, [html]);
 
@@ -239,6 +241,6 @@ export function animateTextHtml(html: string): string {
   result = wrapCharactersForWave(result);
   return DOMPurify.sanitize(result, {
     ALLOWED_TAGS: ["strong", "em", "br", "span"],
-    ALLOWED_ATTR: ["class", "style"],
+    ALLOWED_ATTR: ["class"],
   });
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3385,6 +3385,40 @@ summary[class*="cursor-pointer"],
   animation: text-wave-char 1.2s ease-in-out infinite;
 }
 
+/* Per-character wave delay buckets (char index modulo 10).
+   Replaces a former inline style="animation-delay" so the wave effect
+   survives DOMPurify stripping the style attribute (security: no inline style). */
+.anim-text-wave-char-0 {
+  animation-delay: 0ms;
+}
+.anim-text-wave-char-1 {
+  animation-delay: 60ms;
+}
+.anim-text-wave-char-2 {
+  animation-delay: 120ms;
+}
+.anim-text-wave-char-3 {
+  animation-delay: 180ms;
+}
+.anim-text-wave-char-4 {
+  animation-delay: 240ms;
+}
+.anim-text-wave-char-5 {
+  animation-delay: 300ms;
+}
+.anim-text-wave-char-6 {
+  animation-delay: 360ms;
+}
+.anim-text-wave-char-7 {
+  animation-delay: 420ms;
+}
+.anim-text-wave-char-8 {
+  animation-delay: 480ms;
+}
+.anim-text-wave-char-9 {
+  animation-delay: 540ms;
+}
+
 /* Flicker — fire, flames (epilepsy-safe: no full opacity drops, gentle variation) */
 @keyframes text-flicker {
   0%,


### PR DESCRIPTION
## Linked issue

Closes #2367

## Why this change

- Game-mode `AnimatedText` renders raw model choice/map text and allowed the `style` attribute in its DOMPurify config. Model output could therefore inject `style="position:fixed;background:url(...)"` — a CSS-exfil beacon (the URL fires on render; `tauri.conf.json` has `security.csp = null`) or a clickjacking overlay. The sibling `game-narration-format.ts` already allows only `["class"]`.

## What changed

- `src/features/modes/game/components/AnimatedText.tsx`: dropped `"style"` from both DOMPurify `ALLOWED_ATTR` arrays (the component `useMemo` and `animateTextHtml`), so they now allow `class` only — matching the sibling narration formatter.
- The one legitimate inline-style use (a per-character wave-animation delay) is relocated onto pre-defined index-bucket CSS classes `anim-text-wave-char-0…9` (char index mod 10) in `src/styles/globals.css`, so the wave animation is unchanged while arbitrary `style` is stripped.

## Refactor impact

Primary owner: game mode

Impact areas reviewed:

- `src/features/modes/game/components/AnimatedText.tsx` (both sanitizer configs + wave wrapping)
- `src/styles/globals.css` (wave-delay buckets)

Boundary notes:

- None. The only inline-`style` carriers in this component were the attacker vector and the wave delay (now class-driven). No Rust touched. Mod-10 bucketing is identical for ≤10-char wave spans and cosmetically repeats the cascade for longer spans.

Pressure points touched:

- GameSurface (AnimatedText is a game-mode render component).

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run` (jsdom AnimatedText) — local-only tests confirmed a malicious `style="position:fixed;background:url(evil…)"` choice string renders with no `style` attribute / no `position:fixed` / no beacon URL in the DOM (text content preserved), and the per-char wave spans still carry their `anim-text-wave-char-N` delay classes with no inline style.
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a security hardening fix.

Reason:

- No new discoverable surface; the wave animation is visually unchanged.

## Docs and release impact

- [x] No docs changes needed
