### PR TITLE
Fix group scenario prompt override

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -314,6 +314,385 @@ describe("assembleGenerationPrompt character markers", () => {
     expect(prompt).not.toContain("Bob description references Alice personality");
     expect(prompt).not.toContain("Alice scenario for Bob");
   });
+
+  it("uses the group scenario override for character prompt context", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "system",
+          presetId: "preset-1",
+          role: "system",
+          content: "Macro scenario is {{scenario}}.",
+          enabled: true,
+        },
+        {
+          id: "characters",
+          presetId: "preset-1",
+          identifier: "character",
+          role: "system",
+          enabled: true,
+          markerConfig: { type: "character", characterFields: ["description", "scenario"] },
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice sees {{scenario}}.",
+            scenario: "Alice old scenario",
+          },
+        },
+        {
+          id: "char-2",
+          data: {
+            name: "Bob",
+            description: "Bob sees {{scenario}}.",
+            scenario: "Bob old scenario",
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1", "char-2"],
+        metadata: { groupScenarioOverride: true, groupScenarioText: "Shared stage scenario" },
+      },
+      storedMessages: [],
+      connection: {},
+      request: {},
+      latestUserInput: "",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Macro scenario is Shared stage scenario.");
+    expect(prompt).toContain("Alice sees Shared stage scenario.");
+    expect(prompt).toContain("Bob sees Shared stage scenario.");
+    expect(prompt).toContain("Scenario: Shared stage scenario");
+    expect(prompt).not.toContain("Alice old scenario");
+    expect(prompt).not.toContain("Bob old scenario");
+  });
+
+  it("suppresses character scenarios when the group scenario override is blank", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "system",
+          presetId: "preset-1",
+          role: "system",
+          content: "Macro scenario is {{scenario}}.",
+          enabled: true,
+        },
+        {
+          id: "characters",
+          presetId: "preset-1",
+          identifier: "character",
+          role: "system",
+          enabled: true,
+          markerConfig: { type: "character", characterFields: ["description", "scenario"] },
+        },
+        {
+          id: "history",
+          presetId: "preset-1",
+          identifier: "chat_history",
+          enabled: true,
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice sees {{scenario}}.",
+            scenario: "Alice old scenario",
+            extensions: {
+              depth_prompt: { prompt: "Depth scenario is {{scenario}}.", depth: 0, role: "system" },
+            },
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1"],
+        metadata: { groupScenarioOverride: true, groupScenarioText: "   " },
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "hello" }],
+      connection: {},
+      request: {},
+      latestUserInput: "hello",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Macro scenario is .");
+    expect(prompt).toContain("Alice sees .");
+    expect(prompt).toContain("Depth scenario is .");
+    expect(prompt).not.toContain("Scenario: Alice old scenario");
+    expect(prompt).not.toContain("Alice old scenario");
+
+    const fallbackStorage = storageWithRows({
+      prompts: [],
+      "prompt-sections": [],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice fallback description.",
+            scenario: "Alice old scenario",
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const fallbackAssembly = await assembleGenerationPrompt(fallbackStorage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1"],
+        metadata: { groupScenarioOverride: true, groupScenarioText: "" },
+      },
+      storedMessages: [],
+      connection: {},
+      request: {},
+      latestUserInput: "",
+    });
+
+    const fallbackPrompt = fallbackAssembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(fallbackPrompt).toContain("Alice fallback description.");
+    expect(fallbackPrompt).not.toContain("Scenario:");
+    expect(fallbackPrompt).not.toContain("<scenario>");
+    expect(fallbackPrompt).not.toContain("Alice old scenario");
+  });
+
+  it("resolves group scenario override macros in markers, fallback, and depth prompts", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "characters",
+          presetId: "preset-1",
+          identifier: "character",
+          role: "system",
+          enabled: true,
+          markerConfig: { type: "character", characterFields: ["description", "scenario"] },
+        },
+        {
+          id: "history",
+          presetId: "preset-1",
+          identifier: "chat_history",
+          enabled: true,
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice sees {{scenario}}.",
+            scenario: "Alice old scenario",
+            extensions: {
+              depth_prompt: { prompt: "Depth sees {{scenario}}.", depth: 0, role: "system" },
+            },
+          },
+        },
+        {
+          id: "char-2",
+          data: {
+            name: "Bob",
+            description: "Bob sees {{scenario}}.",
+            scenario: "Bob old scenario",
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1", "char-2"],
+        metadata: {
+          groupScenarioOverride: true,
+          groupScenarioText: "Shared scene for {{user}} and {{char}}.",
+        },
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "hello" }],
+      connection: {},
+      request: {},
+      latestUserInput: "hello",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Alice sees Shared scene for Celia and Alice.");
+    expect(prompt).toContain("Bob sees Shared scene for Celia and Bob.");
+    expect(prompt).toContain("Scenario: Shared scene for Celia and Alice.");
+    expect(prompt).toContain("Depth sees Shared scene for Celia and Alice.");
+    expect(prompt).not.toContain("{{user}}");
+    expect(prompt).not.toContain("{{char}}");
+    expect(prompt).not.toContain("Alice old scenario");
+    expect(prompt).not.toContain("Bob old scenario");
+
+    const fallbackStorage = storageWithRows({
+      prompts: [],
+      "prompt-sections": [],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice fallback description.",
+            scenario: "Alice old scenario",
+          },
+        },
+      ],
+      personas: [{ id: "persona-1", isActive: true, data: { name: "Celia" } }],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const fallbackAssembly = await assembleGenerationPrompt(fallbackStorage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1"],
+        metadata: {
+          groupScenarioOverride: true,
+          groupScenarioText: "Fallback scene for {{user}} and {{char}}.",
+        },
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "hello" }],
+      connection: {},
+      request: {},
+      latestUserInput: "hello",
+    });
+
+    const fallbackPrompt = fallbackAssembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(fallbackPrompt).toContain("Fallback scene for Celia and Alice.");
+    expect(fallbackPrompt).not.toContain("{{user}}");
+    expect(fallbackPrompt).not.toContain("{{char}}");
+    expect(fallbackPrompt).not.toContain("Alice old scenario");
+  });
+
+  it("does not append a group scenario block when a custom character marker excludes scenario", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "characters",
+          presetId: "preset-1",
+          identifier: "character",
+          role: "system",
+          enabled: true,
+          markerConfig: { type: "character", characterFields: ["description"] },
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        {
+          id: "char-1",
+          data: {
+            name: "Alice",
+            description: "Alice description.",
+            scenario: "Alice old scenario",
+          },
+        },
+      ],
+      personas: [],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1"],
+        metadata: { groupScenarioOverride: true, groupScenarioText: "Shared stage scenario" },
+      },
+      storedMessages: [],
+      connection: {},
+      request: {},
+      latestUserInput: "",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Description: Alice description.");
+    expect(prompt).not.toContain("Scenario:");
+    expect(prompt).not.toContain("Shared stage scenario");
+    expect(prompt).not.toContain("Alice old scenario");
+  });
 });
 
 describe("assembleGenerationPrompt game sprites", () => {

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -161,6 +161,7 @@ interface PromptAssemblyReusableContext {
   promptParameters: StoredGenerationParameters | null;
   maxContext: number | null;
   wrapFormat: WrapFormat;
+  groupScenarioOverride: GroupScenarioOverride;
   promptCharacters: GenerationCharacterContext[];
   baseLorebookIncludedPositions: ActiveLorebookIncludedPositions;
   loreScan: ActiveLorebookScannerResult;
@@ -205,6 +206,13 @@ type PromptAssemblyEntry = ChatMLMessage & {
   promptGroupId?: string | null;
   promptGroupName?: string | null;
 };
+
+type GroupScenarioOverride = {
+  enabled: boolean;
+  text: string;
+};
+
+const NO_GROUP_SCENARIO_OVERRIDE: GroupScenarioOverride = { enabled: false, text: "" };
 
 interface SelectedPromptPreset {
   id: string;
@@ -599,6 +607,11 @@ function characterCardText(character: GenerationCharacterContext, gameCard?: Jso
   if (character.scenario) parts.push(`Scenario: ${character.scenario}`);
   appendGameCardFields(parts, gameCard);
   return parts.join("\n");
+}
+
+function groupScenarioOverride(meta: JsonRecord): GroupScenarioOverride {
+  if (!boolish(meta.groupScenarioOverride, false)) return NO_GROUP_SCENARIO_OVERRIDE;
+  return { enabled: true, text: cleanPromptText(readString(meta.groupScenarioText).trim()) };
 }
 
 function personaCardText(persona: GenerationPersonaContext | null, gameCard?: JsonRecord): string | null {
@@ -1123,8 +1136,11 @@ function macroContext(input: {
   agentData?: Record<string, string>;
   variables?: Record<string, string>;
   request: JsonRecord;
+  groupScenarioOverride: GroupScenarioOverride;
 }): MacroContext {
   const first = input.characters[0];
+  const scenarioValue = (scenario: string | undefined) =>
+    input.groupScenarioOverride.enabled ? input.groupScenarioOverride.text : scenario;
   return {
     user: input.persona?.name || "User",
     char: first?.name || "Character",
@@ -1135,7 +1151,7 @@ function macroContext(input: {
       personality: character.personality,
       backstory: character.backstory,
       appearance: character.appearance,
-      scenario: character.scenario,
+      scenario: scenarioValue(character.scenario),
       example: character.mesExample,
       systemPrompt: character.systemPrompt,
       postHistoryInstructions: character.postHistoryInstructions,
@@ -1152,7 +1168,7 @@ function macroContext(input: {
           personality: first.personality,
           backstory: first.backstory,
           appearance: first.appearance,
-          scenario: first.scenario,
+          scenario: scenarioValue(first.scenario),
           example: first.mesExample,
           systemPrompt: first.systemPrompt,
           postHistoryInstructions: first.postHistoryInstructions,
@@ -1239,9 +1255,13 @@ function characterMarkerFieldValue(
   character: GenerationCharacterContext,
   fieldName: string,
   macros: MacroContext | null,
+  groupScenarioOverride: GroupScenarioOverride,
 ): string {
+  if (fieldName === "scenario" && groupScenarioOverride.enabled) return "";
   const value = characterFieldValue(character, fieldName);
-  return macros ? resolveMacros(value, macroContextForCharacter(macros, character), { trimResult: false }) : value;
+  return macros
+    ? resolveMacros(value, macroContextForCharacter(macros, character, groupScenarioOverride), { trimResult: false })
+    : value;
 }
 
 function characterMarkerFields(marker: MarkerConfig | null): string[] {
@@ -1265,16 +1285,17 @@ function renderCharacters(
   wrapFormat: WrapFormat,
   marker: MarkerConfig | null,
   macros: MacroContext | null = null,
+  groupScenarioOverride: GroupScenarioOverride = NO_GROUP_SCENARIO_OVERRIDE,
 ): string {
   const fields = characterMarkerFields(marker);
-  return characters
+  const characterBlocks = characters
     .map((character) => {
       const content = renderNamedFields(
         [
           ["Name", character.name],
           ...fields.map((fieldName): [string, string] => [
             CHARACTER_FIELD_LABELS[fieldName] ?? fieldName,
-            characterMarkerFieldValue(character, fieldName, macros),
+            characterMarkerFieldValue(character, fieldName, macros, groupScenarioOverride),
           ]),
         ],
         wrapFormat,
@@ -1283,8 +1304,23 @@ function renderCharacters(
       if (!content) return "";
       return wrapFormat === "none" ? content : wrapContent(content, character.name, wrapFormat, 1);
     })
-    .filter(Boolean)
-    .join("\n\n");
+    .filter(Boolean);
+  const groupScenarioBlock =
+    groupScenarioOverride.enabled && groupScenarioOverride.text && fields.includes("scenario")
+      ? renderNamedFields(
+          [
+            [
+              "Scenario",
+              macros
+                ? resolveMacros(groupScenarioOverride.text, macros, { trimResult: false })
+                : groupScenarioOverride.text,
+            ],
+          ],
+          wrapFormat,
+          1,
+        )
+      : "";
+  return [...characterBlocks, groupScenarioBlock].filter(Boolean).join("\n\n");
 }
 
 function renderDialogueExamples(characters: GenerationCharacterContext[]): string {
@@ -1595,12 +1631,13 @@ function fallbackSystemPrompt(
     summary: string | null;
     wrapFormat: WrapFormat;
     macros: MacroContext;
+    groupScenarioOverride: GroupScenarioOverride;
   },
 ): string {
   const mode = readString(input.chat.mode || input.chat.chatMode, "conversation");
   const meta = parseRecord(input.chat.metadata);
   const common = [
-    renderCharacters(args.characters, args.wrapFormat, null, args.macros),
+    renderCharacters(args.characters, args.wrapFormat, null, args.macros, args.groupScenarioOverride),
     renderPersona(args.persona, args.wrapFormat),
     args.worldBefore,
     args.worldAfter,
@@ -3003,6 +3040,7 @@ function authorNotesDepthEntry(chat: JsonRecord): { content: string; role: "syst
 
 function macroProfileForCharacter(
   character: GenerationCharacterContext,
+  groupScenarioOverride: GroupScenarioOverride = NO_GROUP_SCENARIO_OVERRIDE,
 ): NonNullable<MacroContext["characterProfiles"]>[number] {
   return {
     name: character.name,
@@ -3010,15 +3048,19 @@ function macroProfileForCharacter(
     personality: character.personality,
     backstory: character.backstory,
     appearance: character.appearance,
-    scenario: character.scenario,
+    scenario: groupScenarioOverride.enabled ? groupScenarioOverride.text : character.scenario,
     example: character.mesExample,
     systemPrompt: character.systemPrompt,
     postHistoryInstructions: character.postHistoryInstructions,
   };
 }
 
-function macroContextForCharacter(base: MacroContext, character: GenerationCharacterContext): MacroContext {
-  const profile = macroProfileForCharacter(character);
+function macroContextForCharacter(
+  base: MacroContext,
+  character: GenerationCharacterContext,
+  groupScenarioOverride: GroupScenarioOverride = NO_GROUP_SCENARIO_OVERRIDE,
+): MacroContext {
+  const profile = macroProfileForCharacter(character, groupScenarioOverride);
   return {
     ...base,
     char: character.name,
@@ -3029,7 +3071,7 @@ function macroContextForCharacter(base: MacroContext, character: GenerationChara
       personality: character.personality,
       backstory: character.backstory,
       appearance: character.appearance,
-      scenario: character.scenario,
+      scenario: groupScenarioOverride.enabled ? groupScenarioOverride.text : character.scenario,
       example: character.mesExample,
       systemPrompt: character.systemPrompt,
       postHistoryInstructions: character.postHistoryInstructions,
@@ -3040,11 +3082,14 @@ function macroContextForCharacter(base: MacroContext, character: GenerationChara
 function characterDepthPromptEntries(
   characters: GenerationCharacterContext[],
   macros: MacroContext,
+  groupScenarioOverride: GroupScenarioOverride,
 ): Array<{ content: string; role: "system" | "user" | "assistant"; depth: number }> {
   return characters.flatMap((character) => {
     const depthPrompt = character.depthPrompt;
     if (!depthPrompt) return [];
-    const content = cleanPromptText(resolveMacros(depthPrompt.prompt, macroContextForCharacter(macros, character)));
+    const content = cleanPromptText(
+      resolveMacros(depthPrompt.prompt, macroContextForCharacter(macros, character, groupScenarioOverride)),
+    );
     if (!content.trim()) return [];
     return [{ content, role: depthPrompt.role, depth: depthPrompt.depth }];
   });
@@ -3061,10 +3106,11 @@ function sectionContent(args: {
   agentData: Record<string, string>;
   wrapFormat: WrapFormat;
   macros: MacroContext | null;
+  groupScenarioOverride: GroupScenarioOverride;
 }) {
   switch (args.marker?.type) {
     case "character":
-      return renderCharacters(args.characters, args.wrapFormat, args.marker, args.macros);
+      return renderCharacters(args.characters, args.wrapFormat, args.marker, args.macros, args.groupScenarioOverride);
     case "persona":
       return renderPersona(args.persona, args.wrapFormat);
     case "dialogue_examples":
@@ -3193,6 +3239,7 @@ export async function assembleGenerationPrompt(
     normalizeWrapFormat(input.chat.wrapFormat) ??
     normalizeWrapFormat(input.connection.wrapFormat) ??
     "xml";
+  const activeGroupScenarioOverride = reusableContext?.groupScenarioOverride ?? groupScenarioOverride(chatMeta);
   const promptCharacters = reusableContext?.promptCharacters ?? promptCharactersForGeneration(input, characters);
   const macros = macroContext({
     chat: input.chat,
@@ -3203,6 +3250,7 @@ export async function assembleGenerationPrompt(
     agentData: input.agentData,
     variables: selectedPreset?.variables,
     request: input.request,
+    groupScenarioOverride: activeGroupScenarioOverride,
   });
   if (selectedPreset) resolvePromptChoiceVariableMacros(macros, selectedPreset.choiceVariableNames);
   const greetingPromptVariables =
@@ -3246,7 +3294,11 @@ export async function assembleGenerationPrompt(
     reusableContext?.history ??
     historyMessages(
       input.storedMessages,
-      compactedHistoryLimit(chatMeta, historyLimit, shouldCompactHistoryForSummary(input.chat, selectedPreset, summary)),
+      compactedHistoryLimit(
+        chatMeta,
+        historyLimit,
+        shouldCompactHistoryForSummary(input.chat, selectedPreset, summary),
+      ),
       chatMeta.excludePastReasoning === false,
     );
   const agentData = input.agentData ?? {};
@@ -3285,6 +3337,7 @@ export async function assembleGenerationPrompt(
         agentData,
         wrapFormat,
         macros,
+        groupScenarioOverride: activeGroupScenarioOverride,
       });
       const resolvedContent = marker?.type === "character" ? rawContent : resolveMacros(rawContent, macros);
       const resolved = cleanPromptText(resolvedContent);
@@ -3336,6 +3389,7 @@ export async function assembleGenerationPrompt(
         summary,
         wrapFormat,
         macros,
+        groupScenarioOverride: activeGroupScenarioOverride,
       }),
       contextKind: "prompt",
     });
@@ -3410,7 +3464,8 @@ export async function assembleGenerationPrompt(
   ]);
 
   const authorNotesEntry = authorNotesDepthEntry(input.chat);
-  const characterDepthEntries = chatMode === "game" ? [] : characterDepthPromptEntries(promptCharacters, macros);
+  const characterDepthEntries =
+    chatMode === "game" ? [] : characterDepthPromptEntries(promptCharacters, macros, activeGroupScenarioOverride);
   messages = injectAtDepth(
     messages,
     authorNotesEntry
@@ -3464,6 +3519,7 @@ export async function assembleGenerationPrompt(
     promptParameters,
     maxContext,
     wrapFormat,
+    groupScenarioOverride: activeGroupScenarioOverride,
     promptCharacters,
     baseLorebookIncludedPositions,
     loreScan,


### PR DESCRIPTION
## Linked issue

Closes #2445

## Why this change

- Group scenario override metadata existed on refactor chats, but prompt assembly still used each character card's individual scenario. Legacy `main` replaced/suppressed per-character scenarios when a shared group scenario override was active.
- Follow-up review found the first fix still treated non-empty group text as the override-active flag, rendered shared scenario blocks even when a marker excluded `scenario`, and left nested macros unresolved in appended group scenario blocks.

## What changed

- Threaded `groupScenarioOverride` as separate enabled/text facts through prompt macro context so blank overrides suppress stale character scenarios.
- Suppressed per-character scenario marker rows whenever override is enabled, regardless of whether the shared text is blank.
- Rendered the shared scenario block only when the marker's effective field list includes `scenario`.
- Resolved shared group scenario text through prompt macros in character marker and fallback rendering.
- Applied the shared scenario to character-scoped macro expansion, fallback character blocks, and character depth prompts.
- Added focused regression tests for non-empty override, blank override, nested macros, fallback rendering, depth prompts, and custom marker field selection.

## Refactor impact

Primary owner:

- Engine generation / prompt assembly.

Impact areas reviewed:

- Chat mode prompt context.
- Roleplay mode prompt context.
- Runtime generation prompt assembly.
- React-free engine contracts already exposed the metadata; no storage/import parity work was needed.

Boundary notes:

- Change stays inside `src/engine/generation` and uses existing chat metadata contracts.
- No React, shared API, Tauri/Rust, import/export, or remote-runtime boundaries changed.

Pressure points touched:

- Prompt assembly character marker rendering.
- Prompt macro context and character-scoped macro context.
- Fallback prompt character rendering.
- Character depth prompt macro resolution.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/generation/prompt-assembly.test.ts` passed: 1 file, 12 tests.
- `pnpm typecheck` passed.
- `git diff --check` passed.
- Earlier on this PR branch, before the follow-up review fixes, `pnpm check` passed. It has not been rerun after the latest focused amendments.
- Durable test rationale: this fixes a known regression from #2445 where group scenario override metadata was not consumed safely; existing prompt assembly tests did not cover override suppression/replacement, blank override behavior, nested group scenario macros, fallback rendering, or marker field selection; the new tests are narrow to prompt assembly output.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing group scenario override setting is already discoverable in UI; this PR fixes runtime prompt consumption only.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes; prompt assembly behavior only.
