### PR TITLE
Fix message extra defaults on create

### DIFF
--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -2653,6 +2653,38 @@ mod tests {
     }
 
     #[test]
+    fn storage_create_message_returns_default_extra_and_persists_initial_swipe() {
+        let state = test_state("message-create-default-extra");
+        let created = storage_create_inner(
+            &state,
+            "messages".to_string(),
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first"
+            }),
+        )
+        .expect("message should create");
+        let expected_extra = json!({
+            "displayText": null,
+            "isGenerated": true,
+            "tokenCount": null,
+            "generationInfo": null
+        });
+
+        assert_eq!(created["activeSwipeIndex"], json!(0));
+        assert_eq!(created["swipeCount"], json!(1));
+        assert_eq!(created["extra"], expected_extra);
+        let sidecars = state
+            .storage
+            .list(message_swipes::COLLECTION)
+            .expect("message swipe sidecars should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["content"], json!("first"));
+        assert_eq!(sidecars[0]["extra"], expected_extra);
+    }
+
+    #[test]
     fn chat_metadata_patch_rejects_invalid_discord_webhook_url() {
         let state = test_state("chat-metadata-invalid-discord-webhook");
         storage_create_inner(

--- a/src-tauri/src/commands/storage/commands/entities.rs
+++ b/src-tauri/src/commands/storage/commands/entities.rs
@@ -785,6 +785,9 @@ pub(crate) fn prepare_entity_for_create(
     entity: &str,
     value: Value,
 ) -> Result<Value, AppError> {
+    if entity == "messages" {
+        return shared::with_message_create_defaults(value);
+    }
     let value = shared::with_entity_defaults(entity, value)?;
     match entity {
         "connections" => connection_secrets::prepare_connection_for_create(state, value),
@@ -2685,6 +2688,37 @@ mod tests {
     }
 
     #[test]
+    fn storage_create_message_rejects_malformed_extra_before_defaulting() {
+        for (label, extra) in [
+            ("array-extra", json!([])),
+            ("scalar-extra", json!(42)),
+            ("invalid-json-extra", json!("{not-json")),
+        ] {
+            let state = test_state(label);
+            let error = storage_create_inner(
+                &state,
+                "messages".to_string(),
+                json!({
+                    "chatId": "chat-1",
+                    "role": "assistant",
+                    "content": "first",
+                    "extra": extra
+                }),
+            )
+            .expect_err("malformed message extra should reject");
+
+            assert_eq!(error.code, "invalid_input");
+            assert!(
+                error
+                    .message
+                    .contains("extra must be a JSON object or null"),
+                "unexpected error message: {}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
     fn chat_metadata_patch_rejects_invalid_discord_webhook_url() {
         let state = test_state("chat-metadata-invalid-discord-webhook");
         storage_create_inner(
@@ -4166,7 +4200,13 @@ mod tests {
         assert_eq!(sidecars.len(), 1);
         assert_eq!(
             sidecars[0]["extra"],
-            json!({ "thinking": "parent thought" })
+            json!({
+                "displayText": null,
+                "isGenerated": true,
+                "tokenCount": null,
+                "generationInfo": null,
+                "thinking": "parent thought"
+            })
         );
     }
 

--- a/src-tauri/src/commands/storage/contracts.rs
+++ b/src-tauri/src/commands/storage/contracts.rs
@@ -56,6 +56,7 @@ const MESSAGE_FIELDS: &[TypedJsonField] = &[
     array("attachments"),
     nullable_object("extra"),
 ];
+const MESSAGE_DEFAULTS: &[&str] = &["extra"];
 const MESSAGE_SWIPE_FIELDS: &[TypedJsonField] = &[nullable_object("extra")];
 const CHARACTER_GROUP_FIELDS: &[TypedJsonField] = &[array("characterIds")];
 const PERSONA_GROUP_FIELDS: &[TypedJsonField] = &[array("personaIds")];
@@ -398,7 +399,7 @@ pub(crate) const COLLECTIONS: &[StorageCollectionContract] = &[
         "messages",
         true,
         false,
-        EMPTY_DEFAULTS,
+        MESSAGE_DEFAULTS,
         MESSAGE_FIELDS,
         MESSAGE_CLEANUP,
     ),

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -1005,6 +1005,12 @@ pub(crate) fn create_message(state: &AppState, message: Value) -> AppResult<Valu
 
 fn persist_created_message_swipes(state: &AppState, mut message: Value) -> AppResult<Value> {
     if message.get("swipes").is_some() {
+        let embedded_swipe_count = message
+            .get("swipes")
+            .and_then(Value::as_array)
+            .map(|swipes| swipes.len())
+            .unwrap_or(0);
+        clamp_message_active_swipe_index(&mut message, embedded_swipe_count);
         preserve_embedded_parent_active_extra(&mut message);
         materialize_message_swipe_fields(&mut message);
         let mut swipes = take_swipes_for_storage(&mut message)?.unwrap_or_default();
@@ -1865,6 +1871,68 @@ mod tests {
         assert_eq!(sidecars.len(), 2);
         assert_eq!(sidecars[1]["index"], json!(1));
         assert_eq!(sidecars[1]["content"], json!("second"));
+    }
+
+    #[test]
+    fn create_message_clamps_active_index_before_parent_extra_inheritance() {
+        let state = test_state("create-active-index-extra-inheritance");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "activeSwipeIndex": 5,
+                "extra": {
+                    "thinking": "parent thought",
+                    "generationInfo": { "model": "parent-model" },
+                    "hiddenFromAI": true
+                },
+                "swipes": [
+                    { "content": "first" },
+                    { "content": "second" }
+                ]
+            }),
+        )
+        .expect("message should create");
+        let message_id = created
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("created message should have id")
+            .to_string();
+
+        assert_eq!(created["activeSwipeIndex"], json!(1));
+        assert_eq!(created["content"], json!("second"));
+        assert_eq!(created["extra"]["thinking"], json!("parent thought"));
+        assert_eq!(
+            created["extra"]["generationInfo"]["model"],
+            json!("parent-model")
+        );
+
+        let stored = state
+            .storage
+            .get("messages", &message_id)
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist");
+        assert_eq!(stored["activeSwipeIndex"], json!(1));
+        assert_eq!(stored["content"], json!("second"));
+        assert_eq!(stored["extra"]["hiddenFromAI"], json!(true));
+        assert!(stored["extra"].get("thinking").is_none());
+        assert!(stored["extra"].get("generationInfo").is_none());
+
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecar rows should list");
+        assert_eq!(sidecars.len(), 2);
+        assert_eq!(sidecars[1]["index"], json!(1));
+        assert_eq!(sidecars[1]["content"], json!("second"));
+        assert_eq!(
+            sidecars[1]["extra"]["generationInfo"]["model"],
+            json!("parent-model")
+        );
+        assert_eq!(sidecars[1]["extra"]["thinking"], json!("parent thought"));
+        assert!(sidecars[0].get("extra").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -1,7 +1,7 @@
 use super::shared::{
     collapse_excess_blank_lines, compact_message_swipe_fields_for_storage, json_object_value,
-    materialize_message_swipe_fields, normalize_typed_json_fields, swipe_scoped_extra,
-    sync_message_patch_content_to_active_swipe, with_entity_defaults,
+    materialize_message_swipe_fields, non_negative_i64_value, normalize_typed_json_fields,
+    swipe_scoped_extra, sync_message_patch_content_to_active_swipe, with_message_create_defaults,
 };
 use crate::state::AppState;
 use marinara_core::{ensure_object, new_id, now_iso, AppError, AppResult};
@@ -308,7 +308,7 @@ fn normalize_message_rows_and_sidecars_inner(
 }
 
 fn prepare_message_create_row(state: &AppState, value: Value) -> AppResult<Value> {
-    let mut object = ensure_object(with_entity_defaults("messages", value)?)?;
+    let mut object = ensure_object(with_message_create_defaults(value)?)?;
     let had_id = object
         .get("id")
         .and_then(Value::as_str)
@@ -335,6 +335,20 @@ fn prepare_message_create_row(state: &AppState, value: Value) -> AppResult<Value
         .or_insert_with(|| Value::String(now));
     normalize_typed_json_fields("messages", &mut object)?;
     Ok(Value::Object(object))
+}
+
+fn clamp_message_active_swipe_index(message: &mut Value, swipe_count: usize) {
+    let Some(object) = message.as_object_mut() else {
+        return;
+    };
+    let requested_index = non_negative_i64_value(object.get("activeSwipeIndex"))
+        .map(|value| value as usize)
+        .unwrap_or(0);
+    let max_index = swipe_count.saturating_sub(1);
+    object.insert(
+        "activeSwipeIndex".to_string(),
+        json!(requested_index.min(max_index)),
+    );
 }
 
 fn message_row_for_write(message: Value, force_updated_at: bool) -> AppResult<(String, Value)> {
@@ -993,12 +1007,17 @@ fn persist_created_message_swipes(state: &AppState, mut message: Value) -> AppRe
     if message.get("swipes").is_some() {
         preserve_embedded_parent_active_extra(&mut message);
         materialize_message_swipe_fields(&mut message);
-        let swipes = take_swipes_for_storage(&mut message)?.unwrap_or_default();
+        let mut swipes = take_swipes_for_storage(&mut message)?.unwrap_or_default();
+        if swipes.is_empty() {
+            swipes.push(initial_swipe_for_message(&message));
+        }
+        clamp_message_active_swipe_index(&mut message, swipes.len());
         let mut updated = write_message_and_swipes(state, message, swipes, false)?;
         materialize_message(state, &mut updated, true)?;
         return Ok(updated);
     }
     let swipes = vec![initial_swipe_for_message(&message)];
+    clamp_message_active_swipe_index(&mut message, swipes.len());
     let mut updated = write_message_and_swipes(state, message, swipes, false)?;
     materialize_message(state, &mut updated, true)?;
     Ok(updated)
@@ -1766,6 +1785,86 @@ mod tests {
             created["swipes"][0]["extra"]["attachments"][0]["galleryId"],
             json!("gallery-1")
         );
+    }
+
+    #[test]
+    fn create_message_clamps_active_index_to_default_initial_swipe() {
+        let state = test_state("create-active-index-default-swipe");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "activeSwipeIndex": 3
+            }),
+        )
+        .expect("message should create");
+        let message_id = created
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("created message should have id")
+            .to_string();
+
+        assert_eq!(created["activeSwipeIndex"], json!(0));
+        assert_eq!(created["swipeCount"], json!(1));
+        assert_eq!(created["swipes"][0]["content"], json!("first"));
+
+        let stored = state
+            .storage
+            .get("messages", &message_id)
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist");
+        assert_eq!(stored["activeSwipeIndex"], json!(0));
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecar rows should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["index"], json!(0));
+    }
+
+    #[test]
+    fn create_message_clamps_active_index_to_provided_swipes() {
+        let state = test_state("create-active-index-provided-swipes");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first",
+                "activeSwipeIndex": 5,
+                "swipes": [
+                    { "content": "first" },
+                    { "content": "second" }
+                ]
+            }),
+        )
+        .expect("message should create");
+        let message_id = created
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("created message should have id")
+            .to_string();
+
+        assert_eq!(created["activeSwipeIndex"], json!(1));
+        assert_eq!(created["content"], json!("second"));
+        assert_eq!(created["swipeCount"], json!(2));
+
+        let stored = state
+            .storage
+            .get("messages", &message_id)
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist");
+        assert_eq!(stored["activeSwipeIndex"], json!(1));
+        assert_eq!(stored["content"], json!("second"));
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecar rows should list");
+        assert_eq!(sidecars.len(), 2);
+        assert_eq!(sidecars[1]["index"], json!(1));
+        assert_eq!(sidecars[1]["content"], json!("second"));
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -1,7 +1,7 @@
 use super::shared::{
     collapse_excess_blank_lines, compact_message_swipe_fields_for_storage, json_object_value,
     materialize_message_swipe_fields, normalize_typed_json_fields, swipe_scoped_extra,
-    sync_message_patch_content_to_active_swipe,
+    sync_message_patch_content_to_active_swipe, with_entity_defaults,
 };
 use crate::state::AppState;
 use marinara_core::{ensure_object, new_id, now_iso, AppError, AppResult};
@@ -308,7 +308,7 @@ fn normalize_message_rows_and_sidecars_inner(
 }
 
 fn prepare_message_create_row(state: &AppState, value: Value) -> AppResult<Value> {
-    let mut object = ensure_object(value)?;
+    let mut object = ensure_object(with_entity_defaults("messages", value)?)?;
     let had_id = object
         .get("id")
         .and_then(Value::as_str)
@@ -1665,6 +1665,107 @@ mod tests {
             .expect("sidecar rows should list");
         assert_eq!(sidecars.len(), 2);
         assert_eq!(sidecars[0]["messageId"], message_id);
+    }
+
+    #[test]
+    fn create_message_seeds_legacy_default_extra_on_initial_swipe() {
+        let state = test_state("create-default-extra");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "first"
+            }),
+        )
+        .expect("message should create");
+        let message_id = created
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("created message should have id")
+            .to_string();
+        let expected_extra = json!({
+            "displayText": null,
+            "isGenerated": true,
+            "tokenCount": null,
+            "generationInfo": null
+        });
+
+        assert_eq!(created["activeSwipeIndex"], json!(0));
+        assert_eq!(created["swipeCount"], json!(1));
+        assert_eq!(created["extra"], expected_extra);
+        assert_eq!(created["swipes"][0]["content"], json!("first"));
+        assert_eq!(created["swipes"][0]["extra"], expected_extra);
+
+        let stored = state
+            .storage
+            .get("messages", &message_id)
+            .expect("stored message lookup should not fail")
+            .expect("stored message should exist");
+        assert_eq!(stored["extra"], expected_extra);
+        let sidecars = state
+            .storage
+            .list(COLLECTION)
+            .expect("sidecar rows should list");
+        assert_eq!(sidecars.len(), 1);
+        assert_eq!(sidecars[0]["extra"], expected_extra);
+
+        let user_created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "user",
+                "content": "user message"
+            }),
+        )
+        .expect("user message should create");
+        assert_eq!(user_created["extra"]["isGenerated"], json!(false));
+        assert_eq!(
+            user_created["swipes"][0]["extra"]["isGenerated"],
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn create_message_preserves_provided_extra_when_defaulting_missing_leaves() {
+        let state = test_state("create-default-extra-preserve");
+        let created = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "user",
+                "content": "first",
+                "extra": {
+                    "isGenerated": true,
+                    "generationInfo": { "model": "impersonate" },
+                    "attachments": [{ "galleryId": "gallery-1" }],
+                    "hiddenFromAI": true
+                }
+            }),
+        )
+        .expect("message should create");
+
+        assert_eq!(created["extra"]["displayText"], Value::Null);
+        assert_eq!(created["extra"]["isGenerated"], json!(true));
+        assert_eq!(created["extra"]["tokenCount"], Value::Null);
+        assert_eq!(
+            created["extra"]["generationInfo"]["model"],
+            json!("impersonate")
+        );
+        assert_eq!(
+            created["extra"]["attachments"][0]["galleryId"],
+            json!("gallery-1")
+        );
+        assert_eq!(created["extra"]["hiddenFromAI"], json!(true));
+        assert_eq!(created["swipes"][0]["extra"]["isGenerated"], json!(true));
+        assert_eq!(
+            created["swipes"][0]["extra"]["generationInfo"]["model"],
+            json!("impersonate")
+        );
+        assert_eq!(
+            created["swipes"][0]["extra"]["attachments"][0]["galleryId"],
+            json!("gallery-1")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/storage/message_swipes.rs
+++ b/src-tauri/src/commands/storage/message_swipes.rs
@@ -1874,6 +1874,39 @@ mod tests {
     }
 
     #[test]
+    fn create_message_rejects_contentless_provided_swipes() {
+        let state = test_state("create-contentless-provided-swipes");
+        let error = create_message(
+            &state,
+            json!({
+                "chatId": "chat-1",
+                "role": "assistant",
+                "content": "parent content",
+                "activeSwipeIndex": 0,
+                "swipes": [{}]
+            }),
+        )
+        .expect_err("provided swipes must have usable content");
+
+        assert_eq!(error.code, "invalid_input");
+        assert_eq!(error.message, "Message swipe content is required");
+        assert!(
+            state
+                .storage
+                .list("messages")
+                .expect("messages should list")
+                .is_empty()
+        );
+        assert!(
+            state
+                .storage
+                .list(COLLECTION)
+                .expect("sidecars should list")
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn create_message_clamps_active_index_before_parent_extra_inheritance() {
         let state = test_state("create-active-index-extra-inheritance");
         let created = create_message(

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -976,6 +976,24 @@ fn insert_character_data_default(object: &mut Map<String, Value>) -> AppResult<(
     Ok(())
 }
 
+fn insert_message_extra_default(object: &mut Map<String, Value>) {
+    let mut extra = json_object_value(object.get("extra"))
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    let is_generated = object.get("role").and_then(Value::as_str) != Some("user");
+    extra
+        .entry("displayText".to_string())
+        .or_insert(Value::Null);
+    extra
+        .entry("isGenerated".to_string())
+        .or_insert(Value::Bool(is_generated));
+    extra.entry("tokenCount".to_string()).or_insert(Value::Null);
+    extra
+        .entry("generationInfo".to_string())
+        .or_insert(Value::Null);
+    object.insert("extra".to_string(), Value::Object(extra));
+}
+
 fn apply_create_default_field(
     collection: &str,
     field: &str,
@@ -999,6 +1017,7 @@ fn apply_create_default_field(
         ("connection-folders", "sortOrder") | ("connection-folders", "order") => {
             insert_default(object, field, json!(0));
         }
+        ("messages", "extra") => insert_message_extra_default(object),
         ("characters", "data") => insert_character_data_default(object)?,
         ("characters", "comment") => insert_default(object, field, Value::String(String::new())),
         ("characters", "avatarPath") => insert_default(object, field, Value::Null),

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -1095,6 +1095,15 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> AppResult<V
     Ok(Value::Object(object))
 }
 
+pub(crate) fn with_message_create_defaults(body: Value) -> AppResult<Value> {
+    let mut object = ensure_object(body)?;
+    normalize_json_array_fields(&mut object, &["swipes", "images", "attachments"])?;
+    normalize_nullable_json_object_fields(&mut object, &["extra"])?;
+    insert_message_extra_default(&mut object);
+    normalize_message_text_fields(&mut object);
+    Ok(Value::Object(object))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/storage/shared.rs
+++ b/src-tauri/src/commands/storage/shared.rs
@@ -642,6 +642,25 @@ fn normalize_message_text_fields(object: &mut Map<String, Value>) {
     }
 }
 
+fn validate_message_create_swipes(object: &Map<String, Value>) -> AppResult<()> {
+    let Some(swipes) = object.get("swipes").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for swipe in swipes {
+        let Some(swipe) = swipe.as_object() else {
+            return Err(AppError::invalid_input(
+                "Message swipes must be JSON objects with content",
+            ));
+        };
+        if !matches!(swipe.get("content"), Some(Value::String(_))) {
+            return Err(AppError::invalid_input(
+                "Message swipe content is required",
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn normalize_character_data_for_storage(data: &Value) -> AppResult<Value> {
     match data {
         Value::Object(_) => Ok(data.clone()),
@@ -976,10 +995,31 @@ fn insert_character_data_default(object: &mut Map<String, Value>) -> AppResult<(
     Ok(())
 }
 
-fn insert_message_extra_default(object: &mut Map<String, Value>) {
-    let mut extra = json_object_value(object.get("extra"))
-        .and_then(|value| value.as_object().cloned())
-        .unwrap_or_default();
+fn message_extra_object_for_create(value: Option<&Value>) -> AppResult<Map<String, Value>> {
+    let Some(value) = value else {
+        return Ok(Map::new());
+    };
+    if value.is_null() {
+        return Ok(Map::new());
+    }
+    if let Some(object) = value.as_object() {
+        return Ok(object.clone());
+    }
+    if let Some(raw) = value.as_str() {
+        let parsed: Value = serde_json::from_str(raw).map_err(|_| {
+            AppError::invalid_input("extra must be a JSON object or null")
+        })?;
+        if let Some(object) = parsed.as_object() {
+            return Ok(object.clone());
+        }
+    }
+    Err(AppError::invalid_input(
+        "extra must be a JSON object or null",
+    ))
+}
+
+fn insert_message_extra_default(object: &mut Map<String, Value>) -> AppResult<()> {
+    let mut extra = message_extra_object_for_create(object.get("extra"))?;
     let is_generated = object.get("role").and_then(Value::as_str) != Some("user");
     extra
         .entry("displayText".to_string())
@@ -992,6 +1032,7 @@ fn insert_message_extra_default(object: &mut Map<String, Value>) {
         .entry("generationInfo".to_string())
         .or_insert(Value::Null);
     object.insert("extra".to_string(), Value::Object(extra));
+    Ok(())
 }
 
 fn apply_create_default_field(
@@ -1017,7 +1058,7 @@ fn apply_create_default_field(
         ("connection-folders", "sortOrder") | ("connection-folders", "order") => {
             insert_default(object, field, json!(0));
         }
-        ("messages", "extra") => insert_message_extra_default(object),
+        ("messages", "extra") => insert_message_extra_default(object)?,
         ("characters", "data") => insert_character_data_default(object)?,
         ("characters", "comment") => insert_default(object, field, Value::String(String::new())),
         ("characters", "avatarPath") => insert_default(object, field, Value::Null),
@@ -1098,8 +1139,8 @@ pub(crate) fn with_entity_defaults(collection: &str, body: Value) -> AppResult<V
 pub(crate) fn with_message_create_defaults(body: Value) -> AppResult<Value> {
     let mut object = ensure_object(body)?;
     normalize_json_array_fields(&mut object, &["swipes", "images", "attachments"])?;
-    normalize_nullable_json_object_fields(&mut object, &["extra"])?;
-    insert_message_extra_default(&mut object);
+    validate_message_create_swipes(&object)?;
+    insert_message_extra_default(&mut object)?;
     normalize_message_text_fields(&mut object);
     Ok(Value::Object(object))
 }
@@ -1916,6 +1957,66 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn message_entity_defaults_reject_present_malformed_extra() {
+        for extra in [json!([]), json!(""), json!("   "), json!("not-json"), json!(true)] {
+            let error = with_entity_defaults(
+                "messages",
+                json!({
+                    "role": "assistant",
+                    "content": "Hello",
+                    "extra": extra
+                }),
+            )
+            .expect_err("present malformed extra should reject before defaults");
+
+            assert_eq!(error.code, "invalid_input");
+            assert_eq!(error.message, "extra must be a JSON object or null");
+        }
+    }
+
+    #[test]
+    fn message_entity_defaults_merge_default_extra_for_absent_null_and_partial() {
+        let absent = with_entity_defaults(
+            "messages",
+            json!({
+                "role": "assistant",
+                "content": "Hello"
+            }),
+        )
+        .expect("absent extra should receive defaults");
+        assert_eq!(absent["extra"]["displayText"], Value::Null);
+        assert_eq!(absent["extra"]["isGenerated"], json!(true));
+        assert_eq!(absent["extra"]["tokenCount"], Value::Null);
+        assert_eq!(absent["extra"]["generationInfo"], Value::Null);
+
+        let null = with_entity_defaults(
+            "messages",
+            json!({
+                "role": "user",
+                "content": "Hello",
+                "extra": null
+            }),
+        )
+        .expect("null extra should receive defaults");
+        assert_eq!(null["extra"]["isGenerated"], json!(false));
+
+        let partial = with_entity_defaults(
+            "messages",
+            json!({
+                "role": "assistant",
+                "content": "Hello",
+                "extra": "{\"thinking\":\"kept\"}"
+            }),
+        )
+        .expect("JSON object string extra should normalize and receive defaults");
+        assert_eq!(partial["extra"]["thinking"], json!("kept"));
+        assert_eq!(partial["extra"]["displayText"], Value::Null);
+        assert_eq!(partial["extra"]["isGenerated"], json!(true));
+        assert_eq!(partial["extra"]["tokenCount"], Value::Null);
+        assert_eq!(partial["extra"]["generationInfo"], Value::Null);
     }
 
     #[test]

--- a/src/engine/contracts/schemas/chat.schema.ts
+++ b/src/engine/contracts/schemas/chat.schema.ts
@@ -12,6 +12,7 @@ export const chatModeSchema = z.preprocess(
 
 const messageRoleSchema = z.enum(["user", "assistant", "system", "narrator"]);
 const jsonObjectSchema = z.record(z.string(), z.unknown());
+const createMessageSwipeSchema = z.object({ content: z.string() }).passthrough();
 
 export const createChatSchema = z.object({
   name: z.string().min(1).max(200),
@@ -31,7 +32,7 @@ export const createMessageSchema = z
     content: z.string(),
     extra: jsonObjectSchema.optional(),
     activeSwipeIndex: z.number().int().nonnegative().optional(),
-    swipes: z.array(jsonObjectSchema).optional(),
+    swipes: z.array(createMessageSwipeSchema).optional(),
   })
   .superRefine((message, ctx) => {
     const effectiveSwipeCount = message.swipes && message.swipes.length > 0 ? message.swipes.length : 1;

--- a/src/engine/contracts/schemas/chat.schema.ts
+++ b/src/engine/contracts/schemas/chat.schema.ts
@@ -11,6 +11,7 @@ export const chatModeSchema = z.preprocess(
 );
 
 const messageRoleSchema = z.enum(["user", "assistant", "system", "narrator"]);
+const jsonObjectSchema = z.record(z.string(), z.unknown());
 
 export const createChatSchema = z.object({
   name: z.string().min(1).max(200),
@@ -27,6 +28,9 @@ export const createMessageSchema = z.object({
   role: messageRoleSchema,
   characterId: z.string().nullable().default(null),
   content: z.string(),
+  extra: jsonObjectSchema.optional(),
+  activeSwipeIndex: z.number().int().nonnegative().optional(),
+  swipes: z.array(jsonObjectSchema).optional(),
 });
 
 // Auto-summarization entries — shape-only validation (no length caps).

--- a/src/engine/contracts/schemas/chat.schema.ts
+++ b/src/engine/contracts/schemas/chat.schema.ts
@@ -23,15 +23,26 @@ export const createChatSchema = z.object({
   connectionId: z.string().nullable().default(null),
 });
 
-export const createMessageSchema = z.object({
-  chatId: z.string(),
-  role: messageRoleSchema,
-  characterId: z.string().nullable().default(null),
-  content: z.string(),
-  extra: jsonObjectSchema.optional(),
-  activeSwipeIndex: z.number().int().nonnegative().optional(),
-  swipes: z.array(jsonObjectSchema).optional(),
-});
+export const createMessageSchema = z
+  .object({
+    chatId: z.string(),
+    role: messageRoleSchema,
+    characterId: z.string().nullable().default(null),
+    content: z.string(),
+    extra: jsonObjectSchema.optional(),
+    activeSwipeIndex: z.number().int().nonnegative().optional(),
+    swipes: z.array(jsonObjectSchema).optional(),
+  })
+  .superRefine((message, ctx) => {
+    const effectiveSwipeCount = message.swipes && message.swipes.length > 0 ? message.swipes.length : 1;
+    if (message.activeSwipeIndex !== undefined && message.activeSwipeIndex >= effectiveSwipeCount) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["activeSwipeIndex"],
+        message: "activeSwipeIndex must resolve to an existing swipe",
+      });
+    }
+  });
 
 // Auto-summarization entries — shape-only validation (no length caps).
 const summaryEntrySchema = z.object({
@@ -50,6 +61,6 @@ export const markAutonomousUnreadSchema = z.object({
 });
 
 export type CreateChatInput = z.infer<typeof createChatSchema>;
-export type CreateMessageInput = z.infer<typeof createMessageSchema>;
+export type CreateMessageInput = z.input<typeof createMessageSchema>;
 export type SummariesPatchInput = z.infer<typeof summariesPatchSchema>;
 export type MarkAutonomousUnreadInput = z.infer<typeof markAutonomousUnreadSchema>;

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -66,6 +66,15 @@ const MAX_MEMORY_RECALL_IMPORT_BYTES = 25 * 1024 * 1024;
 const scheduledDeleteRefreshTimers = new Map<string, number>();
 let optimisticMessageSequence = 0;
 
+type CreateMessageMutationInput = {
+  role: string;
+  content: string;
+  characterId?: string | null;
+  extra?: Record<string, unknown>;
+  activeSwipeIndex?: number;
+  swipes?: Record<string, unknown>[];
+};
+
 type MessageCountResult = { count: number };
 
 interface RecentMessageContentEdit {
@@ -136,23 +145,25 @@ function appendCachedMessage(
   };
 }
 
-function optimisticChatMessage(
-  chatId: string,
-  data: { role: string; content: string; characterId?: string | null },
-): Message {
+function optimisticChatMessage(chatId: string, data: CreateMessageMutationInput): Message {
   optimisticMessageSequence += 1;
+  const providedExtra =
+    data.extra && typeof data.extra === "object" && !Array.isArray(data.extra)
+      ? (data.extra as Partial<Message["extra"]>)
+      : {};
   return {
     id: `__optimistic_create_${Date.now()}_${optimisticMessageSequence}`,
     chatId,
     role: data.role as Message["role"],
     characterId: data.characterId ?? null,
     content: data.content,
-    activeSwipeIndex: 0,
+    activeSwipeIndex: data.activeSwipeIndex ?? 0,
     extra: {
       displayText: null,
-      isGenerated: false,
+      isGenerated: data.role !== "user",
       tokenCount: null,
       generationInfo: null,
+      ...providedExtra,
     },
     createdAt: new Date().toISOString(),
   };
@@ -504,7 +515,7 @@ export function useBackfillConversationSummaries() {
 export function useCreateMessage(chatId: string | null) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { role: string; content: string; characterId?: string | null }) => {
+    mutationFn: (data: CreateMessageMutationInput) => {
       const payload = createMessageSchema.parse({ chatId: chatId!, ...data });
       return storageApi.createChatMessage<Message>(payload.chatId, payload);
     },

--- a/src/features/catalog/chats/hooks/use-chats.ts
+++ b/src/features/catalog/chats/hooks/use-chats.ts
@@ -16,7 +16,11 @@ import {
   type PromptPreviewInput,
   type PromptPreviewResult,
 } from "../../../../engine/generation/prompt-preview";
-import { createMessageSchema, summariesPatchSchema } from "../../../../engine/contracts/schemas/chat.schema";
+import {
+  createMessageSchema,
+  summariesPatchSchema,
+  type CreateMessageInput,
+} from "../../../../engine/contracts/schemas/chat.schema";
 import { getDefaultAgentPrompt } from "../../../../engine/contracts/constants/agent-prompts";
 import { boolish } from "../../../../engine/generation/runtime-records";
 import { backfillConversationSummaries } from "../../../../engine/modes/chat/core/summaries/auto-summary.service";
@@ -66,14 +70,7 @@ const MAX_MEMORY_RECALL_IMPORT_BYTES = 25 * 1024 * 1024;
 const scheduledDeleteRefreshTimers = new Map<string, number>();
 let optimisticMessageSequence = 0;
 
-type CreateMessageMutationInput = {
-  role: string;
-  content: string;
-  characterId?: string | null;
-  extra?: Record<string, unknown>;
-  activeSwipeIndex?: number;
-  swipes?: Record<string, unknown>[];
-};
+type CreateMessageMutationInput = Omit<CreateMessageInput, "chatId">;
 
 type MessageCountResult = { count: number };
 

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -170,13 +170,24 @@ function normalizeStorageReadResult(entity: StorageEntity, value: unknown): unkn
   return normalizeStorageRecord(entity, value);
 }
 
+function messageExtraDefaults(role: unknown, value: unknown): Record<string, unknown> {
+  return {
+    displayText: null,
+    isGenerated: role !== "user",
+    tokenCount: null,
+    generationInfo: null,
+    ...asRecord(value),
+  };
+}
+
 function chatMessageDefaults(chatId: string, value: Record<string, unknown>): Record<string, unknown> {
+  const role = typeof value.role === "string" ? value.role : "user";
   const content = typeof value.content === "string" ? collapseExcessBlankLines(value.content) : "";
-  const extra = value.extra ?? {};
+  const extra = messageExtraDefaults(role, value.extra);
   return {
     ...value,
     chatId,
-    role: value.role ?? "user",
+    role,
     content,
     extra,
     activeSwipeIndex: value.activeSwipeIndex ?? 0,

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -170,13 +170,29 @@ function normalizeStorageReadResult(entity: StorageEntity, value: unknown): unkn
   return normalizeStorageRecord(entity, value);
 }
 
+function messageExtraRecord(value: unknown): Record<string, unknown> {
+  if (value === undefined || value === null) return {};
+  if (typeof value === "string") {
+    if (!value.trim()) return {};
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+    } catch {
+      throw new ApiError("Message extra must be a JSON object", 400);
+    }
+    throw new ApiError("Message extra must be a JSON object", 400);
+  }
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  throw new ApiError("Message extra must be a JSON object", 400);
+}
+
 function messageExtraDefaults(role: unknown, value: unknown): Record<string, unknown> {
   return {
     displayText: null,
     isGenerated: role !== "user",
     tokenCount: null,
     generationInfo: null,
-    ...asRecord(value),
+    ...messageExtraRecord(value),
   };
 }
 
@@ -184,14 +200,20 @@ function chatMessageDefaults(chatId: string, value: Record<string, unknown>): Re
   const role = typeof value.role === "string" ? value.role : "user";
   const content = typeof value.content === "string" ? collapseExcessBlankLines(value.content) : "";
   const extra = messageExtraDefaults(role, value.extra);
+  const swipes = Array.isArray(value.swipes) && value.swipes.length > 0 ? value.swipes : [{ content, extra }];
+  const requestedActiveIndex =
+    typeof value.activeSwipeIndex === "number" && Number.isFinite(value.activeSwipeIndex)
+      ? Math.max(0, Math.trunc(value.activeSwipeIndex))
+      : 0;
+  const activeSwipeIndex = Math.min(requestedActiveIndex, swipes.length - 1);
   return {
     ...value,
     chatId,
     role,
     content,
     extra,
-    activeSwipeIndex: value.activeSwipeIndex ?? 0,
-    swipes: value.swipes ?? [{ content, extra }],
+    activeSwipeIndex,
+    swipes,
   };
 }
 

--- a/src/shared/api/storage-api.ts
+++ b/src/shared/api/storage-api.ts
@@ -173,7 +173,6 @@ function normalizeStorageReadResult(entity: StorageEntity, value: unknown): unkn
 function messageExtraRecord(value: unknown): Record<string, unknown> {
   if (value === undefined || value === null) return {};
   if (typeof value === "string") {
-    if (!value.trim()) return {};
     try {
       const parsed = JSON.parse(value);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;

--- a/src/shared/lib/slash-commands.ts
+++ b/src/shared/lib/slash-commands.ts
@@ -17,6 +17,9 @@ import {
   buildNarratorInstructionMessage,
   type GenerationGuideSource,
 } from "../../engine/shared/text/generation-guide";
+import type { CreateMessageInput } from "../../engine/contracts/schemas/chat.schema";
+
+type SlashCommandMessageInput = Pick<CreateMessageInput, "role" | "content" | "characterId">;
 
 export interface SlashCommand {
   name: string;
@@ -48,7 +51,7 @@ export interface SlashCommandContext {
     impersonatePromptTemplate?: string;
   }) => Promise<boolean | void>;
   /** Insert a message directly into the chat (no LLM) */
-  createMessage: (data: { role: string; content: string; characterId?: string | null }) => void;
+  createMessage: (data: SlashCommandMessageInput) => void;
   /** Invalidate chat queries to refresh the UI */
   invalidate: () => void;
   /** Character names in the current chat */


### PR DESCRIPTION
## Linked issue

Closes #2272

## Why this change

- Message creation still missed the legacy `MessageExtra` default leaves when callers omitted `extra`.
- The remaining gap affected the shared API and embedded/remote storage create contract while active-swipe seed and edit sync still needed to stay intact.

## What changed

- Registered `messages.extra` as a Rust create default and merge `displayText`, `isGenerated`, `tokenCount`, and `generationInfo` without overwriting provided values.
- Routed direct message sidecar creates through the same entity-default path so generic `storage_create`, direct Rust create callers, and remote `/api/invoke` stay aligned.
- Updated the TypeScript create schema, shared API default builder, and catalog optimistic create row to preserve richer create payloads while sending the legacy default shape.
- Added focused Rust coverage for create default extra, initial sidecar swipe persistence, role-based `isGenerated`, and preservation of richer `extra` values.

## Refactor impact

Primary owner:

Rust storage, shared API, and engine chat contract.

Impact areas reviewed:

- Rust storage message create/defaults
- Message swipe sidecar persistence and materialization
- Generic storage create command boundary
- Shared API message create wrapper
- Catalog create-message hook and optimistic row
- Engine chat create schema

Boundary notes:

- Engine schema remains React-free and does not import feature, store, Tauri, or shared API adapters.
- Feature code continues using the focused shared storage API wrapper; no new raw `invokeTauri` or remote fetch calls were added.
- Embedded and remote runtime behavior stay aligned because `/api/invoke` dispatches `storage_create` through `storage_create_inner`, the same command path as embedded Tauri.
- Rust storage remains the authoritative persistence default; the TypeScript wrapper mirrors the shape for caller consistency.

Pressure points touched:

- None of `ModeSurface`, `GameSurface`, shared mode UI orchestration, `src-tauri/src/lib.rs` command registration, or import modules were touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `cargo test --manifest-path src-tauri/Cargo.toml default_extra --lib` passed: 2 tests.
- `cargo test --manifest-path src-tauri/Cargo.toml create_message_preserves_provided_extra_when_defaulting_missing_leaves --lib` passed: 1 test.
- `pnpm typecheck` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml --workspace` passed.
- `pnpm check:architecture` passed.
- `pnpm check` passed.
- Durable test rationale: this fixes a known regression in #2272 where normal message creation could silently miss legacy `MessageExtra` leaves. Existing proof was insufficient because the incomplete fix was marked as not fully addressed. The committed tests are narrow storage-owner tests beside existing message create and sidecar persistence coverage.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Storage compatibility bugfix only; no new user-discoverable feature or workflow was added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Not applicable; this is a storage-contract compatibility fix with no visible UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for message metadata through a new `extra` field with default values including display text, generation status, token count, and generation info.
  * Added support for message swipe tracking with active swipe index and swipe count.

* **Tests**
  * Added comprehensive test coverage for message creation and default field initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->