### PR TITLE
Fix lorebook budget skip selection

### DIFF
--- a/src/engine/generation/active-lorebook-scanner.test.ts
+++ b/src/engine/generation/active-lorebook-scanner.test.ts
@@ -557,7 +557,7 @@ describe("scanActiveLorebooks", () => {
     expect(macros.variables.flag).toBe("selected");
   });
 
-  it("keeps lorebook exhaustion active for recursive frontiers after macro-stable replay", async () => {
+  it("does not keep lorebook budget exhaustion active for recursive frontiers after macro-stable replay", async () => {
     const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
     const storage = storageWithRows(
       {
@@ -608,14 +608,14 @@ describe("scanActiveLorebooks", () => {
       embeddingSource: null,
     });
 
-    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual(["entry-b-recursive"]);
-    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual([
-      "entry-a-large",
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual([
+      "entry-b-recursive",
       "entry-a-recursive",
     ]);
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-a-large"]);
   });
 
-  it("keeps chat budget exhaustion active for recursive frontiers after macro-stable replay", async () => {
+  it("does not keep chat budget exhaustion active for recursive frontiers after macro-stable replay", async () => {
     const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
     const storage = storageWithRows(
       {
@@ -666,11 +666,9 @@ describe("scanActiveLorebooks", () => {
 
     expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual([
       "entry-selected-recursive",
-    ]);
-    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual([
-      "entry-chat-large",
       "entry-recursive-after-chat-exhaustion",
     ]);
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-chat-large"]);
   });
 
   it("keeps earlier skipped diagnostics when later replay passes skip another survivor", async () => {
@@ -730,7 +728,7 @@ describe("scanActiveLorebooks", () => {
     expect(macros.variables.payload).toBe("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
   });
 
-  it("keeps lower-priority entries skipped after the chat lorebook budget is exhausted", async () => {
+  it("selects lower-priority entries after an oversized entry is skipped when they fit the chat lorebook budget", async () => {
     const calls = { batchedEntryReads: 0, singleEntryReads: 0 };
     const storage = storageWithRows(
       {
@@ -766,11 +764,11 @@ describe("scanActiveLorebooks", () => {
       characters: [],
       persona: null,
       storedMessages: [{ id: "message-1", role: "user", content: "alpha-key" }],
-      request: { lorebookTokenBudget: 1 },
+      request: { lorebookTokenBudget: 2 },
       embeddingSource: null,
     });
 
-    expect(result.processedLore.includedEntries).toEqual([]);
-    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-large", "entry-small"]);
+    expect(result.processedLore.includedEntries.map((entry) => entry.entry.id)).toEqual(["entry-small"]);
+    expect(result.budgetSkippedLorebookEntries.map((entry) => entry.id)).toEqual(["entry-large"]);
   });
 });

--- a/src/engine/generation/active-lorebook-scanner.ts
+++ b/src/engine/generation/active-lorebook-scanner.ts
@@ -147,9 +147,7 @@ interface LorebookBudgetSelectionState {
   selected: ActivatedEntry[];
   selectedIds: Set<string>;
   perLorebookTokens: Map<string, number>;
-  exhaustedLorebookIds: Set<string>;
   totalTokens: number;
-  chatBudgetExhausted: boolean;
 }
 
 interface LorebookResolvedCandidatePass {
@@ -562,9 +560,7 @@ function createLorebookBudgetSelectionState(): LorebookBudgetSelectionState {
     selected: [],
     selectedIds: new Set(),
     perLorebookTokens: new Map(),
-    exhaustedLorebookIds: new Set(),
     totalTokens: 0,
-    chatBudgetExhausted: false,
   };
 }
 
@@ -573,9 +569,7 @@ function cloneLorebookBudgetSelectionState(state: LorebookBudgetSelectionState):
     selected: [...state.selected],
     selectedIds: new Set(state.selectedIds),
     perLorebookTokens: new Map(state.perLorebookTokens),
-    exhaustedLorebookIds: new Set(state.exhaustedLorebookIds),
     totalTokens: state.totalTokens,
-    chatBudgetExhausted: state.chatBudgetExhausted,
   };
 }
 
@@ -586,9 +580,7 @@ function applyLorebookBudgetSelectionState(
   target.selected = source.selected;
   target.selectedIds = source.selectedIds;
   target.perLorebookTokens = source.perLorebookTokens;
-  target.exhaustedLorebookIds = source.exhaustedLorebookIds;
   target.totalTokens = source.totalTokens;
-  target.chatBudgetExhausted = source.chatBudgetExhausted;
 }
 
 function activatedEntryWithResolvedContent(
@@ -650,20 +642,6 @@ function recordBudgetSelectionPass(
   }
 }
 
-function applySkippedBudgetExhaustion(
-  state: LorebookBudgetSelectionState,
-  skippedEntries: Iterable<BudgetSkippedLorebookEntry>,
-): void {
-  for (const skipped of skippedEntries) {
-    if (skipped.blockedBy === "lorebook" || skipped.blockedBy === "both") {
-      state.exhaustedLorebookIds.add(skipped.lorebookId);
-    }
-    if (skipped.blockedBy === "chat" || skipped.blockedBy === "both") {
-      state.chatBudgetExhausted = true;
-    }
-  }
-}
-
 function sortedBudgetSkippedEntries(
   skippedById: ReadonlyMap<string, BudgetSkippedLorebookEntry>,
 ): BudgetSkippedLorebookEntry[] {
@@ -691,14 +669,10 @@ function trySelectBudgetedLorebookEntry(
   const lorebookBudget = lorebookMeta?.lorebookBudget ?? 0;
   const lorebookUsedTokens = state.perLorebookTokens.get(candidate.entry.lorebookId) ?? 0;
   const exceedsLorebookBudget =
-    state.exhaustedLorebookIds.has(candidate.entry.lorebookId) ||
-    (lorebookBudget > 0 && lorebookUsedTokens + entryTokens > lorebookBudget);
-  const exceedsChatBudget =
-    state.chatBudgetExhausted || (chatBudget > 0 && state.totalTokens + entryTokens > chatBudget);
+    lorebookBudget > 0 && lorebookUsedTokens + entryTokens > lorebookBudget;
+  const exceedsChatBudget = chatBudget > 0 && state.totalTokens + entryTokens > chatBudget;
 
   if (exceedsLorebookBudget || exceedsChatBudget) {
-    if (exceedsLorebookBudget) state.exhaustedLorebookIds.add(candidate.entry.lorebookId);
-    if (exceedsChatBudget) state.chatBudgetExhausted = true;
     return {
       selected: false,
       skipped: {
@@ -758,7 +732,6 @@ function selectBudgetedLorebookEntries(
     recordBudgetSelectionPass(skippedById, selectedFromCandidates, skippedFromCandidates);
 
     if (sameActivatedEntrySet(pool, selectedFromCandidates)) {
-      applySkippedBudgetExhaustion(nextState, skippedById.values());
       applyLorebookBudgetSelectionState(state, nextState);
       return {
         selectedFromCandidates,
@@ -770,7 +743,6 @@ function selectBudgetedLorebookEntries(
     pool = selectedFromCandidates;
   }
 
-  applySkippedBudgetExhaustion(state, skippedById.values());
   return {
     selectedFromCandidates: [],
     budgetSkippedEntries: sortedBudgetSkippedEntries(skippedById),


### PR DESCRIPTION
## Linked issue

Closes #2448

## Why this change

- Refactor lorebook budget selection treated the first over-budget lorebook entry as exhausting that lorebook/chat budget, which dropped later smaller candidates that still fit remaining budget.

## What changed

- Removed persistent per-lorebook/chat budget exhaustion flags from active lorebook selection.
- Kept budget skip diagnostics for oversized entries while allowing later fitting entries through.
- Updated scanner regression coverage for lorebook budget, chat budget, and recursive frontier selection.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Active lorebook scanning and budget selection.
- Prompt assembly consumers that receive activated/skipped lorebook entries.
- Recursive lorebook frontier selection.

Boundary notes:

- Engine-only change; no React, shared API, Tauri/Rust, storage adapter, or remote runtime boundary changes.

Pressure points touched:

- None of ModeSurface, GameSurface, shared mode UI, src-tauri command registration, or import modules.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/active-lorebook-scanner.test.ts` passed: 1 test file, 13 tests.
- `pnpm typecheck` passed.
- Durable test rationale: this fixes a known prompt assembly regression where later lorebook entries could be silently dropped; existing type checks cannot prove budget selection semantics, and the updated scanner tests are narrow owner-level coverage for lorebook/chat budget behavior and skipped diagnostics.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Bugfix for existing lorebook budget selection behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- Not applicable; engine-only prompt selection fix.
