### PR TITLE
Fix regen context and Secret Plot guidance

### DIFF
--- a/src/engine/generation/agent-memory-runtime.ts
+++ b/src/engine/generation/agent-memory-runtime.ts
@@ -37,6 +37,39 @@ export function secretPlotStateFromMemory(memory: Record<string, unknown>): Reco
   return Object.keys(state).length > 0 ? state : null;
 }
 
+function normalizeSecretPlotArc(value: unknown): unknown {
+  if (typeof value === "string") return value.trim() ? value.trim() : null;
+  if (value && typeof value === "object") return value;
+  return null;
+}
+
+function secretPlotArcText(value: unknown): string {
+  const arc = normalizeSecretPlotArc(value);
+  if (!arc) return "";
+  if (typeof arc === "string") return arc;
+  return JSON.stringify(arc);
+}
+
+export function secretPlotPromptGuidanceFromData(data: unknown): string | null {
+  if (!isRecord(data)) return null;
+  const arc = secretPlotArcText(data.overarchingArc);
+  const directions = normalizeSecretPlotSceneDirections(data.sceneDirections)
+    .filter((direction) => !direction.fulfilled)
+    .map((direction) => direction.direction);
+  const parts: string[] = [];
+  if (arc) {
+    parts.push(["<overarching_arc>", arc, "</overarching_arc>"].join("\n"));
+  }
+  if (directions.length > 0) {
+    parts.push(
+      ["<scene_directions>", directions.map((direction) => `- ${direction}`).join("\n"), "</scene_directions>"].join(
+        "\n",
+      ),
+    );
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
 export async function persistSecretPlotAgentMemory(
   storage: StorageGateway,
   chatId: string,
@@ -48,8 +81,14 @@ export async function persistSecretPlotAgentMemory(
   const agentConfigId = result.agentId;
   const data = result.data;
 
-  if (data.overarchingArc && options.rerollMode !== "turn_only") {
-    await setAgentMemoryValue(storage, agentConfigId, chatId, "overarchingArc", data.overarchingArc);
+  if (Object.prototype.hasOwnProperty.call(data, "overarchingArc") && options.rerollMode !== "turn_only") {
+    await setAgentMemoryValue(
+      storage,
+      agentConfigId,
+      chatId,
+      "overarchingArc",
+      normalizeSecretPlotArc(data.overarchingArc),
+    );
   }
 
   if (data.sceneDirections !== undefined) {

--- a/src/engine/generation/agent-runner.ts
+++ b/src/engine/generation/agent-runner.ts
@@ -53,7 +53,7 @@ import {
   isBuiltInAgent,
 } from "./built-in-agent-fallback";
 import { llmParameters } from "./context";
-import { loadAgentMemory, secretPlotStateFromMemory } from "./agent-memory-runtime";
+import { loadAgentMemory, secretPlotPromptGuidanceFromData, secretPlotStateFromMemory } from "./agent-memory-runtime";
 import {
   buildAvailableSpriteCharacter,
   normalizeSpriteDisplayModes,
@@ -151,6 +151,7 @@ const ILLUSTRATOR_AGENT_TYPE = "illustrator";
 const CARD_EVOLUTION_AUDITOR_AGENT_TYPE = "card-evolution-auditor";
 const CHAT_SUMMARY_AGENT_TYPE = "chat-summary";
 const HAPTIC_AGENT_TYPE = "haptic";
+const SECRET_PLOT_DRIVER_AGENT_TYPE = "secret-plot-driver";
 const KNOWLEDGE_RETRIEVAL_AGENT_TYPE = "knowledge-retrieval";
 const KNOWLEDGE_ROUTER_AGENT_TYPE = "knowledge-router";
 const KNOWLEDGE_AGENT_TYPES = new Set([KNOWLEDGE_RETRIEVAL_AGENT_TYPE, KNOWLEDGE_ROUTER_AGENT_TYPE]);
@@ -169,7 +170,7 @@ const MAX_CUSTOM_AGENT_USER_RUN_INTERVAL = 200;
 const MAX_AGENT_PARALLEL_JOBS = 16;
 const MAX_ILLUSTRATOR_REFERENCE_IMAGES = 8;
 const IMAGE_REFERENCE_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
-const PROMPT_INJECTABLE_RESULT_TYPES = new Set(["context_injection", "director_event"]);
+const PROMPT_INJECTABLE_RESULT_TYPES = new Set(["context_injection", "director_event", "secret_plot"]);
 type AutomaticIntervalMessageRole = "assistant" | "user";
 
 const DEFAULT_ROLEPLAY_EXPRESSIONS = [
@@ -1552,13 +1553,14 @@ async function buildAgentContext(
   const chatMode = readString(input.chat.mode || input.chat.chatMode, "roleplay");
   const chatMeta = parseRecord(input.chat.metadata);
   const recentSourceMessages = promptVisibleStoredMessages(input, chatMode, chatMeta);
+  const resolvedAgentIds = uniqueStrings(agents.map((agent) => agent.id).filter((id) => readString(id).trim()));
   const memoryRows = await Promise.all(
-    (await deps.storage.list<JsonRecord>("agents"))
-      .filter((agent) => readString(agent.id).trim())
-      .map((agent) => loadAgentMemory(deps.storage, readString(agent.id), chatId)),
+    resolvedAgentIds.map((agentId) => loadAgentMemory(deps.storage, agentId, chatId)),
   );
   const memory = Object.assign({}, ...memoryRows);
-  const secretPlotState = secretPlotStateFromMemory(memory);
+  const secretPlotAgent = agents.find((agent) => agent.type === SECRET_PLOT_DRIVER_AGENT_TYPE);
+  const secretPlotMemory = secretPlotAgent ? await loadAgentMemory(deps.storage, secretPlotAgent.id, chatId) : null;
+  const secretPlotState = secretPlotMemory ? secretPlotStateFromMemory(secretPlotMemory) : null;
   if (secretPlotState) memory._secretPlotState = secretPlotState;
   memory._spotifyDjConstraints = buildSpotifyDjConstraints(chatMode, chatMeta, {
     manualRetry: input.spotifyDjManualRetry === true,
@@ -1617,10 +1619,28 @@ async function buildAgentContext(
 function resultText(result: AgentResult): string | null {
   if (!result.success) return null;
   if (!PROMPT_INJECTABLE_RESULT_TYPES.has(result.type)) return null;
+  if (result.type === "secret_plot") return secretPlotPromptGuidanceFromData(result.data);
   if (typeof result.data === "string") return result.data;
   if (!isRecord(result.data)) return null;
   const text = result.data.text ?? result.data.direction ?? result.data.summary ?? result.data.raw;
   return typeof text === "string" && text.trim() ? text.trim() : null;
+}
+
+function cachedInjectionResult(injection: AgentInjection): AgentResult {
+  const agentType = injection.agentType;
+  return {
+    agentId: agentType,
+    agentType,
+    type: agentType === DIRECTOR_AGENT_TYPE ? "director_event" : "context_injection",
+    data:
+      agentType === DIRECTOR_AGENT_TYPE
+        ? { direction: injection.text, source: "cached_context_injection" }
+        : { text: injection.text, source: "cached_context_injection" },
+    tokensUsed: 0,
+    durationMs: 0,
+    success: true,
+    error: null,
+  };
 }
 
 function resultEventData(result: AgentResult): AgentResult {
@@ -1640,6 +1660,10 @@ export async function createGenerationAgentRuntime(
   for (const result of skippedResults) {
     onResult?.(result);
   }
+  for (const result of overrideInjections.map(cachedInjectionResult)) {
+    preResults.push(result);
+    onResult?.(result);
+  }
   if (agents.length === 0) {
     return {
       preInjections: initialInjections,
@@ -1653,6 +1677,8 @@ export async function createGenerationAgentRuntime(
   }
 
   const context = await buildAgentContext(deps, input, agents);
+  const secretPlotGuidance = secretPlotPromptGuidanceFromData(context.memory._secretPlotState);
+  if (secretPlotGuidance) agentData[SECRET_PLOT_DRIVER_AGENT_TYPE] = secretPlotGuidance;
   const availableSprites = availableSpritesFromContext(context);
   const pipelineAgents = agents.filter((agent) => !KNOWLEDGE_AGENT_TYPES.has(agent.type));
   const pipeline = createAgentPipeline(pipelineAgents, context, (result) => {

--- a/src/engine/generation/generation-replay.ts
+++ b/src/engine/generation/generation-replay.ts
@@ -3,8 +3,10 @@ import {
   stripGenerationGuideInstruction,
   type GenerationGuideSource,
 } from "../shared/text/generation-guide";
+import type { AgentInjectionOverride } from "./start-generation-input";
 
 type GenerationReplayGuideSource = GenerationGuideSource;
+const SECRET_PLOT_DRIVER_AGENT_TYPE = "secret-plot-driver";
 
 export interface GenerationReplay {
   impersonate?: true;
@@ -26,6 +28,7 @@ export interface GenerationReplayInput {
   impersonateConnectionId?: string | null;
   impersonateBlockAgents?: boolean;
   impersonatePromptTemplate?: string | null;
+  agentInjectionOverrides?: AgentInjectionOverride[];
 }
 
 const GUIDE_SOURCES = new Set<GenerationReplayGuideSource>(GENERATION_GUIDE_SOURCES);
@@ -42,6 +45,37 @@ function asGuideSource(value: unknown): GenerationReplayGuideSource | null {
   return typeof value === "string" && GUIDE_SOURCES.has(value as GenerationReplayGuideSource)
     ? (value as GenerationReplayGuideSource)
     : null;
+}
+
+function normalizeCachedContextInjections(value: unknown): AgentInjectionOverride[] {
+  if (!Array.isArray(value)) return [];
+  const injections: AgentInjectionOverride[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      const text = entry.trim();
+      if (text) injections.push({ agentType: "prose-guardian", text });
+      continue;
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const raw = entry as Record<string, unknown>;
+    const agentType = typeof raw.agentType === "string" ? raw.agentType.trim() : "";
+    const text = typeof raw.text === "string" ? raw.text.trim() : "";
+    if (!agentType || agentType === SECRET_PLOT_DRIVER_AGENT_TYPE || !text) continue;
+    const agentName = typeof raw.agentName === "string" ? raw.agentName.trim() : "";
+    injections.push({ agentType, ...(agentName ? { agentName } : {}), text });
+  }
+  return injections;
+}
+
+export function applyCachedContextInjectionsToRegenerateInput(
+  input: GenerationReplayInput,
+  contextInjections: unknown,
+): boolean {
+  if (Array.isArray(input.agentInjectionOverrides) && input.agentInjectionOverrides.length > 0) return false;
+  const cached = normalizeCachedContextInjections(contextInjections);
+  if (cached.length === 0) return false;
+  input.agentInjectionOverrides = cached;
+  return true;
 }
 
 export function buildGenerationReplay(input: GenerationReplayInput): GenerationReplay | null {

--- a/src/engine/generation/start-generation.ts
+++ b/src/engine/generation/start-generation.ts
@@ -64,6 +64,7 @@ import {
 } from "../shared/attachments/image-attachments";
 import type { GenerationEvent } from "./generation-events";
 import {
+  applyCachedContextInjectionsToRegenerateInput,
   applyGenerationReplayToRegenerateInput,
   buildGenerationReplay,
   normalizeGenerationReplay,
@@ -1177,14 +1178,18 @@ async function inputWithStoredGenerationReplay(
   if (!isRecord(target) || readString(target.chatId).trim() !== chatId) return input;
 
   const targetExtra = parseRecord(target.extra);
-  const replay = normalizeGenerationReplay(targetExtra.generationReplay);
-  if (!replay) return input;
-  const currentFingerprint = fingerprintChatSummary(chatSummaryForGeneration(chat));
-  if (!chatSummaryFingerprintMatches(targetExtra, currentFingerprint)) return input;
-
   const nextInput = { ...input };
-  applyGenerationReplayToRegenerateInput(nextInput, replay);
-  return nextInput;
+  let applied = applyCachedContextInjectionsToRegenerateInput(nextInput, targetExtra.contextInjections);
+
+  const replay = normalizeGenerationReplay(targetExtra.generationReplay);
+  if (replay) {
+    const currentFingerprint = fingerprintChatSummary(chatSummaryForGeneration(chat));
+    if (chatSummaryFingerprintMatches(targetExtra, currentFingerprint)) {
+      applied = applyGenerationReplayToRegenerateInput(nextInput, replay) || applied;
+    }
+  }
+
+  return applied ? nextInput : input;
 }
 
 function requestMessages(input: StartGenerationInput): LlmMessage[] | null {

--- a/tests/unit/agent-memory-runtime.spec.ts
+++ b/tests/unit/agent-memory-runtime.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { AgentResult } from "../../src/engine/contracts/types/agent";
+import type { StorageGateway } from "../../src/engine/capabilities/storage";
+import {
+  persistSecretPlotAgentMemory,
+  secretPlotPromptGuidanceFromData,
+} from "../../src/engine/generation/agent-memory-runtime";
+
+function memoryStorage(rows: Array<Record<string, unknown>>): StorageGateway {
+  return {
+    async list(collection, options) {
+      if (collection !== "agent-memory") return [] as never;
+      const filters = (options?.filters ?? {}) as Record<string, unknown>;
+      return rows.filter((row) =>
+        Object.entries(filters).every(([key, value]) => value === undefined || row[key] === value),
+      ) as never;
+    },
+    async update(collection, id, patch) {
+      if (collection !== "agent-memory") return null as never;
+      const row = rows.find((entry) => entry.id === id);
+      if (row) Object.assign(row, patch);
+      return row as never;
+    },
+    async create(collection, value) {
+      if (collection !== "agent-memory") return value as never;
+      const row = { id: `row-${rows.length + 1}`, ...(value as Record<string, unknown>) };
+      rows.push(row);
+      return row as never;
+    },
+  } as StorageGateway;
+}
+
+function secretPlotResult(data: Record<string, unknown>): AgentResult {
+  return {
+    agentId: "secret-plot-config",
+    agentType: "secret-plot-driver",
+    type: "secret_plot",
+    data,
+    tokensUsed: 0,
+    durationMs: 0,
+    success: true,
+    error: null,
+  };
+}
+
+describe("secret plot memory runtime", () => {
+  it("formats active arc and scene directions as hidden main-prompt guidance", () => {
+    const guidance = secretPlotPromptGuidanceFromData({
+      overarchingArc: { description: "A lost treaty resurfaces.", protagonistArc: "Trust becomes costly." },
+      sceneDirections: [
+        { direction: "Let the clue surface quietly.", fulfilled: false },
+        { direction: "Resolve the old detour.", fulfilled: true },
+      ],
+    });
+
+    expect(guidance).toContain("<overarching_arc>");
+    expect(guidance).toContain("- Let the clue surface quietly.");
+    expect(
+      secretPlotPromptGuidanceFromData({
+        sceneDirections: [{ direction: "Resolve the old detour.", fulfilled: true }],
+      }),
+    ).toBeNull();
+  });
+
+  it("allows full reroll to clear an explicit empty arc", async () => {
+    const rows = [
+      {
+        id: "arc-row",
+        agentConfigId: "secret-plot-config",
+        chatId: "chat-1",
+        key: "overarchingArc",
+        value: JSON.stringify({ description: "Existing arc" }),
+      },
+    ];
+    const storage = memoryStorage(rows);
+
+    await persistSecretPlotAgentMemory(storage, "chat-1", [
+      secretPlotResult({ overarchingArc: null, sceneDirections: [] }),
+    ]);
+
+    expect(rows[0]?.value).toBe("null");
+  });
+
+  it("preserves the existing arc on turn-only reroll", async () => {
+    const rows = [
+      {
+        id: "arc-row",
+        agentConfigId: "secret-plot-config",
+        chatId: "chat-1",
+        key: "overarchingArc",
+        value: JSON.stringify({ description: "Existing arc" }),
+      },
+    ];
+    const storage = memoryStorage(rows);
+
+    await persistSecretPlotAgentMemory(
+      storage,
+      "chat-1",
+      [secretPlotResult({ overarchingArc: null, sceneDirections: [] })],
+      { rerollMode: "turn_only" },
+    );
+
+    expect(rows[0]?.value).toBe(JSON.stringify({ description: "Existing arc" }));
+  });
+});

--- a/tests/unit/generation-replay.spec.ts
+++ b/tests/unit/generation-replay.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { applyCachedContextInjectionsToRegenerateInput } from "../../src/engine/generation/generation-replay";
+import type { StartGenerationInput } from "../../src/engine/generation/start-generation-input";
+
+describe("applyCachedContextInjectionsToRegenerateInput", () => {
+  it("reuses cached target injections on regeneration and filters Secret Plot", () => {
+    const input = { chatId: "chat-1", regenerateMessageId: "msg-2" } as StartGenerationInput;
+
+    const applied = applyCachedContextInjectionsToRegenerateInput(input, [
+      "Avoid repeated phrasing.",
+      { agentType: "knowledge-router", agentName: "Knowledge Router", text: "Use selected entry." },
+      { agentType: "secret-plot-driver", agentName: "Secret Plot Driver", text: "Hidden plot" },
+      { agentType: "director", text: "  Let the scene breathe.  " },
+    ]);
+
+    expect(applied).toBe(true);
+    expect(input.agentInjectionOverrides).toEqual([
+      { agentType: "prose-guardian", text: "Avoid repeated phrasing." },
+      { agentType: "knowledge-router", agentName: "Knowledge Router", text: "Use selected entry." },
+      { agentType: "director", text: "Let the scene breathe." },
+    ]);
+  });
+
+  it("does not replace explicit review overrides", () => {
+    const input = {
+      chatId: "chat-1",
+      regenerateMessageId: "msg-2",
+      agentInjectionOverrides: [{ agentType: "director", text: "Reviewer-approved override." }],
+    } as StartGenerationInput;
+
+    const applied = applyCachedContextInjectionsToRegenerateInput(input, [
+      { agentType: "director", text: "Cached target text." },
+    ]);
+
+    expect(applied).toBe(false);
+    expect(input.agentInjectionOverrides).toEqual([{ agentType: "director", text: "Reviewer-approved override." }]);
+  });
+});


### PR DESCRIPTION
## Linked issue

Closes #2491
Closes #2492

## Why this change

- Regenerating a message could ignore the target message's cached context injections, so rerolls lost the same Knowledge Router / Prose Guardian / Director guidance that shaped the original turn.
- Secret Plot Driver memory was loaded too broadly and its hidden arc/directions were not reliably fed back into the main prompt, leaving gaps between memory, prompt assembly, and reroll behavior.

## What changed

- Reapply cached `extra.contextInjections` to regeneration input even when replay metadata is missing or the chat summary fingerprint no longer matches.
- Normalize cached injection shapes, preserve explicit `agentInjectionOverrides`, and filter Secret Plot Driver cached guidance out of generic context injection replay.
- Scope Secret Plot memory to the resolved Secret Plot Driver agent config, then format active arc and unfulfilled scene directions into hidden main-prompt guidance.
- Allow full Secret Plot rerolls to persist an explicit cleared arc while preserving the arc on turn-only rerolls.
- Add focused unit specs for regeneration context replay and Secret Plot memory/prompt/reroll invariants.

## Refactor impact

Primary owner:

Engine generation

Impact areas reviewed:

- Regeneration replay input shaping
- Agent runtime context/memory loading
- Prompt assembly `agentData` insertion path
- Secret Plot Driver memory persistence
- Saved message `extra.contextInjections` reuse
- Chat/roleplay/game mode boundary impact from shared generation changes

Boundary notes:

- Engine-only change; no React, Tauri, shared API, Rust, or remote-runtime boundary changes.
- Prompt/generation changes stay inside `src/engine` and use existing storage/LLM capability ports.

Pressure points touched:

- Runtime generation agent pre-generation flow
- Prompt assembly agent-data injection path
- Regeneration replay metadata path

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

Durable test rationale:

- Regression/risky invariant: regeneration must reuse cached context injections, and Secret Plot Driver must preserve hidden memory/prompt/reroll semantics without leaking stale generic cached injections.
- Existing proof was insufficient because these are silent prompt-shaping regressions that can pass typecheck while changing generated behavior.
- The added tests are narrow helper/runtime-memory specs around normalization, explicit override preservation, hidden prompt guidance formatting, and full-vs-turn-only reroll persistence.

Commands run:

- `git diff --check`
- `pnpm exec vitest run tests/unit/generation-replay.spec.ts tests/unit/agent-memory-runtime.spec.ts`
- `pnpm typecheck`
- `pnpm check:architecture`
- `pnpm check`
- Failpath and Bunny-style review found no confirmed issues; residual risk is no live provider/browser regeneration run.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- Existing regeneration and Secret Plot behavior is fixed; no new user-discoverable feature or setting is added.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

- N/A; no visible UI changes.
