### PR TITLE
Address open agent and image issues

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -108,6 +108,8 @@ function createCustomAgentType(name: string): string {
   return `custom-${slug}-${suffix}`;
 }
 
+const LOREBOOK_WRITE_TOOL_NAME = "save_lorebook_entry";
+
 // Mirrors the server's buildSpotifyRedirectUri rule: Spotify only accepts
 // https:// or http://127.0.0.1, so fall back to loopback whenever the page
 // is served over plain HTTP from a non-loopback host.
@@ -234,6 +236,8 @@ export function AgentEditor() {
   const [localIncludePreGenInjections, setLocalIncludePreGenInjections] = useState(false);
   const [localIncludeParallelResults, setLocalIncludeParallelResults] = useState(false);
   const [localEnabledTools, setLocalEnabledTools] = useState<string[]>([]);
+  const [localLorebookWriteEnabled, setLocalLorebookWriteEnabled] = useState(false);
+  const [localWritableLorebookId, setLocalWritableLorebookId] = useState("");
   const [localSpotifyClientId, setLocalSpotifyClientId] = useState("");
   const [localSourceLorebookIds, setLocalSourceLorebookIds] = useState<string[]>([]);
   const [localUseChatActiveLorebooks, setLocalUseChatActiveLorebooks] = useState(false);
@@ -298,7 +302,20 @@ export function AgentEditor() {
       setLocalInjectAsSection(
         (settings.injectAsSection as boolean | undefined) ?? defaultSettings.injectAsSection === true,
       );
-      setLocalEnabledTools(settings.enabledTools ?? DEFAULT_AGENT_TOOLS[dbConfig.type] ?? []);
+      const enabledTools = Array.isArray(settings.enabledTools)
+        ? settings.enabledTools.filter((tool: unknown): tool is string => typeof tool === "string")
+        : (DEFAULT_AGENT_TOOLS[dbConfig.type] ?? []);
+      const writableLorebookId =
+        typeof settings.writableLorebookId === "string"
+          ? settings.writableLorebookId
+          : typeof settings.targetLorebookId === "string"
+            ? settings.targetLorebookId
+            : Array.isArray(settings.writableLorebookIds) && typeof settings.writableLorebookIds[0] === "string"
+              ? settings.writableLorebookIds[0]
+              : "";
+      setLocalEnabledTools(enabledTools);
+      setLocalLorebookWriteEnabled(settings.lorebookWriteEnabled === true || enabledTools.includes(LOREBOOK_WRITE_TOOL_NAME));
+      setLocalWritableLorebookId(writableLorebookId);
       setLocalSpotifyClientId(settings.spotifyClientId ?? "");
       setLocalSourceLorebookIds(settings.sourceLorebookIds ?? []);
       setLocalUseChatActiveLorebooks(
@@ -342,6 +359,8 @@ export function AgentEditor() {
       setLocalResultType("context_injection");
       setLocalIncludePreGenInjections(false);
       setLocalIncludeParallelResults(false);
+      setLocalLorebookWriteEnabled(false);
+      setLocalWritableLorebookId("");
       setLocalPrompt("");
     } else {
       // Brand new custom agent — start empty
@@ -370,6 +389,8 @@ export function AgentEditor() {
       setLocalResultType("context_injection");
       setLocalIncludePreGenInjections(false);
       setLocalIncludeParallelResults(false);
+      setLocalLorebookWriteEnabled(false);
+      setLocalWritableLorebookId("");
       setLocalPrompt("");
     }
     setDirty(false);
@@ -510,6 +531,19 @@ export function AgentEditor() {
             1,
             Math.min(MAX_CUSTOM_AGENT_ACTIVATION_SCAN_DEPTH, Math.floor(Number(localActivationScanDepth) || 1)),
           );
+    const writableLorebookId = localWritableLorebookId.trim();
+    const lorebookWriterEnabled = isEditingCustomAgent && localLorebookWriteEnabled;
+    if (lorebookWriterEnabled && !writableLorebookId) {
+      setSaveError("Select a target lorebook before enabling lorebook writing for this agent.");
+      return;
+    }
+    const effectiveEnabledTools = Array.from(
+      new Set(
+        lorebookWriterEnabled
+          ? [...localEnabledTools, LOREBOOK_WRITE_TOOL_NAME]
+          : localEnabledTools.filter((tool) => tool !== LOREBOOK_WRITE_TOOL_NAME),
+      ),
+    );
 
     // Preserve OAuth fields the form doesn't expose. The server replaces
     // `settings` wholesale, so anything we omit here would be wiped — and the
@@ -546,7 +580,10 @@ export function AgentEditor() {
         ...(localMaxTokens !== "" ? { maxTokens: clampAgentMaxTokens(localMaxTokens) } : {}),
         ...(localRunInterval !== "" ? { runInterval: Number(localRunInterval) } : {}),
         ...(localInjectAsSection ? { injectAsSection: true } : {}),
-        enabledTools: localEnabledTools,
+        enabledTools: effectiveEnabledTools,
+        ...(lorebookWriterEnabled
+          ? { lorebookWriteEnabled: true, writableLorebookId, writableLorebookIds: [writableLorebookId] }
+          : {}),
         ...(localSpotifyClientId ? { spotifyClientId: localSpotifyClientId } : {}),
         ...(isKnowledgeRetrievalAgent || isKnowledgeRouterAgent
           ? { useChatActiveLorebooks: localUseChatActiveLorebooks }
@@ -607,6 +644,8 @@ export function AgentEditor() {
     localActivationScanDepth,
     localInjectAsSection,
     localEnabledTools,
+    localLorebookWriteEnabled,
+    localWritableLorebookId,
     localSpotifyClientId,
     localUseChatActiveLorebooks,
     localSourceLorebookIds,
@@ -644,6 +683,10 @@ export function AgentEditor() {
   const effectivePhase =
     (isCustomAgent || isNewCustomAgent) && localResultType === "text_rewrite" ? "post_processing" : localPhase;
   const showTurnDataAccess = (isCustomAgent || isNewCustomAgent) && effectivePhase === "post_processing";
+  const visibleBuiltInTools = useMemo(
+    () => BUILT_IN_TOOLS.filter((tool) => tool.name !== LOREBOOK_WRITE_TOOL_NAME),
+    [],
+  );
 
   // ── Loading / not found ──
   if (!agentDetailId || (!builtIn && !dbConfig && agentDetailId !== "__new__")) {
@@ -973,6 +1016,69 @@ export function AgentEditor() {
             </FieldGroup>
           )}
 
+          {(isCustomAgent || isNewCustomAgent) && (
+            <FieldGroup
+              label="Lorebook Writer"
+              icon={<BookOpen size="0.875rem" className="text-amber-400" />}
+              help="Lets this custom agent call a function that creates or updates entries in one selected lorebook."
+            >
+              <div className="space-y-3">
+                <button
+                  type="button"
+                  aria-pressed={localLorebookWriteEnabled}
+                  onClick={() => {
+                    setLocalLorebookWriteEnabled((value) => !value);
+                    markDirty();
+                  }}
+                  className={cn(
+                    "flex w-full items-start gap-3 rounded-xl p-3 text-left text-xs ring-1 transition-all",
+                    localLorebookWriteEnabled
+                      ? "bg-[var(--primary)]/10 ring-[var(--primary)] text-[var(--foreground)]"
+                      : "ring-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                  )}
+                >
+                  {localLorebookWriteEnabled ? (
+                    <ToggleRight size="1.25rem" className="mt-0.5 shrink-0 text-emerald-400" />
+                  ) : (
+                    <ToggleLeft size="1.25rem" className="mt-0.5 shrink-0" />
+                  )}
+                  <span className="min-w-0">
+                    <span className="block font-semibold">Allow lorebook entry writes</span>
+                    <span className="mt-0.5 block text-[0.625rem] leading-tight">
+                      The agent can only write to the lorebook selected below.
+                    </span>
+                  </span>
+                </button>
+
+                <div className="space-y-1.5">
+                  <p className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Target lorebook</p>
+                  {allLorebooks && allLorebooks.length > 0 ? (
+                    <select
+                      value={localWritableLorebookId}
+                      disabled={!localLorebookWriteEnabled}
+                      onChange={(event) => {
+                        setLocalWritableLorebookId(event.target.value);
+                        markDirty();
+                      }}
+                      className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    >
+                      <option value="">Select a lorebook</option>
+                      {allLorebooks.map((lorebook) => (
+                        <option key={lorebook.id} value={lorebook.id}>
+                          {lorebook.name}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <p className="rounded-lg border border-amber-400/20 bg-amber-400/10 px-3 py-2 text-[0.625rem] text-amber-200">
+                      Create a lorebook before enabling writes for this agent.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </FieldGroup>
+          )}
+
           {/* ── Connection Override ── */}
           <FieldGroup
             label="Connection Override"
@@ -1080,11 +1186,11 @@ export function AgentEditor() {
                   }}
                   className="rounded border-[var(--border)] bg-[var(--secondary)] text-[var(--primary)] focus:ring-[var(--ring)]"
                 />
-                <span className="text-sm">Send character &amp; persona avatars as reference images</span>
+                <span className="text-sm">Send matching character &amp; persona avatars as reference images</span>
               </label>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Sends all character avatars in the scene plus your persona avatar to the image generator for visual
-                reference. Works best with providers that support reference images (NovelAI, Stability, A1111, ComfyUI).
+                Sends references only for characters or persona names matched in the Illustrator request. Works best
+                with providers that support reference images (NovelAI, Stability, A1111, ComfyUI).
               </p>
             </FieldGroup>
           )}
@@ -2172,7 +2278,7 @@ export function AgentEditor() {
               during generation.
             </p>
             <div className="space-y-2">
-              {BUILT_IN_TOOLS.map((tool: ToolDefinition) => (
+              {visibleBuiltInTools.map((tool: ToolDefinition) => (
                 <ToolCard
                   key={tool.name}
                   tool={tool}

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -2543,7 +2543,16 @@ export function GameNarration({
         ? null
         : (() => {
             const avatar = findNamedMapValue(speakerAvatarInfos, active.speaker);
-            return avatar ? { name: active.speaker, avatarUrl: avatar.url, expression: active.sprite } : null;
+            if (avatar) return { name: active.speaker, avatarUrl: avatar.url, expression: active.sprite };
+            const sprites = spriteMap ? findNamedMapValue(spriteMap, active.speaker) : null;
+            const expressionSprites = sprites?.filter((sprite) => !sprite.expression.toLowerCase().startsWith("full_"));
+            if (!expressionSprites?.length) return null;
+            const exprKey = active.sprite ? normalizeSpriteExpressionKey(active.sprite) : "";
+            const sprite =
+              (exprKey
+                ? expressionSprites.find((item) => normalizeSpriteExpressionKey(item.expression) === exprKey)
+                : null) ?? expressionSprites[0];
+            return sprite ? { name: active.speaker, avatarUrl: sprite.url, expression: active.sprite } : null;
           })();
 
     // Composite key catches legitimate expression/avatar changes, not just name
@@ -2551,7 +2560,7 @@ export function GameNarration({
     if (nextKey === lastReportedSpeakerRef.current) return;
     lastReportedSpeakerRef.current = nextKey;
     onActiveSpeakerChange(next);
-  }, [active, speakerAvatarInfos, onActiveSpeakerChange]);
+  }, [active, speakerAvatarInfos, spriteMap, onActiveSpeakerChange]);
 
   // How many segments are prepended before the actual GM narration segments
   const playerSegmentOffset = latestUserMessage?.content && latestAssistant ? 1 : 0;

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2621,8 +2621,9 @@ export function GameSurface({
   // Also resolve persona sprite ID for expression lookup
   const personaSpriteId = useMemo(() => {
     const config = chatMeta.gameSetupConfig as Record<string, unknown> | undefined;
-    return (config?.personaId as string | undefined) ?? null;
-  }, [chatMeta.gameSetupConfig]);
+    const configuredPersonaId = typeof config?.personaId === "string" ? config.personaId.trim() : "";
+    return personaInfo?.id ?? (configuredPersonaId || null);
+  }, [chatMeta.gameSetupConfig, personaInfo?.id]);
 
   const spriteQueries = useQueries({
     queries: characterIds.map((id) => ({
@@ -2774,6 +2775,15 @@ export function GameSurface({
 
   const activeFullBodySprite = useMemo(() => {
     if (!fullBodyTarget) return null;
+    const targetName = normalizeSceneAssetName(fullBodyTarget.name);
+    const personaName = personaInfo?.name ? normalizeSceneAssetName(personaInfo.name) : "";
+    if (personaSpriteId && personaName && targetName === personaName) {
+      const pose =
+        fullBodyTarget.mode === "combat"
+          ? resolveCombatFullBodyPose(fullBodyTarget.token, personaSpriteQuery.data)
+          : resolveDialogueFullBodyPose(fullBodyTarget.token, personaSpriteQuery.data);
+      return pose ? { characterId: personaSpriteId, pose: `full_${pose}` } : null;
+    }
     const activeCharacterEntries = characterIds.flatMap((id) => {
       const character = characterMap.get(id);
       return character ? ([[id, character]] as Array<[string, NonNullable<ReturnType<typeof characterMap.get>>]>) : [];
@@ -2802,7 +2812,17 @@ export function GameSurface({
       characterId,
       pose: `full_${pose}`,
     };
-  }, [characterIds, characterMap, fullBodyTarget, librarySpriteQueries, speakingLibraryCharacters, spriteQueries]);
+  }, [
+    characterIds,
+    characterMap,
+    fullBodyTarget,
+    librarySpriteQueries,
+    personaInfo?.name,
+    personaSpriteId,
+    personaSpriteQuery.data,
+    speakingLibraryCharacters,
+    spriteQueries,
+  ]);
 
   // Build sprite expression map for the full-body SpriteOverlay.
   const gameSpriteExpressions = useMemo(

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -311,22 +311,35 @@ export async function connectionsRoutes(app: FastifyInstance) {
     const debugLog = (message: string, ...args: any[]) => logDebugOverride(requestDebug, message, ...args);
     const start = Date.now();
     try {
-      // Claude (Subscription) has no HTTP endpoint — verify the local SDK
-      // can be loaded and that an auth source exists, then return success.
       if (conn.provider === "claude_subscription") {
-        try {
-          await import("@anthropic-ai/claude-agent-sdk");
-        } catch (err) {
+        if (!conn.model) {
           return {
             success: false,
-            message: `Claude Agent SDK unavailable: ${err instanceof Error ? err.message : "Unknown error"}`,
+            message: "No model configured. Set a Claude subscription model first.",
             latencyMs: Date.now() - start,
             modelName: null,
           };
         }
+        const provider = createLLMProvider(
+          conn.provider,
+          "",
+          conn.apiKey,
+          conn.maxContext,
+          conn.openrouterProvider,
+          conn.maxTokensOverride,
+          conn.claudeFastMode === "true",
+        );
+        let responseText = "";
+        for await (const chunk of provider.chat([{ role: "user", content: "Reply with OK." }], {
+          model: conn.model,
+          maxTokens: 32,
+          stream: false,
+        })) {
+          responseText += chunk;
+        }
         return {
           success: true,
-          message: "Claude Agent SDK loaded. The first chat will fail if `claude login` has not been run on this host.",
+          message: `Claude Agent SDK completed a real request: ${responseText.trim().slice(0, 120) || "OK"}`,
           latencyMs: Date.now() - start,
           modelName: conn.model,
         };

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -367,6 +367,41 @@ export function normalizeHapticAgentCommands(data: Record<string, unknown>): Arr
   return [];
 }
 
+const SELFIE_WORD_RE = /\b(?:selfie|photo|pic|picture|image)\b/i;
+const USER_SELFIE_REQUEST_RE =
+  /\b(?:send|show|share|take|snap|give|attach|post|can\s+i\s+see|could\s+i\s+see|let\s+me\s+see|want|wanna)\b[\s\S]{0,120}\b(?:selfie|photo|pic|picture)\b|\b(?:selfie|photo|pic|picture)\b[\s\S]{0,80}\b(?:please|pls|send|show|share|take|snap)\b/i;
+const ASSISTANT_SELFIE_CLAIM_RE =
+  /\b(?:send|sent|sending|share|shares|shared|attach|attaches|attached|post|posts|posted|take|takes|took|snap|snaps|snapped)\b[\s\S]{0,120}\b(?:selfie|photo|pic|picture)\b|\[\s*[^\]]{0,80}\b(?:send|sends|sent|share|shares|take|takes|snap|snaps)\b[^\]]{0,120}\b(?:selfie|photo|pic|picture)\b[^\]]*\]/i;
+
+function inferSelfieContextFromResponse(response: string): string | undefined {
+  const compact = response.replace(/\s+/g, " ").trim();
+  if (!compact) return undefined;
+  const bracketMatch = compact.match(/\[[^\]]*\b(?:selfie|photo|pic|picture)\b[^\]]*\]/i);
+  const source = bracketMatch?.[0] ?? compact;
+  return source
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .replace(/^.*?\b(?:selfie|photo|pic|picture)\b[:\s-]*/i, "")
+    .trim()
+    .slice(0, 240);
+}
+
+function recoverImplicitSelfieCommand(args: {
+  response: string;
+  latestUserMessage?: string | null;
+  imageGenerationEnabled: boolean;
+  existingCommands: CharacterCommand[];
+}): SelfieCommand | null {
+  if (!args.imageGenerationEnabled) return null;
+  if (args.existingCommands.some((command) => command.type === "selfie")) return null;
+  const response = args.response.trim();
+  if (!SELFIE_WORD_RE.test(response)) return null;
+  const userAskedForSelfie = USER_SELFIE_REQUEST_RE.test(args.latestUserMessage ?? "");
+  const assistantClaimsSelfie = ASSISTANT_SELFIE_CLAIM_RE.test(response);
+  if (!userAskedForSelfie && !assistantClaimsSelfie) return null;
+  return { type: "selfie", context: inferSelfieContextFromResponse(response) };
+}
+
 const COMPLETE_OUTPUT_END_RE = /[.!?…。！？]["'”’)\]}»›]*$/;
 const COMPLETE_SENTENCE_RE = /[.!?…。！？](?:["'”’)\]}»›]+)?(?=\s|$)/g;
 
@@ -3181,6 +3216,7 @@ export async function generateRoutes(app: FastifyInstance) {
             if (hasImageGen) {
               commandLines.push(
                 `- [selfie] or [selfie: context="description of what the selfie shows"] - you send a photo of yourself. Use this when the user asks for a selfie, photo, or pic, or when you want to share what you look like right now.`,
+                `   If you say you are sending, sharing, taking, or attaching a selfie/photo/pic, include [selfie] in that same response. Do not only narrate the action.`,
                 ``,
               );
             }
@@ -5984,6 +6020,7 @@ export async function generateRoutes(app: FastifyInstance) {
         let toolDefs: LLMToolDefinition[] | undefined;
         const allToolDefs: LLMToolDefinition[] = [];
         const agentOnlyToolNames = new Set([
+          "save_lorebook_entry",
           "read_chat_summary",
           "append_chat_summary",
           "read_chat_variable",
@@ -6203,6 +6240,98 @@ export async function generateRoutes(app: FastifyInstance) {
           chatMeta,
           onUpdateMetadata: updateChatMetadataForTools,
         };
+        const resolveAgentWritableLorebookId = (agentSettings: Record<string, unknown>): string | null => {
+          const enabledTools = Array.isArray(agentSettings.enabledTools) ? agentSettings.enabledTools : [];
+          const lorebookWriteEnabled =
+            agentSettings.lorebookWriteEnabled === true || enabledTools.includes("save_lorebook_entry");
+          if (!lorebookWriteEnabled) return null;
+          for (const key of ["writableLorebookId", "targetLorebookId"]) {
+            const value = agentSettings[key];
+            if (typeof value === "string" && value.trim()) return value.trim();
+          }
+          const writableIds = agentSettings.writableLorebookIds;
+          if (Array.isArray(writableIds)) {
+            const first = writableIds.find((value): value is string => typeof value === "string" && value.trim().length > 0);
+            if (first) return first.trim();
+          }
+          return null;
+        };
+        const createLorebookEntryWriter = (agent: ResolvedAgent, agentSettings: Record<string, unknown>) => {
+          const writableLorebookId = resolveAgentWritableLorebookId(agentSettings);
+          if (!writableLorebookId) return undefined;
+          return async (entry: {
+            name: string;
+            content: string;
+            description?: string;
+            keys: string[];
+            tag?: string;
+            mode: "create" | "replace" | "append";
+          }) => {
+            const targetLorebook = await lorebooksStore.getById(writableLorebookId);
+            if (!targetLorebook) {
+              return { error: "Selected lorebook is no longer available.", lorebookId: writableLorebookId };
+            }
+
+            const existingEntries = await lorebooksStore.listEntries(writableLorebookId);
+            const normalizedName = entry.name.trim().toLocaleLowerCase();
+            const existing = existingEntries.find(
+              (candidate: any) =>
+                typeof candidate.name === "string" && candidate.name.trim().toLocaleLowerCase() === normalizedName,
+            ) as any;
+            const keys = Array.from(new Set(entry.keys.map((key) => key.trim()).filter(Boolean)));
+
+            if (!existing || entry.mode === "create") {
+              const created = await lorebooksStore.createEntry({
+                lorebookId: writableLorebookId,
+                name: entry.name,
+                content: entry.content,
+                description: entry.description ?? "",
+                keys,
+                tag: entry.tag ?? "",
+                enabled: true,
+                constant: false,
+                selective: false,
+                position: 0,
+                depth: 4,
+                role: "system",
+              });
+              return {
+                applied: true,
+                action: "created",
+                lorebookId: writableLorebookId,
+                lorebookName: (targetLorebook as any).name,
+                entryId: (created as any)?.id ?? null,
+                name: entry.name,
+                sourceAgentId: agent.id,
+              };
+            }
+
+            const existingContent = typeof existing.content === "string" ? existing.content : "";
+            const nextContent =
+              entry.mode === "append" && existingContent.trim()
+                ? existingContent.includes(entry.content)
+                  ? existingContent
+                  : `${existingContent.trim()}\n\n${entry.content}`
+                : entry.content;
+            const existingKeys = Array.isArray(existing.keys) ? existing.keys.filter((key: unknown): key is string => typeof key === "string") : [];
+            const updated = await lorebooksStore.updateEntry(existing.id, {
+              content: nextContent,
+              description: entry.description ?? existing.description ?? "",
+              keys: Array.from(new Set([...existingKeys, ...keys])),
+              ...(entry.tag !== undefined ? { tag: entry.tag } : {}),
+              enabled: true,
+            });
+            return {
+              applied: true,
+              action: entry.mode === "append" ? "appended" : "replaced",
+              lorebookId: writableLorebookId,
+              lorebookName: (targetLorebook as any).name,
+              entryId: (updated as any)?.id ?? existing.id,
+              name: entry.name,
+              sourceAgentId: agent.id,
+            };
+          };
+        };
 
         // ── Resolve tool context for all agents ──
         // This enables built-in and custom tools for any agent in the pipeline.
@@ -6227,6 +6356,7 @@ export async function generateRoutes(app: FastifyInstance) {
           );
           if (agentTools.length === 0) continue;
           const allowedToolNames = new Set(agentTools.map((td) => td.function.name));
+          const saveLorebookEntry = createLorebookEntryWriter(agent, agentSettings);
           if (agent.type === "spotify") {
             const spotifyAgent = agent as SpotifyRuntimeAgent;
             spotifyAgent.__spotifyToolCalls = new Set<string>();
@@ -6256,6 +6386,7 @@ export async function generateRoutes(app: FastifyInstance) {
               }
               const results = await executeToolCalls([call], {
                 ...baseToolExecutionContext,
+                saveLorebookEntry,
               });
               const result = results[0]?.result ?? "Tool execution failed";
               if (agent.type === "spotify" && call.function.name === "spotify_play") {
@@ -7923,6 +8054,17 @@ export async function generateRoutes(app: FastifyInstance) {
                   parsed.commands.length,
                   parsed.commands.map((c) => c.type),
                 );
+              }
+              const recoveredSelfieCommand = recoverImplicitSelfieCommand({
+                response: fullResponse,
+                latestUserMessage: input.userMessage,
+                imageGenerationEnabled:
+                  typeof chatMeta.imageGenConnectionId === "string" && chatMeta.imageGenConnectionId.trim().length > 0,
+                existingCommands: parsedCommands,
+              });
+              if (recoveredSelfieCommand) {
+                parsedCommands = [...parsedCommands, recoveredSelfieCommand];
+                logger.info("[generate] Recovered implicit selfie command for chat %s", input.chatId);
               }
             }
             if (roleplayDmCommandsEnabled) {
@@ -9770,7 +9912,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
                       // Collect character reference images when enabled. Prefer
                       // full-body sprites, then fall back to avatar portraits.
-                      const useAvatarRefs = illustratorAgent?.settings?.useAvatarReferences !== false;
+                      const useAvatarRefs = illustratorAgent?.settings?.useAvatarReferences === true;
                       let illustratorRefImages: string[] | undefined;
                       if (useAvatarRefs) {
                         const referenceResolution = await resolveIllustratorCharacterReferences({
@@ -9794,6 +9936,7 @@ export async function generateRoutes(app: FastifyInstance) {
                             typeof illData.reason === "string" ? illData.reason : "",
                             combinedResponse,
                           ].join("\n"),
+                          fallbackToChatCharacters: false,
                         });
                         if (referenceResolution.referenceImages.length > 0) {
                           illustratorRefImages = referenceResolution.referenceImages;

--- a/packages/server/src/routes/generate/illustrator-references.ts
+++ b/packages/server/src/routes/generate/illustrator-references.ts
@@ -165,7 +165,7 @@ export async function resolveIllustratorCharacterReferences(args: {
     ) ||
       personaAliases.some((alias) => textContainsAlias(normalizedPromptText, alias)));
 
-  if (selected.size === 0 && args.fallbackToChatCharacters !== false) {
+  if (selected.size === 0 && args.fallbackToChatCharacters === true) {
     for (const character of args.chatCharacters) {
       const source = sourcesById.get(character.id);
       if (source) selected.set(source.id, source);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -813,6 +813,133 @@ const CHAT_METADATA_TOOL_NAMES = new Set([
   "read_chat_variable",
   "write_chat_variable",
 ]);
+const LOREBOOK_WRITE_TOOL_NAME = "save_lorebook_entry";
+
+function resolveRetryAgentWritableLorebookId(settings: Record<string, unknown>): string | null {
+  const enabledTools = Array.isArray(settings.enabledTools) ? settings.enabledTools : [];
+  const lorebookWriteEnabled = settings.lorebookWriteEnabled === true || enabledTools.includes(LOREBOOK_WRITE_TOOL_NAME);
+  if (!lorebookWriteEnabled) return null;
+  for (const key of ["writableLorebookId", "targetLorebookId"]) {
+    const value = settings[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  const writableIds = settings.writableLorebookIds;
+  if (Array.isArray(writableIds)) {
+    const first = writableIds.find((value): value is string => typeof value === "string" && value.trim().length > 0);
+    if (first) return first.trim();
+  }
+  return null;
+}
+
+async function attachRetryLorebookWriterToolContexts(args: {
+  lorebooksStore: ReturnType<typeof createLorebooksStorage>;
+  resolvedAgents: ResolvedRetryAgent[];
+}) {
+  const { lorebooksStore, resolvedAgents } = args;
+  const tool = toLLMToolDefinition(LOREBOOK_WRITE_TOOL_NAME);
+  if (!tool) return;
+
+  for (const entry of resolvedAgents) {
+    const settings = parseSettingsRecord(entry.resolved.settings);
+    const writableLorebookId = resolveRetryAgentWritableLorebookId(settings);
+    if (!writableLorebookId) continue;
+
+    const existingContext = entry.resolved.toolContext;
+    const tools = existingContext?.tools.some((item) => item.function.name === LOREBOOK_WRITE_TOOL_NAME)
+      ? [...existingContext.tools]
+      : [...(existingContext?.tools ?? []), tool];
+
+    entry.resolved.toolContext = {
+      tools,
+      executeToolCall: async (call) => {
+        if (call.function.name !== LOREBOOK_WRITE_TOOL_NAME) {
+          if (existingContext) return existingContext.executeToolCall(call);
+          return JSON.stringify({
+            error: `Tool not allowed for agent ${entry.resolved.type}: ${call.function.name}`,
+            allowed: [LOREBOOK_WRITE_TOOL_NAME],
+          });
+        }
+
+        const saveLorebookEntry = async (loreEntry: {
+          name: string;
+          content: string;
+          description?: string;
+          keys: string[];
+          tag?: string;
+          mode: "create" | "replace" | "append";
+        }) => {
+          const targetLorebook = await lorebooksStore.getById(writableLorebookId);
+          if (!targetLorebook) {
+            return { error: "Selected lorebook is no longer available.", lorebookId: writableLorebookId };
+          }
+          const existingEntries = await lorebooksStore.listEntries(writableLorebookId);
+          const normalizedName = loreEntry.name.trim().toLocaleLowerCase();
+          const existing = existingEntries.find(
+            (candidate: any) =>
+              typeof candidate.name === "string" && candidate.name.trim().toLocaleLowerCase() === normalizedName,
+          ) as any;
+          const keys = Array.from(new Set(loreEntry.keys.map((key) => key.trim()).filter(Boolean)));
+
+          if (!existing || loreEntry.mode === "create") {
+            const created = await lorebooksStore.createEntry({
+              lorebookId: writableLorebookId,
+              name: loreEntry.name,
+              content: loreEntry.content,
+              description: loreEntry.description ?? "",
+              keys,
+              tag: loreEntry.tag ?? "",
+              enabled: true,
+              constant: false,
+              selective: false,
+              position: 0,
+              depth: 4,
+              role: "system",
+            });
+            return {
+              applied: true,
+              action: "created",
+              lorebookId: writableLorebookId,
+              lorebookName: (targetLorebook as any).name,
+              entryId: (created as any)?.id ?? null,
+              name: loreEntry.name,
+              sourceAgentId: entry.resolved.id,
+            };
+          }
+
+          const existingContent = typeof existing.content === "string" ? existing.content : "";
+          const nextContent =
+            loreEntry.mode === "append" && existingContent.trim()
+              ? existingContent.includes(loreEntry.content)
+                ? existingContent
+                : `${existingContent.trim()}\n\n${loreEntry.content}`
+              : loreEntry.content;
+          const existingKeys = Array.isArray(existing.keys)
+            ? existing.keys.filter((key: unknown): key is string => typeof key === "string")
+            : [];
+          const updated = await lorebooksStore.updateEntry(existing.id, {
+            content: nextContent,
+            description: loreEntry.description ?? existing.description ?? "",
+            keys: Array.from(new Set([...existingKeys, ...keys])),
+            ...(loreEntry.tag !== undefined ? { tag: loreEntry.tag } : {}),
+            enabled: true,
+          });
+          return {
+            applied: true,
+            action: loreEntry.mode === "append" ? "appended" : "replaced",
+            lorebookId: writableLorebookId,
+            lorebookName: (targetLorebook as any).name,
+            entryId: (updated as any)?.id ?? existing.id,
+            name: loreEntry.name,
+            sourceAgentId: entry.resolved.id,
+          };
+        };
+
+        const results = await executeToolCalls([call], { saveLorebookEntry });
+        return results[0]?.result ?? "Tool execution failed";
+      },
+    };
+  }
+}
 
 async function attachRetryChatMetadataToolContexts(args: {
   chats: ReturnType<typeof createChatsStorage>;
@@ -1914,7 +2041,7 @@ async function applyRetryResultEffects(args: {
 
             // Collect character reference images when enabled. Prefer full-body
             // sprites, then fall back to avatar portraits.
-            const useAvatarRefs = illustratorAgent?.resolved.settings?.useAvatarReferences !== false;
+            const useAvatarRefs = illustratorAgent?.resolved.settings?.useAvatarReferences === true;
             let referenceImages: string[] | undefined;
             if (useAvatarRefs) {
               const referenceResolution = await resolveIllustratorCharacterReferences({
@@ -1940,6 +2067,7 @@ async function applyRetryResultEffects(args: {
                   typeof illData.reason === "string" ? illData.reason : "",
                   agentContext.mainResponse ?? "",
                 ].join("\n"),
+                fallbackToChatCharacters: false,
               });
               if (referenceResolution.referenceImages.length > 0) {
                 referenceImages = referenceResolution.referenceImages;
@@ -2213,6 +2341,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       });
       await attachRetrySpotifyToolContexts({ agentsStore, chats, chatId, chatMeta, resolvedAgents });
       await attachRetryChatMetadataToolContexts({ chats, chatId, chatMeta, resolvedAgents });
+      await attachRetryLorebookWriterToolContexts({ lorebooksStore, resolvedAgents });
       const cyoaAgentWillRun = resolvedAgents.some((e) => e.resolved.type === "cyoa");
       const agentContext = await buildRetryAgentContext({
         cyoaAgentWillRun,

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -76,6 +76,52 @@ function loadSdk(): Promise<SdkModule> {
   return cachedSdk;
 }
 
+const SDK_ERROR_DETAIL_LIMIT = 1600;
+
+function compactSdkErrorText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const compact = value.trim().replace(/\s+/g, " ");
+  return compact ? compact.slice(0, SDK_ERROR_DETAIL_LIMIT) : null;
+}
+
+function collectSdkErrorDetails(err: unknown, seen = new Set<unknown>()): string[] {
+  if (!err || seen.has(err)) return [];
+  seen.add(err);
+
+  const parts: string[] = [];
+  if (err instanceof Error) {
+    const message = compactSdkErrorText(err.message);
+    if (message) parts.push(message);
+  } else {
+    const message = compactSdkErrorText(String(err));
+    if (message && message !== "[object Object]") parts.push(message);
+  }
+
+  if (typeof err === "object") {
+    const record = err as Record<string, unknown>;
+    for (const key of ["stderr", "stdout", "details", "detail", "code", "status"]) {
+      const value = compactSdkErrorText(record[key]);
+      if (value) parts.push(`${key}: ${value}`);
+    }
+    const errors = record.errors;
+    if (Array.isArray(errors)) {
+      for (const item of errors) parts.push(...collectSdkErrorDetails(item, seen));
+    }
+    if (record.cause) parts.push(...collectSdkErrorDetails(record.cause, seen));
+  }
+
+  return Array.from(new Set(parts));
+}
+
+function formatClaudeSdkError(err: unknown): string {
+  const parts = collectSdkErrorDetails(err);
+  const message = parts.length > 0 ? parts.join(" | ") : err instanceof Error ? err.message : String(err);
+  if (/Claude Code request failed/i.test(message)) {
+    return `${message}. Confirm \`claude login\` was run by the same OS user/HOME as the Marinara server, or set ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN in the server environment. HOME=${process.env.HOME ?? "unset"}.`;
+  }
+  return message;
+}
+
 /** @internal Test-only seam. Replaces the cached SDK module with a fake or clears it. */
 export function __setSdkForTesting(mod: Pick<SdkModule, "query"> | null): void {
   cachedSdk = mod ? (Promise.resolve(mod as SdkModule) as Promise<SdkModule>) : null;
@@ -548,7 +594,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
         options.model,
         resumeSessionId ?? "fold-path",
       );
-      const friendly = err instanceof Error ? err.message : String(err);
+      const friendly = formatClaudeSdkError(err);
       throw new Error(`Claude (Subscription) request failed: ${friendly}`);
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onUpstreamAbort);

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -32,6 +32,16 @@ export type LorebookSearchFn = (
   category?: string | null,
 ) => Promise<Array<{ name: string; content: string; tag: string; keys: string[] }>>;
 
+/** Lorebook writer function injected from the route layer. */
+export type SaveLorebookEntryFn = (entry: {
+  name: string;
+  content: string;
+  description?: string;
+  keys: string[];
+  tag?: string;
+  mode: "create" | "replace" | "append";
+}) => Promise<Record<string, unknown>>;
+
 /** Spotify API credentials injected from the route layer. */
 export interface SpotifyCredentials {
   accessToken: string;
@@ -42,6 +52,10 @@ export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promis
 export type MetadataPatchInput = MetadataPatch | MetadataUpdater;
 
 const MAX_APPEND_BYTES = 16 * 1024;
+const MAX_LOREBOOK_ENTRY_CONTENT_BYTES = 64 * 1024;
+const MAX_LOREBOOK_ENTRY_DESCRIPTION_BYTES = 4 * 1024;
+const MAX_LOREBOOK_ENTRY_NAME_LENGTH = 160;
+const MAX_LOREBOOK_ENTRY_KEYS = 24;
 const MAX_CHAT_VARIABLE_KEY_LENGTH = 128;
 const MAX_CHAT_VARIABLE_VALUE_BYTES = 64 * 1024;
 const MAX_CHAT_VARIABLES = 256;
@@ -137,6 +151,7 @@ export interface ToolExecutionContext {
   onUpdateMetadata?: (patch: MetadataPatchInput) => Promise<MetadataPatch>;
   customTools?: CustomToolDef[];
   searchLorebook?: LorebookSearchFn;
+  saveLorebookEntry?: SaveLorebookEntryFn;
   spotify?: SpotifyCredentials;
   spotifyRepeatAfterPlay?: "off" | "track" | "context";
 }
@@ -196,6 +211,8 @@ async function executeSingleTool(
       return triggerEvent(args);
     case "search_lorebook":
       return searchLorebook(args, context?.searchLorebook);
+    case "save_lorebook_entry":
+      return saveLorebookEntry(args, context?.saveLorebookEntry);
     case "read_chat_summary":
       return readChatSummary(context?.chatMeta);
     case "append_chat_summary":
@@ -228,6 +245,7 @@ async function executeSingleTool(
           "set_expression",
           "trigger_event",
           "search_lorebook",
+          "save_lorebook_entry",
           "read_chat_summary",
           "append_chat_summary",
           "read_chat_variable",
@@ -564,6 +582,52 @@ async function searchLorebook(
     results,
     count: results.length,
   };
+}
+
+function normalizeLorebookEntryKeys(value: unknown, fallbackName: string): string[] {
+  const raw = Array.isArray(value) ? value : [];
+  const keys = raw
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0)
+    .slice(0, MAX_LOREBOOK_ENTRY_KEYS);
+  if (keys.length > 0) return Array.from(new Set(keys));
+  return fallbackName ? [fallbackName] : [];
+}
+
+function normalizeLorebookWriteMode(value: unknown): "create" | "replace" | "append" {
+  return value === "create" || value === "append" || value === "replace" ? value : "replace";
+}
+
+async function saveLorebookEntry(
+  args: Record<string, unknown>,
+  saveFn?: SaveLorebookEntryFn,
+): Promise<Record<string, unknown>> {
+  if (!saveFn) {
+    return { error: "Lorebook writing is not available in this context." };
+  }
+  if (typeof args.name !== "string" || !args.name.trim()) {
+    return { error: "save_lorebook_entry requires a non-empty name" };
+  }
+  if (typeof args.content !== "string" || !args.content.trim()) {
+    return { error: "save_lorebook_entry requires non-empty content" };
+  }
+
+  const name = args.name.trim().slice(0, MAX_LOREBOOK_ENTRY_NAME_LENGTH);
+  const content = trimToUtf8Bytes(args.content.trim(), MAX_LOREBOOK_ENTRY_CONTENT_BYTES);
+  const description =
+    typeof args.description === "string" && args.description.trim()
+      ? trimToUtf8Bytes(args.description.trim(), MAX_LOREBOOK_ENTRY_DESCRIPTION_BYTES)
+      : undefined;
+  const tag = typeof args.tag === "string" && args.tag.trim() ? args.tag.trim().slice(0, 80) : undefined;
+
+  return saveFn({
+    name,
+    content,
+    description,
+    keys: normalizeLorebookEntryKeys(args.keys, name),
+    tag,
+    mode: normalizeLorebookWriteMode(args.mode),
+  });
 }
 
 // ── Spotify Tool Implementations ──

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -486,7 +486,7 @@ export function getDefaultBuiltInAgentSettings(agentType: string): Record<string
   }
 
   if (agentType === "illustrator") {
-    settings.useAvatarReferences = true;
+    settings.useAvatarReferences = false;
   }
 
   if (agentType === "knowledge-retrieval" || agentType === "knowledge-router") {
@@ -757,6 +757,32 @@ export const BUILT_IN_TOOLS: ToolDefinition[] = [
         category: { type: "string", description: "Optional category filter" },
       },
       required: ["query"],
+    },
+  },
+  {
+    name: "save_lorebook_entry",
+    description:
+      "Create or update an entry in the lorebook selected for this agent. Use it only for durable facts, world lore, characters, locations, or long-term story developments worth remembering.",
+    parameters: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Short entry title, such as a character, location, object, or event name" },
+        content: { type: "string", description: "Concise lorebook entry content to store" },
+        description: { type: "string", description: "Optional one-line description for routing and editor context" },
+        keys: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional trigger/search keys. If omitted, the title is used as a key.",
+        },
+        tag: { type: "string", description: "Optional category tag" },
+        mode: {
+          type: "string",
+          enum: ["create", "replace", "append"],
+          description:
+            "How to handle an existing entry with the same name in the selected lorebook. Defaults to replace.",
+        },
+      },
+      required: ["name", "content"],
     },
   },
   {


### PR DESCRIPTION
## Why

Addresses the current open issue batch around Illustrator references, Claude Agent SDK testing, custom-agent lorebook writes, game-mode persona sprites, and conversation selfies.

## Changes

- Makes Illustrator reference images explicit opt-in and only attaches matched character/persona references.
- Adds a custom-agent Lorebook Writer toggle that grants a gated save_lorebook_entry tool for one selected lorebook.
- Lets Game mode resolve and display persona sprites when the active speaker is the player persona.
- Makes Claude Subscription connection testing perform a real SDK request and surfaces richer SDK failure details.
- Strengthens selfie command prompting and recovers implicit selfie sends when image generation is configured.

## Issues

Addresses #2517
Addresses #2518
Addresses #2519
Addresses #2520
Addresses #2522

## Validation

- pnpm install
- pnpm check

Notes: this shell is using Node v20.11.1, so pnpm emitted the repo engine warning (`>=24 <26`) and Vite warned that it prefers Node 20.19+ or 22.12+, but the full check completed successfully.

## Manual verification needed

- Manually verify Illustrator local Stable Diffusion generation does not switch into reference/img2img mode unless the Illustrator reference checkbox is enabled and a character/persona is matched.
- Manually verify Claude Subscription Test Connection and Send Test Message report useful auth/SDK errors on an unauthenticated host.
- Manually verify a custom agent with Lorebook Writer enabled can save/update one selected lorebook entry and cannot write without a selected target.
- Manually verify Game mode shows persona sprites for the active player persona when sprites exist.
- Manually verify conversation selfies generate when a character claims to send a selfie/photo and image generation is configured.
