### PR TITLE
Fix remote stream unload cancellation

### DIFF
--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -2,7 +2,7 @@ import type { LlmChunk, LlmGateway, LlmRequest } from "../../engine/capabilities
 import { Channel } from "@tauri-apps/api/core";
 import { ignoreLlmStreamCancelFailure } from "./llm-cancel-logging";
 import { invokeTauri } from "./tauri-client";
-import { cancelRemoteLlmStream, remoteRuntimeTarget, streamRemoteLlm } from "./remote-runtime";
+import { cancelRemoteLlmStream, remoteRuntimeTarget, streamRemoteLlm, type RuntimeTarget } from "./remote-runtime";
 
 function createStreamId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
@@ -10,6 +10,7 @@ function createStreamId(): string {
 }
 
 const activeTauriStreamIds = new Set<string>();
+const activeRemoteStreams = new Map<string, RuntimeTarget>();
 let unloadCancellationInstalled = false;
 const TAURI_STREAM_TERMINAL_CLEANUP_GRACE_MS = 250;
 
@@ -25,11 +26,22 @@ function cancelActiveTauriStreams() {
   }
 }
 
+function cancelActiveRemoteStreams() {
+  for (const [streamId, target] of activeRemoteStreams) {
+    void cancelRemoteLlmStream(streamId, target, { keepalive: true });
+  }
+}
+
+function cancelActiveLlmStreams() {
+  cancelActiveTauriStreams();
+  cancelActiveRemoteStreams();
+}
+
 function installUnloadCancellation() {
   if (unloadCancellationInstalled || typeof window === "undefined") return;
   unloadCancellationInstalled = true;
-  window.addEventListener("pagehide", cancelActiveTauriStreams);
-  window.addEventListener("beforeunload", cancelActiveTauriStreams);
+  window.addEventListener("pagehide", cancelActiveLlmStreams);
+  window.addEventListener("beforeunload", cancelActiveLlmStreams);
 }
 
 export const llmApi: LlmGateway = {
@@ -57,6 +69,8 @@ export const llmApi: LlmGateway = {
     const streamId = createStreamId();
     const remoteTarget = remoteRuntimeTarget();
     if (remoteTarget) {
+      installUnloadCancellation();
+      activeRemoteStreams.set(streamId, remoteTarget);
       const abort = () => void cancelRemoteLlmStream(streamId, remoteTarget);
       if (signal?.aborted) abort();
       signal?.addEventListener("abort", abort, { once: true });
@@ -67,6 +81,7 @@ export const llmApi: LlmGateway = {
         }
       } finally {
         signal?.removeEventListener("abort", abort);
+        activeRemoteStreams.delete(streamId);
       }
       return;
     }

--- a/src/shared/api/remote-runtime.test.ts
+++ b/src/shared/api/remote-runtime.test.ts
@@ -127,14 +127,71 @@ describe("remote runtime cache policy", () => {
     const stream = streamRemoteLlm("stream-1", {} as Parameters<typeof streamRemoteLlm>[1], target);
     await stream.next();
     await cancelRemoteLlmStream("stream-1", target);
+    await cancelRemoteLlmStream("stream-2", target, { keepalive: true });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "http://runtime.example/api/llm/stream",
       expect.objectContaining({ cache: "no-store", method: "POST" }),
     );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://runtime.example/api/llm/stream/stream-1/cancel",
-      expect.objectContaining({ cache: "no-store", method: "POST" }),
+    const fetchCalls = fetchMock.mock.calls as unknown as Array<[string, RequestInit]>;
+    const defaultCancelCall = fetchCalls.find(([url]) => url === "http://runtime.example/api/llm/stream/stream-1/cancel");
+    const keepaliveCancelCall = fetchCalls.find(
+      ([url]) => url === "http://runtime.example/api/llm/stream/stream-2/cancel",
     );
+
+    expect(defaultCancelCall?.[1]).toEqual(expect.objectContaining({ cache: "no-store", method: "POST" }));
+    expect(defaultCancelCall?.[1]).not.toHaveProperty("keepalive");
+    expect(keepaliveCancelCall?.[1]).toEqual(
+      expect.objectContaining({ cache: "no-store", method: "POST", keepalive: true }),
+    );
+  });
+
+  it("cancels active LLM API remote streams on pagehide with keepalive", async () => {
+    useUIStore.setState({ remoteRuntimeUrl: "http://runtime.example" });
+    vi.stubGlobal("crypto", { randomUUID: () => "stream-unload" });
+    const listeners = new Map<string, Array<(event: Event) => void>>();
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn((type: string, listener: (event: Event) => void) => {
+        listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+      }),
+    });
+
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const streamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+        controller.enqueue(new TextEncoder().encode('data: {"type":"start"}\n\n'));
+      },
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "http://runtime.example/api/llm/stream") {
+        return new Response(streamBody, {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        });
+      }
+      if (url === "http://runtime.example/api/llm/stream/stream-unload/cancel") {
+        return new Response("{}", { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { llmApi } = await import("./llm-api");
+
+    const stream = llmApi.stream({ messages: [] });
+    await expect(stream.next()).resolves.toEqual({ done: false, value: { type: "start" } });
+    for (const listener of listeners.get("pagehide") ?? []) {
+      listener(new Event("pagehide"));
+    }
+
+    const fetchCalls = fetchMock.mock.calls as unknown as Array<[RequestInfo | URL, RequestInit | undefined]>;
+    const cancelCall = fetchCalls.find(
+      ([url]) => String(url) === "http://runtime.example/api/llm/stream/stream-unload/cancel",
+    );
+    expect(cancelCall?.[1]).toEqual(expect.objectContaining({ cache: "no-store", keepalive: true, method: "POST" }));
+
+    streamController.close();
+    await stream.return(undefined);
   });
 });

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -615,7 +615,11 @@ export async function* streamRemoteLlm(
   }
 }
 
-export async function cancelRemoteLlmStream(streamId: string, target: RuntimeTarget | null): Promise<void> {
+export async function cancelRemoteLlmStream(
+  streamId: string,
+  target: RuntimeTarget | null,
+  options: { keepalive?: boolean } = {},
+): Promise<void> {
   if (!target) return;
   await ignoreLlmStreamCancelFailure(
     "remote",
@@ -624,6 +628,7 @@ export async function cancelRemoteLlmStream(streamId: string, target: RuntimeTar
       const response = await fetch(`${target.baseUrl}/api/llm/stream/${encodeURIComponent(streamId)}/cancel`, remoteFetchInit({
         method: "POST",
         headers: remoteHeaders(target),
+        ...(options.keepalive === undefined ? {} : { keepalive: options.keepalive }),
       }));
       if (!response.ok) throw await readRemoteError(response);
     })(),


### PR DESCRIPTION
## Linked issue

Closes #2416

## Why this change

- Remote Runtime LLM streams only cancelled on an explicit `AbortSignal`, so page unload/navigation could leave the remote provider stream and Rust stream registry active after the web shell went away.

## What changed

- Track active remote LLM stream IDs in the shared LLM API wrapper.
- Reuse the existing unload cancellation listener for both embedded Tauri and remote runtime streams.
- Send remote unload cancellation through `/api/llm/stream/:stream_id/cancel` with `keepalive` so unload delivery has the best browser-supported chance to reach the runtime.
- Add focused proof for remote cancel `keepalive` propagation and `llmApi` pagehide cancellation.
- Keep existing explicit abort cancellation behavior unchanged.

## Refactor impact

Primary owner:

Shared API / remote runtime LLM stream lifecycle.

Impact areas reviewed:

- Shared LLM API stream wrapper.
- Remote runtime cancel helper.
- Rust HTTP stream cancel route and active/pending stream cancellation registry.
- Embedded Tauri stream unload cancellation path.

Boundary notes:

- Frontend feature code still calls the typed shared LLM gateway.
- Remote-capable behavior stays in `src/shared/api` and the existing dedicated Rust HTTP stream/cancel route.
- No engine, React feature, storage schema, or provider transport contract changes.

Pressure points touched:

- Remote Runtime LLM streaming lifecycle only.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/shared/api/remote-runtime.test.ts` passed after adding focused proof for `keepalive` propagation and pagehide-triggered remote stream cancellation.
- `pnpm check` passed after the proof update.
- Earlier branch validation also included `pnpm typecheck`, `pnpm check:architecture`, parityscan against `origin/main`, and Bunny-style local review.
- Native Tauri/manual remote-runtime unload QA was not run.

Durable test rationale:

- Regression/risky invariant: #2416 covers remote streams leaking when the web shell unloads without explicit abort.
- Existing proof gap: prior validation used a temporary local harness and did not leave a committed guard for Bunny's unload-time `keepalive` warning.
- Narrowness: the added proof extends existing `src/shared/api/remote-runtime.test.ts` coverage only around `cancelRemoteLlmStream` request options and `llmApi.stream(...)` pagehide cancellation.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal stream lifecycle bugfix; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes.