### PR TITLE
Fix LLM stream error event parity

### DIFF
--- a/src/engine/generation/agent-runner.test.ts
+++ b/src/engine/generation/agent-runner.test.ts
@@ -73,6 +73,15 @@ function llmWithJsonAgentResponse(calls: { count: number }): LlmGateway {
   } as unknown as LlmGateway;
 }
 
+function llmWithStreamError(calls: { count: number }): LlmGateway {
+  return {
+    async *stream() {
+      calls.count += 1;
+      yield { type: "error", data: { message: "Agent provider failed" } };
+    },
+  } as unknown as LlmGateway;
+}
+
 const integrations = {} as IntegrationGateway;
 const chat = {
   id: "chat-1",
@@ -174,6 +183,37 @@ describe("createGenerationAgentRuntime regeneration cadence", () => {
 
     expect(calls.count).toBe(0);
     expect(runtime.preInjections).toEqual([]);
+  });
+
+  it("records LLM stream error chunks as pre-generation agent failures", async () => {
+    const calls = { count: 0 };
+    const runtime = await createGenerationAgentRuntime(
+      {
+        storage: storageWithAgentRuns([]),
+        llm: llmWithStreamError(calls),
+        integrations,
+      },
+      {
+        chat,
+        connection,
+        storedMessages: storedMessages.slice(0, 1),
+        cadenceMessages: storedMessages.slice(0, 1),
+        characters: [],
+        persona: null,
+        activatedLorebookEntries: [],
+        chatSummary: null,
+      },
+    );
+
+    expect(calls.count).toBe(1);
+    expect(runtime.preInjections).toEqual([]);
+    expect(runtime.preResults).toEqual([
+      expect.objectContaining({
+        agentType: "director",
+        error: "Agent provider failed",
+        success: false,
+      }),
+    ]);
   });
 });
 

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -424,6 +424,17 @@ interface AutomaticIntervalGate {
   runInterval: number;
 }
 
+function llmChunkText(chunk: { text?: unknown; data?: unknown; error?: unknown; message?: unknown }): string {
+  if (typeof chunk.text === "string") return chunk.text;
+  if (typeof chunk.data === "string") return chunk.data;
+  const data = isRecord(chunk.data) ? chunk.data : {};
+  return readString(chunk.message) || readString(chunk.error) || readString(data.message) || readString(data.error);
+}
+
+function llmStreamErrorMessage(chunk: { text?: unknown; data?: unknown; error?: unknown; message?: unknown }): string {
+  return llmChunkText(chunk).trim() || "LLM stream failed";
+}
+
 function llmProvider(
   llm: LlmGateway,
   connectionId: string | null,
@@ -458,12 +469,17 @@ function llmProvider(
         },
         options.signal,
       )) {
-        if (chunk.type === "token" && chunk.text) {
-          content += chunk.text;
-          options.onToken?.(chunk.text);
+        if (chunk.type === "token") {
+          const text = llmChunkText(chunk);
+          if (text) {
+            content += text;
+            options.onToken?.(text);
+          }
         } else if (chunk.type === "tool_call") {
           const toolCall = normalizeToolCall(chunk.data);
           if (toolCall) toolCalls.push(toolCall);
+        } else if (chunk.type === "error") {
+          throw new Error(llmStreamErrorMessage(chunk));
         }
       }
       return { content, toolCalls };

--- a/src/engine/generation/makers.ts
+++ b/src/engine/generation/makers.ts
@@ -392,10 +392,26 @@ async function* runMakerRequest(
         yield { type: "token", data: token };
       }
     } else if (chunk.type === "error") {
-      throw new Error(typeof chunk.data === "string" ? chunk.data : "Generation failed");
+      throw new Error(llmStreamErrorMessage(chunk));
     }
   }
   return raw;
+}
+
+function llmChunkText(chunk: { text?: unknown; data?: unknown; error?: unknown; message?: unknown }): string {
+  if (typeof chunk.text === "string") return chunk.text;
+  if (typeof chunk.data === "string") return chunk.data;
+  const data = chunk.data && typeof chunk.data === "object" && !Array.isArray(chunk.data) ? chunk.data : {};
+  return (
+    stringOrEmpty(chunk.message).trim() ||
+    stringOrEmpty(chunk.error).trim() ||
+    stringOrEmpty((data as { message?: unknown }).message).trim() ||
+    stringOrEmpty((data as { error?: unknown }).error).trim()
+  );
+}
+
+function llmStreamErrorMessage(chunk: { text?: unknown; data?: unknown; error?: unknown; message?: unknown }): string {
+  return llmChunkText(chunk).trim() || "Generation failed";
 }
 
 function buildContinuationLorebookPrompt(

--- a/src/engine/generation/makers.ts
+++ b/src/engine/generation/makers.ts
@@ -386,7 +386,7 @@ async function* runMakerRequest(
   for await (const chunk of llm.stream(request, signal)) {
     if (signal?.aborted) throw new DOMException("The operation was aborted.", "AbortError");
     if (chunk.type === "token") {
-      const token = typeof chunk.text === "string" ? chunk.text : typeof chunk.data === "string" ? chunk.data : "";
+      const token = llmChunkText(chunk);
       if (token) {
         raw += token;
         yield { type: "token", data: token };

--- a/src/engine/generation/start-generation.test.ts
+++ b/src/engine/generation/start-generation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { IntegrationGateway } from "../capabilities/integrations";
-import type { LlmGateway } from "../capabilities/llm";
+import type { LlmChunk, LlmGateway } from "../capabilities/llm";
 import type { StorageEntity, StorageGateway } from "../capabilities/storage";
 import type { WeekSchedule } from "../modes/chat/schedules/schedule.service";
 import { retryGenerationAgents, startGeneration, type StartGenerationInput } from "./start-generation";
@@ -316,6 +316,7 @@ function createDeps(
       extraPatches?: Array<{ messageId: string; patch: Record<string, unknown> }>;
       streamParameters?: Record<string, unknown>[];
     };
+    streamChunks?: LlmChunk[];
   } = {},
 ) {
   const llm: LlmGateway = {
@@ -324,7 +325,9 @@ function createDeps(
     },
     async *stream(request) {
       options.capture?.streamParameters?.push(request.parameters ?? {});
-      yield { type: "token" as const, text: "Hello." };
+      for (const chunk of options.streamChunks ?? [{ type: "token" as const, text: "Hello." }]) {
+        yield chunk;
+      }
     },
     async listModels() {
       return [];
@@ -473,6 +476,12 @@ async function collectLorebookKeeperBackfillEvents() {
   });
 }
 
+async function drainGeneration(stream: AsyncGenerator<unknown>): Promise<void> {
+  for await (const _event of stream) {
+    void _event;
+  }
+}
+
 describe("startGeneration conversation availability delays", () => {
   it("uses short legacy mention delays for explicit conversation mentions and manual targets", async () => {
     const random = vi.spyOn(Math, "random").mockReturnValue(0);
@@ -522,6 +531,19 @@ describe("startGeneration conversation availability delays", () => {
     } finally {
       random.mockRestore();
     }
+  });
+});
+
+describe("startGeneration LLM stream errors", () => {
+  it("throws the provider message from terminal stream error chunks", async () => {
+    const deps = createDeps("idle", {
+      mode: "roleplay",
+      streamChunks: [{ type: "error", data: { message: "Provider failed" } }],
+    });
+
+    await expect(drainGeneration(startGeneration(deps, { chatId: "chat-1", message: "Hi Mira" }))).rejects.toThrow(
+      "Provider failed",
+    );
   });
 });
 

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -3338,8 +3338,15 @@ function rerollSeedParameters(input: StartGenerationInput, parameters: Record<st
  */
 const MAX_MAIN_TOOL_ITERATIONS = 8;
 
-function llmChunkText(chunk: { text?: unknown; data?: unknown }): string {
-  return typeof chunk.text === "string" ? chunk.text : typeof chunk.data === "string" ? chunk.data : "";
+function llmChunkText(chunk: { text?: unknown; data?: unknown; error?: unknown; message?: unknown }): string {
+  if (typeof chunk.text === "string") return chunk.text;
+  if (typeof chunk.data === "string") return chunk.data;
+  const data = isRecord(chunk.data) ? chunk.data : {};
+  return readString(chunk.message) || readString(chunk.error) || readString(data.message) || readString(data.error);
+}
+
+function llmStreamErrorMessage(chunk: { text?: unknown; data?: unknown }): string {
+  return llmChunkText(chunk).trim() || "LLM stream failed";
 }
 
 /**
@@ -3456,6 +3463,8 @@ async function* streamMainGenerationLoop(args: {
         if (normalized) pendingToolCalls.push(normalized);
       } else if (chunk.type === "usage" && chunk.data != null) {
         streamUsages.push(chunk.data);
+      } else if (chunk.type === "error") {
+        throw new Error(llmStreamErrorMessage(chunk));
       }
     }
     const streamUsage = mergeStreamUsageChunks(streamUsages);

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -1,5 +1,6 @@
 import type { LlmChunk, LlmGateway, LlmRequest } from "../../engine/capabilities/llm";
 import { Channel } from "@tauri-apps/api/core";
+import { ApiError } from "./api-errors";
 import { ignoreLlmStreamCancelFailure } from "./llm-cancel-logging";
 import { invokeTauri } from "./tauri-client";
 import { cancelRemoteLlmStream, remoteRuntimeTarget, streamRemoteLlm } from "./remote-runtime";
@@ -17,6 +18,51 @@ function wait(ms: number): Promise<false> {
   return new Promise((resolve) => {
     globalThis.setTimeout(() => resolve(false), ms);
   });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isAbortError(error: unknown): boolean {
+  return isRecord(error) && error.name === "AbortError";
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function chunkText(event: LlmChunk): string | undefined {
+  if (typeof event.text === "string") return event.text;
+  if (typeof event.data === "string") return event.data;
+  const record = event as LlmChunk & { error?: unknown; message?: unknown };
+  const data = isRecord(event.data) ? event.data : {};
+  return (
+    readString(record.message) ||
+    readString(record.error) ||
+    readString(data.message) ||
+    readString(data.error) ||
+    undefined
+  );
+}
+
+function streamErrorChunk(error: unknown): LlmChunk {
+  const message = error instanceof Error ? error.message : String(error ?? "LLM stream failed");
+  const details =
+    error instanceof ApiError && isRecord(error.details)
+      ? error.details
+      : error instanceof ApiError && error.details !== undefined
+        ? { details: error.details }
+        : {};
+  return {
+    type: "error",
+    text: message || "LLM stream failed",
+    data: {
+      ...details,
+      message: message || "LLM stream failed",
+      ...(error instanceof ApiError ? { status: error.status } : {}),
+    },
+  };
 }
 
 function cancelActiveTauriStreams() {
@@ -64,6 +110,7 @@ export const llmApi: LlmGateway = {
         for await (const event of streamRemoteLlm(streamId, request, remoteTarget, signal)) {
           if (event.type === "done") continue;
           yield event;
+          if (event.type === "error") return;
         }
       } finally {
         signal?.removeEventListener("abort", abort);
@@ -99,8 +146,7 @@ export const llmApi: LlmGateway = {
     signal?.addEventListener("abort", abort, { once: true });
 
     const onEvent = new Channel<LlmChunk>((event) => {
-      const text =
-        typeof event.text === "string" ? event.text : typeof event.data === "string" ? event.data : undefined;
+      const text = chunkText(event);
       const normalized = text === undefined ? event : { ...event, text };
       if (normalized.type === "done" || normalized.type === "error") {
         terminalEventReceived = true;
@@ -119,9 +165,12 @@ export const llmApi: LlmGateway = {
         commandSettled = true;
       },
       (error) => {
-        // A native command rejection is fatal; prefer surfacing it over yielding already-buffered partial tokens.
         commandSettled = true;
-        failure = error;
+        if (cancelRequested || isAbortError(error)) {
+          failure ??= error;
+        } else {
+          queue.push(streamErrorChunk(error));
+        }
         completed = true;
         notify();
       },
@@ -137,7 +186,6 @@ export const llmApi: LlmGateway = {
           continue;
         }
         const event = queue.shift()!;
-        if (event.type === "error") throw new Error(String(event.text ?? event.data ?? "LLM stream failed"));
         if (event.type === "done") continue;
         yield event;
       }

--- a/src/shared/api/llm-api.ts
+++ b/src/shared/api/llm-api.ts
@@ -32,6 +32,10 @@ function readString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 function chunkText(event: LlmChunk): string | undefined {
   if (typeof event.text === "string") return event.text;
   if (typeof event.data === "string") return event.data;
@@ -47,20 +51,44 @@ function chunkText(event: LlmChunk): string | undefined {
 }
 
 function streamErrorChunk(error: unknown): LlmChunk {
-  const message = error instanceof Error ? error.message : String(error ?? "LLM stream failed");
-  const details =
-    error instanceof ApiError && isRecord(error.details)
-      ? error.details
-      : error instanceof ApiError && error.details !== undefined
+  let message = "LLM stream failed";
+  let status: number | undefined;
+  let details: Record<string, unknown> = {};
+
+  if (error instanceof ApiError) {
+    message = error.message || message;
+    status = error.status;
+    details = isRecord(error.details)
+      ? { ...error.details }
+      : error.details !== undefined
         ? { details: error.details }
         : {};
+  } else if (error instanceof Error) {
+    message = error.message || message;
+  } else if (isRecord(error)) {
+    message = readString(error.message) || readString(error.error) || message;
+    details = isRecord(error.data)
+      ? { ...error.data }
+      : isRecord(error.details)
+        ? { ...error.details }
+        : error.details !== undefined
+          ? { details: error.details }
+          : {};
+    const code = readString(error.code);
+    const nextStatus = readNumber(error.status) ?? readNumber(error.statusCode);
+    if (code && details.code === undefined) details.code = code;
+    if (nextStatus !== null) status = nextStatus;
+  } else {
+    message = String(error ?? message) || message;
+  }
+
   return {
     type: "error",
-    text: message || "LLM stream failed",
+    text: message,
     data: {
       ...details,
-      message: message || "LLM stream failed",
-      ...(error instanceof ApiError ? { status: error.status } : {}),
+      message,
+      ...(status !== undefined ? { status } : {}),
     },
   };
 }

--- a/src/shared/api/remote-runtime.test.ts
+++ b/src/shared/api/remote-runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LlmChunk, LlmRequest } from "../../engine/capabilities/llm";
 import { ApiError } from "./api-errors";
 import { apiQueryRetryDelay, shouldRetryApiQuery } from "./query-retry";
 import {
@@ -136,5 +137,137 @@ describe("remote runtime cache policy", () => {
       "http://runtime.example/api/llm/stream/stream-1/cancel",
       expect.objectContaining({ cache: "no-store", method: "POST" }),
     );
+  });
+});
+
+describe("remote LLM stream events", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("yields SSE error events instead of throwing them", async () => {
+    const target: RuntimeTarget = { baseUrl: "http://runtime.example" };
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        'data: {"type":"error","code":"llm_provider_error","message":"Provider failed","data":{"safe":true}}\n\n',
+        {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stream = streamRemoteLlm("stream-1", {} as Parameters<typeof streamRemoteLlm>[1], target);
+
+    await expect(stream.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        type: "error",
+        code: "llm_provider_error",
+        message: "Provider failed",
+        text: "Provider failed",
+        data: { safe: true },
+      },
+    });
+    await expect(stream.next()).resolves.toMatchObject({ done: true });
+  });
+});
+
+const llmRequest: LlmRequest = {
+  messages: [{ role: "user", content: "Hello" }],
+};
+
+async function collectLlmChunks(stream: AsyncGenerator<LlmChunk>): Promise<LlmChunk[]> {
+  const chunks: LlmChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+async function loadMockedLlmApi() {
+  const mocks = {
+    cancelRemoteLlmStream: vi.fn(),
+    invokeTauri: vi.fn(),
+    remoteRuntimeTarget: vi.fn().mockReturnValue(null),
+    streamRemoteLlm: vi.fn(),
+  };
+
+  vi.resetModules();
+  vi.doMock("@tauri-apps/api/core", () => ({
+    Channel: class<T> {
+      private readonly handler: (event: T) => void;
+
+      constructor(handler: (event: T) => void) {
+        this.handler = handler;
+      }
+
+      send(event: T): void {
+        this.handler(event);
+      }
+    },
+  }));
+  vi.doMock("./tauri-client", () => ({
+    invokeTauri: mocks.invokeTauri,
+  }));
+  vi.doMock("./remote-runtime", () => ({
+    cancelRemoteLlmStream: mocks.cancelRemoteLlmStream,
+    remoteRuntimeTarget: mocks.remoteRuntimeTarget,
+    streamRemoteLlm: mocks.streamRemoteLlm,
+  }));
+
+  const [{ ApiError: MockedApiError }, { llmApi }] = await Promise.all([import("./api-errors"), import("./llm-api")]);
+  return { ApiError: MockedApiError, llmApi, mocks };
+}
+
+describe("embedded LLM stream events", () => {
+  afterEach(() => {
+    vi.doUnmock("@tauri-apps/api/core");
+    vi.doUnmock("./tauri-client");
+    vi.doUnmock("./remote-runtime");
+    vi.resetModules();
+  });
+
+  it("yields a stream error chunk when the native stream command rejects", async () => {
+    const { ApiError: MockedApiError, llmApi, mocks } = await loadMockedLlmApi();
+    mocks.invokeTauri.mockImplementation((command: string) => {
+      if (command === "llm_stream_channel") {
+        return Promise.reject(
+          new MockedApiError("Provider failed", 500, {
+            code: "llm_provider_error",
+            safe: true,
+          }),
+        );
+      }
+      return Promise.resolve(null);
+    });
+
+    await expect(collectLlmChunks(llmApi.stream(llmRequest))).resolves.toEqual([
+      {
+        type: "error",
+        text: "Provider failed",
+        data: {
+          code: "llm_provider_error",
+          message: "Provider failed",
+          safe: true,
+          status: 500,
+        },
+      },
+    ]);
+  });
+
+  it("keeps cancellation as a thrown AbortError", async () => {
+    const { llmApi, mocks } = await loadMockedLlmApi();
+    const controller = new AbortController();
+    controller.abort();
+    mocks.invokeTauri.mockImplementation((command: string) => {
+      if (command === "llm_stream_cancel") return Promise.resolve({ cancelled: true });
+      return new Promise(() => {});
+    });
+
+    await expect(llmApi.stream(llmRequest, controller.signal).next()).rejects.toMatchObject({
+      name: "AbortError",
+    });
   });
 });

--- a/src/shared/api/remote-runtime.test.ts
+++ b/src/shared/api/remote-runtime.test.ts
@@ -12,6 +12,10 @@ import {
 } from "./remote-runtime";
 import { useUIStore } from "../stores/ui.store";
 
+const llmRequest: LlmRequest = {
+  messages: [{ role: "user", content: "Hello" }],
+};
+
 describe("remote runtime retry metadata", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -125,7 +129,7 @@ describe("remote runtime cache policy", () => {
     const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const stream = streamRemoteLlm("stream-1", {} as Parameters<typeof streamRemoteLlm>[1], target);
+    const stream = streamRemoteLlm("stream-1", llmRequest, target);
     await stream.next();
     await cancelRemoteLlmStream("stream-1", target);
 
@@ -158,7 +162,7 @@ describe("remote LLM stream events", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const stream = streamRemoteLlm("stream-1", {} as Parameters<typeof streamRemoteLlm>[1], target);
+    const stream = streamRemoteLlm("stream-1", llmRequest, target);
 
     await expect(stream.next()).resolves.toMatchObject({
       done: false,
@@ -173,10 +177,6 @@ describe("remote LLM stream events", () => {
     await expect(stream.next()).resolves.toMatchObject({ done: true });
   });
 });
-
-const llmRequest: LlmRequest = {
-  messages: [{ role: "user", content: "Hello" }],
-};
 
 async function collectLlmChunks(stream: AsyncGenerator<LlmChunk>): Promise<LlmChunk[]> {
   const chunks: LlmChunk[] = [];
@@ -204,7 +204,7 @@ async function loadMockedLlmApi() {
       }
 
       send(event: T): void {
-        this.handler(event);
+        void Promise.resolve().then(() => this.handler(event));
       }
     },
   }));
@@ -243,7 +243,8 @@ describe("embedded LLM stream events", () => {
       return Promise.resolve(null);
     });
 
-    await expect(collectLlmChunks(llmApi.stream(llmRequest))).resolves.toEqual([
+    const stream = llmApi.stream(llmRequest);
+    await expect(collectLlmChunks(stream)).resolves.toEqual([
       {
         type: "error",
         text: "Provider failed",
@@ -255,6 +256,37 @@ describe("embedded LLM stream events", () => {
         },
       },
     ]);
+    await expect(stream.next()).resolves.toMatchObject({ done: true });
+  });
+
+  it("normalizes serialized native stream rejections into an error chunk", async () => {
+    const { llmApi, mocks } = await loadMockedLlmApi();
+    mocks.invokeTauri.mockImplementation((command: string) => {
+      if (command === "llm_stream_channel") {
+        return Promise.reject({
+          code: "llm_provider_error",
+          data: { safe: true },
+          message: "Serialized provider failed",
+          status: 502,
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const stream = llmApi.stream(llmRequest);
+    await expect(collectLlmChunks(stream)).resolves.toEqual([
+      {
+        type: "error",
+        text: "Serialized provider failed",
+        data: {
+          code: "llm_provider_error",
+          message: "Serialized provider failed",
+          safe: true,
+          status: 502,
+        },
+      },
+    ]);
+    await expect(stream.next()).resolves.toMatchObject({ done: true });
   });
 
   it("keeps cancellation as a thrown AbortError", async () => {

--- a/src/shared/api/remote-runtime.ts
+++ b/src/shared/api/remote-runtime.ts
@@ -339,10 +339,6 @@ function readString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function readNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
@@ -438,26 +434,23 @@ export async function readRemoteError(response: Response): Promise<ApiError> {
   }
 }
 
-function remoteStreamError(event: LlmChunk): ApiError {
-  const record = event as LlmChunk & { code?: unknown; message?: unknown };
-  const data = event.data;
-  const dataRecord = isRecord(data) ? data : {};
-  const message =
-    readString(record.message) ||
-    readString(event.text) ||
-    readString(data) ||
-    readString(dataRecord.message) ||
-    "LLM stream failed";
-  const status = readNumber(dataRecord.status) ?? readNumber(dataRecord.statusCode) ?? 0;
-  const code = readString(record.code) || readString(dataRecord.code);
-  return new ApiError(message, status, {
-    ...(code ? { code } : {}),
-    event,
-  });
-}
-
 function normalizeRemoteLlmChunk(event: LlmChunk): LlmChunk {
-  const text = typeof event.text === "string" ? event.text : typeof event.data === "string" ? event.data : undefined;
+  const record = event as LlmChunk & { error?: unknown; message?: unknown };
+  const data = isRecord(event.data) ? event.data : {};
+  const text =
+    typeof event.text === "string"
+      ? event.text
+      : typeof event.data === "string"
+        ? event.data
+        : typeof record.message === "string"
+          ? record.message
+          : typeof record.error === "string"
+            ? record.error
+            : typeof data.message === "string"
+              ? data.message
+              : typeof data.error === "string"
+                ? data.error
+                : undefined;
   return text === undefined ? event : { ...event, text };
 }
 
@@ -606,8 +599,8 @@ export async function* streamRemoteLlm(
       buffer = parsed.rest;
       for (const data of parsed.events) {
         const event = normalizeRemoteLlmChunk(JSON.parse(data) as LlmChunk);
-        if (event.type === "error") throw remoteStreamError(event);
         yield event;
+        if (event.type === "error") return;
       }
     }
   } finally {


### PR DESCRIPTION
## Linked issue

Closes #2415

## Why this change

- Embedded Tauri LLM streaming could reject the native command on provider/Rust failures instead of yielding the documented `error` stream chunk.
- Remote runtime already emitted stream error events, but the shared remote adapter converted them back into thrown API errors.
- This made `11-PROV-RUNTIME-stream-event-contract` drift between embedded and remote runtime paths.

## What changed

- Convert embedded `llm_stream_channel` command rejections into terminal `type: "error"` chunks while preserving thrown `AbortError` cancellation behavior.
- Preserve remote `/api/llm/stream` SSE `error` chunks as yielded terminal stream events.
- Normalize provider error text from `text`, string `data`, top-level `message`/`error`, and `data.message`/`data.error`.
- Make generation, agent, and maker stream consumers fail normally when they receive a stream `error` chunk.
- Add focused shared API tests for remote SSE error events, embedded native command rejection, and embedded cancellation.

## Refactor impact

Primary owner:

Shared API / runtime generation / engine generation.

Impact areas reviewed:

- Shared API LLM wrapper and remote runtime SSE reader.
- Embedded Tauri LLM stream command rejection path.
- Main generation, agent runner, and maker stream consumers.
- Legacy `origin/main` SSE stream error behavior for parity.

Boundary notes:

- Runtime adapter behavior stays in `src/shared/api`.
- Product generation behavior stays in `src/engine`.
- Rust command and HTTP route behavior already emitted or returned the needed error shape; no Rust changes were needed.
- Remote stream cancellation remains routed through the existing focused shared API wrapper.

Pressure points touched:

- `src/shared/api/llm-api.ts`
- `src/shared/api/remote-runtime.ts`
- `src/engine/generation/start-generation.ts`
- `src/engine/generation/agent-runner.ts`
- `src/engine/generation/makers.ts`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/shared/api/remote-runtime.test.ts src/engine/generation/agent-runner.test.ts src/engine/generation/start-generation.test.ts` passed: 3 test files, 30 tests.
- `pnpm typecheck` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed.
- Static comparison against refreshed `origin/main` confirmed legacy generation SSE sends terminal `type: "error"` events and legacy client handling treats error events as terminal.
- Manual live Tauri/provider and live remote-runtime streaming QA were not run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Stream error contract bugfix only; no new user-discoverable feature or workflow.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes. No screenshots or recordings attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM stream error handling with consistent message extraction across different provider response formats.
  * Enhanced error recovery in generation workflows when LLM providers report failures.
  * Standardized error handling for both remote and native streaming modes.

* **Tests**
  * Added test coverage for LLM streaming error scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->