### PR TITLE
Staging to main (added Bunny Review for staging)

### DIFF
--- a/.github/workflows/bunny-review-auto.yml
+++ b/.github/workflows/bunny-review-auto.yml
@@ -18,7 +18,8 @@ jobs:
   dispatch:
     if: >
       github.event.pull_request.base.ref == 'refactor' ||
-      github.event.pull_request.base.ref == 'main'
+      github.event.pull_request.base.ref == 'main' ||
+      github.event.pull_request.base.ref == 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch trusted Bunny reviewer
@@ -35,7 +36,7 @@ jobs:
           # This pull_request_target workflow is intentionally a dispatcher only.
           # It must not checkout, install, or execute code from the pull request.
           TARGET_REF="$PR_BASE_REF"
-          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ]; then
+          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ] && [ "$TARGET_REF" != "staging" ]; then
             echo "::error::Unsupported Bunny review base ref: $TARGET_REF"
             exit 1
           fi

--- a/.github/workflows/bunny-review-command.yml
+++ b/.github/workflows/bunny-review-command.yml
@@ -35,7 +35,7 @@ jobs:
           fi
           TARGET_REF="$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json baseRefName -q .baseRefName)"
           PR_IS_DRAFT="$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json isDraft -q .isDraft)"
-          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ]; then
+          if [ "$TARGET_REF" != "refactor" ] && [ "$TARGET_REF" != "main" ] && [ "$TARGET_REF" != "staging" ]; then
             echo "::error::Unsupported Bunny review base ref: $TARGET_REF"
             exit 1
           fi


### PR DESCRIPTION
## Linked issue

No separate issue for this. It carries #2513 (already merged into `staging`) up to `main` so Bunny Review's base-ref support is complete on the default branch.

## Why this change

#2513 added `staging` to the Bunny dispatchers, but the two dispatchers resolve their workflow file from different branches:

- `bunny-review-auto.yml` runs on `pull_request_target`, which uses the workflow file from the PR **base** branch. #2513 on `staging` already makes auto-dispatch work for staging PRs.
- `bunny-review-command.yml` runs on `issue_comment`, which always uses the workflow file from the **default** branch (`main`). So `/bunny-review` on a staging PR only dispatches once the guard change is on `main`.

Per Bunny's author, the change needs to land on `main` as well. This staging-to-main PR puts both updated dispatcher guards on the default branch, so the `/bunny-review` command works on staging PRs and the default-branch copies stay consistent with `staging` and `refactor`.

## What changed

- `.github/workflows/bunny-review-auto.yml`: `staging` added to the `dispatch` job `if` condition and the `TARGET_REF` guard.
- `.github/workflows/bunny-review-command.yml`: `staging` added to the `TARGET_REF` guard.

Same two-file diff already reviewed in #2513; this is the staging-to-main carry. No change to `bunny-review.yml` or the `.github/bunny-review/` tooling.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- CI-config-only change; no app code, so the app-level boxes above are not applicable.
- #2513 is already merged into `staging`, so auto-dispatch on staging PRs is live from the base-branch copy.
- Once this merges to `main`, the `issue_comment` command workflow (which resolves from the default branch) will dispatch `/bunny-review` for staging-based PRs. That is the piece this PR enables.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to support additional pull request deployment targets, enabling broader automated review capabilities across development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
