### PR TITLE
generation: preserve conversation preset summaries

### DIFF
--- a/src/engine/generation/prompt-assembly.test.ts
+++ b/src/engine/generation/prompt-assembly.test.ts
@@ -88,6 +88,108 @@ function depthInjectionRows(): RowMap {
   };
 }
 
+function occurrenceCount(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
+function summaryPresetRows(includeSummaryMarker: boolean): RowMap {
+  return {
+    prompts: [
+      {
+        id: "preset-1",
+        wrapFormat: "none",
+        parameters: { strictRoleFormatting: false },
+      },
+    ],
+    "prompt-sections": [
+      {
+        id: "system",
+        presetId: "preset-1",
+        role: "system",
+        name: "System",
+        content: "Conversation shell.",
+        enabled: true,
+      },
+      ...(includeSummaryMarker
+        ? [
+            {
+              id: "summary",
+              presetId: "preset-1",
+              role: "system",
+              name: "Summary",
+              markerConfig: { type: "chat_summary" },
+              enabled: true,
+            },
+          ]
+        : []),
+      {
+        id: "history",
+        presetId: "preset-1",
+        identifier: "chat_history",
+        enabled: true,
+      },
+    ],
+    "prompt-groups": [],
+    "prompt-variables": [],
+    characters: [],
+    personas: [],
+    lorebooks: [],
+    "lorebook-folders": [],
+    "lorebook-entries": [],
+    "regex-scripts": [],
+  };
+}
+
+describe("assembleGenerationPrompt chat summary preset insertion", () => {
+  it("fallback-inserts a conversation summary when the selected preset has no summary marker", async () => {
+    const storage = storageWithRows(summaryPresetRows(false));
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "conversation",
+        promptPresetId: "preset-1",
+        metadata: { summary: "Remember the lighthouse." },
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "What did we discuss?" }],
+      connection: {},
+      request: {},
+      latestUserInput: "What did we discuss?",
+    });
+
+    expect(assembly.promptPresetId).toBe("preset-1");
+    const previewContents = assembly.previewMessages.map((message) => message.content);
+    expect(previewContents[0]).toBe("Conversation shell.\n\nRemember the lighthouse.");
+    expect(previewContents.at(-1)).toBe("What did we discuss?");
+    expect(assembly.chatSummaryFingerprint).not.toBeNull();
+  });
+
+  it("keeps explicit conversation summary marker placement without duplicating the summary", async () => {
+    const storage = storageWithRows(summaryPresetRows(true));
+
+    const assembly = await assembleGenerationPrompt(storage, {
+      chat: {
+        id: "chat-1",
+        mode: "conversation",
+        promptPresetId: "preset-1",
+        metadata: { summary: "Remember the lighthouse." },
+      },
+      storedMessages: [{ id: "message-1", role: "user", content: "What did we discuss?" }],
+      connection: {},
+      request: {},
+      latestUserInput: "What did we discuss?",
+    });
+
+    const promptText = assembly.previewMessages.map((message) => message.content).join("\n\n");
+    expect(assembly.promptPresetId).toBe("preset-1");
+    const previewContents = assembly.previewMessages.map((message) => message.content);
+    expect(previewContents[0]).toBe("Conversation shell.");
+    expect(previewContents[1]).toBe("Remember the lighthouse.");
+    expect(previewContents.at(-1)).toBe("What did we discuss?");
+    expect(occurrenceCount(promptText, "Remember the lighthouse.")).toBe(1);
+  });
+});
+
 describe("assembleGenerationPrompt depth injection", () => {
   it("anchors lorebook depth entries to chat history bounds", async () => {
     const storage = storageWithRows(depthInjectionRows());

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1648,6 +1648,17 @@ function shouldForceRoleplaySummaryIntoSystem(chat: JsonRecord): boolean {
   return mode === "roleplay" || meta.sceneStatus === "active";
 }
 
+function shouldFallbackInsertChatSummary(
+  chat: JsonRecord,
+  selectedPreset: SelectedPromptPreset | null,
+  summary: string | null,
+): boolean {
+  if (!selectedPreset || !summary?.trim()) return false;
+  if (presetCanInsertChatSummary(selectedPreset, summary)) return false;
+  const mode = readString(chat.mode || chat.chatMode, "conversation");
+  return mode === "conversation" || shouldForceRoleplaySummaryIntoSystem(chat);
+}
+
 function appendSummaryToSystemPrompt(
   messages: ChatMLMessage[],
   summary: string | null,
@@ -1798,7 +1809,10 @@ function shouldCompactHistoryForSummary(
   const meta = parseRecord(chat.metadata);
   if (!hasConversationSummaryCompaction(meta)) return false;
   if (!selectedPreset) return true;
-  return presetCanInsertChatSummary(selectedPreset, summary) || shouldForceRoleplaySummaryIntoSystem(chat);
+  return (
+    presetCanInsertChatSummary(selectedPreset, summary) ||
+    shouldFallbackInsertChatSummary(chat, selectedPreset, summary)
+  );
 }
 
 function compactedHistoryLimit(meta: JsonRecord, fallbackLimit: number, shouldCompact: boolean): number {
@@ -3246,7 +3260,11 @@ export async function assembleGenerationPrompt(
     reusableContext?.history ??
     historyMessages(
       input.storedMessages,
-      compactedHistoryLimit(chatMeta, historyLimit, shouldCompactHistoryForSummary(input.chat, selectedPreset, summary)),
+      compactedHistoryLimit(
+        chatMeta,
+        historyLimit,
+        shouldCompactHistoryForSummary(input.chat, selectedPreset, summary),
+      ),
       chatMeta.excludePastReasoning === false,
     );
   const agentData = input.agentData ?? {};
@@ -3341,7 +3359,11 @@ export async function assembleGenerationPrompt(
     });
   }
 
-  if (!usedFallbackSystemPrompt && !insertedSummary && shouldForceRoleplaySummaryIntoSystem(input.chat)) {
+  if (
+    !usedFallbackSystemPrompt &&
+    !insertedSummary &&
+    shouldFallbackInsertChatSummary(input.chat, selectedPreset, summary)
+  ) {
     appendSummaryToSystemPrompt(messages, summary, wrapFormat);
   }
 

--- a/src/engine/generation/prompt-preset-selection.ts
+++ b/src/engine/generation/prompt-preset-selection.ts
@@ -44,8 +44,6 @@ export function buildGenerationPromptPresetCandidates(args: {
   impersonatePromptPresetId?: unknown;
   requestPromptPresetId?: unknown;
 }): PromptPresetCandidate[] {
-  if (args.chatMode === "conversation") return [];
-
   const candidates: PromptPresetCandidate[] = [];
   const seen = new Set<string>();
 


### PR DESCRIPTION
## Linked issue

Closes #2447

## Why this change

Conversation prompt presets with prompt sections but no `chat_summary` marker skipped compiled chat summaries instead of using the legacy fallback insertion path. That meant generated conversation prompts could lose summary context even though explicit summary markers and the no-preset fallback still worked.

## What changed

- Allow conversation chats to select request/chat prompt presets in the generation preset candidate path.
- Add a summary fallback predicate for selected presets without an explicit `chat_summary` marker.
- Keep explicit summary marker placement unchanged and avoid duplicate summary insertion.
- Add focused prompt assembly coverage for conversation preset fallback insertion and marker no-duplication.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Conversation/chat prompt assembly
- Roleplay summary fallback path
- Game prompt path
- Prompt preset selection

Boundary notes:

- Engine-only change; no React UI, shared API, Tauri/Rust, storage schema, or remote runtime route changes.
- Connection-level prompt preset override remains limited to roleplay/legacy visual-novel modes.

Pressure points touched:

- `src/engine/generation/prompt-assembly.ts`
- `src/engine/generation/prompt-preset-selection.ts`

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts`
- `pnpm typecheck`
- `pnpm check`

Durable test rationale: the regression silently drops compiled chat summary context from conversation prompt presets. Existing tests covered nearby roleplay/lore prompt assembly behavior but not conversation summary fallback or marker no-duplication. The new tests are narrow assembler rows that exercise only selected conversation presets with and without the `chat_summary` marker.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

Bugfix for existing prompt assembly behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A. Engine prompt assembly bugfix; no visible UI change.
