### PR TITLE
Flush pending game-state edits before retrying agents

### DIFF
--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -1822,6 +1822,17 @@ export function useGenerate() {
         await assertChatCanGenerate(queryClient, chatId);
         const agentStore = useAgentStore.getState();
         agentStore.setProcessing(true);
+        // Flush any pending debounced game-state edits before the engine re-reads
+        // storage; otherwise retryGenerationAgents reads a stale snapshot and the
+        // regenerated agent result clobbers the user's just-made manual HUD edit.
+        const flushPatch = useGameStateStore.getState().flushPatch;
+        if (flushPatch) {
+          try {
+            await flushPatch();
+          } catch (cause) {
+            throw new Error("Failed to flush pending game-state edits", { cause });
+          }
+        }
         if (agentTypes && agentTypes.length > 0) {
           // Targeted retry: clear only the entries for agents we're about to re-run, so
           // prior-turn failures for agents that aren't being retried stay visible. If any

--- a/src/features/runtime/tracker/components/TrackerSectionList.tsx
+++ b/src/features/runtime/tracker/components/TrackerSectionList.tsx
@@ -35,7 +35,6 @@ export function TrackerSectionList({
     enabledAgentTypes,
     expressionSpritesEnabled,
     featuredCharacterCards,
-    flushPatch,
     gameState,
     gameStateRefreshing,
     getSnapshot,
@@ -62,7 +61,6 @@ export function TrackerSectionList({
   const { rerunTracker, trackerRetryBusy } = useTrackerRerun({
     activeChatId,
     enabledAgentTypes,
-    flushPatch,
     gameStateRefreshing,
   });
   const {

--- a/src/features/runtime/tracker/hooks/use-tracker-rerun.ts
+++ b/src/features/runtime/tracker/hooks/use-tracker-rerun.ts
@@ -7,12 +7,10 @@ import { TRACKER_AGENT_TYPE_IDS } from "../../world-state/index";
 export function useTrackerRerun({
   activeChatId,
   enabledAgentTypes,
-  flushPatch,
   gameStateRefreshing,
 }: {
   activeChatId: string | null;
   enabledAgentTypes: Set<string>;
-  flushPatch: () => Promise<void>;
   gameStateRefreshing: boolean;
 }) {
   const streamingChatId = useChatStore((s) => s.streamingChatId);
@@ -33,17 +31,12 @@ export function useTrackerRerun({
         return;
       }
       try {
-        await flushPatch();
-      } catch {
-        return;
-      }
-      try {
         await retryAgents(activeChatId, [agentType]);
       } catch (error) {
         console.warn("Failed to re-run tracker agents.", error);
       }
     },
-    [activeChatId, enabledAgentTypes, flushPatch, retryAgents, trackerRetryBusy],
+    [activeChatId, enabledAgentTypes, retryAgents, trackerRetryBusy],
   );
 
   return { rerunTracker, trackerRetryBusy };


### PR DESCRIPTION
## Linked issue

Closes #2371

## Why this change

- `retryAgents` re-ran the tracker/agent engine without first flushing pending debounced game-state edits, so the engine re-read a stale storage snapshot and the regenerated output clobbered the user's just-made manual HUD tracker edit (data loss). This is a regression vs main, where the pre-retry flush was centralized. All four roleplay-HUD handlers (Re-run Trackers / Re-run Single Tracker / Retry Failed Agents / Retry Agent) funnel through `retryAgents`.

## What changed

- `src/features/runtime/generation/hooks/use-generate.ts`: `retryAgents` now flushes `useGameStateStore.flushPatch()` after `setProcessing(true)` and before `retryGenerationAgents`, mirroring the in-repo guard. A single site covers all four HUD handlers plus the other callers. A flush failure now aborts the retry (throws, surfaced via the existing error toast) instead of silently corrupting state.
- `src/features/runtime/tracker/hooks/use-tracker-rerun.ts` + `TrackerSectionList.tsx`: removed the now-redundant per-call `flushPatch()` (superseded by the centralized flush) and tidied the dead `flushPatch` prop.

## Refactor impact

Primary owner: runtime generation / world-state

Impact areas reviewed:

- `src/features/runtime/generation/hooks/use-generate.ts` (`retryAgents`)
- `src/features/runtime/tracker/hooks/use-tracker-rerun.ts`, `src/features/runtime/tracker/components/TrackerSectionList.tsx` (redundant flush + prop cleanup)

Boundary notes:

- None. `flushPatch` is a no-op when no patcher is registered (`buildFlushPatch` returns `null`) and idempotent on an empty buffer, so the added await is negligible. No conflict with #2373 quest logic (flush-only). No Rust touched.

Pressure points touched:

- Runtime generation, world-state, shared mode UI (tracker section).

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run` — a local-only test against the real `useGameStateStore` flush seam confirmed the flush runs BEFORE `retryGenerationAgents` (via `invocationCallOrder`), a flush rejection throws and `retryGenerationAgents` is never called, and a no-patcher flush is a safe no-op.
- `pnpm exec tsc -b`, `pnpm lint:eslint`, `pnpm check:architecture` — all clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a data-loss regression fix.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
