### PR TITLE
fix(import): surface real error instead of 500 when character import throws

### DIFF
--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -363,27 +363,36 @@ async function importCharacterBuffer(
 
     const avatarB64 = buffer.toString("base64");
     charData._avatarDataUrl = `data:image/png;base64,${avatarB64}`;
-    return importSTCharacter(charData, db, {
-      timestampOverrides,
-      importEmbeddedLorebook,
-      tagImportMode,
-      existingTagKeys,
-    });
+    try {
+      return await importSTCharacter(charData, db, {
+        timestampOverrides,
+        importEmbeddedLorebook,
+        tagImportMode,
+        existingTagKeys,
+      });
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   if (fileName.toLowerCase().endsWith(".charx")) {
     return importCharX(buffer, db, { timestampOverrides, importEmbeddedLorebook, tagImportMode, existingTagKeys });
   }
 
+  let json: Record<string, unknown>;
   try {
-    const json = JSON.parse(buffer.toString("utf-8"));
-    return importSTCharacter(json, db, { timestampOverrides, importEmbeddedLorebook, tagImportMode, existingTagKeys });
+    json = JSON.parse(buffer.toString("utf-8"));
   } catch {
     return {
       success: false,
       error:
         "Invalid file format. Expected a JSON character card, a PNG with embedded character data, or a .charx file.",
     };
+  }
+  try {
+    return await importSTCharacter(json, db, { timestampOverrides, importEmbeddedLorebook, tagImportMode, existingTagKeys });
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
 
@@ -684,11 +693,15 @@ export async function importRoutes(app: FastifyInstance) {
     if (rawTagImportMode !== undefined && tagImportMode === undefined) return invalidTagImportModeResponse();
     delete body.importEmbeddedLorebook;
     delete body.tagImportMode;
-    return importSTCharacter(body, app.db, {
-      timestampOverrides: readTimestampOverridesFromBody(body),
-      importEmbeddedLorebook,
-      tagImportMode,
-    });
+    try {
+      return await importSTCharacter(body, app.db, {
+        timestampOverrides: readTimestampOverridesFromBody(body),
+        importEmbeddedLorebook,
+        tagImportMode,
+      });
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   /** Inspect character cards before importing, so clients can ask about embedded lorebooks. */

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -213,7 +213,9 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
         });
       } else if (hasEmbeddedLorebook) {
         throw new Error(
-          typeof result?.error === "string" ? result.error : "Embedded lorebook import failed without a lorebook ID.",
+          typeof result?.error === "string"
+            ? result.error
+            : "Character imported but the embedded lorebook could not be saved — the import has been rolled back.",
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

`importSTCharacter` was called without a `try/catch` in three places inside the import route:

- JSON body path (`POST /import/st-character` from bot browser / JSON card drop)
- PNG buffer path (`importCharacterBuffer` for `.png` uploads)
- JSON buffer path (`importCharacterBuffer` for `.json` uploads)

Any uncaught exception — most commonly the embedded lorebook rollback failure — escaped to Fastify's global error handler, which returned a generic HTTP 500 `{ error: "Internal Server Error" }`. The client displayed this as an opaque toast with no actionable information.

The JSON buffer path had a `try/catch` but it wrapped both `JSON.parse` and `importSTCharacter` together, so real import errors were swallowed and reported as "Invalid file format" — also wrong.

## Fix

- Wrap all three `importSTCharacter` call sites so failures return `{ success: false, error }` with the actual error message (or `String(err)` if the thrown value isn't an `Error` object).
- Split the JSON buffer path `try/catch` so parse errors and import errors are reported separately with accurate messages.
- Improve the embedded lorebook rollback error message from internal jargon ("failed without a lorebook ID") to a user-facing message.

## Test plan

- [ ] Import a character card from bot browser (JannyAI or similar) — success case still works
- [ ] Import a PNG character card — success case still works
- [ ] Import a JSON character card — success case still works
- [ ] Trigger a lorebook rollback failure (e.g. corrupt character_book) — toast now shows the actual error instead of "Internal Server Error"
- [ ] Upload a non-character JSON file — still shows "Invalid file format"

🤖 Generated with [Claude Code](https://claude.com/claude-code)