### PR TITLE
ci: allow Bunny Review on staging-based PRs

### DIFF
--- a/.github/workflows/bunny-review-auto.yml
+++ b/.github/workflows/bunny-review-auto.yml
@@ -18,7 +18,8 @@ jobs:
   dispatch:
     if: >
       github.event.pull_request.base.ref == 'refactor' ||
-      github.event.pull_request.base.ref == 'main'
+      github.event.pull_request.base.ref == 'main' ||
+      github.event.pull_request.base.ref == 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch trusted Bunny reviewer
@@ -35,7 +36,7 @@ jobs:
           # This pull_request_target workflow is intentionally a dispatcher only.
           # It must not checkout, install, or execute code from the pull request.
           TARGET_REF="$PR_BASE_REF"
-          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ]; then
+          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ] && [ "$TARGET_REF" != "staging" ]; then
             echo "::error::Unsupported Bunny review base ref: $TARGET_REF"
             exit 1
           fi

--- a/.github/workflows/bunny-review-command.yml
+++ b/.github/workflows/bunny-review-command.yml
@@ -35,7 +35,7 @@ jobs:
           fi
           TARGET_REF="$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json baseRefName -q .baseRefName)"
           PR_IS_DRAFT="$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json isDraft -q .isDraft)"
-          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ]; then
+          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ] && [ "$TARGET_REF" != "staging" ]; then
             echo "::error::Unsupported Bunny review base ref: $TARGET_REF"
             exit 1
           fi


### PR DESCRIPTION
## Linked issue

No issue was open for this. It is a small CI-enablement change scoped to the two Bunny dispatcher guards; happy to open one to track it if you would prefer.

## Why this change

Bunny Review only dispatches for PRs based on `refactor` or `main`. A PR based on `staging` is rejected with `Unsupported Bunny review base ref: staging` by both the auto dispatcher and the `/bunny-review` command, so PRs targeting `staging` get no Bunny pass at all. Since active development happens on `staging`, this adds `staging` to the supported base refs so those PRs are reviewed like `main`/`refactor` ones.

## What changed

- `.github/workflows/bunny-review-auto.yml`: add `staging` to the `dispatch` job `if` condition and the `TARGET_REF` guard.
- `.github/workflows/bunny-review-command.yml`: add `staging` to the `TARGET_REF` guard.

No change to `bunny-review.yml` (the trusted reviewer): it is dispatched with `--ref $TARGET_REF`, and `staging` already carries that workflow plus the `.github/bunny-review/` tooling, so it resolves cleanly once the base ref is allowed.

## Activation note (event-source asymmetry)

The two dispatchers resolve their workflow file from different branches, by GitHub's rules:

- `bunny-review-auto.yml` runs on `pull_request_target`, which uses the workflow file from the PR **base** branch. Once this merges to `staging`, auto-dispatch works on staging PRs immediately.
- `bunny-review-command.yml` runs on `issue_comment`, which always uses the workflow file from the **default** branch (`main`). So `/bunny-review` on a staging PR starts working once this change also reaches `main` via the normal staging-to-main flow.

I kept both edits in one change for consistency; the auto path is the one that activates on merge here.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- This is a CI-config-only change (no app code), so the app-level boxes above are not applicable.
- It cannot be exercised end-to-end before merge: the change only takes effect from the merged base-branch copy of the workflow, and this PR is itself staging-based so Bunny will not review it until the change lands. Please give the workflow logic a maintainer eye.
- Diff is limited to the two `TARGET_REF` guards plus the auto-dispatch `if` condition; the folded `if:` scalar and shell guards are otherwise unchanged.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)