### PR TITLE
Fix storage recovery and tracker edit context

### DIFF
--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -363,7 +363,7 @@ async function atomicWriteFile(path: string, content: string, options: { refresh
   }
 }
 
-type ParseResult<T> = { value: T; recoveredFromBackup: boolean };
+type ParseResult<T> = { value: T; recoveredFromBackup: boolean; recoveredFromFallback: boolean };
 
 function describeStaleness(mainPath: string, backupPath: string): string {
   try {
@@ -385,26 +385,50 @@ function describeStaleness(mainPath: string, backupPath: string): string {
 }
 
 function parseJsonFile<T>(path: string, fallback: T): ParseResult<T> {
-  if (!existsSync(path)) return { value: fallback, recoveredFromBackup: false };
+  if (!existsSync(path)) return { value: fallback, recoveredFromBackup: false, recoveredFromFallback: false };
   try {
-    return { value: JSON.parse(readFileSync(path, "utf8")) as T, recoveredFromBackup: false };
+    return { value: JSON.parse(readFileSync(path, "utf8")) as T, recoveredFromBackup: false, recoveredFromFallback: false };
   } catch (err) {
     const backupPath = `${path}.bak`;
     if (existsSync(backupPath)) {
       const staleness = describeStaleness(path, backupPath);
-      logger.error(
-        err,
-        "[file-storage] %s is corrupt; recovering from %s (backup is %s older). Edits made since the backup are unrecoverable.",
-        path,
-        backupPath,
-        staleness,
-      );
-      return {
-        value: JSON.parse(readFileSync(backupPath, "utf8")) as T,
-        recoveredFromBackup: true,
-      };
+      try {
+        const value = JSON.parse(readFileSync(backupPath, "utf8")) as T;
+        logger.error(
+          err,
+          "[file-storage] %s is corrupt; recovering from %s (backup is %s older). Edits made since the backup are unrecoverable.",
+          path,
+          backupPath,
+          staleness,
+        );
+        return {
+          value,
+          recoveredFromBackup: true,
+          recoveredFromFallback: false,
+        };
+      } catch (backupErr) {
+        logger.error(
+          err,
+          "[file-storage] %s is corrupt and backup %s could not be used (backup is %s older); continuing with fallback data. Data in the primary and backup files is unrecoverable.",
+          path,
+          backupPath,
+          staleness,
+        );
+        logger.error(
+          backupErr,
+          "[file-storage] Backup %s parse failure while recovering %s.",
+          backupPath,
+          path,
+        );
+        return { value: fallback, recoveredFromBackup: false, recoveredFromFallback: true };
+      }
     }
-    throw err;
+    logger.error(
+      err,
+      "[file-storage] %s is corrupt and no usable backup exists; continuing with fallback data. Data in this file is unrecoverable.",
+      path,
+    );
+    return { value: fallback, recoveredFromBackup: false, recoveredFromFallback: true };
   }
 }
 
@@ -1026,8 +1050,8 @@ class FileTableStore {
       const path = manifestPath(this.rootDir);
       const result = parseJsonFile<TableSnapshotManifest | null>(path, null);
       loadedManifest = result.value;
-      needsManifestRewrite = result.recoveredFromBackup;
-      if (result.recoveredFromBackup) {
+      needsManifestRewrite = result.recoveredFromBackup || result.recoveredFromFallback;
+      if (result.recoveredFromBackup || result.recoveredFromFallback) {
         this.backupRecoveredPaths.add(path);
       }
     } catch (err) {
@@ -1051,16 +1075,15 @@ class FileTableStore {
     for (const table of FILE_BACKED_TABLES) {
       const meta = getMeta(table);
       const path = tableFilePath(this.rootDir, table);
-      const { value: rows, recoveredFromBackup } = parseJsonFile<Row[]>(path, []);
+      const { value: rows, recoveredFromBackup, recoveredFromFallback } = parseJsonFile<Row[]>(path, []);
       const normalized = (Array.isArray(rows) ? rows : []).map((row) => normalizeRow(meta, row));
       this.tables.set(table, normalized);
       counts[table] = normalized.length;
-      if (recoveredFromBackup) {
+      if (recoveredFromBackup || recoveredFromFallback) {
         this.backupRecoveredPaths.add(path);
-        // Same self-heal: rewrite the corrupt main file from in-memory data
-        // (which now matches the recovered backup) on the next flush, while
-        // suppressing .bak refresh for that write so the recovery source is
-        // preserved until the primary is repaired.
+        // Same self-heal: rewrite the corrupt main file from in-memory data on
+        // the next flush, while suppressing .bak refresh for that write so a
+        // corrupt primary is never copied over the recovery source.
         this.dirtyTables.add(table);
         this.dirty = true;
       }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3060,6 +3060,13 @@ export async function generateRoutes(app: FastifyInstance) {
         // Batch-fetch committed game state snapshots for assistant messages in the agent context
         const assistantMsgIds = agentSlice.filter((m: any) => m.role === "assistant").map((m: any) => m.id as string);
         const committedSnapshots = await gameStateStore.getCommittedForMessages(assistantMsgIds);
+        const visibleHistorySnapshot =
+          latestGameState &&
+          visibleGameStateAnchor &&
+          latestGameState.messageId === visibleGameStateAnchor.messageId &&
+          latestGameState.swipeIndex === visibleGameStateAnchor.swipeIndex
+            ? latestGameState
+            : null;
 
         const recentMsgs = agentSlice.map((m: any) => {
           const msg: AgentContext["recentMessages"][number] = {
@@ -3068,7 +3075,16 @@ export async function generateRoutes(app: FastifyInstance) {
             characterId: m.characterId ?? undefined,
           };
           if (m.role === "assistant") {
-            const snapRow = committedSnapshots.get(m.id as string);
+            const messageSwipeIndex =
+              typeof m.activeSwipeIndex === "number" && Number.isInteger(m.activeSwipeIndex) && m.activeSwipeIndex >= 0
+                ? m.activeSwipeIndex
+                : 0;
+            const snapRow =
+              visibleHistorySnapshot &&
+              m.id === visibleHistorySnapshot.messageId &&
+              messageSwipeIndex === visibleHistorySnapshot.swipeIndex
+                ? visibleHistorySnapshot
+                : committedSnapshots.get(m.id as string);
             if (snapRow) {
               msg.gameState = parseGameStateRow(snapRow as Record<string, unknown>);
             }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -345,6 +345,12 @@ async function buildRetryAgentContext(args: {
     .filter((message: any) => message.role === "assistant")
     .map((message: any) => message.id as string);
   const retryCommittedSnapshots = await gameStateStore.getCommittedForMessages(retryAssistantMsgIds);
+  const retryVisibleAnchor =
+    historicalGameStateAnchor ??
+    (useLatestGameStateFallback && lastAssistant ? resolveVisibleGameStateAnchor([lastAssistant]) : null);
+  const retryVisibleHistorySnapshot = retryVisibleAnchor
+    ? await gameStateStore.getByChatAndMessage(chatId, retryVisibleAnchor.messageId, retryVisibleAnchor.swipeIndex)
+    : null;
 
   const agentContext: AgentContext = {
     chatId,
@@ -356,7 +362,18 @@ async function buildRetryAgentContext(args: {
         characterId: message.characterId ?? undefined,
       };
       if (message.role === "assistant") {
-        const snapRow = retryCommittedSnapshots.get(message.id as string);
+        const messageSwipeIndex =
+          typeof message.activeSwipeIndex === "number" &&
+          Number.isInteger(message.activeSwipeIndex) &&
+          message.activeSwipeIndex >= 0
+            ? message.activeSwipeIndex
+            : 0;
+        const snapRow =
+          retryVisibleHistorySnapshot &&
+          message.id === retryVisibleHistorySnapshot.messageId &&
+          messageSwipeIndex === retryVisibleHistorySnapshot.swipeIndex
+            ? retryVisibleHistorySnapshot
+            : retryCommittedSnapshots.get(message.id as string);
         if (snapRow) {
           nextMessage.gameState = parseGameStateRow(snapRow as Record<string, unknown>);
         }

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -257,7 +257,7 @@ export interface AgentContext {
     role: string;
     content: string;
     characterId?: string;
-    /** Committed game state snapshot for this message (if any). */
+    /** Tracker state snapshot for this message (if any). */
     gameState?: import("./game-state.js").GameState | null;
   }>;
   /** The main response text (available for post-processing agents) */


### PR DESCRIPTION
## Why

Fixes #2553.
Addresses the #2551 follow-up where manual tracker edits were saved but tracker agents could still use stale pre-edit committed tracker context on the next run.

## What changed

- Hardened file-native JSON loading so startup continues when both a primary JSON file and its `.bak` are corrupt or NUL-filled.
- Marked fallback-loaded files dirty and suppressed the immediate backup refresh so a corrupt primary is not copied over the recovery source during self-heal.
- Updated normal generation and retry-agent context building to prefer the active visible tracker snapshot for the matching assistant message, so manual edits become the base context for the next tracker generation.
- Relaxed the shared agent context comment because recent-message tracker state can now be visible/uncommitted, not only committed.

## Validation

- `pnpm install`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm check`
- Temp FILE_STORAGE_DIR repro with NUL-filled `manifest.json`, `manifest.json.bak`, `tables/chats.json`, and `tables/chats.json.bak`; file-native DB initialized, flushed, closed, and printed `file storage recovered`.
- GitHub `pnpm-validate` passed.
- GitHub `container-build-test` passed.
- CodeRabbit passed/skipped with no suggestions.

## Manual verification needed

- Manually edit a roleplay tracker field, send the next turn, and confirm debug/agent prompt context contains the edited tracker value before the tracker agent produces its replacement.
- Launch with a copied damaged storage folder if available from the reporter and confirm the app starts far enough to make/export a backup.
