### PR TITLE
Scope regenerate and streaming character ids per chat

### DIFF
--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1175,8 +1175,8 @@ export async function runGenerationWithUi(
   const controller = new AbortController();
   chatStore.setAbortController(chatId, controller);
   chatStore.setStreaming(true, chatId);
-  chatStore.setRegenerateMessageId(regenerateMessageId);
-  chatStore.setStreamingCharacterId(requestedCharacterId);
+  chatStore.setRegenerateMessageId(regenerateMessageId, chatId);
+  chatStore.setStreamingCharacterId(requestedCharacterId, chatId);
   chatStore.setGenerationPhase("Starting generation...");
   chatStore.setStreamBuffer("", chatId);
   chatStore.setThinkingBuffer("", chatId);
@@ -1432,11 +1432,14 @@ export async function runGenerationWithUi(
     state.setAbortController(chatId, null);
     state.setMariPhase(chatId, "idle");
     clearChatAvailabilityState();
+    // Clear this chat's own regenerate/streaming-character ids regardless of
+    // whether it's the foreground chat, so a background chat's generation
+    // doesn't leave stale per-chat ids that leak when it's next opened.
+    state.setRegenerateMessageId(null, chatId);
+    state.setStreamingCharacterId(null, chatId);
     if (state.streamingChatId === chatId) {
       state.setStreaming(false, chatId);
-      state.setRegenerateMessageId(null);
       state.setGenerationPhase(null);
-      state.setStreamingCharacterId(null);
     }
     if (useChatStore.getState().abortControllers.size === 0) {
       useAgentStore.getState().setProcessing(false);
@@ -1535,9 +1538,7 @@ export async function runGenerationWithUi(
           const characterName = readString(data.characterName).trim();
           groupTurnIndex = typeof data.index === "number" && Number.isFinite(data.index) ? data.index : 0;
           groupTurnTotal = typeof data.total === "number" && Number.isFinite(data.total) ? Math.max(1, data.total) : 1;
-          if (useChatStore.getState().activeChatId === chatId) {
-            useChatStore.getState().setStreamingCharacterId(characterId || null);
-          }
+          useChatStore.getState().setStreamingCharacterId(characterId || null, chatId);
           if (characterName) {
             const state = useChatStore.getState();
             state.setPerChatTyping(chatId, characterName);

--- a/src/shared/stores/chat.store.ts
+++ b/src/shared/stores/chat.store.ts
@@ -77,8 +77,12 @@ interface ChatState {
   abortControllers: Map<string, AbortController>;
   /** When regenerating, the ID of the message being regenerated (so streaming shows in-place). */
   regenerateMessageId: string | null;
+  /** Per-chat regenerate target so switching chats mid-stream doesn't leak one chat's regenerate id into another. */
+  regenerateMessageIdByChatId: Map<string, string>;
   /** During group chat individual mode, the character currently streaming. */
   streamingCharacterId: string | null;
+  /** Per-chat streaming character so switching chats mid-stream doesn't leak one chat's streaming character into another. */
+  streamingCharacterIdByChatId: Map<string, string>;
   /** Character name(s) shown in typing indicator when generation is active. */
   typingCharacterName: string | null;
   /** Human-readable label for the current server-side generation phase (e.g. "Running agents..."). */
@@ -138,8 +142,8 @@ interface ChatState {
   appendThinkingBuffer: (text: string, chatId?: string) => void;
   setThinkingBuffer: (text: string, chatId?: string) => void;
   clearThinkingBuffer: (chatId?: string) => void;
-  setRegenerateMessageId: (id: string | null) => void;
-  setStreamingCharacterId: (id: string | null) => void;
+  setRegenerateMessageId: (id: string | null, chatId?: string) => void;
+  setStreamingCharacterId: (id: string | null, chatId?: string) => void;
   setTypingCharacterName: (name: string | null) => void;
   setGenerationPhase: (phase: string | null) => void;
   setDelayedCharacterInfo: (info: { name: string; status: string } | null) => void;
@@ -193,7 +197,9 @@ export const useChatStore = create<ChatState>()(
     thinkingBuffers: new Map(),
     abortControllers: new Map(),
     regenerateMessageId: null,
+    regenerateMessageIdByChatId: new Map(),
     streamingCharacterId: null,
+    streamingCharacterIdByChatId: new Map(),
     typingCharacterName: null,
     generationPhase: null,
     delayedCharacterInfo: null,
@@ -239,7 +245,15 @@ export const useChatStore = create<ChatState>()(
         // Clearing it would cause a black flash and wipe the background for new chats.
         // Restore per-chat typing/delayed indicators for the newly active chat
         if (id) {
-          const { perChatTyping, perChatDelayed, abortControllers, streamBuffers, thinkingBuffers } = get();
+          const {
+            perChatTyping,
+            perChatDelayed,
+            abortControllers,
+            streamBuffers,
+            thinkingBuffers,
+            regenerateMessageIdByChatId,
+            streamingCharacterIdByChatId,
+          } = get();
           const typing = perChatTyping.get(id) ?? null;
           const delayed = perChatDelayed.get(id) ?? null;
           // If this chat has an active generation, restore streaming state so the
@@ -252,6 +266,8 @@ export const useChatStore = create<ChatState>()(
             streamingChatId: hasActiveGeneration ? id : null,
             streamBuffer: hasActiveGeneration ? (streamBuffers.get(id) ?? "") : "",
             thinkingBuffer: hasActiveGeneration ? (thinkingBuffers.get(id) ?? "") : "",
+            regenerateMessageId: regenerateMessageIdByChatId.get(id) ?? null,
+            streamingCharacterId: streamingCharacterIdByChatId.get(id) ?? null,
           });
         } else {
           set({
@@ -261,6 +277,8 @@ export const useChatStore = create<ChatState>()(
             streamingChatId: null,
             streamBuffer: "",
             thinkingBuffer: "",
+            regenerateMessageId: null,
+            streamingCharacterId: null,
           });
         }
       }
@@ -400,9 +418,31 @@ export const useChatStore = create<ChatState>()(
         };
       }),
 
-    setRegenerateMessageId: (id) => set({ regenerateMessageId: id }),
+    setRegenerateMessageId: (id, chatId) =>
+      set((state) => {
+        const targetChatId = chatId ?? state.streamingChatId ?? state.activeChatId ?? "";
+        if (!targetChatId) return { regenerateMessageId: id };
+        const m = new Map(state.regenerateMessageIdByChatId);
+        if (id) m.set(targetChatId, id);
+        else m.delete(targetChatId);
+        return {
+          regenerateMessageIdByChatId: m,
+          ...(state.activeChatId === targetChatId ? { regenerateMessageId: id } : {}),
+        };
+      }),
 
-    setStreamingCharacterId: (id) => set({ streamingCharacterId: id }),
+    setStreamingCharacterId: (id, chatId) =>
+      set((state) => {
+        const targetChatId = chatId ?? state.streamingChatId ?? state.activeChatId ?? "";
+        if (!targetChatId) return { streamingCharacterId: id };
+        const m = new Map(state.streamingCharacterIdByChatId);
+        if (id) m.set(targetChatId, id);
+        else m.delete(targetChatId);
+        return {
+          streamingCharacterIdByChatId: m,
+          ...(state.activeChatId === targetChatId ? { streamingCharacterId: id } : {}),
+        };
+      }),
 
     setTypingCharacterName: (name) => set({ typingCharacterName: name, delayedCharacterInfo: null }),
 
@@ -641,7 +681,9 @@ export const useChatStore = create<ChatState>()(
         thinkingBuffers: new Map(),
         abortControllers: new Map(),
         regenerateMessageId: null,
+        regenerateMessageIdByChatId: new Map(),
         streamingCharacterId: null,
+        streamingCharacterIdByChatId: new Map(),
         typingCharacterName: null,
         generationPhase: null,
         delayedCharacterInfo: null,


### PR DESCRIPTION
## Linked issue

Closes #2321

## Why this change

- `regenerateMessageId` and `streamingCharacterId` were the last two generation-UI fields left as global scalars in `chat.store`, while their siblings (`streamBuffers` / `thinkingBuffers` / `abortControllers`) are already per-chat Maps. During concurrent generation across chats, chat A's regenerate/streaming-character id leaked into chat B's foreground view (typing routed to the wrong bubble, wrong streaming card/voice).

## What changed

- `src/shared/stores/chat.store.ts`: added `regenerateMessageIdByChatId` / `streamingCharacterIdByChatId` Maps next to the existing per-chat maps. The setters take an optional `chatId`, write the per-chat entry, and mirror to the global scalar only when that chat is active — byte-for-byte the same shape as `setStreamBuffer`. `setActiveChatId` restores both globals from the maps on switch (and nulls them on no-chat); `reset()` clears the maps.
- `src/features/runtime/generation/hooks/use-generate.ts`: set/clear both ids with the explicit `chatId`. `releaseForegroundGenerationUi` now clears the completing chat's own ids regardless of foreground (they self-scope by chatId), so a background chat's completion can't leave stale per-chat entries.

## Refactor impact

Primary owner: shared API / chat store

Impact areas reviewed:

- `src/shared/stores/chat.store.ts` (per-chat maps + global mirror)
- `src/features/runtime/generation/hooks/use-generate.ts` (explicit chatId at set/clear sites)

Boundary notes:

- None. The new `chatId` arg is optional and falls back to the active chat (only callers are in use-generate.ts, now all explicit). Existing consumers (`ConversationView`, `ChatRoleplaySurface`) read the global mirror unchanged. No persistence/IPC/Rust change.

Pressure points touched:

- Shared mode UI (chat store), runtime generation.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/features/runtime/generation src/engine/generation` — 67 passed. A local-only store test confirmed cross-chat isolation: chat A's regenerate/streaming ids do not bleed into B on switch, A's values restore on switch back, a background chat's completion clears its own ids without touching the foreground, and switching to no-chat clears both globals.
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a state-isolation bugfix.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
