### PR TITLE
Preserve prompt merge boundaries

### DIFF
--- a/src/engine/generation-core/prompt/merger.ts
+++ b/src/engine/generation-core/prompt/merger.ts
@@ -1,10 +1,26 @@
 import type { ChatMLMessage } from "../../contracts/types/prompt";
 
+export function mergePromptContextKind(
+  a?: ChatMLMessage["contextKind"],
+  b?: ChatMLMessage["contextKind"],
+): ChatMLMessage["contextKind"] | undefined {
+  if (a === b) return a;
+  return undefined;
+}
+
+export function canMergePromptMessages(a: ChatMLMessage, b: ChatMLMessage): boolean {
+  if (a.role !== b.role) return false;
+  if ((a.characterId ?? null) !== (b.characterId ?? null)) return false;
+  if (!a.contextKind || !b.contextKind) return true;
+  return a.contextKind === b.contextKind;
+}
+
 /**
  * Merge consecutive messages that share the same role, with a double-newline separator.
  *
  * Rules:
- * - Only merges when adjacent messages have the **exact same** role.
+ * - Only merges when adjacent messages have the **exact same** role and character id.
+ * - Preserves prompt/history/injection context boundaries when both messages carry context.
  * - Preserves the `name` of the first message if set.
  * - Skips empty messages entirely.
  *
@@ -18,34 +34,23 @@ export function mergeAdjacentMessages(messages: ChatMLMessage[]): ChatMLMessage[
   const result: ChatMLMessage[] = [];
   let current: ChatMLMessage | null = null;
 
-  const mergeContextKind = (a?: ChatMLMessage["contextKind"], b?: ChatMLMessage["contextKind"]) => {
-    if (a === b) return a;
-    if ((a === "history" && b === "injection") || (a === "injection" && b === "history")) {
-      return "history";
-    }
-    return undefined;
-  };
-
-  const canMerge = (a: ChatMLMessage, b: ChatMLMessage) => {
-    return a.role === b.role;
-  };
-
   for (const msg of messages) {
     // Skip empty messages
     if (!msg.content.trim()) continue;
 
-    if (current && canMerge(current, msg)) {
+    if (current && canMergePromptMessages(current, msg)) {
       // Same role — merge
       const mergedImages: string[] | undefined =
         current.images || msg.images ? [...(current.images ?? []), ...(msg.images ?? [])] : undefined;
       // Prefer the later message's providerMetadata (most recent thought signature)
       const mergedMeta: Record<string, unknown> | undefined = msg.providerMetadata ?? current.providerMetadata;
-      const mergedContextKind = mergeContextKind(current.contextKind, msg.contextKind);
+      const mergedContextKind = mergePromptContextKind(current.contextKind, msg.contextKind);
       current = {
         role: current.role,
         content: current.content + "\n\n" + msg.content,
         ...(mergedContextKind ? { contextKind: mergedContextKind } : {}),
         name: current.name,
+        ...(current.characterId ? { characterId: current.characterId } : {}),
         ...(mergedImages ? { images: mergedImages } : {}),
         ...(mergedMeta ? { providerMetadata: mergedMeta } : {}),
       };

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -11,7 +11,12 @@ import type { VisualAssetGateway } from "../capabilities/visual-assets";
 import { getCharacterDescriptionWithExtensions } from "../generation-core/prompt/character-description-extensions";
 import { injectAtDepth } from "../generation-core/lorebooks/prompt-injector";
 import { wrapContent, wrapGroup } from "../generation-core/prompt/format-engine";
-import { mergeAdjacentMessages, squashLeadingSystemMessages } from "../generation-core/prompt/merger";
+import {
+  canMergePromptMessages,
+  mergeAdjacentMessages,
+  mergePromptContextKind,
+  squashLeadingSystemMessages,
+} from "../generation-core/prompt/merger";
 import { applyRegexScriptsToPromptMessages } from "../generation-core/regex/regex-application";
 import { stripConversationPromptTimestamps } from "../modes/chat/core/summaries/transcript-sanitize";
 import { resolveMacros, type MacroContext } from "../shared/macros/macro-engine";
@@ -2789,22 +2794,11 @@ function applyReusableGreetingPromptVariables(macros: MacroContext, variables: R
 
 function shouldMergeSameRolePromptMessage(
   previous: ChatMLMessage | undefined,
-  _message: ChatMLMessage,
+  message: ChatMLMessage,
   effectiveRole: "user" | "assistant",
 ): previous is ChatMLMessage {
   if (!previous || previous.role !== effectiveRole) return false;
-  return true;
-}
-
-function mergedPromptContextKind(
-  previous: ChatMLMessage["contextKind"] | undefined,
-  next: ChatMLMessage["contextKind"] | undefined,
-): ChatMLMessage["contextKind"] | undefined {
-  if (previous === next) return previous;
-  if ((previous === "history" && next === "injection") || (previous === "injection" && next === "history")) {
-    return "history";
-  }
-  return undefined;
+  return canMergePromptMessages(previous, { ...message, role: effectiveRole });
 }
 
 function mergeIntoPreviousPromptMessage(previous: ChatMLMessage, message: ChatMLMessage): void {
@@ -2813,7 +2807,7 @@ function mergeIntoPreviousPromptMessage(previous: ChatMLMessage, message: ChatML
   if ((previous.displayName ?? null) !== (message.displayName ?? null)) {
     delete previous.displayName;
   }
-  const contextKind = mergedPromptContextKind(previous.contextKind, message.contextKind);
+  const contextKind = mergePromptContextKind(previous.contextKind, message.contextKind);
   if (contextKind) {
     previous.contextKind = contextKind;
   } else {
@@ -3000,7 +2994,7 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
     const message = messages[index]!;
     if (message.contextKind === "injection") {
       const previous = result[result.length - 1];
-      if (message.role !== "system" && previous?.role === message.role) {
+      if (message.role !== "system" && previous && canMergePromptMessages(previous, message)) {
         mergeIntoPreviousPromptMessage(previous, message);
         continue;
       }

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -2825,6 +2825,45 @@ function mergeIntoPreviousPromptMessage(previous: ChatMLMessage, message: ChatML
   }
 }
 
+function strictRoleBoundaryLabel(message: ChatMLMessage): string {
+  const speaker =
+    readString(message.name).trim() || readString(message.displayName).trim() || readString(message.characterId).trim();
+  if (speaker) return `${speaker}:`;
+  if (message.contextKind === "prompt") return "[Prompt]";
+  if (message.contextKind === "history") return "[History]";
+  if (message.contextKind === "injection") return "[Injection]";
+  return `[${message.role}]`;
+}
+
+function strictRoleSegmentContent(message: ChatMLMessage): string {
+  return `${strictRoleBoundaryLabel(message)}\n${message.content}`;
+}
+
+function mergeIntoStrictRoleSafeMessage(
+  previous: ChatMLMessage,
+  message: ChatMLMessage,
+  normalizedMessages: WeakSet<ChatMLMessage>,
+): void {
+  const previousContent = normalizedMessages.has(previous) ? previous.content : strictRoleSegmentContent(previous);
+  previous.content = collapseExcessBlankLines(`${previousContent}\n\n${strictRoleSegmentContent(message)}`);
+  const contextKind = mergePromptContextKind(previous.contextKind, message.contextKind);
+  if (contextKind) {
+    previous.contextKind = contextKind;
+  } else {
+    delete previous.contextKind;
+  }
+  if ((previous.displayName ?? null) !== (message.displayName ?? null)) {
+    delete previous.displayName;
+  }
+  delete previous.characterId;
+  delete previous.name;
+  delete previous.providerMetadata;
+  if (message.images?.length) {
+    previous.images = [...(previous.images ?? []), ...message.images];
+  }
+  normalizedMessages.add(previous);
+}
+
 function promptMessageWithRole(message: ChatMLMessage, role: "user" | "assistant"): ChatMLMessage {
   const next = { ...message, role };
   if (role !== "assistant") {
@@ -2971,6 +3010,7 @@ function scopeIndividualGroupHistoryRoles(messages: ChatMLMessage[], targetChara
 function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
   if (messages.length === 0) return messages;
   const result: ChatMLMessage[] = [];
+  const strictRoleNormalizedMessages = new WeakSet<ChatMLMessage>();
   let index = 0;
   const systemParts: string[] = [];
   while (index < messages.length && messages[index]!.role === "system") {
@@ -2994,8 +3034,12 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
     const message = messages[index]!;
     if (message.contextKind === "injection") {
       const previous = result[result.length - 1];
-      if (message.role !== "system" && previous && canMergePromptMessages(previous, message)) {
-        mergeIntoPreviousPromptMessage(previous, message);
+      if (message.role !== "system" && previous?.role === message.role) {
+        if (canMergePromptMessages(previous, message)) {
+          mergeIntoPreviousPromptMessage(previous, message);
+        } else {
+          mergeIntoStrictRoleSafeMessage(previous, message, strictRoleNormalizedMessages);
+        }
         continue;
       }
 
@@ -3023,8 +3067,13 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
     }
 
     const previous = result[result.length - 1];
-    if (shouldMergeSameRolePromptMessage(previous, message, effectiveRole)) {
-      mergeIntoPreviousPromptMessage(previous, message);
+    if (previous?.role === effectiveRole) {
+      const sameRoleMessage = promptMessageWithRole(message, effectiveRole);
+      if (shouldMergeSameRolePromptMessage(previous, sameRoleMessage, effectiveRole)) {
+        mergeIntoPreviousPromptMessage(previous, sameRoleMessage);
+      } else {
+        mergeIntoStrictRoleSafeMessage(previous, sameRoleMessage, strictRoleNormalizedMessages);
+      }
       continue;
     }
 


### PR DESCRIPTION
## Linked issue

Closes #2443

## Why this change

- Refactor prompt shaping merged adjacent same-role messages even when legacy would preserve separate speaker or context boundaries.

## What changed

- Require prompt merge compatibility to include matching `characterId` values.
- Preserve prompt/history/injection context boundaries when both adjacent messages carry incompatible context kinds.
- Reuse the same merge compatibility check in strict-role prompt shaping's optional same-role merge path.
- Added focused proof for differing `characterId`, incompatible `contextKind`, and still-valid same-speaker/context merges.

## Refactor impact

Primary owner:

engine generation / runtime generation prompt shaping

Impact areas reviewed:

- Provider-ready prompt messages for chat, roleplay, and game.
- Strict role formatting's optional same-role merge path.
- Image and provider metadata merging for still-compatible prompt messages.

Boundary notes:

- Engine-only change under `src/engine`.
- No React feature UI, shared API wrapper, Tauri/Rust, storage, import/export, or remote-runtime routing boundaries changed.

Pressure points touched:

- Prompt assembly final shaping.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run src/engine/generation/prompt-assembly.test.ts`
- `pnpm typecheck`
- `pnpm check`
- Durable test rationale: this fixes a provider prompt regression where speaker/context boundaries could silently collapse. Existing line inspection was insufficient because both compatible and incompatible merge rows need to stay stable. The added test coverage is narrow and exercises only prompt message merge boundaries plus one positive merge row.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal provider-ready prompt shaping compatibility fix only.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A; no UI changes.
