### PR TITLE
ci(bunny-review): retarget review brain to the web monorepo

### DIFF
--- a/.github/bunny-review/bunny_review.py
+++ b/.github/bunny-review/bunny_review.py
@@ -371,30 +371,30 @@ def select_guidance(files):
     joined = "\n".join(files)
     if any(
         marker in joined
-        for marker in ("src/engine/", "src/features/", "src/shared/api/", "src-tauri/")
+        for marker in ("packages/shared/", "packages/server/src/", "packages/client/src/")
     ):
-        guidance.append("skills/marinara-architecture-guard/SKILL.md")
+        guidance.append("docs/ARCHITECTURE_MAP.md")
     if any(
         marker in joined
         for marker in (
             "chat",
             "roleplay",
             "game",
-            "modes",
+            "conversation",
             "prompt",
             "generation",
             "summary",
             "memory",
         )
     ):
-        guidance.append("skills/marinara-mode-separation/SKILL.md")
+        guidance.append("packages/client/.instructions.md")
     if any(
         marker in joined
-        for marker in ("fix/", "storage", "imports", "provider", "transport", "commands")
+        for marker in ("storage", "import", "provider", "db/", "migration", "services/")
     ):
-        guidance.append("skills/marinara-bugfix-discipline/SKILL.md")
-    if any(marker in joined for marker in ("README", "docs/", "skills/", "AGENTS.md")):
-        guidance.append("skills/marinara-getting-started/SKILL.md")
+        guidance.append("docs/FILE_STORAGE_MIGRATION.md")
+    if any(marker in joined for marker in ("README", "docs/", "AGENTS.md", "CONTRIBUTING.md", "CLAUDE.md")):
+        guidance.append("CONTRIBUTING.md")
     return list(dict.fromkeys(guidance))
 
 
@@ -1441,7 +1441,7 @@ def is_ci_check(item):
 
 def is_stale_ci_text(text):
     lowered = text.lower()
-    if "ci" not in lowered and "cargo" not in lowered and "rust check" not in lowered:
+    if "ci" not in lowered and "pnpm" not in lowered and "build" not in lowered:
         return False
     stale_markers = (
         "still running",

--- a/.github/bunny-review/reviewer-prompt.md
+++ b/.github/bunny-review/reviewer-prompt.md
@@ -57,10 +57,12 @@ One rule: critique code and contracts only. Never personalize or address the aut
    - `git diff --name-only <base>...HEAD`.
 2. Read `AGENTS.md`.
 3. Load only guidance that matches touched areas:
-   - Architecture or ownership changes: `skills/marinara-architecture-guard/SKILL.md`.
-   - Chat, roleplay, or game mode changes: `skills/marinara-mode-separation/SKILL.md`.
-   - Bug fixes or regressions: `skills/marinara-bugfix-discipline/SKILL.md`.
-   - Onboarding/docs/run-build guidance: `skills/marinara-getting-started/SKILL.md`.
+   - Package boundaries or architecture changes: `docs/ARCHITECTURE_MAP.md`.
+   - Frontend (`packages/client`) changes: `packages/client/.instructions.md` and `docs/FRONTEND.md`.
+   - Server (`packages/server`) changes, including logging and route/service boundaries: `CLAUDE.md` and `CONTRIBUTING.md`.
+   - Chat, roleplay, or game mode changes: `docs/ARCHITECTURE_MAP.md` (Mode Ownership), `docs/GAME_MODE.md`, `docs/ROLEPLAY.md`, `docs/CONVERSATION.md`.
+   - Storage, migration, or import/export changes: `docs/FILE_STORAGE_MIGRATION.md`.
+   - Build, container, or CI changes: `docs/installation/containers.md` and `CONTRIBUTING.md`.
 4. Read the changed patch overview, per-file patch context, Bunny path rules, and focused guidance included in the packet.
 5. Inspect callers, contracts, tests, and adjacent implementations from the packet before reporting a finding. If a concrete suspected issue needs missing caller, schema, or contract context, request that focused context once. If context remains missing after the extra batch, say so instead of inventing certainty.
 6. Review mode matters:
@@ -94,13 +96,14 @@ When the packet includes prior Bunny findings or repair contracts from earlier h
 
 Treat these as high-signal Marinara review concerns:
 
-- Product behavior placed outside its owner.
-- Engine code importing React, Zustand stores, Tauri APIs, feature internals, or concrete shared API adapters.
-- Feature code bypassing focused shared API wrappers.
-- Remote-capable behavior that skips the explicit HTTP pipeline.
-- Chat, roleplay, and game mode behavior crossing ownership boundaries.
+- Product behavior placed outside its owning package or mode.
+- `packages/shared` importing React, DOM, Fastify, Drizzle, filesystem, network, or provider SDK code; it must stay the runtime-agnostic contract.
+- Client code calling the server with raw `fetch()` instead of the `@/lib/api-client` wrapper, putting async logic in Zustand stores, or adding barrel/index files.
+- Server code using `console.*` instead of the shared Pino logger, logging errors without the error object first, or putting domain logic in route handlers instead of services.
+- Chat, roleplay, and game mode behavior crossing ownership boundaries, or shared generation/prompt changes silently altering an unrelated mode.
+- SSE/streaming changes that break the token or event contract between `api.stream`/`streamEvents` and the server generate route.
 - Fake success states, silent catches, broad fallbacks, or UI-only guards over broken contracts.
-- Changes without tests when the touched behavior has realistic regression risk.
+- Changes without tests or focused manual proof when the touched behavior has realistic regression risk.
 
 For import, storage, migration, and persistence changes, explicitly check for invariant drift:
 

--- a/.github/bunny-review/rules.json
+++ b/.github/bunny-review/rules.json
@@ -11,7 +11,7 @@
   ],
   "severity_policy": {
     "blocking": "The PR should not merge because the changed behavior is broken, unsafe, or violates a hard architecture boundary.",
-    "high": "A likely production or data-loss regression, security/privacy issue, or serious cross-mode/remote-runtime contract risk.",
+    "high": "A likely production or data-loss regression, security/privacy issue, or serious cross-mode/persistence contract risk.",
     "medium": "A concrete bug, edge case, maintainability trap, or missing test tied directly to changed behavior.",
     "low": "A small but actionable correctness, proof, or maintainability risk tied to changed behavior.",
     "nitpick": "Optional changed-line polish with no behavior risk, such as readability, naming, tiny duplication, stale comments, dead code, type clarity, or local consistency."
@@ -29,71 +29,144 @@
   },
   "path_instructions": [
     {
-      "name": "Engine and runtime boundaries",
+      "name": "Shared contract package",
       "prefixes": [
-        "src/engine/",
-        "src/features/",
-        "src/shared/api/",
-        "src-tauri/"
+        "packages/shared/"
       ],
       "guidance": [
-        "skills/marinara-architecture-guard/SKILL.md"
+        "docs/ARCHITECTURE_MAP.md"
       ],
       "checks": [
-        "Engine code stays React-free and does not import feature internals, Tauri APIs, Zustand stores, or concrete shared API adapters.",
-        "Feature code uses focused shared API wrappers instead of raw invokeTauri or raw remote-runtime fetch.",
-        "Remote-capable behavior follows the explicit HTTP pipeline."
+        "packages/shared stays runtime-agnostic: no React, DOM, Fastify, Drizzle, filesystem, network, or provider SDK imports. It holds only shared types, schemas, constants, and pure helpers.",
+        "When a contract changes, the shared types/schemas/constants change first, then client and server are updated to match. A shared change without matching consumer updates is a likely break.",
+        "Do not move client-only or server-only helpers into shared; keep it the cross-runtime contract, not a dumping ground."
+      ]
+    },
+    {
+      "name": "Client (frontend) conventions",
+      "prefixes": [
+        "packages/client/"
+      ],
+      "guidance": [
+        "packages/client/.instructions.md",
+        "docs/FRONTEND.md"
+      ],
+      "checks": [
+        "Server calls go through the @/lib/api-client wrapper (api.get/post/patch/delete/upload/download/stream/streamEvents), never raw fetch().",
+        "Async server access lives in React Query hooks; Zustand stores stay synchronous state plus actions. Only ui.store uses persist.",
+        "Navigation is state-based via ui.store (no URL router), new editors are lazy-loaded in AppShell, and there are no barrel/index files.",
+        "console.* is acceptable in client code (the browser has no Pino and production builds strip console.log); do not flag it here as a logging violation."
+      ]
+    },
+    {
+      "name": "Server (backend) conventions",
+      "prefixes": [
+        "packages/server/src/"
+      ],
+      "guidance": [
+        "CLAUDE.md",
+        "CONTRIBUTING.md"
+      ],
+      "checks": [
+        "Server code never uses console.log/warn/error. It imports the shared Pino logger from packages/server/src/lib/logger.ts and logs errors error-first: logger.error(err, \"message\").",
+        "Multi-argument logs use Pino format specifiers (%s, %d, %j) or a single template literal, not comma-separated arguments that Pino silently drops.",
+        "Fastify route files validate HTTP input and delegate domain decisions to services; storage, LLM, prompt, and game logic belong in services, not in route handlers.",
+        "Provider, storage, and transport changes preserve existing error contracts and self-hostable behavior; no fake success, silent catches, broad fallbacks, or response-shape drift."
       ]
     },
     {
       "name": "Mode separation",
       "prefixes": [
-        "src/engine/chat/",
-        "src/engine/roleplay/",
-        "src/engine/game/",
-        "src/features/modes/"
+        "packages/client/src/components/game/",
+        "packages/client/src/components/chat/",
+        "packages/server/src/services/game/",
+        "packages/server/src/services/conversation/",
+        "packages/server/src/routes/game.routes.ts",
+        "packages/server/src/routes/conversation.routes.ts"
       ],
       "guidance": [
-        "skills/marinara-mode-separation/SKILL.md"
+        "docs/ARCHITECTURE_MAP.md",
+        "docs/GAME_MODE.md",
+        "docs/ROLEPLAY.md",
+        "docs/CONVERSATION.md"
       ],
       "checks": [
-        "Chat, roleplay, and game behavior remain in their owning mode.",
-        "Shared generation or prompt changes do not silently alter unrelated modes."
+        "Conversation, roleplay/visual-novel, and game behavior stay with their owning mode. Conversation must not know about game dice, GM tags, QTE, maps, or game combat.",
+        "Game mode must not depend on chat-mode UI except through shared primitives or explicitly shared feature components.",
+        "Shared generation or prompt changes (use-generate.ts, generate.routes.ts, services/prompt) must not silently alter the behavior of an unrelated mode."
       ]
     },
     {
-      "name": "Bug fixes and privileged contracts",
+      "name": "Generation, prompt, and parser pipeline",
       "prefixes": [
-        "src-tauri/src/commands/",
-        "src-tauri/src/storage/",
-        "src-tauri/src/providers/",
-        "src/shared/api/"
+        "packages/server/src/routes/generate.routes.ts",
+        "packages/server/src/services/prompt/",
+        "packages/server/src/services/llm/",
+        "packages/client/src/hooks/use-generate.ts",
+        "packages/client/src/lib/api-client.ts"
       ],
       "guidance": [
-        "skills/marinara-bugfix-discipline/SKILL.md"
+        "docs/ARCHITECTURE_MAP.md",
+        "docs/GENERATION_PARAMETERS.md"
       ],
       "checks": [
-        "Fixes address root causes instead of adding fake success, silent catches, broad fallbacks, or UI-only guards.",
-        "Provider, storage, command, and transport changes preserve error contracts and hostable behavior.",
+        "SSE/streaming changes preserve the token and event contract on both ends: api.stream/streamEvents on the client and the onToken/event emitters in generate.routes.ts on the server.",
+        "Prompt assembly changes are evaluated against every chat mode that shares the path, not only the mode being edited.",
+        "Parser, tag-stripper, or JSON-extraction changes must not eat legitimate content. Prefer root-cause fixes over blanket trailing-character strips, and confirm a negative control (content that should pass through untouched)."
+      ]
+    },
+    {
+      "name": "Storage, migrations, and import/export",
+      "prefixes": [
+        "packages/server/src/db/",
+        "packages/server/src/services/storage/",
+        "packages/server/src/services/import/"
+      ],
+      "guidance": [
+        "docs/FILE_STORAGE_MIGRATION.md"
+      ],
+      "checks": [
         "Parent records must not collect IDs, metadata, counts, or relationships from child rows that later skip import or fail to persist.",
-        "Pre-scan logic should use the same eligibility criteria as the write loop, especially for imports, migrations, and rollback-sensitive storage paths."
+        "Pre-scan logic should use the same eligibility criteria as the write loop, especially for imports, migrations, and rollback-sensitive storage paths.",
+        "Existing user data and SillyTavern/Marinara exports must remain importable; old persisted shapes still need to load.",
+        "file-backed-store autosave and JSON snapshot durability must survive partial writes and rollback without leaving inconsistent message, chat, character, branch, or asset metadata."
       ]
     },
     {
-      "name": "Docs and agent guidance",
+      "name": "Build, CI, and deployment",
       "prefixes": [
-        "README",
-        "docs/",
-        "skills/",
-        "AGENTS.md",
+        "Dockerfile",
+        "Dockerfile.lite",
+        "docker-compose.yml",
         ".github/"
       ],
       "guidance": [
-        "skills/marinara-getting-started/SKILL.md"
+        "docs/installation/containers.md",
+        "CONTRIBUTING.md"
       ],
       "checks": [
-        "Durable feature-area additions update relevant maps or guidance.",
-        "Workflow and agent changes remain concrete, testable, and narrow."
+        "Container and image changes must keep the app buildable and runnable; the pnpm-validate and container-build-test checks must still pass.",
+        "Workflow changes stay narrow, testable, and least-privilege; pull_request_target dispatchers must not check out or execute pull-request code.",
+        "If CI check-run names change, mirror them in .github/bunny-review/ci-checks.json so Bunny gates on the real checks."
+      ]
+    },
+    {
+      "name": "Docs, version truth, and agent guidance",
+      "prefixes": [
+        "README",
+        "docs/",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "CHANGELOG.md",
+        "CONTRIBUTING.md"
+      ],
+      "guidance": [
+        "CONTRIBUTING.md"
+      ],
+      "checks": [
+        "Durable feature-area additions update the relevant docs or architecture map; a behavior change that makes an existing doc misleading should fix that doc in the same PR.",
+        "Version-bearing files stay in sync. Root package.json is canonical; the per-package package.json files, packages/shared/src/constants/defaults.ts, and the win/android version files must not drift.",
+        "Workflow and agent-guidance changes remain concrete, testable, and narrow."
       ]
     }
   ]


### PR DESCRIPTION
## Linked issue

No dedicated tracking issue exists yet for the Bunny rewrite. This builds directly on the base-ref enablement work in #2513 (added `staging` as an allowed Bunny base ref) and #2514 (the staging to main carry of the same), where @Promansis noted that the tooling itself would still need a rewrite because it was authored against the refactor layout. Happy to open a tracking issue if you would prefer one, @Promansis, since this is your component.

Closes # <!-- intentionally left without an issue number; see note above -->

## Why this change

The Bunny review tooling was built for the refactor (Tauri) tree, so its review brain still describes a codebase that does not exist on `staging`. `rules.json` path rules and the reviewer prompt point at `src/engine`, `src/features`, `src/shared/api`, `src-tauri`, the Rust capability layer, raw `invokeTauri`, and the in-repo discipline skills (`marinara-architecture-guard`, `marinara-mode-separation`, `marinara-bugfix-discipline`, `marinara-getting-started`). None of those paths or guidance files are present on the web monorepo (`packages/server`, `packages/client`, `packages/shared` on Fastify + React + Vite), so on `staging`-based PRs Bunny loads dead path rules and points at guidance docs that are not in the tree.

#2513 / #2514 enabled Bunny to *run* on `staging`-based PRs. This PR is the brain retarget @Promansis flagged as the remaining work: it swaps the refactor-specific architecture out of Bunny's review guidance and points it at the web stack and the repo's own docs. I have done the bulk of the rewrite so it is reviewable as a concrete starting point, but the intent is for @Promansis to review, adjust, and own it, since the design (persona, pass structure, output contract) is theirs.

## What changed

- **`rules.json`** — replaced the four refactor path groups with eight web path groups: shared contract, client conventions, server conventions, mode separation, generation/prompt/parser pipeline, storage/migrations/import-export, build/CI/deployment, and docs/version-truth/agent-guidance. The path globs now match `packages/shared/**`, `packages/client/**`, `packages/server/src/**`, `Dockerfile` / `Dockerfile.lite`, `packages/server/src/db/**`, and the prompt/parser/generation hot paths. Per-path `guidance` now points at the repo's own docs (`CLAUDE.md`, `packages/client/.instructions.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE_MAP.md`, `docs/FRONTEND.md`, `docs/FILE_STORAGE_MIGRATION.md`, the mode docs, `docs/installation/containers.md`). The `severity_policy`, `nitpick_policy`, `control_warn_types`, and the import/persistence invariant checks (parent-from-child population, pre-scan vs write-loop eligibility, rollback consistency) are kept as-is, since they are codebase-neutral and were the strongest part of the original.
- **`reviewer-prompt.md`** — retargeted the Setup guidance pointers and the high-signal concerns list to the web stack: package boundaries (shared stays runtime-agnostic), the server Pino-logger rule vs the client `console.*` rule, the `@/lib/api-client` wrapper vs raw `fetch()`, the Zustand / React Query split, mode ownership as it exists here, storage/migration/import safety, and the SSE token/event contract. The Bunny / Dottore reviewer voice, the three-pass structure (broad, skeptical specialist, judge), the `FINAL_REVIEW` JSON output contract, and the bounded-packet protocol are unchanged.
- **`bunny_review.py`** — minimal retarget only. The `rules.json`-absent guidance fallback markers now match the web packages and point at web docs, and the stale-CI text heuristic now keys off `pnpm` / `build` instead of `cargo` / `rust check`. No behavior change beyond path and term retargeting; the produce/render/post/status-state machinery is untouched.
- **`ci-checks.json`** — left unchanged. It already lists the real web gating checks (`pnpm-validate`, `container-build-test`), which I confirmed against the actual check-run names on a recent `staging`-based PR.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

This PR only touches the Bunny review tooling under `.github/bunny-review/`, so the app-build checkboxes above are not the relevant validation surface and I have left them unticked. What I actually verified:

- `python -m py_compile .github/bunny-review/bunny_review.py` succeeds.
- `rules.json` and `ci-checks.json` parse as valid JSON; `rules.json` deserializes to 8 path groups with the expected schema (`name` / `prefixes` / `guidance` / `checks`).
- Confirmed the `ci-checks.json` names (`pnpm-validate`, `container-build-test`) match the real check-run names produced on a recent `staging`-based PR via `gh api .../commits/<sha>/check-runs`.
- Grepped the whole `.github/bunny-review/` directory for residual refactor vocabulary (`tauri`, `src-tauri`, `cargo`, `rust`, `src/engine`, the discipline-skill paths, the refactor CI check names): none remain.
- Confirmed every guidance doc referenced by the new `rules.json` and prompt exists on `staging`.

**What I could not do:** I cannot exercise Bunny end-to-end before merge. The reviewer run needs the workflow secrets (`OPENAI_API_KEY`, `LLM_BASE_URL`) and the trusted dispatcher, which copies the review brain from the *base* branch. So the retargeted brain only takes effect once this lands on `staging`. The safest way to smoke-test it is to merge and watch Bunny's first `staging`-based review, or run a throwaway PR afterward. I would value @Promansis confirming the guidance and path groups match how Bunny is meant to weight them.

**One follow-up I left for you, @Promansis:** the trusted `bunny-review.yml` workflow still has a hardcoded fallback `ci-checks.json` heredoc with the three refactor check names ("Frontend, Architecture, and Organization", "Rust Capability Layer", "Browser Smoke and Performance"). It is dormant on `staging` because `ci-checks.json` is present and non-empty, so the fallback never fires. I deliberately did not touch any workflow file here to keep this diff to the review brain only (and to avoid a `workflow`-scope change on your dispatchers), but you may want to update that fallback in a separate pass.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this PR changes CI review tooling only, with no user-facing UI.
