### PR TITLE
Fix user-message regeneration source prompt

### DIFF
--- a/src/engine/generation/generate-route-utils.ts
+++ b/src/engine/generation/generate-route-utils.ts
@@ -7,6 +7,8 @@ export type StoredGenerationParameters = Partial<GenerationParameters>;
 export type { PromptAttachment };
 export { getAttachmentFilename };
 
+export type SimplePromptMessage = { role: "system" | "user" | "assistant"; content: string; images?: string[] };
+
 const TEXT_ATTACHMENT_CHAR_LIMIT = 60_000;
 const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
 const TEXT_ATTACHMENT_EXTENSIONS = new Set([
@@ -101,6 +103,17 @@ export function resolveRegenerationGameStateFallbackMessageIds(
     }
   }
   return Array.from(targets.values());
+}
+
+function isPromptAttachment(value: unknown): value is PromptAttachment {
+  return isPlainRecord(value);
+}
+
+export function promptAttachmentsFromExtra(extra: unknown): PromptAttachment[] | undefined {
+  const rawAttachments = parseRecord(extra).attachments;
+  if (!Array.isArray(rawAttachments)) return undefined;
+  const attachments = rawAttachments.filter(isPromptAttachment);
+  return attachments.length ? attachments : undefined;
 }
 
 export function extractImageAttachmentDataUrls(attachments: PromptAttachment[] | undefined): string[] {
@@ -210,6 +223,51 @@ export function appendReadableAttachmentsToContent(
   const blocks = buildReadableAttachmentBlocks(attachments);
   if (blocks.length === 0) return content;
   return `${content}${content.trim() ? "\n\n" : ""}${blocks.join("\n\n")}`;
+}
+
+function contentAlreadyHasReadableAttachmentBlock(content: string): boolean {
+  return /<attached_file\b/i.test(content);
+}
+
+function userRegenerationContentWithAttachments(content: string, attachments: PromptAttachment[] | undefined): string {
+  if (contentAlreadyHasReadableAttachmentBlock(content)) return content;
+  return appendReadableAttachmentsToContent(content, attachments);
+}
+
+export function buildUserMessageRegenerationInstruction(message: { content?: unknown; extra?: unknown }): string {
+  const original = readString(message.content).trim();
+  const attachments = promptAttachmentsFromExtra(message.extra);
+  const originalWithAttachments = userRegenerationContentWithAttachments(original, attachments);
+  return [
+    "Regenerate the user's previous message as an alternate swipe.",
+    "Write only the replacement user message text.",
+    "Do not answer as the assistant, continue the assistant side, or describe what the assistant does next.",
+    "",
+    "<original_user_message>",
+    originalWithAttachments,
+    "</original_user_message>",
+  ].join("\n");
+}
+
+export function buildUserMessageRegenerationPromptFromSource(source: SimplePromptMessage): SimplePromptMessage {
+  return {
+    role: "user",
+    content: buildUserMessageRegenerationInstruction({ content: source.content }),
+    ...(source.images?.length ? { images: source.images } : {}),
+  };
+}
+
+export function buildUserMessageRegenerationSourceMessage(
+  message: { content?: unknown; extra?: unknown },
+  images?: string[],
+): SimplePromptMessage {
+  const attachments = promptAttachmentsFromExtra(message.extra);
+  const promptImages = images ?? extractImageAttachmentDataUrls(attachments);
+  return {
+    role: "user",
+    content: userRegenerationContentWithAttachments(readString(message.content), attachments),
+    ...(promptImages.length ? { images: promptImages } : {}),
+  };
 }
 
 /** Parse connection/chat stored generation parameters without injecting schema defaults. */

--- a/src/engine/generation/generate-route-utils.ts
+++ b/src/engine/generation/generate-route-utils.ts
@@ -225,12 +225,7 @@ export function appendReadableAttachmentsToContent(
   return `${content}${content.trim() ? "\n\n" : ""}${blocks.join("\n\n")}`;
 }
 
-function contentAlreadyHasReadableAttachmentBlock(content: string): boolean {
-  return /<attached_file\b/i.test(content);
-}
-
 function userRegenerationContentWithAttachments(content: string, attachments: PromptAttachment[] | undefined): string {
-  if (contentAlreadyHasReadableAttachmentBlock(content)) return content;
   return appendReadableAttachmentsToContent(content, attachments);
 }
 

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -122,6 +122,7 @@ export interface PromptAssemblyResult {
   promptPresetId: string | null;
   parameters: StoredGenerationParameters | null;
   wrapFormat: WrapFormat;
+  userRegenerationSourceMessage: ChatMLMessage | null;
   characters: GenerationCharacterContext[];
   persona: GenerationPersonaContext | null;
   activatedLorebookEntries: Array<{
@@ -148,6 +149,7 @@ export interface PromptAssemblyInput {
   connection: JsonRecord;
   request: JsonRecord;
   latestUserInput: string;
+  userRegenerationSourceMessage?: ChatMLMessage | null;
   agentData?: Record<string, string>;
   embeddingSource?: {
     embed(
@@ -3344,6 +3346,11 @@ export async function assembleGenerationPrompt(
   rawInput: PromptAssemblyInput,
 ): Promise<PromptAssemblyResult> {
   let input = rawInput;
+  let promptRegexScripts: JsonRecord[] | null = null;
+  const loadPromptRegexScripts = async () => {
+    promptRegexScripts ??= (await storage.list<JsonRecord>("regex-scripts")).sort(bySortOrder);
+    return promptRegexScripts;
+  };
   const reusableContext = input.reusableContext;
   const chatMeta = reusableContext?.chatMeta ?? parseRecord(input.chat.metadata);
   const chatMode = reusableContext?.chatMode ?? readString(input.chat.mode || input.chat.chatMode, "conversation");
@@ -3402,6 +3409,28 @@ export async function assembleGenerationPrompt(
   });
   if (selectedPreset)
     resolvePromptChoiceVariableMacros(macros, selectedPreset.choiceVariableNames, deferCharacterMacros);
+  let userRegenerationSourceMessage: ChatMLMessage | null = input.userRegenerationSourceMessage
+    ? {
+        ...input.userRegenerationSourceMessage,
+        role: "user",
+        content: readString(input.userRegenerationSourceMessage.content),
+        contextKind: "history",
+      }
+    : null;
+  if (userRegenerationSourceMessage) {
+    applyRegexScriptsToPromptMessages([userRegenerationSourceMessage], await loadPromptRegexScripts(), {
+      resolveMacros: (value) => resolveMacros(value, macros, { trimResult: false }),
+    });
+    userRegenerationSourceMessage.content = collapseExcessBlankLines(
+      stripPromptComments(userRegenerationSourceMessage.content),
+    ).trim();
+    if (userRegenerationSourceMessage.content || userRegenerationSourceMessage.images?.length) {
+      input = { ...input, latestUserInput: userRegenerationSourceMessage.content };
+      macros.lastInput = userRegenerationSourceMessage.content;
+    } else {
+      userRegenerationSourceMessage = null;
+    }
+  }
   const greetingPromptVariables =
     canReuseMacroSensitiveContext && reusableContext
       ? reusableContext.greetingPromptVariables
@@ -3415,7 +3444,16 @@ export async function assembleGenerationPrompt(
       chat: input.chat,
       characters,
       persona,
-      storedMessages: input.storedMessages,
+      storedMessages: userRegenerationSourceMessage
+        ? [
+            ...input.storedMessages,
+            {
+              role: "user",
+              content: userRegenerationSourceMessage.content,
+              ...(userRegenerationSourceMessage.images?.length ? { images: userRegenerationSourceMessage.images } : {}),
+            },
+          ]
+        : input.storedMessages,
       request: input.request,
       latestUserInput: input.latestUserInput,
       embeddingSource,
@@ -3633,7 +3671,7 @@ export async function assembleGenerationPrompt(
       : [...processedLore.depthEntries, ...characterDepthEntries],
     chatHistoryDepthInjectionBounds(messages),
   );
-  const regexScripts = (await storage.list<JsonRecord>("regex-scripts")).sort(bySortOrder);
+  const regexScripts = await loadPromptRegexScripts();
   applyRegexScriptsToPromptMessages(messages, regexScripts, {
     resolveMacros: (value) => resolvePromptMacros(value, macros, deferCharacterMacros),
   });
@@ -3703,6 +3741,7 @@ export async function assembleGenerationPrompt(
     promptPresetId: presetId,
     parameters: selectedPreset?.parameters ?? null,
     wrapFormat,
+    userRegenerationSourceMessage,
     characters: promptCharacters,
     persona,
     activatedLorebookEntries: processedLore.includedEntries.map(lorebookActivatedEntryForEvent),

--- a/src/engine/generation/prompt-assembly.ts
+++ b/src/engine/generation/prompt-assembly.ts
@@ -182,6 +182,7 @@ interface PromptAssemblyReusableContext {
   memoryRecallBlock: string | null;
   history: ChatMLMessage[];
   greetingPromptVariables: Record<string, string>;
+  userRegenerationSourceFingerprint: string | null;
   macroSensitiveScope: {
     deferCharacterMacros: boolean;
     targetCharacterId: string | null;
@@ -3218,6 +3219,14 @@ function reusableContextMacroScopeMatches(
   );
 }
 
+function userRegenerationSourceFingerprint(message: ChatMLMessage | null): string | null {
+  if (!message) return null;
+  return JSON.stringify({
+    content: readString(message.content),
+    images: (message.images ?? []).filter((image) => typeof image === "string"),
+  });
+}
+
 function characterDepthPromptEntries(
   characters: GenerationCharacterContext[],
   macros: MacroContext,
@@ -3394,7 +3403,7 @@ export async function assembleGenerationPrompt(
     deferCharacterMacros,
     individualGroupTarget,
   );
-  const embeddingSource =
+  let embeddingSource =
     reusableContext && canReuseMacroSensitiveContext ? null : memoizedEmbeddingSource(input.embeddingSource);
   const macros = macroContext({
     chat: input.chat,
@@ -3431,6 +3440,13 @@ export async function assembleGenerationPrompt(
       userRegenerationSourceMessage = null;
     }
   }
+  const regenerationSourceFingerprint = userRegenerationSourceFingerprint(userRegenerationSourceMessage);
+  const canReuseSourceSensitiveContext =
+    canReuseMacroSensitiveContext &&
+    reusableContext?.userRegenerationSourceFingerprint === regenerationSourceFingerprint;
+  if (!canReuseSourceSensitiveContext && !embeddingSource) {
+    embeddingSource = memoizedEmbeddingSource(input.embeddingSource);
+  }
   const greetingPromptVariables =
     canReuseMacroSensitiveContext && reusableContext
       ? reusableContext.greetingPromptVariables
@@ -3464,22 +3480,23 @@ export async function assembleGenerationPrompt(
       },
     });
   let loreScan =
-    canReuseMacroSensitiveContext && reusableContext
+    canReuseSourceSensitiveContext && reusableContext
       ? reusableContext.loreScan
       : await scanLorebooksForPositions(baseLorebookIncludedPositions);
   let processedLore =
-    canReuseMacroSensitiveContext && reusableContext ? reusableContext.processedLore : loreScan.processedLore;
+    canReuseSourceSensitiveContext && reusableContext ? reusableContext.processedLore : loreScan.processedLore;
   const summary = reusableContext?.summary ?? chatSummaryForGeneration(input.chat);
   const memoryRecallBlock =
-    reusableContext?.memoryRecallBlock ??
-    (await buildMemoryRecallBlock(
-      storage,
-      input.chat,
-      input.storedMessages,
-      input.latestUserInput,
-      maxContext || undefined,
-      embeddingSource,
-    ));
+    canReuseSourceSensitiveContext && reusableContext
+      ? reusableContext.memoryRecallBlock
+      : await buildMemoryRecallBlock(
+          storage,
+          input.chat,
+          input.storedMessages,
+          input.latestUserInput,
+          maxContext || undefined,
+          embeddingSource,
+        );
   const metadataHistoryLimit = readNumber(chatMeta.contextMessageLimit, 0);
   const requestedHistoryLimit = readNumber(input.request.historyLimit, metadataHistoryLimit || 300);
   const historyLimit = Math.max(1, Math.min(300, metadataHistoryLimit || requestedHistoryLimit || 300));
@@ -3709,7 +3726,7 @@ export async function assembleGenerationPrompt(
     messages = collapseToSingleUserMessage(messages);
   }
   const summaryFingerprint = fingerprintChatSummary(summary);
-  const nextReusableContext: PromptAssemblyReusableContext = reusableContext ?? {
+  const nextReusableContext: PromptAssemblyReusableContext = {
     chatMeta,
     chatMode,
     storedMessages: input.storedMessages,
@@ -3729,6 +3746,7 @@ export async function assembleGenerationPrompt(
     memoryRecallBlock,
     history,
     greetingPromptVariables,
+    userRegenerationSourceFingerprint: regenerationSourceFingerprint,
     macroSensitiveScope: {
       deferCharacterMacros,
       targetCharacterId: individualGroupTarget,

--- a/src/engine/generation/start-generation.bunny.test.ts
+++ b/src/engine/generation/start-generation.bunny.test.ts
@@ -152,14 +152,22 @@ function baseGenerationRecords() {
 
 function generationStorage(args: {
   getTarget: (call: number, target: JsonRecord) => JsonRecord | null | Promise<JsonRecord | null>;
-  onSwipe?: (content: string) => void;
+  chatMetadata?: JsonRecord;
+  agentRows?: JsonRecord[];
+  onSwipe?: (content: string, options: unknown) => void;
+  onPatchExtra?: (messageId: string, patch: Record<string, unknown>) => void;
 }): StorageGateway {
   const records = baseGenerationRecords();
+  const chatMetadata =
+    records.chat.metadata && typeof records.chat.metadata === "object" && !Array.isArray(records.chat.metadata)
+      ? (records.chat.metadata as JsonRecord)
+      : {};
+  records.chat.metadata = { ...chatMetadata, ...args.chatMetadata };
   let targetGetCalls = 0;
   return {
     async list<T = unknown>(entity: StorageEntity): Promise<T[]> {
       if (entity === "connections") return asStorageValue<T[]>([records.connection]);
-      if (entity === "agents") return [];
+      if (entity === "agents") return asStorageValue<T[]>(args.agentRows ?? []);
       if (entity === "lorebooks") return [];
       if (entity === "prompts") return [];
       if (entity === "regex-scripts") return [];
@@ -200,11 +208,17 @@ function generationStorage(args: {
     async deleteChatMessage() {
       return { deleted: false };
     },
-    async patchChatMessageExtra<T = unknown>() {
+    async patchChatMessageExtra<T = unknown>(messageId: string, patch: Record<string, unknown>) {
+      args.onPatchExtra?.(messageId, patch);
       return asStorageValue<T>(records.target);
     },
-    async addChatMessageSwipe<T = unknown>(_chatId: string, _messageId: string, content: string) {
-      args.onSwipe?.(content);
+    async addChatMessageSwipe<T = unknown>(
+      _chatId: string,
+      _messageId: string,
+      content: string,
+      options?: unknown,
+    ) {
+      args.onSwipe?.(content, options);
       return asStorageValue<T>(records.target);
     },
     async patchChatMetadata<T = unknown>() {
@@ -419,6 +433,63 @@ describe("user-message regeneration review guards", () => {
     expect(events).toEqual(expect.arrayContaining([expect.objectContaining({ type: "user_message" })]));
     expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "command_error" })]));
     expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "assistant_action" })]));
+  });
+
+  it("saves assembled user-message regeneration without assistant agent metadata", async () => {
+    let modelCalls = 0;
+    const savedSwipes: string[] = [];
+    const swipeOptions: unknown[] = [];
+    const extraPatches: Array<Record<string, unknown>> = [];
+    const storage = generationStorage({
+      chatMetadata: { activeAgentIds: ["html"] },
+      agentRows: [
+        {
+          id: "html",
+          type: "html",
+          name: "Immersive HTML",
+          enabled: true,
+          phase: "pre_generation",
+          promptTemplate: "Assistant-only HTML context should not decorate user rewrites.",
+        },
+      ],
+      getTarget: (_call, target) => target,
+      onSwipe: (content, options) => {
+        savedSwipes.push(content);
+        swipeOptions.push(options);
+      },
+      onPatchExtra: (_messageId, patch) => {
+        extraPatches.push(patch);
+      },
+    });
+
+    const events = await collect(
+      startGeneration(
+        {
+          storage,
+          llm: llmThatStreams(() => {
+            modelCalls += 1;
+          }),
+          integrations: noopIntegrations,
+        },
+        { chatId: "chat-1", regenerateMessageId: "message-target", connectionId: "conn-1" },
+      ),
+    );
+
+    const savedSwipeExtra = ((swipeOptions[0] as { extra?: Record<string, unknown> } | undefined)?.extra ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    expect(modelCalls).toBe(1);
+    expect(savedSwipes).toEqual(["rewrite"]);
+    expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "agent_result" })]));
+    expect(savedSwipeExtra).not.toHaveProperty("contextInjections");
+    expect(savedSwipeExtra).not.toHaveProperty("spriteExpressions");
+    expect(savedSwipeExtra).not.toHaveProperty("cyoaChoices");
+    expect(extraPatches).toHaveLength(1);
+    expect(extraPatches[0]).not.toHaveProperty("contextInjections");
+    expect(extraPatches[0]).not.toHaveProperty("spriteExpressions");
+    expect(extraPatches[0]).not.toHaveProperty("cyoaChoices");
   });
 
   it("recomputes source-sensitive lore when reusable context receives a regeneration source", async () => {

--- a/src/engine/generation/start-generation.bunny.test.ts
+++ b/src/engine/generation/start-generation.bunny.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from "vitest";
+import type { IntegrationGateway } from "../capabilities/integrations";
+import type { LlmGateway } from "../capabilities/llm";
+import type { StorageEntity, StorageGateway, StorageListOptions } from "../capabilities/storage";
+import { assembleGenerationPrompt } from "./prompt-assembly";
+import { startGeneration } from "./start-generation";
+import type { JsonRecord } from "./runtime-records";
+
+async function drain(generator: AsyncGenerator<unknown>): Promise<void> {
+  for await (const _event of generator) {
+    // Exhaust the generation stream so assertions see provider/save side effects.
+  }
+}
+
+function asStorageValue<T>(value: unknown): T {
+  return value as T;
+}
+
+function recordList<T = JsonRecord>(records: JsonRecord[], options?: StorageListOptions): T[] {
+  let rows = [...records];
+  if (options?.filters) {
+    rows = rows.filter((row) => Object.entries(options.filters ?? {}).every(([key, value]) => row[key] === value));
+  }
+  if (options?.whereIn) {
+    const values = new Set(options.whereIn.values);
+    rows = rows.filter((row) => values.has(String(row[options.whereIn!.field] ?? "")));
+  }
+  if (typeof options?.limit === "number") rows = rows.slice(-options.limit);
+  return rows as T[];
+}
+
+function llmThatStreams(onStream: () => void): LlmGateway {
+  return {
+    async complete() {
+      return "";
+    },
+    async listModels() {
+      return [];
+    },
+    async *stream() {
+      onStream();
+      yield { type: "token", text: "rewrite" };
+    },
+  };
+}
+
+const noopIntegrations: IntegrationGateway = {
+  spotify: {
+    async player() {
+      return asStorageValue({});
+    },
+    async playlists() {
+      return asStorageValue({});
+    },
+    async playlistTracks() {
+      return asStorageValue({});
+    },
+    async searchTracks() {
+      return asStorageValue({});
+    },
+    async playTrack() {
+      return asStorageValue({});
+    },
+    async play() {
+      return asStorageValue({});
+    },
+    async volume() {
+      return asStorageValue({});
+    },
+  },
+  haptic: {
+    async status() {
+      return asStorageValue({});
+    },
+    async connect() {
+      return asStorageValue({});
+    },
+    async command() {
+      return asStorageValue({});
+    },
+    async stopAll() {
+      return asStorageValue({});
+    },
+  },
+  customTools: {
+    async execute() {
+      return asStorageValue({});
+    },
+  },
+  image: {
+    async generate() {
+      return asStorageValue({});
+    },
+  },
+};
+
+function baseGenerationRecords() {
+  const chat: JsonRecord = {
+    id: "chat-1",
+    title: "QA chat",
+    mode: "rp",
+    characterIds: ["char-1"],
+    metadata: {},
+    createdAt: "2026-06-06T00:00:00.000Z",
+    updatedAt: "2026-06-06T00:00:00.000Z",
+  };
+  const character: JsonRecord = {
+    id: "char-1",
+    name: "QA Character",
+    description: "A concise QA responder.",
+    tags: [],
+  };
+  const connection: JsonRecord = {
+    id: "conn-1",
+    name: "QA Non-Google",
+    provider: "openai",
+    model: "qa-model",
+    enabled: true,
+  };
+  const previous: JsonRecord = {
+    id: "message-prev",
+    chatId: chat.id,
+    role: "user",
+    content: "Earlier user context.",
+    extra: {},
+    createdAt: "2026-06-06T00:00:01.000Z",
+    updatedAt: "2026-06-06T00:00:01.000Z",
+  };
+  const target: JsonRecord = {
+    id: "message-target",
+    chatId: chat.id,
+    role: "user",
+    content: "Original user message.",
+    extra: {},
+    createdAt: "2026-06-06T00:00:02.000Z",
+    updatedAt: "2026-06-06T00:00:02.000Z",
+  };
+  return { chat, character, connection, previous, target };
+}
+
+function generationStorage(args: {
+  getTarget: (call: number, target: JsonRecord) => JsonRecord | null | Promise<JsonRecord | null>;
+  onSwipe?: () => void;
+}): StorageGateway {
+  const records = baseGenerationRecords();
+  let targetGetCalls = 0;
+  return {
+    async list<T = unknown>(entity: StorageEntity): Promise<T[]> {
+      if (entity === "connections") return asStorageValue<T[]>([records.connection]);
+      if (entity === "agents") return [];
+      if (entity === "lorebooks") return [];
+      if (entity === "prompts") return [];
+      if (entity === "regex-scripts") return [];
+      return [];
+    },
+    async get<T = unknown>(entity: StorageEntity, id: string): Promise<T | null> {
+      if (entity === "chats" && id === records.chat.id) return asStorageValue<T>(records.chat);
+      if (entity === "connections" && id === records.connection.id) return asStorageValue<T>(records.connection);
+      if (entity === "characters" && id === records.character.id) return asStorageValue<T>(records.character);
+      if (entity === "messages" && id === records.target.id) {
+        targetGetCalls += 1;
+        return asStorageValue<T | null>(await args.getTarget(targetGetCalls, records.target));
+      }
+      return null;
+    },
+    async create() {
+      throw new Error("create should not be called");
+    },
+    async update() {
+      throw new Error("update should not be called");
+    },
+    async delete() {
+      return { deleted: false };
+    },
+    async listChatMessages<T = unknown>(
+      _chatId: string,
+      options?: Parameters<StorageGateway["listChatMessages"]>[1],
+    ): Promise<T[]> {
+      if (options?.before) return asStorageValue<T[]>([records.previous]);
+      return asStorageValue<T[]>([records.previous, records.target]);
+    },
+    async createChatMessage() {
+      throw new Error("createChatMessage should not be called");
+    },
+    async updateChatMessage() {
+      throw new Error("updateChatMessage should not be called");
+    },
+    async deleteChatMessage() {
+      return { deleted: false };
+    },
+    async patchChatMessageExtra<T = unknown>() {
+      return asStorageValue<T>(records.target);
+    },
+    async addChatMessageSwipe<T = unknown>() {
+      args.onSwipe?.();
+      return asStorageValue<T>(records.target);
+    },
+    async patchChatMetadata<T = unknown>() {
+      return asStorageValue<T>(records.chat);
+    },
+    async patchChatSummaries<T = unknown>() {
+      return asStorageValue<T>(records.chat);
+    },
+    async listChatMemories() {
+      return [];
+    },
+    async getWorldState() {
+      return null;
+    },
+    async saveTrackerSnapshot<T = unknown>() {
+      return asStorageValue<T>({});
+    },
+    async listLorebookEntries() {
+      return [];
+    },
+    async listLorebookEntriesByLorebookIds() {
+      return [];
+    },
+    async createLorebookEntries() {
+      return [];
+    },
+    async promptFull() {
+      return null;
+    },
+  };
+}
+
+describe("user-message regeneration review guards", () => {
+  it("aborts before model call or saved swipe when the full source row load fails", async () => {
+    let modelCalls = 0;
+    let swipeCalls = 0;
+    const storage = generationStorage({
+      getTarget: (call, target) => {
+        if (call >= 3) throw new Error("storage unavailable");
+        return target;
+      },
+      onSwipe: () => {
+        swipeCalls += 1;
+      },
+    });
+
+    await expect(
+      drain(
+        startGeneration(
+          {
+            storage,
+            llm: llmThatStreams(() => {
+              modelCalls += 1;
+            }),
+            integrations: noopIntegrations,
+          },
+          { chatId: "chat-1", regenerateMessageId: "message-target", connectionId: "conn-1" },
+        ),
+      ),
+    ).rejects.toThrow("storage unavailable");
+
+    expect(modelCalls).toBe(0);
+    expect(swipeCalls).toBe(0);
+  });
+
+  it("rejects a hidden authoritative full source row even when the timeline row is visible", async () => {
+    let modelCalls = 0;
+    let swipeCalls = 0;
+    const storage = generationStorage({
+      getTarget: (call, target) => (call >= 3 ? { ...target, extra: { hiddenFromAI: true } } : target),
+      onSwipe: () => {
+        swipeCalls += 1;
+      },
+    });
+
+    await expect(
+      drain(
+        startGeneration(
+          {
+            storage,
+            llm: llmThatStreams(() => {
+              modelCalls += 1;
+            }),
+            integrations: noopIntegrations,
+          },
+          { chatId: "chat-1", regenerateMessageId: "message-target", connectionId: "conn-1" },
+        ),
+      ),
+    ).rejects.toThrow("Cannot regenerate a message hidden from AI");
+
+    expect(modelCalls).toBe(0);
+    expect(swipeCalls).toBe(0);
+  });
+
+  it("recomputes source-sensitive lore when reusable context receives a regeneration source", async () => {
+    const chat: JsonRecord = {
+      id: "chat-1",
+      mode: "rp",
+      characterIds: [],
+      metadata: {},
+    };
+    const lorebook: JsonRecord = {
+      id: "lore-1",
+      name: "Blue Lantern Lore",
+      enabled: true,
+      isGlobal: true,
+    };
+    const loreEntry: JsonRecord = {
+      id: "entry-1",
+      lorebookId: lorebook.id,
+      name: "Blue Lantern",
+      content: "Blue lantern constructs are powered by hope.",
+      keys: ["blue lantern"],
+      enabled: true,
+      position: 0,
+      role: "system",
+      order: 0,
+    };
+    const storage: StorageGateway = {
+      async list<T = unknown>(entity: StorageEntity, options?: StorageListOptions): Promise<T[]> {
+        if (entity === "lorebooks") return recordList<T>([lorebook], options);
+        if (entity === "lorebook-folders") return [];
+        if (entity === "regex-scripts") return [];
+        if (entity === "prompts") return [];
+        if (entity === "personas") return [];
+        return [];
+      },
+      async get() {
+        return null;
+      },
+      async create() {
+        throw new Error("create should not be called");
+      },
+      async update() {
+        throw new Error("update should not be called");
+      },
+      async delete() {
+        return { deleted: false };
+      },
+      async listChatMessages() {
+        return [];
+      },
+      async createChatMessage() {
+        throw new Error("createChatMessage should not be called");
+      },
+      async updateChatMessage() {
+        throw new Error("updateChatMessage should not be called");
+      },
+      async deleteChatMessage() {
+        return { deleted: false };
+      },
+      async patchChatMessageExtra<T = unknown>() {
+        return asStorageValue<T>({});
+      },
+      async addChatMessageSwipe<T = unknown>() {
+        return asStorageValue<T>({});
+      },
+      async patchChatMetadata<T = unknown>() {
+        return asStorageValue<T>(chat);
+      },
+      async patchChatSummaries<T = unknown>() {
+        return asStorageValue<T>(chat);
+      },
+      async listChatMemories() {
+        return [];
+      },
+      async getWorldState() {
+        return null;
+      },
+      async saveTrackerSnapshot<T = unknown>() {
+        return asStorageValue<T>({});
+      },
+      async listLorebookEntries<T = unknown>() {
+        return asStorageValue<T[]>([loreEntry]);
+      },
+      async listLorebookEntriesByLorebookIds<T = unknown>() {
+        return asStorageValue<T[]>([loreEntry]);
+      },
+      async createLorebookEntries() {
+        return [];
+      },
+      async promptFull() {
+        return null;
+      },
+    };
+
+    const first = await assembleGenerationPrompt(storage, {
+      chat,
+      storedMessages: [{ role: "user", content: "plain source" }],
+      connection: { provider: "openai", model: "qa-model" },
+      request: {},
+      latestUserInput: "plain source",
+    });
+    expect(first.activatedLorebookEntries).toEqual([]);
+
+    const second = await assembleGenerationPrompt(storage, {
+      chat,
+      storedMessages: [{ role: "user", content: "plain source" }],
+      connection: { provider: "openai", model: "qa-model" },
+      request: {},
+      latestUserInput: "plain source",
+      userRegenerationSourceMessage: {
+        role: "user",
+        content: "Please rewrite a message about a blue lantern.",
+      },
+      reusableContext: first.reusableContext,
+    });
+
+    expect(second.activatedLorebookEntries.map((entry) => entry.id)).toContain(loreEntry.id);
+  });
+});

--- a/src/engine/generation/start-generation.bunny.test.ts
+++ b/src/engine/generation/start-generation.bunny.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { IntegrationGateway } from "../capabilities/integrations";
 import type { LlmGateway } from "../capabilities/llm";
 import type { StorageEntity, StorageGateway, StorageListOptions } from "../capabilities/storage";
+import {
+  buildUserMessageRegenerationPromptFromSource,
+  buildUserMessageRegenerationSourceMessage,
+} from "./generate-route-utils";
 import { assembleGenerationPrompt } from "./prompt-assembly";
 import { startGeneration } from "./start-generation";
 import type { JsonRecord } from "./runtime-records";
@@ -226,6 +230,61 @@ function generationStorage(args: {
 }
 
 describe("user-message regeneration review guards", () => {
+  it("keeps stored text attachments when literal user text mentions attached_file tags", () => {
+    const source = buildUserMessageRegenerationSourceMessage({
+      content: "The quoted docs mention <attached_file but that is not a stored attachment.",
+      extra: {
+        attachments: [
+          {
+            filename: "notes.txt",
+            type: "text/plain",
+            data: "data:text/plain,Stored%20attachment%20body",
+          },
+        ],
+      },
+    });
+
+    expect(source.content).toContain("The quoted docs mention <attached_file");
+    expect(source.content).toContain('<attached_file name="notes.txt" type="text/plain">');
+    expect(source.content).toContain("Stored attachment body");
+  });
+
+  it("keeps stored text attachments when literal user text copies a helper-shaped block", () => {
+    const attachment = {
+      filename: "notes.txt",
+      type: "text/plain",
+      data: "data:text/plain,Stored%20attachment%20body",
+    };
+    const copiedBlock = [
+      '<attached_file name="notes.txt" type="text/plain">',
+      "Stored attachment body",
+      "</attached_file>",
+    ].join("\n");
+    const source = buildUserMessageRegenerationSourceMessage({
+      content: `The user quoted this block:\n${copiedBlock}`,
+      extra: { attachments: [attachment] },
+    });
+
+    expect(source.content.split('<attached_file name="notes.txt" type="text/plain">')).toHaveLength(3);
+    expect(source.content).toContain("The user quoted this block:");
+  });
+
+  it("does not duplicate a helper-generated readable attachment block when building the rewrite prompt", () => {
+    const attachment = {
+      filename: "notes.txt",
+      type: "text/plain",
+      data: "data:text/plain,Stored%20attachment%20body",
+    };
+    const normalized = buildUserMessageRegenerationSourceMessage({
+      content: "Original source.",
+      extra: { attachments: [attachment] },
+    });
+    const prompt = buildUserMessageRegenerationPromptFromSource(normalized);
+
+    expect(prompt.content.split('<attached_file name="notes.txt" type="text/plain">')).toHaveLength(2);
+    expect(prompt.content).toContain("Stored attachment body");
+  });
+
   it("aborts before model call or saved swipe when the full source row load fails", async () => {
     let modelCalls = 0;
     let swipeCalls = 0;

--- a/src/engine/generation/start-generation.bunny.test.ts
+++ b/src/engine/generation/start-generation.bunny.test.ts
@@ -16,6 +16,14 @@ async function drain(generator: AsyncGenerator<unknown>): Promise<void> {
   }
 }
 
+async function collect(generator: AsyncGenerator<unknown>): Promise<unknown[]> {
+  const events: unknown[] = [];
+  for await (const event of generator) {
+    events.push(event);
+  }
+  return events;
+}
+
 function asStorageValue<T>(value: unknown): T {
   return value as T;
 }
@@ -33,7 +41,7 @@ function recordList<T = JsonRecord>(records: JsonRecord[], options?: StorageList
   return rows as T[];
 }
 
-function llmThatStreams(onStream: () => void): LlmGateway {
+function llmThatStreams(onStream: () => void, text = "rewrite"): LlmGateway {
   return {
     async complete() {
       return "";
@@ -43,7 +51,7 @@ function llmThatStreams(onStream: () => void): LlmGateway {
     },
     async *stream() {
       onStream();
-      yield { type: "token", text: "rewrite" };
+      yield { type: "token", text };
     },
   };
 }
@@ -144,7 +152,7 @@ function baseGenerationRecords() {
 
 function generationStorage(args: {
   getTarget: (call: number, target: JsonRecord) => JsonRecord | null | Promise<JsonRecord | null>;
-  onSwipe?: () => void;
+  onSwipe?: (content: string) => void;
 }): StorageGateway {
   const records = baseGenerationRecords();
   let targetGetCalls = 0;
@@ -195,8 +203,8 @@ function generationStorage(args: {
     async patchChatMessageExtra<T = unknown>() {
       return asStorageValue<T>(records.target);
     },
-    async addChatMessageSwipe<T = unknown>() {
-      args.onSwipe?.();
+    async addChatMessageSwipe<T = unknown>(_chatId: string, _messageId: string, content: string) {
+      args.onSwipe?.(content);
       return asStorageValue<T>(records.target);
     },
     async patchChatMetadata<T = unknown>() {
@@ -344,6 +352,73 @@ describe("user-message regeneration review guards", () => {
 
     expect(modelCalls).toBe(0);
     expect(swipeCalls).toBe(0);
+  });
+
+  it("saves assembled user-message regeneration text without running connected command tags", async () => {
+    let modelCalls = 0;
+    const savedSwipes: string[] = [];
+    const storage = generationStorage({
+      getTarget: (_call, target) => target,
+      onSwipe: (content) => {
+        savedSwipes.push(content);
+      },
+    });
+    const connectedCommandText = "<note>do not persist this</note>\nrewritten user text";
+
+    const events = await collect(
+      startGeneration(
+        {
+          storage,
+          llm: llmThatStreams(() => {
+            modelCalls += 1;
+          }, connectedCommandText),
+          integrations: noopIntegrations,
+        },
+        { chatId: "chat-1", regenerateMessageId: "message-target", connectionId: "conn-1" },
+      ),
+    );
+
+    expect(modelCalls).toBe(1);
+    expect(savedSwipes).toEqual([connectedCommandText]);
+    expect(events).toEqual(expect.arrayContaining([expect.objectContaining({ type: "user_message" })]));
+    expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "command_error" })]));
+    expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "assistant_action" })]));
+  });
+
+  it("saves direct user-message regeneration text without running connected command tags", async () => {
+    let modelCalls = 0;
+    const savedSwipes: string[] = [];
+    const storage = generationStorage({
+      getTarget: (_call, target) => target,
+      onSwipe: (content) => {
+        savedSwipes.push(content);
+      },
+    });
+    const connectedCommandText = "<note>do not persist this direct rewrite</note>\nrewritten direct user text";
+
+    const events = await collect(
+      startGeneration(
+        {
+          storage,
+          llm: llmThatStreams(() => {
+            modelCalls += 1;
+          }, connectedCommandText),
+          integrations: noopIntegrations,
+        },
+        {
+          chatId: "chat-1",
+          regenerateMessageId: "message-target",
+          connectionId: "conn-1",
+          messages: [{ role: "user", content: "Direct rewrite request" }],
+        },
+      ),
+    );
+
+    expect(modelCalls).toBe(1);
+    expect(savedSwipes).toEqual([connectedCommandText]);
+    expect(events).toEqual(expect.arrayContaining([expect.objectContaining({ type: "user_message" })]));
+    expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "command_error" })]));
+    expect(events).not.toEqual(expect.arrayContaining([expect.objectContaining({ type: "assistant_action" })]));
   });
 
   it("recomputes source-sensitive lore when reusable context receives a regeneration source", async () => {

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -40,12 +40,16 @@ import {
 } from "./context";
 import {
   appendReadableAttachmentsToContent,
+  buildUserMessageRegenerationPromptFromSource,
+  buildUserMessageRegenerationSourceMessage,
   getAttachmentFilename,
+  promptAttachmentsFromExtra,
   resolveRegenerationGameStateAnchor,
   resolveRegenerationGameStateFallbackMessageIds,
   resolveVisibleGameStateAnchor,
   shouldPreferLatestVisibleGameState,
   type PromptAttachment,
+  type SimplePromptMessage,
 } from "./generate-route-utils";
 import {
   deletePreparedManagedImageAttachments,
@@ -1336,6 +1340,57 @@ function messagesBeforeRegenerationTarget(
   return targetIndex >= 0 ? storedMessages.slice(0, targetIndex) : storedMessages;
 }
 
+function regenerationTargetFromMessages(
+  storedMessages: JsonRecord[],
+  regenerateMessageId: string | null | undefined,
+): JsonRecord | null {
+  const targetId = readString(regenerateMessageId).trim();
+  if (!targetId) return null;
+  return storedMessages.find((message) => readString(message.id) === targetId) ?? null;
+}
+
+function isUserRegenerationTarget(target: JsonRecord | null): target is JsonRecord {
+  return readString(target?.role).trim() === "user";
+}
+
+async function loadFullRegenerationTarget(
+  storage: StorageGateway,
+  chatId: string,
+  target: JsonRecord | null,
+): Promise<JsonRecord | null> {
+  const targetId = readString(target?.id).trim();
+  if (!targetId) return null;
+  const loaded = await storage.get<unknown>("messages", targetId).catch(() => null);
+  const loadedRecord = isRecord(loaded) ? loaded : null;
+  return targetBelongsToChat(loadedRecord, chatId) ? loadedRecord : target;
+}
+
+async function userMessageRegenerationSourceMessage(
+  storage: StorageGateway,
+  chatId: string,
+  target: JsonRecord | null,
+): Promise<SimplePromptMessage | null> {
+  if (!isUserRegenerationTarget(target)) return null;
+  if (hiddenFromAi(target)) throw new Error("Cannot regenerate a message hidden from AI");
+
+  const fullTarget = await loadFullRegenerationTarget(storage, chatId, target);
+  if (!fullTarget) return null;
+  if (hiddenFromAi(fullTarget)) throw new Error("Cannot regenerate a message hidden from AI");
+
+  const attachments = promptAttachmentsFromExtra(fullTarget.extra);
+  const images = await resolveImageAttachmentDataUrls(storage, attachments);
+  const source = buildUserMessageRegenerationSourceMessage(fullTarget, images);
+  return source.content.trim() || source.images?.length ? source : null;
+}
+
+function withUserMessageRegenerationRewritePrompt(
+  messages: LlmMessage[],
+  source: SimplePromptMessage | null,
+): LlmMessage[] {
+  if (!source) return messages;
+  return [...messages, buildUserMessageRegenerationPromptFromSource(source)];
+}
+
 async function regenerationTargetExtra(
   storage: StorageGateway,
   chatId: string,
@@ -2350,8 +2405,10 @@ async function saveAssistantMessage(args: {
   spriteExpressions?: Record<string, string> | null;
   contextInjections?: AgentInjectionOverride[] | null;
   existingExtra?: unknown;
+  regenerationTarget?: JsonRecord | null;
 }): Promise<unknown | null> {
   const regenerateMessageId = readString(args.input.regenerateMessageId).trim();
+  const regenerationTargetRole = readString(args.regenerationTarget?.role).trim();
   const generationReplay = buildGenerationReplay(args.input);
   const content = collapseExcessBlankLines(args.content);
   assertVisibleGeneratedContent(content, args.attachments);
@@ -2404,6 +2461,23 @@ async function saveAssistantMessage(args: {
           : {}),
         chatSummaryFingerprint: args.chatSummaryFingerprint,
       },
+    });
+  }
+
+  if (regenerateMessageId && regenerationTargetRole === "user") {
+    return saveRegeneratedMessage({
+      storage: args.storage,
+      chatId: args.input.chatId,
+      messageId: regenerateMessageId,
+      content,
+      characterId: null,
+      thinking: thinking || undefined,
+      generationReplay,
+      chatSummaryFingerprint: args.chatSummaryFingerprint,
+      promptSnapshot,
+      providerMetadata,
+      spriteExpressions: args.spriteExpressions,
+      agentExtra,
     });
   }
 
@@ -2559,8 +2633,12 @@ function generationReplayExtraPatch(args: {
   return extraPatch;
 }
 
-function savedGenerationEventType(input: StartGenerationInput): "assistant_message" | "user_message" {
-  return input.impersonate === true ? "user_message" : "assistant_message";
+function savedGenerationEventType(
+  input: StartGenerationInput,
+  regenerationTarget?: JsonRecord | null,
+): "assistant_message" | "user_message" {
+  if (input.impersonate === true || isUserRegenerationTarget(regenerationTarget ?? null)) return "user_message";
+  return "assistant_message";
 }
 
 function savedGenerationEventData(saved: unknown): unknown {
@@ -2602,6 +2680,7 @@ async function persistPartialOnAbort(args: {
   chatSummaryFingerprint: string | null;
   signal: AbortSignal | undefined;
   existingExtra?: unknown;
+  regenerationTarget?: JsonRecord | null;
 }): Promise<unknown | null> {
   if (!args.signal?.aborted) return null;
   if (!args.partial.content.trim()) return null;
@@ -2620,6 +2699,7 @@ async function persistPartialOnAbort(args: {
       providerMetadata: args.partial.providerMetadata,
       promptSnapshot: args.partial.promptSnapshot,
       existingExtra: args.existingExtra,
+      regenerationTarget: args.regenerationTarget,
     });
   } catch {
     return null;
@@ -3134,9 +3214,18 @@ export async function* startGeneration(
   } else {
     storedMessages = await loadMessagesForGenerationTarget({ storage: deps.storage, chatId, chat, input });
   }
+  let regenerationTarget = regenerationTargetFromMessages(storedMessages, input.regenerateMessageId);
+  const userRegenerationSourceMessage = await userMessageRegenerationSourceMessage(
+    deps.storage,
+    chatId,
+    regenerationTarget,
+  );
   let generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
   const latestUserInput =
-    readString(internalOptions.latestUserInput).trim() || preparedUserInput.content || inputUserMessage(input);
+    readString(internalOptions.latestUserInput).trim() ||
+    userRegenerationSourceMessage?.content ||
+    preparedUserInput.content ||
+    inputUserMessage(input);
   if (internalOptions.groupTurnChild !== true) {
     const groupTurnIds = await resolveIndividualGroupTurnIds({
       deps,
@@ -3222,6 +3311,7 @@ export async function* startGeneration(
       await abortableDelay(availability.delayMs, signal);
       throwIfAborted(signal);
       storedMessages = await loadMessagesForGenerationTarget({ storage: deps.storage, chatId, chat, input });
+      regenerationTarget = regenerationTargetFromMessages(storedMessages, input.regenerateMessageId);
       generationMessages = messagesBeforeRegenerationTarget(storedMessages, input.regenerateMessageId);
     }
     if (characterNames.length > 0) {
@@ -3241,6 +3331,7 @@ export async function* startGeneration(
     connection,
     request: input,
     latestUserInput,
+    userRegenerationSourceMessage,
     embeddingSource: turnEmbeddingSource,
     visuals: deps.visuals,
     persistPromptVariables: true,
@@ -3308,6 +3399,7 @@ export async function* startGeneration(
         connection,
         request: input,
         latestUserInput,
+        userRegenerationSourceMessage,
         agentData: runtime.agentData,
         embeddingSource: turnEmbeddingSource,
         visuals: deps.visuals,
@@ -3350,8 +3442,9 @@ export async function* startGeneration(
       chatSummary: assembly.chatSummary,
       hideAutomatedSummarySourceMessages: input.hideAutomatedSummarySourceMessages === true,
     };
-    const baseMessages: LlmMessage[] = [...prompt, generationGuide(input, runtime?.preInjections)].filter(
-      (message): message is LlmMessage => !!message,
+    const baseMessages: LlmMessage[] = withUserMessageRegenerationRewritePrompt(
+      [...prompt, generationGuide(input, runtime?.preInjections)].filter((message): message is LlmMessage => !!message),
+      assembly.userRegenerationSourceMessage,
     );
     const mainPartial: StreamPartialSink = {
       content: "",
@@ -3379,8 +3472,11 @@ export async function* startGeneration(
         chat: chatForGeneration,
         parameters: llmParameters(connection, input, chatForGeneration, assembly.parameters),
         baseMessages,
-        previewMessages: [...promptPreviewMessages, generationGuide(input, runtime?.preInjections)].filter(
-          (message): message is LlmMessage => !!message,
+        previewMessages: withUserMessageRegenerationRewritePrompt(
+          [...promptPreviewMessages, generationGuide(input, runtime?.preInjections)].filter(
+            (message): message is LlmMessage => !!message,
+          ),
+          assembly.userRegenerationSourceMessage,
         ),
         promptPresetId: assembly.promptPresetId,
         mainTools,
@@ -3401,9 +3497,13 @@ export async function* startGeneration(
         chatSummaryFingerprint: assembly.chatSummaryFingerprint,
         signal,
         existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
+        regenerationTarget,
       });
       if (savedPartial) {
-        yield { type: savedGenerationEventType(input), data: savedGenerationEventData(savedPartial) };
+        yield {
+          type: savedGenerationEventType(input, regenerationTarget),
+          data: savedGenerationEventData(savedPartial),
+        };
       }
       throw err;
     }
@@ -3452,7 +3552,10 @@ export async function* startGeneration(
           spriteExpressions: preSaveSpriteExpressions,
           contextInjections: runtime?.preInjections ?? null,
           existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
+          regenerationTarget,
         });
+    const savedAssistantGeneration =
+      !!saved && input.impersonate !== true && !isUserRegenerationTarget(regenerationTarget);
     let latestSaved = saved;
     if (saved) {
       await persistLorebookTimingStatesSafely(
@@ -3463,7 +3566,7 @@ export async function* startGeneration(
       );
     }
     throwIfAborted(signal);
-    if (saved && input.impersonate !== true) {
+    if (savedAssistantGeneration) {
       await mirrorSavedAssistantMessageToDiscord({
         deps,
         chat,
@@ -3473,15 +3576,16 @@ export async function* startGeneration(
         characters: assembly.characters,
       });
     }
-    if (saved) yield { type: savedGenerationEventType(input), data: savedGenerationEventData(saved) };
-    if (saved && input.impersonate !== true) {
+    if (saved)
+      yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(saved) };
+    if (savedAssistantGeneration) {
       await evictStalePromptSnapshotsSafely(deps.storage, chatId);
     }
     throwIfAborted(signal);
 
     const parallelResults = await parallelAgents;
     throwIfAborted(signal);
-    const postResults = runtime ? await runtime.runPost(content) : [];
+    const postResults = runtime && savedAssistantGeneration ? await runtime.runPost(content) : [];
     throwIfAborted(signal);
     let emittedAgentResults = uniqueAgentResults([...parallelResults, ...postResults, ...agentEvents]);
     emittedAgentResults = await generateTrackerAvatarsForResults({
@@ -3507,12 +3611,12 @@ export async function* startGeneration(
       });
       if (patched) {
         latestSaved = patched;
-        yield { type: savedGenerationEventType(input), data: savedGenerationEventData(patched) };
+        yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(patched) };
       }
     }
 
     const hasIllustrationRequest = emittedAgentResults.some((result) => illustratorPromptData(result) !== null);
-    if (saved && hasIllustrationRequest) {
+    if (savedAssistantGeneration && hasIllustrationRequest) {
       yield { type: "phase", data: "Generating illustration..." };
       const illustration = await generateIllustrationAttachments({
         deps,
@@ -3529,11 +3633,11 @@ export async function* startGeneration(
       });
       if (patched) {
         latestSaved = patched;
-        yield { type: savedGenerationEventType(input), data: savedGenerationEventData(patched) };
+        yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(patched) };
       }
     }
     throwIfAborted(signal);
-    if (saved && input.impersonate !== true) {
+    if (savedAssistantGeneration) {
       await persistTrackerSnapshotSafely(
         deps.storage,
         chatId,
@@ -3550,7 +3654,7 @@ export async function* startGeneration(
     throwIfAborted(signal);
     await persistAgentResults(deps.storage, chatId, messageId(latestSaved), allAgentResults);
     throwIfAborted(signal);
-    if (saved && input.impersonate !== true) {
+    if (savedAssistantGeneration) {
       const autoLorebookBackfill = await runLorebookKeeperBackfill(
         deps,
         {
@@ -3568,7 +3672,7 @@ export async function* startGeneration(
         yield { type: "agent_result", data: result };
       }
     }
-    if (saved && input.impersonate !== true) {
+    if (savedAssistantGeneration) {
       scheduleMemoryRecallRefresh(deps.storage, chat);
     }
     yield { type: "done", data: { transcript: visibleTranscript(generationMessages) } };
@@ -3605,8 +3709,9 @@ export async function* startGeneration(
     chatSummary: assembly.chatSummary,
     hideAutomatedSummarySourceMessages: input.hideAutomatedSummarySourceMessages === true,
   };
-  const baseMessagesDirect: LlmMessage[] = [...(prompt ?? []), generationGuide(input)].filter(
-    (message): message is LlmMessage => !!message,
+  const baseMessagesDirect: LlmMessage[] = withUserMessageRegenerationRewritePrompt(
+    [...(prompt ?? []), generationGuide(input)].filter((message): message is LlmMessage => !!message),
+    assembly.userRegenerationSourceMessage,
   );
   const directPartial: StreamPartialSink = {
     content: "",
@@ -3634,8 +3739,11 @@ export async function* startGeneration(
       chat: chatForGeneration,
       parameters: llmParameters(connection, input, chatForGeneration, assembly.parameters),
       baseMessages: baseMessagesDirect,
-      previewMessages: [...(promptPreviewMessagesDirect ?? []), generationGuide(input)].filter(
-        (message): message is LlmMessage => !!message,
+      previewMessages: withUserMessageRegenerationRewritePrompt(
+        [...(promptPreviewMessagesDirect ?? []), generationGuide(input)].filter(
+          (message): message is LlmMessage => !!message,
+        ),
+        assembly.userRegenerationSourceMessage,
       ),
       promptPresetId: assembly.promptPresetId,
       mainTools: mainToolsDirect,
@@ -3656,9 +3764,10 @@ export async function* startGeneration(
       chatSummaryFingerprint: assembly.chatSummaryFingerprint,
       signal,
       existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
+      regenerationTarget,
     });
     if (savedPartial) {
-      yield { type: savedGenerationEventType(input), data: savedGenerationEventData(savedPartial) };
+      yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(savedPartial) };
     }
     throw err;
   }
@@ -3699,7 +3808,10 @@ export async function* startGeneration(
         providerMetadata,
         promptSnapshot: promptSnapshotDirect,
         existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
+        regenerationTarget,
       });
+  const savedAssistantGeneration =
+    !!saved && input.impersonate !== true && !isUserRegenerationTarget(regenerationTarget);
   if (saved) {
     await persistLorebookTimingStatesSafely(
       deps.storage,
@@ -3709,7 +3821,7 @@ export async function* startGeneration(
     );
   }
   throwIfAborted(signal);
-  if (saved && input.impersonate !== true) {
+  if (savedAssistantGeneration) {
     await mirrorSavedAssistantMessageToDiscord({
       deps,
       chat,
@@ -3719,12 +3831,12 @@ export async function* startGeneration(
       characters: assembly.characters,
     });
   }
-  if (saved) yield { type: savedGenerationEventType(input), data: savedGenerationEventData(saved) };
-  if (saved && input.impersonate !== true) {
+  if (saved) yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(saved) };
+  if (savedAssistantGeneration) {
     await evictStalePromptSnapshotsSafely(deps.storage, chatId);
   }
   throwIfAborted(signal);
-  if (saved && input.impersonate !== true) {
+  if (savedAssistantGeneration) {
     const autoLorebookBackfill = await runLorebookKeeperBackfill(
       deps,
       {
@@ -3742,7 +3854,7 @@ export async function* startGeneration(
       yield { type: "agent_result", data: result };
     }
   }
-  if (saved && input.impersonate !== true) {
+  if (savedAssistantGeneration) {
     scheduleMemoryRecallRefresh(deps.storage, chat);
   }
   yield { type: "done" };

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -1360,9 +1360,14 @@ async function loadFullRegenerationTarget(
 ): Promise<JsonRecord | null> {
   const targetId = readString(target?.id).trim();
   if (!targetId) return null;
-  const loaded = await storage.get<unknown>("messages", targetId).catch(() => null);
-  const loadedRecord = isRecord(loaded) ? loaded : null;
-  return targetBelongsToChat(loadedRecord, chatId) ? loadedRecord : target;
+  const loaded = await storage.get<unknown>("messages", targetId);
+  if (!isRecord(loaded)) {
+    throw new Error("Cannot regenerate user message because its full source record was not found");
+  }
+  if (!targetBelongsToChat(loaded, chatId)) {
+    throw new Error("Cannot regenerate user message because its full source record belongs to another chat");
+  }
+  return loaded;
 }
 
 async function userMessageRegenerationSourceMessage(

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -3361,7 +3361,7 @@ export async function* startGeneration(
   mirrorSavedUserMessageToDiscord({ deps, chat, input, prepared: preparedUserInput, persona: assembly.persona });
 
   if (!directMessages) {
-    const agentsEnabled = input.impersonateBlockAgents !== true;
+    const agentsEnabled = input.impersonateBlockAgents !== true && !isUserMessageRegeneration;
     yield { type: "phase", data: agentsEnabled ? "Running pre-generation agents..." : "Calling model..." };
     const runtime = agentsEnabled
       ? await createGenerationAgentRuntime(
@@ -3429,8 +3429,10 @@ export async function* startGeneration(
       });
       throwIfAborted(signal);
     }
-    await consumePendingConnectedInfluences(deps.storage, chatForGeneration);
-    throwIfAborted(signal);
+    if (!isUserMessageRegeneration) {
+      await consumePendingConnectedInfluences(deps.storage, chatForGeneration);
+      throwIfAborted(signal);
+    }
     const generationDirectiveMessages = directiveMessages(
       input,
       chat,
@@ -3531,11 +3533,10 @@ export async function* startGeneration(
     throwIfAborted(signal);
     let content = streamedContent;
 
-    const preSaveAgentResults = uniqueAgentResults(runtime?.preResults ?? []);
-    const preSaveSpriteExpressions = spriteExpressionsFromAgentResults(
-      preSaveAgentResults,
-      runtime?.availableSprites ?? [],
-    );
+    const preSaveAgentResults = isUserMessageRegeneration ? [] : uniqueAgentResults(runtime?.preResults ?? []);
+    const preSaveSpriteExpressions = isUserMessageRegeneration
+      ? null
+      : spriteExpressionsFromAgentResults(preSaveAgentResults, runtime?.availableSprites ?? []);
     content = await applyRuntimeRegexScripts(deps.storage, "ai_output", content);
     throwIfAborted(signal);
     const connected = isUserMessageRegeneration
@@ -3573,7 +3574,7 @@ export async function* startGeneration(
           providerMetadata,
           promptSnapshot,
           spriteExpressions: preSaveSpriteExpressions,
-          contextInjections: runtime?.preInjections ?? null,
+          contextInjections: isUserMessageRegeneration ? null : runtime?.preInjections ?? null,
           existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
           regenerationTarget,
         });
@@ -3605,77 +3606,79 @@ export async function* startGeneration(
     }
     throwIfAborted(signal);
 
-    const parallelResults = await parallelAgents;
-    throwIfAborted(signal);
-    const postResults = runtime && savedAssistantGeneration ? await runtime.runPost(content) : [];
-    throwIfAborted(signal);
-    let emittedAgentResults = uniqueAgentResults([...parallelResults, ...postResults, ...agentEvents]);
-    emittedAgentResults = await generateTrackerAvatarsForResults({
-      deps,
-      chat: chatForGeneration,
-      results: emittedAgentResults,
-      baseline: generationTrackerBaseline,
-      signal,
-    });
-    for (const result of emittedAgentResults) {
-      yield { type: "agent_result", data: result };
-    }
-    agentEvents.length = 0;
-    const allAgentResults = uniqueAgentResults([...preSaveAgentResults, ...emittedAgentResults]);
-    const spriteExpressions = spriteExpressionsFromAgentResults(allAgentResults, runtime?.availableSprites ?? []);
-    if (saved) {
-      const patched = await patchSavedMessageAgentExtra({
-        storage: deps.storage,
-        saved: latestSaved,
-        results: allAgentResults,
-        contextInjections: runtime?.preInjections ?? null,
-        spriteExpressions,
-      });
-      if (patched) {
-        latestSaved = patched;
-        yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(patched) };
-      }
-    }
-
-    const hasIllustrationRequest = emittedAgentResults.some((result) => illustratorPromptData(result) !== null);
-    if (savedAssistantGeneration && hasIllustrationRequest) {
-      yield { type: "phase", data: "Generating illustration..." };
-      const illustration = await generateIllustrationAttachments({
+    if (!isUserMessageRegeneration) {
+      const parallelResults = await parallelAgents;
+      throwIfAborted(signal);
+      const postResults = runtime && savedAssistantGeneration ? await runtime.runPost(content) : [];
+      throwIfAborted(signal);
+      let emittedAgentResults = uniqueAgentResults([...parallelResults, ...postResults, ...agentEvents]);
+      emittedAgentResults = await generateTrackerAvatarsForResults({
         deps,
-        chat,
+        chat: chatForGeneration,
         results: emittedAgentResults,
+        baseline: generationTrackerBaseline,
         signal,
       });
-      throwIfAborted(signal);
-      for (const event of illustration.events) yield event;
-      const patched = await appendSavedMessageAttachments({
-        storage: deps.storage,
-        saved: latestSaved,
-        attachments: illustration.attachments,
-      });
-      if (patched) {
-        latestSaved = patched;
-        yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(patched) };
+      for (const result of emittedAgentResults) {
+        yield { type: "agent_result", data: result };
       }
+      agentEvents.length = 0;
+      const allAgentResults = uniqueAgentResults([...preSaveAgentResults, ...emittedAgentResults]);
+      const spriteExpressions = spriteExpressionsFromAgentResults(allAgentResults, runtime?.availableSprites ?? []);
+      if (saved) {
+        const patched = await patchSavedMessageAgentExtra({
+          storage: deps.storage,
+          saved: latestSaved,
+          results: allAgentResults,
+          contextInjections: runtime?.preInjections ?? null,
+          spriteExpressions,
+        });
+        if (patched) {
+          latestSaved = patched;
+          yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(patched) };
+        }
+      }
+
+      const hasIllustrationRequest = emittedAgentResults.some((result) => illustratorPromptData(result) !== null);
+      if (savedAssistantGeneration && hasIllustrationRequest) {
+        yield { type: "phase", data: "Generating illustration..." };
+        const illustration = await generateIllustrationAttachments({
+          deps,
+          chat,
+          results: emittedAgentResults,
+          signal,
+        });
+        throwIfAborted(signal);
+        for (const event of illustration.events) yield event;
+        const patched = await appendSavedMessageAttachments({
+          storage: deps.storage,
+          saved: latestSaved,
+          attachments: illustration.attachments,
+        });
+        if (patched) {
+          latestSaved = patched;
+          yield { type: savedGenerationEventType(input, regenerationTarget), data: savedGenerationEventData(patched) };
+        }
+      }
+      throwIfAborted(signal);
+      if (savedAssistantGeneration) {
+        await persistTrackerSnapshotSafely(
+          deps.storage,
+          chatId,
+          latestSaved,
+          allAgentResults,
+          generationTrackerBaseline,
+          readString(parseRecord(latestSaved).content),
+          deps.onTrackerSnapshotSaved,
+          true,
+        );
+      }
+      throwIfAborted(signal);
+      await persistSecretPlotAgentMemorySafely(deps.storage, chatId, allAgentResults);
+      throwIfAborted(signal);
+      await persistAgentResults(deps.storage, chatId, messageId(latestSaved), allAgentResults);
+      throwIfAborted(signal);
     }
-    throwIfAborted(signal);
-    if (savedAssistantGeneration) {
-      await persistTrackerSnapshotSafely(
-        deps.storage,
-        chatId,
-        latestSaved,
-        allAgentResults,
-        generationTrackerBaseline,
-        readString(parseRecord(latestSaved).content),
-        deps.onTrackerSnapshotSaved,
-        true,
-      );
-    }
-    throwIfAborted(signal);
-    await persistSecretPlotAgentMemorySafely(deps.storage, chatId, allAgentResults);
-    throwIfAborted(signal);
-    await persistAgentResults(deps.storage, chatId, messageId(latestSaved), allAgentResults);
-    throwIfAborted(signal);
     if (savedAssistantGeneration) {
       const autoLorebookBackfill = await runLorebookKeeperBackfill(
         deps,

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -20,7 +20,11 @@ import {
 import { persistSecretPlotAgentMemory, type SecretPlotRerollMode } from "./agent-memory-runtime";
 import { createGenerationAgentRuntime } from "./agent-runner";
 import { buildBuiltInAgentFallback, canonicalAgentActiveIdSet } from "./built-in-agent-fallback";
-import { consumePendingConnectedInfluences, persistConnectedCommandTags } from "./connected-commands";
+import {
+  consumePendingConnectedInfluences,
+  persistConnectedCommandTags,
+  type ConnectedCommandResult,
+} from "./connected-commands";
 import { fitMessagesToContextWindow } from "./context-window";
 import type { LLMToolCall } from "../generation-core/llm/base-provider";
 import { createInlineThinkingStreamParser } from "../generation-core/llm/inline-thinking";
@@ -1351,6 +1355,17 @@ function regenerationTargetFromMessages(
 
 function isUserRegenerationTarget(target: JsonRecord | null): target is JsonRecord {
   return readString(target?.role).trim() === "user";
+}
+
+function connectedCommandPassthrough(content: string): ConnectedCommandResult {
+  return {
+    displayContent: content,
+    createdNotes: [],
+    executedCommands: [],
+    events: [],
+    assistantAttachments: [],
+    suppressAssistantMessage: false,
+  };
 }
 
 async function loadFullRegenerationTarget(
@@ -3323,6 +3338,7 @@ export async function* startGeneration(
       yield { type: "typing", data: { characters: characterNames } };
     }
   }
+  const isUserMessageRegeneration = isUserRegenerationTarget(regenerationTarget);
   const agentEvents: AgentResult[] = [];
   const continueAssistantResponse = shouldContinueAssistantResponse(input, preparedUserInput, generationMessages);
   const agentInjectionOverrides = normalizedAgentInjectionOverrides(input);
@@ -3522,16 +3538,18 @@ export async function* startGeneration(
     );
     content = await applyRuntimeRegexScripts(deps.storage, "ai_output", content);
     throwIfAborted(signal);
-    const connected = await persistConnectedCommandTags(
-      deps.storage,
-      chat,
-      content,
-      deps.integrations,
-      deps.llm,
-      readString(connection.id) || input.connectionId || null,
-      input.imagePromptSettings,
-      deps.visuals,
-    );
+    const connected = isUserMessageRegeneration
+      ? connectedCommandPassthrough(content)
+      : await persistConnectedCommandTags(
+          deps.storage,
+          chat,
+          content,
+          deps.integrations,
+          deps.llm,
+          readString(connection.id) || input.connectionId || null,
+          input.imagePromptSettings,
+          deps.visuals,
+        );
     throwIfAborted(signal);
     for (const event of connected.events) yield event;
     const displayContent = finalAssistantContent(input, connected.displayContent);
@@ -3559,8 +3577,7 @@ export async function* startGeneration(
           existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
           regenerationTarget,
         });
-    const savedAssistantGeneration =
-      !!saved && input.impersonate !== true && !isUserRegenerationTarget(regenerationTarget);
+    const savedAssistantGeneration = !!saved && input.impersonate !== true && !isUserMessageRegeneration;
     let latestSaved = saved;
     if (saved) {
       await persistLorebookTimingStatesSafely(
@@ -3780,16 +3797,18 @@ export async function* startGeneration(
   let content = streamedContentDirect;
   content = await applyRuntimeRegexScripts(deps.storage, "ai_output", content);
   throwIfAborted(signal);
-  const connected = await persistConnectedCommandTags(
-    deps.storage,
-    chat,
-    content,
-    deps.integrations,
-    deps.llm,
-    readString(connection.id) || input.connectionId || null,
-    input.imagePromptSettings,
-    deps.visuals,
-  );
+  const connected = isUserMessageRegeneration
+    ? connectedCommandPassthrough(content)
+    : await persistConnectedCommandTags(
+        deps.storage,
+        chat,
+        content,
+        deps.integrations,
+        deps.llm,
+        readString(connection.id) || input.connectionId || null,
+        input.imagePromptSettings,
+        deps.visuals,
+      );
   throwIfAborted(signal);
   for (const event of connected.events) yield event;
   const displayContentDirect = finalAssistantContent(input, connected.displayContent);
@@ -3815,8 +3834,7 @@ export async function* startGeneration(
         existingExtra: await regenerationTargetExtra(deps.storage, chatId, storedMessages, input.regenerateMessageId),
         regenerationTarget,
       });
-  const savedAssistantGeneration =
-    !!saved && input.impersonate !== true && !isUserRegenerationTarget(regenerationTarget);
+  const savedAssistantGeneration = !!saved && input.impersonate !== true && !isUserMessageRegeneration;
   if (saved) {
     await persistLorebookTimingStatesSafely(
       deps.storage,


### PR DESCRIPTION
## Linked issue

Closes #2450

## Why this change

- Regenerating a user message removed the target user turn from prompt history without preserving the original source/rewrite path, so providers could continue as the assistant while the result was saved as a user swipe.

## What changed

- Added user-message regeneration source helpers that preserve original user content, readable text attachments, and image payloads without duplicating stored readable attachment blocks.
- Fed the transformed source through prompt-only regex, latest-user macros, and lorebook scanning without replaying the target as visible chat history.
- Appended the user-message rewrite instruction for provider-normal user-role prompts and saved/emitted regenerated user swipes as user messages.

## Refactor impact

Primary owner:

- Engine generation / runtime generation

Impact areas reviewed:

- Prompt assembly regex, macros, lorebook scan, and semantic latest-input behavior.
- Main and direct generation request messages plus prompt preview snapshots.
- Regenerated swipe save/event routing for user vs assistant targets.

Boundary notes:

- Engine-only TypeScript change; no React feature, shared API, Rust, Tauri command, or remote-runtime boundary changes.

Pressure points touched:

- Prompt assembly and startGeneration request/save setup only; no ModeSurface, GameSurface, shared mode UI, src-tauri command registration, or import modules touched.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm check`
- Focused Vitest proof was run during development before the base branch removed tracked TypeScript test files; final rebased branch validation used the current repo gate above.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Internal generation prompt/runtime bugfix; no new user-discoverable surface.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

N/A: engine-only prompt/runtime bugfix; no visible UI changes.
