### PR TITLE
Fix prompt regex coverage

### DIFF
--- a/src/engine/generation-core/regex/regex-application.ts
+++ b/src/engine/generation-core/regex/regex-application.ts
@@ -110,7 +110,6 @@ export function applyRegexScriptsToPromptMessages<T extends RegexMessageLike>(
   const totalMessages = messages.length;
   for (let index = 0; index < totalMessages; index++) {
     const message = messages[index]!;
-    if (message.contextKind === "prompt" || message.contextKind === "injection") continue;
     const placement = message.role === "user" ? "user_input" : "ai_output";
     const depth = totalMessages - 1 - index;
     message.content = applyRegexScriptsToPromptText(message.content, scripts, placement, depth, options);

--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -316,6 +316,134 @@ describe("assembleGenerationPrompt character markers", () => {
   });
 });
 
+describe("assembleGenerationPrompt prompt regex scripts", () => {
+  it("applies prompt-only regex scripts to prompt and injection messages", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "system",
+          presetId: "preset-1",
+          role: "system",
+          content: "replace-system",
+          enabled: true,
+        },
+        {
+          id: "history",
+          presetId: "preset-1",
+          identifier: "chat_history",
+          enabled: true,
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [],
+      personas: [],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [
+        {
+          id: "script-1",
+          enabled: true,
+          promptOnly: true,
+          placement: ["ai_output"],
+          findRegex: "replace-system|replace-agent",
+          flags: "g",
+          replaceString: "transformed",
+        },
+      ],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: { id: "chat-1", mode: "roleplay", promptPresetId: "preset-1", metadata: {} },
+      storedMessages: [{ id: "message-1", role: "user", content: "latest user message" }],
+      connection: {},
+      request: {},
+      latestUserInput: "latest user message",
+      agentData: { html: "replace-agent" },
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("transformed");
+    expect(prompt).not.toContain("replace-system");
+    expect(prompt).not.toContain("replace-agent");
+  });
+
+  it("applies prompt-only regex scripts to group turn prompt messages", async () => {
+    const storage = storageWithRows({
+      prompts: [
+        {
+          id: "preset-1",
+          isDefault: true,
+          wrapFormat: "none",
+          parameters: { strictRoleFormatting: false },
+        },
+      ],
+      "prompt-sections": [
+        {
+          id: "system",
+          presetId: "preset-1",
+          role: "system",
+          content: "system prompt",
+          enabled: true,
+        },
+        {
+          id: "history",
+          presetId: "preset-1",
+          identifier: "chat_history",
+          enabled: true,
+        },
+      ],
+      "prompt-groups": [],
+      "prompt-choice-blocks": [],
+      characters: [
+        { id: "char-1", data: { name: "Alice", description: "A careful speaker." } },
+        { id: "char-2", data: { name: "Bob", description: "A quiet listener." } },
+      ],
+      personas: [],
+      lorebooks: [],
+      "lorebook-folders": [],
+      "lorebook-entries": [],
+      "regex-scripts": [
+        {
+          id: "script-1",
+          enabled: true,
+          promptOnly: true,
+          placement: ["ai_output"],
+          findRegex: "Respond only as Alice",
+          replaceString: "Only Alice answers",
+        },
+      ],
+    });
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "roleplay",
+        characterIds: ["char-1", "char-2"],
+        metadata: { groupChatMode: "individual" },
+        promptPresetId: "preset-1",
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "latest user message" }],
+      connection: {},
+      request: { forCharacterId: "char-1" },
+      latestUserInput: "latest user message",
+    });
+
+    const prompt = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(prompt).toContain("Only Alice answers");
+    expect(prompt).not.toContain("Respond only as Alice");
+  });
+});
+
 describe("assembleGenerationPrompt game sprites", () => {
   const visuals: VisualAssetGateway = {
     listSprites: async (ownerId) =>

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -3418,10 +3418,6 @@ export async function assembleGenerationPrompt(
       : [...processedLore.depthEntries, ...characterDepthEntries],
     chatHistoryDepthInjectionBounds(messages),
   );
-  const regexScripts = await storage.list<JsonRecord>("regex-scripts");
-  applyRegexScriptsToPromptMessages(messages, regexScripts, {
-    resolveMacros: (value) => resolveMacros(value, macros, { trimResult: false }),
-  });
   const turnPrompt =
     individualGroupTurnPromptMessage(input, characters) ??
     mergedRoleplayGroupTurnPromptMessage(input, characters) ??
@@ -3429,6 +3425,10 @@ export async function assembleGenerationPrompt(
   if (turnPrompt) {
     messages.push(turnPrompt);
   }
+  const regexScripts = await storage.list<JsonRecord>("regex-scripts");
+  applyRegexScriptsToPromptMessages(messages, regexScripts, {
+    resolveMacros: (value) => resolveMacros(value, macros, { trimResult: false }),
+  });
   messages = messages
     .map((message) => ({
       ...message,


### PR DESCRIPTION
## Linked issue

Closes Pasta-Devs/Marinara-Engine#2449

## Why this change

Prompt-only regex scripts were applied after macro context existed, but refactor skipped messages marked as prompt or injection context. Group turn prompt messages were also appended after the regex pass, so they could not be transformed before provider send.

## What changed

- Apply prompt-only regex scripts to every assembled prompt message, including prompt and injection context messages.
- Append group turn prompt messages before the prompt regex pass.
- Add focused prompt assembly coverage for prompt/injection messages and group turn prompt messages.

## Refactor impact

Primary owner:

engine generation / prompt assembly

Impact areas reviewed:

- Chat mode provider-ready prompt assembly
- Roleplay mode provider-ready prompt assembly
- Game mode shared prompt regex pass
- Runtime prompt regex helper behavior

Boundary notes:

- Engine-only change. No React, shared API, Tauri/Rust, or remote-runtime boundary changes.
- Non-prompt runtime user input and AI output regex paths are unchanged.

Pressure points touched:

- Prompt assembly ordering around depth injections, group turn prompt messages, and regex application.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/immersive-html-agent.test.ts src/engine/generation/prompt-assembly.test.ts` passed: 2 files, 12 tests.
- `pnpm typecheck` passed.
- `pnpm check` passed, including line endings, scratch, architecture, frontend typecheck, Rust check, docs, discovery, launcher safety, and unused-code report.

Durable test rationale: issue 2449 is a known provider-ready prompt regression; prompt regex ordering and context filtering are easy to break silently; the new coverage is narrow and lives beside existing prompt assembly tests.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for existing prompt regex behavior; no new user-discoverable feature or setting.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes.
