### PR TITLE
Keep just-completed quests on tracker re-run

### DIFF
--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1675,6 +1675,7 @@ async function persistTrackerSnapshotSafely(
   baseSnapshot?: GameState | null,
   sourceText?: string | null,
   onSavedSnapshot?: TrackerSnapshotSavedHook,
+  autoRemoveFullyCompletedQuests = false,
 ): Promise<void> {
   const target = trackerSnapshotTargetFromMessage(targetMessage);
   if (!target) return;
@@ -1683,6 +1684,7 @@ async function persistTrackerSnapshotSafely(
       baseSnapshot,
       sourceText,
       onSavedSnapshot,
+      autoRemoveFullyCompletedQuests,
     });
   } catch (error) {
     console.warn("[generation] tracker snapshot persist failed", error);
@@ -3079,6 +3081,7 @@ export async function* startGeneration(
         generationTrackerBaseline,
         readString(parseRecord(latestSaved).content),
         deps.onTrackerSnapshotSaved,
+        true,
       );
     }
     throwIfAborted(signal);

--- a/src/engine/generation/tracker-snapshots.ts
+++ b/src/engine/generation/tracker-snapshots.ts
@@ -419,6 +419,7 @@ function gameStatePatchFromAgentResult(
   previousWorldState: GameState,
   persona?: TrackerPersonaIdentity | null,
   sourceText?: string | null,
+  autoRemoveFullyCompletedQuests = false,
 ): TrackerStatePatch | null {
   if (!result.success) return null;
   if (result.agentType === "world-state" || result.type === "game_state_update") {
@@ -480,7 +481,9 @@ function gameStatePatchFromAgentResult(
   }
 
   if (result.agentType === "quest" || result.type === "quest_update") {
-    const questMerge = applyQuestUpdatesToPlayerStats(snapshot.playerStats, data.updates);
+    const questMerge = applyQuestUpdatesToPlayerStats(snapshot.playerStats, data.updates, {
+      autoRemoveFullyCompleted: autoRemoveFullyCompletedQuests,
+    });
     return questMerge.changed ? { playerStats: questMerge.playerStats } : null;
   }
 
@@ -496,6 +499,7 @@ export async function persistTrackerSnapshotForTurn(
     baseSnapshot?: GameState | null;
     sourceText?: string | null;
     onSavedSnapshot?: TrackerSnapshotSavedHook;
+    autoRemoveFullyCompletedQuests?: boolean;
   } = {},
 ): Promise<GameState | null> {
   if (!target || !target.messageId || results.length === 0) return null;
@@ -515,7 +519,14 @@ export async function persistTrackerSnapshotForTurn(
 
   for (const result of results) {
     const previousWorldState = options.baseSnapshot ?? snapshot;
-    const patch = gameStatePatchFromAgentResult(result, snapshot, previousWorldState, persona, options.sourceText);
+    const patch = gameStatePatchFromAgentResult(
+      result,
+      snapshot,
+      previousWorldState,
+      persona,
+      options.sourceText,
+      options.autoRemoveFullyCompletedQuests === true,
+    );
     if (!patch) continue;
     snapshot = normalizeGameState({ ...snapshot, ...patch }, chatId, target, persona);
     changed = true;

--- a/src/engine/shared/game-state/player-stats.ts
+++ b/src/engine/shared/game-state/player-stats.ts
@@ -307,6 +307,7 @@ function cloneQuest(quest: QuestProgress): QuestProgress {
 export function applyQuestUpdatesToPlayerStats(
   value: unknown,
   updatesValue: unknown,
+  options: { autoRemoveFullyCompleted?: boolean } = {},
 ): { playerStats: PlayerStats; changed: boolean } {
   const updates = Array.isArray(updatesValue)
     ? updatesValue.map(normalizeQuestUpdate).filter((update): update is NormalizedQuestUpdate => !!update)
@@ -340,13 +341,15 @@ export function applyQuestUpdatesToPlayerStats(
     }
   }
 
-  for (let index = quests.length - 1; index >= 0; index -= 1) {
-    const quest = quests[index]!;
-    if (
-      quest.completed &&
-      (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))
-    ) {
-      quests.splice(index, 1);
+  if (options.autoRemoveFullyCompleted === true) {
+    for (let index = quests.length - 1; index >= 0; index -= 1) {
+      const quest = quests[index]!;
+      if (
+        quest.completed &&
+        (quest.objectives.length === 0 || quest.objectives.every((objective) => objective.completed))
+      ) {
+        quests.splice(index, 1);
+      }
     }
   }
 

--- a/src/features/runtime/generation/hooks/use-generate.ts
+++ b/src/features/runtime/generation/hooks/use-generate.ts
@@ -84,6 +84,9 @@ type AgentResultEffectOptions = {
   skipTrackerSync?: boolean;
   cacheBackgroundResults?: boolean;
   showTrackerBubbles?: boolean;
+  // Per-turn quest updates remove fully-completed quests; the single-tracker
+  // re-run path leaves them visible (mirrors the engine persist split).
+  autoRemoveFullyCompletedQuests?: boolean;
 };
 const HAPTIC_COMMAND_INTERVAL_MS = 225;
 const TYPEWRITER_MAX_FRAME_MS = 120;
@@ -787,11 +790,12 @@ async function applyBackgroundChoice(chatId: string, chosen: unknown) {
   }
 }
 
-function applyQuestUpdates(rawData: unknown) {
+function applyQuestUpdates(rawData: unknown, autoRemoveFullyCompleted: boolean) {
   const current = useGameStateStore.getState().current;
   const { playerStats, changed } = applyQuestUpdatesToPlayerStats(
     current?.playerStats,
     parseMaybeRecord(rawData).updates,
+    { autoRemoveFullyCompleted },
   );
   if (!changed) return;
 
@@ -1151,7 +1155,7 @@ async function applyAgentResultEffects(
   if (result.type === "background_change" || result.agentType === "background") {
     await applyBackgroundChoice(chatId, data.chosen);
   }
-  if (result.agentType === "quest") applyQuestUpdates(result.data);
+  if (result.agentType === "quest") applyQuestUpdates(result.data, options.autoRemoveFullyCompletedQuests === true);
   if (!options.skipTrackerSync) await applyTrackerResultToGameState(queryClient, chatId, result);
 }
 
@@ -1412,6 +1416,7 @@ export async function runGenerationWithUi(
         await applyAgentResultEffects(queryClient, chatId, rawResult, {
           cacheBackgroundResults: false,
           showTrackerBubbles: false,
+          autoRemoveFullyCompletedQuests: true,
         });
       }
       if (pendingAgentResultEffects.length > 0) drainAgentResultEffects();


### PR DESCRIPTION
## Linked issue

Closes #2373

## Why this change

- Regression vs main. The refactor's port of `applyQuestUpdatesToPlayerStats` dropped main's `autoRemoveFullyCompleted` opt-out, so the fully-completed-quest splice ran unconditionally. Clicking the quest-refresh / re-run tracker button silently removed quests the user had just completed, whereas main keeps them visible until the next normal turn.

## What changed

- `src/engine/shared/game-state/player-stats.ts`: re-added an `options?: { autoRemoveFullyCompleted?: boolean }` param to `applyQuestUpdatesToPlayerStats` and gated the fully-completed splice behind it (default = keep).
- `src/engine/generation/tracker-snapshots.ts` + `src/engine/generation/start-generation.ts`: threaded an `autoRemoveFullyCompletedQuests` flag through `persistTrackerSnapshotSafely` → `persistTrackerSnapshotForTurn` → `gameStatePatchFromAgentResult` → the engine fn. The per-turn persist site passes `true` (remove — unchanged normal-turn behavior); the single-tracker re-run persist site keeps the default `false` (keep), restoring main's two-route split.
- The two engine persist call sites are physically distinct (per-turn vs re-run), so the distinction is preserved without a flag on the client path.

## Refactor impact

Primary owner: engine generation (world-state / game-state)

Impact areas reviewed:

- `src/engine/shared/game-state/player-stats.ts` (`applyQuestUpdatesToPlayerStats`)
- `src/engine/generation/tracker-snapshots.ts`, `src/engine/generation/start-generation.ts` (persist threading)

Boundary notes:

- None. Engine-layer only; the pure function stays pure (no feature/React imports). Verified exactly two `persistTrackerSnapshotSafely` callers — per-turn (passes `true`) and re-run (default `false`).

Pressure points touched:

- Runtime generation, world-state.

## Validation

- [x] Matching validation command passes locally
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run` — local-only tests confirmed `applyQuestUpdatesToPlayerStats` keeps a fully-completed quest by default and with `{ autoRemoveFullyCompleted: false }`, and removes it with `true`. `tracker-snapshots.test.ts` — 4 passed (no persist-path regression).
- `pnpm exec tsc -b` — clean.

## Feature Discoverability

- [ ] Updated `src/features/shell/discovery/`
- [x] N/A because this PR is a data-loss regression fix.

Reason:

- No new discoverable surface.

## Docs and release impact

- [x] No docs changes needed
