### PR TITLE
Fix creator notes character marker rendering

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -244,6 +244,57 @@ describe("assembleGenerationPrompt lorebook marker gating", () => {
 });
 
 describe("assembleGenerationPrompt character markers", () => {
+  it("renders requested creator notes fields with character macro resolution", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "characters",
+          presetId: "preset-1",
+          identifier: "character",
+          role: "system",
+          enabled: true,
+          markerConfig: { type: "character", characterFields: ["creator_notes", "creatorNotes"] },
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice description.",
+            creator_notes: "Creator note for {{char}} and {{user}}.",
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", characterIds: ["char-1"], metadata: {} },
+      storedMessages: [],
+      connection: {},
+      request: {},
+      latestUserInput: "",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt.match(/Creator Notes: Creator note for Alice and Celia\./g)).toHaveLength(2);
+  });
+
   it("resolves character field macros against each rendered character in a group", async () => {
     const storage = storageWithRows({
       prompts: [

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1223,7 +1223,7 @@ function characterFieldValue(character: GenerationCharacterContext, fieldName: s
       return character.mesExample ?? "";
     case "creator_notes":
     case "creatorNotes":
-      return "";
+      return character.creatorNotes ?? "";
     case "system_prompt":
     case "systemPrompt":
       return character.systemPrompt ?? "";


### PR DESCRIPTION
## Linked issue

Closes #2444

## Why this change

- Character prompt marker rendering loaded creator notes into generation context but returned an empty string when a prompt marker requested `creator_notes` or `creatorNotes`.
- This restores legacy parity for requested creator-notes character fields without changing default prompt behavior.

## What changed

- Return `GenerationCharacterContext.creatorNotes` from character marker field rendering for both `creator_notes` and `creatorNotes`.
- Add a focused prompt assembly regression test that requests both aliases and verifies character/persona macro resolution still runs through the existing prompt assembly path.

## Refactor impact

Primary owner:

- Engine generation / prompt assembly.

Impact areas reviewed:

- Chat and roleplay prompt assembly paths that render character prompt markers.
- Runtime generation context loading for character creator notes.
- Sibling defaults for character markers; default marker fields remain unchanged.

Boundary notes:

- Change stays in React-free `src/engine/generation` behavior.
- No React feature, shared API, Tauri/Rust, provider transport, storage schema, or remote-runtime boundary changes.

Pressure points touched:

- None. Did not touch `ModeSurface`, `GameSurface`, shared mode UI, `src-tauri/src/lib.rs` command registration, or import modules.

## Validation

<!-- Check only what you personally ran or manually verified. Treat unchecked items as explicit TODOs. -->
<!--
Proof is session evidence, not permission to add durable test artifacts by reflex.
Temporary local tests or harnesses are fine when they remain uncommitted.
If this PR adds a committed test artifact, explain the durable test rationale in
the notes below: the regression or risky invariant, why existing proof is
insufficient, and why this test is narrow.
-->

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Focused proof: `pnpm vitest run src/engine/generation/prompt-assembly.test.ts` passed with 9 tests.
- TypeScript lane check: `pnpm typecheck` passed.
- Pre-PR gate: `pnpm check` passed, including line endings, scratch cleanliness, architecture, TypeScript, Rust check, docs, discovery, launcher safety, and warning-only unused-code scan.
- Whitespace check: `git diff --check` passed.
- Durable test rationale: this fixes a regression in private character marker field mapping; existing prompt assembly tests covered nearby marker macro behavior but not creator notes; the new test is narrow because it exercises one prompt section with both creator-notes aliases through `assembleGenerationPrompt`.
- Human/manual UI validation not run; this is an engine prompt assembly fix with no visible UI change.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This is an internal prompt assembly bugfix and regression test; it does not add or change a discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [ ] Confirmed this PR does not restore old staging/package-workspace/release claims

No docs changes needed: behavior restores requested prompt marker field rendering and does not change setup, architecture, user workflows, contributor guidance, or release claims.

## UI evidence

N/A. No visible UI changes.