### PR TITLE
fix(mobile): recent chat pill overflow, chibi spacing, FAQ placement

### DIFF
--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -449,7 +449,7 @@ export function HomeFaq({
         <div className="overflow-hidden rounded-lg border border-[var(--border)]/60 bg-[var(--card)]/70">
           <button
             type="button"
-            onClick={() => setExpanded((current) => !current)}
+            onClick={() => setExpanded(!expanded)}
             className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
             aria-expanded={expanded}
           >
@@ -489,7 +489,7 @@ export function HomeFaq({
                     >
                       <button
                         type="button"
-                        onClick={() => setOpenItemId((current) => (current === item.id ? null : item.id))}
+                        onClick={() => setOpenItemId(openItemId === item.id ? null : item.id)}
                         className="flex w-full items-start gap-2 px-2.5 py-2 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
                         aria-expanded={isOpen}
                       >
@@ -546,7 +546,7 @@ export function HomeFaq({
       <div className="overflow-hidden rounded-[1rem] border border-[var(--border)]/60 bg-[var(--card)] shadow-[0_14px_38px_rgba(0,0,0,0.24)] backdrop-blur-xl dark:bg-[linear-gradient(180deg,rgba(18,14,23,0.92),rgba(11,10,16,0.86))]">
         <button
           type="button"
-          onClick={() => setExpanded((current) => !current)}
+          onClick={() => setExpanded(!expanded)}
           className="flex w-full items-start gap-2.5 px-3.5 py-2.5 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5 sm:items-center sm:gap-3 sm:px-4"
           aria-expanded={expanded}
         >
@@ -639,7 +639,7 @@ export function HomeFaq({
                     >
                       <button
                         type="button"
-                        onClick={() => setOpenItemId((current) => (current === item.id ? null : item.id))}
+                        onClick={() => setOpenItemId(openItemId === item.id ? null : item.id)}
                         className="flex w-full items-start gap-3 px-3 py-3 text-left transition-colors hover:bg-black/5 dark:hover:bg-white/5"
                         aria-expanded={isOpen}
                       >

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -416,13 +416,32 @@ export function HomeFaq({
   defaultExpanded = false,
   className,
   compact = false,
+  expanded: expandedProp,
+  onExpandedChange,
+  openItemId: openItemIdProp,
+  onOpenItemIdChange,
 }: {
   defaultExpanded?: boolean;
   className?: string;
   compact?: boolean;
+  expanded?: boolean;
+  onExpandedChange?: (v: boolean) => void;
+  openItemId?: string | null;
+  onOpenItemIdChange?: (v: string | null) => void;
 } = {}) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
-  const [openItemId, setOpenItemId] = useState<string | null>("game-mode-model");
+  const [expandedInternal, setExpandedInternal] = useState(defaultExpanded);
+  const [openItemIdInternal, setOpenItemIdInternal] = useState<string | null>("game-mode-model");
+
+  const expanded = expandedProp ?? expandedInternal;
+  const setExpanded = (v: boolean) => {
+    setExpandedInternal(v);
+    onExpandedChange?.(v);
+  };
+  const openItemId = openItemIdProp !== undefined ? openItemIdProp : openItemIdInternal;
+  const setOpenItemId = (v: string | null) => {
+    setOpenItemIdInternal(v);
+    onOpenItemIdChange?.(v);
+  };
 
   if (compact) {
     return (

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -319,13 +319,15 @@ export function HomeProfessorMariChat() {
   };
 
   return (
-    <section className="w-full max-w-3xl rounded-xl border border-[var(--border)] bg-[var(--card)]/85 shadow-lg shadow-black/10">
+    <section className="w-full max-w-3xl rounded-xl border border-[var(--border)] bg-[var(--card)]/85 shadow-lg shadow-black/10 mt-10 sm:mt-0">
       <div className="grid gap-2.5 p-2 sm:grid-cols-[minmax(0,0.72fr)_minmax(0,1.45fr)] sm:p-2.5">
         <div className="flex min-w-0 flex-col items-center justify-start gap-2 rounded-lg border border-[var(--border)]/70 bg-[var(--secondary)]/25 p-2.5">
           <div className="w-full max-w-[14rem] [--mari-professor-sprite-bottom:5%]">
             <ProfessorMariPixelScene active={isBusy || mariPhase !== null} />
           </div>
-          <HomeFaq compact />
+          <div className="hidden sm:block w-full">
+            <HomeFaq compact />
+          </div>
         </div>
 
         <div className="flex h-[clamp(24rem,70dvh,31rem)] min-w-0 flex-col rounded-lg border border-[var(--border)]/70 bg-[var(--background)]/70">
@@ -466,6 +468,9 @@ export function HomeProfessorMariChat() {
             </div>
           </form>
         </div>
+      </div>
+      <div className="sm:hidden px-2 pb-2">
+        <HomeFaq compact />
       </div>
     </section>
   );

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -143,6 +143,8 @@ export function HomeProfessorMariChat() {
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [sending, setSending] = useState(false);
   const [connectionMenuOpen, setConnectionMenuOpen] = useState(false);
+  const [faqExpanded, setFaqExpanded] = useState(false);
+  const [faqOpenItemId, setFaqOpenItemId] = useState<string | null>("game-mode-model");
   const hasLoadedRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const connectionButtonRef = useRef<HTMLButtonElement>(null);
@@ -326,7 +328,7 @@ export function HomeProfessorMariChat() {
             <ProfessorMariPixelScene active={isBusy || mariPhase !== null} />
           </div>
           <div className="hidden sm:block w-full">
-            <HomeFaq compact />
+            <HomeFaq compact expanded={faqExpanded} onExpandedChange={setFaqExpanded} openItemId={faqOpenItemId} onOpenItemIdChange={setFaqOpenItemId} />
           </div>
         </div>
 
@@ -470,7 +472,7 @@ export function HomeProfessorMariChat() {
         </div>
       </div>
       <div className="sm:hidden px-2 pb-2">
-        <HomeFaq compact />
+        <HomeFaq compact expanded={faqExpanded} onExpandedChange={setFaqExpanded} openItemId={faqOpenItemId} onOpenItemIdChange={setFaqOpenItemId} />
       </div>
     </section>
   );

--- a/packages/client/src/components/chat/RecentChats.tsx
+++ b/packages/client/src/components/chat/RecentChats.tsx
@@ -66,7 +66,7 @@ export function RecentChats() {
           No chats yet
         </p>
       ) : (
-        <div className="flex w-full items-center justify-center gap-1.5">
+        <div className="flex w-full items-center justify-center gap-1.5 overflow-x-auto">
           {recentChats.map((chat) => (
             <RecentChatChip
               key={chat.id}

--- a/packages/client/src/components/chat/RecentChats.tsx
+++ b/packages/client/src/components/chat/RecentChats.tsx
@@ -66,7 +66,7 @@ export function RecentChats() {
           No chats yet
         </p>
       ) : (
-        <div className="flex w-full items-center justify-center gap-1.5 overflow-x-auto">
+        <div className="flex w-full items-center justify-start gap-1.5 overflow-x-auto">
           {recentChats.map((chat) => (
             <RecentChatChip
               key={chat.id}


### PR DESCRIPTION
## Linked issue

Closes nothing, irked me.

## Why this change

Three extremely tiny (+8,-3) mobile UI issues on the frontpage:

- Recent chat pills overflowed the viewport left/right when three chats were shown
- The chibi sprite (intentionally overflowing above the card) was clipping into the recent chat pills above it on mobile
- The FAQ accordion felt out of place on top of the chat it makes more sense below the entire Ask Professor Mari block ON MOBILE ONLY

## What changed

- `RecentChats.tsx` — added `overflow-x-auto` to the pills row so they scroll horizontally instead of breaking out of the viewport
- `HomeProfessorMariChat.tsx` — added `mt-10 sm:mt-0` to the section so the overflowing chibi has headroom on mobile without touching the pills above; desktop layout unaffected
- `HomeProfessorMariChat.tsx` — FAQ hidden inside the left column on mobile (`hidden sm:block`) and re-rendered below the grid (`sm:hidden`) so it appears under the full section on small screens; desktop two-column layout unchanged

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify on a 390×844 mobile viewport:
  - Recent chat pills scroll horizontally with 3 chats present and do not clip past the viewport
  - Chibi sprite overflows above the card without covering the pills row
  - FAQ accordion appears below the Ask Professor Mari section, not inside the left column
- Verify on desktop (>640px) that the two-column layout looks identical to before

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

before
<img width="571" height="983" alt="Bildschirmfoto 2026-06-12 um 18 56 06" src="https://github.com/user-attachments/assets/0fcb4c9b-f915-4da0-813b-96e5f09914d9" />

after, slightly scrolled down so you see faq is now below
<img width="568" height="985" alt="Bildschirmfoto 2026-06-12 um 18 46 49" src="https://github.com/user-attachments/assets/42684680-06d0-478d-8673-b0760c064de4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Chat interface layout refined with responsive design improvements to optimize FAQ visibility and placement across mobile and desktop devices
  * Recent chats section now features horizontal scrolling capability to enhance navigation and improve usability on mobile devices and smaller viewports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->