### PR TITLE
Restore missing chat connection error parity

### DIFF
--- a/src/engine/generation/context.ts
+++ b/src/engine/generation/context.ts
@@ -75,12 +75,7 @@ export async function resolveGenerationConnection(
   if (chatConnection === "random") return randomConnection();
   if (chatConnection) return requireRecord(await storage.get("connections", chatConnection), "Chat connection");
 
-  const connections = await storage.list<JsonRecord>("connections");
-  const selected =
-    connections.find((connection) => boolish(connection.isDefault, false) || boolish(connection.default, false)) ??
-    connections[0];
-  if (!selected) throw new Error("No API connection configured for this chat");
-  return selected;
+  throw new Error("No API connection configured for this chat");
 }
 
 export async function loadChatMessages(


### PR DESCRIPTION
## Linked issue

Addresses #2442

## Why this change

- Target 12 parityscan found a remaining blocker: generation without a request or chat connection id still resolved the default or first stored connection.
- Legacy stops before provider send with `No API connection configured for this chat`; this restores that negative-control path while preserving explicit request/chat connection and random-pool resolution.

## What changed

- Removed the default/first stored connection fallback from `resolveGenerationConnection` when no request or chat connection id is set.
- Kept the `"random"` sentinel and concrete connection id lookup branches intact.

## Refactor impact

Primary owner:

engine generation

Impact areas reviewed:

- Runtime generation connection resolution
- Prompt preview and start-generation resolver callers
- Agent retry path that uses the shared generation resolver

Boundary notes:

- Engine-only change in `src/engine/generation/context.ts`.
- No React feature, shared API, Tauri/Rust, storage schema, or remote-runtime boundary changes.

Pressure points touched:

- None. No ModeSurface, GameSurface, shared mode UI, `src-tauri/src/lib.rs`, or import module changes.

## Validation

- [x] Matching validation command passes locally (for example `pnpm typecheck`, `pnpm build`, `pnpm check:architecture`, `pnpm check:docs`, or full `pnpm check` when warranted)
- [x] Full `pnpm check` passes before PR push/handoff
- [ ] Human/manual validation completed by contributor or reviewer

### Manual verification notes

- Static legacy trace confirmed legacy generation uses request/chat connection id, handles `"random"`, and returns `No API connection configured for this chat` when neither id is present before provider send.
- `pnpm check`: passed.

## Feature Discoverability

Check exactly one:

- [ ] Updated `src/features/shell/discovery/` because this PR adds or materially changes a user-discoverable feature, workflow, setting, mode, panel, import path, agent, media capability, or advanced tool.
- [x] N/A because this PR is only a bugfix, refactor, test, docs, internal wiring, visual polish, copy edit, or compatibility fix and does not add a new thing users need to find.

Reason:

- This restores existing generation connection error behavior and does not add a new discoverable feature.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated `README.md`
- [ ] Updated `CONTRIBUTING.md`
- [ ] Updated `docs/developer/`
- [ ] Updated repo skills or `AGENTS.md`
- [x] Confirmed this PR does not restore old staging/package-workspace/release claims

## UI evidence

No UI evidence needed; engine-only generation connection resolver fix.
