### PR TITLE
Fix shared scenario macro scope

### DIFF
--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -1298,6 +1298,35 @@ function renderNamedFields(entries: Array<[string, string | undefined]>, wrapFor
     .join("\n\n");
 }
 
+function groupScenarioMacroContext(base: MacroContext, characters: GenerationCharacterContext[]): MacroContext {
+  const names = characters.map((character) => character.name.trim()).filter(Boolean);
+  const characterList = names.join(", ") || base.char;
+  return {
+    ...base,
+    char: characterList,
+    characters: names.length ? names : base.characters,
+    characterProfiles: [],
+    characterFields: {
+      description: "",
+      personality: "",
+      backstory: "",
+      appearance: "",
+      scenario: "",
+      example: "",
+      systemPrompt: "",
+      postHistoryInstructions: "",
+    },
+  };
+}
+
+function groupScenarioMarkerValue(
+  text: string,
+  macros: MacroContext | null,
+  characters: GenerationCharacterContext[],
+): string {
+  return macros ? resolveMacros(text, groupScenarioMacroContext(macros, characters), { trimResult: false }) : text;
+}
+
 function renderCharacters(
   characters: GenerationCharacterContext[],
   wrapFormat: WrapFormat,
@@ -1326,14 +1355,7 @@ function renderCharacters(
   const groupScenarioBlock =
     groupScenarioOverride.enabled && groupScenarioOverride.text && fields.includes("scenario")
       ? renderNamedFields(
-          [
-            [
-              "Scenario",
-              macros
-                ? resolveMacros(groupScenarioOverride.text, macros, { trimResult: false })
-                : groupScenarioOverride.text,
-            ],
-          ],
+          [["Scenario", groupScenarioMarkerValue(groupScenarioOverride.text, macros, characters)]],
           wrapFormat,
           1,
         )


### PR DESCRIPTION
## Linked issue

Follow-up to #2445 and #2453.

## Why this change

- The merged group scenario override fix resolved raw macro tokens, but the appended shared Scenario marker block still used the base prompt macro context. In a group chat, that made `{{char}}` resolve as the first character while the block was rendered as shared group truth.

## What changed

- Added a group-safe macro context for the single appended shared Scenario marker block.
- `{{char}}` inside the appended shared Scenario block now resolves to the rendered character list, while per-character `{{scenario}}` usage in character fields and depth prompts still resolves with per-character scope.
- Updated the focused prompt assembly assertion to prove shared marker Scenario output uses group identity.

## Refactor impact

Primary owner:

- Engine generation / prompt assembly.

Impact areas reviewed:

- Chat mode prompt context.
- Roleplay mode prompt context.
- Runtime generation prompt assembly.

Boundary notes:

- Change stays inside `src/engine/generation`.
- No React, shared API, Tauri/Rust, import/export, or remote-runtime boundaries changed.

Pressure points touched:

- Prompt assembly character marker rendering.
- Group scenario macro resolution for appended shared Scenario blocks.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [ ] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm vitest run src/engine/generation/prompt-assembly.test.ts` passed: 1 file, 17 tests.
- `pnpm typecheck` passed.
- `git diff --check` passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Runtime prompt assembly fix only; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No visible UI changes; prompt assembly behavior only.
