### PR TITLE
fix(game): match non-Latin speaker names for avatars and sprites

### DIFF
--- a/packages/client/src/lib/game-character-name-match.ts
+++ b/packages/client/src/lib/game-character-name-match.ts
@@ -24,7 +24,11 @@ function normalizeCharacterName(name: string): string {
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
+    // Keep letters/numbers from any script (plus combining marks so e.g. the
+    // katakana voiced-sound mark survives) instead of ASCII-only [a-z0-9].
+    // ASCII-only normalization collapsed non-Latin names (Japanese, Cyrillic,
+    // etc.) to an empty string, so speaker lookups for those names always failed.
+    .replace(/[^\p{L}\p{N}\p{M}]+/gu, " ")
     .trim();
 }
 


### PR DESCRIPTION
## Linked issue

Closes #2534

## Why this change

In Game Mode, characters whose names are written in non-Latin scripts (Japanese
hiragana/katakana/kanji, Cyrillic, etc.) never showed their message-window avatar
or full-body character sprite — the avatar fell back to the default silhouette.
The same character's round icon rendered correctly, which pointed at speaker-name
matching rather than asset loading.

Root cause: `normalizeCharacterName`
(`packages/client/src/lib/game-character-name-match.ts`) normalized with
`[^a-z0-9]`, stripping every non-Latin character. Non-Latin names collapsed to an
empty string, so `findNamedEntry` bailed out early and
`findNamedMapValue(speakerAvatarInfos, speaker)` never matched. That single
failure caused both symptoms: the silhouette avatar fallback, and an unset
`activeSpeaker` that blocked full-body sprite resolution.

## What changed

- `normalizeCharacterName`: replaced ASCII-only `[^a-z0-9]+` with
  `[^\p{L}\p{N}\p{M}]+` and the `u` flag, keeping letters/numbers/combining marks
  from any script (the combining-mark class preserves e.g. the katakana
  voiced-sound mark). ASCII/Latin names normalize exactly as before — a one-line
  behavioral change.

Out of scope (follow-up): fuzzy/partial matching is still tuned for Latin —
`getCharacterNameTokens` drops tokens of length ≤ 2 and `includesWholeVariant`
requires length ≥ 3, so short CJK names (e.g. a 2-char name with a decorated
speaker label like `ナミ（怒）`) may still miss exact match. Left for a separate
PR to keep this focused.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Tested on a local production build:

- `pnpm check` (impeccable check + lint + typecheck + production build) — passed.
- Game Mode, katakana-named character (`カエデ`): message-window avatar now shows the character image instead of `npc-silhouette`.
- Game Mode, hiragana-named character (`かえで`): same result.
- Game Mode: the character's full-body sprite renders when a `full_*` sprite exists.
- ASCII/Latin-named character (like `kaede`): avatar + sprite still resolve as before (no regression).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A