### PR TITLE
Fix chat setup wizards for new mode chats

### DIFF
--- a/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
+++ b/src/features/modes/shared/chat-ui/hooks/use-chat-overlays.ts
@@ -98,16 +98,25 @@ export function useChatOverlays(activeChatId: string) {
   useEffect(() => {
     if (!activeChatId) return;
 
-    const intent = useChatStore.getState().consumeNewChatSetupIntent(activeChatId);
+    const intent = newChatSetupIntent?.chatId === activeChatId ? newChatSetupIntent : null;
     if (intent) {
       setNewChatSetupChatId(intent.chatId);
       queueSetupOverlayOpen(`intent:${intent.chatId}`, () => {
-        if (intent.openWizard) {
-          if (intent.shortcutMode) useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
+        const consumed = useChatStore.getState().consumeNewChatSetupIntent(activeChatId);
+        if (!consumed) {
+          setNewChatSetupChatId(null);
+          return;
+        }
+
+        setNewChatSetupChatId(consumed.chatId);
+        if (consumed.openWizard) {
+          if (consumed.shortcutMode) useChatStore.getState().setShouldOpenWizardInShortcutMode(true);
           setWizardOpen(true);
-        } else if (intent.openSettings) {
+        } else if (consumed.openSettings) {
           setSettingsOpen(true);
         }
+      }, () => {
+        setNewChatSetupChatId((current) => (current === intent.chatId ? null : current));
       });
       return;
     }

--- a/tests/unit/use-chat-overlays.spec.tsx
+++ b/tests/unit/use-chat-overlays.spec.tsx
@@ -1,0 +1,104 @@
+import { StrictMode, useEffect } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useChatOverlays } from "../../src/features/modes/shared/chat-ui/hooks/use-chat-overlays";
+import { useChatStore } from "../../src/shared/stores/chat.store";
+
+type OverlaySnapshot = {
+  wizardOpen: boolean;
+  settingsOpen: boolean;
+  newChatSetupChatId: string | null;
+};
+
+function OverlayProbe({
+  activeChatId,
+  onSnapshot,
+}: {
+  activeChatId: string;
+  onSnapshot: (snapshot: OverlaySnapshot) => void;
+}) {
+  const overlays = useChatOverlays(activeChatId);
+
+  useEffect(() => {
+    onSnapshot({
+      wizardOpen: overlays.wizardOpen,
+      settingsOpen: overlays.settingsOpen,
+      newChatSetupChatId: overlays.newChatSetupChatId,
+    });
+  }, [onSnapshot, overlays.newChatSetupChatId, overlays.settingsOpen, overlays.wizardOpen]);
+
+  return null;
+}
+
+async function flushScheduledOverlayOpen() {
+  await act(async () => {
+    await vi.runOnlyPendingTimersAsync();
+  });
+  await act(async () => {
+    await vi.runOnlyPendingTimersAsync();
+  });
+}
+
+describe("useChatOverlays", () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 0),
+    );
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => window.clearTimeout(handle));
+    vi.stubGlobal("requestIdleCallback", (callback: IdleRequestCallback) =>
+      window.setTimeout(() => callback({ didTimeout: false, timeRemaining: () => 50 }), 0),
+    );
+    vi.stubGlobal("cancelIdleCallback", (handle: number) => window.clearTimeout(handle));
+
+    window.localStorage.clear();
+    useChatStore.getState().reset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    useChatStore.getState().reset();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("keeps targeted new-chat wizard intent alive through StrictMode effect cleanup", async () => {
+    const chatId = "chat-1";
+    const snapshots: OverlaySnapshot[] = [];
+
+    act(() => {
+      const store = useChatStore.getState();
+      store.setShouldOpenSettings(true, chatId);
+      store.setShouldOpenWizard(true, chatId);
+    });
+
+    await act(async () => {
+      root = createRoot(container!);
+      root.render(
+        <StrictMode>
+          <OverlayProbe activeChatId={chatId} onSnapshot={(snapshot) => snapshots.push(snapshot)} />
+        </StrictMode>,
+      );
+    });
+    await flushScheduledOverlayOpen();
+
+    expect(snapshots.some((snapshot) => snapshot.wizardOpen && snapshot.newChatSetupChatId === chatId)).toBe(true);
+    expect(useChatStore.getState().newChatSetupIntent).toBeNull();
+    expect(useChatStore.getState().shouldOpenWizard).toBe(false);
+    expect(useChatStore.getState().shouldOpenSettings).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
-    include: ["src/**/*.test.{ts,tsx}", "tests/unit/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "tests/unit/**/*.{spec,test}.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Linked issue

Closes #2483

## Why this change

- New Conversation, Roleplay, and Game chats were creating records without reliably opening their setup wizards.
- The targeted setup intent could be consumed before the delayed overlay open actually ran, so cleanup during the route/effect transition could erase the only pending wizard request.

## What changed

- Keep targeted new-chat setup intent in the chat store until the scheduled overlay open callback runs.
- Clear only local pending overlay state when a scheduled open is canceled.
- Add a focused StrictMode regression spec for the setup-intent handoff.
- Update Vitest unit include rules so `tests/unit/**/*.spec.tsx` files run under `pnpm test`.

## Refactor impact

Primary owner:

- Shared mode UI overlays.

Impact areas reviewed:

- Sidebar new-chat creation for Conversation, Roleplay, and Game.
- Legacy `origin/main` setup-wizard flow for the expected behavior.
- Shared chat setup intent handoff through `useChatStore` and `useChatOverlays`.
- Game setup routing, where Game mode uses its own setup wizard after chat creation.

Boundary notes:

- Feature/shared mode UI only; no engine, shared API, Rust command, storage schema, provider, or remote-runtime boundary changes.

Pressure points touched:

- Shared mode UI hook: `use-chat-overlays.ts`.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [x] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- `pnpm exec vitest run tests/unit/use-chat-overlays.spec.tsx` passed.
- `pnpm test` passed.
- `pnpm typecheck` passed.
- `pnpm check` passed.
- Native Tauri QA before fix: clicked `New RP`; a `New Roleplay` chat was created without a setup dialog.
- Native Tauri QA after fix: `New chat` showed `New Conversation`, `New RP` showed `Choose a Connection` and `Next`, and `New game` showed `New Game Setup`.
- Durable test rationale: the regression was a setup intent being consumed before the delayed overlay open survived React StrictMode cleanup. Existing manual proof would not guard that timing invariant. The new spec is narrow: it mounts `useChatOverlays` with `useChatStore` under `StrictMode` and verifies only the targeted wizard intent handoff.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Restores the existing new-chat setup wizard behavior; it does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

Native Tauri WebView text checks were performed in-session. No screenshots are attached.