### PR TITLE
feat: rework agents and unify chat game UI

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -423,6 +423,7 @@ export function AgentEditor() {
   const [localEnabledTools, setLocalEnabledTools] = useState<string[]>([]);
   const [localLorebookWriteEnabled, setLocalLorebookWriteEnabled] = useState(false);
   const [localWritableLorebookId, setLocalWritableLorebookId] = useState("");
+  const [localMusicProvider, setLocalMusicProvider] = useState<"spotify" | "youtube">("spotify");
   const [localSpotifyClientId, setLocalSpotifyClientId] = useState("");
   const [localSourceLorebookIds, setLocalSourceLorebookIds] = useState<string[]>([]);
   const [localUseChatActiveLorebooks, setLocalUseChatActiveLorebooks] = useState(false);
@@ -451,6 +452,8 @@ export function AgentEditor() {
   const [youtubeError, setYoutubeError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
+  const musicPlayerSource = useUIStore((s) => s.musicPlayerSource);
+  const setMusicPlayerSource = useUIStore((s) => s.setMusicPlayerSource);
   useEffect(() => {
     setEditorDirty(dirty);
   }, [dirty, setEditorDirty]);
@@ -507,6 +510,7 @@ export function AgentEditor() {
       setLocalEnabledTools(enabledTools);
       setLocalLorebookWriteEnabled(settings.lorebookWriteEnabled === true || enabledTools.includes(LOREBOOK_WRITE_TOOL_NAME));
       setLocalWritableLorebookId(writableLorebookId);
+      setLocalMusicProvider(settings.musicProvider === "youtube" || settings.musicPlayerSource === "youtube" ? "youtube" : "spotify");
       setLocalSpotifyClientId(typeof settings.spotifyClientId === "string" ? settings.spotifyClientId : "");
       setLocalSourceLorebookIds(normalizeStringArray(settings.sourceLorebookIds));
       setLocalUseChatActiveLorebooks(
@@ -556,6 +560,7 @@ export function AgentEditor() {
       setLocalIncludeParallelResults(false);
       setLocalLorebookWriteEnabled(false);
       setLocalWritableLorebookId("");
+      setLocalMusicProvider(defaultSettings.musicProvider === "youtube" ? "youtube" : "spotify");
       setLocalPrompt("");
     } else {
       // Brand new custom agent — start empty
@@ -589,17 +594,20 @@ export function AgentEditor() {
       setLocalIncludeParallelResults(false);
       setLocalLorebookWriteEnabled(false);
       setLocalWritableLorebookId("");
+      setLocalMusicProvider("spotify");
       setLocalPrompt("");
     }
     setDirty(false);
     setSaveError(null);
   }, [agentDetailId, dbConfig, builtIn, connections, customRunIntervalMeta?.defaultValue, isCustomAgent]);
 
-  // Fetch Spotify connection status when viewing a Spotify agent
+  // Fetch music connection status when viewing Music DJ.
   const isSpotifyAgent = agentDetailId === "spotify" || dbConfig?.type === "spotify";
+  const isMusicAgent = isSpotifyAgent;
 
-  // YouTube DJ agent — free Data API key, in-app embedded player
+  // Legacy YouTube DJ agent — free Data API key, in-app embedded player
   const isYoutubeAgent = agentDetailId === "youtube" || dbConfig?.type === "youtube";
+  const showsYoutubeSettings = isMusicAgent || isYoutubeAgent;
 
   // Lorebook Keeper agent — run interval setting
   const isLorebookKeeperAgent = agentDetailId === "lorebook-keeper" || dbConfig?.type === "lorebook-keeper";
@@ -661,7 +669,7 @@ export function AgentEditor() {
   const deleteSource = useDeleteKnowledgeSource();
   const fileInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
-    if (!isSpotifyAgent || !dbConfig?.id) {
+    if (!isMusicAgent || !dbConfig?.id) {
       setSpotifyStatus(null);
       return;
     }
@@ -678,11 +686,11 @@ export function AgentEditor() {
     return () => {
       cancelled = true;
     };
-  }, [isSpotifyAgent, dbConfig?.id]);
+  }, [isMusicAgent, dbConfig?.id]);
 
-  // Fetch YouTube DJ key-configured status when viewing a YouTube agent
+  // Fetch YouTube key-configured status when viewing Music DJ or a legacy YouTube agent.
   useEffect(() => {
-    if (!isYoutubeAgent || !dbConfig?.id) {
+    if (!showsYoutubeSettings || !dbConfig?.id) {
       setYoutubeConfigured(false);
       return;
     }
@@ -698,7 +706,7 @@ export function AgentEditor() {
     return () => {
       cancelled = true;
     };
-  }, [isYoutubeAgent, dbConfig?.id]);
+  }, [showsYoutubeSettings, dbConfig?.id]);
 
   // Clean up Spotify polling timers on unmount
   useEffect(() => {
@@ -784,7 +792,7 @@ export function AgentEditor() {
       "spotifyRefreshToken",
       "spotifyExpiresAt",
       "spotifyScope",
-      // YouTube DJ key is encrypted server-side and not exposed by the form — preserve it
+      // YouTube key is encrypted server-side and not exposed by the form — preserve it
       // so a normal agent Save (e.g. toggling Enabled) doesn't wipe the stored key.
       "youtubeApiKey",
     ]) {
@@ -816,7 +824,8 @@ export function AgentEditor() {
         ...(localMaxTokens !== "" ? { maxTokens: clampAgentMaxTokens(localMaxTokens) } : {}),
         ...(localRunInterval !== "" ? { runInterval: Number(localRunInterval) } : {}),
         ...(localInjectAsSection ? { injectAsSection: true } : {}),
-        enabledTools: effectiveEnabledTools,
+        ...(isMusicAgent ? { musicProvider: localMusicProvider } : {}),
+        enabledTools: isMusicAgent && localMusicProvider === "youtube" ? [] : effectiveEnabledTools,
         ...(lorebookWriterEnabled
           ? { lorebookWriteEnabled: true, writableLorebookId, writableLorebookIds: [writableLorebookId] }
           : {}),
@@ -885,6 +894,7 @@ export function AgentEditor() {
     localEnabledTools,
     localLorebookWriteEnabled,
     localWritableLorebookId,
+    localMusicProvider,
     localSpotifyClientId,
     localUseChatActiveLorebooks,
     localSourceLorebookIds,
@@ -899,6 +909,7 @@ export function AgentEditor() {
     isCustomAgent,
     isNewCustomAgent,
     isIllustratorAgent,
+    isMusicAgent,
     isKnowledgeRetrievalAgent,
     isKnowledgeRouterAgent,
     updateAgent,
@@ -941,6 +952,7 @@ export function AgentEditor() {
     const savedAuthor = localAuthor.trim() || (builtIn ? DEFAULT_AGENT_AUTHOR : "Unknown");
     const savedPromptTemplates = normalizeAgentPromptTemplateOptions(localPromptTemplates);
     const agentType = dbConfig?.type ?? builtIn?.id ?? createCustomAgentType(localName);
+    const exportingMusicAgent = agentType === "spotify";
     const settings = {
       author: savedAuthor,
       promptTemplates: savedPromptTemplates,
@@ -953,7 +965,8 @@ export function AgentEditor() {
       ...(localMaxTokens !== "" ? { maxTokens: clampAgentMaxTokens(localMaxTokens) } : {}),
       ...(localRunInterval !== "" ? { runInterval: Number(localRunInterval) } : {}),
       ...(localInjectAsSection ? { injectAsSection: true } : {}),
-      enabledTools: effectiveEnabledTools,
+      ...(exportingMusicAgent ? { musicProvider: localMusicProvider } : {}),
+      enabledTools: exportingMusicAgent && localMusicProvider === "youtube" ? [] : effectiveEnabledTools,
       ...(lorebookWriterEnabled
         ? { lorebookWriteEnabled: true, writableLorebookId, writableLorebookIds: [writableLorebookId] }
         : {}),
@@ -1012,6 +1025,18 @@ export function AgentEditor() {
   }, [defaultPrompt]);
 
   const markDirty = useCallback(() => setDirty(true), []);
+
+  const handleMusicProviderChange = useCallback(
+    (provider: "spotify" | "youtube") => {
+      setLocalMusicProvider(provider);
+      setMusicPlayerSource(provider);
+      if (provider === "spotify" && localEnabledTools.length === 0) {
+        setLocalEnabledTools(DEFAULT_AGENT_TOOLS.spotify ?? []);
+      }
+      setDirty(true);
+    },
+    [localEnabledTools.length, setMusicPlayerSource],
+  );
 
   const toggleCustomCapability = useCallback(
     (capability: CustomAgentCapability) => {
@@ -2074,8 +2099,43 @@ export function AgentEditor() {
             </button>
           </FieldGroup>
 
+          {isMusicAgent && (
+            <FieldGroup
+              label="Music Player"
+              icon={<Music size="0.875rem" className="text-[var(--muted-foreground)]" />}
+              help="Choose which service Music DJ should use for future music picks. The same choice switches the visible player surface."
+            >
+              <div className="flex flex-col gap-2">
+                <div className="grid grid-cols-2 gap-2 rounded-xl border border-white/10 bg-white/[0.03] p-1">
+                  {(["spotify", "youtube"] as const).map((provider) => {
+                    const active = localMusicProvider === provider;
+                    return (
+                      <button
+                        key={provider}
+                        type="button"
+                        onClick={() => handleMusicProviderChange(provider)}
+                        className={cn(
+                          "rounded-lg px-3 py-2 text-xs font-medium transition-all",
+                          active
+                            ? "bg-white/12 text-white shadow-sm"
+                            : "text-white/45 hover:bg-white/8 hover:text-white/75",
+                        )}
+                      >
+                        {provider === "spotify" ? "Spotify" : "YouTube"}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="text-[0.625rem] text-white/40">
+                  Visible player: {musicPlayerSource === "spotify" ? "Spotify" : "YouTube"}. Saved provider:{" "}
+                  {localMusicProvider === "spotify" ? "Spotify" : "YouTube"}.
+                </p>
+              </div>
+            </FieldGroup>
+          )}
+
           {/* ── Spotify Settings (only shown for Spotify agent) ── */}
-          {(agentDetailId === "spotify" || dbConfig?.type === "spotify") && (
+          {isMusicAgent && (
             <FieldGroup
               label="Spotify Connection"
               icon={<Music size="0.875rem" className="text-green-400" />}
@@ -2376,10 +2436,10 @@ export function AgentEditor() {
             </FieldGroup>
           )}
 
-          {/* ── YouTube DJ Settings (only shown for YouTube agent) ── */}
-          {isYoutubeAgent && (
+          {/* ── YouTube Settings (shown for Music DJ and legacy YouTube agent) ── */}
+          {showsYoutubeSettings && (
             <FieldGroup
-              label="YouTube DJ"
+              label="YouTube Connection"
               icon={<Music size="0.875rem" className="text-red-400" />}
               help="Plays mood-matched music from YouTube in an embedded in-app player. Needs a free YouTube Data API key — no Premium, no account login."
             >
@@ -2406,7 +2466,7 @@ export function AgentEditor() {
                       setYoutubeSaving(true);
                       setYoutubeError(null);
                       try {
-                        // agentId is optional — the server creates the built-in YouTube DJ
+                        // agentId is optional — the server creates the built-in Music DJ
                         // config if it doesn't exist yet, so the user never has to hit the
                         // top-right Save first.
                         const res = await fetch("/api/youtube/save-key", {

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -46,7 +46,6 @@ import {
   ChevronUp,
   ExternalLink,
   BookOpen,
-  Download,
   Upload,
   Loader2,
   ImageIcon,
@@ -1170,7 +1169,7 @@ export function AgentEditor() {
             onClick={handleExportAgent}
             className="flex items-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
           >
-            <Download size="0.8125rem" /> <span className="max-md:hidden">Export</span>
+            <Upload size="0.8125rem" /> <span className="max-md:hidden">Export</span>
           </button>
           <button
             onClick={handleSave}

--- a/packages/client/src/components/agents/RegexScriptEditor.tsx
+++ b/packages/client/src/components/agents/RegexScriptEditor.tsx
@@ -27,7 +27,7 @@ import {
   Plus,
   Minus,
   Users,
-  Download,
+  Upload,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
@@ -457,7 +457,7 @@ export function RegexScriptEditor() {
             onClick={handleExport}
             className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-[0.98]"
           >
-            <Download size="0.8125rem" /> Export
+            <Upload size="0.8125rem" /> Export
           </button>
           {dbRow && (
             <button

--- a/packages/client/src/components/agents/ToolEditor.tsx
+++ b/packages/client/src/components/agents/ToolEditor.tsx
@@ -26,7 +26,7 @@ import {
   Trash2,
   Plus,
   Minus,
-  Download,
+  Upload,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
@@ -316,7 +316,7 @@ export function ToolEditor() {
               onClick={handleExport}
               className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:scale-[0.98]"
             >
-              <Download size="0.8125rem" /> Export
+              <Upload size="0.8125rem" /> Export
             </button>
           )}
           {dbTool && (

--- a/packages/client/src/components/chat/ActiveLorebookEntriesButton.tsx
+++ b/packages/client/src/components/chat/ActiveLorebookEntriesButton.tsx
@@ -5,6 +5,7 @@ import { cn } from "../../lib/utils";
 import { useActiveLorebookEntries } from "../../hooks/use-lorebooks";
 import { useUIStore } from "../../stores/ui.store";
 import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
+import { getChatToolbarButtonClass } from "./ChatToolbarControls";
 
 const ActiveLorebookEntriesPanel = lazy(async () => {
   const module = await import("./ChatRoleplayPanels");
@@ -107,15 +108,11 @@ export function ActiveLorebookEntriesButton({
     typeof buttonClassName === "function"
       ? buttonClassName({ open, hasEntries, hasSkippedEntries, isLoading, compact })
       : (buttonClassName ??
-        cn(
-          "flex items-center justify-center rounded-full border backdrop-blur-md transition-all",
-          compact ? "p-1" : "p-1.5",
-          open
-            ? "bg-foreground/15 border-foreground/20 text-foreground/90"
-            : (hasEntries || hasSkippedEntries) && !isLoading
-              ? "bg-foreground/10 border-foreground/25 text-foreground/80 hover:bg-foreground/15 hover:text-foreground"
-              : "bg-foreground/5 border-foreground/10 text-foreground/60 hover:bg-foreground/10 hover:text-foreground",
-        ));
+        getChatToolbarButtonClass({
+          active: (hasEntries || hasSkippedEntries) && !isLoading,
+          compact,
+          open,
+        }));
 
   return (
     <div className="relative" ref={ref} onClick={(e) => e.stopPropagation()}>

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2044,7 +2044,6 @@ export function ChatArea() {
             sceneInfo={conversationSceneInfo}
             settingsOpen={settingsOpen}
             settingsAnchor={settingsAnchor}
-            filesOpen={filesOpen}
             galleryOpen={galleryOpen}
             galleryAnchor={galleryAnchor}
             wizardOpen={wizardOpen}
@@ -2062,15 +2061,14 @@ export function ChatArea() {
             onSetActiveSwipe={handleSetActiveSwipe}
             onToggleHiddenFromAI={handleToggleHiddenFromAI}
             onPeekPrompt={handlePeekPrompt}
+            onBranch={isSceneChat ? undefined : handleBranch}
             onToggleSelectMessage={handleToggleSelectMessage}
             onSwitchChat={chat?.connectedChatId ? () => setActiveChatId(chat.connectedChatId!) : undefined}
             onConcludeScene={chatMeta.sceneStatus === "active" ? () => concludeScene(activeChatId) : undefined}
             onAbandonScene={chatMeta.sceneStatus === "active" ? () => abandonScene(activeChatId) : undefined}
             onOpenSettings={handleOpenSettingsPanel}
-            onOpenFiles={() => setFilesOpen(true)}
             onOpenGallery={handleOpenGalleryPanel}
             onCloseSettings={handleCloseSettingsPanel}
-            onCloseFiles={() => setFilesOpen(false)}
             onCloseGallery={handleCloseGalleryPanel}
             onWizardFinish={() => {
               setWizardOpen(false);

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2137,7 +2137,6 @@ export function ChatArea() {
           onForkScene={forkScene}
           isForkingScene={isForking || isStreaming}
           onOpenSettings={() => setSettingsOpen(true)}
-          onOpenFiles={() => setFilesOpen(true)}
           onOpenGallery={() => setGalleryOpen(true)}
           onCloseSettings={() => setSettingsOpen(false)}
           onCloseFiles={() => setFilesOpen(false)}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1,7 +1,17 @@
 // ──────────────────────────────────────────────
 // Chat: Main chat area — mode-aware rendering
 // ──────────────────────────────────────────────
-import { Suspense, lazy, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import { useQueries } from "@tanstack/react-query";
 import {
   useChatMessages,
@@ -199,6 +209,8 @@ const GameSurface = lazy(async () => {
   return { default: module.GameSurface };
 });
 
+type FloatingPanelAnchor = { right: number; top: number } | null;
+
 export function ChatArea() {
   const activeChatId = useChatStore((s) => s.activeChatId);
   const streamingChatId = useChatStore((s) => s.streamingChatId);
@@ -228,6 +240,8 @@ export function ChatArea() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [filesOpen, setFilesOpen] = useState(false);
   const [galleryOpen, setGalleryOpen] = useState(false);
+  const [settingsAnchor, setSettingsAnchor] = useState<FloatingPanelAnchor>(null);
+  const [galleryAnchor, setGalleryAnchor] = useState<FloatingPanelAnchor>(null);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [spriteArrangeMode, setSpriteArrangeMode] = useState(false);
   const [agentInjectionReview, setAgentInjectionReview] = useState<AgentInjectionReviewRequest | null>(null);
@@ -246,6 +260,36 @@ export function ChatArea() {
     () => (activeChatId ? (allChats?.find((candidate) => candidate.id === activeChatId) ?? null) : null),
     [activeChatId, allChats],
   );
+  const readFloatingPanelAnchor = useCallback((event?: ReactMouseEvent<HTMLElement>): FloatingPanelAnchor => {
+    if (!event || typeof window === "undefined" || window.innerWidth < 768) return null;
+    const rect = event.currentTarget.getBoundingClientRect();
+    return {
+      right: Math.max(12, Math.round(window.innerWidth - rect.right)),
+      top: Math.max(56, Math.round(rect.bottom + 8)),
+    };
+  }, []);
+  const handleOpenSettingsPanel = useCallback(
+    (event?: ReactMouseEvent<HTMLElement>) => {
+      setSettingsAnchor(readFloatingPanelAnchor(event));
+      setSettingsOpen(true);
+    },
+    [readFloatingPanelAnchor],
+  );
+  const handleOpenGalleryPanel = useCallback(
+    (event?: ReactMouseEvent<HTMLElement>) => {
+      setGalleryAnchor(readFloatingPanelAnchor(event));
+      setGalleryOpen(true);
+    },
+    [readFloatingPanelAnchor],
+  );
+  const handleCloseSettingsPanel = useCallback(() => {
+    setSettingsOpen(false);
+    setSettingsAnchor(null);
+  }, []);
+  const handleCloseGalleryPanel = useCallback(() => {
+    setGalleryOpen(false);
+    setGalleryAnchor(null);
+  }, []);
   const chat = chatDetail ?? null;
   // Game mode loads ALL messages (no pagination) so the in-game log
   // shows the full session history instead of only the latest page.
@@ -1355,11 +1399,11 @@ export function ChatArea() {
         setWizardOpen(true);
         useChatStore.getState().setShouldOpenWizard(false);
       } else {
-        setSettingsOpen(true);
+        handleOpenSettingsPanel();
       }
       useChatStore.getState().setShouldOpenSettings(false);
     }
-  }, [shouldOpenSettings, shouldOpenWizard, activeChatId]);
+  }, [shouldOpenSettings, shouldOpenWizard, activeChatId, handleOpenSettingsPanel]);
 
   // Auto-scroll on new messages / streaming (but not on "load more")
   // Only scroll if user is already near the bottom (within 150px).
@@ -1922,7 +1966,7 @@ export function ChatArea() {
             characters={gameCharacters}
             personaInfo={personaInfo}
             chatBackground={chatBackground}
-            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenSettings={handleOpenSettingsPanel}
             onDeleteMessage={handleDelete}
             multiSelectMode={multiSelectMode}
             selectedMessageIds={selectedMessageIds}
@@ -1932,8 +1976,10 @@ export function ChatArea() {
             chat={chat}
             activeChatId={activeChatId}
             settingsOpen={settingsOpen}
+            settingsAnchor={settingsAnchor}
             filesOpen={filesOpen}
             galleryOpen={galleryOpen}
+            galleryAnchor={galleryAnchor}
             wizardOpen={wizardOpen}
             peekPromptData={peekPromptData}
             deleteDialogMessageId={deleteDialogMessageId}
@@ -1948,13 +1994,13 @@ export function ChatArea() {
               onResetSpritePlacements: handleResetSpritePlacements,
               onSpriteSideChange: handleSetSpritePosition,
             }}
-            onCloseSettings={() => setSettingsOpen(false)}
+            onCloseSettings={handleCloseSettingsPanel}
             onCloseFiles={() => setFilesOpen(false)}
-            onCloseGallery={() => setGalleryOpen(false)}
+            onCloseGallery={handleCloseGalleryPanel}
             onIllustrate={() => retryAgents(activeChatId, ["illustrator"])}
             onWizardFinish={() => {
               setWizardOpen(false);
-              setSettingsOpen(true);
+              handleOpenSettingsPanel();
             }}
             onClosePeekPrompt={() => setPeekPromptData(null)}
             onDeleteConfirm={handleDeleteConfirm}
@@ -1997,8 +2043,10 @@ export function ChatArea() {
             connectedChatName={connectedChatName}
             sceneInfo={conversationSceneInfo}
             settingsOpen={settingsOpen}
+            settingsAnchor={settingsAnchor}
             filesOpen={filesOpen}
             galleryOpen={galleryOpen}
+            galleryAnchor={galleryAnchor}
             wizardOpen={wizardOpen}
             peekPromptData={peekPromptData}
             deleteDialogMessageId={deleteDialogMessageId}
@@ -2018,15 +2066,15 @@ export function ChatArea() {
             onSwitchChat={chat?.connectedChatId ? () => setActiveChatId(chat.connectedChatId!) : undefined}
             onConcludeScene={chatMeta.sceneStatus === "active" ? () => concludeScene(activeChatId) : undefined}
             onAbandonScene={chatMeta.sceneStatus === "active" ? () => abandonScene(activeChatId) : undefined}
-            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenSettings={handleOpenSettingsPanel}
             onOpenFiles={() => setFilesOpen(true)}
-            onOpenGallery={() => setGalleryOpen(true)}
-            onCloseSettings={() => setSettingsOpen(false)}
+            onOpenGallery={handleOpenGalleryPanel}
+            onCloseSettings={handleCloseSettingsPanel}
             onCloseFiles={() => setFilesOpen(false)}
-            onCloseGallery={() => setGalleryOpen(false)}
+            onCloseGallery={handleCloseGalleryPanel}
             onWizardFinish={() => {
               setWizardOpen(false);
-              setSettingsOpen(true);
+              handleOpenSettingsPanel();
             }}
             onClosePeekPrompt={() => setPeekPromptData(null)}
             onResetSpritePlacements={handleResetSpritePlacements}
@@ -2103,8 +2151,10 @@ export function ChatArea() {
           totalMessageCount={totalMessageCount}
           lastAssistantMessageId={lastAssistantMessageId}
           settingsOpen={settingsOpen}
+          settingsAnchor={settingsAnchor}
           filesOpen={filesOpen}
           galleryOpen={galleryOpen}
+          galleryAnchor={galleryAnchor}
           wizardOpen={wizardOpen}
           peekPromptData={peekPromptData}
           deleteDialogMessageId={deleteDialogMessageId}
@@ -2136,15 +2186,15 @@ export function ChatArea() {
           onAbandonScene={() => abandonScene(activeChatId)}
           onForkScene={forkScene}
           isForkingScene={isForking || isStreaming}
-          onOpenSettings={() => setSettingsOpen(true)}
-          onOpenGallery={() => setGalleryOpen(true)}
-          onCloseSettings={() => setSettingsOpen(false)}
+          onOpenSettings={handleOpenSettingsPanel}
+          onOpenGallery={handleOpenGalleryPanel}
+          onCloseSettings={handleCloseSettingsPanel}
           onCloseFiles={() => setFilesOpen(false)}
-          onCloseGallery={() => setGalleryOpen(false)}
+          onCloseGallery={handleCloseGalleryPanel}
           onIllustrate={() => retryAgents(activeChatId, ["illustrator"])}
           onWizardFinish={() => {
             setWizardOpen(false);
-            setSettingsOpen(true);
+            handleOpenSettingsPanel();
           }}
           onClosePeekPrompt={() => setPeekPromptData(null)}
           onResetSpritePlacements={handleResetSpritePlacements}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -71,7 +71,7 @@ export type { CharacterMap };
 
 const BUILT_IN_AGENT_ID_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const BUILT_IN_TRACKER_AGENT_ID_SET = new Set(
-  BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker").map((agent) => agent.id),
+  BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker" && !agent.libraryHidden).map((agent) => agent.id),
 );
 
 const normalizeSpriteDisplayValue = (value: unknown, fallback: number, min: number, max: number): number => {

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -1,6 +1,17 @@
 import { createPortal } from "react-dom";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
-import { Check, ChevronDown, Download, FileText, GitBranch, Loader2, MessageSquare, Pencil, Trash2, Upload } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Download,
+  FileText,
+  GitBranch,
+  Loader2,
+  MessageSquare,
+  Pencil,
+  Trash2,
+  Upload,
+} from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -144,7 +155,8 @@ export function ChatBranchSelector({
     ) {
       return;
     }
-    const nextActiveChatId = branchId === activeChatId ? displayBranches.find((branch) => branch.id !== branchId)?.id : null;
+    const nextActiveChatId =
+      branchId === activeChatId ? displayBranches.find((branch) => branch.id !== branchId)?.id : null;
     try {
       await deleteChat.mutateAsync({ id: branchId, groupId: groupId ?? null });
       if (nextActiveChatId) setActiveChatId(nextActiveChatId);
@@ -205,11 +217,8 @@ export function ChatBranchSelector({
   const branchLabel = currentBranch?.name ?? activeChatName ?? "Current branch";
   const roleplayMinimal = variant === "roleplay" && !compact;
   const buttonClassName =
-    variant === "roleplay"
-      ? "border border-foreground/10 bg-foreground/5 text-foreground/80 hover:bg-foreground/10 hover:text-foreground"
-      : "bg-black/30 text-foreground/90 hover:bg-black/50";
-  const badgeClassName =
-    variant === "roleplay" ? "bg-foreground/10 text-foreground/60" : "bg-black/30 text-foreground/60";
+    "marinara-chat-toolbar-button border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
+  const badgeClassName = "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-muted)]";
 
   return (
     <>
@@ -226,8 +235,10 @@ export function ChatBranchSelector({
             ? "relative flex h-8 w-8 items-center justify-center rounded-lg backdrop-blur-sm transition-colors"
             : roleplayMinimal
               ? "flex h-8 min-w-14 items-center gap-1.5 rounded-lg px-2 py-1 text-left backdrop-blur-sm transition-colors"
-            : "flex max-w-[min(15rem,calc(100vw-9rem))] items-center gap-2 rounded-lg px-2.5 py-1.5 text-left backdrop-blur-sm transition-colors",
+              : "flex max-w-[min(15rem,calc(100vw-9rem))] items-center gap-2 rounded-lg px-2.5 py-1.5 text-left backdrop-blur-sm transition-colors",
           buttonClassName,
+          open &&
+            "marinara-chat-toolbar-button--active border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]",
           className,
         )}
         title="Switch branch"
@@ -278,9 +289,7 @@ export function ChatBranchSelector({
                 <GitBranch size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
                 Chat Branches
               </div>
-              <div className={ROLEPLAY_POPOVER_SUBTITLE}>
-                Switch, import, export, or clean up this chat's branches.
-              </div>
+              <div className={ROLEPLAY_POPOVER_SUBTITLE}>Switch, import, export, or clean up this chat's branches.</div>
             </div>
 
             <div className="border-b border-[var(--border)] p-2">
@@ -316,7 +325,9 @@ export function ChatBranchSelector({
               </div>
             </div>
 
-            <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "max-h-[min(22rem,calc(100vh-12rem))] overflow-y-auto p-2")}>
+            <div
+              className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "max-h-[min(22rem,calc(100vh-12rem))] overflow-y-auto p-2")}
+            >
               {displayBranches.map((branch) => {
                 const isActive = branch.id === activeChatId;
                 const updatedAt = new Date(branch.updatedAt).toLocaleString(undefined, {
@@ -342,21 +353,21 @@ export function ChatBranchSelector({
                       }}
                       className="flex min-w-0 flex-1 items-center gap-3 text-left"
                     >
-                    <div
-                      className={cn(
-                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl",
-                        isActive
-                          ? "bg-[var(--foreground)]/15 text-[var(--foreground)]"
-                          : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
-                      )}
-                    >
-                      {isActive ? <Check size="0.875rem" /> : <MessageSquare size="0.875rem" />}
-                    </div>
+                      <div
+                        className={cn(
+                          "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl",
+                          isActive
+                            ? "bg-[var(--foreground)]/15 text-[var(--foreground)]"
+                            : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
+                        )}
+                      >
+                        {isActive ? <Check size="0.875rem" /> : <MessageSquare size="0.875rem" />}
+                      </div>
 
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium">{getChatDisplayName(branch)}</div>
-                      <div className="text-[0.6875rem] text-[var(--muted-foreground)]">Updated {updatedAt}</div>
-                    </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium">{getChatDisplayName(branch)}</div>
+                        <div className="text-[0.6875rem] text-[var(--muted-foreground)]">Updated {updatedAt}</div>
+                      </div>
                     </button>
 
                     {isActive && (

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -1,7 +1,18 @@
 import { createPortal } from "react-dom";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, GitBranch, Loader2, MessageSquare } from "lucide-react";
-import { useChatGroup } from "../../hooks/use-chats";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { Check, ChevronDown, Download, FileText, GitBranch, Loader2, MessageSquare, Pencil, Trash2, Upload } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  chatKeys,
+  useChatGroup,
+  useDeleteChat,
+  useDeleteChatGroup,
+  useExportChat,
+  useUpdateChatMetadata,
+} from "../../hooks/use-chats";
+import { showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
+import { getChatDisplayName } from "../../lib/chat-display";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
 import {
@@ -10,6 +21,12 @@ import {
   ROLEPLAY_POPOVER_SUBTITLE,
   ROLEPLAY_POPOVER_TITLE,
 } from "./roleplay-popover-styles";
+
+type BranchRow = {
+  id: string;
+  name: string;
+  updatedAt: string;
+};
 
 interface ChatBranchSelectorProps {
   activeChatId: string | null;
@@ -30,9 +47,16 @@ export function ChatBranchSelector({
 }: ChatBranchSelectorProps) {
   const { data: groupChats, isLoading } = useChatGroup(groupId ?? null);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const exportChat = useExportChat();
+  const deleteChat = useDeleteChat();
+  const deleteChatGroup = useDeleteChatGroup();
+  const updateMetadata = useUpdateChatMetadata();
+  const qc = useQueryClient();
   const [open, setOpen] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
   const [position, setPosition] = useState<{ top: number; left: number; width: number }>({
     top: 0,
     left: 0,
@@ -49,12 +73,90 @@ export function ChatBranchSelector({
     return rows;
   }, [activeChatId, groupChats]);
 
+  const displayBranches = useMemo<BranchRow[]>(() => {
+    if (branches.length > 0) return branches;
+    if (!activeChatId) return [];
+    return [
+      {
+        id: activeChatId,
+        name: activeChatName || "Current branch",
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+  }, [activeChatId, activeChatName, branches]);
+
   const currentBranch = branches.find((chat) => chat.id === activeChatId);
+  const branchCount = isLoading ? branches.length : displayBranches.length;
+
+  const handleImportChat = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || !activeChatId) return;
+    event.target.value = "";
+
+    setIsImporting(true);
+    try {
+      const formData = new FormData();
+      formData.append("chatId", activeChatId);
+      formData.append("file", file);
+      const res = await fetch("/api/import/st-chat-into-group", { method: "POST", body: formData });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data?.success === false || data?.error) {
+        toast.error(`Import failed: ${data?.error ?? res.statusText ?? "Unknown error"}`);
+        return;
+      }
+      toast.success(`Imported ${data.messagesImported ?? 0} messages as a new branch`);
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+      await qc.invalidateQueries({ queryKey: chatKeys.detail(activeChatId) });
+      const newGroupId = data.groupId ?? groupId;
+      if (newGroupId) {
+        await qc.invalidateQueries({ queryKey: chatKeys.group(newGroupId) });
+      }
+      if (data.chatId) setActiveChatId(data.chatId);
+    } catch (err) {
+      toast.error(err instanceof Error ? `Import failed: ${err.message}` : "Import failed.");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  const handleRenameBranch = async (branch: BranchRow) => {
+    const nextName = await showPromptDialog({
+      title: "Rename Branch",
+      message: "Set a display name for this chat branch.",
+      defaultValue: getChatDisplayName(branch),
+      placeholder: "Branch name",
+      confirmLabel: "Rename",
+    });
+    if (nextName === null) return;
+    const trimmed = nextName.trim();
+    if (!trimmed || trimmed === getChatDisplayName(branch)) return;
+    await updateMetadata.mutateAsync({ id: branch.id, branchName: trimmed });
+  };
+
+  const handleDeleteBranch = async (branchId: string) => {
+    if (
+      !(await showConfirmDialog({
+        title: "Delete Branch",
+        message: "Delete this branch? Messages will be lost.",
+        confirmLabel: "Delete",
+        tone: "destructive",
+      }))
+    ) {
+      return;
+    }
+    const nextActiveChatId = branchId === activeChatId ? displayBranches.find((branch) => branch.id !== branchId)?.id : null;
+    try {
+      await deleteChat.mutateAsync({ id: branchId, groupId: groupId ?? null });
+      if (nextActiveChatId) setActiveChatId(nextActiveChatId);
+    } catch (err) {
+      toast.error(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed.");
+    }
+  };
 
   useLayoutEffect(() => {
     if (!open || !buttonRef.current) return;
     const rect = buttonRef.current.getBoundingClientRect();
-    const width = Math.max(rect.width, 280);
+    const width = Math.max(rect.width, 360);
     const viewportPadding = 12;
     const maxLeft = Math.max(viewportPadding, window.innerWidth - width - viewportPadding);
     setPosition({
@@ -62,7 +164,7 @@ export function ChatBranchSelector({
       left: Math.max(viewportPadding, Math.min(rect.right - width, maxLeft)),
       width,
     });
-  }, [branches.length, open]);
+  }, [displayBranches.length, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -97,8 +199,8 @@ export function ChatBranchSelector({
     };
   }, [open]);
 
-  if (!groupId) return null;
-  if (!isLoading && branches.length <= 1) return null;
+  if (!activeChatId) return null;
+  if (variant !== "roleplay" && (!groupId || (!isLoading && branches.length <= 1))) return null;
 
   const branchLabel = currentBranch?.name ?? activeChatName ?? "Current branch";
   const roleplayMinimal = variant === "roleplay" && !compact;
@@ -118,7 +220,7 @@ export function ChatBranchSelector({
           if (compact) event.stopPropagation();
           setOpen((value) => !value);
         }}
-        aria-label={isLoading ? "Switch branch" : `Switch branch (${branches.length} branches)`}
+        aria-label={isLoading ? "Switch branch" : `Switch branch (${branchCount} branches)`}
         className={cn(
           compact
             ? "relative flex h-8 w-8 items-center justify-center rounded-lg backdrop-blur-sm transition-colors"
@@ -138,7 +240,7 @@ export function ChatBranchSelector({
               badgeClassName,
             )}
           >
-            {isLoading ? <Loader2 size="0.5625rem" className="mt-0.5 animate-spin" /> : branches.length}
+            {isLoading ? <Loader2 size="0.5625rem" className="mt-0.5 animate-spin" /> : branchCount}
           </span>
         ) : roleplayMinimal ? (
           <>
@@ -148,7 +250,7 @@ export function ChatBranchSelector({
                 badgeClassName,
               )}
             >
-              {isLoading ? <Loader2 size="0.6875rem" className="animate-spin" /> : branches.length}
+              {isLoading ? <Loader2 size="0.6875rem" className="animate-spin" /> : branchCount}
             </span>
             <ChevronDown size="0.75rem" className={cn("shrink-0 transition-transform", open && "rotate-180")} />
           </>
@@ -156,7 +258,7 @@ export function ChatBranchSelector({
           <>
             <span className="min-w-0 flex-1 truncate text-[0.75rem] font-medium">{branchLabel}</span>
             <span className={cn("shrink-0 rounded-full px-1.5 py-0.5 text-[0.625rem] font-medium", badgeClassName)}>
-              {isLoading ? <Loader2 size="0.6875rem" className="animate-spin" /> : branches.length}
+              {isLoading ? <Loader2 size="0.6875rem" className="animate-spin" /> : branchCount}
             </span>
             <ChevronDown size="0.75rem" className={cn("shrink-0 transition-transform", open && "rotate-180")} />
           </>
@@ -177,12 +279,45 @@ export function ChatBranchSelector({
                 Chat Branches
               </div>
               <div className={ROLEPLAY_POPOVER_SUBTITLE}>
-                Switch branches without opening Manage Chat Files.
+                Switch, import, export, or clean up this chat's branches.
               </div>
             </div>
 
-            <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "max-h-[min(22rem,calc(100vh-8rem))] overflow-y-auto p-2")}>
-              {branches.map((branch) => {
+            <div className="border-b border-[var(--border)] p-2">
+              <input ref={importInputRef} type="file" accept=".jsonl" onChange={handleImportChat} className="hidden" />
+              <div className="grid grid-cols-3 gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => exportChat.mutate({ chatId: activeChatId, format: "jsonl" })}
+                  disabled={exportChat.isPending}
+                  className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2 py-2 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+                >
+                  <Upload size="0.75rem" />
+                  JSONL
+                </button>
+                <button
+                  type="button"
+                  onClick={() => exportChat.mutate({ chatId: activeChatId, format: "text" })}
+                  disabled={exportChat.isPending}
+                  className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2 py-2 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+                >
+                  <FileText size="0.75rem" />
+                  Text
+                </button>
+                <button
+                  type="button"
+                  onClick={() => importInputRef.current?.click()}
+                  disabled={isImporting}
+                  className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2 py-2 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+                >
+                  <Download size="0.75rem" />
+                  {isImporting ? "..." : "Import"}
+                </button>
+              </div>
+            </div>
+
+            <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "max-h-[min(22rem,calc(100vh-12rem))] overflow-y-auto p-2")}>
+              {displayBranches.map((branch) => {
                 const isActive = branch.id === activeChatId;
                 const updatedAt = new Date(branch.updatedAt).toLocaleString(undefined, {
                   month: "short",
@@ -192,18 +327,21 @@ export function ChatBranchSelector({
                 });
 
                 return (
-                  <button
+                  <div
                     key={branch.id}
-                    type="button"
-                    onClick={() => {
-                      setActiveChatId(branch.id);
-                      setOpen(false);
-                    }}
                     className={cn(
                       "flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition-colors",
                       isActive ? "bg-[var(--accent)]/70 text-[var(--foreground)]" : "hover:bg-[var(--accent)]/45",
                     )}
                   >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setActiveChatId(branch.id);
+                        setOpen(false);
+                      }}
+                      className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                    >
                     <div
                       className={cn(
                         "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl",
@@ -216,19 +354,68 @@ export function ChatBranchSelector({
                     </div>
 
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium">{branch.name}</div>
+                      <div className="truncate text-sm font-medium">{getChatDisplayName(branch)}</div>
                       <div className="text-[0.6875rem] text-[var(--muted-foreground)]">Updated {updatedAt}</div>
                     </div>
+                    </button>
 
                     {isActive && (
                       <span className="shrink-0 rounded-full bg-[var(--foreground)]/10 px-2 py-0.5 text-[0.625rem] font-medium text-[var(--foreground)]/75">
                         Active
                       </span>
                     )}
-                  </button>
+                    {!isActive && (
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => void handleRenameBranch(branch)}
+                          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                          title="Rename branch"
+                        >
+                          <Pencil size="0.75rem" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleDeleteBranch(branch.id)}
+                          disabled={deleteChat.isPending}
+                          className="rounded-lg p-1.5 text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 disabled:opacity-50"
+                          title="Delete branch"
+                        >
+                          <Trash2 size="0.75rem" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 );
               })}
             </div>
+            {groupId && displayBranches.length > 1 && (
+              <div className="border-t border-[var(--border)] p-2">
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (
+                      !(await showConfirmDialog({
+                        title: "Delete All Branches",
+                        message: `Delete all ${displayBranches.length} branches? This cannot be undone.`,
+                        confirmLabel: "Delete All",
+                        tone: "destructive",
+                      }))
+                    ) {
+                      return;
+                    }
+                    deleteChatGroup.mutate(groupId);
+                    setActiveChatId(null);
+                    setOpen(false);
+                  }}
+                  disabled={deleteChatGroup.isPending}
+                  className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-2 text-[0.6875rem] font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-colors hover:bg-[var(--destructive)]/20 disabled:opacity-50"
+                >
+                  <Trash2 size="0.75rem" />
+                  Delete All Branches
+                </button>
+              </div>
+            )}
           </div>,
           document.body,
         )}

--- a/packages/client/src/components/chat/ChatCommonOverlays.tsx
+++ b/packages/client/src/components/chat/ChatCommonOverlays.tsx
@@ -30,6 +30,7 @@ const PeekPromptModal = lazy(async () => {
 });
 
 type ChatData = ComponentProps<typeof ChatSettingsDrawer>["chat"];
+export type ChatFloatingPanelAnchor = { right: number; top: number } | null;
 
 type SharedSceneSettingsProps = {
   spriteArrangeMode: boolean;
@@ -176,8 +177,10 @@ type ChatCommonOverlaysProps = {
   chat: ChatData | null | undefined;
   activeChatId: string;
   settingsOpen: boolean;
+  settingsAnchor: ChatFloatingPanelAnchor;
   filesOpen: boolean;
   galleryOpen: boolean;
+  galleryAnchor: ChatFloatingPanelAnchor;
   wizardOpen: boolean;
   peekPromptData: PeekPromptData | null;
   deleteDialogMessageId: string | null;
@@ -209,8 +212,10 @@ export function ChatCommonOverlays({
   chat,
   activeChatId,
   settingsOpen,
+  settingsAnchor,
   filesOpen,
   galleryOpen,
+  galleryAnchor,
   wizardOpen,
   peekPromptData,
   deleteDialogMessageId,
@@ -245,6 +250,7 @@ export function ChatCommonOverlays({
               chat={chat}
               open={settingsOpen}
               onClose={onCloseSettings}
+              anchor={settingsAnchor}
               spriteArrangeMode={sceneSettings.spriteArrangeMode}
               onToggleSpriteArrange={sceneSettings.onToggleSpriteArrange}
               onResetSpritePlacements={sceneSettings.onResetSpritePlacements}
@@ -261,7 +267,13 @@ export function ChatCommonOverlays({
       {chat && (
         <Suspense fallback={null}>
           {galleryOpen && (
-            <ChatGalleryDrawer chat={chat} open={galleryOpen} onClose={onCloseGallery} onIllustrate={onIllustrate} />
+            <ChatGalleryDrawer
+              chat={chat}
+              open={galleryOpen}
+              onClose={onCloseGallery}
+              anchor={galleryAnchor}
+              onIllustrate={onIllustrate}
+            />
           )}
         </Suspense>
       )}

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -36,7 +36,6 @@ type ConversationSurfaceProps = {
   sceneInfo?: SceneInfo;
   settingsOpen: boolean;
   settingsAnchor: ComponentProps<typeof ChatCommonOverlays>["settingsAnchor"];
-  filesOpen: boolean;
   galleryOpen: boolean;
   galleryAnchor: ComponentProps<typeof ChatCommonOverlays>["galleryAnchor"];
   wizardOpen: boolean;
@@ -54,15 +53,14 @@ type ConversationSurfaceProps = {
   onSetActiveSwipe: (messageId: string, index: number) => void;
   onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
+  onBranch?: (messageId: string) => void;
   onToggleSelectMessage: (toggle: MessageSelectionToggle) => void;
   onSwitchChat?: () => void;
   onConcludeScene?: () => void;
   onAbandonScene?: () => void;
   onOpenSettings: ComponentProps<typeof ConversationView>["onOpenSettings"];
-  onOpenFiles: () => void;
   onOpenGallery: ComponentProps<typeof ConversationView>["onOpenGallery"];
   onCloseSettings: () => void;
-  onCloseFiles: () => void;
   onCloseGallery: () => void;
   onIllustrate?: () => void;
   onWizardFinish: () => void;
@@ -101,7 +99,6 @@ export function ChatConversationSurface({
   sceneInfo,
   settingsOpen,
   settingsAnchor,
-  filesOpen,
   galleryOpen,
   galleryAnchor,
   wizardOpen,
@@ -119,15 +116,14 @@ export function ChatConversationSurface({
   onSetActiveSwipe,
   onToggleHiddenFromAI,
   onPeekPrompt,
+  onBranch,
   onToggleSelectMessage,
   onSwitchChat,
   onConcludeScene,
   onAbandonScene,
   onOpenSettings,
-  onOpenFiles,
   onOpenGallery,
   onCloseSettings,
-  onCloseFiles,
   onCloseGallery,
   onIllustrate,
   onWizardFinish,
@@ -173,8 +169,8 @@ export function ChatConversationSurface({
           onPeekPrompt={onPeekPrompt}
           lastAssistantMessageId={lastAssistantMessageId}
           onOpenSettings={onOpenSettings}
-          onOpenFiles={onOpenFiles}
           onOpenGallery={onOpenGallery}
+          onBranch={onBranch}
           multiSelectMode={multiSelectMode}
           selectedMessageIds={selectedMessageIds}
           onToggleSelectMessage={onToggleSelectMessage}
@@ -191,7 +187,7 @@ export function ChatConversationSurface({
         activeChatId={activeChatId}
         settingsOpen={settingsOpen}
         settingsAnchor={settingsAnchor}
-        filesOpen={filesOpen}
+        filesOpen={false}
         galleryOpen={galleryOpen}
         galleryAnchor={galleryAnchor}
         wizardOpen={wizardOpen}
@@ -209,7 +205,7 @@ export function ChatConversationSurface({
           onSpriteSideChange,
         }}
         onCloseSettings={onCloseSettings}
-        onCloseFiles={onCloseFiles}
+        onCloseFiles={() => undefined}
         onCloseGallery={onCloseGallery}
         onIllustrate={onIllustrate}
         onWizardFinish={onWizardFinish}

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -35,8 +35,10 @@ type ConversationSurfaceProps = {
   connectedChatName?: string;
   sceneInfo?: SceneInfo;
   settingsOpen: boolean;
+  settingsAnchor: ComponentProps<typeof ChatCommonOverlays>["settingsAnchor"];
   filesOpen: boolean;
   galleryOpen: boolean;
+  galleryAnchor: ComponentProps<typeof ChatCommonOverlays>["galleryAnchor"];
   wizardOpen: boolean;
   peekPromptData: PeekPromptData | null;
   deleteDialogMessageId: string | null;
@@ -56,9 +58,9 @@ type ConversationSurfaceProps = {
   onSwitchChat?: () => void;
   onConcludeScene?: () => void;
   onAbandonScene?: () => void;
-  onOpenSettings: () => void;
+  onOpenSettings: ComponentProps<typeof ConversationView>["onOpenSettings"];
   onOpenFiles: () => void;
-  onOpenGallery: () => void;
+  onOpenGallery: ComponentProps<typeof ConversationView>["onOpenGallery"];
   onCloseSettings: () => void;
   onCloseFiles: () => void;
   onCloseGallery: () => void;
@@ -98,8 +100,10 @@ export function ChatConversationSurface({
   connectedChatName,
   sceneInfo,
   settingsOpen,
+  settingsAnchor,
   filesOpen,
   galleryOpen,
+  galleryAnchor,
   wizardOpen,
   peekPromptData,
   deleteDialogMessageId,
@@ -186,8 +190,10 @@ export function ChatConversationSurface({
         chat={chat}
         activeChatId={activeChatId}
         settingsOpen={settingsOpen}
+        settingsAnchor={settingsAnchor}
         filesOpen={filesOpen}
         galleryOpen={galleryOpen}
+        galleryAnchor={galleryAnchor}
         wizardOpen={wizardOpen}
         peekPromptData={peekPromptData}
         deleteDialogMessageId={deleteDialogMessageId}

--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -129,7 +129,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     return (
       <>
         <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
-        <div className="absolute right-0 top-0 z-50 flex h-full w-80 max-md:w-full flex-col border-l border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:pt-[env(safe-area-inset-top)]">
+        <div className="absolute bottom-3 right-3 top-14 z-50 flex w-[min(28rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto">
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <h3 className="text-sm font-bold">Manage Chat Files</h3>
             <button
@@ -200,7 +200,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
       <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
 
       {/* Drawer */}
-      <div className="absolute right-0 top-0 z-50 flex h-full w-80 max-md:w-full flex-col border-l border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:pt-[env(safe-area-inset-top)]">
+      <div className="absolute bottom-3 right-3 top-14 z-50 flex w-[min(28rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
           <h3 className="text-sm font-bold">Manage Chat Files</h3>

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -167,7 +167,7 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
 
       {/* Delete confirmation */}
       {confirmDeleteId && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]">
+        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]">
           <div className="mx-4 rounded-xl bg-[var(--background)] p-5 shadow-2xl ring-1 ring-[var(--border)]">
             <p className="mb-4 text-sm font-medium">Delete this image?</p>
             <div className="flex gap-2">
@@ -191,7 +191,7 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
       {/* Lightbox */}
       {lightbox && (
         <div
-          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
+          className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
           onClick={() => setLightbox(null)}
         >
           <div

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -2,6 +2,7 @@
 // Chat Gallery — Image grid for per-chat generated images
 // ──────────────────────────────────────────────
 import { useCallback, useState } from "react";
+import { createPortal } from "react-dom";
 import { ImagePlus, Paintbrush, Trash2, X, Download, Sparkles, Pin, Minimize2, Loader2 } from "lucide-react";
 import {
   useGalleryImages,
@@ -39,6 +40,7 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
   const setChatIllustrating = useGalleryStore((s) => s.setChatIllustrating);
   const lightboxPrompt = lightbox?.prompt.trim() ?? "";
   const lightboxMeta = lightbox ? formatImageMeta(lightbox) : "";
+  const portalRoot = typeof document !== "undefined" ? document.body : null;
 
   const handleUpload = useCallback(
     (files: File[]) => {
@@ -68,183 +70,191 @@ export function ChatGallery({ chatId, onIllustrate }: ChatGalleryProps) {
   };
 
   return (
-    <div className="flex flex-col gap-3 p-4">
-      {/* Illustrate button */}
-      {onIllustrate && (
-        <button
-          type="button"
-          onClick={() => void handleIllustrate()}
-          disabled={isIllustrating}
-          aria-busy={isIllustrating}
-          className="flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)]/15 px-4 py-3 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25 disabled:cursor-wait disabled:opacity-75"
-        >
-          {isIllustrating ? <Loader2 size="1rem" className="animate-spin" /> : <Paintbrush size="1rem" />}
-          {isIllustrating ? "Generating image..." : "Illustrate"}
-        </button>
-      )}
+    <>
+      <div className="flex flex-col gap-3 p-4">
+        {/* Illustrate button */}
+        {onIllustrate && (
+          <button
+            type="button"
+            onClick={() => void handleIllustrate()}
+            disabled={isIllustrating}
+            aria-busy={isIllustrating}
+            className="flex items-center justify-center gap-2 rounded-xl bg-[var(--primary)]/15 px-4 py-3 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25 disabled:cursor-wait disabled:opacity-75"
+          >
+            {isIllustrating ? <Loader2 size="1rem" className="animate-spin" /> : <Paintbrush size="1rem" />}
+            {isIllustrating ? "Generating image..." : "Illustrate"}
+          </button>
+        )}
 
-      {isIllustrating && (
-        <div
-          className="rounded-xl border border-[var(--primary)]/25 bg-[var(--primary)]/10 px-3 py-2 text-xs text-[var(--primary)]"
-          role="status"
-          aria-live="polite"
-        >
-          AI image generation is running. The new image will appear here when it finishes.
-        </div>
-      )}
+        {isIllustrating && (
+          <div
+            className="rounded-xl border border-[var(--primary)]/25 bg-[var(--primary)]/10 px-3 py-2 text-xs text-[var(--primary)]"
+            role="status"
+            aria-live="polite"
+          >
+            AI image generation is running. The new image will appear here when it finishes.
+          </div>
+        )}
 
-      <ImageUploadDropzone
-        label="Upload Images"
-        pending={upload.isPending}
-        pendingLabel="Uploading…"
-        dragLabel="Drop images to upload"
-        onFilesSelected={handleUpload}
-        icon={<ImagePlus size="1rem" />}
-      />
+        <ImageUploadDropzone
+          label="Upload Images"
+          pending={upload.isPending}
+          pendingLabel="Uploading…"
+          dragLabel="Drop images to upload"
+          onFilesSelected={handleUpload}
+          icon={<ImagePlus size="1rem" />}
+        />
 
-      {/* Loading state */}
-      {isLoading && <p className="text-center text-xs text-[var(--muted-foreground)]">Loading gallery…</p>}
+        {/* Loading state */}
+        {isLoading && <p className="text-center text-xs text-[var(--muted-foreground)]">Loading gallery…</p>}
 
-      {/* Empty state */}
-      {!isLoading && (!images || images.length === 0) && (
-        <div className="flex flex-col items-center gap-2 py-8 text-[var(--muted-foreground)]">
-          <Sparkles size="1.5rem" className="opacity-40" />
-          <p className="text-xs">No images yet</p>
-          <p className="text-[0.625rem] opacity-60">Upload images or generate them to build your gallery</p>
-        </div>
-      )}
+        {/* Empty state */}
+        {!isLoading && (!images || images.length === 0) && (
+          <div className="flex flex-col items-center gap-2 py-8 text-[var(--muted-foreground)]">
+            <Sparkles size="1.5rem" className="opacity-40" />
+            <p className="text-xs">No images yet</p>
+            <p className="text-[0.625rem] opacity-60">Upload images or generate them to build your gallery</p>
+          </div>
+        )}
 
-      {/* Image grid */}
-      {images && images.length > 0 && (
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-2">
-          {images.map((img) => (
-            <div
-              key={img.id}
-              className="group relative overflow-hidden rounded-lg bg-[var(--secondary)] ring-1 ring-transparent transition-all hover:ring-[var(--primary)]/40 hover:shadow-lg focus-within:ring-2 focus-within:ring-[var(--primary)]"
-            >
-              <button
-                type="button"
-                onClick={() => setLightbox(img)}
-                className="block w-full"
-                aria-label="Open gallery image"
+        {/* Image grid */}
+        {images && images.length > 0 && (
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-2">
+            {images.map((img) => (
+              <div
+                key={img.id}
+                className="group relative overflow-hidden rounded-lg bg-[var(--secondary)] ring-1 ring-transparent transition-all hover:ring-[var(--primary)]/40 hover:shadow-lg focus-within:ring-2 focus-within:ring-[var(--primary)]"
               >
-                <img
-                  src={img.url}
-                  alt={img.prompt || "Gallery image"}
-                  loading="lazy"
-                  decoding="async"
-                  className="aspect-square w-full object-cover transition-transform group-hover:scale-105"
-                />
-              </button>
-              {/* Overlay */}
-              <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-                <div className="flex w-full items-center justify-between p-2">
-                  <div className="flex gap-1">
+                <button
+                  type="button"
+                  onClick={() => setLightbox(img)}
+                  className="block w-full"
+                  aria-label="Open gallery image"
+                >
+                  <img
+                    src={img.url}
+                    alt={img.prompt || "Gallery image"}
+                    loading="lazy"
+                    decoding="async"
+                    className="aspect-square w-full object-cover transition-transform group-hover:scale-105"
+                  />
+                </button>
+                {/* Overlay */}
+                <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                  <div className="flex w-full items-center justify-between p-2">
+                    <div className="flex gap-1">
+                      <button
+                        type="button"
+                        onClick={() => pinImage(img)}
+                        aria-label="Pin image to chat"
+                        className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
+                        title="Pin to chat"
+                      >
+                        <Pin size="0.75rem" />
+                      </button>
+                    </div>
                     <button
                       type="button"
-                      onClick={() => pinImage(img)}
-                      aria-label="Pin image to chat"
-                      className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
-                      title="Pin to chat"
+                      onClick={() => setConfirmDeleteId(img.id)}
+                      aria-label="Delete gallery image"
+                      className="pointer-events-auto rounded-md bg-red-500/40 p-1.5 text-white transition-colors hover:bg-red-500/60"
                     >
-                      <Pin size="0.75rem" />
+                      <Trash2 size="0.75rem" />
                     </button>
                   </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Delete confirmation */}
+      {portalRoot &&
+        confirmDeleteId &&
+        createPortal(
+          <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]">
+            <div className="mx-4 rounded-xl bg-[var(--background)] p-5 shadow-2xl ring-1 ring-[var(--border)]">
+              <p className="mb-4 text-sm font-medium">Delete this image?</p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setConfirmDeleteId(null)}
+                  className="flex-1 rounded-lg bg-[var(--secondary)] px-4 py-2 text-xs transition-colors hover:bg-[var(--accent)]"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => handleDelete(confirmDeleteId)}
+                  className="flex-1 rounded-lg bg-red-500/20 px-4 py-2 text-xs text-red-400 transition-colors hover:bg-red-500/30"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          </div>,
+          portalRoot,
+        )}
+
+      {/* Lightbox */}
+      {portalRoot &&
+        lightbox &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
+            onClick={() => setLightbox(null)}
+          >
+            <div
+              className="flex max-h-[90vh] w-[min(90vw,64rem)] max-w-[90vw] flex-col items-center gap-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="relative flex min-h-0 max-w-full justify-center">
+                <img
+                  src={lightbox.url}
+                  alt={lightbox.prompt || "Gallery image"}
+                  decoding="async"
+                  className={
+                    lightboxPrompt || lightboxMeta
+                      ? "max-h-[calc(90vh-10rem)] max-w-full rounded-lg object-contain shadow-2xl"
+                      : "max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
+                  }
+                />
+                {/* Controls */}
+                <div className="absolute right-2 top-2 flex gap-2">
                   <button
                     type="button"
-                    onClick={() => setConfirmDeleteId(img.id)}
-                    aria-label="Delete gallery image"
-                    className="pointer-events-auto rounded-md bg-red-500/40 p-1.5 text-white transition-colors hover:bg-red-500/60"
+                    onClick={() => {
+                      pinImage(lightbox);
+                      setLightbox(null);
+                    }}
+                    aria-label="Pin image to chat"
+                    className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+                    title="Pin to chat"
                   >
-                    <Trash2 size="0.75rem" />
+                    <Minimize2 size="0.875rem" />
+                  </button>
+                  <a
+                    href={lightbox.url}
+                    download
+                    aria-label="Download image"
+                    className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+                  >
+                    <Download size="0.875rem" />
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => setLightbox(null)}
+                    aria-label="Close image"
+                    className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
+                  >
+                    <X size="0.875rem" />
                   </button>
                 </div>
               </div>
+              <ImagePromptPanel prompt={lightboxPrompt} meta={lightboxMeta} className="w-full max-w-3xl" />
             </div>
-          ))}
-        </div>
-      )}
-
-      {/* Delete confirmation */}
-      {confirmDeleteId && (
-        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]">
-          <div className="mx-4 rounded-xl bg-[var(--background)] p-5 shadow-2xl ring-1 ring-[var(--border)]">
-            <p className="mb-4 text-sm font-medium">Delete this image?</p>
-            <div className="flex gap-2">
-              <button
-                onClick={() => setConfirmDeleteId(null)}
-                className="flex-1 rounded-lg bg-[var(--secondary)] px-4 py-2 text-xs transition-colors hover:bg-[var(--accent)]"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => handleDelete(confirmDeleteId)}
-                className="flex-1 rounded-lg bg-red-500/20 px-4 py-2 text-xs text-red-400 transition-colors hover:bg-red-500/30"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Lightbox */}
-      {lightbox && (
-        <div
-          className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
-          onClick={() => setLightbox(null)}
-        >
-          <div
-            className="flex max-h-[90vh] w-[min(90vw,64rem)] max-w-[90vw] flex-col items-center gap-2"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="relative flex min-h-0 max-w-full justify-center">
-              <img
-                src={lightbox.url}
-                alt={lightbox.prompt || "Gallery image"}
-                decoding="async"
-                className={
-                  lightboxPrompt || lightboxMeta
-                    ? "max-h-[calc(90vh-10rem)] max-w-full rounded-lg object-contain shadow-2xl"
-                    : "max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl"
-                }
-              />
-              {/* Controls */}
-              <div className="absolute right-2 top-2 flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    pinImage(lightbox);
-                    setLightbox(null);
-                  }}
-                  aria-label="Pin image to chat"
-                  className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-                  title="Pin to chat"
-                >
-                  <Minimize2 size="0.875rem" />
-                </button>
-                <a
-                  href={lightbox.url}
-                  download
-                  aria-label="Download image"
-                  className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-                >
-                  <Download size="0.875rem" />
-                </a>
-                <button
-                  type="button"
-                  onClick={() => setLightbox(null)}
-                  aria-label="Close image"
-                  className="rounded-lg bg-black/60 p-2 text-white transition-colors hover:bg-black/80"
-                >
-                  <X size="0.875rem" />
-                </button>
-              </div>
-            </div>
-            <ImagePromptPanel prompt={lightboxPrompt} meta={lightboxMeta} className="w-full max-w-3xl" />
-          </div>
-        </div>
-      )}
-    </div>
+          </div>,
+          portalRoot,
+        )}
+    </>
   );
 }

--- a/packages/client/src/components/chat/ChatGalleryDrawer.tsx
+++ b/packages/client/src/components/chat/ChatGalleryDrawer.tsx
@@ -21,15 +21,15 @@ export function ChatGalleryDrawer({ chat, open, onClose, onIllustrate }: ChatGal
       {/* Backdrop */}
       <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
 
-      {/* Drawer */}
-      <div className="absolute right-0 top-0 z-50 flex h-full w-80 max-md:w-full flex-col border-l border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:pt-[env(safe-area-inset-top)]">
+      {/* Floating panel */}
+      <div className="absolute bottom-3 right-3 top-14 z-50 flex w-[min(44rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
           <h3 className="text-sm font-bold">Gallery</h3>
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close gallery drawer"
+            aria-label="Close gallery"
             className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
           >
             <X size="1rem" />

--- a/packages/client/src/components/chat/ChatGalleryDrawer.tsx
+++ b/packages/client/src/components/chat/ChatGalleryDrawer.tsx
@@ -1,31 +1,52 @@
 // ──────────────────────────────────────────────
 // Chat: Gallery Drawer — per-chat image gallery
 // ──────────────────────────────────────────────
-import { X } from "lucide-react";
+import { Image, X } from "lucide-react";
+import type { CSSProperties } from "react";
+import { cn } from "../../lib/utils";
 import { ChatGallery } from "./ChatGallery";
+import {
+  ROLEPLAY_POPOVER_HEADER,
+  ROLEPLAY_POPOVER_SCROLL_AREA,
+  ROLEPLAY_POPOVER_SHELL,
+  ROLEPLAY_POPOVER_TITLE,
+} from "./roleplay-popover-styles";
 import type { Chat } from "@marinara-engine/shared";
 
 interface ChatGalleryDrawerProps {
   chat: Chat;
   open: boolean;
   onClose: () => void;
+  anchor?: { right: number; top: number } | null;
   /** Manually trigger the Illustrator agent */
   onIllustrate?: () => void | Promise<void>;
 }
 
-export function ChatGalleryDrawer({ chat, open, onClose, onIllustrate }: ChatGalleryDrawerProps) {
+export function ChatGalleryDrawer({ chat, open, onClose, anchor, onIllustrate }: ChatGalleryDrawerProps) {
   if (!open) return null;
+  const panelStyle: CSSProperties | undefined = anchor
+    ? { right: `${anchor.right}px`, top: `${anchor.top}px` }
+    : undefined;
 
   return (
     <>
-      {/* Backdrop */}
-      <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="fixed inset-0 z-[65] bg-transparent" onClick={onClose} />
 
       {/* Floating panel */}
-      <div className="absolute bottom-3 right-3 top-14 z-50 flex w-[min(44rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto">
+      <div
+        className={cn(
+          ROLEPLAY_POPOVER_SHELL,
+          "fixed bottom-3 z-[70] flex w-[min(44rem,calc(100vw-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
+          anchor ? "" : "right-3 top-14",
+        )}
+        style={panelStyle}
+      >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <h3 className="text-sm font-bold">Gallery</h3>
+        <div className={cn(ROLEPLAY_POPOVER_HEADER, "flex items-center justify-between")}>
+          <h3 className={ROLEPLAY_POPOVER_TITLE}>
+            <Image size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
+            Gallery
+          </h3>
           <button
             type="button"
             onClick={onClose}
@@ -36,7 +57,7 @@ export function ChatGalleryDrawer({ chat, open, onClose, onIllustrate }: ChatGal
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto">
+        <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "flex-1 overflow-y-auto")}>
           <ChatGallery chatId={chat.id} onIllustrate={onIllustrate} />
         </div>
       </div>

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -154,9 +154,12 @@ export const ChatInput = memo(function ChatInput({
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreamingGlobal = useChatStore((s) => s.isStreaming);
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
+  const responseQueue = useChatStore((s) => (activeChatId ? (s.responseQueues.get(activeChatId) ?? []) : []));
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
   const setCurrentInput = useChatStore((s) => s.setCurrentInput);
+  const removeFromResponseQueue = useChatStore((s) => s.removeFromResponseQueue);
+  const clearResponseQueue = useChatStore((s) => s.clearResponseQueue);
   const activeChat = useChatStore((s) => s.activeChat);
   const chatMetadata = useMemo(() => parseChatMetadata(activeChat?.metadata), [activeChat?.metadata]);
   const inactiveCharacterIds = useMemo(
@@ -175,6 +178,10 @@ export const ChatInput = memo(function ChatInput({
   const activeCharacterNames = useMemo(
     () => (activeChatCharacters ? activeChatCharacters.map((character) => character.name) : characterNames),
     [activeChatCharacters, characterNames],
+  );
+  const queuedResponseOrder = useMemo(
+    () => new Map(responseQueue.map((characterId, index) => [characterId, index + 1])),
+    [responseQueue],
   );
   const { generate } = useGenerate();
   const { applyToUserInput } = useApplyRegex();
@@ -485,6 +492,17 @@ export const ChatInput = memo(function ChatInput({
     if (!hasText && !hasFiles) {
       // Manual mode: no auto-retry/continue — use the character picker instead
       if (groupResponseOrder === "manual") return;
+      const queuedCharacterId = groupResponseOrder === "smart" ? responseQueue[0] : null;
+      if (queuedCharacterId) {
+        removeFromResponseQueue(activeChatId, queuedCharacterId);
+        try {
+          await generate({ chatId: activeChatId, connectionId: null, forCharacterId: queuedCharacterId });
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : "Generation failed";
+          toast.error(msg);
+        }
+        return;
+      }
       const cached = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(activeChatId));
       const firstPage = cached?.pages?.[0];
       const lastMsg = firstPage?.[firstPage.length - 1];
@@ -602,6 +620,7 @@ export const ChatInput = memo(function ChatInput({
     const pendingAttachments = attachments.map((a) => ({ type: a.type, data: a.data, filename: a.name, name: a.name }));
     replaceAttachments([]);
     clearInputDraft(activeChatId);
+    clearResponseQueue(activeChatId);
 
     // Manual mode: only create the user message, no auto-generation
     if (groupResponseOrder === "manual") {
@@ -649,6 +668,9 @@ export const ChatInput = memo(function ChatInput({
     isReadingAttachments,
     mode,
     groupResponseOrder,
+    responseQueue,
+    removeFromResponseQueue,
+    clearResponseQueue,
     createMessage,
     updateMessageExtra,
     syncInputState,
@@ -789,6 +811,7 @@ export const ChatInput = memo(function ChatInput({
     setCompletions([]);
     replaceAttachments([]);
     clearInputDraft(submittingChatId);
+    clearResponseQueue(submittingChatId);
 
     let createdMessageId: string | null = null;
     try {
@@ -851,6 +874,7 @@ export const ChatInput = memo(function ChatInput({
     createMessage,
     deleteMessage,
     updateMessageExtra,
+    clearResponseQueue,
     quoteFormat,
   ]);
 
@@ -1050,6 +1074,9 @@ export const ChatInput = memo(function ChatInput({
       if (!activeChatId || isStreaming) return;
       setCharPickerOpen(false);
       setCharPickerPos(null);
+      if (responseQueue.includes(characterId)) {
+        removeFromResponseQueue(activeChatId, characterId);
+      }
       const guideText = getValue();
       try {
         await generate(
@@ -1068,7 +1095,7 @@ export const ChatInput = memo(function ChatInput({
         toast.error(msg);
       }
     },
-    [activeChatId, isStreaming, generate, hasInput, guideGenerations],
+    [activeChatId, isStreaming, generate, hasInput, guideGenerations, responseQueue, removeFromResponseQueue],
   );
 
   // Close character picker on outside click
@@ -1409,29 +1436,37 @@ export const ChatInput = memo(function ChatInput({
               Trigger Response
             </div>
             <div className="overflow-y-auto p-1">
-              {activeChatCharacters!.map((char) => (
-                <button
-                  key={char.id}
-                  onClick={() => handleCharacterResponse(char.id)}
-                  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10"
-                >
-                  {char.avatarUrl ? (
-                    <span className="relative h-7 w-7 shrink-0 overflow-hidden rounded-full">
-                      <img
-                        src={char.avatarUrl}
-                        alt={char.name}
-                        className="h-full w-full object-cover"
-                        style={getAvatarCropStyle(char.avatarCrop)}
-                      />
-                    </span>
-                  ) : (
-                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
-                      {(char.name || "?")[0].toUpperCase()}
-                    </div>
-                  )}
-                  <span className="truncate text-xs">{char.name}</span>
-                </button>
-              ))}
+              {activeChatCharacters!.map((char) => {
+                const queuedOrder = queuedResponseOrder.get(char.id);
+                return (
+                  <button
+                    key={char.id}
+                    onClick={() => handleCharacterResponse(char.id)}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10"
+                  >
+                    {char.avatarUrl ? (
+                      <span className="relative h-7 w-7 shrink-0 overflow-hidden rounded-full">
+                        <img
+                          src={char.avatarUrl}
+                          alt={char.name}
+                          className="h-full w-full object-cover"
+                          style={getAvatarCropStyle(char.avatarCrop)}
+                        />
+                      </span>
+                    ) : (
+                      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
+                        {(char.name || "?")[0].toUpperCase()}
+                      </div>
+                    )}
+                    <span className="min-w-0 flex-1 truncate text-xs">{char.name}</span>
+                    {queuedOrder && (
+                      <span className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full border border-foreground/15 bg-foreground/10 px-1 text-[0.625rem] font-semibold text-foreground/70">
+                        {queuedOrder}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
           </div>,
           document.body,

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1179,7 +1179,7 @@ export const ChatInput = memo(function ChatInput({
                   : "text-foreground/70 hover:bg-foreground/5",
               )}
             >
-              <span className="shrink-0 whitespace-nowrap font-mono font-semibold text-blue-400">/{cmd.name}</span>
+              <span className="shrink-0 whitespace-nowrap font-mono font-semibold text-foreground/80">/{cmd.name}</span>
               <span className="min-w-0 flex-1 text-xs leading-snug opacity-60 [overflow-wrap:anywhere]">
                 {cmd.description}
               </span>
@@ -1197,7 +1197,7 @@ export const ChatInput = memo(function ChatInput({
           {attachments.map((att, i) => (
             <div
               key={i}
-              className="group relative flex items-center gap-1.5 rounded-lg bg-foreground/10 px-2 py-1 text-xs text-foreground/70"
+              className="group relative flex items-center gap-1.5 rounded-lg bg-foreground/10 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10"
             >
               {att.type.startsWith("image/") ? (
                 <img src={att.data} alt={att.name} className="h-8 w-8 rounded object-cover" />
@@ -1214,7 +1214,7 @@ export const ChatInput = memo(function ChatInput({
             </div>
           ))}
           {isReadingAttachments && (
-            <div className="flex items-center gap-1.5 rounded-lg bg-foreground/10 px-2 py-1 text-xs text-foreground/60">
+            <div className="flex items-center gap-1.5 rounded-lg bg-foreground/10 px-2 py-1 text-xs text-foreground/60 ring-1 ring-foreground/10">
               <Loader2 size="0.875rem" className="animate-spin" />
               Reading file...
             </div>
@@ -1229,13 +1229,13 @@ export const ChatInput = memo(function ChatInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={cn(
-          "mari-chat-input-box relative flex items-center gap-1 rounded-2xl border-2 px-2 py-1.5 transition-all duration-200 sm:gap-2 sm:px-4 sm:py-2.5",
-          "bg-[var(--card)]",
+          "mari-chat-input-box relative flex items-center gap-1 rounded-2xl border px-2 py-1.5 shadow-sm transition-all duration-200 focus-within:border-foreground/35 focus-within:ring-1 focus-within:ring-foreground/10 sm:gap-2 sm:px-4 sm:py-2.5",
+          "border-foreground/20 bg-[var(--card)]",
           isDragging
-            ? "border-blue-400/50 bg-blue-500/10 shadow-lg shadow-blue-500/10"
+            ? "border-foreground/40 bg-foreground/10 shadow-lg shadow-black/10"
             : hasInput || attachments.length
-              ? "border-blue-400/30 shadow-md shadow-blue-500/5"
-              : "border-foreground/25",
+              ? "shadow-md shadow-black/5"
+              : "",
         )}
       >
         {/* Attachment button */}
@@ -1253,7 +1253,7 @@ export const ChatInput = memo(function ChatInput({
           className={cn(
             "flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 disabled:cursor-not-allowed disabled:text-foreground/25 disabled:opacity-50 sm:h-8 sm:w-8",
             attachments.length
-              ? "bg-foreground/10 text-foreground/75"
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
           )}
           title="Attach files"
@@ -1300,7 +1300,7 @@ export const ChatInput = memo(function ChatInput({
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
               emojiOpen
-                ? "bg-foreground/10 text-foreground/75"
+                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                 : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
             title="Emoji"
@@ -1326,7 +1326,7 @@ export const ChatInput = memo(function ChatInput({
               guideGenerations && hasInput
                 ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
                 : charPickerOpen
-                  ? "bg-foreground/10 text-foreground/75"
+                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                   : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
             title={guideGenerations && hasInput ? "Trigger character response (guided)" : "Trigger character response"}
@@ -1380,9 +1380,9 @@ export const ChatInput = memo(function ChatInput({
           className={cn(
             "mari-chat-send-btn flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
             isStreaming
-              ? "text-foreground/75 hover:text-foreground/90"
+              ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90"
               : (hasInput || attachments.length || canRetry || canContinue) && activeChatId && !isReadingAttachments
-                ? "text-foreground/75 hover:text-foreground/90 active:scale-90"
+                ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90 active:scale-90"
                 : "text-foreground/20",
           )}
         >
@@ -1400,12 +1400,12 @@ export const ChatInput = memo(function ChatInput({
         createPortal(
           <div
             ref={charPickerMenuRef}
-            className="fixed z-[9999] flex min-w-[220px] max-w-[280px] max-h-[320px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+            className="fixed z-[9999] flex min-w-[220px] max-w-[280px] max-h-[320px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
             style={
               charPickerPos ? { left: charPickerPos.left, top: charPickerPos.top } : { visibility: "hidden" as const }
             }
           >
-            <div className="flex items-center justify-center border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold">
+            <div className="flex items-center justify-center border-b border-foreground/10 px-3 py-2 text-[0.6875rem] font-semibold">
               Trigger Response
             </div>
             <div className="overflow-y-auto p-1">
@@ -1413,7 +1413,7 @@ export const ChatInput = memo(function ChatInput({
                 <button
                   key={char.id}
                   onClick={() => handleCharacterResponse(char.id)}
-                  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-[var(--accent)]"
+                  className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10"
                 >
                   {char.avatarUrl ? (
                     <span className="relative h-7 w-7 shrink-0 overflow-hidden rounded-full">
@@ -1425,7 +1425,7 @@ export const ChatInput = memo(function ChatInput({
                       />
                     </span>
                   ) : (
-                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--secondary)] text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">
+                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
                       {(char.name || "?")[0].toUpperCase()}
                     </div>
                   )}

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -52,6 +52,8 @@ interface Attachment {
   name: string;
 }
 
+const EMPTY_RESPONSE_QUEUE: string[] = [];
+
 const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "csv",
   "json",
@@ -154,7 +156,9 @@ export const ChatInput = memo(function ChatInput({
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreamingGlobal = useChatStore((s) => s.isStreaming);
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
-  const responseQueue = useChatStore((s) => (activeChatId ? (s.responseQueues.get(activeChatId) ?? []) : []));
+  const responseQueue = useChatStore((s) =>
+    activeChatId ? (s.responseQueues.get(activeChatId) ?? EMPTY_RESPONSE_QUEUE) : EMPTY_RESPONSE_QUEUE,
+  );
   const setInputDraft = useChatStore((s) => s.setInputDraft);
   const clearInputDraft = useChatStore((s) => s.clearInputDraft);
   const setCurrentInput = useChatStore((s) => s.setCurrentInput);

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -44,7 +44,7 @@ import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { CyoaChoices } from "./CyoaChoices";
 import { ChatBranchSelector } from "./ChatBranchSelector";
-import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
+import { ChatToolbarButton, ChatToolbarMenu, getChatToolbarButtonClass } from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { EndSceneBar } from "./SceneBanner";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
@@ -385,22 +385,16 @@ function ActiveContextLinksButton({
   };
 
   const itemClassName =
-    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs text-foreground/80 transition-colors hover:bg-foreground/10 hover:text-foreground";
-  const iconClassName = "shrink-0 text-foreground/55";
+    "marinara-chat-popover__item flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs text-[var(--marinara-chat-chrome-panel-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]";
+  const iconClassName = "shrink-0 text-[var(--marinara-chat-chrome-panel-muted)]";
   const entryClassName =
-    "flex min-w-0 items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-[0.625rem] text-foreground/70 ring-1 ring-foreground/10";
+    "flex min-w-0 items-center gap-1.5 rounded-md bg-[var(--marinara-chat-chrome-highlight-bg)] px-2 py-1 text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)] ring-1 ring-[var(--marinara-chat-chrome-panel-divider)]";
 
   return (
     <div className="relative" ref={ref} onClick={(event) => event.stopPropagation()}>
       <button
         onClick={() => setOpen((prev) => !prev)}
-        className={cn(
-          "flex items-center justify-center rounded-full border backdrop-blur-md transition-all",
-          compact ? "p-1" : "p-1.5",
-          open
-            ? "bg-foreground/15 border-foreground/20 text-foreground/90"
-            : "bg-foreground/5 border-foreground/10 text-foreground/60 hover:bg-foreground/10 hover:text-foreground",
-        )}
+        className={getChatToolbarButtonClass({ compact, open })}
         title="Active Context"
         aria-label="Active Context"
         aria-haspopup="menu"
@@ -527,15 +521,7 @@ function SummaryButton({
     <div className="relative" onClick={(e) => e.stopPropagation()}>
       <button
         onClick={() => setOpen(!open)}
-        className={cn(
-          "flex items-center justify-center rounded-full border backdrop-blur-md transition-all",
-          compact ? "p-1" : "p-1.5",
-          open
-            ? "bg-foreground/15 border-foreground/20 text-foreground/90"
-            : summary
-              ? "bg-foreground/10 border-foreground/25 text-foreground/80 hover:bg-foreground/15 hover:text-foreground"
-              : "bg-foreground/5 border-foreground/10 text-foreground/60 hover:bg-foreground/10 hover:text-foreground",
-        )}
+        className={getChatToolbarButtonClass({ active: !!summary, compact, open })}
         title="Chat Summary"
       >
         <ScrollText size="0.875rem" />
@@ -590,15 +576,7 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
     <div className="relative" ref={ref} onClick={(e) => e.stopPropagation()}>
       <button
         onClick={() => setOpen(!open)}
-        className={cn(
-          "flex items-center justify-center rounded-full border backdrop-blur-md transition-all",
-          compact ? "p-1" : "p-1.5",
-          open
-            ? "bg-foreground/15 border-foreground/20 text-foreground/90"
-            : hasNotes
-              ? "bg-foreground/10 border-foreground/25 text-foreground/80 hover:bg-foreground/15 hover:text-foreground"
-              : "bg-foreground/5 border-foreground/10 text-foreground/60 hover:bg-foreground/10 hover:text-foreground",
-        )}
+        className={getChatToolbarButtonClass({ active: hasNotes, compact, open })}
         title="Author's Notes"
       >
         <PenLine size="0.875rem" />

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -20,7 +20,6 @@ import {
 } from "@marinara-engine/shared";
 import {
   BookOpen,
-  FolderOpen,
   FileText,
   Image,
   Loader2,
@@ -817,7 +816,6 @@ type RoleplaySurfaceProps = {
   onForkScene: (sceneChatId: string, mode: SceneForkMode) => void;
   isForkingScene?: boolean;
   onOpenSettings: () => void;
-  onOpenFiles: () => void;
   onOpenGallery: () => void;
   onCloseSettings: () => void;
   onCloseFiles: () => void;
@@ -916,7 +914,6 @@ export function ChatRoleplaySurface({
   onForkScene,
   isForkingScene,
   onOpenSettings,
-  onOpenFiles,
   onOpenGallery,
   onCloseSettings,
   onCloseFiles,
@@ -1176,11 +1173,6 @@ export function ChatRoleplaySurface({
                       characterMap={characterMap}
                     />
                     <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
-                    <RpToolbarButton
-                      icon={<FolderOpen size="0.875rem" />}
-                      title="Manage Chat Files"
-                      onClick={onOpenFiles}
-                    />
                     <RpToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
                     {chat?.connectedChatId && (
                       <RpToolbarButton
@@ -1262,11 +1254,6 @@ export function ChatRoleplaySurface({
                           characterMap={characterMap}
                         />
                         <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
-                        <RpToolbarButton
-                          icon={<FolderOpen size="0.875rem" />}
-                          title="Manage Chat Files"
-                          onClick={onOpenFiles}
-                        />
                         <RpToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
                         {chat?.connectedChatId && (
                           <RpToolbarButton
@@ -1318,11 +1305,6 @@ export function ChatRoleplaySurface({
                         characterMap={characterMap}
                       />
                       <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
-                      <RpToolbarButton
-                        icon={<FolderOpen size="0.875rem" />}
-                        title="Manage Chat Files"
-                        onClick={onOpenFiles}
-                      />
                       <RpToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
                       {chat?.connectedChatId && (
                         <RpToolbarButton

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -10,7 +10,6 @@ import {
   type ComponentProps,
   type CSSProperties,
   type MouseEvent as ReactMouseEvent,
-  type ReactNode,
   type RefObject,
 } from "react";
 import {
@@ -24,7 +23,6 @@ import {
   FileText,
   Image,
   Loader2,
-  MoreHorizontal,
   PenLine,
   ScrollText,
   Settings2,
@@ -46,6 +44,7 @@ import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { CyoaChoices } from "./CyoaChoices";
 import { ChatBranchSelector } from "./ChatBranchSelector";
+import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { EndSceneBar } from "./SceneBanner";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
@@ -286,92 +285,6 @@ function RegeneratingMessageContent({
 function isHiddenFromUser(message: MessageWithSwipes) {
   const extra = typeof message.extra === "string" ? JSON.parse(message.extra) : (message.extra ?? {});
   return extra.hiddenFromUser === true;
-}
-
-function RpToolbarButton({
-  icon,
-  title,
-  onClick,
-  size,
-}: {
-  icon: ReactNode;
-  title: string;
-  onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
-  size?: "sm";
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "flex items-center justify-center rounded-full border bg-foreground/5 text-foreground/60 backdrop-blur-md transition-all hover:bg-foreground/10 hover:text-foreground",
-        size === "sm" ? "p-1" : "p-1.5",
-        "border-foreground/10",
-      )}
-      title={title}
-    >
-      {icon}
-    </button>
-  );
-}
-
-function ToolbarMenu({ children }: { children: ReactNode }) {
-  const [open, setOpen] = useState(false);
-  const compact = useUIStore((s) => s.centerCompact);
-  const btnRef = useRef<HTMLDivElement>(null);
-  const popRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
-
-  useLayoutEffect(() => {
-    if (!open || !btnRef.current) return;
-    const rect = btnRef.current.getBoundingClientRect();
-    setPos({
-      top: rect.bottom + 4,
-      right: window.innerWidth - rect.right,
-    });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handle = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (target instanceof Element && target.closest("[data-chat-branch-popover]")) return;
-      if (btnRef.current?.contains(target) || popRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handle);
-    return () => document.removeEventListener("mousedown", handle);
-  }, [open]);
-
-  return (
-    <>
-      <div className={cn("items-center gap-1.5 max-md:hidden", compact ? "hidden" : "flex")}>{children}</div>
-      <div className={cn("relative shrink-0", compact ? "block" : "block md:hidden")} ref={btnRef}>
-        <button
-          onClick={() => setOpen(!open)}
-          className={cn(
-            "flex w-9 items-center justify-center rounded-xl border bg-[var(--card)] p-1.5 text-foreground/60 backdrop-blur-md transition-all hover:bg-[var(--accent)] hover:text-foreground",
-            "border-foreground/10",
-            open && "bg-[var(--accent)] border-foreground/20 text-foreground",
-          )}
-          title="More options"
-        >
-          <MoreHorizontal size="0.9375rem" />
-        </button>
-        {open &&
-          createPortal(
-            <div
-              ref={popRef}
-              className={cn(ROLEPLAY_POPOVER_SHELL, "fixed z-[9999] flex w-9 flex-col items-center gap-0.5 p-1")}
-              style={{ top: pos.top, right: pos.right }}
-              onClick={() => setOpen(false)}
-            >
-              {children}
-            </div>,
-            document.body,
-          )}
-      </div>
-    </>
-  );
 }
 
 function readStringArray(value: unknown): string[] {
@@ -1153,7 +1066,7 @@ export function ChatRoleplaySurface({
                     groupId={chat?.groupId ?? null}
                     variant="roleplay"
                   />
-                  <ToolbarMenu>
+                  <ChatToolbarMenu>
                     <SummaryButton
                       chatId={chat?.id ?? null}
                       summary={chatMeta.summary ?? null}
@@ -1178,20 +1091,20 @@ export function ChatRoleplaySurface({
                       characterMap={characterMap}
                     />
                     <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
-                    <RpToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
+                    <ChatToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
                     {chat?.connectedChatId && (
-                      <RpToolbarButton
+                      <ChatToolbarButton
                         icon={<ArrowRightLeft size="0.875rem" />}
                         title={linkedChatName ? `Switch to ${linkedChatName}` : "Connected chat"}
                         onClick={() => useChatStore.getState().setActiveChatId(chat.connectedChatId!)}
                       />
                     )}
-                    <RpToolbarButton
+                    <ChatToolbarButton
                       icon={<Settings2 size="0.875rem" />}
                       title="Chat Settings"
                       onClick={onOpenSettings}
                     />
-                  </ToolbarMenu>
+                  </ChatToolbarMenu>
                 </div>
               </div>
               <div
@@ -1225,7 +1138,7 @@ export function ChatRoleplaySurface({
                       />
                     </Suspense>
                     <div className="flex shrink-0 items-center gap-1.5">
-                      <ToolbarMenu>
+                      <ChatToolbarMenu>
                         <ChatBranchSelector
                           activeChatId={activeChatId}
                           activeChatName={chat?.name}
@@ -1259,26 +1172,26 @@ export function ChatRoleplaySurface({
                           characterMap={characterMap}
                         />
                         <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
-                        <RpToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
+                        <ChatToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
                         {chat?.connectedChatId && (
-                          <RpToolbarButton
+                          <ChatToolbarButton
                             icon={<ArrowRightLeft size="0.875rem" />}
                             title={linkedChatName ? `Switch to ${linkedChatName}` : "Connected chat"}
                             onClick={() => useChatStore.getState().setActiveChatId(chat.connectedChatId!)}
                           />
                         )}
-                        <RpToolbarButton
+                        <ChatToolbarButton
                           icon={<Settings2 size="0.875rem" />}
                           title="Chat Settings"
                           onClick={onOpenSettings}
                         />
-                      </ToolbarMenu>
+                      </ChatToolbarMenu>
                     </div>
                   </div>
                 )}
                 {chat && !chatMeta.enableAgents && (
                   <div className="flex w-full items-center justify-end gap-1.5 px-2 pb-1 pt-2">
-                    <ToolbarMenu>
+                    <ChatToolbarMenu>
                       <ChatBranchSelector
                         activeChatId={activeChatId}
                         activeChatName={chat?.name}
@@ -1310,20 +1223,20 @@ export function ChatRoleplaySurface({
                         characterMap={characterMap}
                       />
                       <AuthorNotesButton chatId={chat?.id ?? null} chatMeta={chatMeta} />
-                      <RpToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
+                      <ChatToolbarButton icon={<Image size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
                       {chat?.connectedChatId && (
-                        <RpToolbarButton
+                        <ChatToolbarButton
                           icon={<ArrowRightLeft size="0.875rem" />}
                           title={linkedChatName ? `Switch to ${linkedChatName}` : "Connected chat"}
                           onClick={() => useChatStore.getState().setActiveChatId(chat.connectedChatId!)}
                         />
                       )}
-                      <RpToolbarButton
+                      <ChatToolbarButton
                         icon={<Settings2 size="0.875rem" />}
                         title="Chat Settings"
                         onClick={onOpenSettings}
                       />
-                    </ToolbarMenu>
+                    </ChatToolbarMenu>
                   </div>
                 )}
               </div>

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   type ComponentProps,
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -295,7 +296,7 @@ function RpToolbarButton({
 }: {
   icon: ReactNode;
   title: string;
-  onClick: () => void;
+  onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
   size?: "sm";
 }) {
   return (
@@ -782,8 +783,10 @@ type RoleplaySurfaceProps = {
   totalMessageCount: number;
   lastAssistantMessageId: string | null;
   settingsOpen: boolean;
+  settingsAnchor: ComponentProps<typeof ChatCommonOverlays>["settingsAnchor"];
   filesOpen: boolean;
   galleryOpen: boolean;
+  galleryAnchor: ComponentProps<typeof ChatCommonOverlays>["galleryAnchor"];
   wizardOpen: boolean;
   peekPromptData: PeekPromptData | null;
   deleteDialogMessageId: string | null;
@@ -815,8 +818,8 @@ type RoleplaySurfaceProps = {
   onAbandonScene: () => void;
   onForkScene: (sceneChatId: string, mode: SceneForkMode) => void;
   isForkingScene?: boolean;
-  onOpenSettings: () => void;
-  onOpenGallery: () => void;
+  onOpenSettings: (event?: ReactMouseEvent<HTMLElement>) => void;
+  onOpenGallery: (event?: ReactMouseEvent<HTMLElement>) => void;
   onCloseSettings: () => void;
   onCloseFiles: () => void;
   onCloseGallery: () => void;
@@ -880,8 +883,10 @@ export function ChatRoleplaySurface({
   totalMessageCount,
   lastAssistantMessageId,
   settingsOpen,
+  settingsAnchor,
   filesOpen,
   galleryOpen,
+  galleryAnchor,
   wizardOpen,
   peekPromptData,
   deleteDialogMessageId,
@@ -1545,8 +1550,10 @@ export function ChatRoleplaySurface({
         chat={chat}
         activeChatId={activeChatId}
         settingsOpen={settingsOpen}
+        settingsAnchor={settingsAnchor}
         filesOpen={filesOpen}
         galleryOpen={galleryOpen}
+        galleryAnchor={galleryAnchor}
         wizardOpen={wizardOpen}
         peekPromptData={peekPromptData}
         deleteDialogMessageId={deleteDialogMessageId}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -143,6 +143,7 @@ import {
   AGENT_COST_HIGH_TOKENS,
   getDefaultBuiltInAgentSettings,
   isAgentAvailableInChatMode,
+  isAgentConfigDeleted,
   isAgentHiddenFromChatSettingsPicker,
   normalizeAgentPromptTemplateSelectionMap,
   resolveAgentPromptTemplate,
@@ -450,7 +451,30 @@ export function ChatSettingsDrawer({
     typeof metadata.lorebookTokenBudget === "number" && Number.isFinite(metadata.lorebookTokenBudget)
       ? Math.max(0, Math.floor(metadata.lorebookTokenBudget))
       : LIMITS.DEFAULT_LOREBOOK_TOKEN_BUDGET;
-  const activeAgentIds = useMemo<string[]>(() => metadata.activeAgentIds ?? [], [metadata.activeAgentIds]);
+  const agentConfigsByType = useMemo(() => {
+    const map = new Map<string, AgentConfigRow>();
+    for (const config of (agentConfigs ?? []) as AgentConfigRow[]) {
+      map.set(config.type, config);
+    }
+    return map;
+  }, [agentConfigs]);
+  const deletedBuiltInAgentTypes = useMemo(
+    () =>
+      new Set(
+        ((agentConfigs ?? []) as AgentConfigRow[])
+          .filter((config) => BUILT_IN_AGENTS.some((agent) => agent.id === config.type))
+          .filter((config) => isAgentConfigDeleted(config.settings))
+          .map((config) => config.type),
+      ),
+    [agentConfigs],
+  );
+  const activeAgentIds = useMemo<string[]>(
+    () =>
+      (Array.isArray(metadata.activeAgentIds) ? metadata.activeAgentIds : []).filter(
+        (id: unknown): id is string => typeof id === "string" && !deletedBuiltInAgentTypes.has(id),
+      ),
+    [deletedBuiltInAgentTypes, metadata.activeAgentIds],
+  );
   const activeToolIds: string[] = metadata.activeToolIds ?? [];
   const spotifyActive = activeAgentIds.includes("spotify");
   const gameLorebookKeeperLorebook = gameLorebookKeeperLorebookId
@@ -508,13 +532,6 @@ export function ChatSettingsDrawer({
     setSpriteOpacityPercent(Math.round(spriteOpacity * 100));
   }, [spriteOpacity]);
 
-  const agentConfigsByType = useMemo(() => {
-    const map = new Map<string, AgentConfigRow>();
-    for (const config of (agentConfigs ?? []) as AgentConfigRow[]) {
-      map.set(config.type, config);
-    }
-    return map;
-  }, [agentConfigs]);
   const agentPromptTemplateSelections = useMemo(
     () => normalizeAgentPromptTemplateSelectionMap(metadata.agentPromptTemplateIds),
     [metadata.agentPromptTemplateIds],
@@ -557,6 +574,7 @@ export function ChatSettingsDrawer({
       if (!isAgentAvailableInChatMode(chatMode, a.id)) continue;
       if (isAgentHiddenFromChatSettingsPicker(chatMode, a.id)) continue;
       const existing = agentConfigsByType.get(a.id);
+      if (existing && isAgentConfigDeleted(existing.settings)) continue;
       agents.push({
         id: a.id,
         name: a.name,
@@ -569,6 +587,7 @@ export function ChatSettingsDrawer({
     // Custom agents from DB
     if (agentConfigs && modeCapabilities.agentPolicy.kind === "all") {
       for (const c of agentConfigs as AgentConfigRow[]) {
+        if (isAgentConfigDeleted(c.settings)) continue;
         if (!BUILT_IN_AGENTS.some((b) => b.id === c.type)) {
           agents.push({
             id: c.type,
@@ -1026,7 +1045,8 @@ export function ChatSettingsDrawer({
   const toggleAgent = async (agentId: string) => {
     const readLatestActiveAgentIds = () => {
       const latestChat = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
-      return latestChat ? getChatActiveAgentIds(latestChat) : [...activeAgentIds];
+      const ids = latestChat ? getChatActiveAgentIds(latestChat) : [...activeAgentIds];
+      return ids.filter((id) => !deletedBuiltInAgentTypes.has(id));
     };
     const wasRemoving = readLatestActiveAgentIds().includes(agentId);
     if (wasRemoving && agentId === "secret-plot-driver") {

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -3086,13 +3086,6 @@ export function ChatSettingsDrawer({
                   </div>
                 </button>
 
-                {metadata.autonomousMessages && !conversationSchedulesEnabled && (
-                  <div className="rounded-lg bg-[var(--primary)]/8 px-3 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--primary)]/20">
-                    Schedules are off. Autonomous messages still use character talkativeness and your active or idle
-                    status; schedules only add routines, availability, and response delays.
-                  </div>
-                )}
-
                 {/* Character exchanges toggle (group chats only) */}
                 {chatCharIds.length > 1 && (
                   <button

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -297,6 +297,7 @@ const CHAT_SETTINGS_ORDER = {
   memoryRecall: -300,
   functionCalling: -200,
   translation: -100,
+  gamePrompt: 0,
 } as const;
 
 type AvailableAgent = {
@@ -406,6 +407,7 @@ export function ChatSettingsDrawer({
   const imageSelfieWidth = useUIStore((s) => s.imageSelfieWidth);
   const imageSelfieHeight = useUIStore((s) => s.imageSelfieHeight);
   const imageStyleProfiles = useUIStore((s) => s.imageStyleProfiles);
+  const musicPlayerSource = useUIStore((s) => s.musicPlayerSource);
   const openToolDetail = useUIStore((s) => s.openToolDetail);
 
   const { data: allCharacters } = useCharacters();
@@ -571,11 +573,10 @@ export function ChatSettingsDrawer({
   const gameSpotifyPlaylistId =
     typeof metadata.gameSpotifyPlaylistId === "string" ? metadata.gameSpotifyPlaylistId : "";
   const gameSpotifyArtist = typeof metadata.gameSpotifyArtist === "string" ? metadata.gameSpotifyArtist : "";
+  const gameMusicDjEnabled =
+    metadata.gameUseMusicDj === true || gameUseSpotifyMusic || activeAgentIds.includes("youtube");
   const gameAgentFeatureCount =
-    (metadata.enableAgents ? 1 : 0) +
-    (gameLorebookKeeperEnabled ? 1 : 0) +
-    (gameUseSpotifyMusic ? 1 : 0) +
-    (activeAgentIds.includes("youtube") ? 1 : 0);
+    (metadata.enableAgents ? 1 : 0) + (gameLorebookKeeperEnabled ? 1 : 0) + (gameMusicDjEnabled ? 1 : 0);
   const spriteCharacterIds: string[] = Array.isArray(metadata.spriteCharacterIds) ? metadata.spriteCharacterIds : [];
   const spriteDisplayModes = normalizeSpriteDisplayModes(metadata.spriteDisplayModes);
   const spritePosition: "left" | "right" = metadata.spritePosition === "right" ? "right" : "left";
@@ -599,8 +600,12 @@ export function ChatSettingsDrawer({
       }>("/spotify/playlists?limit=50"),
     enabled:
       open &&
-      ((isGame && gameUseSpotifyMusic && gameSpotifySourceType === "playlist") ||
-        (isRoleplayMode && metadata.enableAgents && spotifyActive && spotifySourceType === "playlist")),
+      ((isGame && gameMusicDjEnabled && musicPlayerSource === "spotify" && gameSpotifySourceType === "playlist") ||
+        (isRoleplayMode &&
+          metadata.enableAgents &&
+          spotifyActive &&
+          musicPlayerSource === "spotify" &&
+          spotifySourceType === "playlist")),
     staleTime: 60_000,
     retry: false,
   });
@@ -1376,14 +1381,17 @@ export function ChatSettingsDrawer({
         new Set(
           activeAgentIds.filter((id) => {
             const agent = availableAgents.find((entry) => entry.id === id);
-            return id !== "spotify" && id !== "lorebook-keeper" && agent?.category !== "custom";
+            return id !== "spotify" && id !== "youtube" && id !== "lorebook-keeper" && agent?.category !== "custom";
           }),
         ),
       ),
     [activeAgentIds, availableAgents],
   );
-  const [extraPromptDraft, setExtraPromptDraft] = useState((metadata.gameExtraPrompt as string) ?? "");
-  const [extraPromptExpanded, setExtraPromptExpanded] = useState(false);
+  const [gamePromptDraft, setGamePromptDraft] = useState((metadata.gameSystemPrompt as string) ?? "");
+  const [gamePromptExpanded, setGamePromptExpanded] = useState(false);
+  const [gameSpecialInstructionsDraft, setGameSpecialInstructionsDraft] = useState(
+    (metadata.gameSpecialInstructions as string) ?? "",
+  );
   const [gameImagePromptInstructionsDraft, setGameImagePromptInstructionsDraft] = useState(
     (metadata.gameImagePromptInstructions as string) ?? "",
   );
@@ -1423,6 +1431,14 @@ export function ChatSettingsDrawer({
   useEffect(() => {
     setGameImagePromptInstructionsDraft((metadata.gameImagePromptInstructions as string) ?? "");
   }, [chat.id, metadata.gameImagePromptInstructions]);
+
+  useEffect(() => {
+    setGamePromptDraft((metadata.gameSystemPrompt as string) ?? "");
+  }, [chat.id, metadata.gameSystemPrompt]);
+
+  useEffect(() => {
+    setGameSpecialInstructionsDraft((metadata.gameSpecialInstructions as string) ?? "");
+  }, [chat.id, metadata.gameSpecialInstructions]);
 
   useEffect(() => {
     setGameSpotifyArtistDraft(gameSpotifyArtist);
@@ -1512,51 +1528,57 @@ export function ChatSettingsDrawer({
     }
   };
 
-  const ensureSpotifyAgent = useCallback(async () => {
-    const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === "spotify");
-    if (!builtInMeta) throw new Error("Music DJ agent metadata is missing.");
-    const config = agentConfigsByType.get("spotify") ?? null;
-    const nextSettings: Record<string, unknown> = {
-      ...getDefaultBuiltInAgentSettings("spotify"),
-      ...parseAgentSettings(config?.settings),
-      enabledTools: DEFAULT_AGENT_TOOLS.spotify ?? [],
-    };
+  const ensureMusicDjAgent = useCallback(
+    async (provider: "spotify" | "youtube") => {
+      const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === "spotify");
+      if (!builtInMeta) throw new Error("Music DJ agent metadata is missing.");
+      const config = agentConfigsByType.get("spotify") ?? null;
+      const nextSettings: Record<string, unknown> = {
+        ...getDefaultBuiltInAgentSettings("spotify"),
+        ...parseAgentSettings(config?.settings),
+        musicProvider: provider,
+        musicPlayerSource: provider,
+        enabledTools: provider === "youtube" ? [] : (DEFAULT_AGENT_TOOLS.spotify ?? []),
+      };
 
-    if (config) {
-      await updateAgentConfig.mutateAsync({ id: config.id, enabled: true, settings: nextSettings });
-      return;
-    }
+      if (config) {
+        await updateAgentConfig.mutateAsync({ id: config.id, enabled: true, settings: nextSettings });
+        return;
+      }
 
-    await createAgent.mutateAsync({
-      type: builtInMeta.id,
-      name: builtInMeta.name,
-      description: builtInMeta.description,
-      phase: builtInMeta.phase,
-      enabled: true,
-      connectionId: null,
-      promptTemplate: "",
-      settings: nextSettings,
-    });
-  }, [agentConfigsByType, createAgent, updateAgentConfig]);
+      await createAgent.mutateAsync({
+        type: builtInMeta.id,
+        name: builtInMeta.name,
+        description: builtInMeta.description,
+        phase: builtInMeta.phase,
+        enabled: true,
+        connectionId: null,
+        promptTemplate: "",
+        settings: nextSettings,
+      });
+    },
+    [agentConfigsByType, createAgent, updateAgentConfig],
+  );
 
-  const toggleGameSpotifyMusic = useCallback(async () => {
-    if (gameUseSpotifyMusic) {
+  const toggleGameMusicDj = useCallback(async () => {
+    if (gameMusicDjEnabled) {
       await updateMeta.mutateAsync({
         id: chat.id,
+        gameUseMusicDj: false,
         gameUseSpotifyMusic: false,
-        activeAgentIds: activeAgentIds.filter((id) => id !== "spotify"),
+        activeAgentIds: activeAgentIds.filter((id) => id !== "spotify" && id !== "youtube"),
       });
       return;
     }
 
     try {
-      await ensureSpotifyAgent();
+      await ensureMusicDjAgent(musicPlayerSource);
       await updateMeta.mutateAsync({
         id: chat.id,
         enableAgents: true,
-        gameUseSpotifyMusic: true,
+        gameUseMusicDj: true,
+        gameUseSpotifyMusic: musicPlayerSource === "spotify",
         gameSpotifySourceType,
-        // Mutually exclusive with legacy YouTube music — only one music source at a time.
         activeAgentIds: Array.from(new Set([...activeAgentIds.filter((id) => id !== "youtube"), "spotify"])),
       });
     } catch (error) {
@@ -1565,66 +1587,18 @@ export function ChatSettingsDrawer({
         message:
           error instanceof Error
             ? error.message
-            : "Music DJ could not be enabled for this game. Check the Spotify setup and try again.",
+            : "Music DJ could not be enabled for this game. Check the setup and try again.",
       });
     }
-  }, [activeAgentIds, chat.id, ensureSpotifyAgent, gameSpotifySourceType, gameUseSpotifyMusic, updateMeta]);
-
-  const ensureYoutubeAgent = useCallback(async () => {
-    const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === "youtube");
-    if (!builtInMeta) throw new Error("YouTube music metadata is missing.");
-    const config = agentConfigsByType.get("youtube") ?? null;
-    const nextSettings: Record<string, unknown> = {
-      ...getDefaultBuiltInAgentSettings("youtube"),
-      ...parseAgentSettings(config?.settings),
-      enabledTools: DEFAULT_AGENT_TOOLS.youtube ?? [],
-    };
-
-    if (config) {
-      await updateAgentConfig.mutateAsync({ id: config.id, enabled: true, settings: nextSettings });
-      return;
-    }
-
-    await createAgent.mutateAsync({
-      type: builtInMeta.id,
-      name: builtInMeta.name,
-      description: builtInMeta.description,
-      phase: builtInMeta.phase,
-      enabled: true,
-      connectionId: null,
-      promptTemplate: "",
-      settings: nextSettings,
-    });
-  }, [agentConfigsByType, createAgent, updateAgentConfig]);
-
-  const toggleGameYouTubeMusic = useCallback(async () => {
-    if (activeAgentIds.includes("youtube")) {
-      await updateMeta.mutateAsync({
-        id: chat.id,
-        activeAgentIds: activeAgentIds.filter((id) => id !== "youtube"),
-      });
-      return;
-    }
-
-    try {
-      await ensureYoutubeAgent();
-      await updateMeta.mutateAsync({
-        id: chat.id,
-        enableAgents: true,
-        // Mutually exclusive with Spotify Music DJ — only one music source at a time.
-        gameUseSpotifyMusic: false,
-        activeAgentIds: Array.from(new Set([...activeAgentIds.filter((id) => id !== "spotify"), "youtube"])),
-      });
-    } catch (error) {
-      await showAlertDialog({
-        title: "Couldn't Enable Music DJ",
-        message:
-          error instanceof Error
-            ? error.message
-            : "Music DJ could not be enabled for this game. Check the YouTube setup and try again.",
-      });
-    }
-  }, [activeAgentIds, chat.id, ensureYoutubeAgent, updateMeta]);
+  }, [
+    activeAgentIds,
+    chat.id,
+    ensureMusicDjAgent,
+    gameMusicDjEnabled,
+    gameSpotifySourceType,
+    musicPlayerSource,
+    updateMeta,
+  ]);
 
   const toggleGameLorebookKeeper = useCallback(() => {
     const nextActiveAgentIds = activeAgentIds.filter((id) => id !== "lorebook-keeper");
@@ -2064,16 +2038,23 @@ export function ChatSettingsDrawer({
             </div>
           )}
 
-          {/* Extra Prompt — game mode only */}
+          {/* Prompt — game mode only */}
           {isGame && (
-            <GameExtraPromptSection
-              expanded={extraPromptExpanded}
-              storedValue={(metadata.gameExtraPrompt as string) ?? ""}
-              value={extraPromptDraft}
-              onCommit={(gameExtraPrompt) => updateMeta.mutate({ id: chat.id, gameExtraPrompt })}
-              onExpandedChange={setExtraPromptExpanded}
-              onValueChange={setExtraPromptDraft}
-            />
+            <div style={{ order: CHAT_SETTINGS_ORDER.gamePrompt }}>
+              <GameExtraPromptSection
+                expanded={gamePromptExpanded}
+                storedValue={(metadata.gameSystemPrompt as string) ?? ""}
+                value={gamePromptDraft}
+                specialInstructionsValue={gameSpecialInstructionsDraft}
+                onCommit={(gameSystemPrompt) => updateMeta.mutate({ id: chat.id, gameSystemPrompt })}
+                onSpecialInstructionsCommit={(gameSpecialInstructions) =>
+                  updateMeta.mutate({ id: chat.id, gameSpecialInstructions })
+                }
+                onExpandedChange={setGamePromptExpanded}
+                onValueChange={setGamePromptDraft}
+                onSpecialInstructionsChange={setGameSpecialInstructionsDraft}
+              />
+            </div>
           )}
 
           {/* Scene System Prompt — shown only for scene-created chats */}
@@ -3959,10 +3940,10 @@ export function ChatSettingsDrawer({
                   <div className="space-y-2">
                     <button
                       type="button"
-                      onClick={() => void toggleGameSpotifyMusic()}
+                      onClick={() => void toggleGameMusicDj()}
                       className={cn(
                         "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                        gameUseSpotifyMusic
+                        gameMusicDjEnabled
                           ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                           : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
                       )}
@@ -3970,68 +3951,33 @@ export function ChatSettingsDrawer({
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-1.5 text-xs font-medium">
                           <Music2 size="0.75rem" className="text-[var(--primary)]" />
-                          <span>Music DJ: Spotify</span>
+                          <span>Music DJ</span>
                         </div>
                         <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                          Use Spotify instead of the built-in Game Mode music library.
+                          Use the active Music Player ({musicPlayerSource === "spotify" ? "Spotify" : "YouTube"})
+                          instead of the built-in Game Mode music library.
                         </p>
                       </div>
                       <div
                         className={cn(
                           "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                          gameUseSpotifyMusic ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                          gameMusicDjEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
                         )}
                       >
                         <div
                           className={cn(
                             "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                            gameUseSpotifyMusic && "translate-x-3.5",
+                            gameMusicDjEnabled && "translate-x-3.5",
                           )}
                         />
                       </div>
                     </button>
 
-                    <button
-                      type="button"
-                      onClick={() => void toggleGameYouTubeMusic()}
-                      className={cn(
-                        "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                        activeAgentIds.includes("youtube")
-                          ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                          : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
-                      )}
-                    >
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-1.5 text-xs font-medium">
-                          <Music2 size="0.75rem" className="text-[var(--primary)]" />
-                          <span>Music DJ: YouTube</span>
-                        </div>
-                        <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                          Use YouTube (in-app player) instead of the built-in Game Mode music library.
-                        </p>
-                      </div>
-                      <div
-                        className={cn(
-                          "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                          activeAgentIds.includes("youtube")
-                            ? "bg-[var(--primary)]"
-                            : "bg-[var(--muted-foreground)]/50",
-                        )}
-                      >
-                        <div
-                          className={cn(
-                            "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                            activeAgentIds.includes("youtube") && "translate-x-3.5",
-                          )}
-                        />
-                      </div>
-                    </button>
-
-                    {gameUseSpotifyMusic && (
-                      <div className="space-y-2 rounded-lg bg-[var(--background)]/55 p-3 ring-1 ring-[var(--border)]">
+                    {gameMusicDjEnabled && musicPlayerSource === "spotify" && (
+                      <div className="mt-1.5 space-y-2 px-3">
                         <label className="flex flex-col gap-1">
                           <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                            Music source
+                            Spotify source
                           </span>
                           <select
                             value={gameSpotifySourceType}
@@ -4452,125 +4398,133 @@ export function ChatSettingsDrawer({
                 )}
 
                 {metadata.enableAgents && isRoleplayMode && spotifyActive && (
-                  <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
+                  <div className="space-y-2 px-3">
                     <div className="flex items-start gap-2">
                       <Music2 size="0.75rem" className="mt-0.5 text-[var(--primary)]" />
                       <div className="min-w-0 flex-1">
                         <div className="text-[0.6875rem] font-medium">Music DJ</div>
                         <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                          Choose where the DJ should look for roleplay music when it reacts to the scene.
+                          Active player: {musicPlayerSource === "spotify" ? "Spotify" : "YouTube"}.
                         </p>
                       </div>
                     </div>
 
-                    <label className="flex flex-col gap-1">
-                      <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Music source</span>
-                      <select
-                        value={spotifySourceType}
-                        onChange={(event) => {
-                          const next = normalizeSpotifySourceType(event.target.value);
-                          updateMeta.mutate({
-                            id: chat.id,
-                            spotifySourceType: next,
-                            spotifyPlaylistId: next === "playlist" ? spotifyPlaylistId || null : null,
-                            spotifyPlaylistName:
-                              next === "playlist" ? (metadata.spotifyPlaylistName as string) || null : null,
-                            spotifyArtist: next === "artist" ? spotifyArtistDraft.trim() || null : null,
-                          });
-                        }}
-                        className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)]"
-                      >
-                        {SPOTIFY_SOURCE_OPTIONS.map((option) => (
-                          <option key={option.id} value={option.id}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                      <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
-                        {SPOTIFY_SOURCE_OPTIONS.find((option) => option.id === spotifySourceType)?.description ?? ""}
-                      </span>
-                    </label>
-
-                    {spotifySourceType === "playlist" && (
-                      <label className="flex flex-col gap-1">
-                        <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Playlist</span>
-                        {spotifyPlaylistsQuery.data?.playlists.length ? (
+                    {musicPlayerSource === "spotify" && (
+                      <>
+                        <label className="flex flex-col gap-1">
+                          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                            Spotify source
+                          </span>
                           <select
-                            value={spotifyPlaylistId}
+                            value={spotifySourceType}
                             onChange={(event) => {
-                              const playlist = spotifyPlaylistsQuery.data?.playlists.find(
-                                (entry) => entry.id === event.target.value,
-                              );
+                              const next = normalizeSpotifySourceType(event.target.value);
                               updateMeta.mutate({
                                 id: chat.id,
-                                spotifyPlaylistId: event.target.value || null,
-                                spotifyPlaylistName: playlist?.name ?? null,
+                                spotifySourceType: next,
+                                spotifyPlaylistId: next === "playlist" ? spotifyPlaylistId || null : null,
+                                spotifyPlaylistName:
+                                  next === "playlist" ? (metadata.spotifyPlaylistName as string) || null : null,
+                                spotifyArtist: next === "artist" ? spotifyArtistDraft.trim() || null : null,
                               });
                             }}
                             className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)]"
                           >
-                            <option value="">Choose playlist...</option>
-                            {spotifyPlaylistsQuery.data.playlists.map((playlist) => {
-                              const suffix =
-                                typeof playlist.trackCount === "number"
-                                  ? ` (${playlist.trackCount})`
-                                  : playlist.owned === false
-                                    ? " (followed, unavailable)"
-                                    : "";
-                              return (
-                                <option key={playlist.id} value={playlist.id}>
-                                  {playlist.name}
-                                  {suffix}
-                                </option>
-                              );
-                            })}
+                            {SPOTIFY_SOURCE_OPTIONS.map((option) => (
+                              <option key={option.id} value={option.id}>
+                                {option.label}
+                              </option>
+                            ))}
                           </select>
-                        ) : (
-                          <input
-                            key={`${chat.id}-${spotifyPlaylistId}`}
-                            defaultValue={spotifyPlaylistId}
-                            onBlur={(event) =>
-                              updateMeta.mutate({
-                                id: chat.id,
-                                spotifyPlaylistId: event.target.value.trim() || null,
-                                spotifyPlaylistName: null,
-                              })
-                            }
-                            placeholder={
-                              spotifyPlaylistsQuery.isFetching ? "Loading playlists..." : "Paste playlist ID"
-                            }
-                            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
-                          />
-                        )}
-                        {spotifyPlaylistsQuery.isError && (
-                          <span className="text-[0.5625rem] text-amber-400/90">
-                            Connect Spotify in the Music DJ agent to load playlist names.
+                          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
+                            {SPOTIFY_SOURCE_OPTIONS.find((option) => option.id === spotifySourceType)?.description ??
+                              ""}
                           </span>
-                        )}
-                      </label>
-                    )}
+                        </label>
 
-                    {spotifySourceType === "artist" && (
-                      <label className="flex flex-col gap-1">
-                        <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Artist</span>
-                        <input
-                          value={spotifyArtistDraft}
-                          onChange={(event) => setSpotifyArtistDraft(event.target.value)}
-                          onBlur={() =>
-                            updateMeta.mutate({
-                              id: chat.id,
-                              spotifyArtist: spotifyArtistDraft.trim() || null,
-                            })
-                          }
-                          placeholder="HOYO-MiX"
-                          className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
-                        />
-                      </label>
+                        {spotifySourceType === "playlist" && (
+                          <label className="flex flex-col gap-1">
+                            <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Playlist</span>
+                            {spotifyPlaylistsQuery.data?.playlists.length ? (
+                              <select
+                                value={spotifyPlaylistId}
+                                onChange={(event) => {
+                                  const playlist = spotifyPlaylistsQuery.data?.playlists.find(
+                                    (entry) => entry.id === event.target.value,
+                                  );
+                                  updateMeta.mutate({
+                                    id: chat.id,
+                                    spotifyPlaylistId: event.target.value || null,
+                                    spotifyPlaylistName: playlist?.name ?? null,
+                                  });
+                                }}
+                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+                              >
+                                <option value="">Choose playlist...</option>
+                                {spotifyPlaylistsQuery.data.playlists.map((playlist) => {
+                                  const suffix =
+                                    typeof playlist.trackCount === "number"
+                                      ? ` (${playlist.trackCount})`
+                                      : playlist.owned === false
+                                        ? " (followed, unavailable)"
+                                        : "";
+                                  return (
+                                    <option key={playlist.id} value={playlist.id}>
+                                      {playlist.name}
+                                      {suffix}
+                                    </option>
+                                  );
+                                })}
+                              </select>
+                            ) : (
+                              <input
+                                key={`${chat.id}-${spotifyPlaylistId}`}
+                                defaultValue={spotifyPlaylistId}
+                                onBlur={(event) =>
+                                  updateMeta.mutate({
+                                    id: chat.id,
+                                    spotifyPlaylistId: event.target.value.trim() || null,
+                                    spotifyPlaylistName: null,
+                                  })
+                                }
+                                placeholder={
+                                  spotifyPlaylistsQuery.isFetching ? "Loading playlists..." : "Paste playlist ID"
+                                }
+                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
+                              />
+                            )}
+                            {spotifyPlaylistsQuery.isError && (
+                              <span className="text-[0.5625rem] text-amber-400/90">
+                                Connect Spotify in the Music DJ agent to load playlist names.
+                              </span>
+                            )}
+                          </label>
+                        )}
+
+                        {spotifySourceType === "artist" && (
+                          <label className="flex flex-col gap-1">
+                            <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Artist</span>
+                            <input
+                              value={spotifyArtistDraft}
+                              onChange={(event) => setSpotifyArtistDraft(event.target.value)}
+                              onBlur={() =>
+                                updateMeta.mutate({
+                                  id: chat.id,
+                                  spotifyArtist: spotifyArtistDraft.trim() || null,
+                                })
+                              }
+                              placeholder="HOYO-MiX"
+                              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
+                            />
+                          </label>
+                        )}
+                      </>
                     )}
 
                     <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                      Roleplay DJ queues several fitting tracks when it changes music. Spotify Premium, a connected
-                      account, and an active Spotify device are still required.
+                      {musicPlayerSource === "spotify"
+                        ? "Roleplay DJ queues several fitting tracks when it changes music."
+                        : "YouTube mode uses the Music DJ agent's YouTube connection and embedded player."}
                     </p>
                   </div>
                 )}
@@ -5314,7 +5268,7 @@ export function ChatSettingsDrawer({
             />
           </div>
 
-          {!isConversation && (
+          {!isConversation && !isGame && (
             <div style={{ order: CHAT_SETTINGS_ORDER.impersonate }}>
               <ImpersonateSection
                 presets={(presets ?? []) as Array<{ id: string; name: string }>}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -5771,7 +5771,7 @@ function AgentCategorySection({
         />
       </button>
       {open && (
-        <div className="px-3 pb-2.5 space-y-1.5">
+        <div className="px-3 pb-2.5 pt-2.5 space-y-1.5">
           <p className="text-[0.5625rem] text-[var(--muted-foreground)] leading-tight">{description}</p>
           {children}
         </div>

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -3338,7 +3338,7 @@ export function ChatSettingsDrawer({
                       onChange={(e) => updateMeta.mutate({ id: chat.id, imageStyleProfileId: e.target.value || null })}
                       className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                     >
-                      <option value="">Use global or connection default</option>
+                      <option value="">Use default style from Style Profiles in Advanced settings</option>
                       {imageStyleProfiles.profiles.map((profile) => (
                         <option key={profile.id} value={profile.id}>
                           {profile.name}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -567,7 +567,7 @@ export function ChatSettingsDrawer({
 
   // Build the available agent list: built-in + custom agents from DB
   // Mode capabilities decide which built-ins are exposed for each chat mode.
-  // Custom agents are currently roleplay/visual-novel only.
+  // Custom agents are user-authored and can be attached to any chat mode.
   const availableAgents = useMemo(() => {
     const agents: AvailableAgent[] = [];
     for (const a of BUILT_IN_AGENTS) {
@@ -586,7 +586,7 @@ export function ChatSettingsDrawer({
       });
     }
     // Custom agents from DB
-    if (agentConfigs && modeCapabilities.agentPolicy.kind === "all") {
+    if (agentConfigs) {
       for (const c of agentConfigs as AgentConfigRow[]) {
         if (isAgentConfigDeleted(c.settings)) continue;
         if (!BUILT_IN_AGENTS.some((b) => b.id === c.type)) {
@@ -602,7 +602,7 @@ export function ChatSettingsDrawer({
       }
     }
     return agents;
-  }, [agentConfigs, agentConfigsByType, chatMode, modeCapabilities.agentPolicy.kind]);
+  }, [agentConfigs, agentConfigsByType, chatMode]);
 
   // Estimate the per-turn cost of the active agent loadout — feeds the readout
   // in the agents picker header and the per-row token badges. Approximate; see
@@ -642,6 +642,10 @@ export function ChatSettingsDrawer({
   const lorebookKeeperActive = activeAgentIds.includes("lorebook-keeper");
   const expressionActive = activeAgentIds.includes("expression");
   const hapticActive = activeAgentIds.includes("haptic");
+  const activeCustomAgents = useMemo(
+    () => availableAgents.filter((agent) => agent.category === "custom" && activeAgentIds.includes(agent.id)),
+    [activeAgentIds, availableAgents],
+  );
   const lorebookKeeperTargetLorebookId =
     typeof metadata.lorebookKeeperTargetLorebookId === "string" ? metadata.lorebookKeeperTargetLorebookId : "";
   const lorebookKeeperReadBehindMessages = normalizeNonNegativeInteger(
@@ -1286,8 +1290,16 @@ export function ChatSettingsDrawer({
   const [groupScenarioDraft, setGroupScenarioDraft] = useState((metadata.groupScenarioText as string) ?? "");
   const [groupScenarioExpanded, setGroupScenarioExpanded] = useState(false);
   const gameAgentPool = useMemo(
-    () => Array.from(new Set(activeAgentIds.filter((id) => id !== "spotify" && id !== "lorebook-keeper"))),
-    [activeAgentIds],
+    () =>
+      Array.from(
+        new Set(
+          activeAgentIds.filter((id) => {
+            const agent = availableAgents.find((entry) => entry.id === id);
+            return id !== "spotify" && id !== "lorebook-keeper" && agent?.category !== "custom";
+          }),
+        ),
+      ),
+    [activeAgentIds, availableAgents],
   );
   const [extraPromptDraft, setExtraPromptDraft] = useState((metadata.gameExtraPrompt as string) ?? "");
   const [extraPromptExpanded, setExtraPromptExpanded] = useState(false);
@@ -1753,8 +1765,8 @@ export function ChatSettingsDrawer({
       {/* Backdrop */}
       <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
 
-      {/* Drawer */}
-      <div className="absolute right-0 top-0 z-50 flex h-full min-h-0 w-80 max-md:w-full flex-col border-l border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:pt-[env(safe-area-inset-top)]">
+      {/* Floating panel */}
+      <div className="absolute bottom-3 right-3 top-14 z-50 flex min-h-0 w-[min(34rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto">
         {/* Header */}
         <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-4 py-3">
           <h3 className="text-sm font-bold">Chat Settings</h3>
@@ -1880,7 +1892,7 @@ export function ChatSettingsDrawer({
                 title="Import preset (.json)"
                 className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
               >
-                <Upload size="0.875rem" />
+                <Download size="0.875rem" />
               </button>
               <button
                 onClick={handleExportPreset}
@@ -1888,7 +1900,7 @@ export function ChatSettingsDrawer({
                 title="Export preset (.json)"
                 className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
               >
-                <Download size="0.875rem" />
+                <Upload size="0.875rem" />
               </button>
               <button
                 onClick={handleDeletePreset}
@@ -3196,6 +3208,37 @@ export function ChatSettingsDrawer({
                             </button>
                           );
                         })}
+                        {(() => {
+                          const inactiveCustom = availableAgents.filter(
+                            (agent) => agent.category === "custom" && !activeAgentIds.includes(agent.id),
+                          );
+                          if (inactiveCustom.length === 0) return null;
+                          return (
+                            <div className="mt-2 rounded-lg bg-[var(--background)]/55 p-2 ring-1 ring-[var(--border)]">
+                              <div className="mb-1.5 flex items-center gap-1.5 px-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                                <Settings2 size="0.6875rem" />
+                                Custom Agents
+                              </div>
+                              <div className="flex flex-col gap-1">
+                                {inactiveCustom.map((agent) => (
+                                  <button
+                                    key={agent.id}
+                                    onClick={() => openAgentAddModal(agent)}
+                                    className="flex items-center gap-2.5 rounded-lg bg-[var(--secondary)] px-3 py-2 text-left transition-all hover:bg-[var(--accent)]"
+                                  >
+                                    <Plus size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                                    <div className="min-w-0 flex-1">
+                                      <span className="block truncate text-xs">{agent.name}</span>
+                                      <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
+                                        {agent.description}
+                                      </span>
+                                    </div>
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          );
+                        })()}
                       </div>
                     </div>
                   )}
@@ -3650,6 +3693,40 @@ export function ChatSettingsDrawer({
                     />
                   </div>
                 </button>
+                {/* Manual trackers toggle — directly under Enable Agents in roleplay/conversation modes */}
+                {metadata.enableAgents && !isGame && (
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, manualTrackers: !metadata.manualTrackers })}
+                    className={cn(
+                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                      metadata.manualTrackers
+                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    <div>
+                      <span className="text-[0.6875rem] font-medium">Manual Trackers</span>
+                      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                        {metadata.manualTrackers
+                          ? "Trackers won't run automatically — use the button in the HUD to trigger them."
+                          : "Trackers run automatically after every generation."}
+                      </p>
+                    </div>
+                    <div
+                      className={cn(
+                        "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors shrink-0",
+                        metadata.manualTrackers ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                          metadata.manualTrackers && "translate-x-3.5",
+                        )}
+                      />
+                    </div>
+                  </button>
+                )}
                 {isGame && metadata.enableAgents && (
                   <div className="mt-1.5 px-3">
                     <select
@@ -4330,39 +4407,66 @@ export function ChatSettingsDrawer({
                   </div>
                 )}
 
-                {/* Manual trackers toggle — not for game mode */}
-                {metadata.enableAgents && !isGame && (
-                  <button
-                    onClick={() => updateMeta.mutate({ id: chat.id, manualTrackers: !metadata.manualTrackers })}
-                    className={cn(
-                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.manualTrackers
-                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
-                    )}
-                  >
-                    <div>
-                      <span className="text-[0.6875rem] font-medium">Manual Trackers</span>
-                      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                        {metadata.manualTrackers
-                          ? "Trackers won't run automatically — use the button in the HUD to trigger them."
-                          : "Trackers run automatically after every generation."}
-                      </p>
+                {metadata.enableAgents && activeCustomAgents.length > 0 && (
+                  <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/70 p-3">
+                    <div className="flex items-start gap-2">
+                      <Settings2 size="0.75rem" className="mt-0.5 text-[var(--primary)]" />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[0.6875rem] font-medium">Custom Agents</div>
+                        <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                          Configure custom agents currently attached to this chat.
+                        </p>
+                      </div>
                     </div>
-                    <div
-                      className={cn(
-                        "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors shrink-0",
-                        metadata.manualTrackers ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-                      )}
-                    >
-                      <div
-                        className={cn(
-                          "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                          metadata.manualTrackers && "translate-x-3.5",
-                        )}
-                      />
+                    <div className="space-y-1.5">
+                      {activeCustomAgents.map((agent) => {
+                        const tokenEst = agentLoadCost.tokensByType.get(agent.id);
+                        const promptOptions = getPromptOptionsForAgent(agent.id);
+                        return (
+                          <div
+                            key={agent.id}
+                            className="rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]"
+                          >
+                            <div className="flex items-start gap-2.5">
+                              <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                              <div className="min-w-0 flex-1">
+                                <div className="flex min-w-0 items-center gap-1.5">
+                                  <span className="block min-w-0 truncate text-xs font-medium">{agent.name}</span>
+                                  {tokenEst != null ? (
+                                    <span
+                                      className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
+                                      title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
+                                    >
+                                      ~{tokenEst.toLocaleString()}
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
+                                  {agent.description}
+                                </span>
+                              </div>
+                              <button
+                                onClick={() => {
+                                  void toggleAgent(agent.id);
+                                }}
+                                className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+                                title="Remove from chat"
+                              >
+                                <Trash2 size="0.6875rem" />
+                              </button>
+                            </div>
+                            <AgentPromptTemplateSelect
+                              options={promptOptions}
+                              selectedId={agentPromptTemplateSelections[agent.id] ?? DEFAULT_AGENT_PROMPT_TEMPLATE_ID}
+                              onChange={(promptTemplateId) =>
+                                updateAgentPromptTemplateSelection(agent.id, promptTemplateId)
+                              }
+                            />
+                          </div>
+                        );
+                      })}
                     </div>
-                  </button>
+                  </div>
                 )}
 
                 {/* Love Toys Control — not for game mode */}
@@ -4837,63 +4941,16 @@ export function ChatSettingsDrawer({
                         {(() => {
                           const customAgents = availableAgents.filter((a) => a.category === "custom");
                           if (customAgents.length === 0) return null;
-                          const activeCustom = customAgents.filter((a) => activeAgentIds.includes(a.id));
+                          const activeCustomCount = customAgents.filter((a) => activeAgentIds.includes(a.id)).length;
                           const inactiveCustom = customAgents.filter((a) => !activeAgentIds.includes(a.id));
                           return (
                             <AgentCategorySection
                               label="Custom Agents"
                               icon={<Settings2 size="0.75rem" />}
-                              description="Your custom-created agents."
-                              count={activeCustom.length}
+                              description="Add your custom-created agents to this chat."
+                              count={activeCustomCount}
                             >
-                              {activeCustom.length > 0 && (
-                                <div className="flex flex-col gap-1 mb-1.5">
-                                  {activeCustom.map((agent) => {
-                                    const tokenEst = agentLoadCost.tokensByType.get(agent.id);
-                                    const promptOptions = getPromptOptionsForAgent(agent.id);
-                                    return (
-                                      <div
-                                        key={agent.id}
-                                        className="rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
-                                      >
-                                        <div className="flex items-center gap-2.5">
-                                          <Sparkles size="0.875rem" className="text-[var(--primary)]" />
-                                          <div className="flex-1 min-w-0">
-                                            <span className="block truncate text-xs">{agent.name}</span>
-                                          </div>
-                                          {tokenEst != null ? (
-                                            <span
-                                              className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
-                                              title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
-                                            >
-                                              ~{tokenEst.toLocaleString()}
-                                            </span>
-                                          ) : null}
-                                          <button
-                                            onClick={() => {
-                                              void toggleAgent(agent.id);
-                                            }}
-                                            className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
-                                            title="Remove from chat"
-                                          >
-                                            <Trash2 size="0.6875rem" />
-                                          </button>
-                                        </div>
-                                        <AgentPromptTemplateSelect
-                                          options={promptOptions}
-                                          selectedId={
-                                            agentPromptTemplateSelections[agent.id] ?? DEFAULT_AGENT_PROMPT_TEMPLATE_ID
-                                          }
-                                          onChange={(promptTemplateId) =>
-                                            updateAgentPromptTemplateSelection(agent.id, promptTemplateId)
-                                          }
-                                        />
-                                      </div>
-                                    );
-                                  })}
-                                </div>
-                              )}
-                              {inactiveCustom.length > 0 && (
+                              {inactiveCustom.length > 0 ? (
                                 <div className="flex flex-col gap-1">
                                   {inactiveCustom.map((agent) => (
                                     <button
@@ -4911,6 +4968,10 @@ export function ChatSettingsDrawer({
                                     </button>
                                   ))}
                                 </div>
+                              ) : (
+                                <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1">
+                                  All custom agents are active. Configure them below the other agent menus.
+                                </p>
                               )}
                             </AgentCategorySection>
                           );
@@ -5549,7 +5610,7 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
               title="Export memories"
               aria-label="Export memories"
             >
-              <Download size="0.8125rem" />
+              <Upload size="0.8125rem" />
             </button>
             <button
               type="button"
@@ -5559,7 +5620,7 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
               title="Import memories"
               aria-label="Import memories"
             >
-              <Upload size="0.8125rem" />
+              <Download size="0.8125rem" />
             </button>
             <button
               type="button"

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -571,6 +571,7 @@ export function ChatSettingsDrawer({
   const availableAgents = useMemo(() => {
     const agents: AvailableAgent[] = [];
     for (const a of BUILT_IN_AGENTS) {
+      if (a.libraryHidden) continue;
       if (!isAgentAvailableInChatMode(chatMode, a.id)) continue;
       if (isAgentHiddenFromChatSettingsPicker(chatMode, a.id)) continue;
       const existing = agentConfigsByType.get(a.id);
@@ -1420,7 +1421,7 @@ export function ChatSettingsDrawer({
 
   const ensureSpotifyAgent = useCallback(async () => {
     const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === "spotify");
-    if (!builtInMeta) throw new Error("Spotify DJ agent metadata is missing.");
+    if (!builtInMeta) throw new Error("Music DJ agent metadata is missing.");
     const config = agentConfigsByType.get("spotify") ?? null;
     const nextSettings: Record<string, unknown> = {
       ...getDefaultBuiltInAgentSettings("spotify"),
@@ -1462,23 +1463,23 @@ export function ChatSettingsDrawer({
         enableAgents: true,
         gameUseSpotifyMusic: true,
         gameSpotifySourceType,
-        // Mutually exclusive with YouTube DJ — only one music source at a time.
+        // Mutually exclusive with legacy YouTube music — only one music source at a time.
         activeAgentIds: Array.from(new Set([...activeAgentIds.filter((id) => id !== "youtube"), "spotify"])),
       });
     } catch (error) {
       await showAlertDialog({
-        title: "Couldn't Enable Spotify DJ",
+        title: "Couldn't Enable Music DJ",
         message:
           error instanceof Error
             ? error.message
-            : "Spotify DJ could not be enabled for this game. Check the Spotify agent setup and try again.",
+            : "Music DJ could not be enabled for this game. Check the Spotify setup and try again.",
       });
     }
   }, [activeAgentIds, chat.id, ensureSpotifyAgent, gameSpotifySourceType, gameUseSpotifyMusic, updateMeta]);
 
   const ensureYoutubeAgent = useCallback(async () => {
     const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === "youtube");
-    if (!builtInMeta) throw new Error("YouTube DJ agent metadata is missing.");
+    if (!builtInMeta) throw new Error("YouTube music metadata is missing.");
     const config = agentConfigsByType.get("youtube") ?? null;
     const nextSettings: Record<string, unknown> = {
       ...getDefaultBuiltInAgentSettings("youtube"),
@@ -1517,17 +1518,17 @@ export function ChatSettingsDrawer({
       await updateMeta.mutateAsync({
         id: chat.id,
         enableAgents: true,
-        // Mutually exclusive with Spotify DJ — only one music source at a time.
+        // Mutually exclusive with Spotify Music DJ — only one music source at a time.
         gameUseSpotifyMusic: false,
         activeAgentIds: Array.from(new Set([...activeAgentIds.filter((id) => id !== "spotify"), "youtube"])),
       });
     } catch (error) {
       await showAlertDialog({
-        title: "Couldn't Enable YouTube DJ",
+        title: "Couldn't Enable Music DJ",
         message:
           error instanceof Error
             ? error.message
-            : "YouTube DJ could not be enabled for this game. Check the YouTube agent setup and try again.",
+            : "Music DJ could not be enabled for this game. Check the YouTube setup and try again.",
       });
     }
   }, [activeAgentIds, chat.id, ensureYoutubeAgent, updateMeta]);
@@ -3726,7 +3727,7 @@ export function ChatSettingsDrawer({
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-1.5 text-xs font-medium">
                           <Music2 size="0.75rem" className="text-[var(--primary)]" />
-                          <span>Spotify DJ Music</span>
+                          <span>Music DJ: Spotify</span>
                         </div>
                         <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
                           Use Spotify instead of the built-in Game Mode music library.
@@ -3760,7 +3761,7 @@ export function ChatSettingsDrawer({
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-1.5 text-xs font-medium">
                           <Music2 size="0.75rem" className="text-[var(--primary)]" />
-                          <span>YouTube DJ Music</span>
+                          <span>Music DJ: YouTube</span>
                         </div>
                         <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
                           Use YouTube (in-app player) instead of the built-in Game Mode music library.
@@ -3867,7 +3868,7 @@ export function ChatSettingsDrawer({
                             )}
                             {spotifyPlaylistsQuery.isError && (
                               <span className="text-[0.5625rem] text-amber-400/90">
-                                Connect Spotify in the Spotify DJ agent to load playlist names.
+                                Connect Spotify in the Music DJ agent to load playlist names.
                               </span>
                             )}
                           </label>
@@ -4210,7 +4211,7 @@ export function ChatSettingsDrawer({
                     <div className="flex items-start gap-2">
                       <Music2 size="0.75rem" className="mt-0.5 text-[var(--primary)]" />
                       <div className="min-w-0 flex-1">
-                        <div className="text-[0.6875rem] font-medium">Spotify DJ</div>
+                        <div className="text-[0.6875rem] font-medium">Music DJ</div>
                         <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                           Choose where the DJ should look for roleplay music when it reacts to the scene.
                         </p>
@@ -4298,7 +4299,7 @@ export function ChatSettingsDrawer({
                         )}
                         {spotifyPlaylistsQuery.isError && (
                           <span className="text-[0.5625rem] text-amber-400/90">
-                            Connect Spotify in the Spotify DJ agent to load playlist names.
+                            Connect Spotify in the Music DJ agent to load playlist names.
                           </span>
                         )}
                       </label>

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -19,7 +19,6 @@ import {
   Sparkles,
   Image,
   Pencil,
-  Clock,
   AlertTriangle,
   GripVertical,
   MessageCircle,
@@ -63,7 +62,6 @@ import { FunctionCallingSection } from "../../features/chat-settings/sections/Fu
 import { GameExtraPromptSection } from "../../features/chat-settings/sections/GameExtraPromptSection";
 import { ImpersonateSection } from "../../features/chat-settings/sections/ImpersonateSection";
 import { LorebooksSection, type ActiveLorebookView } from "../../features/chat-settings/sections/LorebooksSection";
-import { ManualRepliesSection } from "../../features/chat-settings/sections/ManualRepliesSection";
 import { PromptPresetSection } from "../../features/chat-settings/sections/PromptPresetSection";
 import { SceneInstructionsSection } from "../../features/chat-settings/sections/SceneInstructionsSection";
 import { TranslationSection } from "../../features/chat-settings/sections/TranslationSection";
@@ -127,6 +125,7 @@ import type {
   ChatMemoryRecallExportPayload,
   ChatPreset,
   ChatPresetSettings,
+  ConversationCommandKey,
   ConversationNote,
   ExportEnvelope,
 } from "@marinara-engine/shared";
@@ -147,6 +146,7 @@ import {
   getAgentPromptTemplateOptions,
   AGENT_COST_HIGH_CALLS,
   AGENT_COST_HIGH_TOKENS,
+  CONVERSATION_COMMAND_KEYS,
   getDefaultBuiltInAgentSettings,
   isAgentAvailableInChatMode,
   isAgentConfigDeleted,
@@ -196,8 +196,77 @@ const SPOTIFY_SOURCE_OPTIONS: Array<{ id: SpotifySourceType; label: string; desc
   { id: "any", label: "Any Spotify", description: "Let the DJ use Spotify search when it fits." },
 ];
 
+const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
+  id: ConversationCommandKey;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "schedule_update",
+    label: "Schedule Updates",
+    description: "Let characters change their current status and activity.",
+  },
+  {
+    id: "cross_post",
+    label: "Cross-Post",
+    description: "Let characters redirect a message into another shared chat.",
+  },
+  {
+    id: "selfie",
+    label: "Selfies",
+    description: "Let characters request a generated selfie.",
+  },
+  {
+    id: "memory",
+    label: "Memories",
+    description: "Let characters create memories for other characters.",
+  },
+  {
+    id: "scene",
+    label: "Scenes",
+    description: "Let characters start an immersive scene from the conversation.",
+  },
+  {
+    id: "music",
+    label: "Music",
+    description: "Let characters play songs through the active Music Player.",
+  },
+  {
+    id: "haptic",
+    label: "Haptics",
+    description: "Let characters control connected haptic devices.",
+  },
+  {
+    id: "influence",
+    label: "Influence",
+    description: "Let characters send one-shot influence to a connected chat.",
+  },
+  {
+    id: "note",
+    label: "Notes",
+    description: "Let characters save durable notes for a connected chat.",
+  },
+];
+
 function normalizeSpotifySourceType(value: unknown): SpotifySourceType {
   return value === "playlist" || value === "artist" || value === "any" ? value : "liked";
+}
+
+function readConversationCommandToggles(value: unknown): Partial<Record<ConversationCommandKey, boolean>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const source = value as Record<string, unknown>;
+  const toggles: Partial<Record<ConversationCommandKey, boolean>> = {};
+  for (const key of CONVERSATION_COMMAND_KEYS) {
+    if (typeof source[key] === "boolean") toggles[key] = source[key] as boolean;
+  }
+  return toggles;
+}
+
+function isConversationCommandToggleEnabled(
+  toggles: Partial<Record<ConversationCommandKey, boolean>>,
+  command: ConversationCommandKey,
+): boolean {
+  return toggles[command] !== false;
 }
 
 const MODE_INTROS: Record<ChatMode, string> = {
@@ -379,6 +448,10 @@ export function ChatSettingsDrawer({
   const metadata = useMemo(
     () => (typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {})),
     [chat.metadata],
+  );
+  const conversationCommandToggles = useMemo(
+    () => readConversationCommandToggles(metadata.conversationCommandToggles),
+    [metadata.conversationCommandToggles],
   );
   const inactiveCharacterIds = useMemo<string[]>(
     () =>
@@ -1804,145 +1877,148 @@ export function ChatSettingsDrawer({
             "flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-[calc(1rem+env(safe-area-inset-bottom))]",
           )}
         >
-        {/* Chat Settings Preset bar — hidden in Game Mode and scene chats. */}
-        {modeCapabilities.supportsChatSettingsPresets && !isSceneChat && (
-          <div
-            style={{ order: CHAT_SETTINGS_ORDER.settingsPresets }}
-            className="flex shrink-0 flex-col gap-2 border-b border-[var(--border)] px-4 py-3"
-          >
-            <input
-              ref={presetFileInputRef}
-              type="file"
-              accept=".json,application/json"
-              className="hidden"
-              onChange={handleImportFile}
-            />
-            {/* Dropdown / rename input + help */}
-            <div className="flex items-center gap-2">
-              {renamingPreset ? (
-                <input
-                  value={renamePresetVal}
-                  onChange={(e) => setRenamePresetVal(e.target.value)}
-                  onBlur={handleCommitRenamePreset}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleCommitRenamePreset();
-                    else if (e.key === "Escape") setRenamingPreset(false);
-                  }}
-                  autoFocus
-                  maxLength={120}
-                  className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--primary)]/40"
-                />
-              ) : (
-                <select
-                  value={selectedChatPreset?.id ?? ""}
-                  onChange={(e) => handleSelectPreset(e.target.value)}
-                  title="Apply a chat-settings preset to this chat"
-                  className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
-                >
-                  {presetList.length === 0 && <option value="">Loading…</option>}
-                  {presetList.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.isDefault ? "Default" : p.name}
-                    </option>
-                  ))}
-                </select>
-              )}
-              <button
-                onClick={handleToggleDefaultPreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isActive || setActiveChatPreset.isPending}
-                title={
-                  !selectedChatPreset
-                    ? "Select a preset to mark it as default"
-                    : selectedChatPreset.isActive
-                      ? "This preset is the default for new chats in this mode"
-                      : "Mark this preset as default for new chats in this mode"
-                }
-                aria-pressed={!!selectedChatPreset?.isActive}
-                aria-label={selectedChatPreset?.isActive ? "Default preset" : "Mark as default preset"}
-                className={cn(
-                  "shrink-0 flex items-center justify-center rounded-md p-1.5 transition-colors disabled:cursor-not-allowed",
-                  selectedChatPreset?.isActive
-                    ? "text-yellow-400 disabled:opacity-100"
-                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-yellow-400 disabled:opacity-40",
-                )}
-              >
-                <Star
-                  size="0.875rem"
-                  fill={selectedChatPreset?.isActive ? "currentColor" : "none"}
-                  strokeWidth={selectedChatPreset?.isActive ? 1.5 : 2}
-                />
-              </button>
-              <HelpTooltip
-                side="left"
-                text={
-                  isConversation
-                    ? "Presets bundle this chat's connection, tools, translation, memory recall, advanced parameters, and other settings. Prompt presets are not applied in conversation mode. Characters, persona, lorebooks, sprites, summary, tags, and scene prompt stay tied to the chat. Star a preset to use it as the default for new chats in this mode."
-                    : "Presets bundle this chat's connection, prompt preset, agents, tools, translation, memory recall, advanced parameters, and other settings. They never touch your characters, persona, lorebooks, sprites, summary, tags, or scene prompt — those stay tied to the chat. Star a preset to use it as the default for new chats in this mode."
-                }
+          {/* Chat Settings Preset bar — hidden in Game Mode and scene chats. */}
+          {modeCapabilities.supportsChatSettingsPresets && !isSceneChat && (
+            <div
+              style={{ order: CHAT_SETTINGS_ORDER.settingsPresets }}
+              className="flex shrink-0 flex-col gap-2 border-b border-[var(--border)] px-4 py-3"
+            >
+              <input
+                ref={presetFileInputRef}
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                onChange={handleImportFile}
               />
+              {/* Dropdown / rename input + help */}
+              <div className="flex items-center gap-2">
+                {renamingPreset ? (
+                  <input
+                    value={renamePresetVal}
+                    onChange={(e) => setRenamePresetVal(e.target.value)}
+                    onBlur={handleCommitRenamePreset}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleCommitRenamePreset();
+                      else if (e.key === "Escape") setRenamingPreset(false);
+                    }}
+                    autoFocus
+                    maxLength={120}
+                    className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--primary)]/40"
+                  />
+                ) : (
+                  <select
+                    value={selectedChatPreset?.id ?? ""}
+                    onChange={(e) => handleSelectPreset(e.target.value)}
+                    title="Apply a chat-settings preset to this chat"
+                    className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+                  >
+                    {presetList.length === 0 && <option value="">Loading…</option>}
+                    {presetList.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.isDefault ? "Default" : p.name}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                <button
+                  onClick={handleToggleDefaultPreset}
+                  disabled={!selectedChatPreset || selectedChatPreset.isActive || setActiveChatPreset.isPending}
+                  title={
+                    !selectedChatPreset
+                      ? "Select a preset to mark it as default"
+                      : selectedChatPreset.isActive
+                        ? "This preset is the default for new chats in this mode"
+                        : "Mark this preset as default for new chats in this mode"
+                  }
+                  aria-pressed={!!selectedChatPreset?.isActive}
+                  aria-label={selectedChatPreset?.isActive ? "Default preset" : "Mark as default preset"}
+                  className={cn(
+                    "shrink-0 flex items-center justify-center rounded-md p-1.5 transition-colors disabled:cursor-not-allowed",
+                    selectedChatPreset?.isActive
+                      ? "text-yellow-400 disabled:opacity-100"
+                      : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-yellow-400 disabled:opacity-40",
+                  )}
+                >
+                  <Star
+                    size="0.875rem"
+                    fill={selectedChatPreset?.isActive ? "currentColor" : "none"}
+                    strokeWidth={selectedChatPreset?.isActive ? 1.5 : 2}
+                  />
+                </button>
+                <HelpTooltip
+                  side="left"
+                  text={
+                    isConversation
+                      ? "Presets bundle this chat's connection, tools, translation, memory recall, advanced parameters, and other settings. Prompt presets are not applied in conversation mode. Characters, persona, lorebooks, sprites, summary, tags, and scene prompt stay tied to the chat. Star a preset to use it as the default for new chats in this mode."
+                      : "Presets bundle this chat's connection, prompt preset, agents, tools, translation, memory recall, advanced parameters, and other settings. They never touch your characters, persona, lorebooks, sprites, summary, tags, or scene prompt — those stay tied to the chat. Star a preset to use it as the default for new chats in this mode."
+                  }
+                />
+              </div>
+              {/* Single row of all preset actions */}
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={handleSaveIntoPreset}
+                  disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+                  title={
+                    selectedChatPreset?.isDefault
+                      ? "Cannot save into the Default preset"
+                      : "Save current chat settings into this preset"
+                  }
+                  className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Save size="0.875rem" />
+                </button>
+                <button
+                  onClick={handleStartRenamePreset}
+                  disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+                  title={selectedChatPreset?.isDefault ? "Cannot rename the Default preset" : "Rename preset"}
+                  className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Pencil size="0.875rem" />
+                </button>
+                <button
+                  onClick={handleSaveAsPreset}
+                  disabled={!selectedChatPreset}
+                  title="Save current chat settings as a new preset"
+                  className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <FilePlus2 size="0.875rem" />
+                </button>
+                <span className="mx-1 h-4 w-px shrink-0 bg-[var(--border)]" aria-hidden />
+                <button
+                  onClick={handleImportClick}
+                  title="Import preset (.json)"
+                  className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                >
+                  <Download size="0.875rem" />
+                </button>
+                <button
+                  onClick={handleExportPreset}
+                  disabled={!selectedChatPreset}
+                  title="Export preset (.json)"
+                  className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Upload size="0.875rem" />
+                </button>
+                <button
+                  onClick={handleDeletePreset}
+                  disabled={!selectedChatPreset || selectedChatPreset.isDefault}
+                  title={selectedChatPreset?.isDefault ? "Cannot delete the Default preset" : "Delete preset"}
+                  className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Trash2 size="0.875rem" />
+                </button>
+              </div>
             </div>
-            {/* Single row of all preset actions */}
-            <div className="flex items-center gap-1">
-              <button
-                onClick={handleSaveIntoPreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isDefault}
-                title={
-                  selectedChatPreset?.isDefault
-                    ? "Cannot save into the Default preset"
-                    : "Save current chat settings into this preset"
-                }
-                className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <Save size="0.875rem" />
-              </button>
-              <button
-                onClick={handleStartRenamePreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isDefault}
-                title={selectedChatPreset?.isDefault ? "Cannot rename the Default preset" : "Rename preset"}
-                className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <Pencil size="0.875rem" />
-              </button>
-              <button
-                onClick={handleSaveAsPreset}
-                disabled={!selectedChatPreset}
-                title="Save current chat settings as a new preset"
-                className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <FilePlus2 size="0.875rem" />
-              </button>
-              <span className="mx-1 h-4 w-px shrink-0 bg-[var(--border)]" aria-hidden />
-              <button
-                onClick={handleImportClick}
-                title="Import preset (.json)"
-                className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-              >
-                <Download size="0.875rem" />
-              </button>
-              <button
-                onClick={handleExportPreset}
-                disabled={!selectedChatPreset}
-                title="Export preset (.json)"
-                className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <Upload size="0.875rem" />
-              </button>
-              <button
-                onClick={handleDeletePreset}
-                disabled={!selectedChatPreset || selectedChatPreset.isDefault}
-                title={selectedChatPreset?.isDefault ? "Cannot delete the Default preset" : "Delete preset"}
-                className="flex-1 flex items-center justify-center rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                <Trash2 size="0.875rem" />
-              </button>
-            </div>
-          </div>
-        )}
+          )}
 
           {/* Hardcoded — CHAT_MODES.defaultAgents looks like the source of truth but is currently
               unused, and wouldn't cover non-agent built-ins (GM pipeline, autonomous messaging, etc.) anyway. */}
           {MODE_INTROS[chatMode as ChatMode] && (
-            <div style={{ order: CHAT_SETTINGS_ORDER.modeIntro }} className="border-b border-[var(--border)] px-4 py-2.5">
+            <div
+              style={{ order: CHAT_SETTINGS_ORDER.modeIntro }}
+              className="border-b border-[var(--border)] px-4 py-2.5"
+            >
               <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
                 {MODE_INTROS[chatMode as ChatMode]}
               </p>
@@ -2682,15 +2758,6 @@ export function ChatSettingsDrawer({
             />
           )}
 
-          {isConversation && (
-            <ManualRepliesSection
-              enabled={metadata.groupResponseOrder === "manual"}
-              onEnabledChange={(enabled) =>
-                updateMeta.mutate({ id: chat.id, groupResponseOrder: enabled ? "manual" : "sequential" })
-              }
-            />
-          )}
-
           {/* Group Chat Settings — only when 2+ characters, game mode handles it internally */}
           {chatCharIds.length > 1 && modeCapabilities.supportsGroupChatControls && (
             <Section
@@ -2981,6 +3048,44 @@ export function ChatSettingsDrawer({
                   </div>
                 </button>
 
+                <button
+                  onClick={() => {
+                    const onlyWhenMentioned = metadata.groupResponseOrder === "manual";
+                    updateMeta.mutate({
+                      id: chat.id,
+                      groupResponseOrder: onlyWhenMentioned ? "sequential" : "manual",
+                    });
+                  }}
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                    metadata.groupResponseOrder === "manual"
+                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                  )}
+                >
+                  <div className="flex-1 min-w-0">
+                    <span className="text-xs font-medium">Reply When Mentioned</span>
+                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                      Characters wait for direct mentions or manual response triggers
+                    </p>
+                  </div>
+                  <div
+                    className={cn(
+                      "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                      metadata.groupResponseOrder === "manual"
+                        ? "bg-[var(--primary)]"
+                        : "bg-[var(--muted-foreground)]/50",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                        metadata.groupResponseOrder === "manual" && "translate-x-3.5",
+                      )}
+                    />
+                  </div>
+                </button>
+
                 {metadata.autonomousMessages && !conversationSchedulesEnabled && (
                   <div className="rounded-lg bg-[var(--primary)]/8 px-3 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--primary)]/20">
                     Schedules are off. Autonomous messages still use character talkativeness and your active or idle
@@ -3062,7 +3167,6 @@ export function ChatSettingsDrawer({
 
                 {/* Schedule status */}
                 <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2.5">
-                  <CalendarClock size="0.875rem" className="text-[var(--muted-foreground)]" />
                   <div className="flex-1 min-w-0">
                     <span className="text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
                       {!conversationSchedulesEnabled
@@ -3137,10 +3241,7 @@ export function ChatSettingsDrawer({
                   )}
                 >
                   <div className="min-w-0 flex-1">
-                    <span className="flex items-center gap-1.5 text-xs font-medium">
-                      <Sparkles size="0.75rem" className="text-[var(--primary)]" />
-                      Commands
-                    </span>
+                    <span className="text-xs font-medium">Commands</span>
                     <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                       Allow models to interact with you via commands. This way, they can send you selfies, play songs
                       for you, change their schedules, start scenes, and do much more!
@@ -3161,12 +3262,61 @@ export function ChatSettingsDrawer({
                   </div>
                 </button>
 
+                {conversationCommandsEnabled && (
+                  <div className="grid gap-1.5 sm:grid-cols-2">
+                    {CONVERSATION_COMMAND_TOGGLE_OPTIONS.map((command) => {
+                      const enabled = isConversationCommandToggleEnabled(conversationCommandToggles, command.id);
+                      return (
+                        <button
+                          key={command.id}
+                          type="button"
+                          onClick={() =>
+                            updateMeta.mutate({
+                              id: chat.id,
+                              conversationCommandToggles: {
+                                ...conversationCommandToggles,
+                                [command.id]: !enabled,
+                              },
+                            })
+                          }
+                          className={cn(
+                            "flex min-h-[4.125rem] items-start justify-between gap-2 rounded-lg px-3 py-2 text-left transition-all",
+                            enabled
+                              ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                              : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                          )}
+                          aria-pressed={enabled}
+                        >
+                          <div className="min-w-0 flex-1">
+                            <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">
+                              {command.label}
+                            </span>
+                            <p className="mt-0.5 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                              {command.description}
+                            </p>
+                          </div>
+                          <div
+                            className={cn(
+                              "mt-0.5 h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
+                              enabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                            )}
+                          >
+                            <div
+                              className={cn(
+                                "h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
+                                enabled && "translate-x-3",
+                              )}
+                            />
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
                 {/* Selfie Connection — connection picker for character selfies */}
                 <div className="space-y-1.5">
-                  <div className="flex items-center gap-2">
-                    <Image size="0.75rem" className="text-[var(--primary)]" />
-                    <span className="text-xs font-medium">Selfie Connection</span>
-                  </div>
+                  <span className="text-xs font-medium">Selfie Connection</span>
                   <select
                     value={(metadata.imageGenConnectionId as string) ?? ""}
                     onChange={(e) => updateMeta.mutate({ id: chat.id, imageGenConnectionId: e.target.value || null })}
@@ -3289,7 +3439,6 @@ export function ChatSettingsDrawer({
                 {/* Schedule generation preferences — free-form authorial guidance */}
                 <label className="flex flex-col gap-1.5">
                   <span className="inline-flex items-center gap-1.5 text-xs font-medium">
-                    <Sparkles size="0.75rem" className="text-[var(--primary)]" />
                     Schedule generation preferences
                     <HelpTooltip text="Free-form guidance that steers how character schedules are generated. Both directives ('no characters past midnight') and factual constraints ('I work 9-5') work. This setting is global, it applies to every conversation chat." />
                   </span>
@@ -3308,10 +3457,9 @@ export function ChatSettingsDrawer({
                 {/* Active schedule-generation preference indicator */}
                 {scheduleGenerationPreferences.trim() && (
                   <div
-                    className="flex items-start gap-2 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2.5"
+                    className="rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-3 py-2.5"
                     title={scheduleGenerationPreferences.trim()}
                   >
-                    <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
                     <div className="min-w-0 flex-1">
                       <span className="block text-[0.6875rem] font-medium leading-snug text-[var(--foreground)]">
                         Schedule generation preference active
@@ -3442,7 +3590,7 @@ export function ChatSettingsDrawer({
                         <MessageSquare size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
                         <span className="truncate">{getConnectedChatDisplayName(c)}</span>
                       </button>
-                  ))}
+                    ))}
                 </PickerDropdown>
               )}
               <DiscordMirrorControls
@@ -3625,7 +3773,7 @@ export function ChatSettingsDrawer({
                         <MessageSquare size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
                         <span className="truncate">{getConnectedChatDisplayName(c)}</span>
                       </button>
-                  ))}
+                    ))}
                 </PickerDropdown>
               )}
               <DiscordMirrorControls
@@ -3872,7 +4020,9 @@ export function ChatSettingsDrawer({
                       <div
                         className={cn(
                           "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                          activeAgentIds.includes("youtube") ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                          activeAgentIds.includes("youtube")
+                            ? "bg-[var(--primary)]"
+                            : "bg-[var(--muted-foreground)]/50",
                         )}
                       >
                         <div
@@ -5044,10 +5194,7 @@ export function ChatSettingsDrawer({
 
                 {/* Day rollover hour */}
                 <div className="space-y-1.5">
-                  <div className="flex items-center gap-2">
-                    <Clock size="0.75rem" className="text-[var(--primary)]" />
-                    <span className="text-xs font-medium">Day Rollover Hour</span>
-                  </div>
+                  <span className="text-xs font-medium">Day Rollover Hour</span>
                   <select
                     value={(metadata.dayRolloverHour as number | undefined) ?? 4}
                     onChange={(e) => {
@@ -5088,10 +5235,7 @@ export function ChatSettingsDrawer({
 
                 {/* Recent message tail */}
                 <div className="space-y-1.5">
-                  <div className="flex items-center gap-2">
-                    <MessageCircle size="0.75rem" className="text-[var(--primary)]" />
-                    <span className="text-xs font-medium">Recent Message Tail</span>
-                  </div>
+                  <span className="text-xs font-medium">Recent Message Tail</span>
                   <input
                     type="number"
                     min={0}
@@ -5177,12 +5321,14 @@ export function ChatSettingsDrawer({
             />
           </div>
 
-          <div style={{ order: CHAT_SETTINGS_ORDER.impersonate }}>
-            <ImpersonateSection
-              presets={(presets ?? []) as Array<{ id: string; name: string }>}
-              connections={textConnectionsList}
-            />
-          </div>
+          {!isConversation && (
+            <div style={{ order: CHAT_SETTINGS_ORDER.impersonate }}>
+              <ImpersonateSection
+                presets={(presets ?? []) as Array<{ id: string; name: string }>}
+                connections={textConnectionsList}
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Chat: Settings Drawer — per-chat configuration
 // ──────────────────────────────────────────────
-import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback, type CSSProperties } from "react";
 import { useQuery, useQueryClient, useQueries } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -46,6 +46,12 @@ import {
   EyeOff,
   Music2,
 } from "lucide-react";
+import {
+  ROLEPLAY_POPOVER_HEADER,
+  ROLEPLAY_POPOVER_SCROLL_AREA,
+  ROLEPLAY_POPOVER_SHELL,
+  ROLEPLAY_POPOVER_TITLE,
+} from "./roleplay-popover-styles";
 import { PickerDropdown } from "../../features/chat-settings/PickerDropdown";
 import { ChatSettingsSection as Section } from "../../features/chat-settings/ChatSettingsSection";
 import { AdvancedParametersSection } from "../../features/chat-settings/sections/AdvancedParametersSection";
@@ -174,6 +180,7 @@ interface ChatSettingsDrawerProps {
   chat: Chat;
   open: boolean;
   onClose: () => void;
+  anchor?: { right: number; top: number } | null;
   spriteArrangeMode?: boolean;
   onToggleSpriteArrange?: () => void;
   onResetSpritePlacements?: () => void;
@@ -308,6 +315,7 @@ export function ChatSettingsDrawer({
   chat,
   open,
   onClose,
+  anchor,
   spriteArrangeMode = false,
   onToggleSpriteArrange,
   onResetSpritePlacements,
@@ -1759,17 +1767,29 @@ export function ChatSettingsDrawer({
   };
 
   if (!open) return null;
+  const panelStyle: CSSProperties | undefined = anchor
+    ? { right: `${anchor.right}px`, top: `${anchor.top}px` }
+    : undefined;
 
   return (
     <>
-      {/* Backdrop */}
-      <div className="absolute inset-0 z-40 bg-black/30 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="fixed inset-0 z-[65] bg-transparent" onClick={onClose} />
 
       {/* Floating panel */}
-      <div className="absolute bottom-3 right-3 top-14 z-50 flex min-h-0 w-[min(34rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)] shadow-2xl animate-fade-in-up max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto">
+      <div
+        className={cn(
+          ROLEPLAY_POPOVER_SHELL,
+          "fixed bottom-3 z-[70] flex min-h-0 w-[min(34rem,calc(100vw-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
+          anchor ? "" : "right-3 top-14",
+        )}
+        style={panelStyle}
+      >
         {/* Header */}
-        <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <h3 className="text-sm font-bold">Chat Settings</h3>
+        <div className={cn(ROLEPLAY_POPOVER_HEADER, "flex shrink-0 items-center justify-between")}>
+          <h3 className={ROLEPLAY_POPOVER_TITLE}>
+            <Settings2 size="0.8125rem" className="shrink-0 text-[var(--muted-foreground)]" />
+            Chat Settings
+          </h3>
           <button
             onClick={onClose}
             className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
@@ -1778,7 +1798,12 @@ export function ChatSettingsDrawer({
           </button>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-[calc(1rem+env(safe-area-inset-bottom))]">
+        <div
+          className={cn(
+            ROLEPLAY_POPOVER_SCROLL_AREA,
+            "flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-[calc(1rem+env(safe-area-inset-bottom))]",
+          )}
+        >
         {/* Chat Settings Preset bar — hidden in Game Mode and scene chats. */}
         {modeCapabilities.supportsChatSettingsPresets && !isSceneChat && (
           <div

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -3377,7 +3377,7 @@ export function ChatSettingsDrawer({
           {isConversation && (
             <Section
               style={{ order: CHAT_SETTINGS_ORDER.connectedChat }}
-              label="Connected Roleplay"
+              label="Connected Chats"
               icon={<ArrowRightLeft size="0.875rem" />}
               help="Link this conversation to a roleplay or game. Recent messages from the linked chat are pulled into context here automatically. To send something the other direction, the character uses `<influence>` (steers the next linked turn, one-shot) or `<note>` (persists on every future linked turn until cleared)."
             >
@@ -3456,7 +3456,7 @@ export function ChatSettingsDrawer({
           {isRoleplayMode && (
             <Section
               style={{ order: CHAT_SETTINGS_ORDER.connectedChat }}
-              label="Connected Conversation"
+              label="Connected Chats"
               icon={<ArrowRightLeft size="0.875rem" />}
               help={
                 'Link to an OOC conversation, and optionally let roleplay characters open direct-message conversations with `[dm: character="Name" message="text"]` when it naturally fits the scene.'
@@ -3541,7 +3541,7 @@ export function ChatSettingsDrawer({
           {isGame && chat.connectedChatId && (
             <Section
               style={{ order: CHAT_SETTINGS_ORDER.connectedChat }}
-              label="Connected Conversation"
+              label="Connected Chats"
               icon={<ArrowRightLeft size="0.875rem" />}
               help="Linked to a conversation. `<influence>` tags from the conversation steer the next turn here (one-shot, then consumed). `<note>` tags persist on every turn until cleared. Raw conversation messages are not injected — use `<note>` for facts this chat should keep remembering."
             >
@@ -3584,7 +3584,7 @@ export function ChatSettingsDrawer({
           {chatMode === "game" && !chat.connectedChatId && (
             <Section
               style={{ order: CHAT_SETTINGS_ORDER.connectedChat }}
-              label="Connected Conversation"
+              label="Connected Chats"
               icon={<ArrowRightLeft size="0.875rem" />}
               help="Link this game to an OOC conversation. The conversation character uses `<influence>` (one-shot) or `<note>` (durable) to bridge content into the game; raw conversation messages are not injected. Game events and roleplay moments flow back into the conversation automatically."
             >

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -26,9 +26,10 @@ export function getChatToolbarButtonClass({
   open = false,
 }: ChatToolbarButtonClassInput = {}) {
   return cn(
-    "flex items-center justify-center rounded-full border border-foreground/10 bg-foreground/5 text-foreground/60 backdrop-blur-md transition-all hover:bg-foreground/10 hover:text-foreground",
+    "marinara-chat-toolbar-button flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
     compact ? "p-1" : "p-1.5",
-    (active || open) && "border-foreground/20 bg-foreground/15 text-foreground/90",
+    (active || open) &&
+      "marinara-chat-toolbar-button--active border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]",
     className,
   );
 }
@@ -106,10 +107,7 @@ export function ChatToolbarMenu({
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className={cn(
-            "flex w-9 items-center justify-center rounded-xl border border-foreground/10 bg-foreground/5 p-1.5 text-foreground/60 backdrop-blur-md transition-all hover:bg-foreground/10 hover:text-foreground",
-            open && "border-foreground/20 bg-foreground/15 text-foreground/90",
-          )}
+          className={getChatToolbarButtonClass({ className: "h-9 w-9", open })}
           title="More options"
           aria-label="More options"
           aria-haspopup="menu"

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -1,0 +1,135 @@
+import { createPortal } from "react-dom";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
+import { MoreHorizontal } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { useUIStore } from "../../stores/ui.store";
+import { ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
+
+type ChatToolbarButtonClassInput = {
+  active?: boolean;
+  className?: string;
+  compact?: boolean;
+  open?: boolean;
+};
+
+export function getChatToolbarButtonClass({
+  active = false,
+  className,
+  compact = false,
+  open = false,
+}: ChatToolbarButtonClassInput = {}) {
+  return cn(
+    "flex items-center justify-center rounded-full border border-foreground/10 bg-foreground/5 text-foreground/60 backdrop-blur-md transition-all hover:bg-foreground/10 hover:text-foreground",
+    compact ? "p-1" : "p-1.5",
+    (active || open) && "border-foreground/20 bg-foreground/15 text-foreground/90",
+    className,
+  );
+}
+
+export function ChatToolbarButton({
+  className,
+  icon,
+  title,
+  onClick,
+  size,
+}: {
+  className?: string;
+  icon: ReactNode;
+  title: string;
+  onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  size?: "sm";
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={getChatToolbarButtonClass({ className, compact: size === "sm" })}
+      title={title}
+      aria-label={title}
+    >
+      {icon}
+    </button>
+  );
+}
+
+export function ChatToolbarMenu({
+  children,
+  desktopChildren,
+  mobileChildren,
+}: {
+  children?: ReactNode;
+  desktopChildren?: ReactNode;
+  mobileChildren?: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const compact = useUIStore((s) => s.centerCompact);
+  const btnRef = useRef<HTMLDivElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
+  const resolvedDesktopChildren = desktopChildren ?? children;
+  const resolvedMobileChildren = mobileChildren ?? children;
+
+  useLayoutEffect(() => {
+    if (!open || !btnRef.current) return;
+    const rect = btnRef.current.getBoundingClientRect();
+    setPos({
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+    });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (target instanceof Element && target.closest("[data-chat-branch-popover]")) return;
+      if (btnRef.current?.contains(target) || popRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [open]);
+
+  return (
+    <>
+      <div className={cn("items-center gap-1.5 max-md:hidden", compact ? "hidden" : "flex")}>
+        {resolvedDesktopChildren}
+      </div>
+      <div className={cn("relative shrink-0", compact ? "block" : "block md:hidden")} ref={btnRef}>
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          className={cn(
+            "flex w-9 items-center justify-center rounded-xl border border-foreground/10 bg-foreground/5 p-1.5 text-foreground/60 backdrop-blur-md transition-all hover:bg-foreground/10 hover:text-foreground",
+            open && "border-foreground/20 bg-foreground/15 text-foreground/90",
+          )}
+          title="More options"
+          aria-label="More options"
+          aria-haspopup="menu"
+          aria-expanded={open}
+        >
+          <MoreHorizontal size="0.9375rem" />
+        </button>
+        {open &&
+          createPortal(
+            <div
+              ref={popRef}
+              className={cn(ROLEPLAY_POPOVER_SHELL, "fixed z-[9999] flex w-9 flex-col items-center gap-0.5 p-1")}
+              style={{ top: pos.top, right: pos.right }}
+              onClick={() => setOpen(false)}
+            >
+              {resolvedMobileChildren}
+            </div>,
+            document.body,
+          )}
+      </div>
+    </>
+  );
+}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -11,7 +11,6 @@ import {
   ImagePlay,
   AtSign,
   Users,
-  UserCheck,
   Languages,
   Loader2,
   FileText,
@@ -72,6 +71,11 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
 
 const SAVED_STATUS_LIMIT = 12;
 const SAVED_STATUS_MAX_LENGTH = 120;
+const CONVERSATION_HIDDEN_SLASH_COMMANDS = new Set(["impersonate", "impersonate_prompt"]);
+
+function isConversationHiddenSlashCommand(command: SlashCommand): boolean {
+  return CONVERSATION_HIDDEN_SLASH_COMMANDS.has(command.name);
+}
 
 interface PersonaStatusRow {
   id: string;
@@ -228,7 +232,6 @@ export function ConversationInput({
   const showQuickRepliesMenu = useUIStore((s) => s.showQuickRepliesMenu);
   const showQuickReplyPostOnly = useUIStore((s) => s.showQuickReplyPostOnly);
   const showQuickReplyGuide = useUIStore((s) => s.showQuickReplyGuide);
-  const showQuickReplyImpersonate = useUIStore((s) => s.showQuickReplyImpersonate);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
   const userActivity = useUIStore((s) => s.userActivity);
@@ -621,8 +624,13 @@ export function ConversationInput({
     // Slash command check
     const matched = matchSlashCommand(raw);
     if (matched) {
+      if (isConversationHiddenSlashCommand(matched.command)) {
+        setFeedback("Impersonate is not available in Conversation mode.");
+        return;
+      }
       const slashCtx: SlashCommandContext = {
         chatId: activeChatId,
+        mode: "conversation",
         generate,
         createMessage: (data) => createMessage.mutate(data),
         invalidate: () => qc.invalidateQueries({ queryKey: chatKeys.all }),
@@ -765,9 +773,14 @@ export function ConversationInput({
       const submittingChatId = activeChatId;
       const matched = matchSlashCommand(commandLine);
       if (!matched) return;
+      if (isConversationHiddenSlashCommand(matched.command)) {
+        toast.info("Impersonate is not available in Conversation mode.");
+        return;
+      }
       const generationStatus: { succeeded?: boolean } = {};
       const slashCtx: SlashCommandContext = {
         chatId: submittingChatId,
+        mode: "conversation",
         generate: async (params) => {
           const succeeded = await generate(params);
           if (succeeded !== undefined) generationStatus.succeeded = succeeded;
@@ -841,17 +854,6 @@ export function ConversationInput({
       syncInputState,
     ],
   );
-
-  const handleImpersonateQuickButton = useCallback(async () => {
-    if (!activeChatId || isStreaming) return;
-    if (hasPendingAttachments) {
-      toast.info("Clear or send attachments before using quick impersonate.");
-      return;
-    }
-    const text = textareaRef.current?.value?.trim() ?? "";
-    if (!text) return;
-    await runQuickSlashCommand(`/impersonate ${text}`, "Impersonate failed");
-  }, [activeChatId, isStreaming, hasPendingAttachments, runQuickSlashCommand]);
 
   const handlePostOnlyButton = useCallback(async () => {
     if (!activeChatId || isStreaming) return;
@@ -1011,13 +1013,6 @@ export function ConversationInput({
       if (!hasInput) return "Type a direction first.";
       return undefined;
     };
-    const getImpersonateDisabledReason = () => {
-      if (!activeChatId) return "Select or create a chat first.";
-      if (isStreaming) return "Wait for the current stream to finish.";
-      if (hasPendingAttachments) return "Clear or post attachments first.";
-      if (!hasInput) return "Type a direction first.";
-      return undefined;
-    };
     if (showQuickReplyPostOnly) {
       actions.push({
         id: "post-only",
@@ -1040,17 +1035,6 @@ export function ConversationInput({
         onSelect: handleGuidedGenerationButton,
       });
     }
-    if (showQuickReplyImpersonate) {
-      actions.push({
-        id: "impersonate",
-        label: "Impersonate",
-        description: "Generate as your persona",
-        icon: <UserCheck size="0.875rem" />,
-        disabled: !activeChatId || isStreaming || !hasInput || hasPendingAttachments,
-        disabledReason: getImpersonateDisabledReason(),
-        onSelect: handleImpersonateQuickButton,
-      });
-    }
     return actions;
   }, [
     activeChatId,
@@ -1062,10 +1046,8 @@ export function ConversationInput({
     requiresManualGuideTarget,
     showQuickReplyPostOnly,
     showQuickReplyGuide,
-    showQuickReplyImpersonate,
     handlePostOnlyButton,
     handleGuidedGenerationButton,
-    handleImpersonateQuickButton,
   ]);
 
   const handleKeyDown = useCallback(
@@ -1172,7 +1154,7 @@ export function ConversationInput({
 
     // Slash completions
     if (formatted.startsWith("/")) {
-      const results = getSlashCompletions(formatted);
+      const results = getSlashCompletions(formatted).filter((command) => !isConversationHiddenSlashCommand(command));
       setCompletions(results);
       setSelectedCompletion(0);
     } else {
@@ -1559,9 +1541,7 @@ export function ConversationInput({
         onDrop={handleDrop}
         className={cn(
           "relative flex flex-wrap items-end gap-1 rounded-2xl border border-foreground/20 bg-[var(--card)] px-2 py-1.5 shadow-sm transition-all duration-200 focus-within:border-foreground/35 focus-within:ring-1 focus-within:ring-foreground/10 sm:flex-nowrap sm:items-center sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
-          isDragging
-            ? "border-foreground/40 bg-foreground/10 shadow-lg shadow-black/10"
-            : "",
+          isDragging ? "border-foreground/40 bg-foreground/10 shadow-lg shadow-black/10" : "",
         )}
       >
         {/* Attach button */}
@@ -1816,9 +1796,7 @@ export function ConversationInput({
                   </div>
                 ))
               ) : (
-                <div className="px-3 py-4 text-center text-[0.6875rem] text-foreground/45">
-                  No saved statuses yet
-                </div>
+                <div className="px-3 py-4 text-center text-[0.6875rem] text-foreground/45">No saved statuses yet</div>
               )}
             </div>
           </div>,

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1463,7 +1463,7 @@ export function ConversationInput({
     <div className="relative px-3 pb-3">
       {/* Slash command autocomplete */}
       {completions.length > 0 && (
-        <div className="absolute bottom-full left-3 right-3 z-40 mb-1 max-h-[min(18rem,45dvh)] overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--card)] shadow-lg [-webkit-overflow-scrolling:touch]">
+        <div className="absolute bottom-full left-3 right-3 z-40 mb-1 max-h-[min(18rem,45dvh)] overflow-y-auto rounded-lg border border-foreground/10 bg-[var(--card)] shadow-lg [-webkit-overflow-scrolling:touch]">
           {completions.map((cmd, i) => (
             <button
               key={cmd.name}
@@ -1479,12 +1479,12 @@ export function ConversationInput({
               }}
               className={cn(
                 "flex w-full min-w-0 items-start gap-2 px-3 py-2.5 text-left text-sm transition-colors",
-                i === selectedCompletion ? "bg-foreground/10 text-foreground" : "hover:bg-[var(--accent)]",
+                i === selectedCompletion ? "bg-foreground/10 text-foreground" : "hover:bg-foreground/10",
               )}
             >
               <span className="shrink-0 whitespace-nowrap font-mono text-xs">/{cmd.name}</span>
               {cmd.description && (
-                <span className="min-w-0 flex-1 text-[0.6875rem] leading-snug text-[var(--muted-foreground)] [overflow-wrap:anywhere]">
+                <span className="min-w-0 flex-1 text-[0.6875rem] leading-snug text-foreground/45 [overflow-wrap:anywhere]">
                   {cmd.description}
                 </span>
               )}
@@ -1495,7 +1495,7 @@ export function ConversationInput({
 
       {/* @mention autocomplete */}
       {mentionCompletions.length > 0 && (
-        <div className="absolute bottom-full left-0 right-0 mb-1 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)] shadow-lg">
+        <div className="absolute bottom-full left-0 right-0 mb-1 overflow-hidden rounded-lg border border-foreground/10 bg-[var(--card)] shadow-lg">
           {mentionCompletions.map((name, i) => (
             <button
               key={name}
@@ -1505,10 +1505,10 @@ export function ConversationInput({
               }}
               className={cn(
                 "flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
-                i === selectedMention ? "bg-foreground/10 text-foreground" : "hover:bg-[var(--accent)]",
+                i === selectedMention ? "bg-foreground/10 text-foreground" : "hover:bg-foreground/10",
               )}
             >
-              <AtSign size="0.75rem" className="shrink-0 text-cyan-400" />
+              <AtSign size="0.75rem" className="shrink-0 text-foreground/45" />
               <span className="font-medium">{name}</span>
             </button>
           ))}
@@ -1528,22 +1528,22 @@ export function ConversationInput({
           {attachments.map((att, i) => (
             <div
               key={i}
-              className="flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-[var(--border)]"
+              className="flex items-center gap-1.5 rounded-lg bg-foreground/10 px-2.5 py-1.5 text-xs ring-1 ring-foreground/10"
             >
               {att.type.startsWith("image/") ? null : (
-                <FileText size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                <FileText size="0.875rem" className="shrink-0 text-foreground/45" />
               )}
               <span className="max-w-[120px] truncate">{att.name}</span>
               <button
                 onClick={() => updateAttachments((prev) => prev.filter((_, idx) => idx !== i))}
-                className="rounded p-0.5 text-[var(--muted-foreground)] hover:text-[var(--destructive)]"
+                className="rounded p-0.5 text-foreground/45 hover:text-[var(--destructive)]"
               >
                 <X size="0.625rem" />
               </button>
             </div>
           ))}
           {isReadingAttachments && (
-            <div className="flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+            <div className="flex items-center gap-1.5 rounded-lg bg-foreground/10 px-2.5 py-1.5 text-xs text-foreground/60 ring-1 ring-foreground/10">
               <Loader2 size="0.875rem" className="animate-spin" />
               Reading file...
             </div>
@@ -1558,8 +1558,10 @@ export function ConversationInput({
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={cn(
-          "relative flex flex-wrap items-end gap-1 rounded-2xl border-2 bg-[var(--card)] px-2 py-1.5 transition-all duration-200 sm:flex-nowrap sm:items-center sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
-          isDragging ? "border-blue-400/50 bg-blue-500/10 shadow-lg shadow-blue-500/10" : "border-[var(--border)]",
+          "relative flex flex-wrap items-end gap-1 rounded-2xl border border-foreground/20 bg-[var(--card)] px-2 py-1.5 shadow-sm transition-all duration-200 focus-within:border-foreground/35 focus-within:ring-1 focus-within:ring-foreground/10 sm:flex-nowrap sm:items-center sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
+          isDragging
+            ? "border-foreground/40 bg-foreground/10 shadow-lg shadow-black/10"
+            : "",
         )}
       >
         {/* Attach button */}
@@ -1579,7 +1581,7 @@ export function ConversationInput({
           className={cn(
             "order-2 flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 sm:order-none sm:h-8 sm:w-8",
             attachments.length
-              ? "bg-foreground/10 text-foreground/75"
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
           )}
           title="Attach file"
@@ -1613,7 +1615,7 @@ export function ConversationInput({
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          className="order-1 max-h-[12.5rem] min-w-0 basis-full flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-[var(--foreground)] outline-none placeholder:text-foreground/30 sm:order-none sm:basis-auto"
+          className="order-1 max-h-[12.5rem] min-w-0 basis-full flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-foreground outline-none placeholder:text-foreground/30 sm:order-none sm:basis-auto"
         />
 
         {/* Right actions */}
@@ -1628,7 +1630,7 @@ export function ConversationInput({
               className={cn(
                 "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
                 gifOpen
-                  ? "bg-foreground/10 text-foreground/75"
+                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                   : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
               )}
               title="GIF"
@@ -1654,7 +1656,7 @@ export function ConversationInput({
               className={cn(
                 "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
                 emojiOpen
-                  ? "bg-foreground/10 text-foreground/75"
+                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                   : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
               )}
               title="Emoji"
@@ -1679,7 +1681,7 @@ export function ConversationInput({
                 guideGenerations && hasInput
                   ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
                   : charPickerOpen
-                    ? "bg-foreground/10 text-foreground/75"
+                    ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                     : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
               )}
               title={
@@ -1724,7 +1726,7 @@ export function ConversationInput({
             className={cn(
               "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
               statusMenuOpen
-                ? "bg-foreground/10 text-foreground/75"
+                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                 : activePersona
                   ? "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70"
                   : "text-foreground/25",
@@ -1748,9 +1750,9 @@ export function ConversationInput({
             className={cn(
               "flex h-11 w-11 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
               isActuallyGenerating
-                ? "text-foreground/75 hover:text-foreground/90"
+                ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90"
                 : canSubmit && !isReadingAttachments
-                  ? "text-foreground/75 hover:text-foreground/90 active:scale-90"
+                  ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90 active:scale-90"
                   : "text-foreground/20",
             )}
             title={sendButtonTitle}
@@ -1769,14 +1771,14 @@ export function ConversationInput({
         createPortal(
           <div
             ref={statusMenuRef}
-            className="fixed z-[9999] flex max-h-[320px] min-w-[240px] max-w-[300px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+            className="fixed z-[9999] flex max-h-[320px] min-w-[240px] max-w-[300px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
             style={
               statusMenuPos ? { left: statusMenuPos.left, top: statusMenuPos.top } : { visibility: "hidden" as const }
             }
           >
-            <div className="border-b border-[var(--border)] px-3 py-2">
+            <div className="border-b border-foreground/10 px-3 py-2">
               <div className="truncate text-xs font-semibold">Saved Statuses</div>
-              <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
+              <div className="truncate text-[0.625rem] text-foreground/45">
                 {activePersona?.name ?? "No persona selected"}
               </div>
             </div>
@@ -1786,7 +1788,7 @@ export function ConversationInput({
                   type="button"
                   onClick={() => void handleSaveCurrentStatus()}
                   disabled={updatePersona.isPending}
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-[var(--primary)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-foreground/80 transition-colors hover:bg-foreground/10 disabled:opacity-50"
                 >
                   <Plus size="0.875rem" className="shrink-0" />
                   <span className="min-w-0 flex-1 truncate">Save &quot;{normalizedUserActivity}&quot;</span>
@@ -1794,7 +1796,7 @@ export function ConversationInput({
               )}
               {savedStatusOptions.length > 0 ? (
                 savedStatusOptions.map((status) => (
-                  <div key={status} className="group flex items-center gap-1 rounded-lg hover:bg-[var(--accent)]">
+                  <div key={status} className="group flex items-center gap-1 rounded-lg hover:bg-foreground/10">
                     <button
                       type="button"
                       onClick={() => handleApplySavedStatus(status)}
@@ -1806,7 +1808,7 @@ export function ConversationInput({
                       type="button"
                       onClick={() => void handleDeleteSavedStatus(status)}
                       disabled={updatePersona.isPending}
-                      className="mr-1 rounded-md p-1.5 text-[var(--muted-foreground)] opacity-70 transition-colors hover:text-[var(--destructive)] disabled:opacity-40 sm:opacity-0 sm:group-hover:opacity-100"
+                      className="mr-1 rounded-md p-1.5 text-foreground/45 opacity-70 transition-colors hover:text-[var(--destructive)] disabled:opacity-40 sm:opacity-0 sm:group-hover:opacity-100"
                       title="Remove saved status"
                     >
                       <Trash2 size="0.75rem" />
@@ -1814,7 +1816,7 @@ export function ConversationInput({
                   </div>
                 ))
               ) : (
-                <div className="px-3 py-4 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
+                <div className="px-3 py-4 text-center text-[0.6875rem] text-foreground/45">
                   No saved statuses yet
                 </div>
               )}
@@ -1827,12 +1829,12 @@ export function ConversationInput({
         createPortal(
           <div
             ref={charPickerMenuRef}
-            className="fixed z-[9999] flex max-h-[320px] min-w-[220px] max-w-[280px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+            className="fixed z-[9999] flex max-h-[320px] min-w-[220px] max-w-[280px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
             style={
               charPickerPos ? { left: charPickerPos.left, top: charPickerPos.top } : { visibility: "hidden" as const }
             }
           >
-            <div className="flex items-center justify-center border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold">
+            <div className="flex items-center justify-center border-b border-foreground/10 px-3 py-2 text-[0.6875rem] font-semibold">
               Trigger Response
             </div>
             <div className="overflow-y-auto p-1">
@@ -1841,7 +1843,7 @@ export function ConversationInput({
                   key={char.id}
                   onClick={() => handleCharacterResponse(char.id)}
                   className={cn(
-                    "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-[var(--accent)]",
+                    "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10",
                     (char.conversationStatus === "dnd" || char.conversationStatus === "offline") && "opacity-60",
                   )}
                 >
@@ -1856,7 +1858,7 @@ export function ConversationInput({
                         />
                       </span>
                     ) : (
-                      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--secondary)] text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">
+                      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
                         {(char.name || "?")[0].toUpperCase()}
                       </div>
                     )}
@@ -1870,7 +1872,7 @@ export function ConversationInput({
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-xs">{char.name}</span>
                     {(char.conversationActivity || statusLabel(char.conversationStatus)) && (
-                      <span className="block truncate text-[0.625rem] text-[var(--muted-foreground)]">
+                      <span className="block truncate text-[0.625rem] text-foreground/45">
                         {char.conversationActivity || statusLabel(char.conversationStatus)}
                       </span>
                     )}

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -54,6 +54,7 @@ interface ConversationMessageProps {
   onSetActiveSwipe?: (messageId: string, index: number) => void;
   onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
   onPeekPrompt?: () => void;
+  onBranch?: (messageId: string) => void;
   isLastAssistantMessage?: boolean;
   characterMap?: CharacterMap;
   personaInfo?: PersonaInfo;
@@ -90,6 +91,7 @@ export const ConversationMessage = memo(function ConversationMessage({
   onSetActiveSwipe,
   onToggleHiddenFromAI,
   onPeekPrompt,
+  onBranch,
   isLastAssistantMessage,
   characterMap,
   personaInfo,
@@ -169,9 +171,8 @@ export const ConversationMessage = memo(function ConversationMessage({
     }
     return null;
   }, [chatCharacterIds, scopedCharacterMap]);
-  const resolvedCharacterInfo = message.characterId !== null
-    ? (charInfo ?? fallbackChatCharacterEntry?.info ?? null)
-    : null;
+  const resolvedCharacterInfo =
+    message.characterId !== null ? (charInfo ?? fallbackChatCharacterEntry?.info ?? null) : null;
   const primaryCharInfo =
     resolvedCharacterInfo ??
     (scopedCharacterMap
@@ -180,17 +181,27 @@ export const ConversationMessage = memo(function ConversationMessage({
 
   const msgPersona = isUser && !plainUserMessages && extra.personaSnapshot ? extra.personaSnapshot : null;
   const avatarUrl = isUser
-    ? plainUserMessages ? null : (msgPersona?.avatarUrl ?? personaInfo?.avatarUrl ?? null)
+    ? plainUserMessages
+      ? null
+      : (msgPersona?.avatarUrl ?? personaInfo?.avatarUrl ?? null)
     : (resolvedCharacterInfo?.avatarUrl ?? null);
   const personaAvatarCrop = isUser
-    ? plainUserMessages ? null : (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
+    ? plainUserMessages
+      ? null
+      : (parseAvatarCropJson(msgPersona?.avatarCrop) ?? personaInfo?.avatarCrop ?? null)
     : null;
-  const avatarCropStyle = isUser ? getAvatarCropStyle(personaAvatarCrop) : getAvatarCropStyle(resolvedCharacterInfo?.avatarCrop);
+  const avatarCropStyle = isUser
+    ? getAvatarCropStyle(personaAvatarCrop)
+    : getAvatarCropStyle(resolvedCharacterInfo?.avatarCrop);
   const displayName = isUser
-    ? plainUserMessages ? "You" : (msgPersona?.name ?? personaInfo?.name ?? "You")
+    ? plainUserMessages
+      ? "You"
+      : (msgPersona?.name ?? personaInfo?.name ?? "You")
     : (primaryCharInfo?.name ?? "Assistant");
   const nameColor = isUser
-    ? plainUserMessages ? undefined : (msgPersona?.nameColor ?? personaInfo?.nameColor)
+    ? plainUserMessages
+      ? undefined
+      : (msgPersona?.nameColor ?? personaInfo?.nameColor)
     : resolvedCharacterInfo?.nameColor;
 
   const macroContext = useMemo(
@@ -205,15 +216,27 @@ export const ConversationMessage = memo(function ConversationMessage({
         scenario: plainUserMessages ? undefined : (msgPersona?.scenario ?? personaInfo?.scenario),
       },
       primaryCharacter: primaryCharInfo ?? { name: displayName },
-      characters: scopedCharacterMap ? Array.from(scopedCharacterMap.values()) : displayName ? [{ name: displayName }] : [],
+      characters: scopedCharacterMap
+        ? Array.from(scopedCharacterMap.values())
+        : displayName
+          ? [{ name: displayName }]
+          : [],
     }),
     [
       displayName,
-      msgPersona?.appearance, msgPersona?.backstory, msgPersona?.description,
-      msgPersona?.personality, msgPersona?.scenario,
-      personaInfo?.appearance, personaInfo?.backstory, personaInfo?.description,
-      personaInfo?.personality, personaInfo?.scenario,
-      plainUserMessages, primaryCharInfo, scopedCharacterMap,
+      msgPersona?.appearance,
+      msgPersona?.backstory,
+      msgPersona?.description,
+      msgPersona?.personality,
+      msgPersona?.scenario,
+      personaInfo?.appearance,
+      personaInfo?.backstory,
+      personaInfo?.description,
+      personaInfo?.personality,
+      personaInfo?.scenario,
+      plainUserMessages,
+      primaryCharInfo,
+      scopedCharacterMap,
     ],
   );
 
@@ -224,7 +247,9 @@ export const ConversationMessage = memo(function ConversationMessage({
   const renderedContentParts = useMemo(() => {
     if (!contentParts?.length) return null;
     const count = Math.max(1, Math.min(visiblePartCount ?? contentParts.length, contentParts.length));
-    return contentParts.slice(0, count).map((part) => formatTextQuotes(resolveMessageMacros(part, macroContext), quoteFormat));
+    return contentParts
+      .slice(0, count)
+      .map((part) => formatTextQuotes(resolveMessageMacros(part, macroContext), quoteFormat));
   }, [contentParts, macroContext, quoteFormat, visiblePartCount]);
 
   // ── Attachment removal ──
@@ -277,7 +302,9 @@ export const ConversationMessage = memo(function ConversationMessage({
   const mentionNames = useMemo(() => {
     if (!scopedCharacterMap) return [] as string[];
     const names: string[] = [];
-    for (const [, v] of scopedCharacterMap) { if (v?.name) names.push(v.name); }
+    for (const [, v] of scopedCharacterMap) {
+      if (v?.name) names.push(v.name);
+    }
     return names;
   }, [scopedCharacterMap]);
 
@@ -308,7 +335,10 @@ export const ConversationMessage = memo(function ConversationMessage({
       prevContentRef.current = renderedContent;
       setVisibleSegments(1);
       let count = 1;
-      const reveal = () => { count++; setVisibleSegments(count); };
+      const reveal = () => {
+        count++;
+        setVisibleSegments(count);
+      };
       const timers: ReturnType<typeof setTimeout>[] = [];
       for (let i = 1; i < segmentCount; i++) timers.push(setTimeout(reveal, i * 1500));
       return () => timers.forEach(clearTimeout);
@@ -318,7 +348,8 @@ export const ConversationMessage = memo(function ConversationMessage({
   }, [renderedContent, segmentCount]);
 
   // ── Hidden from AI ──
-  const isHiddenExpanded = isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || !!isStreaming);
+  const isHiddenExpanded =
+    isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || !!isStreaming);
   const isHiddenCollapsed = isHiddenFromAI && collapseHiddenMessages && !isHiddenExpanded;
   const hiddenFromAIHeader = isHiddenFromAI ? (
     <HiddenFromAIConversationButton
@@ -390,7 +421,12 @@ export const ConversationMessage = memo(function ConversationMessage({
       const target = e.target as HTMLElement;
       if (target.closest("button, a, textarea")) return;
       if (multiSelectMode) {
-        onToggleSelect?.({ messageId: message.id, orderIndex: messageOrderIndex ?? 0, checked: !isSelected, shiftKey: e.shiftKey });
+        onToggleSelect?.({
+          messageId: message.id,
+          orderIndex: messageOrderIndex ?? 0,
+          checked: !isSelected,
+          shiftKey: e.shiftKey,
+        });
         return;
       }
       if (!matchMedia("(pointer: coarse)").matches) return;
@@ -400,9 +436,15 @@ export const ConversationMessage = memo(function ConversationMessage({
   );
 
   // ── Effects ──
-  useEffect(() => { setManuallyExpandedHidden(false); }, [message.id]);
-  useEffect(() => { if (!isHiddenFromAI || !collapseHiddenMessages) setManuallyExpandedHidden(false); }, [collapseHiddenMessages, isHiddenFromAI]);
-  useEffect(() => { if (!generationReplay) setShowGenerationReplay(false); }, [generationReplay]);
+  useEffect(() => {
+    setManuallyExpandedHidden(false);
+  }, [message.id]);
+  useEffect(() => {
+    if (!isHiddenFromAI || !collapseHiddenMessages) setManuallyExpandedHidden(false);
+  }, [collapseHiddenMessages, isHiddenFromAI]);
+  useEffect(() => {
+    if (!generationReplay) setShowGenerationReplay(false);
+  }, [generationReplay]);
   useEffect(() => {
     if (!showActions) return;
     const handleTouch = (e: TouchEvent) => {
@@ -417,40 +459,82 @@ export const ConversationMessage = memo(function ConversationMessage({
     isBubbleStyle && !!isStreaming && renderedContentParts?.length ? renderedContentParts.join("\n\n") : null;
   const shouldHideUserAvatar = (isUser && !!hideUserAvatar) || (isBubbleStyle && isUser);
   const bubbleCornerClass = isUser
-    ? bubbleGroupPosition === "single" ? "rounded-2xl"
-    : bubbleGroupPosition === "first" ? "rounded-2xl rounded-br-md"
-    : bubbleGroupPosition === "middle" ? "rounded-2xl rounded-r-md"
-    : "rounded-2xl rounded-tr-md"
-    : bubbleGroupPosition === "single" ? "rounded-2xl"
-    : bubbleGroupPosition === "first" ? "rounded-2xl rounded-bl-md"
-    : bubbleGroupPosition === "middle" ? "rounded-2xl rounded-l-md"
-    : "rounded-2xl rounded-tl-md";
+    ? bubbleGroupPosition === "single"
+      ? "rounded-2xl"
+      : bubbleGroupPosition === "first"
+        ? "rounded-2xl rounded-br-md"
+        : bubbleGroupPosition === "middle"
+          ? "rounded-2xl rounded-r-md"
+          : "rounded-2xl rounded-tr-md"
+    : bubbleGroupPosition === "single"
+      ? "rounded-2xl"
+      : bubbleGroupPosition === "first"
+        ? "rounded-2xl rounded-bl-md"
+        : bubbleGroupPosition === "middle"
+          ? "rounded-2xl rounded-l-md"
+          : "rounded-2xl rounded-tl-md";
 
   // ── Build shared render context ──
   const ctx: MessageRenderContext = {
-    message, extra, isUser, isGrouped: !!isGrouped,
-    displayName, avatarUrl, avatarCropStyle, nameColor,
-    mentionNames, charByName,
+    message,
+    extra,
+    isUser,
+    isGrouped: !!isGrouped,
+    displayName,
+    avatarUrl,
+    avatarCropStyle,
+    nameColor,
+    mentionNames,
+    charByName,
     quoteFormat,
-    renderedContent, renderedContentParts, groupedSegments, visibleSegments,
-    streamingBubbleDraftContent, isStreaming,
-    editing, editValue, editRef,
+    renderedContent,
+    renderedContentParts,
+    groupedSegments,
+    visibleSegments,
+    streamingBubbleDraftContent,
+    isStreaming,
+    editing,
+    editValue,
+    editRef,
     onEditValueChange: setEditValue,
     onSaveEdit: handleSaveEdit,
     onCancelEdit: () => setEditing(false),
-    isHiddenFromAI, isHiddenCollapsed, hiddenFromAIHeader,
+    isHiddenFromAI,
+    isHiddenCollapsed,
+    hiddenFromAIHeader,
     onExpandHidden: () => setManuallyExpandedHidden(true),
-    showActions, forceShowActions, hideActions, noHoverGroup,
-    hideTimestamp, hideUserAvatar, showMessageNumbers, messageIndex,
-    copied, isGuided, regenerateButtonTitle, regenerateGuidedClass,
-    thinking, generationReplay, canRegenerate, isLastAssistantMessage,
-    translatedText, isTranslating,
+    showActions,
+    forceShowActions,
+    hideActions,
+    noHoverGroup,
+    hideTimestamp,
+    hideUserAvatar,
+    showMessageNumbers,
+    messageIndex,
+    copied,
+    isGuided,
+    regenerateButtonTitle,
+    regenerateGuidedClass,
+    thinking,
+    generationReplay,
+    canRegenerate,
+    isLastAssistantMessage,
+    translatedText,
+    isTranslating,
     hasSwipes: (message.swipeCount ?? 0) > 1,
     swipeCount: message.swipeCount ?? 0,
-    multiSelectMode, isSelected,
-    onToggleSelect: multiSelectMode && onToggleSelect
-      ? () => onToggleSelect({ messageId: message.id, orderIndex: messageOrderIndex ?? 0, checked: !isSelected, shiftKey: false })
-      : undefined,
+    multiSelectMode,
+    isSelected,
+    onToggleSelect:
+      multiSelectMode && onToggleSelect
+        ? () =>
+            onToggleSelect({
+              messageId: message.id,
+              orderIndex: messageOrderIndex ?? 0,
+              checked: !isSelected,
+              shiftKey: false,
+            })
+        : undefined,
     handleMobileTap,
     onCopy: handleCopy,
     onTranslate: handleTranslate,
@@ -465,38 +549,63 @@ export const ConversationMessage = memo(function ConversationMessage({
     onShowGenerationReplay: () => setShowGenerationReplay(true),
     onShowThinking: () => setShowThinking(true),
     messageTextStyle,
-    isBubbleStyle, bubbleGroupPosition, bubbleCornerClass, shouldHideUserAvatar,
+    isBubbleStyle,
+    bubbleGroupPosition,
+    bubbleCornerClass,
+    shouldHideUserAvatar,
   };
 
   // ── Shared modals (portals, rendered outside the layout) ──
   const modals = (
     <>
-      {showThinking && thinking && createPortal(
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]" onClick={() => setShowThinking(false)}>
-          <div className="relative mx-4 flex max-h-[70vh] w-full max-w-xl flex-col rounded-xl bg-[var(--card)] shadow-2xl ring-1 ring-[var(--border)]" onClick={(e) => e.stopPropagation()}>
-            <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-              <div className="flex items-center gap-2 text-sm font-semibold">
-                <Brain size="0.875rem" className="text-[var(--muted-foreground)]" />
-                Model Thoughts
+      {showThinking &&
+        thinking &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]"
+            onClick={() => setShowThinking(false)}
+          >
+            <div
+              className="relative mx-4 flex max-h-[70vh] w-full max-w-xl flex-col rounded-xl bg-[var(--card)] shadow-2xl ring-1 ring-[var(--border)]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <Brain size="0.875rem" className="text-[var(--muted-foreground)]" />
+                  Model Thoughts
+                </div>
+                <button
+                  onClick={() => setShowThinking(false)}
+                  className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+                >
+                  <X size="0.875rem" />
+                </button>
               </div>
-              <button onClick={() => setShowThinking(false)} className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]">
-                <X size="0.875rem" />
-              </button>
+              <div className="overflow-y-auto px-4 py-3">
+                <pre className="whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-[var(--muted-foreground)]">
+                  {thinking}
+                </pre>
+              </div>
             </div>
-            <div className="overflow-y-auto px-4 py-3">
-              <pre className="whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-[var(--muted-foreground)]">{thinking}</pre>
-            </div>
-          </div>
-        </div>,
-        document.body,
-      )}
+          </div>,
+          document.body,
+        )}
       {generationReplay && (
-        <GenerationReplayDetailsModal open={showGenerationReplay} replay={generationReplay} onClose={() => setShowGenerationReplay(false)} />
+        <GenerationReplayDetailsModal
+          open={showGenerationReplay}
+          replay={generationReplay}
+          onClose={() => setShowGenerationReplay(false)}
+        />
       )}
-      {imageLightbox && createPortal(
-        <ConversationMessageLightbox url={imageLightbox.url} prompt={imageLightbox.prompt} onClose={() => setImageLightbox(null)} />,
-        document.body,
-      )}
+      {imageLightbox &&
+        createPortal(
+          <ConversationMessageLightbox
+            url={imageLightbox.url}
+            prompt={imageLightbox.prompt}
+            onClose={() => setImageLightbox(null)}
+          />,
+          document.body,
+        )}
     </>
   );
 
@@ -505,14 +614,23 @@ export const ConversationMessage = memo(function ConversationMessage({
     return (
       <div
         ref={msgRef}
-        className={cn("group flex justify-center py-1", multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/10")}
+        className={cn(
+          "group flex justify-center py-1",
+          multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/10",
+        )}
         onClick={handleMobileTap}
       >
         <div className="relative">
           {!multiSelectMode && onDelete && (
             <button
-              onClick={(e) => { e.stopPropagation(); onDelete(message.id); }}
-              className={cn("absolute -right-1 -top-1 rounded-md p-1 text-[var(--muted-foreground)]/30 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100", showActions && "opacity-100")}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(message.id);
+              }}
+              className={cn(
+                "absolute -right-1 -top-1 rounded-md p-1 text-[var(--muted-foreground)]/30 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100",
+                showActions && "opacity-100",
+              )}
               title="Delete"
             >
               <Trash2 size="0.75rem" />
@@ -546,16 +664,19 @@ export const ConversationMessage = memo(function ConversationMessage({
           !noHoverGroup && "group",
           isBubbleStyle
             ? cn("py-1", isUser ? "mari-message-user" : "mari-message-assistant", !isGrouped && "mt-2.5")
-            : cn("flex gap-4 py-0.5 hover:bg-[var(--secondary)]/30", isUser ? "mari-message-user" : "mari-message-assistant", isGrouped ? "mt-0" : "mt-4", isStreaming && "bg-[var(--secondary)]/20"),
+            : cn(
+                "flex gap-4 py-0.5 hover:bg-[var(--secondary)]/30",
+                isUser ? "mari-message-user" : "mari-message-assistant",
+                isGrouped ? "mt-0" : "mt-4",
+                isStreaming && "bg-[var(--secondary)]/20",
+              ),
           multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
         )}
         data-message-id={message.id}
         data-message-role={message.role}
         onClick={handleMobileTap}
       >
-        {isBubbleStyle
-          ? <ConversationMessageBubble ctx={ctx} />
-          : <ConversationMessageLine ctx={ctx} />}
+        {isBubbleStyle ? <ConversationMessageBubble ctx={ctx} /> : <ConversationMessageLine ctx={ctx} />}
 
         {!hideActions && (
           <ConversationMessageActions
@@ -577,7 +698,10 @@ export const ConversationMessage = memo(function ConversationMessage({
             onTranslate={handleTranslate}
             onEdit={handleStartEdit}
             onRegenerate={onRegenerate ? () => onRegenerate(message.id) : undefined}
-            onToggleHiddenFromAI={onToggleHiddenFromAI ? () => onToggleHiddenFromAI(message.id, isHiddenFromAI) : undefined}
+            onBranch={onBranch ? () => onBranch(message.id) : undefined}
+            onToggleHiddenFromAI={
+              onToggleHiddenFromAI ? () => onToggleHiddenFromAI(message.id, isHiddenFromAI) : undefined
+            }
             onPeekPrompt={onPeekPrompt}
             onDelete={onDelete ? () => onDelete(message.id) : undefined}
             onShowGenerationReplay={() => setShowGenerationReplay(true)}

--- a/packages/client/src/components/chat/ConversationMessageActions.tsx
+++ b/packages/client/src/components/chat/ConversationMessageActions.tsx
@@ -1,7 +1,19 @@
 // ──────────────────────────────────────────────
 // Hover action bar — floats above the message row
 // ──────────────────────────────────────────────
-import { Brain, Copy, Eye, EyeOff, Languages, Pencil, RefreshCw, ScrollText, Search, Trash2 } from "lucide-react";
+import {
+  Brain,
+  Copy,
+  Eye,
+  EyeOff,
+  GitBranch,
+  Languages,
+  Pencil,
+  RefreshCw,
+  ScrollText,
+  Search,
+  Trash2,
+} from "lucide-react";
 import type { MessageExtra } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
 import { MsgAction } from "./ConversationMessageShared";
@@ -29,6 +41,7 @@ export interface ConversationMessageActionsProps {
   onTranslate: () => void;
   onEdit: () => void;
   onRegenerate?: () => void;
+  onBranch?: () => void;
   onToggleHiddenFromAI?: () => void;
   onPeekPrompt?: () => void;
   onDelete?: () => void;
@@ -54,6 +67,7 @@ export function ConversationMessageActions({
   onTranslate,
   onEdit,
   onRegenerate,
+  onBranch,
   onToggleHiddenFromAI,
   onPeekPrompt,
   onDelete,
@@ -103,8 +117,16 @@ export function ConversationMessageActions({
       {isLastAssistantMessage && !isUser && onPeekPrompt && (
         <MsgAction icon={<Search size="0.75rem" />} onClick={onPeekPrompt} title="Peek prompt" tabIndex={tabIdx} />
       )}
+      {onBranch && (
+        <MsgAction icon={<GitBranch size="0.75rem" />} onClick={onBranch} title="Branch from here" tabIndex={tabIdx} />
+      )}
       {generationReplay && (
-        <MsgAction icon={<ScrollText size="0.75rem" />} onClick={onShowGenerationReplay} title="Stored guidance" tabIndex={tabIdx} />
+        <MsgAction
+          icon={<ScrollText size="0.75rem" />}
+          onClick={onShowGenerationReplay}
+          title="Stored guidance"
+          tabIndex={tabIdx}
+        />
       )}
       {thinking && !isUser && (
         <MsgAction icon={<Brain size="0.75rem" />} onClick={onShowThinking} title="View thoughts" tabIndex={tabIdx} />

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -13,6 +13,7 @@ import {
   useMemo,
   useState,
   type ReactNode,
+  type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -69,9 +70,9 @@ interface ConversationViewProps {
   onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
   lastAssistantMessageId: string | null;
-  onOpenSettings: () => void;
+  onOpenSettings: (event?: ReactMouseEvent<HTMLElement>) => void;
   onOpenFiles: () => void;
-  onOpenGallery: () => void;
+  onOpenGallery: (event?: ReactMouseEvent<HTMLElement>) => void;
   multiSelectMode?: boolean;
   selectedMessageIds?: Set<string>;
   onToggleSelectMessage?: (toggle: MessageSelectionToggle) => void;

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -1,7 +1,6 @@
 // ──────────────────────────────────────────────
 // Chat: Conversation View — Discord-style composite
 // ──────────────────────────────────────────────
-import { createPortal } from "react-dom";
 import {
   Fragment,
   Suspense,
@@ -12,24 +11,16 @@ import {
   useCallback,
   useMemo,
   useState,
-  type ReactNode,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  BookOpen,
-  Loader2,
-  ChevronUp,
-  Settings2,
-  Image as ImageIcon,
-  ArrowRightLeft,
-  MoreHorizontal,
-} from "lucide-react";
+import { Loader2, ChevronUp, Settings2, Image as ImageIcon, ArrowRightLeft } from "lucide-react";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
 import { ChatBranchSelector } from "./ChatBranchSelector";
-import { ActiveLorebookEntriesButton, ActiveLorebookEntriesModal } from "./ActiveLorebookEntriesButton";
+import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
+import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -242,68 +233,6 @@ function splitAssistantContentLines(content: string, charName?: string | null): 
 // from replaying when the user navigates away from a chat and comes back.
 const globalSeenKeys = new Set<string>();
 
-const HEADER_BTN =
-  "flex items-center justify-center rounded-lg bg-[var(--card)]/80 p-1.5 text-foreground/80 backdrop-blur-sm transition-colors hover:bg-[var(--card)] hover:text-foreground dark:bg-black/30 dark:hover:bg-black/50";
-const MOBILE_MENU_BTN =
-  "flex h-8 w-8 items-center justify-center rounded-lg text-foreground/80 transition-colors hover:bg-[var(--accent)] hover:text-foreground";
-
-function ConversationToolbarMenu({
-  desktopChildren,
-  mobileChildren,
-}: {
-  desktopChildren: ReactNode;
-  mobileChildren: ReactNode;
-}) {
-  const [open, setOpen] = useState(false);
-  const btnRef = useRef<HTMLDivElement>(null);
-  const popRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
-
-  useLayoutEffect(() => {
-    if (!open || !btnRef.current) return;
-    const rect = btnRef.current.getBoundingClientRect();
-    setPos({
-      top: rect.bottom + 4,
-      right: window.innerWidth - rect.right,
-    });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handle = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (target instanceof Element && target.closest("[data-chat-branch-popover]")) return;
-      if (btnRef.current?.contains(target) || popRef.current?.contains(target)) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handle);
-    return () => document.removeEventListener("mousedown", handle);
-  }, [open]);
-
-  return (
-    <>
-      <div className="hidden items-center gap-1.5 md:flex">{desktopChildren}</div>
-      <div className="relative shrink-0 md:hidden" ref={btnRef}>
-        <button onClick={() => setOpen(!open)} className={HEADER_BTN} title="More options" aria-label="More options">
-          <MoreHorizontal size="0.875rem" />
-        </button>
-        {open &&
-          createPortal(
-            <div
-              ref={popRef}
-              className="fixed z-[9999] flex w-9 flex-col items-center gap-0.5 rounded-xl border border-[var(--border)] bg-[var(--card)] p-1 shadow-xl backdrop-blur-xl animate-message-in"
-              style={{ top: pos.top, right: pos.right }}
-              onClick={() => setOpen(false)}
-            >
-              {mobileChildren}
-            </div>,
-            document.body,
-          )}
-      </div>
-    </>
-  );
-}
-
 export function ConversationView({
   chatId,
   messages,
@@ -422,7 +351,6 @@ export function ConversationView({
     return { background: `linear-gradient(135deg, ${g.from}, ${g.to})` };
   }, [convoGradient, theme]);
   const hasAutonomousMessaging = !!chatMeta.autonomousMessages || !!chatMeta.characterExchanges;
-  const [mobileActiveContextOpen, setMobileActiveContextOpen] = useState(false);
   const renderToolbarActions = (compact = false) => (
     <>
       <ChatBranchSelector
@@ -431,37 +359,17 @@ export function ConversationView({
         groupId={chatGroupId}
         variant="roleplay"
         compact={compact}
-        className={
-          compact ? "bg-transparent text-foreground/80 hover:bg-[var(--accent)] hover:text-foreground" : undefined
-        }
       />
-      {compact ? (
-        <button
-          onClick={() => setMobileActiveContextOpen(true)}
-          className={MOBILE_MENU_BTN}
-          title="Active Context"
-          aria-label="Active Context"
-        >
-          <BookOpen size="0.875rem" />
-        </button>
-      ) : (
-        <ActiveLorebookEntriesButton chatId={chatId} buttonClassName={HEADER_BTN} />
-      )}
-      <button onClick={onOpenGallery} className={compact ? MOBILE_MENU_BTN : HEADER_BTN} title="Gallery">
-        <ImageIcon size="0.875rem" />
-      </button>
+      <ActiveLorebookEntriesButton chatId={chatId} />
+      <ChatToolbarButton icon={<ImageIcon size="0.875rem" />} title="Gallery" onClick={onOpenGallery} />
       {onSwitchChat && (
-        <button
-          onClick={onSwitchChat}
-          className={compact ? MOBILE_MENU_BTN : HEADER_BTN}
+        <ChatToolbarButton
+          icon={<ArrowRightLeft size="0.875rem" />}
           title={connectedChatName ? `Switch to ${connectedChatName}` : "Switch to connected chat"}
-        >
-          <ArrowRightLeft size="0.875rem" />
-        </button>
+          onClick={onSwitchChat}
+        />
       )}
-      <button onClick={onOpenSettings} className={compact ? MOBILE_MENU_BTN : HEADER_BTN} title="Chat Settings">
-        <Settings2 size="0.875rem" />
-      </button>
+      <ChatToolbarButton icon={<Settings2 size="0.875rem" />} title="Chat Settings" onClick={onOpenSettings} />
     </>
   );
 
@@ -972,14 +880,19 @@ export function ConversationView({
                     ? "bg-red-500"
                     : "bg-gray-400";
             };
+            const identityPillClass =
+              "flex items-center gap-2 rounded-full border border-foreground/10 bg-foreground/5 px-2.5 py-1.5 text-foreground/80 backdrop-blur-md";
+            const avatarShellClass = "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-foreground/10";
+            const avatarFallbackClass =
+              "flex h-5 w-5 items-center justify-center rounded-full bg-foreground/10 text-[0.5rem] font-bold text-foreground/70 ring-1 ring-foreground/10";
 
             if (chars.length === 1) {
               const c = chars[0]!;
               return (
-                <div className="flex items-center gap-2 rounded-lg bg-[var(--card)]/80 px-2.5 py-1.5 backdrop-blur-sm dark:bg-black/30">
+                <div className={identityPillClass}>
                   <div className="relative flex-shrink-0">
                     {c.avatarUrl ? (
-                      <span className="relative block h-5 w-5 overflow-hidden rounded-full">
+                      <span className={avatarShellClass}>
                         <img
                           src={c.avatarUrl}
                           alt={c.name}
@@ -988,12 +901,10 @@ export function ConversationView({
                         />
                       </span>
                     ) : (
-                      <div className="flex h-5 w-5 items-center justify-center rounded-full bg-foreground/20 text-[0.5rem] font-bold text-foreground">
-                        {c.name[0]}
-                      </div>
+                      <div className={avatarFallbackClass}>{c.name[0]}</div>
                     )}
                     <span
-                      className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-[1.5px] ring-[var(--border)] ${statusColor(c.conversationStatus)}`}
+                      className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-[1.5px] ring-[var(--card)] ${statusColor(c.conversationStatus)}`}
                     />
                   </div>
                   <div className="flex flex-col leading-tight">
@@ -1008,7 +919,7 @@ export function ConversationView({
 
             // Multiple characters — show stacked avatars + names
             return (
-              <div className="flex items-center gap-2 rounded-lg bg-[var(--card)]/80 px-2.5 py-1.5 backdrop-blur-sm dark:bg-black/30">
+              <div className={identityPillClass}>
                 <div
                   className="relative flex-shrink-0"
                   style={{ width: `${Math.min(chars.length, 3) * 12 + 8}px`, height: 20 }}
@@ -1017,7 +928,7 @@ export function ConversationView({
                     <div key={i} className="absolute top-0" style={{ left: i * 12 }}>
                       <div className="relative">
                         {c.avatarUrl ? (
-                          <span className="relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]">
+                          <span className={avatarShellClass}>
                             <img
                               src={c.avatarUrl}
                               alt={c.name}
@@ -1026,12 +937,10 @@ export function ConversationView({
                             />
                           </span>
                         ) : (
-                          <div className="flex h-5 w-5 items-center justify-center rounded-full bg-foreground/20 text-[0.5rem] font-bold text-foreground ring-1 ring-[var(--border)]">
-                            {c.name[0]}
-                          </div>
+                          <div className={avatarFallbackClass}>{c.name[0]}</div>
                         )}
                         <span
-                          className={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-[1px] ring-[var(--border)] ${statusColor(c.conversationStatus)}`}
+                          className={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-[1px] ring-[var(--card)] ${statusColor(c.conversationStatus)}`}
                         />
                       </div>
                     </div>
@@ -1044,15 +953,7 @@ export function ConversationView({
             );
           })()}
 
-          <ConversationToolbarMenu
-            desktopChildren={renderToolbarActions()}
-            mobileChildren={renderToolbarActions(true)}
-          />
-          <ActiveLorebookEntriesModal
-            chatId={chatId}
-            open={mobileActiveContextOpen}
-            onClose={() => setMobileActiveContextOpen(false)}
-          />
+          <ChatToolbarMenu desktopChildren={renderToolbarActions()} mobileChildren={renderToolbarActions(true)} />
         </div>
 
         {/* Load More */}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -20,7 +20,7 @@ import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
 import { ChatBranchSelector } from "./ChatBranchSelector";
 import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
-import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
+import { ChatToolbarButton, ChatToolbarMenu, getChatToolbarButtonClass } from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -880,16 +880,23 @@ export function ConversationView({
                     ? "bg-red-500"
                     : "bg-gray-400";
             };
-            const identityPillClass =
-              "flex items-center gap-2 rounded-full border border-foreground/10 bg-foreground/5 px-2.5 py-1.5 text-foreground/80 backdrop-blur-md";
-            const avatarShellClass = "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-foreground/10";
+            const identityPillClass = getChatToolbarButtonClass({
+              compact: true,
+              className:
+                "w-auto min-w-0 max-w-[min(20rem,calc(100vw-8rem))] justify-start gap-2 px-2.5 text-[var(--foreground)]/80 hover:text-[var(--foreground)]/90",
+            });
+            const avatarShellClass =
+              "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]/80";
             const avatarFallbackClass =
-              "flex h-5 w-5 items-center justify-center rounded-full bg-foreground/10 text-[0.5rem] font-bold text-foreground/70 ring-1 ring-foreground/10";
+              "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--foreground)]/10 text-[0.5rem] font-bold text-[var(--foreground)]/70 ring-1 ring-[var(--border)]/80";
 
             if (chars.length === 1) {
               const c = chars[0]!;
               return (
-                <div className={identityPillClass}>
+                <div
+                  className={identityPillClass}
+                  title={c.conversationActivity ? `${c.name}: ${c.conversationActivity}` : c.name}
+                >
                   <div className="relative flex-shrink-0">
                     {c.avatarUrl ? (
                       <span className={avatarShellClass}>
@@ -907,10 +914,12 @@ export function ConversationView({
                       className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-[1.5px] ring-[var(--card)] ${statusColor(c.conversationStatus)}`}
                     />
                   </div>
-                  <div className="flex flex-col leading-tight">
-                    <span className="text-[0.75rem] font-medium text-foreground/90">{c.name}</span>
+                  <div className="flex min-w-0 flex-col leading-tight">
+                    <span className="truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">{c.name}</span>
                     {c.conversationActivity && (
-                      <span className="text-[0.5625rem] text-foreground/50">{c.conversationActivity}</span>
+                      <span className="truncate text-[0.5625rem] text-[var(--foreground)]/50">
+                        {c.conversationActivity}
+                      </span>
                     )}
                   </div>
                 </div>
@@ -919,7 +928,12 @@ export function ConversationView({
 
             // Multiple characters — show stacked avatars + names
             return (
-              <div className={identityPillClass}>
+              <div
+                className={identityPillClass}
+                title={chars
+                  .map((c) => (c.conversationActivity ? `${c.name}: ${c.conversationActivity}` : c.name))
+                  .join(", ")}
+              >
                 <div
                   className="relative flex-shrink-0"
                   style={{ width: `${Math.min(chars.length, 3) * 12 + 8}px`, height: 20 }}
@@ -946,7 +960,7 @@ export function ConversationView({
                     </div>
                   ))}
                 </div>
-                <span className="text-[0.75rem] font-medium text-[var(--foreground)]/90">
+                <span className="min-w-0 truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">
                   {chars.length <= 2 ? chars.map((c) => c.name).join(" & ") : `${chars[0]!.name} + ${chars.length - 1}`}
                 </span>
               </div>

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -21,7 +21,6 @@ import {
   Loader2,
   ChevronUp,
   Settings2,
-  FolderOpen,
   Image as ImageIcon,
   ArrowRightLeft,
   MoreHorizontal,
@@ -71,8 +70,8 @@ interface ConversationViewProps {
   onPeekPrompt: () => void;
   lastAssistantMessageId: string | null;
   onOpenSettings: (event?: ReactMouseEvent<HTMLElement>) => void;
-  onOpenFiles: () => void;
   onOpenGallery: (event?: ReactMouseEvent<HTMLElement>) => void;
+  onBranch?: (messageId: string) => void;
   multiSelectMode?: boolean;
   selectedMessageIds?: Set<string>;
   onToggleSelectMessage?: (toggle: MessageSelectionToggle) => void;
@@ -329,8 +328,8 @@ export function ConversationView({
   onPeekPrompt,
   lastAssistantMessageId,
   onOpenSettings,
-  onOpenFiles,
   onOpenGallery,
+  onBranch,
   multiSelectMode,
   selectedMessageIds,
   onToggleSelectMessage,
@@ -367,7 +366,10 @@ export function ConversationView({
   // us hide draft rows immediately so the real updated message shows without a flash.
   const streamHadContentRef = useRef(false);
   useEffect(() => {
-    if (!hasLiveStream) { streamHadContentRef.current = false; return; }
+    if (!hasLiveStream) {
+      streamHadContentRef.current = false;
+      return;
+    }
     if (streamBuffer || thinkingBuffer) streamHadContentRef.current = true;
   }, [hasLiveStream, streamBuffer, thinkingBuffer]);
   const isStreamWindingDown =
@@ -427,6 +429,7 @@ export function ConversationView({
         activeChatId={chatId}
         activeChatName={chatName}
         groupId={chatGroupId}
+        variant="roleplay"
         compact={compact}
         className={
           compact ? "bg-transparent text-foreground/80 hover:bg-[var(--accent)] hover:text-foreground" : undefined
@@ -444,9 +447,6 @@ export function ConversationView({
       ) : (
         <ActiveLorebookEntriesButton chatId={chatId} buttonClassName={HEADER_BTN} />
       )}
-      <button onClick={onOpenFiles} className={compact ? MOBILE_MENU_BTN : HEADER_BTN} title="Manage Chat Files">
-        <FolderOpen size="0.875rem" />
-      </button>
       <button onClick={onOpenGallery} className={compact ? MOBILE_MENU_BTN : HEADER_BTN} title="Gallery">
         <ImageIcon size="0.875rem" />
       </button>
@@ -523,7 +523,15 @@ export function ConversationView({
     if (isOptimistic || (isNearBottomRef.current && !userScrolledAwayRef.current)) {
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }
-  }, [newestMsgId, streamBuffer, thinkingBuffer, hasLiveStream, delayedCharacterInfo, typingCharacterName, isOptimistic]);
+  }, [
+    newestMsgId,
+    streamBuffer,
+    thinkingBuffer,
+    hasLiveStream,
+    delayedCharacterInfo,
+    typingCharacterName,
+    isOptimistic,
+  ]);
 
   // Preserve scroll on load-more
   useLayoutEffect(() => {
@@ -617,7 +625,11 @@ export function ConversationView({
         const otherTime = new Date(other.createdAt).getTime();
         const timeGap = currentIsAfterOther ? currentTime - otherTime : otherTime - currentTime;
         if (timeGap > TIME_GAP_MS) return false;
-        if (current.role !== other.role || current.characterId !== other.characterId || getDayKey(other.createdAt) !== day) {
+        if (
+          current.role !== other.role ||
+          current.characterId !== other.characterId ||
+          getDayKey(other.createdAt) !== day
+        ) {
           return false;
         }
         const currentHiddenFromAI = getMessageExtraRecord(current).hiddenFromAI === true;
@@ -700,7 +712,14 @@ export function ConversationView({
         thinking: thinkingBuffer || null,
       },
     };
-  }, [chatId, conversationMessageStyle, liveStreamCharacterId, shouldRenderLiveStreamMessage, streamBuffer, thinkingBuffer]);
+  }, [
+    chatId,
+    conversationMessageStyle,
+    liveStreamCharacterId,
+    shouldRenderLiveStreamMessage,
+    streamBuffer,
+    thinkingBuffer,
+  ]);
 
   const buildStreamingBubblePreview = useCallback(
     (content: string, characterId: string | null) => {
@@ -737,7 +756,10 @@ export function ConversationView({
     hasLiveStream && conversationMessageStyle === "bubble" && !delayedCharacterInfo
       ? `${chatId}:${regenerateMessageId ?? "new"}:${liveStreamCharacterId ?? "assistant"}`
       : null;
-  const [streamingBubbleDraft, setStreamingBubbleDraft] = useState<{ key: string; text: string }>({ key: "", text: "" });
+  const [streamingBubbleDraft, setStreamingBubbleDraft] = useState<{ key: string; text: string }>({
+    key: "",
+    text: "",
+  });
 
   useEffect(() => {
     if (!streamingDraftKey) {
@@ -892,7 +914,9 @@ export function ConversationView({
           if (useUIStore.getState().convoNotificationSound) {
             playNotificationPing();
           }
-          staggerTimersRef.current[key] = (staggerTimersRef.current[key] ?? []).filter((activeTimer) => activeTimer !== timer);
+          staggerTimersRef.current[key] = (staggerTimersRef.current[key] ?? []).filter(
+            (activeTimer) => activeTimer !== timer,
+          );
           if (partIndex === count) {
             staggerTimersRef.current[key]?.forEach(clearTimeout);
             delete staggerTimersRef.current[key];
@@ -1081,9 +1105,7 @@ export function ConversationView({
             return (
               <div key={item.key} className="relative my-4 flex items-center px-4">
                 <div className="flex-1 border-t border-[var(--border)]/40" />
-                <span className="mx-4 text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">
-                  {item.label}
-                </span>
+                <span className="mx-4 text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">{item.label}</span>
                 <div className="flex-1 border-t border-[var(--border)]/40" />
               </div>
             );
@@ -1097,34 +1119,36 @@ export function ConversationView({
           // illustration doesn't linger while new text is streaming in. Bubble
           // regeneration keeps the real message stable and renders a separate
           // presentation-only draft row below it.
-          const displayMsg = isRegenerating && !isBubbleRegenerating
-            ? (() => {
-                const parsed = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
-                return {
-                  ...msg,
-                  content: streamBuffer || (thinkingBuffer ? "Thinking..." : msg.content),
-                  extra: { ...parsed, attachments: null, thinking: thinkingBuffer || parsed.thinking },
-                };
-              })()
-            : msg;
+          const displayMsg =
+            isRegenerating && !isBubbleRegenerating
+              ? (() => {
+                  const parsed = typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {});
+                  return {
+                    ...msg,
+                    content: streamBuffer || (thinkingBuffer ? "Thinking..." : msg.content),
+                    extra: { ...parsed, attachments: null, thinking: thinkingBuffer || parsed.thinking },
+                  };
+                })()
+              : msg;
           const contentParts = isRegenerating ? undefined : item.contentParts;
           const visiblePartCount = contentParts ? (visiblePartCounts[item.key] ?? contentParts.length) : undefined;
           const originalContent = displayMsg.content !== msg.content ? msg.content : undefined;
-          const regenerationDraftMessage = isBubbleRegenerating && !isStreamWindingDown
-            ? ({
-                ...msg,
-                id: `__conversation_regeneration_stream__${msg.id}`,
-                content: "",
-                activeSwipeIndex: 0,
-                swipeCount: 0,
-                extra: {
-                  ...(typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {})),
-                  attachments: null,
-                  displayText: null,
-                  thinking: thinkingBuffer || null,
-                },
-              } as Message)
-            : null;
+          const regenerationDraftMessage =
+            isBubbleRegenerating && !isStreamWindingDown
+              ? ({
+                  ...msg,
+                  id: `__conversation_regeneration_stream__${msg.id}`,
+                  content: "",
+                  activeSwipeIndex: 0,
+                  swipeCount: 0,
+                  extra: {
+                    ...(typeof msg.extra === "string" ? JSON.parse(msg.extra) : (msg.extra ?? {})),
+                    attachments: null,
+                    displayText: null,
+                    thinking: thinkingBuffer || null,
+                  },
+                } as Message)
+              : null;
 
           return (
             <Fragment key={item.key}>
@@ -1149,6 +1173,7 @@ export function ConversationView({
                 isSelected={selectedMessageIds?.has(msg.id)}
                 onToggleSelect={onToggleSelectMessage}
                 hasDraftInput={hasDraftInput}
+                onBranch={onBranch}
                 messageStyle={conversationMessageStyle}
                 contentParts={contentParts}
                 visiblePartCount={visiblePartCount}

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -39,9 +39,46 @@ const WIDGET_BAR_H = 76; // top HUD toolbar: py-2 (16px) + widget buttons h-[3.7
 const INPUT_BOX_H = 72; // bottom chat input area height
 const HUD_EDGE_GAP = 16; // Aligns with the roleplay HUD edge padding.
 const FLOATING_EDGE_GAP = 16;
+const TOP_BUTTON_GAP = 6; // Matches the tracker panel gap below the top controls.
+const ROLEPLAY_TOP_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
+const TOP_BAR_SELECTOR = '[data-component="TopBar"]';
 
 interface EchoChamberPanelProps {
   hiddenOnMobile?: boolean;
+}
+
+function readVisibleRect(element: HTMLElement) {
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0 || window.getComputedStyle(element).display === "none") return null;
+  return rect;
+}
+
+function findVisibleHud(): HTMLElement | null {
+  const els = document.querySelectorAll<HTMLElement>(".rpg-hud");
+  for (const el of els) {
+    if (readVisibleRect(el)) return el;
+  }
+  return null;
+}
+
+function getRoleplayAreaTop() {
+  return document.querySelector<HTMLElement>(".rpg-chat-area")?.getBoundingClientRect().top ?? 0;
+}
+
+function getTopChromeBottomOffset() {
+  const containerTop = getRoleplayAreaTop();
+  const candidates: number[] = [];
+  const topBarRect = document.querySelector<HTMLElement>(TOP_BAR_SELECTOR);
+  const topBarBottom = topBarRect ? readVisibleRect(topBarRect)?.bottom : null;
+  if (topBarBottom != null) candidates.push(Math.ceil(topBarBottom - containerTop + TOP_BUTTON_GAP));
+
+  const anchors = Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR));
+  anchors.forEach((anchor) => {
+    const rect = readVisibleRect(anchor);
+    if (rect) candidates.push(Math.ceil(rect.bottom - containerTop + TOP_BUTTON_GAP));
+  });
+
+  return candidates.length > 0 ? Math.max(TOP_BUTTON_GAP, ...candidates) : WIDGET_BAR_H + TOP_BUTTON_GAP;
 }
 
 /** Tiny 4-square grid icon; the active corner is highlighted. */
@@ -196,14 +233,6 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     if (!echoChamberOpen) return;
     // On mobile, position below the HUD bar.
     if (typeof window !== "undefined" && window.innerWidth < 768) {
-      const findVisibleHud = (): HTMLElement | null => {
-        const els = document.querySelectorAll<HTMLElement>(".rpg-hud");
-        for (const el of els) {
-          if (el.getBoundingClientRect().height > 0) return el;
-        }
-        return null;
-      };
-
       const update = () => {
         const hudEl = findVisibleHud();
         // Position relative to container, so measure HUD bottom relative to rpg-chat-area
@@ -227,16 +256,61 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     // Desktop: position within the chat area container (absolute, not fixed)
     const isTop = echoChamberSide.startsWith("top");
     const isLeft = echoChamberSide.endsWith("left");
-    const topOffset = isTop ? WIDGET_BAR_H + FLOATING_EDGE_GAP : undefined;
-    const bottomOffset = !isTop ? INPUT_BOX_H + FLOATING_EDGE_GAP : undefined;
-    const leftOffset = isLeft ? `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-left, 0px))` : undefined;
-    const rightOffset = !isLeft ? `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-right, 0px))` : undefined;
-    setPosStyle({
-      ...(topOffset !== undefined && { top: topOffset }),
-      ...(bottomOffset !== undefined && { bottom: bottomOffset }),
-      ...(leftOffset !== undefined && { left: leftOffset }),
-      ...(rightOffset !== undefined && { right: rightOffset }),
-    });
+    const update = () => {
+      const topOffset = isTop ? getTopChromeBottomOffset() : undefined;
+      const bottomOffset = !isTop ? INPUT_BOX_H + FLOATING_EDGE_GAP : undefined;
+      const leftOffset = isLeft ? `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-left, 0px))` : undefined;
+      const rightOffset = !isLeft ? `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-right, 0px))` : undefined;
+      setPosStyle({
+        ...(topOffset !== undefined && { top: topOffset }),
+        ...(bottomOffset !== undefined && { bottom: bottomOffset }),
+        ...(leftOffset !== undefined && { left: leftOffset }),
+        ...(rightOffset !== undefined && { right: rightOffset }),
+      });
+    };
+
+    update();
+    if (!isTop) return;
+
+    let frame = 0;
+    let discoveryObserver: MutationObserver | null = null;
+    const observedTargets = new Set<HTMLElement>();
+    const observer = new ResizeObserver(() => scheduleUpdate());
+    const observeTargets = () => {
+      const targets = [
+        ...Array.from(document.querySelectorAll<HTMLElement>(TOP_BAR_SELECTOR)),
+        ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR)),
+      ];
+      targets.forEach((target) => {
+        if (observedTargets.has(target)) return;
+        observer.observe(target);
+        observedTargets.add(target);
+      });
+      return targets.length > 0;
+    };
+    function scheduleUpdate() {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        const foundTargets = observeTargets();
+        update();
+        if (foundTargets) {
+          discoveryObserver?.disconnect();
+          discoveryObserver = null;
+        }
+      });
+    }
+
+    scheduleUpdate();
+    discoveryObserver = new MutationObserver(() => scheduleUpdate());
+    discoveryObserver.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      discoveryObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
   }, [echoChamberOpen, echoChamberSide]);
 
   if (!echoChamberOpen || !echoEnabled || (isMobile && hiddenOnMobile)) return null;
@@ -247,7 +321,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       className={cn(
         ROLEPLAY_POPOVER_SHELL,
         "absolute z-[60] flex flex-col",
-        "pointer-events-auto w-60 max-md:w-auto max-h-44 max-md:max-h-28",
+        "pointer-events-auto w-60 max-md:w-auto md:max-h-[22rem] max-md:max-h-28",
       )}
       style={posStyle}
     >

--- a/packages/client/src/components/chat/QuickConnectionSwitcher.tsx
+++ b/packages/client/src/components/chat/QuickConnectionSwitcher.tsx
@@ -91,7 +91,7 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
         className={cn(
           "flex h-8 w-8 items-center justify-center rounded-xl transition-all",
           open
-            ? "bg-foreground/10 text-foreground/75"
+            ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
             : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
           className,
         )}
@@ -102,10 +102,10 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
       {open && (
         <div
           ref={menuRef}
-          className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[360px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+          className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[360px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
           style={pos ? { left: pos.left, top: pos.top } : { visibility: "hidden" as const }}
         >
-          <div className="flex items-center justify-between gap-2 border-b border-[var(--border)] px-3 py-2">
+          <div className="flex items-center justify-between gap-2 border-b border-foreground/10 px-3 py-2">
             <span className="text-[0.6875rem] font-semibold">Connections</span>
             <button
               onClick={handleToggleRandom}
@@ -113,8 +113,8 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
               className={cn(
                 "flex h-6 w-6 items-center justify-center rounded-md transition-all active:scale-90",
                 isRandom
-                  ? "bg-amber-400/20 text-amber-400 ring-1 ring-amber-400/40"
-                  : "text-[var(--muted-foreground)] hover:bg-amber-400/10 hover:text-amber-400",
+                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
+                  : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
               )}
             >
               <Dices size="0.875rem" />
@@ -129,7 +129,7 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
                   <button
                     key={conn.id}
                     onClick={() => handleTogglePool(conn.id, inPool)}
-                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10"
                     title={inPool ? "In random pool — click to remove" : "Click to add to random pool"}
                   >
                     <span className="flex-1 truncate">{conn.name || conn.id}</span>
@@ -137,8 +137,8 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
                       className={cn(
                         "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
                         inPool
-                          ? "border-amber-400/60 bg-amber-400/20 text-amber-400"
-                          : "border-[var(--border)] bg-transparent",
+                          ? "border-foreground/35 bg-foreground/10 text-foreground/75"
+                          : "border-foreground/20 bg-transparent",
                       )}
                     >
                       {inPool && <Check size="0.625rem" strokeWidth={3} />}
@@ -151,7 +151,7 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
                   key={conn.id}
                   onClick={() => handleSwitch(conn.id)}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10",
                     isActive && "text-foreground font-semibold",
                   )}
                 >
@@ -162,7 +162,7 @@ export function QuickConnectionSwitcher({ className }: { className?: string }) {
             })}
 
             {sorted.length === 0 && (
-              <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+              <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
                 No connections found.
               </div>
             )}

--- a/packages/client/src/components/chat/QuickPersonaSwitcher.tsx
+++ b/packages/client/src/components/chat/QuickPersonaSwitcher.tsx
@@ -164,13 +164,13 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
         key={persona.id}
         onClick={() => handleSwitch(persona.id)}
         className={cn(
-          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
-          isActive && "text-foreground",
+          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+          isActive ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15" : "hover:bg-foreground/10",
           indented && "pl-6",
         )}
       >
         {persona.avatarPath ? (
-          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-foreground/10">
             <img
               src={persona.avatarPath}
               alt={persona.name}
@@ -179,7 +179,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             />
           </div>
         ) : (
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
             {(persona.name || "?")[0].toUpperCase()}
           </div>
         )}
@@ -188,7 +188,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             {persona.name || persona.id}
           </span>
           {persona.comment && (
-            <span className="truncate text-[0.625rem] leading-tight text-[var(--muted-foreground)]">
+            <span className="truncate text-[0.625rem] leading-tight text-foreground/45">
               {persona.comment.length > 60 ? persona.comment.substring(0, 60) + "…" : persona.comment}
             </span>
           )}
@@ -222,7 +222,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             style={getAvatarCropStyle(parseAvatarCropJson(activePersona.avatarCrop))}
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center rounded-full bg-[var(--secondary)] text-[0.75rem] font-semibold text-[var(--muted-foreground)]">
+          <div className="flex h-full w-full items-center justify-center rounded-full bg-foreground/10 text-[0.75rem] font-semibold text-foreground/45">
             {activePersona ? (activePersona.name || "?")[0].toUpperCase() : "?"}
           </div>
         )}
@@ -231,10 +231,10 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
       {open && (
         <div
           ref={menuRef}
-          className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[400px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+          className="fixed z-[9999] flex min-w-[280px] max-w-[340px] max-h-[400px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
           style={pos ? { left: pos.left, top: pos.top } : { visibility: "hidden" as const }}
         >
-          <div className="flex items-center justify-center border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold">
+          <div className="flex items-center justify-center border-b border-foreground/10 px-3 py-2 text-[0.6875rem] font-semibold">
             Personas
           </div>
           <div className="overflow-y-auto p-1">
@@ -242,21 +242,23 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             <button
               onClick={() => handleSwitch(null)}
               className={cn(
-                "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
-                !activePersonaId && "text-foreground",
+                "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+                !activePersonaId
+                  ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
+                  : "hover:bg-foreground/10",
               )}
             >
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
                 ?
               </div>
               <div className="flex min-w-0 flex-1 flex-col">
                 <span className={cn("text-xs font-semibold", !activePersonaId && "text-foreground")}>None</span>
-                <span className="text-[0.625rem] text-[var(--muted-foreground)]">No persona selected</span>
+                <span className="text-[0.625rem] text-foreground/45">No persona selected</span>
               </div>
               {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
             </button>
 
-            <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+            <div className="mx-2 my-1 h-px bg-foreground/10" />
 
             {/* Groups */}
             {groups.map((group) => {
@@ -269,12 +271,14 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
                   <button
                     onClick={() => toggleGroup(group.id)}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
-                      hasActiveInGroup && "text-foreground",
+                      "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+                      hasActiveInGroup
+                        ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
+                        : "hover:bg-foreground/10",
                     )}
                   >
                     {firstMember?.avatarPath ? (
-                      <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+                      <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-foreground/10">
                         <img
                           src={firstMember.avatarPath}
                           alt={group.name}
@@ -283,30 +287,30 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
                         />
                       </div>
                     ) : (
-                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
                         {group.name[0].toUpperCase()}
                       </div>
                     )}
                     <div className="flex min-w-0 flex-1 flex-col">
                       <span className="flex items-center gap-1 text-xs font-semibold">
                         {isExpanded ? (
-                          <FolderOpen size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                          <FolderOpen size="0.75rem" className="shrink-0 text-foreground/45" />
                         ) : (
-                          <Folder size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                          <Folder size="0.75rem" className="shrink-0 text-foreground/45" />
                         )}
                         {group.name} ({group.members.length})
                       </span>
-                      <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+                      <span className="text-[0.625rem] text-foreground/45">
                         {group.members.length} persona{group.members.length !== 1 ? "s" : ""}
                       </span>
                     </div>
-                    <span className="ml-auto shrink-0 text-[var(--muted-foreground)]">
+                    <span className="ml-auto shrink-0 text-foreground/45">
                       {isExpanded ? <ChevronDown size="0.875rem" /> : <ChevronRight size="0.875rem" />}
                     </span>
                   </button>
 
                   {isExpanded && (
-                    <div className="ml-2 border-l border-[var(--border)]/50 pl-1">
+                    <div className="ml-2 border-l border-foreground/10 pl-1">
                       {group.members.map((persona) => renderPersonaRow(persona, true))}
                     </div>
                   )}
@@ -315,9 +319,7 @@ export function QuickPersonaSwitcher({ className }: { className?: string }) {
             })}
 
             {personas.length === 0 && (
-              <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
-                No personas found.
-              </div>
+              <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">No personas found.</div>
             )}
           </div>
         </div>

--- a/packages/client/src/components/chat/QuickReplyMenu.tsx
+++ b/packages/client/src/components/chat/QuickReplyMenu.tsx
@@ -148,7 +148,7 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
         disabled={singleDisabled}
         aria-label={`${singleAction.label}: ${singleAction.description}`}
         className={cn(
-          "flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-all duration-200 focus-visible:ring-2 focus-visible:ring-[var(--primary)] sm:h-8 sm:w-8",
+          "flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-all duration-200 focus-visible:ring-2 focus-visible:ring-foreground/20 sm:h-8 sm:w-8",
           !singleDisabled
             ? "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70 active:scale-90"
             : "cursor-not-allowed text-foreground/20",
@@ -214,10 +214,10 @@ export function QuickReplyMenu({ actions, disabled = false }: QuickReplyMenuProp
                   onKeyDown={(event) => handleItemKeyDown(event, index)}
                   aria-label={`${action.label}: ${action.description}`}
                   className={cn(
-                    "group relative flex h-11 w-11 items-center justify-center rounded-full border shadow-xl outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--primary)] sm:h-10 sm:w-10",
+                    "group relative flex h-11 w-11 items-center justify-center rounded-full border shadow-xl outline-none transition-colors focus-visible:ring-2 focus-visible:ring-foreground/20 sm:h-10 sm:w-10",
                     action.disabled
-                      ? "cursor-not-allowed border-[var(--border)] bg-[var(--card)]/75 opacity-45"
-                      : "border-foreground/20 bg-[var(--card)] text-foreground/65 hover:border-foreground/35 hover:bg-foreground/10 hover:text-foreground/80 active:scale-95",
+                      ? "cursor-not-allowed border-foreground/10 bg-[var(--card)]/75 opacity-45"
+                      : "border-foreground/20 bg-[var(--card)] text-foreground/55 hover:bg-foreground/10 hover:text-foreground/80 active:scale-95",
                   )}
                   title={formatActionTitle(action)}
                   variants={{

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -202,13 +202,13 @@ export function QuickSwitcherMobile() {
         key={persona.id}
         onClick={() => handleSwitchPersona(persona.id)}
         className={cn(
-          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-foreground/10",
           isActive && "text-foreground",
           indented && "pl-6",
         )}
       >
         {persona.avatarPath ? (
-          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-foreground/10">
             <img
               src={persona.avatarPath}
               alt={persona.name}
@@ -217,7 +217,7 @@ export function QuickSwitcherMobile() {
             />
           </div>
         ) : (
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
             {(persona.name || "?")[0].toUpperCase()}
           </div>
         )}
@@ -226,7 +226,7 @@ export function QuickSwitcherMobile() {
             {persona.name || persona.id}
           </span>
           {persona.comment && (
-            <span className="truncate text-[0.625rem] leading-tight text-[var(--muted-foreground)]">
+            <span className="truncate text-[0.625rem] leading-tight text-foreground/45">
               {persona.comment.length > 60 ? persona.comment.substring(0, 60) + "…" : persona.comment}
             </span>
           )}
@@ -244,7 +244,7 @@ export function QuickSwitcherMobile() {
         className={cn(
           "flex h-11 w-11 items-center justify-center rounded-xl transition-all",
           open
-            ? "bg-foreground/10 text-foreground/75"
+            ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
             : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
         )}
       >
@@ -254,17 +254,17 @@ export function QuickSwitcherMobile() {
       {open && (
         <div
           ref={menuRef}
-          className="fixed z-[9999] flex max-h-[400px] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+          className="fixed z-[9999] flex max-h-[400px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
           style={pos ? { left: pos.left, top: pos.top, width: pos.width } : { visibility: "hidden" as const }}
         >
-          <div className="flex border-b border-[var(--border)]">
+          <div className="flex border-b border-foreground/10">
             <button
               onClick={() => setTab("connections")}
               className={cn(
                 "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
                 tab === "connections"
-                  ? "text-[var(--foreground)] border-b-2 border-[var(--primary)]"
-                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+                  ? "border-b-2 border-foreground/25 bg-foreground/10 text-foreground/85"
+                  : "text-foreground/50 hover:text-foreground/80",
               )}
             >
               <Link size="0.75rem" />
@@ -275,8 +275,8 @@ export function QuickSwitcherMobile() {
               className={cn(
                 "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
                 tab === "personas"
-                  ? "text-[var(--foreground)] border-b-2 border-[var(--primary)]"
-                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+                  ? "border-b-2 border-foreground/25 bg-foreground/10 text-foreground/85"
+                  : "text-foreground/50 hover:text-foreground/80",
               )}
             >
               <CircleUser size="0.75rem" />
@@ -292,15 +292,15 @@ export function QuickSwitcherMobile() {
                   className={cn(
                     "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors",
                     isRandom
-                      ? "bg-amber-400/15 text-amber-400 font-semibold ring-1 ring-amber-400/40"
-                      : "hover:bg-[var(--accent)]",
+                      ? "bg-foreground/10 font-semibold text-foreground/85 ring-1 ring-foreground/15"
+                      : "hover:bg-foreground/10",
                   )}
                   title={isRandom ? "Random pool active — click to disable" : "Use random connection from pool"}
                 >
                   <span>🎲 Random</span>
                   {isRandom && <span className="ml-auto text-[0.6875rem]">active</span>}
                 </button>
-                <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+                <div className="mx-2 my-1 h-px bg-foreground/10" />
                 {sortedConnections.map((conn) => {
                   const inPool = conn.useForRandom === "true";
                   const isActive = activeConnectionId === conn.id;
@@ -309,7 +309,7 @@ export function QuickSwitcherMobile() {
                       <button
                         key={conn.id}
                         onClick={() => handleTogglePool(conn.id, inPool)}
-                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]"
+                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10"
                         title={inPool ? "In random pool — click to remove" : "Click to add to random pool"}
                       >
                         <span className="flex-1 truncate">{conn.name || conn.id}</span>
@@ -317,8 +317,8 @@ export function QuickSwitcherMobile() {
                           className={cn(
                             "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
                             inPool
-                              ? "border-amber-400/60 bg-amber-400/20 text-amber-400"
-                              : "border-[var(--border)] bg-transparent",
+                              ? "border-foreground/35 bg-foreground/10 text-foreground/75"
+                              : "border-foreground/20 bg-transparent",
                           )}
                         >
                           {inPool && <Check size="0.625rem" strokeWidth={3} />}
@@ -331,7 +331,7 @@ export function QuickSwitcherMobile() {
                       key={conn.id}
                       onClick={() => handleSwitchConnection(conn.id)}
                       className={cn(
-                        "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-[var(--accent)]",
+                        "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10",
                         isActive && "text-foreground font-semibold",
                       )}
                     >
@@ -341,7 +341,7 @@ export function QuickSwitcherMobile() {
                   );
                 })}
                 {sortedConnections.length === 0 && (
-                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
                     No connections found.
                   </div>
                 )}
@@ -353,16 +353,16 @@ export function QuickSwitcherMobile() {
                 <button
                   onClick={() => handleSwitchPersona(null)}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-foreground/10",
                     !activePersonaId && "text-foreground",
                   )}
                 >
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
                     ?
                   </div>
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className={cn("text-xs font-semibold", !activePersonaId && "text-foreground")}>None</span>
-                    <span className="text-[0.625rem] text-[var(--muted-foreground)]">No persona selected</span>
+                    <span className="text-[0.625rem] text-foreground/45">No persona selected</span>
                   </div>
                   {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
                 </button>
@@ -376,12 +376,12 @@ export function QuickSwitcherMobile() {
                       <button
                         onClick={() => toggleGroup(group.id)}
                         className={cn(
-                          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--accent)]",
+                          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-foreground/10",
                           hasActiveInGroup && "text-foreground",
                         )}
                       >
                         {firstMember?.avatarPath ? (
-                          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-[var(--border)]">
+                          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-foreground/10">
                             <img
                               src={firstMember.avatarPath}
                               alt={group.name}
@@ -390,29 +390,29 @@ export function QuickSwitcherMobile() {
                             />
                           </div>
                         ) : (
-                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--secondary)] text-xs font-semibold text-[var(--muted-foreground)]">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
                             {group.name[0].toUpperCase()}
                           </div>
                         )}
                         <div className="flex min-w-0 flex-1 flex-col">
                           <span className="flex items-center gap-1 text-xs font-semibold">
                             {isExpanded ? (
-                              <FolderOpen size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                              <FolderOpen size="0.75rem" className="shrink-0 text-foreground/45" />
                             ) : (
-                              <Folder size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                              <Folder size="0.75rem" className="shrink-0 text-foreground/45" />
                             )}
                             {group.name} ({group.members.length})
                           </span>
-                          <span className="text-[0.625rem] text-[var(--muted-foreground)]">
+                          <span className="text-[0.625rem] text-foreground/45">
                             {group.members.length} persona{group.members.length !== 1 ? "s" : ""}
                           </span>
                         </div>
-                        <span className="ml-auto shrink-0 text-[var(--muted-foreground)]">
+                        <span className="ml-auto shrink-0 text-foreground/45">
                           {isExpanded ? <ChevronDown size="0.875rem" /> : <ChevronRight size="0.875rem" />}
                         </span>
                       </button>
                       {isExpanded && (
-                        <div className="ml-2 border-l border-[var(--border)]/50 pl-1">
+                        <div className="ml-2 border-l border-foreground/10 pl-1">
                           {group.members.map((persona) => renderPersonaRow(persona, true))}
                         </div>
                       )}
@@ -420,7 +420,7 @@ export function QuickSwitcherMobile() {
                   );
                 })}
                 {sortedPersonas.length === 0 && (
-                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-[var(--muted-foreground)]">
+                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
                     No personas found.
                   </div>
                 )}

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -202,8 +202,8 @@ export function QuickSwitcherMobile() {
         key={persona.id}
         onClick={() => handleSwitchPersona(persona.id)}
         className={cn(
-          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-foreground/10",
-          isActive && "text-foreground",
+          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+          isActive ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15" : "hover:bg-foreground/10",
           indented && "pl-6",
         )}
       >
@@ -353,8 +353,10 @@ export function QuickSwitcherMobile() {
                 <button
                   onClick={() => handleSwitchPersona(null)}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-foreground/10",
-                    !activePersonaId && "text-foreground",
+                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+                    !activePersonaId
+                      ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
+                      : "hover:bg-foreground/10",
                   )}
                 >
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
@@ -366,7 +368,7 @@ export function QuickSwitcherMobile() {
                   </div>
                   {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
                 </button>
-                <div className="mx-2 my-1 h-px bg-[var(--border)]" />
+                <div className="mx-2 my-1 h-px bg-foreground/10" />
                 {groups.map((group) => {
                   const isExpanded = expandedGroups.has(group.id);
                   const firstMember = group.members[0];
@@ -376,8 +378,10 @@ export function QuickSwitcherMobile() {
                       <button
                         onClick={() => toggleGroup(group.id)}
                         className={cn(
-                          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-foreground/10",
-                          hasActiveInGroup && "text-foreground",
+                          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+                          hasActiveInGroup
+                            ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
+                            : "hover:bg-foreground/10",
                         )}
                       >
                         {firstMember?.avatarPath ? (

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -34,10 +34,8 @@ import {
   getTemperatureKeywordHint,
   parseTemperatureValue,
 } from "../../features/tracker-panel/lib/world-state-display";
-import {
-  ROLEPLAY_POPOVER_SCROLL_AREA,
-  ROLEPLAY_POPOVER_SHELL,
-} from "./roleplay-popover-styles";
+import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
+import { getChatToolbarButtonClass } from "./ChatToolbarControls";
 import type {
   GameState,
   PresentCharacter,
@@ -437,8 +435,8 @@ export function RoleplayHUD({
 // ═══════════════════════════════════════════════
 
 /** Common mobile HUD button sizing – used by all four strip buttons */
-const MOBILE_HUD_BTN =
-  "flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)]/80 backdrop-blur-md px-2 py-1.5 transition-all hover:bg-[var(--card)] dark:border-foreground/10 cursor-pointer select-none";
+const HUD_ICON_BUTTON = getChatToolbarButtonClass({ compact: true });
+const MOBILE_HUD_BTN = cn(HUD_ICON_BUTTON, "cursor-pointer select-none");
 
 function DeferredHUDPanelFallback({ label }: { label: string }) {
   return <div className="px-3 py-4 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">{label}</div>;
@@ -581,6 +579,10 @@ function ActionsGroup({
   ]);
   if (echoMessages.length > 0 && !generatedAgentIds.has("echo-chamber")) generatedAgentIds.add("echo-chamber");
   const generatedAgentCount = generatedAgentIds.size;
+  const agentsLabel = `Agents & Actions${generatedAgentCount > 0 ? ` - ${generatedAgentCount} generated` : ""}${
+    failedAgentTypes.length > 0 ? ` - ${failedAgentTypes.length} failed` : ""
+  }`;
+  const hasAgentCount = generatedAgentCount > 0 || failedAgentTypes.length > 0;
 
   // ── Shared dropdown portal (used by both desktop & mobile) ──
   const dropdownContent =
@@ -633,12 +635,15 @@ function ActionsGroup({
         ref={btnRef}
         onClick={() => setAgentsOpen(!agentsOpen)}
         className={cn(
-          "group flex items-center gap-1.5 md:gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)]/80 backdrop-blur-md px-2 py-1.5 md:px-2 md:py-2 md:h-10 transition-all hover:bg-[var(--card)] dark:border-foreground/10 cursor-pointer select-none",
-          agentsOpen && "bg-[var(--card)] border-[var(--border)] dark:border-foreground/20",
+          getChatToolbarButtonClass({
+            compact: true,
+            open: agentsOpen,
+            className: hasAgentCount ? "w-auto min-w-8 gap-1.5 px-2" : undefined,
+          }),
+          "group cursor-pointer select-none",
         )}
-        title={`Agents & Actions${generatedAgentCount > 0 ? ` - ${generatedAgentCount} generated` : ""}${
-          failedAgentTypes.length > 0 ? ` - ${failedAgentTypes.length} failed` : ""
-        }`}
+        title={agentsLabel}
+        aria-label={agentsLabel}
       >
         {isAgentProcessing ? (
           <Loader2
@@ -657,12 +662,21 @@ function ActionsGroup({
           />
         )}
         {generatedAgentCount > 0 && (
-          <span className="hidden md:flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-foreground/15 px-1 text-[0.5rem] font-bold text-foreground/80 ring-1 ring-foreground/10">
+          <span
+            className={cn(
+              "shrink-0 rounded-full bg-[var(--foreground)]/10 px-1.5 py-0.5 text-[0.625rem] font-medium tabular-nums text-[var(--foreground)]/65",
+              agentsOpen && "text-[var(--foreground)]/75",
+            )}
+            aria-hidden="true"
+          >
             {generatedAgentCount}
           </span>
         )}
         {failedAgentTypes.length > 0 && (
-          <span className="flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-amber-500/80 px-1 text-[0.5rem] font-bold text-foreground">
+          <span
+            className="shrink-0 rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[0.625rem] font-medium tabular-nums text-amber-200"
+            aria-hidden="true"
+          >
             {failedAgentTypes.length}
           </span>
         )}
@@ -729,12 +743,10 @@ function CombinedPlayerWidget({
         className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
         title="Player & Tracker"
       >
-        <div className="flex h-7 max-md:h-auto items-center justify-center shrink-0">
+        <div className="flex h-4 items-center justify-center shrink-0">
           <Swords size="0.875rem" className="text-orange-400/70 max-md:h-4 max-md:w-4" />
         </div>
-        <span className="max-w-full truncate text-[0.5625rem] font-semibold leading-tight shrink-0 max-md:hidden">
-          Tracker
-        </span>
+        <span className="sr-only">Tracker</span>
       </button>
 
       <WidgetPopover
@@ -1007,9 +1019,7 @@ function PersonaStatsWidget({
         ) : (
           <BarChart3 size="0.875rem" className="text-sky-400/45 max-md:h-3.5 max-md:w-3.5" />
         )}
-        <span className="max-w-full truncate text-[0.5625rem] max-md:text-[0.4375rem] font-semibold leading-tight shrink-0 md:hidden">
-          Persona
-        </span>
+        <span className="sr-only">Persona</span>
       </button>
 
       <WidgetPopover
@@ -1266,8 +1276,10 @@ function QuestsWidget({
 // Uniform World-State Widgets
 // ═══════════════════════════════════════════════
 
-const WIDGET =
-  "group flex w-10 h-10 max-md:w-auto max-md:h-auto max-md:px-2 max-md:py-1.5 flex-col items-center justify-center gap-0.5 max-md:gap-0 rounded-xl max-md:rounded-lg border border-[var(--border)] bg-[var(--card)]/80 backdrop-blur-md transition-all hover:bg-[var(--card)] dark:border-foreground/15 cursor-pointer select-none overflow-hidden";
+const WIDGET = cn(
+  HUD_ICON_BUTTON,
+  "group flex-col gap-0 overflow-hidden cursor-pointer select-none dark:border-foreground/15",
+);
 
 // ═══════════════════════════════════════════════
 // Combined World-State Widget (icon strip + popover, desktop & mobile)
@@ -1325,6 +1337,7 @@ function CombinedWorldWidget({
   const tempFill =
     temperatureDisplay.percent == null ? 0.3 : Math.max(0, Math.min(1, temperatureDisplay.percent / 100));
   const tempFillColor = temperatureDisplay.color;
+  const sideLayout = layout === "left" || layout === "right";
 
   return (
     <div className="relative">
@@ -1332,8 +1345,9 @@ function CombinedWorldWidget({
         ref={buttonRef}
         onClick={() => setOpen(!open)}
         className={cn(
-          "flex items-center gap-1.5 md:gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)]/80 backdrop-blur-md px-2 py-1.5 md:px-2 md:py-2 md:h-10 transition-all hover:bg-[var(--card)] dark:border-foreground/10 cursor-pointer select-none",
-          open && "bg-[var(--card)] border-[var(--border)] dark:border-foreground/20",
+          getChatToolbarButtonClass({ compact: true, open }),
+          "cursor-pointer select-none",
+          !sideLayout && "w-auto min-w-8 gap-1 px-2",
         )}
         title="World State"
       >
@@ -1341,137 +1355,141 @@ function CombinedWorldWidget({
         <MapPin size="0.9375rem" className={cn(pinColor, "drop-shadow-sm shrink-0")} />
 
         {/* Mini calendar with day number */}
-        <svg viewBox="0 0 20 20" fill="none" className="shrink-0 h-4 w-4">
-          <rect
-            x="2"
-            y="4"
-            width="16"
-            height="14"
-            rx="2"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            className="text-zinc-300/70"
-          />
-          <line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" strokeWidth="1.2" className="text-zinc-400/50" />
-          <line
-            x1="6"
-            y1="2"
-            x2="6"
-            y2="5.5"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            className="text-zinc-300/70"
-          />
-          <line
-            x1="14"
-            y1="2"
-            x2="14"
-            y2="5.5"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            className="text-zinc-300/70"
-          />
-          {dateParts.day && (
-            <text
-              x="10"
-              y="15.5"
-              textAnchor="middle"
-              fill="currentColor"
-              fontSize="7"
-              fontWeight="700"
-              className="text-zinc-100"
-            >
-              {dateParts.day}
-            </text>
-          )}
-        </svg>
-
-        {/* Mini clock with dynamic hands */}
-        <svg viewBox="0 0 20 20" fill="none" className="shrink-0 h-4 w-4">
-          <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="1.5" className="text-amber-400/70" />
-          {hour >= 0 ? (
-            <>
-              <line
-                x1="10"
-                y1="10"
-                x2={10 + 4.2 * Math.sin((hourAngle * Math.PI) / 180)}
-                y2={10 - 4.2 * Math.cos((hourAngle * Math.PI) / 180)}
+        {!sideLayout && (
+          <>
+            <svg viewBox="0 0 20 20" fill="none" className="shrink-0 h-4 w-4">
+              <rect
+                x="2"
+                y="4"
+                width="16"
+                height="14"
+                rx="2"
                 stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                className="text-amber-300"
+                strokeWidth="1.5"
+                className="text-zinc-300/70"
               />
+              <line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" strokeWidth="1.2" className="text-zinc-400/50" />
               <line
-                x1="10"
-                y1="10"
-                x2={10 + 5.8 * Math.sin((minuteAngle * Math.PI) / 180)}
-                y2={10 - 5.8 * Math.cos((minuteAngle * Math.PI) / 180)}
-                stroke="currentColor"
-                strokeWidth="1.2"
-                strokeLinecap="round"
-                className="text-amber-400/80"
-              />
-            </>
-          ) : (
-            <>
-              <line
-                x1="10"
-                y1="10"
-                x2="10"
+                x1="6"
+                y1="2"
+                x2="6"
                 y2="5.5"
                 stroke="currentColor"
-                strokeWidth="1.8"
+                strokeWidth="1.5"
                 strokeLinecap="round"
-                className="text-amber-300"
+                className="text-zinc-300/70"
               />
               <line
-                x1="10"
-                y1="10"
+                x1="14"
+                y1="2"
                 x2="14"
-                y2="10"
+                y2="5.5"
                 stroke="currentColor"
-                strokeWidth="1.2"
+                strokeWidth="1.5"
                 strokeLinecap="round"
-                className="text-amber-400/80"
+                className="text-zinc-300/70"
               />
-            </>
-          )}
-          <circle cx="10" cy="10" r="1" fill="currentColor" className="text-amber-300" />
-        </svg>
+              {dateParts.day && (
+                <text
+                  x="10"
+                  y="15.5"
+                  textAnchor="middle"
+                  fill="currentColor"
+                  fontSize="7"
+                  fontWeight="700"
+                  className="text-zinc-100"
+                >
+                  {dateParts.day}
+                </text>
+              )}
+            </svg>
 
-        {/* Weather emoji */}
-        <span className="text-sm leading-none shrink-0">{weatherEmoji}</span>
+            {/* Mini clock with dynamic hands */}
+            <svg viewBox="0 0 20 20" fill="none" className="shrink-0 h-4 w-4">
+              <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="1.5" className="text-amber-400/70" />
+              {hour >= 0 ? (
+                <>
+                  <line
+                    x1="10"
+                    y1="10"
+                    x2={10 + 4.2 * Math.sin((hourAngle * Math.PI) / 180)}
+                    y2={10 - 4.2 * Math.cos((hourAngle * Math.PI) / 180)}
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    className="text-amber-300"
+                  />
+                  <line
+                    x1="10"
+                    y1="10"
+                    x2={10 + 5.8 * Math.sin((minuteAngle * Math.PI) / 180)}
+                    y2={10 - 5.8 * Math.cos((minuteAngle * Math.PI) / 180)}
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                    className="text-amber-400/80"
+                  />
+                </>
+              ) : (
+                <>
+                  <line
+                    x1="10"
+                    y1="10"
+                    x2="10"
+                    y2="5.5"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    className="text-amber-300"
+                  />
+                  <line
+                    x1="10"
+                    y1="10"
+                    x2="14"
+                    y2="10"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                    strokeLinecap="round"
+                    className="text-amber-400/80"
+                  />
+                </>
+              )}
+              <circle cx="10" cy="10" r="1" fill="currentColor" className="text-amber-300" />
+            </svg>
 
-        {/* Mini thermometer with fill — vivid color & fill level changes dynamically */}
-        <svg viewBox="0 0 10 20" fill="none" className="shrink-0 h-4 w-[0.625rem]">
-          <rect
-            x="3"
-            y="1"
-            width="4"
-            height="13"
-            rx="2"
-            stroke={tempFillColor}
-            strokeWidth="1.2"
-            fill="none"
-            opacity={temp !== null ? 1 : 0.3}
-          />
-          <rect
-            x="3.8"
-            y={1 + 12 * (1 - tempFill)}
-            width="2.4"
-            height={12 * tempFill + 1}
-            rx="1"
-            fill={tempFillColor}
-            opacity={temp !== null ? 0.9 : 0.2}
-          />
-          <circle cx="5" cy="17" r="2.5" fill={tempFillColor} opacity={temp !== null ? 1 : 0.25} />
-        </svg>
-        {tempNumeric !== null && (
-          <span className={cn("text-[0.5rem] md:text-[0.5625rem] font-bold leading-none shrink-0", tempColor)}>
-            {temperatureDisplay.label}
-          </span>
+            {/* Weather emoji */}
+            <span className="text-sm leading-none shrink-0">{weatherEmoji}</span>
+
+            {/* Mini thermometer with fill — vivid color & fill level changes dynamically */}
+            <svg viewBox="0 0 10 20" fill="none" className="shrink-0 h-4 w-[0.625rem]">
+              <rect
+                x="3"
+                y="1"
+                width="4"
+                height="13"
+                rx="2"
+                stroke={tempFillColor}
+                strokeWidth="1.2"
+                fill="none"
+                opacity={temp !== null ? 1 : 0.3}
+              />
+              <rect
+                x="3.8"
+                y={1 + 12 * (1 - tempFill)}
+                width="2.4"
+                height={12 * tempFill + 1}
+                rx="1"
+                fill={tempFillColor}
+                opacity={temp !== null ? 0.9 : 0.2}
+              />
+              <circle cx="5" cy="17" r="2.5" fill={tempFillColor} opacity={temp !== null ? 1 : 0.25} />
+            </svg>
+            {tempNumeric !== null && (
+              <span className={cn("text-[0.5rem] md:text-[0.5625rem] font-bold leading-none shrink-0", tempColor)}>
+                {temperatureDisplay.label}
+              </span>
+            )}
+          </>
         )}
       </button>
 

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Loader2, Music, Pause, Play, X } from "lucide-react";
+import { ChevronDown, ChevronUp, Loader2, Pause, Play, X } from "lucide-react";
 import { useAgentStore } from "@/stores/agent.store";
 import { useUIStore } from "@/stores/ui.store";
 import { api } from "@/lib/api-client";
@@ -61,7 +61,12 @@ export function YouTubePlayer() {
   const lastQueryRef = useRef("");
   const volumeRef = useRef<number | null>(null);
 
-  const [nowPlaying, setNowPlaying] = useState<{ title: string; mood: string } | null>(null);
+  const [nowPlaying, setNowPlaying] = useState<{
+    title: string;
+    mood: string;
+    channel: string;
+    thumbnail: string | null;
+  } | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [paused, setPaused] = useState(false);
@@ -130,7 +135,12 @@ export function YouTubePlayer() {
         lastQueryRef.current = query;
         player.loadVideoById(top.videoId);
         if (volumeRef.current != null) player.setVolume(volumeRef.current);
-        setNowPlaying({ title: top.title, mood: youtubePlay.mood });
+        setNowPlaying({
+          title: top.title,
+          mood: youtubePlay.mood,
+          channel: top.channel,
+          thumbnail: top.thumbnail,
+        });
         setPaused(false);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "YouTube playback failed");
@@ -193,53 +203,79 @@ export function YouTubePlayer() {
 
   const active = musicPlayerActive;
   const hasPlayerContent = !!nowPlaying || loading || !!error;
+  const displayTitle = loading ? "Finding a track..." : error ? error : (nowPlaying?.title ?? "YouTube");
+  const displaySubtitle = loading
+    ? "Searching YouTube"
+    : error
+      ? "Playback needs attention"
+      : (nowPlaying?.channel ?? nowPlaying?.mood ?? "Ready for Music DJ");
 
   return (
     <>
       {/* Compact mini-player pill — lives in the top bar (upper-left), like Spotify's. */}
       {active && (
-        <div className="flex h-8 min-w-0 max-w-[15rem] items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--card)] pl-1 pr-1">
-          <MusicSourceButton source="youtube" className="h-6 w-6 border-[var(--border)] bg-[var(--secondary)]" />
-          <span
-            className="hidden min-w-0 flex-1 truncate text-xs text-[var(--foreground)] sm:inline"
-            title={nowPlaying?.title ?? undefined}
-          >
-            {loading ? "Finding a track…" : error ? error : (nowPlaying?.title ?? "YouTube")}
-          </span>
-          {!loading && !nowPlaying && !error && <Music className="size-3.5 shrink-0 text-[var(--muted-foreground)] sm:hidden" />}
-          {loading && (
-            <Loader2 className="size-3.5 shrink-0 animate-spin text-[var(--muted-foreground)] sm:hidden" />
-          )}
+        <div className="relative flex h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border border-[#ff0033]/25 bg-[oklch(0.16_0.006_29)] px-2.5 shadow-[0_1px_10px_rgba(255,0,51,0.10)]">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <MusicSourceButton source="youtube" className="border-[#ff0033]/30 bg-[#ff0033]/10 hover:bg-[#ff0033]/15" />
+            <div className="flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] bg-[oklch(0.23_0.006_29)] ring-1 ring-[#ff0033]/25">
+              {loading ? (
+                <Loader2 size="0.875rem" className="animate-spin text-[#ff0033]" />
+              ) : nowPlaying?.thumbnail ? (
+                <img src={nowPlaying.thumbnail} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <Play size="0.875rem" className="translate-x-px text-[#ff0033]" />
+              )}
+            </div>
+            <div className="min-w-0">
+              <p
+                className="truncate text-[0.6875rem] font-semibold leading-tight text-[oklch(0.96_0.006_29)]"
+                title={displayTitle}
+              >
+                {displayTitle}
+              </p>
+              <p className="truncate text-[0.5625rem] leading-tight text-[oklch(0.72_0.012_29)]">
+                {displaySubtitle}
+              </p>
+            </div>
+          </div>
           {nowPlaying && (
             <button
               type="button"
               onClick={togglePlay}
-              className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] active:scale-90"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#ff0033] text-[oklch(0.98_0.006_29)] shadow-[0_1px_8px_rgba(255,0,51,0.20)] transition-transform hover:scale-105 active:scale-95"
               aria-label={paused ? "Play" : "Pause"}
             >
-              {paused ? <Play className="size-3.5" /> : <Pause className="size-3.5" />}
+              {paused ? <Play size="0.8125rem" className="translate-x-px" /> : <Pause size="0.8125rem" />}
             </button>
           )}
           {hasPlayerContent && (
             <button
               type="button"
               onClick={() => setShowVideo((v) => !v)}
-              className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] active:scale-90"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.72_0.012_29)] transition-colors hover:text-[oklch(0.96_0.006_29)] active:scale-90"
               aria-label={showVideo ? "Hide video" : "Show video"}
             >
-              {showVideo ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
+              {showVideo ? <ChevronUp size="0.8125rem" /> : <ChevronDown size="0.8125rem" />}
             </button>
           )}
           {hasPlayerContent && (
             <button
               type="button"
               onClick={close}
-              className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)] active:scale-90"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.72_0.012_29)] transition-colors hover:text-[#ff6b6b] active:scale-90"
               aria-label="Stop"
             >
-              <X className="size-3.5" />
+              <X size="0.8125rem" />
             </button>
           )}
+          <div className="pointer-events-none absolute bottom-0 left-3 right-3 h-px overflow-hidden rounded-full bg-[oklch(0.28_0.01_29)]">
+            <div
+              className={cn(
+                "h-full rounded-full bg-[#ff0033]",
+                hasPlayerContent && !paused ? "w-full opacity-80" : "w-8 opacity-50",
+              )}
+            />
+          </div>
         </div>
       )}
 
@@ -248,7 +284,7 @@ export function YouTubePlayer() {
           so audio never stops. */}
       <div
         className={cn(
-          "fixed top-14 z-40 w-72 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-lg transition-opacity",
+          "fixed top-14 z-40 w-80 overflow-hidden rounded-xl border border-[#ff0033]/25 bg-[oklch(0.16_0.006_29)] shadow-[0_18px_50px_rgba(0,0,0,0.35)] transition-opacity",
           active && hasPlayerContent && showVideo
             ? "left-2 opacity-100"
             : "pointer-events-none -left-[9999px] opacity-0",
@@ -259,17 +295,17 @@ export function YouTubePlayer() {
         {(nowPlaying || error) && (
           <div className="px-3 py-2">
             {error ? (
-              <div className="text-xs text-[var(--destructive)]">{error}</div>
+              <div className="text-xs text-[#ff6b6b]">{error}</div>
             ) : (
               <div className="min-w-0">
                 <div
-                  className="truncate text-xs font-medium text-[var(--foreground)]"
+                  className="truncate text-xs font-medium text-[oklch(0.96_0.006_29)]"
                   title={nowPlaying?.title}
                 >
                   {nowPlaying?.title}
                 </div>
                 {nowPlaying?.mood && (
-                  <div className="truncate text-[11px] text-[var(--muted-foreground)]">{nowPlaying.mood}</div>
+                  <div className="truncate text-[11px] text-[oklch(0.72_0.012_29)]">{nowPlaying.mood}</div>
                 )}
               </div>
             )}

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -1,10 +1,18 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Loader2, Pause, Play, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { ChevronDown, ChevronUp, GripVertical, Loader2, Pause, Play, X } from "lucide-react";
 import { useAgentStore } from "@/stores/agent.store";
 import { useUIStore } from "@/stores/ui.store";
 import { api } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
-import { MusicSourceButton } from "@/components/music/MusicSourceButton";
+import { MusicSourceButton, MusicSourceGlyph } from "@/components/music/MusicSourceButton";
 
 // The YouTube IFrame API attaches itself to window; it has no bundled types.
 type YTPlayer = {
@@ -25,6 +33,75 @@ interface SearchResult {
 }
 
 let ytApiPromise: Promise<void> | null = null;
+
+const MUSIC_NEUTRAL_BORDER_CLASS = "border-[oklch(0.30_0.012_145)]";
+const MUSIC_NEUTRAL_BG_CLASS = "bg-[oklch(0.16_0.006_145)]";
+const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[oklch(0.20_0.008_145)]";
+const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[oklch(0.23_0.006_145)]";
+const MUSIC_NEUTRAL_TEXT_CLASS = "text-[oklch(0.96_0.006_145)]";
+const MUSIC_NEUTRAL_MUTED_CLASS = "text-[oklch(0.72_0.012_145)]";
+const MUSIC_NEUTRAL_ICON_CLASS = "text-[oklch(0.70_0.012_145)]";
+const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[oklch(0.28_0.01_145)]";
+const MUSIC_NEUTRAL_PROGRESS_FILL_CLASS = "bg-[oklch(0.96_0.006_145)]";
+const YOUTUBE_LOGO_CLASS = "text-[oklch(0.62_0.16_25)]";
+const MOBILE_WIDGET_COLLAPSED_SIZE = 48;
+const MOBILE_WIDGET_EXPANDED_MAX_WIDTH = 320;
+const MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER = 24;
+const MOBILE_WIDGET_EXPANDED_HEIGHT = 132;
+const MOBILE_WIDGET_VIEWPORT_PADDING = 8;
+
+function clampMobilePosition(x: number, y: number, collapsed: boolean) {
+  if (typeof window === "undefined") return { x, y };
+  const width = collapsed
+    ? MOBILE_WIDGET_COLLAPSED_SIZE
+    : Math.min(MOBILE_WIDGET_EXPANDED_MAX_WIDTH, window.innerWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER);
+  const height = collapsed ? MOBILE_WIDGET_COLLAPSED_SIZE : MOBILE_WIDGET_EXPANDED_HEIGHT;
+  return {
+    x: Math.max(
+      MOBILE_WIDGET_VIEWPORT_PADDING,
+      Math.min(window.innerWidth - width - MOBILE_WIDGET_VIEWPORT_PADDING, x),
+    ),
+    y: Math.max(
+      MOBILE_WIDGET_VIEWPORT_PADDING,
+      Math.min(window.innerHeight - height - MOBILE_WIDGET_VIEWPORT_PADDING, y),
+    ),
+  };
+}
+
+function getMobileWidgetStyle(
+  position: { x: number; y: number },
+  collapsed: boolean,
+): Pick<CSSProperties, "left" | "top"> {
+  if (typeof window === "undefined") {
+    return { left: position.x, top: position.y };
+  }
+
+  return {
+    left: Math.max(
+      MOBILE_WIDGET_VIEWPORT_PADDING,
+      Math.min(window.innerWidth - MOBILE_WIDGET_COLLAPSED_SIZE - MOBILE_WIDGET_VIEWPORT_PADDING, position.x),
+    ),
+    top: collapsed
+      ? position.y
+      : Math.max(
+          MOBILE_WIDGET_VIEWPORT_PADDING,
+          Math.min(window.innerHeight - MOBILE_WIDGET_EXPANDED_HEIGHT - MOBILE_WIDGET_VIEWPORT_PADDING, position.y),
+        ),
+  };
+}
+
+function getMobileExpandedPanelStyle(position: { x: number; y: number }): CSSProperties {
+  if (typeof window === "undefined") return {};
+  const width = Math.min(MOBILE_WIDGET_EXPANDED_MAX_WIDTH, window.innerWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER);
+  return {
+    width,
+    maxWidth: `calc(100vw - ${MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER}px)`,
+    transform:
+      position.x + width > window.innerWidth - MOBILE_WIDGET_VIEWPORT_PADDING
+        ? `translateX(-${Math.max(0, width - MOBILE_WIDGET_COLLAPSED_SIZE)}px)`
+        : undefined,
+  };
+}
 
 /** Load the YouTube IFrame Player API script exactly once. */
 function loadYouTubeApi(): Promise<void> {
@@ -49,17 +126,29 @@ function loadYouTubeApi(): Promise<void> {
  * intent in the agent store, resolves the search query to a video server-side,
  * and plays it in an in-app IFrame player. No OAuth, no external device.
  */
-export function YouTubePlayer() {
+export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
   const youtubePlay = useAgentStore((s) => s.youtubePlay);
   const youtubeVolume = useAgentStore((s) => s.youtubeVolume);
   const clearYoutube = useAgentStore((s) => s.clearYoutube);
   const musicPlayerActive = useUIStore((s) => s.musicPlayerEnabled && s.musicPlayerSource === "youtube");
+  const collapsed = useUIStore((s) => s.spotifyMobileWidgetCollapsed);
+  const setCollapsed = useUIStore((s) => s.setSpotifyMobileWidgetCollapsed);
+  const mobilePosition = useUIStore((s) => s.spotifyMobileWidgetPosition);
+  const setMobilePosition = useUIStore((s) => s.setSpotifyMobileWidgetPosition);
+  const desktopViewport = useMediaQuery("(min-width: 768px)");
 
   const hostRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<YTPlayer | null>(null);
   const lastNonceRef = useRef(0);
   const lastQueryRef = useRef("");
   const volumeRef = useRef<number | null>(null);
+  const dragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+  } | null>(null);
 
   const [nowPlaying, setNowPlaying] = useState<{
     title: string;
@@ -73,6 +162,7 @@ export function YouTubePlayer() {
   const [showVideo, setShowVideo] = useState(false);
 
   volumeRef.current = youtubeVolume;
+  const active = musicPlayerActive && (mobile || desktopViewport);
 
   /** Create the IFrame player on first use (idempotent). */
   const ensurePlayer = useCallback(async () => {
@@ -109,7 +199,7 @@ export function YouTubePlayer() {
 
   // React to a new "play" intent.
   useEffect(() => {
-    if (!musicPlayerActive) return; // player disabled in Settings — don't fetch or play
+    if (!active) return; // player disabled or handled by the other viewport instance
     if (!youtubePlay) return;
     if (youtubePlay.nonce === lastNonceRef.current) return;
     lastNonceRef.current = youtubePlay.nonce;
@@ -151,11 +241,11 @@ export function YouTubePlayer() {
     return () => {
       cancelled = true;
     };
-  }, [youtubePlay, ensurePlayer, musicPlayerActive]);
+  }, [youtubePlay, ensurePlayer, active]);
 
   // Stop playback immediately if the user disables the player mid-track.
   useEffect(() => {
-    if (musicPlayerActive) return;
+    if (active) return;
     try {
       playerRef.current?.stopVideo();
     } catch {
@@ -163,7 +253,7 @@ export function YouTubePlayer() {
     }
     lastQueryRef.current = "";
     setNowPlaying(null);
-  }, [musicPlayerActive]);
+  }, [active]);
 
   // Apply DJ volume changes without changing the track.
   useEffect(() => {
@@ -201,7 +291,46 @@ export function YouTubePlayer() {
     clearYoutube();
   };
 
-  const active = musicPlayerActive;
+  const startDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!mobile) return;
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        originX: mobilePosition.x,
+        originY: mobilePosition.y,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [mobile, mobilePosition.x, mobilePosition.y],
+  );
+
+  const moveDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const next = clampMobilePosition(
+        drag.originX + event.clientX - drag.startX,
+        drag.originY + event.clientY - drag.startY,
+        collapsed,
+      );
+      setMobilePosition(next);
+    },
+    [collapsed, setMobilePosition],
+  );
+
+  const endDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const moved = Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY);
+      dragRef.current = null;
+      if (moved < 6 && mobile && collapsed) setCollapsed(false);
+    },
+    [collapsed, mobile, setCollapsed],
+  );
+
   const hasPlayerContent = !!nowPlaying || loading || !!error;
   const displayTitle = loading ? "Finding a track..." : error ? error : (nowPlaying?.title ?? "YouTube");
   const displaySubtitle = loading
@@ -209,69 +338,201 @@ export function YouTubePlayer() {
     : error
       ? "Playback needs attention"
       : (nowPlaying?.channel ?? nowPlaying?.mood ?? "Ready for Music DJ");
+  const mobileWidgetStyle = useMemo(() => getMobileWidgetStyle(mobilePosition, collapsed), [collapsed, mobilePosition]);
+  const mobileExpandedPanelStyle = useMemo(() => getMobileExpandedPanelStyle(mobilePosition), [mobilePosition]);
+
+  const compactBody = (
+    <>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <MusicSourceButton
+          source="youtube"
+          className={cn(MUSIC_NEUTRAL_BORDER_CLASS, MUSIC_NEUTRAL_BUTTON_BG_CLASS)}
+        />
+        <div
+          className={cn(
+            "flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1",
+            MUSIC_NEUTRAL_TILE_BG_CLASS,
+            "ring-[oklch(0.34_0.01_145)]",
+          )}
+        >
+          {loading ? (
+            <Loader2 size="0.875rem" className={cn("animate-spin", MUSIC_NEUTRAL_MUTED_CLASS)} />
+          ) : nowPlaying?.thumbnail ? (
+            <img src={nowPlaying.thumbnail} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <Play size="0.875rem" className={cn("translate-x-px", MUSIC_NEUTRAL_MUTED_CLASS)} />
+          )}
+        </div>
+        <div className="min-w-0">
+          <p
+            className={cn("truncate text-[0.6875rem] font-semibold leading-tight", MUSIC_NEUTRAL_TEXT_CLASS)}
+            title={displayTitle}
+          >
+            {displayTitle}
+          </p>
+          <p className={cn("truncate text-[0.5625rem] leading-tight", MUSIC_NEUTRAL_MUTED_CLASS)}>
+            {displaySubtitle}
+          </p>
+        </div>
+      </div>
+      {nowPlaying && (
+        <button
+          type="button"
+          onClick={togglePlay}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[oklch(0.96_0.006_145)] text-[oklch(0.16_0.006_145)] shadow-[0_1px_8px_rgba(255,255,255,0.10)] transition-transform hover:scale-105 active:scale-95"
+          aria-label={paused ? "Play" : "Pause"}
+        >
+          {paused ? <Play size="0.8125rem" className="translate-x-px" /> : <Pause size="0.8125rem" />}
+        </button>
+      )}
+      {hasPlayerContent && (
+        <button
+          type="button"
+          onClick={() => setShowVideo((v) => !v)}
+          className={cn(
+            "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:text-[oklch(0.96_0.006_145)] active:scale-90",
+            MUSIC_NEUTRAL_ICON_CLASS,
+          )}
+          aria-label={showVideo ? "Hide video" : "Show video"}
+        >
+          {showVideo ? <ChevronUp size="0.8125rem" /> : <ChevronDown size="0.8125rem" />}
+        </button>
+      )}
+      {hasPlayerContent && (
+        <button
+          type="button"
+          onClick={close}
+          className={cn(
+            "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:text-[oklch(0.96_0.006_145)] active:scale-90",
+            MUSIC_NEUTRAL_ICON_CLASS,
+          )}
+          aria-label="Stop"
+        >
+          <X size="0.8125rem" />
+        </button>
+      )}
+    </>
+  );
+
+  const videoPanel = (
+    <div
+      className={cn(
+        "fixed top-14 z-40 w-[calc(100vw-1rem)] max-w-80 overflow-hidden rounded-xl border shadow-[0_18px_50px_rgba(0,0,0,0.35)] transition-opacity",
+        MUSIC_NEUTRAL_BORDER_CLASS,
+        MUSIC_NEUTRAL_BG_CLASS,
+        active && hasPlayerContent && showVideo
+          ? "left-2 opacity-100"
+          : "pointer-events-none -left-[9999px] opacity-0",
+      )}
+    >
+      {/* The IFrame player lives here; YT injects the iframe into this host. */}
+      <div ref={hostRef} className="aspect-video w-full bg-black [&_iframe]:size-full" />
+      {(nowPlaying || error) && (
+        <div className="px-3 py-2">
+          {error ? (
+            <div className="text-xs text-[var(--destructive)]">{error}</div>
+          ) : (
+            <div className="min-w-0">
+              <div className={cn("truncate text-xs font-medium", MUSIC_NEUTRAL_TEXT_CLASS)} title={nowPlaying?.title}>
+                {nowPlaying?.title}
+              </div>
+              {nowPlaying?.mood && (
+                <div className={cn("truncate text-[11px]", MUSIC_NEUTRAL_MUTED_CLASS)}>{nowPlaying.mood}</div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (mobile) {
+    return (
+      <>
+        {active && (
+          <div
+            className="fixed z-[60] md:hidden"
+            style={mobileWidgetStyle}
+            onPointerDown={startDrag}
+            onPointerMove={moveDrag}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+          >
+            {collapsed ? (
+              <div
+                className={cn(
+                  "flex h-12 w-12 items-center justify-center rounded-full border shadow-lg backdrop-blur-xl",
+                  MUSIC_NEUTRAL_BORDER_CLASS,
+                  MUSIC_NEUTRAL_BG_CLASS,
+                )}
+              >
+                <MusicSourceGlyph source="youtube" className={cn("h-5 w-5", YOUTUBE_LOGO_CLASS)} />
+              </div>
+            ) : (
+              <div
+                className={cn(
+                  "rounded-xl border p-2 shadow-2xl backdrop-blur-xl",
+                  MUSIC_NEUTRAL_BORDER_CLASS,
+                  MUSIC_NEUTRAL_BG_CLASS,
+                )}
+                style={mobileExpandedPanelStyle}
+              >
+                <div className="mb-1 flex items-center gap-1">
+                  <GripVertical size="0.875rem" className={MUSIC_NEUTRAL_ICON_CLASS} />
+                  <span className={cn("flex-1 truncate text-[0.625rem] font-medium", MUSIC_NEUTRAL_ICON_CLASS)}>
+                    YouTube
+                  </span>
+                  <button
+                    type="button"
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onPointerMove={(event) => event.stopPropagation()}
+                    onPointerUp={(event) => event.stopPropagation()}
+                    onPointerCancel={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setCollapsed(true);
+                    }}
+                    className={cn(
+                      "rounded-full p-1 transition-colors hover:text-[oklch(0.96_0.006_145)]",
+                      MUSIC_NEUTRAL_ICON_CLASS,
+                    )}
+                    title="Close player"
+                  >
+                    <X size="0.875rem" />
+                  </button>
+                </div>
+                <div className="flex items-center gap-2">{compactBody}</div>
+              </div>
+            )}
+          </div>
+        )}
+        {videoPanel}
+      </>
+    );
+  }
 
   return (
     <>
       {/* Compact mini-player pill — lives in the top bar (upper-left), like Spotify's. */}
       {active && (
-        <div className="relative flex h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border border-[#ff0033]/25 bg-[oklch(0.16_0.006_29)] px-2.5 shadow-[0_1px_10px_rgba(255,0,51,0.10)]">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <MusicSourceButton source="youtube" className="border-[#ff0033]/30 bg-[#ff0033]/10 hover:bg-[#ff0033]/15" />
-            <div className="flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] bg-[oklch(0.23_0.006_29)] ring-1 ring-[#ff0033]/25">
-              {loading ? (
-                <Loader2 size="0.875rem" className="animate-spin text-[#ff0033]" />
-              ) : nowPlaying?.thumbnail ? (
-                <img src={nowPlaying.thumbnail} alt="" className="h-full w-full object-cover" />
-              ) : (
-                <Play size="0.875rem" className="translate-x-px text-[#ff0033]" />
-              )}
-            </div>
-            <div className="min-w-0">
-              <p
-                className="truncate text-[0.6875rem] font-semibold leading-tight text-[oklch(0.96_0.006_29)]"
-                title={displayTitle}
-              >
-                {displayTitle}
-              </p>
-              <p className="truncate text-[0.5625rem] leading-tight text-[oklch(0.72_0.012_29)]">
-                {displaySubtitle}
-              </p>
-            </div>
-          </div>
-          {nowPlaying && (
-            <button
-              type="button"
-              onClick={togglePlay}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#ff0033] text-[oklch(0.98_0.006_29)] shadow-[0_1px_8px_rgba(255,0,51,0.20)] transition-transform hover:scale-105 active:scale-95"
-              aria-label={paused ? "Play" : "Pause"}
-            >
-              {paused ? <Play size="0.8125rem" className="translate-x-px" /> : <Pause size="0.8125rem" />}
-            </button>
+        <div
+          className={cn(
+            "relative hidden h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border px-2.5 md:flex",
+            MUSIC_NEUTRAL_BORDER_CLASS,
+            MUSIC_NEUTRAL_BG_CLASS,
           )}
-          {hasPlayerContent && (
-            <button
-              type="button"
-              onClick={() => setShowVideo((v) => !v)}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.72_0.012_29)] transition-colors hover:text-[oklch(0.96_0.006_29)] active:scale-90"
-              aria-label={showVideo ? "Hide video" : "Show video"}
-            >
-              {showVideo ? <ChevronUp size="0.8125rem" /> : <ChevronDown size="0.8125rem" />}
-            </button>
-          )}
-          {hasPlayerContent && (
-            <button
-              type="button"
-              onClick={close}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.72_0.012_29)] transition-colors hover:text-[#ff6b6b] active:scale-90"
-              aria-label="Stop"
-            >
-              <X size="0.8125rem" />
-            </button>
-          )}
-          <div className="pointer-events-none absolute bottom-0 left-3 right-3 h-px overflow-hidden rounded-full bg-[oklch(0.28_0.01_29)]">
+        >
+          {compactBody}
+          <div
+            className={cn(
+              "pointer-events-none absolute bottom-0 left-3 right-3 h-px overflow-hidden rounded-full",
+              MUSIC_NEUTRAL_PROGRESS_BG_CLASS,
+            )}
+          >
             <div
               className={cn(
-                "h-full rounded-full bg-[#ff0033]",
+                "h-full rounded-full",
+                MUSIC_NEUTRAL_PROGRESS_FILL_CLASS,
                 hasPlayerContent && !paused ? "w-full opacity-80" : "w-8 opacity-50",
               )}
             />
@@ -279,39 +540,33 @@ export function YouTubePlayer() {
         </div>
       )}
 
-      {/* Video panel anchored under the top bar. ALWAYS mounted so the IFrame keeps
-          playing; when collapsed it is parked offscreen (full size, never display:none)
-          so audio never stops. */}
-      <div
-        className={cn(
-          "fixed top-14 z-40 w-80 overflow-hidden rounded-xl border border-[#ff0033]/25 bg-[oklch(0.16_0.006_29)] shadow-[0_18px_50px_rgba(0,0,0,0.35)] transition-opacity",
-          active && hasPlayerContent && showVideo
-            ? "left-2 opacity-100"
-            : "pointer-events-none -left-[9999px] opacity-0",
-        )}
-      >
-        {/* The IFrame player lives here; YT injects the iframe into this host. */}
-        <div ref={hostRef} className="aspect-video w-full bg-black [&_iframe]:size-full" />
-        {(nowPlaying || error) && (
-          <div className="px-3 py-2">
-            {error ? (
-              <div className="text-xs text-[#ff6b6b]">{error}</div>
-            ) : (
-              <div className="min-w-0">
-                <div
-                  className="truncate text-xs font-medium text-[oklch(0.96_0.006_29)]"
-                  title={nowPlaying?.title}
-                >
-                  {nowPlaying?.title}
-                </div>
-                {nowPlaying?.mood && (
-                  <div className="truncate text-[11px] text-[oklch(0.72_0.012_29)]">{nowPlaying.mood}</div>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      {videoPanel}
     </>
   );
+}
+
+export function YouTubeMobileWidget() {
+  const enabled = useUIStore((s) => s.musicPlayerEnabled && s.musicPlayerSource === "youtube");
+  const isMobileViewport = useMediaQuery("(max-width: 767px)");
+
+  if (!enabled || !isMobileViewport) return null;
+
+  return <YouTubePlayer mobile />;
+}
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const media = window.matchMedia(query);
+    const update = () => setMatches(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, [query]);
+
+  return matches;
 }

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -4,6 +4,7 @@ import { useAgentStore } from "@/stores/agent.store";
 import { useUIStore } from "@/stores/ui.store";
 import { api } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
+import { MusicSourceButton } from "@/components/music/MusicSourceButton";
 
 // The YouTube IFrame API attaches itself to window; it has no bundled types.
 type YTPlayer = {
@@ -44,7 +45,7 @@ function loadYouTubeApi(): Promise<void> {
 }
 
 /**
- * Embedded player for the YouTube DJ agent. Listens for the agent's "play"
+ * Embedded player for Music DJ's YouTube mode. Listens for the agent's "play"
  * intent in the agent store, resolves the search query to a video server-side,
  * and plays it in an in-app IFrame player. No OAuth, no external device.
  */
@@ -52,7 +53,7 @@ export function YouTubePlayer() {
   const youtubePlay = useAgentStore((s) => s.youtubePlay);
   const youtubeVolume = useAgentStore((s) => s.youtubeVolume);
   const clearYoutube = useAgentStore((s) => s.clearYoutube);
-  const youtubePlayerEnabled = useUIStore((s) => s.youtubePlayerEnabled);
+  const musicPlayerActive = useUIStore((s) => s.musicPlayerEnabled && s.musicPlayerSource === "youtube");
 
   const hostRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<YTPlayer | null>(null);
@@ -103,7 +104,7 @@ export function YouTubePlayer() {
 
   // React to a new "play" intent.
   useEffect(() => {
-    if (!youtubePlayerEnabled) return; // player disabled in Settings — don't fetch or play
+    if (!musicPlayerActive) return; // player disabled in Settings — don't fetch or play
     if (!youtubePlay) return;
     if (youtubePlay.nonce === lastNonceRef.current) return;
     lastNonceRef.current = youtubePlay.nonce;
@@ -140,11 +141,11 @@ export function YouTubePlayer() {
     return () => {
       cancelled = true;
     };
-  }, [youtubePlay, ensurePlayer, youtubePlayerEnabled]);
+  }, [youtubePlay, ensurePlayer, musicPlayerActive]);
 
   // Stop playback immediately if the user disables the player mid-track.
   useEffect(() => {
-    if (youtubePlayerEnabled) return;
+    if (musicPlayerActive) return;
     try {
       playerRef.current?.stopVideo();
     } catch {
@@ -152,7 +153,7 @@ export function YouTubePlayer() {
     }
     lastQueryRef.current = "";
     setNowPlaying(null);
-  }, [youtubePlayerEnabled]);
+  }, [musicPlayerActive]);
 
   // Apply DJ volume changes without changing the track.
   useEffect(() => {
@@ -190,20 +191,22 @@ export function YouTubePlayer() {
     clearYoutube();
   };
 
-  const active = youtubePlayerEnabled && (!!nowPlaying || loading || !!error);
+  const active = musicPlayerActive;
+  const hasPlayerContent = !!nowPlaying || loading || !!error;
 
   return (
     <>
       {/* Compact mini-player pill — lives in the top bar (upper-left), like Spotify's. */}
       {active && (
-        <div className="flex h-8 min-w-0 max-w-[15rem] items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--card)] pl-2.5 pr-1">
-          <Music className="size-3.5 shrink-0 text-[var(--primary)]" />
+        <div className="flex h-8 min-w-0 max-w-[15rem] items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--card)] pl-1 pr-1">
+          <MusicSourceButton source="youtube" className="h-6 w-6 border-[var(--border)] bg-[var(--secondary)]" />
           <span
             className="hidden min-w-0 flex-1 truncate text-xs text-[var(--foreground)] sm:inline"
             title={nowPlaying?.title ?? undefined}
           >
-            {loading ? "Finding a track…" : error ? error : (nowPlaying?.title ?? "YouTube DJ")}
+            {loading ? "Finding a track…" : error ? error : (nowPlaying?.title ?? "YouTube")}
           </span>
+          {!loading && !nowPlaying && !error && <Music className="size-3.5 shrink-0 text-[var(--muted-foreground)] sm:hidden" />}
           {loading && (
             <Loader2 className="size-3.5 shrink-0 animate-spin text-[var(--muted-foreground)] sm:hidden" />
           )}
@@ -217,22 +220,26 @@ export function YouTubePlayer() {
               {paused ? <Play className="size-3.5" /> : <Pause className="size-3.5" />}
             </button>
           )}
-          <button
-            type="button"
-            onClick={() => setShowVideo((v) => !v)}
-            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] active:scale-90"
-            aria-label={showVideo ? "Hide video" : "Show video"}
-          >
-            {showVideo ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
-          </button>
-          <button
-            type="button"
-            onClick={close}
-            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)] active:scale-90"
-            aria-label="Stop"
-          >
-            <X className="size-3.5" />
-          </button>
+          {hasPlayerContent && (
+            <button
+              type="button"
+              onClick={() => setShowVideo((v) => !v)}
+              className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] active:scale-90"
+              aria-label={showVideo ? "Hide video" : "Show video"}
+            >
+              {showVideo ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
+            </button>
+          )}
+          {hasPlayerContent && (
+            <button
+              type="button"
+              onClick={close}
+              className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)] active:scale-90"
+              aria-label="Stop"
+            >
+              <X className="size-3.5" />
+            </button>
+          )}
         </div>
       )}
 
@@ -242,7 +249,9 @@ export function YouTubePlayer() {
       <div
         className={cn(
           "fixed top-14 z-40 w-72 overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-lg transition-opacity",
-          active && showVideo ? "left-2 opacity-100" : "pointer-events-none -left-[9999px] opacity-0",
+          active && hasPlayerContent && showVideo
+            ? "left-2 opacity-100"
+            : "pointer-events-none -left-[9999px] opacity-0",
         )}
       >
         {/* The IFrame player lives here; YT injects the iframe into this host. */}

--- a/packages/client/src/components/chat/roleplay-popover-styles.ts
+++ b/packages/client/src/components/chat/roleplay-popover-styles.ts
@@ -1,12 +1,7 @@
-export const ROLEPLAY_POPOVER_SHELL =
-  "rounded-xl border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 shadow-2xl shadow-black/40 backdrop-blur-md animate-message-in [--accent:rgb(39_39_42)] [--accent-foreground:rgb(244_244_245)] [--background:rgb(18_18_21)] [--border:rgb(63_63_70)] [--card:rgb(24_24_27)] [--foreground:rgb(244_244_245)] [--input:rgb(63_63_70)] [--muted:rgb(39_39_42)] [--muted-foreground:rgb(161_161_170)] [--popover:rgb(24_24_27)] [--popover-foreground:rgb(244_244_245)] [--primary:rgb(212_212_216)] [--primary-foreground:rgb(18_18_21)] [--ring:rgb(161_161_170)] [--secondary:rgb(39_39_42)]";
-
-export const ROLEPLAY_POPOVER_HEADER = "border-b border-[var(--border)] px-3 py-2.5";
-
-export const ROLEPLAY_POPOVER_TITLE =
-  "flex min-w-0 items-center gap-1.5 text-xs font-semibold leading-tight text-[var(--foreground)]";
-
-export const ROLEPLAY_POPOVER_SUBTITLE = "mt-0.5 text-[0.625rem] leading-snug text-[var(--muted-foreground)]";
-
-export const ROLEPLAY_POPOVER_SCROLL_AREA =
-  "scrollbar-thin scrollbar-thumb-[var(--border)] scrollbar-track-transparent";
+export {
+  NEUTRAL_PANEL_HEADER as ROLEPLAY_POPOVER_HEADER,
+  NEUTRAL_PANEL_SCROLL_AREA as ROLEPLAY_POPOVER_SCROLL_AREA,
+  NEUTRAL_PANEL_SHELL as ROLEPLAY_POPOVER_SHELL,
+  NEUTRAL_PANEL_SUBTITLE as ROLEPLAY_POPOVER_SUBTITLE,
+  NEUTRAL_PANEL_TITLE as ROLEPLAY_POPOVER_TITLE,
+} from "../ui/neutral-surface-styles";

--- a/packages/client/src/components/game-assets/AssetGrid.tsx
+++ b/packages/client/src/components/game-assets/AssetGrid.tsx
@@ -109,21 +109,23 @@ export function AssetGrid({
                 else onSelectFile(node);
               }}
               className={
-                "group relative flex flex-col items-center gap-2 rounded-xl border bg-[var(--card)] p-[clamp(0.5rem,1.3vmin,0.875rem)] transition-all hover:border-[var(--primary)]/30 hover:shadow-sm " +
-                (isSelected ? "border-[var(--primary)] ring-2 ring-[var(--primary)]/30" : "border-[var(--border)]")
+                "group relative flex flex-col items-center gap-2 rounded-xl border bg-[var(--card)] p-[clamp(0.5rem,1.3vmin,0.875rem)] transition-all hover:border-[var(--foreground)]/25 hover:shadow-sm " +
+                (isSelected
+                  ? "border-[var(--foreground)]/30 ring-2 ring-[var(--foreground)]/20"
+                  : "border-[var(--border)]")
               }
             >
               {/* Checkbox — files only, always visible */}
               {isFile && (
                 <label
                   onClick={(e) => e.stopPropagation()}
-                  className="absolute left-1.5 top-1.5 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded border border-[var(--border)] bg-[var(--background)] shadow-sm transition-colors hover:border-[var(--primary)]"
+                  className="absolute left-1.5 top-1.5 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded border border-[var(--border)] bg-[var(--background)] shadow-sm transition-colors hover:border-[var(--foreground)]/30"
                 >
                   <input
                     type="checkbox"
                     checked={isSelected}
                     onChange={() => onToggleSelect(node)}
-                    className="h-3.5 w-3.5 accent-[var(--primary)]"
+                    className="h-3.5 w-3.5 accent-[var(--foreground)]"
                   />
                 </label>
               )}
@@ -137,8 +139,8 @@ export function AssetGrid({
                   className={
                     "absolute left-1.5 top-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-full border shadow-sm transition-colors " +
                     (folderSelectionStatus === "excluded"
-                      ? "border-[var(--border)] bg-[var(--background)] text-[var(--muted-foreground)] hover:border-[var(--primary)]"
-                      : "border-[var(--primary)]/40 bg-[var(--primary)] text-white hover:opacity-90")
+                      ? "border-[var(--border)] bg-[var(--background)] text-[var(--muted-foreground)] hover:border-[var(--foreground)]/30"
+                      : "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)] hover:bg-[var(--foreground)]/15")
                   }
                   title="Select assets for this game"
                   aria-label={`Select ${node.name} assets for this game`}
@@ -162,7 +164,7 @@ export function AssetGrid({
                   (() => {
                     const CategoryIcon = CATEGORY_ICONS[node.name] || Folder;
                     return (
-                      <CategoryIcon className="h-[52%] min-h-8 w-[52%] min-w-8 max-h-16 max-w-16 text-[var(--primary)]" />
+                      <CategoryIcon className="h-[52%] min-h-8 w-[52%] min-w-8 max-h-16 max-w-16 text-[var(--foreground)]/80" />
                     );
                   })()
                 ) : isImage(node.ext) ? (
@@ -173,7 +175,7 @@ export function AssetGrid({
                     loading="lazy"
                   />
                 ) : (
-                  <FileIcon ext={node.ext} className="h-8 w-8 text-[var(--primary)]" />
+                  <FileIcon ext={node.ext} className="h-8 w-8 text-[var(--foreground)]/80" />
                 )}
               </div>
               <span className="w-full truncate text-center text-xs text-[var(--foreground)]">{node.name}</span>
@@ -211,7 +213,7 @@ export function AssetGrid({
             }}
             className={
               `group grid ${gridColsClass} items-center gap-3 rounded-lg px-3 py-2 transition-colors ` +
-              (isSelected ? "bg-[var(--primary)]/10" : "hover:bg-[var(--accent)]")
+              (isSelected ? "bg-[var(--foreground)]/10" : "hover:bg-[var(--accent)]")
             }
           >
             {/* Checkbox — files only */}
@@ -221,7 +223,7 @@ export function AssetGrid({
                   type="checkbox"
                   checked={isSelected}
                   onChange={() => onToggleSelect(node)}
-                  className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
+                  className="h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--foreground)]"
                 />
               )}
               {folderSelectionStatus && (
@@ -234,8 +236,8 @@ export function AssetGrid({
                   className={
                     "flex h-5 w-5 items-center justify-center rounded-full border transition-colors " +
                     (folderSelectionStatus === "excluded"
-                      ? "border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)]"
-                      : "border-[var(--primary)]/40 bg-[var(--primary)] text-white hover:opacity-90")
+                      ? "border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--foreground)]/30"
+                      : "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)] hover:bg-[var(--foreground)]/15")
                   }
                   title="Select assets for this game"
                   aria-label={`Select ${node.name} assets for this game`}
@@ -248,7 +250,7 @@ export function AssetGrid({
             {node.type === "folder" ? (
               (() => {
                 const CategoryIcon = CATEGORY_ICONS[node.name] || Folder;
-                return <CategoryIcon size="1rem" className="shrink-0 text-[var(--primary)]" />;
+                return <CategoryIcon size="1rem" className="shrink-0 text-[var(--foreground)]/80" />;
               })()
             ) : isImage(node.ext) ? (
               <div className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded bg-[var(--accent)]">

--- a/packages/client/src/components/game-assets/FileEditorModal.tsx
+++ b/packages/client/src/components/game-assets/FileEditorModal.tsx
@@ -125,7 +125,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[var(--border)]/40 px-4 py-3">
           <div className="flex items-center gap-2">
-            <FileText size="1rem" className="text-[var(--primary)]" />
+            <FileText size="1rem" className="text-[var(--foreground)]/80" />
             <span className="text-sm font-semibold text-[var(--foreground)]">
               {node.name}
               {isDirty && <span className="ml-1.5 text-[var(--muted-foreground)]">•</span>}
@@ -139,7 +139,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
                   className={cn(
                     "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
                     mode === "preview"
-                      ? "bg-[var(--accent)] text-[var(--primary)]"
+                      ? "bg-[var(--accent)] text-[var(--foreground)]/80"
                       : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
                   )}
                 >
@@ -150,7 +150,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
                   className={cn(
                     "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
                     mode === "edit"
-                      ? "bg-[var(--accent)] text-[var(--primary)]"
+                      ? "bg-[var(--accent)] text-[var(--foreground)]/80"
                       : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
                   )}
                 >
@@ -214,7 +214,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
             <button
               onClick={handleSave}
               disabled={saveFile.isPending || !isDirty}
-              className="rounded-lg bg-[var(--primary)] px-4 py-2 text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-[var(--secondary)] px-4 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               {saveFile.isPending ? "Saving..." : "Save"}
             </button>

--- a/packages/client/src/components/game-assets/FolderTree.tsx
+++ b/packages/client/src/components/game-assets/FolderTree.tsx
@@ -67,7 +67,7 @@ export function FolderTree({
         className={cn(
           "flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-sm transition-colors",
           isSelected
-            ? "bg-[var(--primary)]/10 text-[var(--primary)]"
+            ? "bg-[var(--foreground)]/10 text-[var(--foreground)]/80"
             : "text-[var(--foreground)] hover:bg-[var(--accent)]",
         )}
         style={{ paddingLeft: `${8 + depth * 14}px` }}
@@ -107,8 +107,8 @@ export function FolderTree({
             className={
               "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors " +
               (selectionStatus === "excluded"
-                ? "border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--primary)]"
-                : "border-[var(--primary)]/40 bg-[var(--primary)] text-white hover:opacity-90")
+                ? "border-[var(--border)] text-[var(--muted-foreground)] hover:border-[var(--foreground)]/30"
+                : "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)] hover:bg-[var(--foreground)]/15")
             }
             title="Select assets for this game"
             aria-label={`Select ${node.name} assets for this game`}

--- a/packages/client/src/components/game-assets/GameAssetsBrowserView.tsx
+++ b/packages/client/src/components/game-assets/GameAssetsBrowserView.tsx
@@ -62,7 +62,7 @@ function sameFolderSelection(a: readonly string[], b: readonly string[]): boolea
 }
 
 /**
- * Full-screen overlay for browsing, previewing, and managing game assets.
+ * Browser for previewing and managing game assets.
  *
  * Features:
  * - Folder tree sidebar with expand/collapse
@@ -74,7 +74,13 @@ function sameFolderSelection(a: readonly string[], b: readonly string[]): boolea
  * - Inline folder description editing
  * - Keyboard shortcuts: Ctrl+A (select all), Esc (clear selection)
  */
-export function GameAssetsBrowserView() {
+export function GameAssetsBrowserView({
+  embedded = false,
+  onClose,
+}: {
+  embedded?: boolean;
+  onClose?: () => void;
+} = {}) {
   const { data: tree, isLoading } = useGameAssetTree();
   const createFolder = useCreateGameAssetFolder();
   const deleteFolder = useDeleteGameAssetFolder();
@@ -638,8 +644,10 @@ export function GameAssetsBrowserView() {
     }
   }, [updateDescription, selectedPath, descriptionValue]);
 
+  const closeAction = onClose ?? (showGameCloseButton ? closeGameAssetsBrowser : undefined);
+
   return (
-    <div className="flex h-full flex-col bg-[var(--background)]">
+    <div className={cn("flex h-full flex-col", embedded ? "bg-transparent" : "bg-[var(--background)]")}>
       {/* Toolbar */}
       <Toolbar
         breadcrumb={breadcrumb}
@@ -665,7 +673,7 @@ export function GameAssetsBrowserView() {
         onBreadcrumbClick={(path) => setSelectedPath(path)}
         listColumns={listColumns}
         onToggleColumn={(col) => setListColumns((prev) => ({ ...prev, [col]: !prev[col] }))}
-        onClose={showGameCloseButton ? closeGameAssetsBrowser : undefined}
+        onClose={closeAction}
         assetSelection={
           canSelectGameAssets
             ? {
@@ -678,8 +686,8 @@ export function GameAssetsBrowserView() {
       />
 
       {canSelectGameAssets && assetSelectionMode && (
-        <div className="flex min-h-[36px] items-center gap-3 border-b border-[var(--border)]/40 bg-[var(--primary)]/5 px-4 py-1.5">
-          <span className="text-xs font-medium text-[var(--primary)]">Game asset selection</span>
+        <div className="flex min-h-[36px] items-center gap-3 border-b border-[var(--border)]/40 bg-[var(--foreground)]/5 px-4 py-1.5">
+          <span className="text-xs font-medium text-[var(--foreground)]/80">Game asset selection</span>
           <span className="text-xs text-[var(--muted-foreground)]">
             {gameAssetExcludedFolders.length === 0
               ? "All folders included"
@@ -713,12 +721,12 @@ export function GameAssetsBrowserView() {
                   if (e.key === "Escape") setEditingDescription(false);
                 }}
                 placeholder="What is this folder for?"
-                className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-xs text-[var(--foreground)] outline-none focus:border-[var(--primary)]/50"
+                className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-xs text-[var(--foreground)] outline-none focus:border-[var(--foreground)]/30/50"
                 maxLength={500}
               />
               <button
                 onClick={handleSaveDescription}
-                className="rounded-md bg-[var(--primary)] px-2 py-1 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                className="rounded-md bg-[var(--secondary)] px-2 py-1 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
               >
                 Save
               </button>
@@ -753,8 +761,8 @@ export function GameAssetsBrowserView() {
 
       {/* Bulk action bar */}
       {selectedPaths.size > 0 && (
-        <div className="flex min-h-[36px] items-center gap-3 border-b border-[var(--border)]/40 bg-[var(--primary)]/5 px-4 py-1.5">
-          <span className="text-xs font-medium text-[var(--primary)]">
+        <div className="flex min-h-[36px] items-center gap-3 border-b border-[var(--border)]/40 bg-[var(--foreground)]/5 px-4 py-1.5">
+          <span className="text-xs font-medium text-[var(--foreground)]/80">
             {selectedPaths.size} file{selectedPaths.size !== 1 ? "s" : ""} selected
           </span>
           <div className="ml-auto flex items-center gap-1.5">
@@ -829,7 +837,7 @@ export function GameAssetsBrowserView() {
         <div
           className={cn(
             "relative flex flex-1 flex-col overflow-hidden transition-colors",
-            dragOver && "bg-[var(--primary)]/5",
+            dragOver && "bg-[var(--foreground)]/5",
           )}
           onDrop={handleDrop}
           onDragOver={handleDragOver}
@@ -862,9 +870,9 @@ export function GameAssetsBrowserView() {
           )}
           {dragOver && (
             <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
-              <div className="rounded-2xl border-2 border-dashed border-[var(--primary)]/30 bg-[var(--primary)]/5 px-8 py-6 text-center">
-                <Upload size="2rem" className="mx-auto mb-2 text-[var(--primary)]" />
-                <p className="text-sm font-medium text-[var(--primary)]">Drop files to upload</p>
+              <div className="rounded-2xl border-2 border-dashed border-[var(--foreground)]/25 bg-[var(--foreground)]/5 px-8 py-6 text-center">
+                <Upload size="2rem" className="mx-auto mb-2 text-[var(--foreground)]/80" />
+                <p className="text-sm font-medium text-[var(--foreground)]/80">Drop files to upload</p>
               </div>
             </div>
           )}
@@ -914,7 +922,7 @@ export function GameAssetsBrowserView() {
                             className={
                               "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border " +
                               (childIncluded
-                                ? "border-[var(--primary)]/40 bg-[var(--primary)] text-white"
+                                ? "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)]"
                                 : "border-[var(--border)] text-[var(--muted-foreground)]")
                             }
                           >
@@ -942,7 +950,7 @@ export function GameAssetsBrowserView() {
                       <button
                         type="button"
                         onClick={() => handleIncludeSubfolders(subfolders)}
-                        className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs font-medium text-[var(--primary)] transition-colors hover:bg-[var(--accent)]"
+                        className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs font-medium text-[var(--foreground)]/80 transition-colors hover:bg-[var(--accent)]"
                       >
                         Include all subfolders
                       </button>
@@ -956,7 +964,7 @@ export function GameAssetsBrowserView() {
                     }}
                     className={cn(
                       "flex w-full items-center justify-between px-3 py-1.5 text-left text-xs font-medium transition-colors hover:bg-[var(--accent)]",
-                      status === "excluded" ? "text-[var(--primary)]" : "text-[var(--destructive)]",
+                      status === "excluded" ? "text-[var(--foreground)]/80" : "text-[var(--destructive)]",
                     )}
                   >
                     {status === "excluded" ? "Include this folder" : "Remove this folder from game"}
@@ -1075,7 +1083,7 @@ export function GameAssetsBrowserView() {
                     className={cn(
                       "flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors",
                       modalValue === f.path
-                        ? "bg-[var(--primary)]/10 text-[var(--primary)]"
+                        ? "bg-[var(--foreground)]/10 text-[var(--foreground)]/80"
                         : "text-[var(--foreground)] hover:bg-[var(--accent)]",
                     )}
                   >
@@ -1103,7 +1111,7 @@ export function GameAssetsBrowserView() {
                 onChange={(e) => setModalValue(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && modalValue.trim() && handleModalConfirm()}
                 placeholder={modal.type === "create-folder" ? "Folder name" : "New name"}
-                className="mb-4 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50 focus:ring-1 focus:ring-[var(--primary)]/20"
+                className="mb-4 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/30/50 focus:ring-1 focus:ring-[var(--foreground)]/20/20"
               />
             )}
 
@@ -1131,7 +1139,7 @@ export function GameAssetsBrowserView() {
                   "rounded-lg px-4 py-2 text-xs font-medium transition-opacity hover:opacity-90",
                   modal.type === "delete" || modal.type === "bulk-delete"
                     ? "bg-[var(--destructive)] text-white"
-                    : "bg-[var(--primary)] text-white",
+                    : "bg-[var(--secondary)] text-[var(--foreground)] ring-1 ring-[var(--border)]",
                   modal.type === "delete" &&
                     modal.node.type === "folder" &&
                     countItems(modal.node) > 0 &&

--- a/packages/client/src/components/game-assets/SearchInput.tsx
+++ b/packages/client/src/components/game-assets/SearchInput.tsx
@@ -54,7 +54,7 @@ export function SearchInput({ search, onSearch }: { search: string; onSearch: (v
             }
           }}
           placeholder="Search in folder..."
-          className="h-8 w-48 rounded-lg border border-(--border) bg-(--background) pl-7 pr-7 text-sm text-(--foreground) outline-none transition-colors focus:border-(--primary)/50 focus:ring-1 focus:ring-(--primary)/20 max-sm:absolute max-sm:right-0 max-sm:top-1/2 max-sm:w-48 max-sm:-translate-y-1/2"
+          className="h-8 w-48 rounded-lg border border-(--border) bg-(--background) pl-7 pr-7 text-sm text-(--foreground) outline-none transition-colors focus:border-(--foreground)/40 focus:ring-1 focus:ring-(--foreground)/15 max-sm:absolute max-sm:right-0 max-sm:top-1/2 max-sm:w-48 max-sm:-translate-y-1/2"
         />
         {expanded && (
           <button

--- a/packages/client/src/components/game-assets/Toolbar.tsx
+++ b/packages/client/src/components/game-assets/Toolbar.tsx
@@ -203,7 +203,7 @@ export function Toolbar({
             className={cn(
               "rounded-md p-1.5 transition-colors",
               viewMode === "grid"
-                ? "bg-[var(--accent)] text-[var(--primary)]"
+                ? "bg-[var(--accent)] text-[var(--foreground)]/80"
                 : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
             )}
             title="Grid view"
@@ -215,7 +215,7 @@ export function Toolbar({
             className={cn(
               "rounded-md p-1.5 transition-colors",
               viewMode === "list"
-                ? "bg-[var(--accent)] text-[var(--primary)]"
+                ? "bg-[var(--accent)] text-[var(--foreground)]/80"
                 : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
             )}
             title="List view"
@@ -273,7 +273,7 @@ export function Toolbar({
             className={cn(
               "flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors",
               assetSelection.active
-                ? "border-[var(--primary)]/40 bg-[var(--primary)]/10 text-[var(--primary)]"
+                ? "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)]/80"
                 : "border-[var(--border)] bg-[var(--background)] text-[var(--foreground)] hover:bg-[var(--accent)]",
             )}
             title="Select assets for this game"
@@ -283,7 +283,7 @@ export function Toolbar({
             <FolderCheck size="0.875rem" />
             <span className="max-md:hidden">{assetSelection.active ? "Selecting" : "Game assets"}</span>
             {assetSelection.excludedCount > 0 && (
-              <span className="rounded-full bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.625rem] leading-none text-[var(--primary)]">
+              <span className="rounded-full bg-[var(--foreground)]/12 px-1.5 py-0.5 text-[0.625rem] leading-none text-[var(--foreground)]/80">
                 {assetSelection.excludedCount}
               </span>
             )}
@@ -292,7 +292,7 @@ export function Toolbar({
 
         <button
           onClick={onUploadClick}
-          className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+          className="flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
         >
           <Upload size="0.875rem" />
           <span className="max-sm:hidden">Upload</span>

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -87,9 +87,9 @@ function formatAttributeModifier(score: number): string {
 
 const FIELD_LABEL_CLASS = "text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]";
 const TEXT_INPUT_CLASS =
-  "w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/40";
+  "w-full rounded-lg border border-zinc-700/80 bg-zinc-950/70 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40";
 const NUMBER_INPUT_CLASS =
-  "w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)]/60 px-2.5 py-1.5 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/40";
+  "w-full rounded-lg border border-zinc-700/80 bg-zinc-950/70 px-2.5 py-1.5 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40";
 
 function normalizeTextValue(value: unknown) {
   if (typeof value === "string") return value;
@@ -389,7 +389,7 @@ export function GameCharacterSheet({
       onClick={onClose}
     >
       <div
-        className="relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+        className="relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-zinc-700/80 bg-zinc-950/95 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {(onSave || onRegenerate) && (
@@ -399,14 +399,14 @@ export function GameCharacterSheet({
                 <button
                   onClick={handleCancelEdit}
                   disabled={isSaving}
-                  className="inline-flex h-8 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)]/90 px-2.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:px-3 sm:py-1.5"
+                  className="inline-flex h-8 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/90 px-2.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:px-3 sm:py-1.5"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={() => void handleSave()}
                   disabled={isSaving}
-                  className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-2 text-xs font-semibold text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
+                  className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg bg-zinc-900 px-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
                   title={isSaving ? "Saving..." : "Save Sheet"}
                   aria-label={isSaving ? "Saving sheet" : "Save sheet"}
                 >
@@ -420,7 +420,7 @@ export function GameCharacterSheet({
                   <button
                     onClick={() => void handleRegenerate()}
                     disabled={isRegenerating || isSaving}
-                    className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)]/90 px-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)] disabled:cursor-wait disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
+                    className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg border border-zinc-700/80 bg-zinc-950/90 px-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] disabled:cursor-wait disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
                     title="Regenerate this sheet from character and current game context"
                     aria-label="Regenerate sheet"
                   >
@@ -432,7 +432,7 @@ export function GameCharacterSheet({
                   <button
                     onClick={() => setIsEditing(true)}
                     disabled={isRegenerating}
-                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)]/90 p-0 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:w-auto sm:min-w-0 sm:gap-1.5 sm:px-3 sm:py-1.5"
+                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/90 p-0 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:w-auto sm:min-w-0 sm:gap-1.5 sm:px-3 sm:py-1.5"
                     title="Edit Sheet"
                     aria-label="Edit sheet"
                   >
@@ -447,17 +447,17 @@ export function GameCharacterSheet({
 
         <button
           onClick={onClose}
-          className="absolute right-3 top-3 z-10 flex h-7 w-7 items-center justify-center rounded-lg p-0 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)] sm:h-auto sm:w-auto sm:p-1.5"
+          className="absolute right-3 top-3 z-10 flex h-7 w-7 items-center justify-center rounded-lg p-0 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] sm:h-auto sm:w-auto sm:p-1.5"
           aria-label="Close character sheet"
           title="Close character sheet"
         >
           <X className="h-4 w-4 sm:h-[18px] sm:w-[18px]" />
         </button>
 
-        <div className="relative border-b border-[var(--border)] bg-[var(--secondary)]/50 px-4 py-4 sm:px-5">
+        <div className="relative border-b border-zinc-700/80 bg-zinc-900/70 px-4 py-4 sm:px-5">
           <div className="flex items-center gap-3 sm:gap-4">
             {card.avatarUrl ? (
-              <span className="relative block h-16 w-16 shrink-0 overflow-hidden rounded-xl border-2 border-[var(--border)] shadow-xl sm:h-20 sm:w-20">
+              <span className="relative block h-16 w-16 shrink-0 overflow-hidden rounded-xl border-2 border-zinc-700/80 shadow-xl sm:h-20 sm:w-20">
                 <img
                   src={card.avatarUrl}
                   alt={card.title}
@@ -466,7 +466,7 @@ export function GameCharacterSheet({
                 />
               </span>
             ) : (
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl border-2 border-[var(--border)] bg-[var(--secondary)] text-xl font-bold text-[var(--muted-foreground)] sm:h-20 sm:w-20 sm:text-2xl">
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl border-2 border-zinc-700/80 bg-zinc-900 text-xl font-bold text-[var(--muted-foreground)] sm:h-20 sm:w-20 sm:text-2xl">
                 {card.title[0]}
               </div>
             )}
@@ -478,7 +478,7 @@ export function GameCharacterSheet({
                 {card.title}
               </h2>
               {previewGameCard?.class && (
-                <p className="text-xs font-medium text-[var(--primary)]">{previewGameCard.class}</p>
+                <p className="text-xs font-medium text-[var(--muted-foreground)]">{previewGameCard.class}</p>
               )}
               {previewGameCard?.shortDescription && !previewGameCard.class && (
                 <p className="text-xs text-[var(--muted-foreground)]">{previewGameCard.shortDescription}</p>
@@ -497,9 +497,9 @@ export function GameCharacterSheet({
               )}
             </div>
             {card.level != null && (
-              <div className="mr-16 flex items-center gap-1 rounded border border-[var(--primary)]/20 bg-[var(--primary)]/10 px-1.5 py-0.5 sm:mr-0">
-                <span className="text-[0.4375rem] uppercase tracking-wider text-[var(--primary)]/60">LVL</span>
-                <span className="text-xs font-bold leading-none text-[var(--primary)]">{card.level}</span>
+              <div className="mr-16 flex items-center gap-1 rounded border border-zinc-700/80 bg-zinc-950/70 px-1.5 py-0.5 sm:mr-0">
+                <span className="text-[0.4375rem] uppercase tracking-wider text-[var(--muted-foreground)]">LVL</span>
+                <span className="text-xs font-bold leading-none text-[var(--foreground)]">{card.level}</span>
               </div>
             )}
           </div>
@@ -513,7 +513,7 @@ export function GameCharacterSheet({
         <div className="flex-1 overflow-y-auto">
           {isEditing && (
             <>
-              <div className="border-b border-[var(--border)] px-5 py-4">
+              <div className="border-b border-zinc-700/80 px-5 py-4">
                 <SectionHeader
                   icon={<Pencil size={12} />}
                   title="Sheet Details"
@@ -543,7 +543,7 @@ export function GameCharacterSheet({
                 </div>
               </div>
 
-              <div className="border-b border-[var(--border)] px-5 py-4">
+              <div className="border-b border-zinc-700/80 px-5 py-4">
                 <div className="mb-2.5 flex items-center justify-between gap-3">
                   <SectionHeader
                     icon={<Shield size={12} />}
@@ -555,7 +555,7 @@ export function GameCharacterSheet({
                       type="checkbox"
                       checked={draft.rpgStatsEnabled}
                       onChange={(e) => setDraft((prev) => ({ ...prev, rpgStatsEnabled: e.target.checked }))}
-                      className="h-4 w-4 rounded accent-[var(--primary)]"
+                      className="h-4 w-4 rounded accent-[var(--foreground)]"
                     />
                     Enable
                   </label>
@@ -605,7 +605,7 @@ export function GameCharacterSheet({
                           />
                           <button
                             onClick={() => removeAttribute(index)}
-                            className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-red-400"
+                            className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
                             title="Remove attribute"
                           >
                             <Trash2 size={13} />
@@ -614,7 +614,7 @@ export function GameCharacterSheet({
                       ))}
                       <button
                         onClick={addAttribute}
-                        className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700/80 px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
                       >
                         <Plus size={13} />
                         Add Attribute
@@ -628,7 +628,7 @@ export function GameCharacterSheet({
                 )}
               </div>
 
-              <div className="border-b border-[var(--border)] px-5 py-4">
+              <div className="border-b border-zinc-700/80 px-5 py-4">
                 <div className="mb-2.5 flex items-center justify-between gap-3">
                   <SectionHeader
                     icon={<Zap size={12} />}
@@ -637,7 +637,7 @@ export function GameCharacterSheet({
                   />
                   <button
                     onClick={() => addListItem("abilities")}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700/80 px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
                   >
                     <Plus size={13} />
                     Add
@@ -655,7 +655,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => removeListItem("abilities", index)}
-                        className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-red-400"
+                        className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
                         title="Remove ability"
                       >
                         <Trash2 size={13} />
@@ -665,7 +665,7 @@ export function GameCharacterSheet({
                 </div>
               </div>
 
-              <div className="border-b border-[var(--border)] px-5 py-4">
+              <div className="border-b border-zinc-700/80 px-5 py-4">
                 <div className="grid gap-4 md:grid-cols-2">
                   <div>
                     <div className="mb-2.5 flex items-center justify-between gap-3">
@@ -676,7 +676,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => addListItem("strengths")}
-                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-[var(--border)] px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-zinc-700/80 px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
                       >
                         <Plus size={12} />
                         Add
@@ -694,7 +694,7 @@ export function GameCharacterSheet({
                           />
                           <button
                             onClick={() => removeListItem("strengths", index)}
-                            className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-red-400"
+                            className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
                             title="Remove strength"
                           >
                             <Trash2 size={13} />
@@ -712,7 +712,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => addListItem("weaknesses")}
-                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-[var(--border)] px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-zinc-700/80 px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
                       >
                         <Plus size={12} />
                         Add
@@ -730,7 +730,7 @@ export function GameCharacterSheet({
                           />
                           <button
                             onClick={() => removeListItem("weaknesses", index)}
-                            className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-red-400"
+                            className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
                             title="Remove weakness"
                           >
                             <Trash2 size={13} />
@@ -742,7 +742,7 @@ export function GameCharacterSheet({
                 </div>
               </div>
 
-              <div className="border-b border-[var(--border)] px-5 py-4">
+              <div className="border-b border-zinc-700/80 px-5 py-4">
                 <div className="mb-2.5 flex items-center justify-between gap-3">
                   <SectionHeader
                     icon={<Info size={12} />}
@@ -751,7 +751,7 @@ export function GameCharacterSheet({
                   />
                   <button
                     onClick={addExtraEntry}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700/80 px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
                   >
                     <Plus size={13} />
                     Add Detail
@@ -782,7 +782,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => removeExtraEntry(index)}
-                        className="inline-flex items-center justify-center rounded-lg border border-[var(--border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-red-400 max-sm:h-10"
+                        className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400 max-sm:h-10"
                         title="Remove detail"
                       >
                         <Trash2 size={13} />
@@ -795,7 +795,7 @@ export function GameCharacterSheet({
           )}
 
           {!isEditing && hasRpgStats && previewGameCard?.rpgStats && (
-            <div className="border-b border-[var(--border)] px-5 py-4">
+            <div className="border-b border-zinc-700/80 px-5 py-4">
               <SectionHeader
                 icon={<Shield size={12} />}
                 title="Attributes"
@@ -806,7 +806,7 @@ export function GameCharacterSheet({
                   {previewGameCard.rpgStats.attributes.map((attr) => (
                     <div
                       key={attr.name}
-                      className="flex flex-col items-center rounded-lg border border-[var(--border)] bg-[var(--secondary)]/50 px-2 py-1.5"
+                      className="flex flex-col items-center rounded-lg border border-zinc-700/80 bg-zinc-900/70 px-2 py-1.5"
                     >
                       <span className="text-[0.5625rem] font-bold uppercase tracking-widest text-[var(--muted-foreground)]">
                         {attr.name}
@@ -831,7 +831,7 @@ export function GameCharacterSheet({
                           {hpValue}/{hpMax}
                         </span>
                       </div>
-                      <div className="h-2.5 overflow-hidden rounded-full bg-[var(--secondary)] ring-1 ring-[var(--border)]">
+                      <div className="h-2.5 overflow-hidden rounded-full bg-zinc-900 ring-1 ring-zinc-700/80">
                         <div
                           className="h-full rounded-full transition-all"
                           style={{
@@ -847,7 +847,7 @@ export function GameCharacterSheet({
           )}
 
           {card.stats && card.stats.length > 0 && (
-            <div className="border-b border-[var(--border)] px-5 py-4">
+            <div className="border-b border-zinc-700/80 px-5 py-4">
               <SectionHeader icon={<Shield size={12} />} title="Stats" className="text-[var(--muted-foreground)]" />
               <div className="space-y-2">
                 {card.stats.map((stat) => {
@@ -862,12 +862,12 @@ export function GameCharacterSheet({
                           {value}/{max}
                         </span>
                       </div>
-                      <div className="h-2 overflow-hidden rounded-full bg-[var(--secondary)] ring-1 ring-[var(--border)]">
+                      <div className="h-2 overflow-hidden rounded-full bg-zinc-900 ring-1 ring-zinc-700/80">
                         <div
                           className="h-full rounded-full transition-all"
                           style={{
                             width: `${width}%`,
-                            background: stat.color || "var(--primary)",
+                            background: stat.color || "var(--foreground)",
                           }}
                         />
                       </div>
@@ -879,13 +879,13 @@ export function GameCharacterSheet({
           )}
 
           {!isEditing && previewGameCard && previewGameCard.abilities.length > 0 && (
-            <div className="border-b border-[var(--border)] px-5 py-4">
+            <div className="border-b border-zinc-700/80 px-5 py-4">
               <SectionHeader icon={<Zap size={12} />} title="Abilities" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1">
                 {previewGameCard.abilities.map((ability, index) => (
                   <div
                     key={`${ability}-${index}`}
-                    className="rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs text-[var(--foreground)]/80"
+                    className="rounded-lg bg-zinc-900 px-2.5 py-1.5 text-xs text-[var(--foreground)]/80"
                   >
                     {ability}
                   </div>
@@ -897,7 +897,7 @@ export function GameCharacterSheet({
           {!isEditing &&
             previewGameCard &&
             (previewGameCard.strengths.length > 0 || previewGameCard.weaknesses.length > 0) && (
-              <div className="border-b border-[var(--border)] px-5 py-4">
+              <div className="border-b border-zinc-700/80 px-5 py-4">
                 <div className="grid grid-cols-2 gap-3">
                   {previewGameCard.strengths.length > 0 && (
                     <div>
@@ -932,7 +932,7 @@ export function GameCharacterSheet({
             )}
 
           {!isEditing && previewGameCard && Object.keys(previewGameCard.extra).length > 0 && (
-            <div className="border-b border-[var(--border)] px-5 py-4">
+            <div className="border-b border-zinc-700/80 px-5 py-4">
               <SectionHeader icon={<Info size={12} />} title="Details" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1.5 text-xs">
                 {Object.entries(previewGameCard.extra).map(([key, value]) => (
@@ -948,20 +948,20 @@ export function GameCharacterSheet({
           )}
 
           {card.inventory && card.inventory.length > 0 && (
-            <div className="border-b border-[var(--border)] px-5 py-4">
+            <div className="border-b border-zinc-700/80 px-5 py-4">
               <SectionHeader icon={<Swords size={12} />} title="Inventory" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1">
                 {card.inventory.map((item) => (
                   <div
                     key={`${item.name}-${item.location ?? "bag"}`}
-                    className="flex items-center justify-between rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs"
+                    className="flex items-center justify-between rounded-lg bg-zinc-900 px-2.5 py-1.5 text-xs"
                   >
                     <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                       <span className="min-w-0 whitespace-normal break-words text-[var(--foreground)]/80 [overflow-wrap:anywhere]">
                         {item.name}
                       </span>
                       {item.location && (
-                        <span className="rounded bg-[var(--primary)]/10 px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)]">
+                        <span className="rounded bg-[var(--foreground)]/10 px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)]">
                           {item.location}
                         </span>
                       )}
@@ -976,7 +976,7 @@ export function GameCharacterSheet({
           )}
 
           {card.customFields && Object.keys(card.customFields).length > 0 && (
-            <div className="border-b border-[var(--border)] px-5 py-4">
+            <div className="border-b border-zinc-700/80 px-5 py-4">
               <SectionHeader icon={<Sparkles size={12} />} title="Traits" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1.5 text-xs">
                 {Object.entries(card.customFields).map(([key, value]) => (

--- a/packages/client/src/components/game/GameGridMap.tsx
+++ b/packages/client/src/components/game/GameGridMap.tsx
@@ -14,9 +14,9 @@ const TERRAIN_COLORS: Record<string, string> = {
   desert: "bg-amber-900/40",
   snow: "bg-slate-300/20",
   town: "bg-yellow-900/30",
-  dungeon: "bg-purple-900/40",
+  dungeon: "bg-zinc-800/55",
   road: "bg-stone-600/30",
-  cave: "bg-gray-800/60",
+  cave: "bg-zinc-800/60",
 };
 
 interface GameGridMapProps {
@@ -85,14 +85,14 @@ export function GameGridMap({
   return (
     <div className="flex flex-col gap-0.5">
       <div className="mb-1 flex items-center gap-2">
-        <span className="text-xs font-medium text-[var(--foreground)]">{map.name}</span>
-        <AnimatedText html={map.description || ""} className="text-xs text-[var(--muted-foreground)]" />
+        <span className="text-xs font-medium text-zinc-100">{map.name}</span>
+        <AnimatedText html={map.description || ""} className="text-xs text-zinc-400" />
       </div>
       <div className="relative">
         {topLeftAction}
         {topRightAction}
         <div
-          className="w-full overflow-auto rounded"
+          className="w-full overflow-auto rounded-lg"
           style={{
             aspectRatio: `${width} / ${height}`,
             maxHeight: "min(52vh, 340px)",
@@ -112,7 +112,7 @@ export function GameGridMap({
                 const isSelected = selectedCell && selectedCell.x === cell.x && selectedCell.y === cell.y;
                 const isAdjacent = adjacentSet.has(`${cell.x},${cell.y}`);
                 const isMovable = !disabled && isAdjacent && cell.discovered;
-                const terrainBg = TERRAIN_COLORS[cell.terrain] || "bg-gray-800/40";
+                const terrainBg = TERRAIN_COLORS[cell.terrain] || "bg-zinc-900/60";
 
                 return (
                   <button
@@ -126,9 +126,9 @@ export function GameGridMap({
                     }
                     className={cn(
                       "relative flex aspect-square items-center justify-center rounded text-base transition-all",
-                      cell.discovered ? terrainBg : "bg-gray-900/70 game-map-fog",
-                      isParty && "ring-2 ring-amber-400 ring-offset-1 ring-offset-[var(--card)]",
-                      isSelected && !isParty && "ring-2 ring-sky-400/70 ring-offset-1 ring-offset-[var(--card)]",
+                      cell.discovered ? terrainBg : "bg-zinc-950/75 game-map-fog",
+                      isParty && "ring-2 ring-amber-400 ring-offset-1 ring-offset-zinc-950",
+                      isSelected && !isParty && "ring-2 ring-sky-400/70 ring-offset-1 ring-offset-zinc-950",
                       isMovable && "hover:brightness-125 cursor-pointer ring-1 ring-amber-400/30",
                       !isMovable && "cursor-default opacity-80",
                     )}

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -357,7 +357,12 @@ export function GameInput({
     >
       {/* Dice picker */}
       {showDice && (
-        <div className="flex flex-wrap items-center gap-1.5 border-b border-foreground/10 px-4 py-2">
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-1.5 border-b border-foreground/10 py-2",
+            inline ? "px-0" : "px-4",
+          )}
+        >
           {QUICK_DICE.map((d) => (
             <button
               type="button"

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -337,7 +337,7 @@ export function GameInput({
   return (
     <div
       className={cn(
-        inline ? "" : "border-t border-[var(--border)] bg-[var(--card)]",
+        inline ? "" : "border-t border-foreground/10 bg-[var(--card)]",
         riskyInterrupt &&
           "rounded-xl ring-1 ring-red-500/40 bg-red-500/5 shadow-[0_0_18px_-6px_rgba(248,113,113,0.55)]",
         forceInterrupt && "rounded-xl ring-1",
@@ -357,13 +357,13 @@ export function GameInput({
     >
       {/* Dice picker */}
       {showDice && (
-        <div className="flex flex-wrap items-center gap-1.5 border-b border-[var(--border)] px-4 py-2">
+        <div className="flex flex-wrap items-center gap-1.5 border-b border-foreground/10 px-4 py-2">
           {QUICK_DICE.map((d) => (
             <button
               type="button"
               key={d}
               onClick={() => handleDiceRoll(d)}
-              className="rounded bg-[var(--muted)]/30 px-2 py-1 text-xs font-mono text-[var(--foreground)]/70 hover:bg-[var(--muted)]/50 transition-colors"
+              className="rounded bg-foreground/10 px-2 py-1 text-xs font-mono text-foreground/70 transition-colors hover:bg-foreground/15"
             >
               🎲 {d}
             </button>
@@ -374,7 +374,7 @@ export function GameInput({
               value={customDice}
               onChange={(e) => setCustomDice(e.target.value)}
               placeholder="3d8+2"
-              className="h-[26px] w-16 rounded bg-[var(--muted)]/30 px-1.5 text-xs font-mono text-[var(--foreground)]/70 outline-none placeholder:text-[var(--muted-foreground)]/50"
+              className="h-[26px] w-16 rounded bg-foreground/10 px-1.5 text-xs font-mono text-foreground/70 outline-none ring-1 ring-foreground/10 placeholder:text-foreground/35 focus:ring-foreground/20"
               onKeyDown={(e) => {
                 if (e.key === "Enter" && customDice.trim()) {
                   handleDiceRoll(customDice.trim());
@@ -390,7 +390,7 @@ export function GameInput({
                   setCustomDice("");
                 }
               }}
-              className="flex h-[26px] items-center rounded bg-[var(--muted)]/30 px-1.5 text-[var(--foreground)]/70 hover:bg-[var(--muted)]/50"
+              className="flex h-[26px] items-center rounded bg-foreground/10 px-1.5 text-foreground/70 hover:bg-foreground/15"
             >
               <Send size={14} />
             </button>
@@ -400,11 +400,11 @@ export function GameInput({
 
       {/* Attachment previews */}
       {attachments.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 border-b border-[var(--border)] px-4 py-2">
+        <div className="flex flex-wrap gap-1.5 border-b border-foreground/10 px-4 py-2">
           {attachments.map((att, i) => (
             <div
               key={i}
-              className="flex items-center gap-1 rounded-lg bg-[var(--secondary)] px-2 py-1 text-[0.625rem] ring-1 ring-[var(--border)]"
+              className="flex items-center gap-1 rounded-lg bg-foreground/10 px-2 py-1 text-[0.625rem] ring-1 ring-foreground/10"
             >
               {att.type.startsWith("image/") && (
                 <img src={att.data} alt={att.name} className="h-5 w-5 rounded object-cover" />
@@ -412,7 +412,7 @@ export function GameInput({
               <span className="max-w-[80px] truncate">{att.name}</span>
               <button
                 onClick={() => setAttachments((prev) => prev.filter((_, idx) => idx !== i))}
-                className="text-[var(--muted-foreground)] hover:text-[var(--destructive)]"
+                className="text-foreground/45 hover:text-[var(--destructive)]"
               >
                 ✕
               </button>
@@ -422,14 +422,14 @@ export function GameInput({
       )}
 
       {pendingMoveLabel && (
-        <div className={cn("flex items-center", inline ? "px-0 pb-1" : "border-b border-[var(--border)] px-4 py-2")}>
-          <div className="flex min-w-0 items-center gap-1.5 rounded-lg border border-sky-400/20 bg-sky-500/10 px-2.5 py-1 text-[0.6875rem] text-sky-100/90">
+        <div className={cn("flex items-center", inline ? "px-0 pb-1" : "border-b border-foreground/10 px-4 py-2")}>
+          <div className="flex min-w-0 items-center gap-1.5 rounded-lg border border-foreground/10 bg-foreground/10 px-2.5 py-1 text-[0.6875rem] text-foreground/80">
             <span className="shrink-0">📍</span>
             <span className="min-w-0 truncate">Destination: {pendingMoveLabel}</span>
             {onClearPendingMove && (
               <button
                 onClick={onClearPendingMove}
-                className="shrink-0 text-sky-100/60 transition-colors hover:text-sky-100"
+                className="shrink-0 text-foreground/45 transition-colors hover:text-foreground/80"
                 title="Clear destination"
               >
                 ✕
@@ -446,7 +446,7 @@ export function GameInput({
           {addressMenuOpen && (
             <div
               ref={addressMenuRef}
-              className="absolute bottom-full left-0 z-20 mb-2 flex min-w-[11rem] flex-col gap-1 rounded-xl border border-[var(--border)] bg-[var(--card)]/95 p-1.5 shadow-lg backdrop-blur"
+              className="absolute bottom-full left-0 z-20 mb-2 flex min-w-[11rem] flex-col gap-1 rounded-xl border border-foreground/10 bg-[var(--card)]/95 p-1.5 shadow-lg backdrop-blur"
             >
               {hasPartyMembers && (
                 <button
@@ -454,8 +454,8 @@ export function GameInput({
                   className={cn(
                     "flex items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs transition-colors",
                     addressMode === "party"
-                      ? "bg-sky-500/15 text-sky-700 dark:text-sky-200"
-                      : "text-[var(--foreground)]/75 hover:bg-black/5 hover:text-[var(--foreground)] dark:hover:bg-white/5",
+                      ? "bg-foreground/10 text-foreground/85 ring-1 ring-foreground/15"
+                      : "text-foreground/65 hover:bg-foreground/10 hover:text-foreground/85",
                   )}
                 >
                   <Users size={14} className="shrink-0" />
@@ -468,8 +468,8 @@ export function GameInput({
                 className={cn(
                   "flex items-center gap-2 rounded-lg px-2.5 py-2 text-left text-xs transition-colors",
                   addressMode === "gm"
-                    ? "bg-amber-500/15 text-amber-700 dark:text-amber-200"
-                    : "text-[var(--foreground)]/75 hover:bg-black/5 hover:text-[var(--foreground)] dark:hover:bg-white/5",
+                    ? "bg-foreground/10 text-foreground/85 ring-1 ring-foreground/15"
+                    : "text-foreground/65 hover:bg-foreground/10 hover:text-foreground/85",
                 )}
               >
                 <MessageCircle size={14} className="shrink-0" />
@@ -484,9 +484,9 @@ export function GameInput({
             className={cn(
               "shrink-0 rounded-lg p-1.5 transition-all active:scale-90",
               addressMode === "party"
-                ? "text-sky-400 hover:bg-foreground/10"
+                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
                 : addressMode === "gm"
-                  ? "text-amber-300 hover:bg-foreground/10"
+                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
                   : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
             title={
@@ -516,7 +516,7 @@ export function GameInput({
           className={cn(
             "shrink-0 rounded-lg p-1.5 transition-all active:scale-90",
             attachments.length
-              ? "text-blue-400 hover:bg-foreground/10"
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
           )}
           title="Attach files"
@@ -552,17 +552,17 @@ export function GameInput({
           }
           disabled={disabled}
           rows={1}
-          className="min-w-0 flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-normal text-[var(--foreground)] outline-none placeholder:text-foreground/30 disabled:opacity-50"
+          className="min-w-0 flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-normal text-foreground outline-none placeholder:text-foreground/30 disabled:opacity-50"
           style={{ minHeight: 36, maxHeight: 120 }}
         />
 
         {queuedDice && (
-          <div className="flex items-center self-stretch rounded-lg border border-[var(--border)] bg-[var(--muted)]/30 px-2 text-xs text-[var(--foreground)]/70">
+          <div className="flex items-center self-stretch rounded-lg border border-foreground/10 bg-foreground/10 px-2 text-xs text-foreground/70">
             🎲 {queuedDice}
             <button
               type="button"
               onClick={() => setQueuedDice(null)}
-              className="ml-1 text-[var(--muted-foreground)]/60 transition-colors hover:text-[var(--foreground)]"
+              className="ml-1 text-foreground/45 transition-colors hover:text-foreground/80"
               title="Clear queued roll"
             >
               ✕
@@ -590,8 +590,8 @@ export function GameInput({
           className={cn(
             "shrink-0 rounded-lg p-1.5 transition-all active:scale-90",
             showDice
-              ? "text-[var(--foreground)]/80 hover:bg-foreground/10"
-              : "text-[var(--foreground)]/50 hover:bg-foreground/10 hover:text-[var(--foreground)]/70",
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
+              : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             riskyInterrupt &&
               !queuedDice &&
               "animate-pulse text-red-300 ring-1 ring-red-400/60 shadow-[0_0_12px_-2px_rgba(248,113,113,0.85)] hover:text-red-200",
@@ -609,7 +609,7 @@ export function GameInput({
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
               emojiOpen
-                ? "text-foreground bg-foreground/10"
+                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                 : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
             title="Emoji"
@@ -633,8 +633,8 @@ export function GameInput({
             className={cn(
               "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all duration-200 active:scale-90",
               !disabled && text.trim() && !isTranslatingDraft
-                ? "text-[var(--foreground)]/50 hover:bg-foreground/10 hover:text-[var(--foreground)]/70"
-                : "text-[var(--muted-foreground)]/40",
+                ? "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70"
+                : "text-foreground/25",
             )}
             title="Translate draft"
           >
@@ -664,8 +664,8 @@ export function GameInput({
             (text.trim() || attachments.length > 0 || (pendingMoveLabel && addressMode === "scene") || queuedDice) &&
               !disabled &&
               !rollingQueuedDice
-              ? "text-[var(--foreground)]/50 hover:bg-foreground/10 hover:text-[var(--foreground)]/70 dark:text-white/70 dark:hover:bg-white/10 dark:hover:text-white"
-              : "text-[var(--muted-foreground)]/40 dark:text-white/30",
+              ? "text-foreground/70 hover:bg-foreground/10 hover:text-foreground/90"
+              : "text-foreground/25",
           )}
           aria-label="Send game turn"
         >

--- a/packages/client/src/components/game/GameInventory.tsx
+++ b/packages/client/src/components/game/GameInventory.tsx
@@ -204,7 +204,7 @@ export function GameInventory({
           <div className="flex items-center gap-2">
             <Package size={15} className="text-amber-400/80" />
             <h2 className="text-sm font-semibold tracking-wide text-white/90">Inventory</h2>
-            <span className="rounded bg-white/8 px-1.5 py-0.5 text-[0.6rem] tabular-nums text-white/40">
+            <span className="rounded bg-white/8 px-1.5 py-0.5 text-[0.6rem] tabular-nums text-white/80">
               {items.length} {items.length === 1 ? "item" : "items"}
             </span>
           </div>
@@ -442,7 +442,7 @@ function InventorySlot({ item, globalIndex, selected, reorderEnabled, onClick }:
                 {item.name}
               </span>
               {item.quantity > 1 && (
-                <span className="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[0.55rem] font-semibold tabular-nums text-white/80">
+                <span className="shrink-0 rounded bg-white/15 px-1.5 py-0.5 text-[0.55rem] font-semibold tabular-nums text-white">
                   x{item.quantity}
                 </span>
               )}

--- a/packages/client/src/components/game/GameJournal.tsx
+++ b/packages/client/src/components/game/GameJournal.tsx
@@ -54,6 +54,7 @@ interface GameJournalProps {
   npcPortraitGenerationEnabled?: boolean;
   generatingNpcPortraitNames?: Set<string>;
   onNpcRemove?: (npcName: string) => Promise<void> | void;
+  embedded?: boolean;
 }
 
 type TabId = "all" | "npcs" | "locations" | "inventory" | "library" | "notes";
@@ -171,6 +172,7 @@ export function GameJournal({
   npcPortraitGenerationEnabled = false,
   generatingNpcPortraitNames,
   onNpcRemove,
+  embedded = false,
 }: GameJournalProps) {
   const [journal, setJournal] = useState<Journal | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>("all");
@@ -257,24 +259,38 @@ export function GameJournal({
 
   if (!journal) {
     return (
-      <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-        <div className="text-sm text-white/60">Loading journal...</div>
+      <div
+        className={
+          embedded
+            ? "flex min-h-40 items-center justify-center"
+            : "absolute inset-0 z-40 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+        }
+      >
+        <div className="text-sm text-[var(--muted-foreground)]">Loading journal...</div>
       </div>
     );
   }
 
   return (
-    <div className="absolute inset-0 z-40 flex flex-col bg-black/85 backdrop-blur-md">
+    <div
+      className={
+        embedded
+          ? "flex min-h-0 flex-1 flex-col bg-transparent"
+          : "absolute inset-0 z-40 flex flex-col bg-black/85 backdrop-blur-md"
+      }
+    >
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
-        <h2 className="text-sm font-bold text-white/90">📖 Adventure Journal</h2>
-        <button
-          onClick={onClose}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-white/60 transition-colors hover:bg-white/10 hover:text-white"
-        >
-          <X size={14} />
-        </button>
-      </div>
+      {!embedded && (
+        <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+          <h2 className="text-sm font-bold text-white/90">Adventure Journal</h2>
+          <button
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
 
       {/* Tabs — horizontally scrollable on mobile */}
       <div className="overflow-x-auto border-b border-white/10 px-4 py-2 scrollbar-hide [-webkit-overflow-scrolling:touch]">
@@ -288,7 +304,7 @@ export function GameJournal({
                 className={cn(
                   "flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[0.625rem] font-medium transition-colors",
                   activeTab === tab.id
-                    ? "bg-[var(--primary)]/20 text-[var(--primary)]"
+                    ? "bg-white/10 text-white/85"
                     : "text-white/50 hover:bg-white/5 hover:text-white/70",
                 )}
               >
@@ -464,7 +480,7 @@ function NpcsView({
                       }}
                       disabled={portraitGenerating}
                       className={cn(
-                        "absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-black/75 text-[var(--primary)] opacity-0 ring-1 ring-white/15 transition-opacity disabled:cursor-wait md:group-hover/journal-avatar:opacity-100",
+                        "absolute -right-1 -top-1 inline-flex h-4 w-4 items-center justify-center rounded-full bg-black/75 text-white/75 opacity-0 ring-1 ring-white/15 transition-opacity disabled:cursor-wait md:group-hover/journal-avatar:opacity-100",
                         (portraitGenerating || mobilePortraitActionsNpc === entry.npc.name.trim().toLowerCase()) &&
                           "max-md:opacity-100",
                       )}

--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { PanelLockButton, useDraggablePanel } from "./DraggablePanel";
+import { getChatToolbarButtonClass } from "../chat/ChatToolbarControls";
 
 const STATE_CONFIG: Record<GameActiveState, { icon: typeof Compass; label: string; color: string }> = {
   exploration: { icon: Compass, label: "Exploration", color: "text-emerald-300" },
@@ -102,9 +103,9 @@ function getTimePhaseLabel(phase: TimePhase): string {
 function getSkyClasses(phase: TimePhase): string {
   switch (phase) {
     case "midnight":
-      return "bg-gradient-to-b from-slate-900 via-indigo-950 to-slate-900";
+      return "bg-gradient-to-b from-slate-900 via-slate-950 to-slate-900";
     case "night":
-      return "bg-gradient-to-b from-slate-800 via-indigo-900 to-slate-950";
+      return "bg-gradient-to-b from-slate-800 via-slate-900 to-slate-950";
     case "dawn":
       return "bg-gradient-to-b from-rose-300 via-amber-200 to-sky-300";
     case "morning":
@@ -114,7 +115,7 @@ function getSkyClasses(phase: TimePhase): string {
     case "afternoon":
       return "bg-gradient-to-b from-sky-400 via-cyan-300 to-amber-100";
     case "evening":
-      return "bg-gradient-to-b from-violet-400 via-rose-300 to-amber-200";
+      return "bg-gradient-to-b from-slate-500 via-rose-300 to-amber-200";
   }
 }
 
@@ -226,7 +227,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
   const skipCommitRef = useRef(false);
   const timeLabel = getTimeOfDayStatusLabel(timeOfDay);
   const rootClassName = cn(
-    "inline-flex shrink-0 items-stretch overflow-hidden rounded-full border border-white/20 bg-black/55 text-white/85 shadow-[0_2px_8px_rgba(0,0,0,0.2)]",
+    "inline-flex shrink-0 items-stretch overflow-hidden rounded-lg border border-zinc-700/80 bg-zinc-950/85 text-zinc-100/85 shadow-[0_2px_8px_rgba(0,0,0,0.2)]",
     size === "mobile" ? "h-7 text-[0.6875rem]" : "h-5 text-[0.625rem]",
     className,
   );
@@ -234,7 +235,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
     "flex items-center justify-center font-semibold leading-none",
     size === "mobile" ? "min-w-14 px-2.5" : "min-w-11 px-1.5",
   );
-  const dividerClassName = cn("my-auto w-px shrink-0 bg-white/20", size === "mobile" ? "h-5" : "h-3.5");
+  const dividerClassName = cn("my-auto w-px shrink-0 bg-zinc-600/70", size === "mobile" ? "h-5" : "h-3.5");
   const timeClassName = cn(
     "h-full rounded-l-none rounded-r-full border-0 shadow-none",
     size === "mobile" ? "w-8" : "w-7",
@@ -264,7 +265,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
   if (editing) {
     return (
       <div
-        className={cn(rootClassName, "focus-within:ring-2 focus-within:ring-white/35")}
+        className={cn(rootClassName, "focus-within:ring-2 focus-within:ring-zinc-500/35")}
         onClick={(event) => event.stopPropagation()}
         onPointerDown={(event) => event.stopPropagation()}
         title={`Day ${safeDay}. ${timeLabel}.`}
@@ -311,7 +312,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
       onPointerDown={(event) => event.stopPropagation()}
       className={cn(
         rootClassName,
-        "transition-colors hover:bg-black/75 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/35",
+        "transition-colors hover:bg-zinc-900 hover:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-zinc-500/35",
       )}
       title={`Day ${safeDay}. ${timeLabel}. Tap to edit day.`}
       aria-label={`Day ${safeDay}. ${timeLabel}. Tap to edit day.`}
@@ -370,7 +371,7 @@ function MapZoomControls({ zoom, onZoomOut, onZoomIn }: MapZoomControlsProps) {
 
   return (
     <div
-      className="absolute right-1.5 top-1.5 z-20 flex h-6 overflow-hidden rounded-md border border-white/15 bg-black/85 shadow-lg shadow-black/35"
+      className="absolute right-1.5 top-1.5 z-20 flex h-6 overflow-hidden rounded-md border border-zinc-700/80 bg-zinc-950/90 shadow-lg shadow-black/35"
       onPointerDown={stopPointer}
       title={`Map zoom: ${Math.round(zoom * 100)}%`}
     >
@@ -381,13 +382,13 @@ function MapZoomControls({ zoom, onZoomOut, onZoomIn }: MapZoomControlsProps) {
           onZoomOut();
         }}
         disabled={atMin}
-        className="flex h-full w-5 items-center justify-center text-white/80 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-35"
+        className="flex h-full w-5 items-center justify-center text-zinc-200/80 transition-colors hover:bg-zinc-800 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-35"
         title="Zoom out"
         aria-label="Zoom out map"
       >
         <Minus size={11} />
       </button>
-      <span className="w-px bg-white/15" />
+      <span className="w-px bg-zinc-700/80" />
       <button
         type="button"
         onClick={(event) => {
@@ -395,7 +396,7 @@ function MapZoomControls({ zoom, onZoomOut, onZoomIn }: MapZoomControlsProps) {
           onZoomIn();
         }}
         disabled={atMax}
-        className="flex h-full w-5 items-center justify-center text-white/80 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-35"
+        className="flex h-full w-5 items-center justify-center text-zinc-200/80 transition-colors hover:bg-zinc-800 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-35"
         title="Zoom in"
         aria-label="Zoom in map"
       >
@@ -444,7 +445,7 @@ function MapGenerateButton({ onGenerateMap, disabled, onAfterGenerate }: MapGene
         onAfterGenerate?.();
       }}
       disabled={disabled}
-      className="absolute left-1.5 top-1.5 z-20 flex h-6 w-6 items-center justify-center rounded-md border border-white/15 bg-black/85 text-white/80 shadow-lg shadow-black/35 transition-colors hover:bg-black hover:text-white disabled:cursor-not-allowed disabled:opacity-45"
+      className="absolute left-1.5 top-1.5 z-20 flex h-6 w-6 items-center justify-center rounded-md border border-zinc-700/80 bg-zinc-950/90 text-zinc-200/80 shadow-lg shadow-black/35 transition-colors hover:bg-zinc-900 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-45"
       title="Generate another map"
       aria-label="Generate another map"
     >
@@ -499,14 +500,14 @@ export function GameMapPanel({
     return (
       <div
         data-tour="game-map"
-        className="flex w-52 flex-col items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 p-3 text-[var(--muted-foreground)] shadow-lg backdrop-blur-sm"
+        className="flex w-52 flex-col items-center justify-center gap-2 rounded-lg border border-zinc-700/80 bg-zinc-950/90 p-3 text-zinc-400 shadow-lg backdrop-blur-sm"
       >
         <span className="text-[0.625rem]">No map yet</span>
         {onGenerateMap && (
           <button
             onClick={onGenerateMap}
             disabled={disabled}
-            className="flex items-center gap-1 rounded-md bg-[var(--primary)] px-2 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:opacity-50"
+            className="flex items-center gap-1 rounded-md bg-zinc-900 px-2 py-1 text-[0.625rem] font-medium text-zinc-100 ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-zinc-900"
           >
             <Wand2 size={10} />
             Generate
@@ -533,8 +534,8 @@ export function GameMapPanel({
       onDragEnd={handleDragEnd}
       style={{ x, y }}
       className={cn(
-        "game-map-container flex w-52 flex-col gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)]/92 p-2 shadow-lg backdrop-blur-sm",
-        !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
+        "game-map-container flex w-52 flex-col gap-1 rounded-lg border border-zinc-700/80 bg-zinc-950/90 p-2 text-zinc-300 shadow-lg shadow-black/35 backdrop-blur-sm",
+        !locked && "cursor-grab ring-1 ring-zinc-500/30 active:cursor-grabbing",
       )}
     >
       <div
@@ -547,7 +548,7 @@ export function GameMapPanel({
             setCollapsed(!collapsed);
           }
         }}
-        className="relative flex cursor-pointer items-center gap-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+        className="relative flex cursor-pointer items-center gap-1.5 text-xs text-zinc-400 transition-colors hover:text-zinc-100"
       >
         {hasLeadingStatus && (
           <div className="flex shrink-0 items-center gap-1.5">
@@ -560,7 +561,7 @@ export function GameMapPanel({
               >
                 <StateIcon size={13} />
                 {stateHovered && (
-                  <span className="absolute -bottom-6 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-black/85 px-1.5 py-0.5 text-[0.55rem] text-white/90 shadow z-50">
+                  <span className="absolute -bottom-6 left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-950/95 px-1.5 py-0.5 text-[0.55rem] text-zinc-100 shadow">
                     {stateCfg!.label}
                   </span>
                 )}
@@ -569,7 +570,7 @@ export function GameMapPanel({
             <DayTimeIndicator day={day} timeOfDay={timeOfDay} onDayChange={onDayChange} />
           </div>
         )}
-        <span className="block min-w-0 flex-1 overflow-hidden text-center font-semibold text-[var(--foreground)]">
+        <span className="block min-w-0 flex-1 overflow-hidden text-center font-semibold text-zinc-100">
           {shouldMarquee ? (
             <span className="game-map-marquee-track inline-flex whitespace-nowrap">
               <span className="pr-8">{mapName}</span>
@@ -580,14 +581,16 @@ export function GameMapPanel({
           )}
         </span>
         <PanelLockButton locked={locked} onToggle={toggleLocked} size={11} />
-        <span className="shrink-0">{collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}</span>
+        <span className="shrink-0 text-zinc-300/70">
+          {collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}
+        </span>
       </div>
       {!collapsed && mapOptions.length > 1 && (
         <div className="flex items-center gap-1">
           <select
             value={selectedMapId ?? ""}
             onChange={(event) => onViewedMapChange?.(event.target.value)}
-            className="min-w-0 flex-1 rounded-md border border-white/10 bg-black/35 px-1.5 py-1 text-[0.625rem] text-[var(--foreground)] outline-none focus:border-[var(--primary)]"
+            className="min-w-0 flex-1 rounded-md border border-zinc-700/80 bg-zinc-950/70 px-1.5 py-1 text-[0.625rem] text-zinc-100 outline-none focus:border-zinc-400/60"
             title="View map"
           >
             {mapOptions.map((option, index) => {
@@ -728,11 +731,11 @@ export function MobileMapButton({
       <div className="flex items-center gap-1.5">
         <button
           onClick={() => setOpen(true)}
-          className="relative flex h-10 w-10 items-center justify-center rounded-xl border border-white/15 bg-black/60 text-white/80 shadow-lg backdrop-blur-md transition-colors active:bg-white/10"
+          className={getChatToolbarButtonClass({ className: "shadow-lg shadow-black/25" })}
           aria-label="Open map"
           title="Open map"
         >
-          <MapIcon size={18} />
+          <MapIcon size={14} />
         </button>
         <DayTimeIndicator day={day} timeOfDay={timeOfDay} onDayChange={onDayChange} size="mobile" />
       </div>
@@ -747,12 +750,12 @@ export function MobileMapButton({
           }}
         >
           <div
-            className="relative flex max-h-[80vh] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-white/15 bg-[var(--card)]/95 shadow-2xl backdrop-blur-md"
+            className="relative flex max-h-[80vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-zinc-700/80 bg-zinc-950/95 shadow-2xl backdrop-blur-md"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
-            <div className="flex items-center gap-2 border-b border-white/10 px-4 py-3">
-              <StateIcon size={14} className={stateCfg?.color ?? "text-white/60"} />
+            <div className="flex items-center gap-2 border-b border-zinc-700/80 px-4 py-3">
+              <StateIcon size={14} className={stateCfg?.color ?? "text-zinc-400"} />
               <DayTimeIndicator day={day} timeOfDay={timeOfDay} onDayChange={onDayChange} size="mobile" />
               <div className="min-w-0 flex-1 overflow-hidden">
                 <p className="block overflow-hidden whitespace-nowrap text-sm font-bold text-[var(--foreground)]">
@@ -784,7 +787,7 @@ export function MobileMapButton({
                       onViewedMapChange?.(event.target.value);
                       setSelectedNode(null);
                     }}
-                    className="mt-1 w-full rounded-md border border-white/10 bg-black/35 px-1.5 py-1 text-[0.625rem] text-[var(--foreground)] outline-none focus:border-[var(--primary)]"
+                    className="mt-1 w-full rounded-md border border-zinc-700/80 bg-zinc-950/70 px-1.5 py-1 text-[0.625rem] text-zinc-100 outline-none focus:border-zinc-400/60"
                     title="View map"
                   >
                     {mapOptions.map((option, index) => {
@@ -804,7 +807,7 @@ export function MobileMapButton({
                   setOpen(false);
                   setSelectedNode(null);
                 }}
-                className="flex h-7 w-7 items-center justify-center rounded-lg text-white/60 transition-colors hover:bg-white/10"
+                className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
               >
                 <X size={14} />
               </button>
@@ -822,7 +825,7 @@ export function MobileMapButton({
                         setOpen(false);
                       }}
                       disabled={disabled}
-                      className="flex items-center gap-1 rounded-md bg-[var(--primary)] px-3 py-1.5 text-xs font-medium text-[var(--primary-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                      className="flex items-center gap-1 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-100 ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Wand2 size={12} />
                       Generate
@@ -881,7 +884,7 @@ export function MobileMapButton({
 
             {/* Selected node footer — shown when a node is tapped */}
             {selectedNodeData && (
-              <div className="flex items-center gap-2 border-t border-white/10 px-4 py-2.5">
+              <div className="flex items-center gap-2 border-t border-zinc-700/80 px-4 py-2.5">
                 <span className="text-sm">{selectedNodeData.discovered ? selectedNodeData.emoji : "❓"}</span>
                 <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--foreground)]">
                   {selectedNodeData.discovered ? selectedNodeData.label : "Unknown location"}
@@ -889,7 +892,7 @@ export function MobileMapButton({
                 {canTravel && selectedNode !== currentNode?.id && (
                   <button
                     onClick={handleTravel}
-                    className="shrink-0 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-[0.6875rem] font-semibold text-[var(--primary-foreground)] transition-colors active:opacity-80"
+                    className="shrink-0 rounded-lg bg-zinc-900 px-3 py-1.5 text-[0.6875rem] font-semibold text-zinc-100 ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 active:opacity-80"
                   >
                     Set destination
                   </button>

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -35,6 +35,7 @@ import {
   Loader2,
   Wand2,
   RotateCcw,
+  GitBranch,
 } from "lucide-react";
 import { cn, copyToClipboard, getAvatarCropStyle, type AvatarCrop, type LegacyAvatarCrop } from "../../lib/utils";
 import { findNamedMapValue } from "../../lib/game-character-name-match";
@@ -417,6 +418,8 @@ interface GameNarrationProps {
   onRetryCombatGeneration?: () => void;
   /** Open the standard delete-message flow for a backing chat message. */
   onDeleteMessage?: (messageId: string) => void;
+  /** Create a chat branch ending at a user-authored game log message. */
+  onBranchMessage?: (messageId: string) => void;
   /** Whether the global multi-delete bar is active. */
   multiSelectMode?: boolean;
   /** Chat message ids selected for global multi-delete. */
@@ -924,6 +927,7 @@ export function GameNarration({
   combatGenerationFailed,
   onRetryCombatGeneration,
   onDeleteMessage,
+  onBranchMessage,
   multiSelectMode = false,
   selectedMessageIds,
   onDeleteSegment,
@@ -3234,6 +3238,8 @@ export function GameNarration({
     "flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/30 px-3 py-1.5 text-xs text-[var(--foreground)]/70 transition-colors hover:bg-[var(--muted)]/50 hover:text-[var(--foreground)] dark:bg-white/10 dark:text-white/70 dark:hover:bg-white/20 dark:hover:text-white";
   const NARRATION_META_BTN =
     "flex min-h-7 items-center gap-1 rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-2.5 py-1 text-xs text-[var(--foreground)]/75 transition-colors hover:bg-[var(--muted)]/40 dark:border-white/10 dark:bg-white/5 dark:text-white/75 dark:hover:bg-white/10";
+  const NARRATION_COUNT_BADGE =
+    "absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--foreground)] px-0.5 text-[0.55rem] font-bold text-[var(--background)] ring-1 ring-[var(--background)]/20 dark:bg-white/90 dark:text-black dark:ring-black/20";
   const combatMetaButton = onRequestCombatStart ? (
     <button
       type="button"
@@ -4065,11 +4071,7 @@ export function GameNarration({
                     <button onClick={onOpenInventory} className={cn("relative", NARRATION_META_BTN)}>
                       <Package size={12} />
                       <span className="hidden sm:inline">Inventory</span>
-                      {(inventoryCount ?? 0) > 0 && (
-                        <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-0.5 text-[0.55rem] font-bold text-black">
-                          {inventoryCount}
-                        </span>
-                      )}
+                      {(inventoryCount ?? 0) > 0 && <span className={NARRATION_COUNT_BADGE}>{inventoryCount}</span>}
                     </button>
                   )}
                   {combatMetaButton}
@@ -4183,11 +4185,7 @@ export function GameNarration({
                     <button onClick={onOpenInventory} className={cn("relative", NARRATION_META_BTN)}>
                       <Package size={12} />
                       <span className="hidden sm:inline">Inventory</span>
-                      {(inventoryCount ?? 0) > 0 && (
-                        <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-0.5 text-[0.55rem] font-bold text-black">
-                          {inventoryCount}
-                        </span>
-                      )}
+                      {(inventoryCount ?? 0) > 0 && <span className={NARRATION_COUNT_BADGE}>{inventoryCount}</span>}
                     </button>
                   )}
                   {combatMetaButton}
@@ -4410,9 +4408,11 @@ export function GameNarration({
                       const sourceMessageId = seg.sourceMessageId ?? entry.messageId;
                       const hasSourceSegmentIndex = seg.sourceSegmentIndex != null;
                       const sourceSegmentIndex = seg.sourceSegmentIndex ?? 0;
-                      const sourceRole =
-                        seg.sourceRole ??
-                        (sourceMessageId ? (sourceMessagesById.get(sourceMessageId)?.role ?? null) : null);
+                      const sourceMessageRole = sourceMessageId
+                        ? (sourceMessagesById.get(sourceMessageId)?.role ?? null)
+                        : null;
+                      const sourceRole = seg.sourceRole ?? sourceMessageRole;
+                      const isUserAuthoredSource = sourceRole === "user" || sourceMessageRole === "user";
                       const isActiveSeg = active?.id === seg.id;
                       const liveSegmentIndex = segments.findIndex((s) => s.id === seg.id);
                       const canJumpToSeg =
@@ -4450,7 +4450,7 @@ export function GameNarration({
                       const jumpRowClasses = canJumpToSeg
                         ? "cursor-pointer hover:ring-1 hover:ring-white/15 focus:outline-none focus-visible:ring-1 focus-visible:ring-white/30"
                         : "";
-                      const canEditMessage = !!onEditMessage && !!sourceMessageId && sourceRole === "user";
+                      const canEditMessage = !!onEditMessage && !!sourceMessageId && isUserAuthoredSource;
                       const canEditSegment =
                         !!onEditSegment &&
                         !!sourceMessageId &&
@@ -4460,7 +4460,8 @@ export function GameNarration({
                         sourceMessageId !== "party-chat";
                       const canEdit = canEditMessage || canEditSegment;
                       const canDeleteMessage =
-                        !!onDeleteMessage && !!sourceMessageId && (sourceRole === "user" || sourceRole === "system");
+                        !!onDeleteMessage && !!sourceMessageId && (isUserAuthoredSource || sourceRole === "system");
+                      const canBranchMessage = !!onBranchMessage && !!sourceMessageId && isUserAuthoredSource;
                       const canDeleteThisSegment =
                         !!onDeleteSegment &&
                         !!sourceMessageId &&
@@ -4493,6 +4494,23 @@ export function GameNarration({
                           title="Copy"
                         >
                           {copiedMessageKey === copyKey ? <Check size={11} /> : <Copy size={11} />}
+                        </button>
+                      ) : null;
+                      const branchButton = canBranchMessage ? (
+                        <button
+                          type="button"
+                          onPointerDown={stopLogActionPointerDown}
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            onBranchMessage?.(sourceMessageId);
+                            setLogsOpen(false);
+                          }}
+                          className="rounded-lg border border-zinc-600/70 bg-zinc-950/85 p-1 text-zinc-100 shadow-sm transition-colors hover:bg-zinc-800 hover:text-white"
+                          title="Branch from here"
+                          aria-label="Branch from here"
+                        >
+                          <GitBranch size={11} />
                         </button>
                       ) : null;
                       const deleteButton = showDeleteButton ? (
@@ -4660,12 +4678,13 @@ export function GameNarration({
                       );
 
                       const actionButtons =
-                        deleteButton || copyButton || editButtons ? (
+                        deleteButton || branchButton || copyButton || editButtons ? (
                           <div
                             onPointerDown={stopLogActionPointerDown}
                             onClick={(event) => event.stopPropagation()}
                             className="absolute right-1.5 top-1.5 z-10 flex items-center gap-0.5"
                           >
+                            {branchButton}
                             {deleteButton}
                             {copyButton}
                             {editButtons}

--- a/packages/client/src/components/game/GameNodeMap.tsx
+++ b/packages/client/src/components/game/GameNodeMap.tsx
@@ -47,7 +47,7 @@ export function GameNodeMap({
   // Guard against empty nodes — no SVG to render
   if (nodes.length === 0) {
     return (
-      <div className="flex items-center justify-center rounded border border-[var(--border)] bg-gray-900/30 p-4 text-xs text-[var(--muted-foreground)]">
+      <div className="flex items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/70 p-4 text-xs text-zinc-400">
         No map nodes available
       </div>
     );
@@ -95,7 +95,7 @@ export function GameNodeMap({
       {topLeftAction}
       {topRightAction}
       <div
-        className="w-full overflow-auto rounded"
+        className="w-full overflow-auto rounded-lg"
         style={{
           aspectRatio: `${viewWidth} / ${viewHeight}`,
           maxHeight: "min(52vh, 340px)",
@@ -103,7 +103,7 @@ export function GameNodeMap({
       >
         <svg
           viewBox={`${visibleMinX} ${visibleMinY} ${visibleViewWidth} ${visibleViewHeight}`}
-          className="block rounded border border-[var(--border)] bg-gray-900/30"
+          className="block rounded-lg border border-zinc-700/80 bg-zinc-950/70"
           style={{ width: mapContentWidth }}
         >
           {/* Edges */}

--- a/packages/client/src/components/game/GamePartyBar.tsx
+++ b/packages/client/src/components/game/GamePartyBar.tsx
@@ -48,7 +48,7 @@ function PartyAvatar({ visual, className }: { visual: PartyMemberVisual; classNa
     return (
       <span
         className={cn(
-          "relative block h-9 w-9 overflow-hidden rounded-full border-2 border-white/20 shadow-lg transition-colors group-hover:border-white/40",
+          "relative block h-8 w-8 overflow-hidden rounded-lg border border-zinc-700/80 shadow-lg shadow-black/25 transition-colors group-hover:border-zinc-500/80",
           className,
         )}
       >
@@ -65,7 +65,7 @@ function PartyAvatar({ visual, className }: { visual: PartyMemberVisual; classNa
   return (
     <span
       className={cn(
-        "flex h-9 w-9 items-center justify-center rounded-full border-2 border-white/20 bg-[var(--accent)] text-xs font-bold shadow-lg transition-colors group-hover:border-white/40",
+        "flex h-8 w-8 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/90 text-xs font-bold shadow-lg shadow-black/25 transition-colors group-hover:border-zinc-500/80",
         className,
       )}
       style={member.nameColor ? { color: member.nameColor } : undefined}
@@ -141,14 +141,14 @@ export function GamePartyBar({
               }
               setMobileMenuOpen((open) => !open);
             }}
-            className="group relative block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
+            className="group relative block rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
             aria-expanded={mobileMenuOpen}
             aria-label={mobileMenuOpen ? "Close party members" : "Open party members"}
             title={memberVisuals.length === 1 ? "Open character sheet" : "Open party members"}
           >
             <PartyAvatar visual={memberVisuals[previewIndex]} />
             {memberVisuals.length > 1 && (
-              <span className="absolute -bottom-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full border border-white/25 bg-black/85 px-1 text-[0.55rem] font-bold leading-none text-white shadow-md">
+              <span className="absolute -bottom-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/95 px-1 text-[0.55rem] font-bold leading-none text-zinc-100 shadow-md">
                 {memberVisuals.length}
               </span>
             )}
@@ -156,7 +156,7 @@ export function GamePartyBar({
         )}
 
         {mobileMenuOpen && memberVisuals.length > 1 && (
-          <div className="absolute left-0 top-11 z-50 rounded-full border border-white/15 bg-black/80 p-1.5 shadow-2xl backdrop-blur-md">
+          <div className="absolute left-0 top-9 z-50 rounded-xl border border-zinc-700/80 bg-zinc-950/95 p-1.5 shadow-2xl backdrop-blur-md">
             <div className="flex max-h-[min(44svh,18rem)] flex-col items-center gap-1.5 overflow-y-auto overscroll-contain pr-0.5 [-webkit-overflow-scrolling:touch]">
               {memberVisuals.map((visual) => (
                 <div key={visual.member.id} className="group relative shrink-0">
@@ -166,7 +166,7 @@ export function GamePartyBar({
                       openCharacterSheet(visual.member.id);
                       setMobileMenuOpen(false);
                     }}
-                    className="block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
+                    className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
                     title={`${visual.member.name} - Click to open character sheet`}
                   >
                     <PartyAvatar visual={visual} />
@@ -179,7 +179,7 @@ export function GamePartyBar({
                         onRemovePartyMember(visual.member);
                       }}
                       disabled={removingPartyMemberId === visual.member.id}
-                      className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-white/30 bg-black/85 text-white shadow-md transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 shadow-md transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60"
                       aria-label={`Remove ${visual.member.name} from party`}
                       title={`Remove ${visual.member.name} from party`}
                     >
@@ -198,11 +198,14 @@ export function GamePartyBar({
           const { member } = visual;
 
           return (
-            <div key={member.id} className="group relative shrink-0 transition-transform hover:scale-110">
+            <div
+              key={member.id}
+              className="group relative shrink-0 origin-left transition-transform duration-150 ease-out hover:scale-[1.03] active:scale-[0.98]"
+            >
               <button
                 type="button"
                 onClick={() => openCharacterSheet(member.id)}
-                className="block rounded-full focus:outline-none focus:ring-2 focus:ring-white/45"
+                className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
                 title={`${member.name} - Click to open character sheet`}
               >
                 <PartyAvatar visual={visual} />
@@ -215,7 +218,7 @@ export function GamePartyBar({
                     onRemovePartyMember(member);
                   }}
                   disabled={removingPartyMemberId === member.id}
-                  className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-white/30 bg-black/80 text-white opacity-80 shadow-md transition-opacity hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60 group-hover:opacity-100 focus:opacity-100 md:opacity-0"
+                  className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 opacity-80 shadow-md transition-opacity hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60 group-hover:opacity-100 focus:opacity-100 md:opacity-0"
                   aria-label={`Remove ${member.name} from party`}
                   title={`Remove ${member.name} from party`}
                 >

--- a/packages/client/src/components/game/GamePartySidebar.tsx
+++ b/packages/client/src/components/game/GamePartySidebar.tsx
@@ -131,8 +131,8 @@ export function GamePartySidebar({
                   className={cn(
                     "group relative shrink-0 rounded-full p-0.5 ring-1 transition-all",
                     selectedMemberId === m.id
-                      ? "ring-[var(--primary)] bg-[var(--primary)]/10"
-                      : "ring-[var(--border)] hover:ring-[var(--primary)]/40",
+                      ? "bg-[var(--foreground)]/10 ring-[var(--foreground)]/25"
+                      : "ring-[var(--border)] hover:ring-[var(--foreground)]/25",
                   )}
                   title={m.name}
                 >
@@ -161,12 +161,12 @@ export function GamePartySidebar({
           {/* RPG character card */}
           {selectedCard && (
             <div className="border-b border-[var(--border)] bg-[var(--secondary)]/55 px-2 py-2">
-              <div className="overflow-hidden rounded-lg border border-amber-500/20 bg-gradient-to-b from-[#1a1510] to-[#0d0b08] shadow-lg">
+              <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/80 shadow-lg">
                 {/* Card header with avatar + name */}
-                <div className="relative border-b border-amber-500/15 bg-gradient-to-r from-amber-900/20 via-amber-800/10 to-amber-900/20 px-2.5 py-2">
+                <div className="relative border-b border-[var(--border)] bg-[var(--secondary)]/45 px-2.5 py-2">
                   <div className="flex items-center gap-2">
                     {selectedCard.avatarUrl ? (
-                      <span className="relative block h-10 w-10 shrink-0 overflow-hidden rounded-md border border-amber-500/25 shadow-md">
+                      <span className="relative block h-10 w-10 shrink-0 overflow-hidden rounded-md border border-[var(--border)] shadow-md">
                         <img
                           src={selectedCard.avatarUrl}
                           alt={selectedCard.title}
@@ -175,22 +175,24 @@ export function GamePartySidebar({
                         />
                       </span>
                     ) : (
-                      <div className="flex h-10 w-10 items-center justify-center rounded-md border border-amber-500/25 bg-amber-900/20 text-sm font-bold text-amber-300/60">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--secondary)] text-sm font-bold text-[var(--muted-foreground)]">
                         {selectedCard.title[0]}
                       </div>
                     )}
                     <div className="min-w-0 flex-1">
-                      <p className="overflow-x-auto whitespace-nowrap scrollbar-hide text-[0.75rem] font-bold text-amber-100 [-webkit-overflow-scrolling:touch]">
+                      <p className="overflow-x-auto whitespace-nowrap scrollbar-hide text-[0.75rem] font-bold text-[var(--foreground)] [-webkit-overflow-scrolling:touch]">
                         {selectedCard.title}
                       </p>
                       {selectedCard.subtitle && (
-                        <p className="text-[0.6rem] text-amber-300/50">{selectedCard.subtitle}</p>
+                        <p className="text-[0.6rem] text-[var(--muted-foreground)]">{selectedCard.subtitle}</p>
                       )}
                     </div>
                     {selectedCard.level != null && (
-                      <div className="flex items-center gap-0.5 rounded border border-amber-500/20 bg-amber-900/25 px-1 py-px">
-                        <span className="text-[0.4375rem] uppercase tracking-wider text-amber-500/50">LVL</span>
-                        <span className="text-[0.5rem] font-bold leading-none text-amber-200">
+                      <div className="flex items-center gap-0.5 rounded border border-[var(--border)] bg-[var(--background)]/60 px-1 py-px">
+                        <span className="text-[0.4375rem] uppercase tracking-wider text-[var(--muted-foreground)]">
+                          LVL
+                        </span>
+                        <span className="text-[0.5rem] font-bold leading-none text-[var(--foreground)]">
                           {selectedCard.level}
                         </span>
                       </div>
@@ -206,7 +208,7 @@ export function GamePartySidebar({
 
                 {/* Stats bars */}
                 {selectedCard.stats && selectedCard.stats.length > 0 && (
-                  <div className="space-y-1 border-b border-amber-500/10 px-2.5 py-2">
+                  <div className="space-y-1 border-b border-[var(--border)] px-2.5 py-2">
                     {selectedCard.stats.slice(0, 6).map((stat) => {
                       const max = Math.max(1, stat.max ?? 100);
                       const value = Math.max(0, Math.min(max, stat.value));
@@ -214,12 +216,12 @@ export function GamePartySidebar({
                       return (
                         <div key={stat.name}>
                           <div className="mb-0.5 flex items-center justify-between text-[0.5625rem]">
-                            <span className="font-medium text-amber-200/70">{stat.name}</span>
-                            <span className="font-mono text-amber-400/50">
+                            <span className="font-medium text-[var(--foreground)]/75">{stat.name}</span>
+                            <span className="font-mono text-[var(--muted-foreground)]">
                               {value}/{max}
                             </span>
                           </div>
-                          <div className="h-1.5 overflow-hidden rounded-full bg-black/50 ring-1 ring-amber-500/10">
+                          <div className="h-1.5 overflow-hidden rounded-full bg-black/50 ring-1 ring-white/10">
                             <div
                               className="h-full rounded-full transition-all"
                               style={{
@@ -236,8 +238,8 @@ export function GamePartySidebar({
 
                 {/* Inventory */}
                 {selectedCard.inventory && selectedCard.inventory.length > 0 && (
-                  <div className="border-b border-amber-500/10 px-2.5 py-1.5">
-                    <div className="mb-1 flex items-center gap-1 text-[0.5625rem] font-semibold uppercase tracking-wider text-amber-500/50">
+                  <div className="border-b border-[var(--border)] px-2.5 py-1.5">
+                    <div className="mb-1 flex items-center gap-1 text-[0.5625rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
                       <Swords size={9} />
                       <span>Inventory</span>
                     </div>
@@ -247,11 +249,11 @@ export function GamePartySidebar({
                           key={`${item.name}-${item.location ?? "bag"}`}
                           className="flex items-start justify-between gap-1 text-[0.5625rem]"
                         >
-                          <span className="min-w-0 flex-1 whitespace-normal break-words leading-tight text-amber-100/70 [overflow-wrap:anywhere]">
+                          <span className="min-w-0 flex-1 whitespace-normal break-words leading-tight text-[var(--foreground)]/75 [overflow-wrap:anywhere]">
                             {item.name}
                           </span>
                           {item.quantity && item.quantity > 1 && (
-                            <span className="ml-1 shrink-0 font-mono text-amber-400/40">×{item.quantity}</span>
+                            <span className="ml-1 shrink-0 font-mono text-white/80">×{item.quantity}</span>
                           )}
                         </div>
                       ))}
@@ -261,8 +263,8 @@ export function GamePartySidebar({
 
                 {/* Custom fields */}
                 {selectedCard.customFields && Object.keys(selectedCard.customFields).length > 0 && (
-                  <div className="border-t border-amber-500/10 px-2.5 py-1.5">
-                    <div className="mb-1 flex items-center gap-1 text-[0.5625rem] font-semibold uppercase tracking-wider text-amber-500/50">
+                  <div className="border-t border-[var(--border)] px-2.5 py-1.5">
+                    <div className="mb-1 flex items-center gap-1 text-[0.5625rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
                       <Sparkles size={9} />
                       <span>Traits</span>
                     </div>
@@ -271,8 +273,8 @@ export function GamePartySidebar({
                         .slice(0, 4)
                         .map(([key, val]) => (
                           <div key={key} className="flex items-center justify-between">
-                            <span className="text-amber-300/50">{key}</span>
-                            <span className="text-amber-100/60">{val}</span>
+                            <span className="text-[var(--muted-foreground)]">{key}</span>
+                            <span className="text-[var(--foreground)]/70">{val}</span>
                           </div>
                         ))}
                     </div>
@@ -282,7 +284,7 @@ export function GamePartySidebar({
                 {/* Fallback status when no stats/inventory */}
                 {!selectedCard.stats?.length && !selectedCard.inventory?.length && selectedCard.status && (
                   <div className="px-2.5 py-2">
-                    <p className="text-[0.625rem] italic text-amber-200/40">{selectedCard.status}</p>
+                    <p className="text-[0.625rem] italic text-[var(--muted-foreground)]">{selectedCard.status}</p>
                   </div>
                 )}
               </div>
@@ -292,11 +294,11 @@ export function GamePartySidebar({
           {/* No card data — show member name at minimum */}
           {!selectedCard && selectedMemberId && (
             <div className="border-b border-[var(--border)] bg-[var(--secondary)]/55 px-2 py-2">
-              <div className="rounded-lg border border-amber-500/20 bg-gradient-to-b from-[#1a1510] to-[#0d0b08] px-2.5 py-3 text-center">
-                <p className="text-[0.6875rem] font-bold text-amber-100">
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--card)]/80 px-2.5 py-3 text-center">
+                <p className="text-[0.6875rem] font-bold text-[var(--foreground)]">
                   {partyMembers?.find((m) => m.id === selectedMemberId)?.name ?? "Unknown"}
                 </p>
-                <p className="mt-0.5 text-[0.5625rem] text-amber-400/40">
+                <p className="mt-0.5 text-[0.5625rem] text-[var(--muted-foreground)]">
                   Card data will populate as the story progresses
                 </p>
               </div>

--- a/packages/client/src/components/game/GameSessionHistory.tsx
+++ b/packages/client/src/components/game/GameSessionHistory.tsx
@@ -1,11 +1,13 @@
 // ──────────────────────────────────────────────
 // Game: Session History Panel (view past sessions)
 // ──────────────────────────────────────────────
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   BookOpen,
   CheckCircle2,
+  Eye,
+  EyeOff,
   GitBranch,
   History,
   ChevronDown,
@@ -195,7 +197,12 @@ interface GameSessionHistoryProps {
   onRegenerateSession?: (sessionNumber: number) => Promise<void> | void;
   onRegenerateLorebook?: (sessionNumber: number) => Promise<void> | void;
   onUpdatePlotArcs?: (sessionNumber: number) => Promise<void> | void;
+  currentSessionActionLabel?: string;
+  currentSessionActionIcon?: ReactNode;
+  currentSessionActionDisabled?: boolean;
+  onCurrentSessionAction?: () => void;
   onClose: () => void;
+  embedded?: boolean;
 }
 
 export function GameSessionHistory({
@@ -215,7 +222,12 @@ export function GameSessionHistory({
   onRegenerateSession,
   onRegenerateLorebook,
   onUpdatePlotArcs,
+  currentSessionActionLabel,
+  currentSessionActionIcon,
+  currentSessionActionDisabled = false,
+  onCurrentSessionAction,
   onClose,
+  embedded = false,
 }: GameSessionHistoryProps) {
   const [expandedSession, setExpandedSession] = useState<number | null>(null);
   const [editingSession, setEditingSession] = useState<number | null>(null);
@@ -359,43 +371,67 @@ export function GameSessionHistory({
       });
 
   return (
-    <div className="absolute inset-0 z-40 flex flex-col bg-[var(--card)]/95 backdrop-blur-sm">
-      <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-        <div className="flex items-center gap-2">
-          <History size={16} className="text-[var(--muted-foreground)]" />
-          <span className="text-sm font-semibold text-[var(--foreground)]">Session History</span>
-          <span className="text-xs text-[var(--muted-foreground)]">
-            ({sorted.length} past session{sorted.length !== 1 ? "s" : ""})
-          </span>
+    <div
+      className={
+        embedded
+          ? "flex min-h-0 flex-1 flex-col"
+          : "absolute inset-0 z-40 flex flex-col bg-[var(--card)]/95 backdrop-blur-sm"
+      }
+    >
+      {!embedded && (
+        <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+          <div className="flex items-center gap-2">
+            <History size={16} className="text-[var(--muted-foreground)]" />
+            <span className="text-sm font-semibold text-[var(--foreground)]">Session History</span>
+            <span className="text-xs text-[var(--muted-foreground)]">
+              ({sorted.length} past session{sorted.length !== 1 ? "s" : ""})
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          >
+            <X size={16} />
+          </button>
         </div>
-        <button
-          onClick={onClose}
-          className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-        >
-          <X size={16} />
-        </button>
-      </div>
+      )}
 
-      <div className="flex-1 overflow-y-auto px-4 py-3">
+      <div className={embedded ? "min-h-0 flex-1 overflow-y-auto px-1 py-2" : "flex-1 overflow-y-auto px-4 py-3"}>
         <div className="flex flex-col gap-2">
-          <div className="rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/5">
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/45">
             <div className="flex flex-wrap items-center gap-3 px-4 py-3">
               <span className="text-sm font-semibold text-[var(--foreground)]">
                 Session {currentSessionNumber} (Current)
               </span>
               <span className="text-xs text-[var(--muted-foreground)]">{currentSessionDateStr}</span>
-              <button
-                type="button"
-                onClick={() => {
-                  setSpoilersVisible((visible) => !visible);
-                  if (!spoilersVisible && currentSecrets) {
-                    setSecretDraft(buildCurrentSecretsDraft(currentSecrets));
-                  }
-                }}
-                className="ml-auto rounded-md bg-amber-500/15 px-2.5 py-1 text-[0.6875rem] font-semibold text-amber-500 ring-1 ring-amber-500/25 transition-colors hover:bg-amber-500/25"
-              >
-                {spoilersVisible ? "Hide Spoilers" : "Show Spoilers"}
-              </button>
+              <div className="ml-auto flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSpoilersVisible((visible) => !visible);
+                    if (!spoilersVisible && currentSecrets) {
+                      setSecretDraft(buildCurrentSecretsDraft(currentSecrets));
+                    }
+                  }}
+                  className="flex h-7 w-7 items-center justify-center rounded-md bg-[var(--secondary)] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                  title={spoilersVisible ? "Hide Spoilers" : "Show Spoilers"}
+                  aria-label={spoilersVisible ? "Hide Spoilers" : "Show Spoilers"}
+                >
+                  {spoilersVisible ? <EyeOff size={13} /> : <Eye size={13} />}
+                </button>
+                {onCurrentSessionAction && currentSessionActionIcon && currentSessionActionLabel && (
+                  <button
+                    type="button"
+                    onClick={onCurrentSessionAction}
+                    disabled={currentSessionActionDisabled}
+                    className="flex h-7 w-7 items-center justify-center rounded-md bg-[var(--secondary)] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                    title={currentSessionActionLabel}
+                    aria-label={currentSessionActionLabel}
+                  >
+                    {currentSessionActionIcon}
+                  </button>
+                )}
+              </div>
             </div>
 
             {spoilersVisible && (
@@ -415,7 +451,7 @@ export function GameSessionHistory({
                         }
                         rows={5}
                         disabled={savingCurrentSecrets}
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -429,7 +465,7 @@ export function GameSessionHistory({
                         }
                         rows={5}
                         disabled={savingCurrentSecrets}
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -444,7 +480,7 @@ export function GameSessionHistory({
                         rows={5}
                         disabled={savingCurrentSecrets}
                         placeholder="One plot twist per line"
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -458,7 +494,7 @@ export function GameSessionHistory({
                         }
                         rows={8}
                         disabled={savingCurrentSecrets}
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -472,7 +508,7 @@ export function GameSessionHistory({
                         }
                         rows={10}
                         disabled={savingCurrentSecrets}
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -486,7 +522,7 @@ export function GameSessionHistory({
                         }
                         rows={8}
                         disabled={savingCurrentSecrets}
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <label className="flex flex-col gap-1">
@@ -500,7 +536,7 @@ export function GameSessionHistory({
                         }
                         rows={8}
                         disabled={savingCurrentSecrets}
-                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                        className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                       />
                     </label>
                     <div className="flex items-center justify-end gap-2">
@@ -516,7 +552,7 @@ export function GameSessionHistory({
                         type="button"
                         onClick={() => void handleSaveCurrentSecrets()}
                         disabled={savingCurrentSecrets}
-                        className="rounded-md bg-[var(--primary)] px-2.5 py-1.5 text-[0.6875rem] font-medium text-white transition-colors hover:bg-[var(--primary)]/90 disabled:opacity-50"
+                        className="rounded-md bg-[var(--foreground)]/12 px-2.5 py-1.5 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--foreground)]/18 disabled:opacity-50"
                       >
                         {savingCurrentSecrets ? "Saving..." : "Save Spoilers"}
                       </button>
@@ -684,7 +720,7 @@ export function GameSessionHistory({
                                 }
                                 disabled={isSaving}
                                 rows={8}
-                                className="min-h-32 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="min-h-32 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -699,7 +735,7 @@ export function GameSessionHistory({
                                 disabled={isSaving}
                                 rows={4}
                                 placeholder="How the next session should resume"
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -713,7 +749,7 @@ export function GameSessionHistory({
                                 }
                                 disabled={isSaving}
                                 rows={4}
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -727,7 +763,7 @@ export function GameSessionHistory({
                                 }
                                 disabled={isSaving}
                                 rows={3}
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -742,7 +778,7 @@ export function GameSessionHistory({
                                 disabled={isSaving}
                                 rows={4}
                                 placeholder="One continuity fact per line, including discoveries, twists, and reveals"
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -757,7 +793,7 @@ export function GameSessionHistory({
                                 disabled={isSaving}
                                 rows={4}
                                 placeholder="One moment per line"
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -772,7 +808,7 @@ export function GameSessionHistory({
                                 disabled={isSaving}
                                 rows={4}
                                 placeholder="One small preference, habit, promise, or past detail per line"
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -787,7 +823,7 @@ export function GameSessionHistory({
                                 disabled={isSaving}
                                 rows={4}
                                 placeholder="One update per line"
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <label className="flex flex-col gap-1">
@@ -801,7 +837,7 @@ export function GameSessionHistory({
                                 }
                                 disabled={isSaving}
                                 rows={8}
-                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]"
+                                className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40"
                               />
                             </label>
                             <div className="flex items-center justify-end gap-2">
@@ -815,7 +851,7 @@ export function GameSessionHistory({
                               <button
                                 onClick={() => void handleSaveSession(session)}
                                 disabled={isSaving || !(draft?.summary ?? "").trim()}
-                                className="rounded-md bg-[var(--primary)] px-2.5 py-1.5 text-[0.6875rem] font-medium text-white transition-colors hover:bg-[var(--primary)]/90 disabled:cursor-not-allowed disabled:opacity-50"
+                                className="rounded-md bg-[var(--foreground)]/12 px-2.5 py-1.5 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--foreground)]/18 disabled:cursor-not-allowed disabled:opacity-50"
                               >
                                 {isSaving ? "Saving..." : "Save Details"}
                               </button>
@@ -943,10 +979,6 @@ export function GameSessionHistory({
             })
           )}
         </div>
-      </div>
-
-      <div className="border-t border-[var(--border)] px-4 py-2 text-center text-xs text-[var(--muted-foreground)]">
-        Currently in Session {currentSessionNumber}
       </div>
     </div>
   );

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -1252,7 +1252,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                         className={enableSpotifyDj ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"}
                       />
                       <div className="min-w-0">
-                        <span className="block text-xs font-medium text-[var(--foreground)]">Spotify DJ Music</span>
+                        <span className="block text-xs font-medium text-[var(--foreground)]">Music DJ: Spotify</span>
                         <span className="block text-[0.575rem] text-[var(--muted-foreground)]">
                           Use Spotify music for this game instead of local music assets
                         </span>
@@ -1350,7 +1350,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                           )}
                           {spotifyPlaylistsQuery.isError && (
                             <span className="text-[0.5625rem] text-amber-400/90">
-                              Connect Spotify in the Spotify DJ agent to load playlist names.
+                              Connect Spotify in the Music DJ agent to load playlist names.
                             </span>
                           )}
                         </label>

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -1252,9 +1252,9 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                         className={enableSpotifyDj ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"}
                       />
                       <div className="min-w-0">
-                        <span className="block text-xs font-medium text-[var(--foreground)]">Music DJ: Spotify</span>
+                        <span className="block text-xs font-medium text-[var(--foreground)]">Music DJ</span>
                         <span className="block text-[0.575rem] text-[var(--muted-foreground)]">
-                          Use Spotify music for this game instead of local music assets
+                          Use the Music DJ for this game instead of local music assets
                         </span>
                       </div>
                     </div>

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -8122,6 +8122,7 @@ export function GameSurface({
               {/* Top-right action controls */}
               <div
                 data-tour="game-controls"
+                data-tracker-panel-anchor="roleplay-hud"
                 className={cn("pointer-events-none absolute right-3 z-30", topOverlayOffsetClass)}
               >
                 {/* Desktop controls */}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -1,7 +1,16 @@
 // ──────────────────────────────────────────────
 // Game: Main Surface (rendered by ChatArea when mode === "game")
 // ──────────────────────────────────────────────
-import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  lazy,
+  Suspense,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 import { useShallow } from "zustand/react/shallow";
 import { toast } from "sonner";
 import { useGameModeStore } from "../../stores/game-mode.store";
@@ -1777,7 +1786,7 @@ interface GameSurfaceProps {
   }>;
   personaInfo?: PersonaInfo;
   chatBackground?: string | null;
-  onOpenSettings: () => void;
+  onOpenSettings: (event?: ReactMouseEvent<HTMLElement>) => void;
   onDeleteMessage: (messageId: string) => void;
   multiSelectMode?: boolean;
   selectedMessageIds?: Set<string>;
@@ -2020,6 +2029,7 @@ export function GameSurface({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [journalOpen, setJournalOpen] = useState(false);
   const [galleryOpen, setGalleryOpen] = useState(false);
+  const [galleryAnchor, setGalleryAnchor] = useState<{ right: number; top: number } | null>(null);
   const [combatLogsOpen, setCombatLogsOpen] = useState(false);
   const [spotifyRetryPending, setSpotifyRetryPending] = useState(false);
   const [youtubeRetryPending, setYoutubeRetryPending] = useState(false);
@@ -2033,6 +2043,25 @@ export function GameSurface({
   const [prepareInitialWidgetsOpen, setPrepareInitialWidgetsOpen] = useState(false);
   const [savingSessionSummary, setSavingSessionSummary] = useState<number | null>(null);
   const [savingCurrentSessionSecrets, setSavingCurrentSessionSecrets] = useState(false);
+  const readFloatingPanelAnchor = useCallback((event?: ReactMouseEvent<HTMLElement>) => {
+    if (!event || typeof window === "undefined" || window.innerWidth < 768) return null;
+    const rect = event.currentTarget.getBoundingClientRect();
+    return {
+      right: Math.max(12, Math.round(window.innerWidth - rect.right)),
+      top: Math.max(56, Math.round(rect.bottom + 8)),
+    };
+  }, []);
+  const handleOpenGalleryPanel = useCallback(
+    (event?: ReactMouseEvent<HTMLElement>) => {
+      setGalleryAnchor(readFloatingPanelAnchor(event));
+      setGalleryOpen(true);
+    },
+    [readFloatingPanelAnchor],
+  );
+  const handleCloseGalleryPanel = useCallback(() => {
+    setGalleryOpen(false);
+    setGalleryAnchor(null);
+  }, []);
   const [activeChoices, setActiveChoices] = useState<string[] | null>(null);
   const [activeQte, setActiveQte] = useState<{ actions: string[]; timer: number } | null>(null);
   const [queuedQte, setQueuedQte] = useState<{ qte: { actions: string[]; timer: number }; messageId: string } | null>(
@@ -8171,7 +8200,7 @@ export function GameSurface({
                     )}
                   </div>
                   <button
-                    onClick={() => setGalleryOpen(true)}
+                    onClick={handleOpenGalleryPanel}
                     className={GAME_TOP_ICON_BUTTON}
                     title="Gallery"
                   >
@@ -8387,8 +8416,8 @@ export function GameSurface({
                           )}
                         </div>
                         <button
-                          onClick={() => {
-                            setGalleryOpen(true);
+                          onClick={(event) => {
+                            handleOpenGalleryPanel(event);
                             setMobileActionsOpen(false);
                           }}
                           className={GAME_MOBILE_ICON_BUTTON}
@@ -8488,8 +8517,8 @@ export function GameSurface({
                           )}
                         </div>
                         <button
-                          onClick={() => {
-                            onOpenSettings();
+                          onClick={(event) => {
+                            onOpenSettings(event);
                             setMobileActionsOpen(false);
                           }}
                           className={GAME_MOBILE_ICON_BUTTON}
@@ -9115,7 +9144,8 @@ export function GameSurface({
               <ChatGalleryDrawer
                 chat={chat}
                 open={galleryOpen}
-                onClose={() => setGalleryOpen(false)}
+                onClose={handleCloseGalleryPanel}
+                anchor={galleryAnchor}
                 onIllustrate={() => retryAgents(activeChatId, ["illustrator"])}
               />
 

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -4692,14 +4692,14 @@ export function GameSurface({
     setMobileActionsOpen(false);
     setYoutubeRetryPending(true);
     try {
-      // YouTube DJ needs no scene-candidate flow — re-running the agent (with the
+      // Music DJ YouTube mode needs no scene-candidate flow — re-running the agent (with the
       // manualRetry constraint the server injects) emits a fresh play intent that
       // the in-app player swaps in.
       await retryAgents(activeChatId, ["youtube"]);
-      toast.success("YouTube DJ picking a fresh track…", { duration: 1800 });
+      toast.success("Music DJ picking a fresh YouTube track…", { duration: 1800 });
     } catch (error) {
       console.warn("[youtube/game] Retry failed:", error);
-      toast.error("YouTube DJ retry failed.");
+      toast.error("Music DJ retry failed.");
     } finally {
       setYoutubeRetryPending(false);
     }
@@ -8227,7 +8227,7 @@ export function GameSurface({
                             ) : (
                               <Volume2 size={13} />
                             )}
-                            <span>Retry Spotify DJ Music Generation</span>
+                            <span>Retry Music DJ: Spotify</span>
                           </button>
                         )}
                         {useYoutubeGameMusic && (
@@ -8241,7 +8241,7 @@ export function GameSurface({
                             ) : (
                               <Volume2 size={13} />
                             )}
-                            <span>Retry YouTube DJ Music</span>
+                            <span>Retry Music DJ: YouTube</span>
                           </button>
                         )}
                         <button
@@ -8455,7 +8455,7 @@ export function GameSurface({
                                   ) : (
                                     <Volume2 size={13} />
                                   )}
-                                  <span>Retry Spotify DJ Music Generation</span>
+                                  <span>Retry Music DJ: Spotify</span>
                                 </button>
                               )}
                               {useYoutubeGameMusic && (
@@ -8469,7 +8469,7 @@ export function GameSurface({
                                   ) : (
                                     <Volume2 size={13} />
                                   )}
-                                  <span>Retry YouTube DJ Music</span>
+                                  <span>Retry Music DJ: YouTube</span>
                                 </button>
                               )}
                               <button

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -45,6 +45,7 @@ import {
 } from "../../hooks/use-game";
 import {
   chatKeys,
+  useBranchChat,
   useCreateMessage,
   useDeleteChat,
   useUpdateChat,
@@ -133,6 +134,16 @@ import {
   normalizeSceneAssetNameForGeneration,
 } from "./game-asset-generation-payload";
 import { ChatGalleryDrawer } from "../chat/ChatGalleryDrawer";
+import { ChatBranchSelector } from "../chat/ChatBranchSelector";
+import { GameAssetsBrowserView } from "../game-assets/GameAssetsBrowserView";
+import { getChatToolbarButtonClass } from "../chat/ChatToolbarControls";
+import {
+  ROLEPLAY_POPOVER_HEADER,
+  ROLEPLAY_POPOVER_SCROLL_AREA,
+  ROLEPLAY_POPOVER_SHELL,
+  ROLEPLAY_POPOVER_SUBTITLE,
+  ROLEPLAY_POPOVER_TITLE,
+} from "../chat/roleplay-popover-styles";
 import type { ReadableTag } from "../../lib/game-tag-parser";
 import type { DirectionCommand, GameNpc } from "@marinara-engine/shared";
 
@@ -163,20 +174,17 @@ type GameAssetGenerationResult = {
   generatedNpcAvatars: Array<{ name: string; avatarUrl: string }>;
 };
 
-const GAME_TOP_ICON_BUTTON =
-  "flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/45 text-white/80 backdrop-blur-md transition-colors hover:bg-black/60 hover:text-white";
-const GAME_MOBILE_ROOT_BUTTON =
-  "flex h-9 w-9 items-center justify-center rounded-full border border-white/15 bg-black/50 text-white/85 backdrop-blur-md transition-colors hover:bg-black/65 hover:text-white";
-const GAME_MOBILE_ICON_BUTTON =
-  "flex h-8 w-8 items-center justify-center rounded-lg text-white/80 transition-colors hover:bg-white/10 hover:text-white";
-const GAME_ACTION_MENU =
-  "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-1 rounded-xl border border-white/15 bg-black/80 p-1.5 shadow-xl backdrop-blur-md";
-const GAME_MOBILE_ACTIONS_MENU =
-  "absolute right-0 top-11 flex w-9 flex-col items-center gap-1 rounded-xl border border-white/15 bg-black/70 p-0.5 shadow-lg backdrop-blur-xl";
-const GAME_MOBILE_ACTION_MENU =
-  "flex w-72 max-w-[calc(100vw-4rem)] flex-col gap-1 rounded-xl border border-white/15 bg-black/85 p-1.5 shadow-xl backdrop-blur-xl";
+const GAME_TOP_ICON_BUTTON = getChatToolbarButtonClass();
+const GAME_MOBILE_ROOT_BUTTON = getChatToolbarButtonClass();
+const GAME_MOBILE_ICON_BUTTON = getChatToolbarButtonClass({ compact: true });
+const GAME_ACTION_MENU = cn(ROLEPLAY_POPOVER_SHELL, "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-1 p-1.5");
+const GAME_MOBILE_ACTIONS_MENU = cn(
+  ROLEPLAY_POPOVER_SHELL,
+  "absolute right-0 top-9 flex w-8 flex-col items-center gap-1 p-0.5",
+);
+const GAME_MOBILE_ACTION_MENU = cn(ROLEPLAY_POPOVER_SHELL, "flex w-72 max-w-[calc(100vw-4rem)] flex-col gap-1 p-1.5");
 const GAME_ACTION_MENU_ITEM =
-  "flex items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-white/85 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent";
+  "marinara-chat-popover__item flex items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-[var(--marinara-chat-chrome-panel-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)] disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent";
 
 type PreparedCombatState = {
   messageId: string;
@@ -1537,9 +1545,9 @@ function renameInventoryItem<T extends { name: string; quantity: number }>(
 import {
   AlertTriangle,
   BookOpen,
+  CircleHelp,
+  Feather,
   Folder,
-  HelpCircle,
-  History,
   Image,
   Loader2,
   MoreHorizontal,
@@ -1597,21 +1605,18 @@ function GameVolumeMixer({
   ];
 
   return (
-    <div
-      className={cn(
-        "w-64 max-w-[calc(100vw-1.5rem)] rounded-xl border border-white/15 bg-black/85 p-3 shadow-xl backdrop-blur-md",
-        className,
-      )}
-    >
-      <div className="mb-2 flex items-center justify-between gap-3 border-b border-white/10 pb-2">
-        <span className="text-[0.6875rem] font-semibold uppercase text-white/60">Volume</span>
+    <div className={cn(ROLEPLAY_POPOVER_SHELL, "w-64 max-w-[calc(100vw-1.5rem)] p-3", className)}>
+      <div className="mb-2 flex items-center justify-between gap-3 border-b border-[var(--marinara-chat-chrome-panel-divider)] pb-2">
+        <span className="text-[0.6875rem] font-semibold uppercase text-[var(--marinara-chat-chrome-panel-muted)]">
+          Volume
+        </span>
         <button
           onClick={onToggleMute}
           className={cn(
-            "flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+            "flex h-7 w-7 items-center justify-center rounded-lg transition-colors",
             audioMuted
               ? "bg-red-500/30 text-red-300 hover:bg-red-500/50"
-              : "bg-white/10 text-white/60 hover:bg-white/20 hover:text-white",
+              : "bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] ring-1 ring-[var(--marinara-chat-chrome-button-border)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
           )}
           title={audioMuted ? "Unmute" : "Mute"}
           aria-label={audioMuted ? "Unmute" : "Mute"}
@@ -1623,7 +1628,7 @@ function GameVolumeMixer({
       <div className="flex flex-col gap-2.5">
         {rows.map((row) => (
           <label key={row.id} className="grid grid-cols-[5.5rem_1fr_2rem] items-center gap-2">
-            <span className="truncate text-[0.6875rem] text-white/70">{row.label}</span>
+            <span className="truncate text-[0.6875rem] text-[var(--foreground)]/75">{row.label}</span>
             <input
               type="range"
               min={0}
@@ -1639,9 +1644,9 @@ function GameVolumeMixer({
                 onAudioInteract?.();
                 row.onChange(Number(e.target.value));
               }}
-              className="h-1.5 w-full cursor-pointer accent-[var(--primary)]"
+              className="h-1.5 w-full cursor-pointer accent-[var(--foreground)]"
             />
-            <span className="text-right text-[0.6875rem] tabular-nums text-white/55">{row.value}</span>
+            <span className="text-right text-[0.6875rem] tabular-nums text-[var(--muted-foreground)]">{row.value}</span>
           </label>
         ))}
       </div>
@@ -1851,17 +1856,21 @@ export function GameSurface({
   const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
   const gameMiddleMouseNav = useUIStore((s) => s.gameMiddleMouseNav);
   const messagesPerPage = useUIStore((s) => s.messagesPerPage);
-  const openGameAssetsBrowser = useUIStore((s) => s.openGameAssetsBrowser);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
+  const musicPlayerSource = useUIStore((s) => s.musicPlayerSource);
   const gameSnapshot = useGameStateStore((s) => (s.current?.chatId === activeChatId ? s.current : null));
   const chatCharacterIds = useMemo(() => getChatCharacterIds(chat.characterIds), [chat.characterIds]);
-  const useSpotifyGameMusic = chatMeta.gameUseSpotifyMusic === true;
-  const useYoutubeGameMusic =
-    Array.isArray(chatMeta.activeAgentIds) && (chatMeta.activeAgentIds as string[]).includes("youtube");
+  const gameMusicDjEnabled =
+    chatMeta.gameUseMusicDj === true ||
+    chatMeta.gameUseSpotifyMusic === true ||
+    (Array.isArray(chatMeta.activeAgentIds) && (chatMeta.activeAgentIds as string[]).includes("youtube"));
+  const useSpotifyGameMusic = gameMusicDjEnabled && musicPlayerSource === "spotify";
+  const useYoutubeGameMusic = gameMusicDjEnabled && musicPlayerSource === "youtube";
   const activeGameMetaId = typeof chatMeta.gameId === "string" ? chatMeta.gameId : "";
   const sceneRuntimeScopeKey = `${activeChatId}:${activeGameMetaId}`;
   const { data: connectionsList } = useConnections();
   const updateChat = useUpdateChat();
+  const branchChat = useBranchChat();
   const languageConnections = useMemo(
     () =>
       filterLanguageGenerationConnections(
@@ -2026,8 +2035,8 @@ export function GameSurface({
     useGameAssetStore.getState().setCurrentMusic(null);
   }, [useSpotifyGameMusic, useYoutubeGameMusic]);
 
-  const [historyOpen, setHistoryOpen] = useState(false);
-  const [journalOpen, setJournalOpen] = useState(false);
+  const [sessionPanelOpen, setSessionPanelOpen] = useState(false);
+  const [sessionPanelTab, setSessionPanelTab] = useState<"history" | "journal">("history");
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [galleryAnchor, setGalleryAnchor] = useState<{ right: number; top: number } | null>(null);
   const [combatLogsOpen, setCombatLogsOpen] = useState(false);
@@ -2275,6 +2284,7 @@ export function GameSurface({
   const [imagePromptReviewSubmitting, setImagePromptReviewSubmitting] = useState(false);
   const imagePromptReviewResolveRef = useRef<((overrides: GameImagePromptOverride[] | null) => void) | null>(null);
   const [volumePopoverOpen, setVolumePopoverOpen] = useState(false);
+  const [gameAssetsPanelOpen, setGameAssetsPanelOpen] = useState(false);
   const [retryMenuOpen, setRetryMenuOpen] = useState(false);
   const [mobileActiveContextOpen, setMobileActiveContextOpen] = useState(false);
   const [persistedGameAudioSettings] = useState(readPersistedGameAudioSettings);
@@ -2292,6 +2302,10 @@ export function GameSurface({
   const volumePopoverRef = useRef<HTMLDivElement>(null);
   const mobileVolumePopoverRef = useRef<HTMLDivElement>(null);
   const retryMenuRef = useRef<HTMLDivElement>(null);
+  const sessionPanelRef = useRef<HTMLDivElement>(null);
+  const mobileSessionPanelRef = useRef<HTMLDivElement>(null);
+  const gameAssetsPanelRef = useRef<HTMLDivElement>(null);
+  const mobileGameAssetsPanelRef = useRef<HTMLDivElement>(null);
   const hudSurfaceRef = useRef<HTMLDivElement>(null);
   const compactHudWidgetsRef = useRef(compactHudWidgets);
   const compactHudReleaseWidthRef = useRef<number | null>(null);
@@ -2319,8 +2333,8 @@ export function GameSurface({
   const narrationAutoPlayBlocked =
     !!activeReadable ||
     !!activeQte ||
-    historyOpen ||
-    journalOpen ||
+    sessionPanelOpen ||
+    gameAssetsPanelOpen ||
     galleryOpen ||
     combatLogsOpen ||
     inventoryOpen ||
@@ -2329,8 +2343,8 @@ export function GameSurface({
     mobileActionsOpen;
   const narrationVoicePlaybackBlocked =
     !!activeReadable ||
-    historyOpen ||
-    journalOpen ||
+    sessionPanelOpen ||
+    gameAssetsPanelOpen ||
     galleryOpen ||
     combatLogsOpen ||
     inventoryOpen ||
@@ -3091,6 +3105,9 @@ export function GameSurface({
       if (!useSpotifyGameMusic || !activeChatId) return [];
       setSpotifyRetryPending(true);
       try {
+        if (chatMeta.gameUseSpotifyMusic !== true) {
+          await api.patch(`/chats/${activeChatId}/metadata`, { gameUseSpotifyMusic: true }).catch(() => undefined);
+        }
         const result = await api.post<GameSpotifyCandidatesResponse>(
           "/game/spotify/candidates",
           {
@@ -3110,7 +3127,7 @@ export function GameSurface({
         setSpotifyRetryPending(false);
       }
     },
-    [activeChatId, useSpotifyGameMusic],
+    [activeChatId, chatMeta.gameUseSpotifyMusic, useSpotifyGameMusic],
   );
 
   const playSpotifySceneTrack = useCallback(
@@ -4724,7 +4741,7 @@ export function GameSurface({
       // Music DJ YouTube mode needs no scene-candidate flow — re-running the agent (with the
       // manualRetry constraint the server injects) emits a fresh play intent that
       // the in-app player swaps in.
-      await retryAgents(activeChatId, ["youtube"]);
+      await retryAgents(activeChatId, ["spotify"]);
       toast.success("Music DJ picking a fresh YouTube track…", { duration: 1800 });
     } catch (error) {
       console.warn("[youtube/game] Retry failed:", error);
@@ -7554,6 +7571,58 @@ export function GameSurface({
     return () => document.removeEventListener("pointerdown", handler);
   }, [retryMenuOpen]);
 
+  useEffect(() => {
+    if (!sessionPanelOpen && !gameAssetsPanelOpen) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const inSessionPanel =
+        (sessionPanelRef.current?.contains(target) ?? false) ||
+        (mobileSessionPanelRef.current?.contains(target) ?? false);
+      const inAssetsPanel =
+        (gameAssetsPanelRef.current?.contains(target) ?? false) ||
+        (mobileGameAssetsPanelRef.current?.contains(target) ?? false);
+      if (sessionPanelOpen && !inSessionPanel) {
+        setSessionPanelOpen(false);
+      }
+      if (gameAssetsPanelOpen && !inAssetsPanel) {
+        setGameAssetsPanelOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handler);
+    return () => document.removeEventListener("pointerdown", handler);
+  }, [gameAssetsPanelOpen, sessionPanelOpen]);
+
+  const handleOpenSessionPanel = useCallback(
+    (tab: "history" | "journal" = "history") => {
+      setSessionPanelTab(tab);
+      setSessionPanelOpen((open) => (tab === sessionPanelTab ? !open : true));
+      setGameAssetsPanelOpen(false);
+      setRetryMenuOpen(false);
+    },
+    [sessionPanelTab],
+  );
+
+  const handleOpenGameAssetsPanel = useCallback(() => {
+    setGameAssetsPanelOpen((open) => !open);
+    setSessionPanelOpen(false);
+    setRetryMenuOpen(false);
+  }, []);
+
+  const handleBranchMessage = useCallback(
+    (messageId: string) => {
+      if (!activeChatId || branchChat.isPending) return;
+      branchChat.mutate(
+        { chatId: activeChatId, upToMessageId: messageId },
+        {
+          onSuccess: (newChat) => {
+            if (newChat) useChatStore.getState().setActiveChatId(newChat.id);
+          },
+        },
+      );
+    },
+    [activeChatId, branchChat],
+  );
+
   // Retry scene analysis for the latest message
   const handleRetryScene = useCallback(() => {
     if (!sceneAnalysisEnabled || !latestAssistantMsg?.content) return;
@@ -7961,7 +8030,7 @@ export function GameSurface({
                   value={chat.connectionId ?? ""}
                   onChange={(e) => handleStartScreenConnectionChange(e.target.value)}
                   disabled={isStreaming || startGame.isPending || updateChat.isPending}
-                  className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-all focus:ring-[var(--primary)]/40 disabled:opacity-60 dark:bg-white/10"
+                  className="w-full rounded-lg bg-zinc-950/80 px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-zinc-700/80 transition-all focus:ring-zinc-400/40 disabled:opacity-60 dark:bg-white/10"
                 >
                   <option value="">None</option>
                   <option value="random">Random</option>
@@ -7990,7 +8059,7 @@ export function GameSurface({
                         // Retry any autoplay-blocked audio now that we have a user gesture
                         audioManager.retryPending();
                       }}
-                      className="group flex items-center gap-2 rounded-xl bg-[var(--primary)] px-6 py-3 text-sm font-semibold text-white transition-all hover:scale-105 hover:shadow-lg hover:shadow-[var(--primary)]/30"
+                      className="group flex items-center gap-2 rounded-lg bg-zinc-900 px-6 py-3 text-sm font-semibold text-zinc-100 ring-1 ring-zinc-700/80 transition-all hover:scale-105 hover:bg-zinc-800 hover:shadow-lg hover:shadow-black/25"
                     >
                       Continue
                     </button>
@@ -8053,7 +8122,7 @@ export function GameSurface({
                     handleStartGameRequest();
                   }}
                   disabled={startGame.isPending || startGameRequested}
-                  className="group flex items-center gap-2 rounded-xl bg-[var(--primary)] px-6 py-3 text-sm font-semibold text-white transition-all hover:scale-105 hover:shadow-lg hover:shadow-[var(--primary)]/30 disabled:opacity-50 disabled:hover:scale-100"
+                  className="group flex items-center gap-2 rounded-lg bg-zinc-900 px-6 py-3 text-sm font-semibold text-zinc-100 ring-1 ring-zinc-700/80 transition-all hover:scale-105 hover:bg-zinc-800 hover:shadow-lg hover:shadow-black/25 disabled:opacity-50 disabled:hover:scale-100"
                 >
                   <Play size={18} className="transition-transform group-hover:scale-110" />
                   Start Game
@@ -8079,6 +8148,162 @@ export function GameSurface({
       </>
     );
   }
+
+  const sessionActionLabel = sessionStatus !== "concluded" ? "End Session" : "New Session";
+  const sessionActionIcon =
+    sessionStatus !== "concluded" ? (
+      <Square size={12} />
+    ) : startSessionLocked ? (
+      <Loader2 size={12} className="animate-spin" />
+    ) : (
+      <Play size={12} />
+    );
+  const sessionActionDisabled = sessionStatus === "concluded" && startSessionLocked;
+  const handleSessionAction = () => {
+    if (sessionStatus !== "concluded") {
+      handleRequestEndSession();
+      return;
+    }
+    handleStartNewSession();
+  };
+
+  const renderSessionPanel = (mobile = false) => (
+    <div
+      className={cn(
+        ROLEPLAY_POPOVER_SHELL,
+        "absolute z-50 flex max-h-[min(42rem,calc(100vh-6rem))] w-[min(42rem,calc(100vw-1.5rem))] flex-col overflow-hidden",
+        mobile ? "right-9 top-0 max-h-[min(40rem,calc(100vh-5rem))] w-[calc(100vw-4rem)]" : "right-0 top-9",
+      )}
+    >
+      <div className={ROLEPLAY_POPOVER_HEADER}>
+        <div>
+          <div className={ROLEPLAY_POPOVER_TITLE}>
+            <Feather size="0.8rem" className="shrink-0 text-[var(--muted-foreground)]" />
+            Session
+          </div>
+          <div className={ROLEPLAY_POPOVER_SUBTITLE}>
+            Session {displaySessionNumber} · {sessionStatus}
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setTutorialOpen(true)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]"
+            title="Game tutorial"
+            aria-label="Game tutorial"
+          >
+            <CircleHelp size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={() => setSessionPanelOpen(false)}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]"
+            title="Close session"
+            aria-label="Close session"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex gap-1 border-b border-[var(--marinara-chat-chrome-panel-divider)] p-2">
+        {(["history", "journal"] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setSessionPanelTab(tab)}
+            className={cn(
+              "flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-[0.6875rem] font-medium transition-colors",
+              sessionPanelTab === tab
+                ? "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-highlight-text)]"
+                : "text-[var(--marinara-chat-chrome-panel-muted)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]",
+            )}
+          >
+            {tab === "history" ? <ScrollText size={12} /> : <BookOpen size={12} />}
+            {tab === "history" ? "Session History" : "Journal"}
+          </button>
+        ))}
+      </div>
+
+      <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "min-h-0 flex-1 overflow-y-auto p-2")}>
+        {sessionPanelTab === "history" ? (
+          <GameSessionHistory
+            summaries={sessionSummaries}
+            currentSessionNumber={displaySessionNumber}
+            currentSessionDate={
+              (chatMeta.gameCurrentSessionStartedAt as string | undefined) || chat.createdAt || chat.updatedAt
+            }
+            currentSecrets={currentSessionSecrets}
+            savingSessionNumber={savingSessionSummary}
+            savingCurrentSecrets={savingCurrentSessionSecrets}
+            regeneratingSessionNumber={
+              regenerateSessionConclusion.isPending
+                ? (regenerateSessionConclusion.variables?.sessionNumber ?? null)
+                : null
+            }
+            lorebookKeeperEnabled={chatMeta.gameLorebookKeeperEnabled === true}
+            lorebookKeeperLastRun={
+              chatMeta.gameLorebookKeeperLastRun &&
+              typeof chatMeta.gameLorebookKeeperLastRun === "object" &&
+              !Array.isArray(chatMeta.gameLorebookKeeperLastRun)
+                ? (chatMeta.gameLorebookKeeperLastRun as {
+                    sessionNumber: number;
+                    status: "running" | "success" | "failed";
+                    updatedAt: string;
+                    entryCount?: number;
+                    error?: string;
+                  })
+                : null
+            }
+            regeneratingLorebookSessionNumber={
+              regenerateSessionLorebook.isPending ? (regenerateSessionLorebook.variables?.sessionNumber ?? null) : null
+            }
+            updatingPlotArcsSessionNumber={
+              updateCampaignProgression.isPending ? (updateCampaignProgression.variables?.sessionNumber ?? null) : null
+            }
+            onSaveCurrentSecrets={handleSaveCurrentSessionSecrets}
+            onSaveSession={handleSaveSessionDetails}
+            onRegenerateSession={handleRegenerateSessionConclusion}
+            onRegenerateLorebook={handleRegenerateSessionLorebook}
+            onUpdatePlotArcs={handleUpdateCampaignProgression}
+            currentSessionActionLabel={sessionActionLabel}
+            currentSessionActionIcon={sessionActionIcon}
+            currentSessionActionDisabled={sessionActionDisabled}
+            onCurrentSessionAction={handleSessionAction}
+            onClose={() => setSessionPanelOpen(false)}
+            embedded
+          />
+        ) : (
+          <GameJournal
+            chatId={activeChatId}
+            npcs={npcs}
+            onClose={() => setSessionPanelOpen(false)}
+            onNpcPortraitClick={handleNpcPortraitClick}
+            onNpcPortraitGenerate={handleNpcPortraitGenerate}
+            npcPortraitGenerationEnabled={
+              chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
+            }
+            generatingNpcPortraitNames={generatingNpcPortraitNames}
+            onNpcRemove={handleRemoveNpcFromJournal}
+            embedded
+          />
+        )}
+      </div>
+    </div>
+  );
+
+  const renderGameAssetsPanel = (mobile = false) => (
+    <div
+      className={cn(
+        ROLEPLAY_POPOVER_SHELL,
+        "absolute z-50 flex h-[min(42rem,calc(100vh-6rem))] w-[min(54rem,calc(100vw-1.5rem))] flex-col overflow-hidden",
+        mobile ? "right-9 top-0 h-[min(40rem,calc(100vh-5rem))] w-[calc(100vw-4rem)]" : "right-0 top-9",
+      )}
+    >
+      <GameAssetsBrowserView embedded onClose={() => setGameAssetsPanelOpen(false)} />
+    </div>
+  );
 
   return (
     <div className="relative flex h-full overflow-hidden bg-black">
@@ -8127,50 +8352,95 @@ export function GameSurface({
               >
                 {/* Desktop controls */}
                 <div className="pointer-events-auto hidden items-center gap-1.5 md:flex">
-                  <button
-                    onClick={() => setTutorialOpen(true)}
-                    className={GAME_TOP_ICON_BUTTON}
-                    title="Game Mode Tutorial"
-                  >
-                    <HelpCircle size={14} />
-                  </button>
-                  <button
-                    onClick={() => setHistoryOpen(true)}
-                    className={GAME_TOP_ICON_BUTTON}
-                    title="History"
-                  >
-                    <History size={14} />
-                  </button>
-                  <ActiveLorebookEntriesButton
-                    chatId={activeChatId}
-                    iconSize={14}
-                    buttonClassName={GAME_TOP_ICON_BUTTON}
+                  <ChatBranchSelector
+                    activeChatId={activeChatId}
+                    activeChatName={chat.name}
+                    groupId={chat.groupId ?? null}
+                    variant="roleplay"
                   />
-                  {sessionStatus !== "concluded" ? (
+                  <div className="relative" ref={retryMenuRef}>
                     <button
-                      onClick={handleRequestEndSession}
+                      onClick={() => setRetryMenuOpen((open) => !open)}
                       className={GAME_TOP_ICON_BUTTON}
-                      title="End Session"
+                      title="Retry..."
+                      aria-label="Retry..."
                     >
-                      <Square size={13} />
+                      <RotateCcw
+                        size={14}
+                        className={sceneAnalysis.isPending || spotifyRetryPending ? "animate-spin" : ""}
+                      />
                     </button>
-                  ) : (
+                    {retryMenuOpen && (
+                      <div className={cn(GAME_ACTION_MENU, "absolute right-0 top-9 z-50")}>
+                        <button
+                          onClick={() => {
+                            void handleRetryTurn();
+                          }}
+                          disabled={!canRetryTurn}
+                          className={GAME_ACTION_MENU_ITEM}
+                        >
+                          <RotateCcw size={13} />
+                          <span>Retry Turn</span>
+                        </button>
+                        <button onClick={handleRetryScene} disabled={!canRetryScene} className={GAME_ACTION_MENU_ITEM}>
+                          <RefreshCw size={13} className={sceneAnalysis.isPending ? "animate-spin" : ""} />
+                          <span>Retry Scene Analysis</span>
+                        </button>
+                        {useSpotifyGameMusic && (
+                          <button
+                            onClick={handleRetrySpotifyMusic}
+                            disabled={!canRetrySpotifyMusic}
+                            className={GAME_ACTION_MENU_ITEM}
+                          >
+                            {spotifyRetryPending ? (
+                              <RefreshCw size={13} className="animate-spin" />
+                            ) : (
+                              <Volume2 size={13} />
+                            )}
+                            <span>Retry Music DJ</span>
+                          </button>
+                        )}
+                        {useYoutubeGameMusic && (
+                          <button
+                            onClick={handleRetryYoutubeMusic}
+                            disabled={!canRetryYoutubeMusic}
+                            className={GAME_ACTION_MENU_ITEM}
+                          >
+                            {youtubeRetryPending ? (
+                              <RefreshCw size={13} className="animate-spin" />
+                            ) : (
+                              <Volume2 size={13} />
+                            )}
+                            <span>Retry Music DJ</span>
+                          </button>
+                        )}
+                        <button
+                          onClick={() => {
+                            setRetryMenuOpen(false);
+                            retryAssetGeneration({ showSuccessToast: true });
+                          }}
+                          disabled={!canRetryAssets}
+                          className={GAME_ACTION_MENU_ITEM}
+                        >
+                          <Image size={13} />
+                          <span>Retry Assets Image Generation</span>
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="relative" ref={sessionPanelRef}>
                     <button
-                      onClick={handleStartNewSession}
-                      disabled={startSessionLocked}
-                      className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-300/25 bg-emerald-500/20 text-emerald-200 backdrop-blur-md transition-colors hover:bg-emerald-500/35 disabled:opacity-50 disabled:hover:bg-emerald-500/20"
-                      title={startSessionLocked ? "Generating next session" : "New Session"}
+                      onClick={() => handleOpenSessionPanel("history")}
+                      className={getChatToolbarButtonClass({
+                        open: sessionPanelOpen,
+                      })}
+                      title="Session"
+                      aria-label="Session"
                     >
-                      {startSessionLocked ? <Loader2 size={13} className="animate-spin" /> : <Play size={13} />}
+                      <Feather size={14} />
                     </button>
-                  )}
-                  <button
-                    onClick={() => setJournalOpen(true)}
-                    className={GAME_TOP_ICON_BUTTON}
-                    title="Journal"
-                  >
-                    <BookOpen size={14} />
-                  </button>
+                    {sessionPanelOpen && renderSessionPanel(false)}
+                  </div>
                   <div className="relative" ref={volumePopoverRef}>
                     <button
                       onClick={() => setVolumePopoverOpen((v) => !v)}
@@ -8181,7 +8451,7 @@ export function GameSurface({
                     </button>
                     {volumePopoverOpen && (
                       <GameVolumeMixer
-                        className="absolute right-0 top-11 z-50"
+                        className="absolute right-0 top-9 z-50"
                         audioMuted={audioMuted || masterVolume === 0}
                         masterVolume={masterVolume}
                         musicVolume={musicVolume}
@@ -8200,99 +8470,28 @@ export function GameSurface({
                       />
                     )}
                   </div>
-                  <button
-                    onClick={handleOpenGalleryPanel}
-                    className={GAME_TOP_ICON_BUTTON}
-                    title="Gallery"
-                  >
+                  <div className="relative" ref={gameAssetsPanelRef}>
+                    <button
+                      onClick={handleOpenGameAssetsPanel}
+                      className={getChatToolbarButtonClass({
+                        open: gameAssetsPanelOpen,
+                      })}
+                      title="Game Assets"
+                      aria-label="Game Assets"
+                    >
+                      <Folder size={14} />
+                    </button>
+                    {gameAssetsPanelOpen && renderGameAssetsPanel(false)}
+                  </div>
+                  <ActiveLorebookEntriesButton
+                    chatId={activeChatId}
+                    iconSize={14}
+                    buttonClassName={GAME_TOP_ICON_BUTTON}
+                  />
+                  <button onClick={handleOpenGalleryPanel} className={GAME_TOP_ICON_BUTTON} title="Gallery">
                     <Image size={14} />
                   </button>
-                  <button
-                    onClick={openGameAssetsBrowser}
-                    className={GAME_TOP_ICON_BUTTON}
-                    title="Game Assets"
-                  >
-                    <Folder size={14} />
-                  </button>
-                  <div className="relative" ref={retryMenuRef}>
-                    <button
-                      onClick={() => setRetryMenuOpen((open) => !open)}
-                      className={GAME_TOP_ICON_BUTTON}
-                      title="Retry..."
-                      aria-label="Retry..."
-                    >
-                      <RotateCcw
-                        size={14}
-                        className={sceneAnalysis.isPending || spotifyRetryPending ? "animate-spin" : ""}
-                      />
-                    </button>
-                    {retryMenuOpen && (
-                      <div className={cn(GAME_ACTION_MENU, "absolute right-0 top-11 z-50")}>
-                        <button
-                          onClick={() => {
-                            void handleRetryTurn();
-                          }}
-                          disabled={!canRetryTurn}
-                          className={GAME_ACTION_MENU_ITEM}
-                        >
-                          <RotateCcw size={13} />
-                          <span>Retry Turn</span>
-                        </button>
-                        <button
-                          onClick={handleRetryScene}
-                          disabled={!canRetryScene}
-                          className={GAME_ACTION_MENU_ITEM}
-                        >
-                          <RefreshCw size={13} className={sceneAnalysis.isPending ? "animate-spin" : ""} />
-                          <span>Retry Scene Analysis</span>
-                        </button>
-                        {useSpotifyGameMusic && (
-                          <button
-                            onClick={handleRetrySpotifyMusic}
-                            disabled={!canRetrySpotifyMusic}
-                            className={GAME_ACTION_MENU_ITEM}
-                          >
-                            {spotifyRetryPending ? (
-                              <RefreshCw size={13} className="animate-spin" />
-                            ) : (
-                              <Volume2 size={13} />
-                            )}
-                            <span>Retry Music DJ: Spotify</span>
-                          </button>
-                        )}
-                        {useYoutubeGameMusic && (
-                          <button
-                            onClick={handleRetryYoutubeMusic}
-                            disabled={!canRetryYoutubeMusic}
-                            className="flex items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-white/85 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent"
-                          >
-                            {youtubeRetryPending ? (
-                              <RefreshCw size={13} className="animate-spin" />
-                            ) : (
-                              <Volume2 size={13} />
-                            )}
-                            <span>Retry Music DJ: YouTube</span>
-                          </button>
-                        )}
-                        <button
-                          onClick={() => {
-                            setRetryMenuOpen(false);
-                            retryAssetGeneration({ showSuccessToast: true });
-                          }}
-                          disabled={!canRetryAssets}
-                          className={GAME_ACTION_MENU_ITEM}
-                        >
-                          <Image size={13} />
-                          <span>Retry Assets Image Generation</span>
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    onClick={onOpenSettings}
-                    className={GAME_TOP_ICON_BUTTON}
-                    title="Chat Settings"
-                  >
+                  <button onClick={onOpenSettings} className={GAME_TOP_ICON_BUTTON} title="Chat Settings">
                     <Settings2 size={14} />
                   </button>
                 </div>
@@ -8317,125 +8516,13 @@ export function GameSurface({
 
                     {mobileActionsOpen && (
                       <div className={GAME_MOBILE_ACTIONS_MENU}>
-                        <button
-                          onClick={() => {
-                            setTutorialOpen(true);
-                            setMobileActionsOpen(false);
-                          }}
-                          className={GAME_MOBILE_ICON_BUTTON}
-                          title="Game Mode Tutorial"
-                        >
-                          <HelpCircle size={14} />
-                        </button>
-                        <button
-                          onClick={() => {
-                            setHistoryOpen(true);
-                            setMobileActionsOpen(false);
-                          }}
-                          className={GAME_MOBILE_ICON_BUTTON}
-                          title="History"
-                        >
-                          <History size={14} />
-                        </button>
-                        <button
-                          onClick={() => {
-                            setMobileActiveContextOpen(true);
-                            setMobileActionsOpen(false);
-                          }}
-                          className={GAME_MOBILE_ICON_BUTTON}
-                          title="Active Context"
-                          aria-label="Active Context"
-                        >
-                          <BookOpen size={14} />
-                        </button>
-                        {sessionStatus !== "concluded" ? (
-                          <button
-                            onClick={() => {
-                              handleRequestEndSession();
-                              setMobileActionsOpen(false);
-                            }}
-                            className={GAME_MOBILE_ICON_BUTTON}
-                            title="End Session"
-                          >
-                            <Square size={13} />
-                          </button>
-                        ) : (
-                          <button
-                            onClick={() => {
-                              handleStartNewSession();
-                              setMobileActionsOpen(false);
-                            }}
-                            disabled={startSessionLocked}
-                            className="flex h-8 w-8 items-center justify-center rounded-lg text-emerald-200 transition-colors hover:bg-emerald-500/20 disabled:opacity-50 disabled:hover:bg-transparent"
-                            title={startSessionLocked ? "Generating next session" : "New Session"}
-                          >
-                            {startSessionLocked ? <Loader2 size={13} className="animate-spin" /> : <Play size={13} />}
-                          </button>
-                        )}
-                        <button
-                          onClick={() => {
-                            setJournalOpen(true);
-                            setMobileActionsOpen(false);
-                          }}
-                          className={GAME_MOBILE_ICON_BUTTON}
-                          title="Journal"
-                        >
-                          <BookOpen size={14} />
-                        </button>
-                        <div className="relative" ref={mobileVolumePopoverRef}>
-                          <button
-                            onClick={() => {
-                              setVolumePopoverOpen((open) => !open);
-                              setMobileRetryMenuOpen(false);
-                            }}
-                            className={GAME_MOBILE_ICON_BUTTON}
-                            title="Volume"
-                          >
-                            {audioMuted || masterVolume === 0 ? <VolumeX size={14} /> : <Volume2 size={14} />}
-                          </button>
-                          {volumePopoverOpen && (
-                            <GameVolumeMixer
-                              className="absolute right-10 top-0 z-50 max-w-[calc(100vw-4.5rem)]"
-                              audioMuted={audioMuted || masterVolume === 0}
-                              masterVolume={masterVolume}
-                              musicVolume={musicVolume}
-                              sfxVolume={sfxVolume}
-                              ttsVolume={ttsVolume}
-                              ambientVolume={ambientVolume}
-                              onMasterVolumeChange={handleMasterVolumeChange}
-                              onMusicVolumeChange={(value) =>
-                                handleChannelVolumeChange("musicVolume", setMusicVolume, value)
-                              }
-                              onSfxVolumeChange={(value) => handleChannelVolumeChange("sfxVolume", setSfxVolume, value)}
-                              onTtsVolumeChange={(value) => handleChannelVolumeChange("ttsVolume", setTtsVolume, value)}
-                              onAmbientVolumeChange={(value) =>
-                                handleChannelVolumeChange("ambientVolume", setAmbientVolume, value)
-                              }
-                              onToggleMute={handleToggleMute}
-                              onAudioInteract={handleAudioInteract}
-                            />
-                          )}
-                        </div>
-                        <button
-                          onClick={(event) => {
-                            handleOpenGalleryPanel(event);
-                            setMobileActionsOpen(false);
-                          }}
-                          className={GAME_MOBILE_ICON_BUTTON}
-                          title="Gallery"
-                        >
-                          <Image size={14} />
-                        </button>
-                        <button
-                          onClick={() => {
-                            openGameAssetsBrowser();
-                            setMobileActionsOpen(false);
-                          }}
-                          className={GAME_MOBILE_ICON_BUTTON}
-                          title="Game Assets"
-                        >
-                          <Folder size={14} />
-                        </button>
+                        <ChatBranchSelector
+                          activeChatId={activeChatId}
+                          activeChatName={chat.name}
+                          groupId={chat.groupId ?? null}
+                          variant="roleplay"
+                          compact
+                        />
                         <div className="relative">
                           <button
                             onClick={() => setMobileRetryMenuOpen((v) => !v)}
@@ -8449,7 +8536,7 @@ export function GameSurface({
                             />
                           </button>
                           {mobileRetryMenuOpen && (
-                            <div className={cn(GAME_MOBILE_ACTION_MENU, "absolute right-10 top-0 z-50")}>
+                            <div className={cn(GAME_MOBILE_ACTION_MENU, "absolute right-9 top-0 z-50")}>
                               <button
                                 onClick={() => {
                                   setMobileRetryMenuOpen(false);
@@ -8485,21 +8572,21 @@ export function GameSurface({
                                   ) : (
                                     <Volume2 size={13} />
                                   )}
-                                  <span>Retry Music DJ: Spotify</span>
+                                  <span>Retry Music DJ</span>
                                 </button>
                               )}
                               {useYoutubeGameMusic && (
                                 <button
                                   onClick={handleRetryYoutubeMusic}
                                   disabled={!canRetryYoutubeMusic}
-                                  className="flex items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-white/85 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent"
+                                  className={GAME_ACTION_MENU_ITEM}
                                 >
                                   {youtubeRetryPending ? (
                                     <RefreshCw size={13} className="animate-spin" />
                                   ) : (
                                     <Volume2 size={13} />
                                   )}
-                                  <span>Retry Music DJ: YouTube</span>
+                                  <span>Retry Music DJ</span>
                                 </button>
                               )}
                               <button
@@ -8517,6 +8604,95 @@ export function GameSurface({
                             </div>
                           )}
                         </div>
+                        <div className="relative" ref={mobileSessionPanelRef}>
+                          <button
+                            onClick={() => {
+                              handleOpenSessionPanel("history");
+                              setMobileRetryMenuOpen(false);
+                            }}
+                            className={getChatToolbarButtonClass({
+                              compact: true,
+                              open: sessionPanelOpen,
+                            })}
+                            title="Session"
+                            aria-label="Session"
+                          >
+                            <Feather size={14} />
+                          </button>
+                          {sessionPanelOpen && renderSessionPanel(true)}
+                        </div>
+                        <div className="relative" ref={mobileVolumePopoverRef}>
+                          <button
+                            onClick={() => {
+                              setVolumePopoverOpen((open) => !open);
+                              setMobileRetryMenuOpen(false);
+                            }}
+                            className={GAME_MOBILE_ICON_BUTTON}
+                            title="Volume"
+                          >
+                            {audioMuted || masterVolume === 0 ? <VolumeX size={14} /> : <Volume2 size={14} />}
+                          </button>
+                          {volumePopoverOpen && (
+                            <GameVolumeMixer
+                              className="absolute right-9 top-0 z-50 max-w-[calc(100vw-4rem)]"
+                              audioMuted={audioMuted || masterVolume === 0}
+                              masterVolume={masterVolume}
+                              musicVolume={musicVolume}
+                              sfxVolume={sfxVolume}
+                              ttsVolume={ttsVolume}
+                              ambientVolume={ambientVolume}
+                              onMasterVolumeChange={handleMasterVolumeChange}
+                              onMusicVolumeChange={(value) =>
+                                handleChannelVolumeChange("musicVolume", setMusicVolume, value)
+                              }
+                              onSfxVolumeChange={(value) => handleChannelVolumeChange("sfxVolume", setSfxVolume, value)}
+                              onTtsVolumeChange={(value) => handleChannelVolumeChange("ttsVolume", setTtsVolume, value)}
+                              onAmbientVolumeChange={(value) =>
+                                handleChannelVolumeChange("ambientVolume", setAmbientVolume, value)
+                              }
+                              onToggleMute={handleToggleMute}
+                              onAudioInteract={handleAudioInteract}
+                            />
+                          )}
+                        </div>
+                        <div className="relative" ref={mobileGameAssetsPanelRef}>
+                          <button
+                            onClick={() => {
+                              handleOpenGameAssetsPanel();
+                              setMobileRetryMenuOpen(false);
+                            }}
+                            className={getChatToolbarButtonClass({
+                              compact: true,
+                              open: gameAssetsPanelOpen,
+                            })}
+                            title="Game Assets"
+                            aria-label="Game Assets"
+                          >
+                            <Folder size={14} />
+                          </button>
+                          {gameAssetsPanelOpen && renderGameAssetsPanel(true)}
+                        </div>
+                        <button
+                          onClick={() => {
+                            setMobileActiveContextOpen(true);
+                            setMobileActionsOpen(false);
+                          }}
+                          className={GAME_MOBILE_ICON_BUTTON}
+                          title="Active Context"
+                          aria-label="Active Context"
+                        >
+                          <BookOpen size={14} />
+                        </button>
+                        <button
+                          onClick={(event) => {
+                            handleOpenGalleryPanel(event);
+                            setMobileActionsOpen(false);
+                          }}
+                          className={GAME_MOBILE_ICON_BUTTON}
+                          title="Gallery"
+                        >
+                          <Image size={14} />
+                        </button>
                         <button
                           onClick={(event) => {
                             onOpenSettings(event);
@@ -8846,6 +9022,7 @@ export function GameSurface({
                           combatGenerationFailed={combatGenerationFailedAtGate}
                           onRetryCombatGeneration={retryCombatGeneration}
                           onDeleteMessage={onDeleteMessage}
+                          onBranchMessage={handleBranchMessage}
                           multiSelectMode={multiSelectMode}
                           selectedMessageIds={selectedMessageIds}
                           onDeleteSegment={handleDeleteSegment}
@@ -8930,6 +9107,7 @@ export function GameSurface({
                       combatGenerationFailed={combatGenerationFailedAtGate}
                       onRetryCombatGeneration={retryCombatGeneration}
                       onDeleteMessage={onDeleteMessage}
+                      onBranchMessage={handleBranchMessage}
                       multiSelectMode={multiSelectMode}
                       selectedMessageIds={selectedMessageIds}
                       onDeleteSegment={handleDeleteSegment}
@@ -8979,55 +9157,6 @@ export function GameSurface({
                   </div>
                 )}
 
-                {/* Session history panel (full overlay) */}
-                {historyOpen && (
-                  <GameSessionHistory
-                    summaries={sessionSummaries}
-                    currentSessionNumber={displaySessionNumber}
-                    currentSessionDate={
-                      (chatMeta.gameCurrentSessionStartedAt as string | undefined) || chat.createdAt || chat.updatedAt
-                    }
-                    currentSecrets={currentSessionSecrets}
-                    savingSessionNumber={savingSessionSummary}
-                    savingCurrentSecrets={savingCurrentSessionSecrets}
-                    regeneratingSessionNumber={
-                      regenerateSessionConclusion.isPending
-                        ? (regenerateSessionConclusion.variables?.sessionNumber ?? null)
-                        : null
-                    }
-                    lorebookKeeperEnabled={chatMeta.gameLorebookKeeperEnabled === true}
-                    lorebookKeeperLastRun={
-                      chatMeta.gameLorebookKeeperLastRun &&
-                      typeof chatMeta.gameLorebookKeeperLastRun === "object" &&
-                      !Array.isArray(chatMeta.gameLorebookKeeperLastRun)
-                        ? (chatMeta.gameLorebookKeeperLastRun as {
-                            sessionNumber: number;
-                            status: "running" | "success" | "failed";
-                            updatedAt: string;
-                            entryCount?: number;
-                            error?: string;
-                          })
-                        : null
-                    }
-                    regeneratingLorebookSessionNumber={
-                      regenerateSessionLorebook.isPending
-                        ? (regenerateSessionLorebook.variables?.sessionNumber ?? null)
-                        : null
-                    }
-                    updatingPlotArcsSessionNumber={
-                      updateCampaignProgression.isPending
-                        ? (updateCampaignProgression.variables?.sessionNumber ?? null)
-                        : null
-                    }
-                    onSaveCurrentSecrets={handleSaveCurrentSessionSecrets}
-                    onSaveSession={handleSaveSessionDetails}
-                    onRegenerateSession={handleRegenerateSessionConclusion}
-                    onRegenerateLorebook={handleRegenerateSessionLorebook}
-                    onUpdatePlotArcs={handleUpdateCampaignProgression}
-                    onClose={() => setHistoryOpen(false)}
-                  />
-                )}
-
                 {combatLogsOpen && (
                   <div
                     className="absolute inset-0 z-40 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
@@ -9045,7 +9174,7 @@ export function GameSurface({
                         <button
                           type="button"
                           onClick={() => setCombatLogsOpen(false)}
-                          className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                          className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-800/80 hover:text-[var(--foreground)]"
                           title="Close logs"
                         >
                           <X size={16} />
@@ -9108,22 +9237,6 @@ export function GameSurface({
                   </div>
                 )}
               </div>
-
-              {/* Journal overlay — positioned on the outer column so it covers state indicator + content */}
-              {journalOpen && (
-                <GameJournal
-                  chatId={activeChatId}
-                  npcs={npcs}
-                  onClose={() => setJournalOpen(false)}
-                  onNpcPortraitClick={handleNpcPortraitClick}
-                  onNpcPortraitGenerate={handleNpcPortraitGenerate}
-                  npcPortraitGenerationEnabled={
-                    chatMeta.enableSpriteGeneration === true && typeof chatMeta.gameImageConnectionId === "string"
-                  }
-                  generatingNpcPortraitNames={generatingNpcPortraitNames}
-                  onNpcRemove={handleRemoveNpcFromJournal}
-                />
-              )}
 
               <input
                 ref={npcPortraitUploadInputRef}
@@ -9261,7 +9374,7 @@ export function GameSurface({
           <div className="flex flex-wrap items-center justify-end gap-2">
             <button
               onClick={closeInterruptModal}
-              className="rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              className="rounded-lg bg-zinc-950/80 px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800/80 hover:text-[var(--foreground)]"
             >
               No
             </button>
@@ -9324,7 +9437,7 @@ export function GameSurface({
                 rows={4}
                 maxLength={5000}
                 placeholder="Leave empty to let the GM steer naturally."
-                className="resize-none rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/70 focus:border-[var(--primary)]"
+                className="resize-none rounded-lg border border-zinc-700/80 bg-zinc-950/80 px-3 py-2 text-sm leading-relaxed text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/70 focus:border-zinc-400/60"
               />
             </label>
           )}
@@ -9333,7 +9446,7 @@ export function GameSurface({
             <button
               onClick={handleCloseEndSessionDialog}
               disabled={concludeSession.isPending}
-              className="rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-lg bg-zinc-950/80 px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800/80 hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               Cancel
             </button>

--- a/packages/client/src/components/game/GameTutorial.tsx
+++ b/packages/client/src/components/game/GameTutorial.tsx
@@ -59,6 +59,7 @@ interface Rect {
 }
 
 const PAD = 8;
+const TOPBAR_SAFE_TOP = 64;
 
 function getTargetRect(target: string): Rect | null {
   // Pick the first visible element matching the selector. This handles cases
@@ -79,13 +80,14 @@ function computeTooltipStyle(rect: Rect, side: "top" | "bottom" | "left" | "righ
   const vh = window.innerHeight;
   const isMobile = vw < 640;
   const VIEWPORT_MARGIN = isMobile ? 12 : 16;
+  const SAFE_TOP = Math.max(VIEWPORT_MARGIN, TOPBAR_SAFE_TOP);
   const TOOLTIP_W = isMobile ? Math.min(vw - VIEWPORT_MARGIN * 2, 340) : Math.min(340, vw - VIEWPORT_MARGIN * 2);
   const GAP = isMobile ? 12 : 16;
   const available = {
     right: vw - (rect.left + rect.width + GAP + PAD) - VIEWPORT_MARGIN,
     left: rect.left - GAP - PAD - VIEWPORT_MARGIN,
     bottom: vh - (rect.top + rect.height + GAP + PAD) - VIEWPORT_MARGIN,
-    top: rect.top - GAP - PAD - VIEWPORT_MARGIN,
+    top: rect.top - GAP - PAD - SAFE_TOP,
   };
 
   if (isMobile) {
@@ -97,10 +99,11 @@ function computeTooltipStyle(rect: Rect, side: "top" | "bottom" | "left" | "righ
     const MARGIN = 12;
     if (placeAtBottom) {
       const top = rect.top + rect.height + GAP + PAD;
-      const maxHeight = vh - top - MARGIN;
+      const safeTop = Math.max(top, SAFE_TOP);
+      const maxHeight = vh - safeTop - MARGIN;
       return {
         position: "fixed",
-        top,
+        top: safeTop,
         left: (vw - TOOLTIP_W) / 2,
         width: TOOLTIP_W,
         maxHeight: `${Math.max(200, maxHeight)}px`,
@@ -111,10 +114,10 @@ function computeTooltipStyle(rect: Rect, side: "top" | "bottom" | "left" | "righ
     }
     // Target is in the lower half (e.g. the dialogue box) → anchor card at top
     const bottomLimit = rect.top - GAP - PAD;
-    const maxHeight = Math.max(200, bottomLimit - MARGIN);
+    const maxHeight = Math.max(200, bottomLimit - SAFE_TOP);
     return {
       position: "fixed",
-      top: MARGIN,
+      top: SAFE_TOP,
       left: (vw - TOOLTIP_W) / 2,
       width: TOOLTIP_W,
       maxHeight: `${maxHeight}px`,
@@ -152,25 +155,25 @@ function computeTooltipStyle(rect: Rect, side: "top" | "bottom" | "left" | "righ
   let left = 0;
 
   if (placement === "right") {
-    maxHeight = Math.max(minScrollableHeight, vh - VIEWPORT_MARGIN * 2);
+    maxHeight = Math.max(minScrollableHeight, vh - SAFE_TOP - VIEWPORT_MARGIN);
     top = rect.top + rect.height / 2 - maxHeight / 2;
     left = rect.left + rect.width + GAP + PAD;
     if (left + TOOLTIP_W > vw - VIEWPORT_MARGIN) {
       left = rect.left - TOOLTIP_W - GAP - PAD;
     }
   } else if (placement === "left") {
-    maxHeight = Math.max(minScrollableHeight, vh - VIEWPORT_MARGIN * 2);
+    maxHeight = Math.max(minScrollableHeight, vh - SAFE_TOP - VIEWPORT_MARGIN);
     top = rect.top + rect.height / 2 - maxHeight / 2;
     left = rect.left - TOOLTIP_W - GAP - PAD;
     if (left < VIEWPORT_MARGIN) {
       left = rect.left + rect.width + GAP + PAD;
     }
   } else if (placement === "bottom") {
-    maxHeight = Math.max(minScrollableHeight, Math.min(vh - VIEWPORT_MARGIN * 2, available.bottom));
+    maxHeight = Math.max(minScrollableHeight, Math.min(vh - SAFE_TOP - VIEWPORT_MARGIN, available.bottom));
     top = rect.top + rect.height + GAP + PAD;
     left = rect.left + rect.width / 2 - TOOLTIP_W / 2;
   } else {
-    maxHeight = Math.max(minScrollableHeight, Math.min(vh - VIEWPORT_MARGIN * 2, available.top));
+    maxHeight = Math.max(minScrollableHeight, Math.min(vh - SAFE_TOP - VIEWPORT_MARGIN, available.top));
     top = rect.top - GAP - PAD - maxHeight;
     left = rect.left + rect.width / 2 - TOOLTIP_W / 2;
     if (top < VIEWPORT_MARGIN) {
@@ -179,7 +182,7 @@ function computeTooltipStyle(rect: Rect, side: "top" | "bottom" | "left" | "righ
   }
 
   left = Math.max(VIEWPORT_MARGIN, Math.min(left, vw - TOOLTIP_W - VIEWPORT_MARGIN));
-  top = Math.max(VIEWPORT_MARGIN, Math.min(top, vh - maxHeight - VIEWPORT_MARGIN));
+  top = Math.max(SAFE_TOP, Math.min(top, vh - maxHeight - VIEWPORT_MARGIN));
 
   return {
     position: "fixed",
@@ -368,7 +371,10 @@ export function GameTutorial({ open, onClose }: GameTutorialProps) {
       ) : (
         // Fallback: target not yet measurable — show a centered card so the tour
         // still works even if a region is momentarily hidden.
-        <div className="pointer-events-none fixed inset-0 flex items-center justify-center">
+        <div
+          className="pointer-events-none fixed inset-x-0 bottom-0 flex items-center justify-center"
+          style={{ top: TOPBAR_SAFE_TOP }}
+        >
           <AnimatePresence mode="wait">
             <motion.div
               key={step}

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -309,21 +309,17 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
       <div className={cn("pointer-events-auto flex flex-col gap-1.5", position === "hud_right" && "items-end")}>
         {filtered.map((w) => {
           const isExpanded = expandedId === w.id;
-          const accent = w.accent ?? "#a78bfa";
 
           if (isExpanded) {
             return (
               <div
                 key={w.id}
-                className="w-40 overflow-hidden rounded-lg border bg-black/70 backdrop-blur-md transition-all"
-                style={{ borderColor: `${accent}30` }}
+                className="w-40 overflow-hidden rounded-lg border border-white/15 bg-black/70 backdrop-blur-md transition-all"
                 data-game-skip-bg-nav="true"
               >
                 <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-left">
                   {w.icon && <span className="text-xs">{w.icon}</span>}
-                  <span className="flex-1 truncate text-[0.6875rem] font-semibold" style={{ color: accent }}>
-                    {w.label}
-                  </span>
+                  <span className="flex-1 truncate text-[0.6875rem] font-semibold text-white/90">{w.label}</span>
                   <button
                     type="button"
                     onClick={() => openEditor(w)}
@@ -341,7 +337,7 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
                     ×
                   </button>
                 </div>
-                <div className="border-t px-2.5 py-2" style={{ borderColor: `${accent}15` }}>
+                <div className="border-t border-white/10 px-2.5 py-2">
                   <WidgetBody widget={w} />
                 </div>
               </div>
@@ -352,8 +348,7 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
             <button
               key={w.id}
               onClick={() => setExpandedId(w.id)}
-              className="flex h-9 w-9 items-center justify-center rounded-xl border bg-black/60 text-base backdrop-blur-md transition-transform active:scale-95"
-              style={{ borderColor: `${accent}30` }}
+              className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/15 bg-black/60 text-base backdrop-blur-md transition-transform active:scale-95"
               title={w.label}
             >
               {w.icon || "📊"}
@@ -386,7 +381,6 @@ function WidgetCard({
   onEdit: (widget: HudWidget) => void;
 }) {
   const [collapsed, setCollapsed] = useState(false);
-  const accent = widget.accent ?? "#a78bfa";
   const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel(chatId, `widget:${widget.id}`);
 
   return (
@@ -396,10 +390,10 @@ function WidgetCard({
       dragElastic={0}
       dragConstraints={constraintsRef as RefObject<Element>}
       onDragEnd={handleDragEnd}
-      style={{ x, y, borderColor: `${accent}30` }}
+      style={{ x, y }}
       data-game-skip-bg-nav="true"
       className={cn(
-        "w-full overflow-hidden rounded-lg border bg-black/60 backdrop-blur-md transition-colors",
+        "w-full overflow-hidden rounded-lg border border-white/15 bg-black/60 backdrop-blur-md transition-colors",
         !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
       )}
     >
@@ -417,10 +411,7 @@ function WidgetCard({
         className="flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-white/5"
       >
         {widget.icon && <span className="text-xs">{widget.icon}</span>}
-        <span
-          className="flex-1 overflow-x-auto scrollbar-hide whitespace-nowrap text-[0.6875rem] font-semibold"
-          style={{ color: accent }}
-        >
+        <span className="flex-1 overflow-x-auto scrollbar-hide whitespace-nowrap text-[0.6875rem] font-semibold text-white/90">
           {widget.label}
         </span>
         <button
@@ -440,7 +431,7 @@ function WidgetCard({
 
       {/* Body */}
       {!collapsed && (
-        <div className="border-t px-2.5 py-2" style={{ borderColor: `${accent}15` }}>
+        <div className="border-t border-white/10 px-2.5 py-2">
           <WidgetBody widget={widget} />
         </div>
       )}

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@
 import { ChatSidebar } from "./ChatSidebar";
 import { TopBar } from "./TopBar";
 import { SpotifyMobileWidget } from "../spotify/SpotifyMiniPlayer";
+import { YouTubeMobileWidget } from "../chat/YouTubePlayer";
 import { ChatNotificationBubbles } from "../chat/ChatNotificationBubbles";
 import {
   getTrackerPanelWidthForProfile,
@@ -897,6 +898,7 @@ export function AppShell() {
         </Suspense>
       )}
       <SpotifyMobileWidget />
+      <YouTubeMobileWidget />
     </div>
   );
 }

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -91,6 +91,12 @@ const TRACKER_PANEL_TOGGLE_SELECTOR = '[data-tracker-panel-toggle="roleplay-hud"
 const TRACKER_PANEL_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
 const TOP_BAR_SELECTOR = '[data-component="TopBar"]';
 
+function readVisibleElementRect(element: HTMLElement) {
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0 || window.getComputedStyle(element).display === "none") return null;
+  return rect;
+}
+
 function MainPaneFallback() {
   return (
     <div className="flex flex-1 items-center justify-center text-sm text-[var(--muted-foreground)]">Loading...</div>
@@ -469,8 +475,8 @@ export function AppShell() {
       root?.querySelector<HTMLElement>(TRACKER_PANEL_TOGGLE_SELECTOR) ??
       document.querySelector<HTMLElement>(TRACKER_PANEL_TOGGLE_SELECTOR);
     if (!toggle) return;
-    const rect = toggle.getBoundingClientRect();
-    if (rect.width <= 0 || rect.height <= 0 || window.getComputedStyle(toggle).display === "none") return;
+    const rect = readVisibleElementRect(toggle);
+    if (!rect) return;
 
     const nextCenterY = rect.top + rect.height / 2;
     setTrackerPanelToggleAnchorY((current) =>
@@ -479,30 +485,21 @@ export function AppShell() {
   }, []);
   const updateTrackerPanelTop = useCallback(() => {
     const root = mainRef.current;
-    if (trackerPanelDockToEdge) {
-      const topBar =
-        root?.querySelector<HTMLElement>(TOP_BAR_SELECTOR) ?? document.querySelector<HTMLElement>(TOP_BAR_SELECTOR);
-      const rect = topBar?.getBoundingClientRect();
-      const nextTop =
-        rect && rect.height > 0
-          ? Math.max(TRACKER_PANEL_EDGE_OFFSET, Math.ceil(rect.bottom))
-          : TRACKER_PANEL_EDGE_OFFSET;
-      setTrackerPanelTop((current) => (current === nextTop ? current : nextTop));
-      return;
-    }
-    const anchors = Array.from((root ?? document).querySelectorAll<HTMLElement>(TRACKER_PANEL_ANCHOR_SELECTOR));
-    const visibleAnchor = anchors.find((anchor) => {
-      const rect = anchor.getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0 && window.getComputedStyle(anchor).display !== "none";
+    const topCandidates = [TRACKER_PANEL_EDGE_OFFSET];
+    const topBar =
+      root?.querySelector<HTMLElement>(TOP_BAR_SELECTOR) ?? document.querySelector<HTMLElement>(TOP_BAR_SELECTOR);
+    const topBarRect = topBar ? readVisibleElementRect(topBar) : null;
+    if (topBarRect) topCandidates.push(Math.ceil(topBarRect.bottom + TRACKER_PANEL_HUD_GAP));
+
+    const anchors = Array.from(document.querySelectorAll<HTMLElement>(TRACKER_PANEL_ANCHOR_SELECTOR));
+    anchors.forEach((anchor) => {
+      const rect = readVisibleElementRect(anchor);
+      if (rect) topCandidates.push(Math.ceil(rect.bottom + TRACKER_PANEL_HUD_GAP));
     });
-    const nextTop = visibleAnchor
-      ? Math.max(
-          TRACKER_PANEL_EDGE_OFFSET,
-          Math.ceil(visibleAnchor.getBoundingClientRect().bottom + TRACKER_PANEL_HUD_GAP),
-        )
-      : TRACKER_PANEL_EDGE_OFFSET;
+
+    const nextTop = Math.max(...topCandidates);
     setTrackerPanelTop((current) => (current === nextTop ? current : nextTop));
-  }, [trackerPanelDockToEdge]);
+  }, []);
 
   useLayoutEffect(() => {
     if (isMobile || trackerPanelVisible || !trackerPanelSurfaceAvailable) return;
@@ -574,14 +571,15 @@ export function AppShell() {
       scheduleUpdate();
     });
     const observeTargets = () => {
-      const selector = trackerPanelDockToEdge ? TOP_BAR_SELECTOR : TRACKER_PANEL_ANCHOR_SELECTOR;
-      const targets = Array.from((mainRef.current ?? document).querySelectorAll<HTMLElement>(selector));
+      const topBarTargets = Array.from(document.querySelectorAll<HTMLElement>(TOP_BAR_SELECTOR));
+      const anchorTargets = Array.from(document.querySelectorAll<HTMLElement>(TRACKER_PANEL_ANCHOR_SELECTOR));
+      const targets = [...topBarTargets, ...anchorTargets];
       targets.forEach((target) => {
         if (observedTargets.has(target)) return;
         observer.observe(target);
         observedTargets.add(target);
       });
-      return targets.length > 0;
+      return anchorTargets.length > 0;
     };
     function scheduleUpdate() {
       if (frame) window.cancelAnimationFrame(frame);

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -172,7 +172,11 @@ export function AppShell() {
   const [rightPanelDragWidth, setRightPanelDragWidth] = useState<number | null>(null);
   const sidebarDragWidthRef = useRef<number | null>(null);
   const rightPanelDragWidthRef = useRef<number | null>(null);
-  const sharedSidebarWidth = clampWidth(rightPanelWidth || sidebarWidth, SHARED_SIDEBAR_WIDTH_MIN, SHARED_SIDEBAR_WIDTH_MAX);
+  const sharedSidebarWidth = clampWidth(
+    rightPanelWidth || sidebarWidth,
+    SHARED_SIDEBAR_WIDTH_MIN,
+    SHARED_SIDEBAR_WIDTH_MAX,
+  );
   const liveSidebarWidth = sidebarDragWidth ?? rightPanelDragWidth ?? sharedSidebarWidth;
   const liveRightPanelWidth = rightPanelDragWidth ?? sidebarDragWidth ?? sharedSidebarWidth;
   const trackerPanelWidth = getTrackerPanelWidthForProfile(trackerPanelSizeProfile);
@@ -446,12 +450,15 @@ export function AppShell() {
 
   const showAmbientDecor = isPageActive && !activeChatId && !detailView && !botBrowserOpen && !gameAssetsBrowserOpen;
   const hasDetailView = detailView != null;
-  const trackerPanelModeAvailable =
-    activeChat?.mode === "roleplay" || activeChat?.mode === "visual_novel" || activeChat?.mode === "game";
+  const trackerPanelModeAvailable = activeChat?.mode === "roleplay" || activeChat?.mode === "visual_novel";
   const trackerPanelActive = trackerPanelEnabled && trackerPanelOpen;
   const trackerPanelSurfaceAvailable =
     trackerPanelModeAvailable && !botBrowserOpen && !gameAssetsBrowserOpen && !hasDetailView;
   const trackerPanelVisible = trackerPanelActive && trackerPanelSurfaceAvailable;
+  useEffect(() => {
+    if (!trackerPanelOpen || !activeChat?.mode || trackerPanelModeAvailable) return;
+    setTrackerPanelOpen(false);
+  }, [activeChat?.mode, setTrackerPanelOpen, trackerPanelModeAvailable, trackerPanelOpen]);
   useEffect(() => {
     if (trackerPanelVisible) {
       trackerPanelWasActiveRef.current = true;

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -24,7 +24,7 @@ import {
   ArrowUpDown,
   Tag,
   Pencil,
-  Download,
+  Upload,
 } from "lucide-react";
 import { useBulkExportChats, useChats, useCreateChat, useDeleteChat, useDeleteChatGroup } from "../../hooks/use-chats";
 import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
@@ -576,9 +576,18 @@ export function ChatSidebar() {
     [reorderFoldersMut],
   );
 
-  const handleDropChatToFolder = useCallback(
-    (chatId: string, folderId: string | null) => {
-      moveChatMut.mutate({ chatId, folderId });
+  const getDragChatIds = useCallback(
+    (chatId: string) =>
+      multiSelectMode && selectedChatIds.has(chatId) ? Array.from(selectedChatIds) : [chatId],
+    [multiSelectMode, selectedChatIds],
+  );
+
+  const handleDropChatsToFolder = useCallback(
+    (chatIds: string[], folderId: string | null) => {
+      const uniqueIds = Array.from(new Set(chatIds.filter(Boolean)));
+      for (const chatId of uniqueIds) {
+        moveChatMut.mutate({ chatId, folderId });
+      }
       setDraggedChatId(null);
       setIsRootDropTarget(false);
     },
@@ -587,7 +596,7 @@ export function ChatSidebar() {
 
   const startTouchDrag = useCallback(
     (chatId: string, event: React.PointerEvent<HTMLDivElement>) => {
-      if (event.pointerType === "mouse" || multiSelectMode) return;
+      if (event.pointerType === "mouse") return;
       const drag = {
         chatId,
         timer: null as number | null,
@@ -602,7 +611,7 @@ export function ChatSidebar() {
       touchDragRef.current = drag;
       event.currentTarget.setPointerCapture(event.pointerId);
     },
-    [multiSelectMode],
+    [],
   );
 
   const updateTouchDrag = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
@@ -628,9 +637,9 @@ export function ChatSidebar() {
         const rootEl = target?.closest<HTMLElement>("[data-chat-root-drop-zone]");
         const folderId = folderEl?.dataset.chatFolderId ?? null;
         if (folderId) {
-          handleDropChatToFolder(drag.chatId, folderId);
+          handleDropChatsToFolder(getDragChatIds(drag.chatId), folderId);
         } else if (rootEl) {
-          handleDropChatToFolder(drag.chatId, null);
+          handleDropChatsToFolder(getDragChatIds(drag.chatId), null);
         }
         setDraggedChatId(null);
         setIsRootDropTarget(false);
@@ -638,7 +647,7 @@ export function ChatSidebar() {
         event.preventDefault();
       }
     },
-    [handleDropChatToFolder],
+    [getDragChatIds, handleDropChatsToFolder],
   );
 
   // ── Batch actions ──
@@ -692,14 +701,12 @@ export function ChatSidebar() {
         tabIndex={0}
         key={chat.groupId ?? chat.id}
         data-chat-id={chat.id}
-        draggable={!multiSelectMode}
+        draggable
         onDragStart={(event) => {
-          if (multiSelectMode) {
-            event.preventDefault();
-            return;
-          }
+          const chatIds = getDragChatIds(chat.id);
           setDraggedChatId(chat.id);
           event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData("application/x-marinara-chat-ids", JSON.stringify(chatIds));
           event.dataTransfer.setData("application/x-marinara-chat-id", chat.id);
           event.dataTransfer.setData("text/plain", chat.id);
         }}
@@ -1127,7 +1134,9 @@ export function ChatSidebar() {
             event.dataTransfer.getData("application/x-marinara-chat-id") ||
             event.dataTransfer.getData("text/plain") ||
             draggedChatId;
-          if (chatId) handleDropChatToFolder(chatId, null);
+          const chatIdsPayload = event.dataTransfer.getData("application/x-marinara-chat-ids");
+          const chatIds = chatIdsPayload ? (JSON.parse(chatIdsPayload) as string[]) : [chatId];
+          if (chatIds.length > 0) handleDropChatsToFolder(chatIds, null);
           setIsRootDropTarget(false);
         }}
       >
@@ -1238,7 +1247,7 @@ export function ChatSidebar() {
                     onRename={handleRenameFolder}
                     onDelete={handleDeleteFolder}
                     draggedChatId={draggedChatId}
-                    onDropChat={handleDropChatToFolder}
+                    onDropChat={handleDropChatsToFolder}
                   />
                 );
               })}
@@ -1262,7 +1271,7 @@ export function ChatSidebar() {
               disabled={selectedChatIds.size === 0 || bulkExportChats.isPending}
               className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium transition-all hover:bg-[var(--accent)] disabled:opacity-40"
             >
-              <Download size="0.75rem" />
+              <Upload size="0.75rem" />
               Export
             </button>
             <button
@@ -1341,7 +1350,7 @@ export function ChatSidebar() {
             disabled={bulkExportChats.isPending}
             className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all hover:bg-[var(--accent)] disabled:opacity-40"
           >
-            <Download size="0.75rem" className="text-[var(--muted-foreground)]" />
+            <Upload size="0.75rem" className="text-[var(--muted-foreground)]" />
             JSONL zip
           </button>
           <button
@@ -1350,7 +1359,7 @@ export function ChatSidebar() {
             disabled={bulkExportChats.isPending}
             className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all hover:bg-[var(--accent)] disabled:opacity-40"
           >
-            <Download size="0.75rem" className="text-[var(--muted-foreground)]" />
+            <Upload size="0.75rem" className="text-[var(--muted-foreground)]" />
             Text zip
           </button>
           <p className="px-1 pt-2 text-[0.625rem] font-medium uppercase tracking-wide text-[var(--muted-foreground)]/60">
@@ -1362,7 +1371,7 @@ export function ChatSidebar() {
             disabled={bulkExportChats.isPending}
             className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all hover:bg-[var(--accent)] disabled:opacity-40"
           >
-            <Download size="0.75rem" className="text-[var(--muted-foreground)]" />
+            <Upload size="0.75rem" className="text-[var(--muted-foreground)]" />
             All chats as JSONL zip
           </button>
           <button
@@ -1371,7 +1380,7 @@ export function ChatSidebar() {
             disabled={bulkExportChats.isPending}
             className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all hover:bg-[var(--accent)] disabled:opacity-40"
           >
-            <Download size="0.75rem" className="text-[var(--muted-foreground)]" />
+            <Upload size="0.75rem" className="text-[var(--muted-foreground)]" />
             All chats as text zip
           </button>
         </div>
@@ -1398,7 +1407,7 @@ function FolderRow({
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
   draggedChatId: string | null;
-  onDropChat: (chatId: string, folderId: string | null) => void;
+  onDropChat: (chatIds: string[], folderId: string | null) => void;
 }) {
   const dragControls = useDragControls();
   const [renaming, setRenaming] = useState(false);
@@ -1435,7 +1444,9 @@ function FolderRow({
           event.dataTransfer.getData("application/x-marinara-chat-id") ||
           event.dataTransfer.getData("text/plain") ||
           draggedChatId;
-        if (chatId) onDropChat(chatId, folder.id);
+        const chatIdsPayload = event.dataTransfer.getData("application/x-marinara-chat-ids");
+        const chatIds = chatIdsPayload ? (JSON.parse(chatIdsPayload) as string[]) : [chatId];
+        if (chatIds.length > 0) onDropChat(chatIds, folder.id);
         setIsDropTarget(false);
       }}
       className={cn(

--- a/packages/client/src/components/music/MusicSourceButton.tsx
+++ b/packages/client/src/components/music/MusicSourceButton.tsx
@@ -20,8 +20,22 @@ function YouTubeGlyph({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
       <rect x="3" y="6.5" width="18" height="11" rx="3" fill="currentColor" />
-      <path d="M10.5 9.4v5.2l4.6-2.6-4.6-2.6Z" fill="var(--music-glyph-stroke, #fff)" />
+      <path d="M10.5 9.4v5.2l4.6-2.6-4.6-2.6Z" fill="var(--music-glyph-stroke, #f7f3ef)" />
     </svg>
+  );
+}
+
+export function MusicSourceGlyph({
+  source,
+  className,
+}: {
+  source: MusicPlayerSource;
+  className?: string;
+}) {
+  return source === "spotify" ? (
+    <SpotifyGlyph className={cn("h-4 w-4 [--music-glyph-stroke:#06110a]", className)} />
+  ) : (
+    <YouTubeGlyph className={cn("h-4 w-4 [--music-glyph-stroke:#f7f3ef]", className)} />
   );
 }
 
@@ -45,16 +59,12 @@ export function MusicSourceButton({
       className={cn(
         "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-colors hover:bg-white/10 active:scale-95",
         className,
-        source === "spotify" ? "text-[#1DB954]" : "text-[#ff0033]",
+        source === "spotify" ? "text-[#1DB954]" : "text-[oklch(0.62_0.16_25)]",
       )}
       title={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}
       aria-label={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}
     >
-      {source === "spotify" ? (
-        <SpotifyGlyph className="h-4 w-4 [--music-glyph-stroke:#06110a]" />
-      ) : (
-        <YouTubeGlyph className="h-4 w-4 [--music-glyph-stroke:#ffffff]" />
-      )}
+      <MusicSourceGlyph source={source} />
     </button>
   );
 }

--- a/packages/client/src/components/music/MusicSourceButton.tsx
+++ b/packages/client/src/components/music/MusicSourceButton.tsx
@@ -44,8 +44,8 @@ export function MusicSourceButton({
       }}
       className={cn(
         "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-colors hover:bg-white/10 active:scale-95",
-        source === "spotify" ? "text-[#1DB954]" : "text-[#ff0033]",
         className,
+        source === "spotify" ? "text-[#1DB954]" : "text-[#ff0033]",
       )}
       title={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}
       aria-label={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}

--- a/packages/client/src/components/music/MusicSourceButton.tsx
+++ b/packages/client/src/components/music/MusicSourceButton.tsx
@@ -1,0 +1,60 @@
+import { useUIStore, type MusicPlayerSource } from "../../stores/ui.store";
+import { cn } from "../../lib/utils";
+
+function SpotifyGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <circle cx="12" cy="12" r="10" fill="currentColor" />
+      <path
+        d="M7.1 9.2c3.4-1 7.2-.7 10.1.8M7.7 12.1c2.8-.8 6-.6 8.5.6M8.4 14.8c2.1-.5 4.6-.4 6.4.5"
+        fill="none"
+        stroke="var(--music-glyph-stroke, #06110a)"
+        strokeLinecap="round"
+        strokeWidth="1.45"
+      />
+    </svg>
+  );
+}
+
+function YouTubeGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+      <rect x="3" y="6.5" width="18" height="11" rx="3" fill="currentColor" />
+      <path d="M10.5 9.4v5.2l4.6-2.6-4.6-2.6Z" fill="var(--music-glyph-stroke, #fff)" />
+    </svg>
+  );
+}
+
+export function MusicSourceButton({
+  source,
+  className,
+}: {
+  source: MusicPlayerSource;
+  className?: string;
+}) {
+  const setMusicPlayerSource = useUIStore((s) => s.setMusicPlayerSource);
+  const nextSource: MusicPlayerSource = source === "spotify" ? "youtube" : "spotify";
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        setMusicPlayerSource(nextSource);
+      }}
+      className={cn(
+        "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-colors hover:bg-white/10 active:scale-95",
+        source === "spotify" ? "text-[#1DB954]" : "text-[#ff0033]",
+        className,
+      )}
+      title={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}
+      aria-label={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}
+    >
+      {source === "spotify" ? (
+        <SpotifyGlyph className="h-4 w-4 [--music-glyph-stroke:#06110a]" />
+      ) : (
+        <YouTubeGlyph className="h-4 w-4 [--music-glyph-stroke:#ffffff]" />
+      )}
+    </button>
+  );
+}

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -28,9 +28,12 @@ import {
 } from "../../hooks/use-agents";
 import {
   BUILT_IN_AGENTS,
+  DEFAULT_AGENT_TOOLS,
   createFolderEntry,
+  getDefaultBuiltInAgentSettings,
   getFolderImportEntries,
   getFolderManifestConfig,
+  isAgentConfigDeleted,
   type AgentCategory,
 } from "@marinara-engine/shared";
 import { showConfirmDialog } from "../../lib/app-dialogs";
@@ -38,6 +41,7 @@ import { cn } from "../../lib/utils";
 import { downloadJsonFile } from "../../lib/download-json";
 
 type JsonRecord = Record<string, unknown>;
+const BUILT_IN_AGENT_TYPE_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 
 function isJsonRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -96,6 +100,30 @@ function serializeAgentFolderEntry(agent: AgentConfigRow) {
   });
 }
 
+function createBuiltInAgentConfigRow(
+  agent: (typeof BUILT_IN_AGENTS)[number],
+  config: AgentConfigRow | null | undefined,
+): AgentConfigRow {
+  const defaultSettings = {
+    ...getDefaultBuiltInAgentSettings(agent.id),
+    ...(DEFAULT_AGENT_TOOLS[agent.id]?.length ? { enabledTools: DEFAULT_AGENT_TOOLS[agent.id] } : {}),
+  };
+  return {
+    id: agent.id,
+    type: agent.id,
+    name: agent.name,
+    description: config?.description ?? agent.description,
+    phase: config?.phase ?? agent.phase,
+    enabled: config?.enabled ?? String(agent.enabledByDefault),
+    connectionId: config?.connectionId ?? null,
+    imagePath: config?.imagePath ?? null,
+    promptTemplate: config?.promptTemplate ?? "",
+    settings: config?.settings ?? JSON.stringify(defaultSettings),
+    createdAt: config?.createdAt ?? "",
+    updatedAt: config?.updatedAt ?? "",
+  };
+}
+
 function normalizeAgentImportEntry(entry: unknown) {
   const source = getFolderManifestConfig(entry);
   if (!isJsonRecord(source)) return null;
@@ -151,15 +179,39 @@ export function AgentsPanel() {
   const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
 
+  const agentConfigRows = useMemo(() => ((agentConfigs ?? []) as AgentConfigRow[]), [agentConfigs]);
+  const visibleAgentConfigs = useMemo(
+    () => agentConfigRows.filter((config) => !isAgentConfigDeleted(config.settings)),
+    [agentConfigRows],
+  );
+  const deletedBuiltInTypes = useMemo(
+    () =>
+      new Set(
+        agentConfigRows
+          .filter((config) => BUILT_IN_AGENT_TYPE_SET.has(config.type))
+          .filter((config) => isAgentConfigDeleted(config.settings))
+          .map((config) => config.type),
+      ),
+    [agentConfigRows],
+  );
+  const visibleBuiltInAgents = useMemo(
+    () => BUILT_IN_AGENTS.filter((agent) => !deletedBuiltInTypes.has(agent.id)),
+    [deletedBuiltInTypes],
+  );
   // Custom agents = DB entries whose type doesn't match any built-in
   const customAgents = useMemo(
-    () => ((agentConfigs ?? []) as AgentConfigRow[]).filter((c) => !BUILT_IN_AGENTS.some((b) => b.id === c.type)),
-    [agentConfigs],
+    () => visibleAgentConfigs.filter((config) => !BUILT_IN_AGENT_TYPE_SET.has(config.type)),
+    [visibleAgentConfigs],
   );
   const configByType = useMemo(
-    () => new Map(((agentConfigs ?? []) as AgentConfigRow[]).map((config) => [config.type, config])),
-    [agentConfigs],
+    () => new Map(visibleAgentConfigs.map((config) => [config.type, config])),
+    [visibleAgentConfigs],
   );
+  const builtInExportRows = useMemo(
+    () => visibleBuiltInAgents.map((agent) => createBuiltInAgentConfigRow(agent, configByType.get(agent.id))),
+    [configByType, visibleBuiltInAgents],
+  );
+  const selectableAgents = useMemo(() => [...builtInExportRows, ...customAgents], [builtInExportRows, customAgents]);
 
   const agentSearchQuery = agentSearch.trim().toLowerCase();
   const matchesAgentSearch = (agent: { name: string; description: string; category: string }) =>
@@ -181,13 +233,17 @@ export function AgentsPanel() {
       }),
     )
     .sort((a, b) => a.name.localeCompare(b.name));
+  const visibleSelectableAgentIds = [
+    ...visibleBuiltInAgents.filter((agent) => matchesAgentSearch(agent)).map((agent) => agent.id),
+    ...visibleCustomAgents.map((agent) => agent.id),
+  ];
   const hasVisibleAgents =
     agentCategorySections.some((section) =>
-      BUILT_IN_AGENTS.some((agent) => agent.category === section.category && matchesAgentSearch(agent)),
+      visibleBuiltInAgents.some((agent) => agent.category === section.category && matchesAgentSearch(agent)),
     ) || visibleCustomAgents.length > 0;
-  const selectedCustomAgents = useMemo(
-    () => customAgents.filter((agent) => selectedAgentIds.has(agent.id)),
-    [customAgents, selectedAgentIds],
+  const selectedAgents = useMemo(
+    () => selectableAgents.filter((agent) => selectedAgentIds.has(agent.id)),
+    [selectableAgents, selectedAgentIds],
   );
 
   const handleCreateAgent = () => {
@@ -210,8 +266,8 @@ export function AgentsPanel() {
   }, []);
 
   const handleExportSelectedAgents = useCallback(async () => {
-    if (selectedCustomAgents.length === 0) {
-      toast.error("Select at least one custom agent to export");
+    if (selectedAgents.length === 0) {
+      toast.error("Select at least one agent to export");
       return;
     }
 
@@ -223,28 +279,30 @@ export function AgentsPanel() {
           version: 1,
           exportedAt: new Date().toISOString(),
           folderName: "Agents",
-          agents: selectedCustomAgents.map(serializeAgentFolderEntry),
+          agents: selectedAgents.map(serializeAgentFolderEntry),
         },
         "marinara-agents.json",
       );
-      toast.success(
-        `Exported ${selectedCustomAgents.length} custom agent${selectedCustomAgents.length === 1 ? "" : "s"}`,
-      );
+      toast.success(`Exported ${selectedAgents.length} agent${selectedAgents.length === 1 ? "" : "s"}`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to export agents");
     } finally {
       setExportingSelected(false);
     }
-  }, [selectedCustomAgents]);
+  }, [selectedAgents]);
 
   const handleDeleteSelectedAgents = useCallback(async () => {
-    const ids = selectedCustomAgents.map((agent) => agent.id);
+    const ids = selectedAgents.map((agent) => agent.id);
     if (ids.length === 0) return;
+    const agentNoun = ids.length === 1 ? "agent" : "agents";
+    const deleteMessage =
+      `Delete ${ids.length} selected ${agentNoun}? ` +
+      "Basic agents will be hidden from the library and pickers.";
 
     if (
       !(await showConfirmDialog({
         title: "Delete Agents",
-        message: `Delete ${ids.length} custom agent${ids.length === 1 ? "" : "s"}?`,
+        message: deleteMessage,
         confirmLabel: "Delete",
         tone: "destructive",
       }))
@@ -257,16 +315,16 @@ export function AgentsPanel() {
     const deletedCount = ids.length - failedIds.length;
 
     if (deletedCount > 0) {
-      toast.success(`Deleted ${deletedCount} custom agent${deletedCount === 1 ? "" : "s"}`);
+      toast.success(`Deleted ${deletedCount} agent${deletedCount === 1 ? "" : "s"}`);
     }
     if (failedIds.length > 0) {
       setSelectedAgentIds(new Set(failedIds));
-      toast.error(`Failed to delete ${failedIds.length} custom agent${failedIds.length === 1 ? "" : "s"}`);
+      toast.error(`Failed to delete ${failedIds.length} agent${failedIds.length === 1 ? "" : "s"}`);
       return;
     }
 
     exitSelectionMode();
-  }, [deleteAgent, exitSelectionMode, selectedCustomAgents]);
+  }, [deleteAgent, exitSelectionMode, selectedAgents]);
 
   const handleImportAgents = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -395,14 +453,14 @@ export function AgentsPanel() {
             if (selectionMode) exitSelectionMode();
             else setSelectionMode(true);
           }}
-          disabled={customAgents.length === 0}
+          disabled={selectableAgents.length === 0}
           className={cn(
             "flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40",
             selectionMode
               ? "bg-violet-400/15 text-violet-400 ring-1 ring-violet-400/30"
               : "bg-[var(--secondary)] text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
           )}
-          title="Select custom agents"
+          title="Select agents"
         >
           <Check size="0.8125rem" /> <span className="md:hidden">Select</span>
         </button>
@@ -418,25 +476,25 @@ export function AgentsPanel() {
       {selectionMode && (
         <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
           <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
-            {selectedCustomAgents.length} selected
+            {selectedAgents.length} selected
           </span>
           <button
-            onClick={() => setSelectedAgentIds(new Set(visibleCustomAgents.map((agent) => agent.id)))}
-            disabled={visibleCustomAgents.length === 0}
+            onClick={() => setSelectedAgentIds(new Set(visibleSelectableAgentIds))}
+            disabled={visibleSelectableAgentIds.length === 0}
             className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-violet-400 transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
           >
             Select visible
           </button>
           <button
             onClick={() => setSelectedAgentIds(new Set())}
-            disabled={selectedCustomAgents.length === 0}
+            disabled={selectedAgents.length === 0}
             className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40"
           >
             Clear
           </button>
           <button
             onClick={handleDeleteSelectedAgents}
-            disabled={selectedCustomAgents.length === 0}
+            disabled={selectedAgents.length === 0}
             className="inline-flex items-center gap-1 rounded-lg bg-[var(--destructive)]/12 px-2.5 py-1 text-[0.625rem] font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20 disabled:opacity-40"
           >
             <Trash2 size="0.6875rem" />
@@ -444,7 +502,7 @@ export function AgentsPanel() {
           </button>
           <button
             onClick={handleExportSelectedAgents}
-            disabled={selectedCustomAgents.length === 0 || exportingSelected}
+            disabled={selectedAgents.length === 0 || exportingSelected}
             className="inline-flex items-center gap-1 rounded-lg bg-violet-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
           >
             <Upload size="0.6875rem" />
@@ -479,7 +537,7 @@ export function AgentsPanel() {
       )}
 
       {agentCategorySections.map((section) => {
-        const visibleAgents = BUILT_IN_AGENTS.filter(
+        const visibleAgents = visibleBuiltInAgents.filter(
           (agent) => agent.category === section.category && matchesAgentSearch(agent),
         );
         if (visibleAgents.length === 0 && agentSearchQuery) return null;
@@ -501,7 +559,23 @@ export function AgentsPanel() {
                   custom: false,
                   openAgentDetail,
                   onImagePick: () => handlePickAgentImage(agent.id),
-                  selectionMode: false,
+                  selectionMode,
+                  selected: selectedAgentIds.has(agent.id),
+                  onToggleSelected: () => toggleAgentSelection(agent.id),
+                  onDelete: async () => {
+                    const deleteMessage =
+                      `Delete "${agent.name}"? ` + "This basic agent will be hidden from the library and pickers.";
+                    if (
+                      await showConfirmDialog({
+                        title: "Delete Agent",
+                        message: deleteMessage,
+                        confirmLabel: "Delete",
+                        tone: "destructive",
+                      })
+                    ) {
+                      deleteAgent.mutate(agent.id);
+                    }
+                  },
                 }),
               )
             )}

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -195,7 +195,7 @@ export function AgentsPanel() {
     [agentConfigRows],
   );
   const visibleBuiltInAgents = useMemo(
-    () => BUILT_IN_AGENTS.filter((agent) => !deletedBuiltInTypes.has(agent.id)),
+    () => BUILT_IN_AGENTS.filter((agent) => !agent.libraryHidden && !deletedBuiltInTypes.has(agent.id)),
     [deletedBuiltInTypes],
   );
   // Custom agents = DB entries whose type doesn't match any built-in

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -7,6 +7,7 @@ import {
   Pencil,
   Plus,
   ChevronDown,
+  ChevronRight,
   Trash2,
   Search,
   PenLine,
@@ -16,6 +17,7 @@ import {
   Download,
   Upload,
   Check,
+  FolderPlus,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useUIStore } from "../../stores/ui.store";
@@ -39,6 +41,14 @@ import {
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { downloadJsonFile } from "../../lib/download-json";
+import {
+  getNextUnnamedLibraryFolderName,
+  useCreateLibraryFolder,
+  useDeleteLibraryFolder,
+  useLibraryFolders,
+  useMoveLibraryItem,
+  useUpdateLibraryFolder,
+} from "../../hooks/use-library-folders";
 
 type JsonRecord = Record<string, unknown>;
 const BUILT_IN_AGENT_TYPE_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
@@ -168,6 +178,11 @@ export function AgentsPanel() {
   const createAgent = useCreateAgent();
   const deleteAgent = useDeleteAgent();
   const uploadAgentImage = useUploadAgentImage();
+  const { data: agentFolders = [] } = useLibraryFolders("agents");
+  const createAgentFolder = useCreateLibraryFolder("agents");
+  const updateAgentFolder = useUpdateLibraryFolder("agents");
+  const deleteAgentFolder = useDeleteLibraryFolder("agents");
+  const moveAgentItem = useMoveLibraryItem("agents");
   const openAgentDetail = useUIStore((s) => s.openAgentDetail);
   const [agentSearch, setAgentSearch] = useState("");
   const agentImageInputRef = useRef<HTMLInputElement>(null);
@@ -178,6 +193,10 @@ export function AgentsPanel() {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedAgentIds, setSelectedAgentIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
+  const [expandedFolderId, setExpandedFolderId] = useState<string | null>(null);
+  const [editingFolderId, setEditingFolderId] = useState<string | null>(null);
+  const [editFolderName, setEditFolderName] = useState("");
+  const [draggedAgentId, setDraggedAgentId] = useState<string | null>(null);
 
   const agentConfigRows = useMemo(() => ((agentConfigs ?? []) as AgentConfigRow[]), [agentConfigs]);
   const visibleAgentConfigs = useMemo(
@@ -212,6 +231,17 @@ export function AgentsPanel() {
     [configByType, visibleBuiltInAgents],
   );
   const selectableAgents = useMemo(() => [...builtInExportRows, ...customAgents], [builtInExportRows, customAgents]);
+  const selectableAgentById = useMemo(
+    () => new Map(selectableAgents.map((agent) => [agent.id, agent])),
+    [selectableAgents],
+  );
+  const folderedAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const folder of agentFolders) {
+      for (const id of folder.itemIds) ids.add(id);
+    }
+    return ids;
+  }, [agentFolders]);
 
   const agentSearchQuery = agentSearch.trim().toLowerCase();
   const matchesAgentSearch = (agent: { name: string; description: string; category: string }) =>
@@ -225,22 +255,30 @@ export function AgentsPanel() {
     { category: "misc", title: "Misc Agents", icon: <Puzzle size="0.8125rem" /> },
   ];
   const visibleCustomAgents = customAgents
-    .filter((agent) =>
-      matchesAgentSearch({
-        name: agent.name,
-        description: agent.description,
-        category: "custom",
-      }),
+    .filter(
+      (agent) =>
+        !folderedAgentIds.has(agent.id) &&
+        matchesAgentSearch({
+          name: agent.name,
+          description: agent.description,
+          category: "custom",
+        }),
     )
     .sort((a, b) => a.name.localeCompare(b.name));
   const visibleSelectableAgentIds = [
-    ...visibleBuiltInAgents.filter((agent) => matchesAgentSearch(agent)).map((agent) => agent.id),
+    ...visibleBuiltInAgents
+      .filter((agent) => !folderedAgentIds.has(agent.id) && matchesAgentSearch(agent))
+      .map((agent) => agent.id),
     ...visibleCustomAgents.map((agent) => agent.id),
   ];
   const hasVisibleAgents =
     agentCategorySections.some((section) =>
-      visibleBuiltInAgents.some((agent) => agent.category === section.category && matchesAgentSearch(agent)),
-    ) || visibleCustomAgents.length > 0;
+      visibleBuiltInAgents.some(
+        (agent) => !folderedAgentIds.has(agent.id) && agent.category === section.category && matchesAgentSearch(agent),
+      ),
+    ) ||
+    visibleCustomAgents.length > 0 ||
+    agentFolders.some((folder) => folder.itemIds.some((id) => selectableAgentById.has(id)));
   const selectedAgents = useMemo(
     () => selectableAgents.filter((agent) => selectedAgentIds.has(agent.id)),
     [selectableAgents, selectedAgentIds],
@@ -264,6 +302,40 @@ export function AgentsPanel() {
       return next;
     });
   }, []);
+
+  const getDraggedAgentIds = useCallback(
+    (agentId: string) => (selectionMode && selectedAgentIds.has(agentId) ? Array.from(selectedAgentIds) : [agentId]),
+    [selectedAgentIds, selectionMode],
+  );
+
+  const handleCreateFolder = useCallback(() => {
+    createAgentFolder.mutate(
+      { name: getNextUnnamedLibraryFolderName(agentFolders) },
+      {
+        onSuccess: (folder) => setExpandedFolderId(folder.id),
+      },
+    );
+  }, [agentFolders, createAgentFolder]);
+
+  const handleRenameFolder = useCallback(
+    (folderId: string) => {
+      const name = editFolderName.trim();
+      if (!name) return;
+      updateAgentFolder.mutate({ id: folderId, name });
+      setEditingFolderId(null);
+      setEditFolderName("");
+    },
+    [editFolderName, updateAgentFolder],
+  );
+
+  const handleAgentDrop = useCallback(
+    (folderId: string | null, agentIds?: string[]) => {
+      if (!draggedAgentId) return;
+      moveAgentItem.mutate({ itemIds: agentIds ?? [draggedAgentId], folderId });
+      setDraggedAgentId(null);
+    },
+    [draggedAgentId, moveAgentItem],
+  );
 
   const handleExportSelectedAgents = useCallback(async () => {
     if (selectedAgents.length === 0) {
@@ -378,6 +450,62 @@ export function AgentsPanel() {
     }
   }, []);
 
+  const renderFolderAgentCard = useCallback(
+    (agent: AgentConfigRow) => {
+      const builtInMeta = BUILT_IN_AGENTS.find((entry) => entry.id === agent.type);
+      const custom = !builtInMeta;
+      const category = custom ? "custom" : builtInMeta.category;
+      return renderAgentCard({
+        id: agent.id,
+        type: agent.type,
+        name: agent.name,
+        description: agent.description,
+        category,
+        imagePath: agent.imagePath ?? null,
+        custom,
+        openAgentDetail,
+        onImagePick: () => handlePickAgentImage(custom ? agent.id : agent.type),
+        selectionMode,
+        selected: selectedAgentIds.has(agent.id),
+        onToggleSelected: () => toggleAgentSelection(agent.id),
+        isDragging: draggedAgentId === agent.id,
+        onDragStart: (event) => {
+          const ids = getDraggedAgentIds(agent.id);
+          setDraggedAgentId(agent.id);
+          event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData("application/x-marinara-agent-ids", JSON.stringify(ids));
+          event.dataTransfer.setData("text/plain", agent.id);
+        },
+        onDragEnd: () => setDraggedAgentId(null),
+        onDelete: async () => {
+          const deleteMessage = custom
+            ? `Delete "${agent.name}"?`
+            : `Delete "${agent.name}"? This basic agent will be hidden from the library and pickers.`;
+          if (
+            await showConfirmDialog({
+              title: "Delete Agent",
+              message: deleteMessage,
+              confirmLabel: "Delete",
+              tone: "destructive",
+            })
+          ) {
+            deleteAgent.mutate(custom ? agent.id : agent.type);
+          }
+        },
+      });
+    },
+    [
+      deleteAgent,
+      draggedAgentId,
+      getDraggedAgentIds,
+      handlePickAgentImage,
+      openAgentDetail,
+      selectedAgentIds,
+      selectionMode,
+      toggleAgentSelection,
+    ],
+  );
+
   const handleAgentImageSelected = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
@@ -417,7 +545,23 @@ export function AgentsPanel() {
   );
 
   return (
-    <div className="flex flex-col gap-2 p-3">
+    <div
+      onDragOver={(event) => {
+        if (draggedAgentId) {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "move";
+        }
+      }}
+      onDrop={(event) => {
+        if (!draggedAgentId) return;
+        event.preventDefault();
+        const target = event.target as Element | null;
+        if (target?.closest("[data-agent-folder-id]")) return;
+        const payload = event.dataTransfer.getData("application/x-marinara-agent-ids");
+        handleAgentDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
+      }}
+      className="flex flex-col gap-2 p-3"
+    >
       <input
         ref={agentImageInputRef}
         type="file"
@@ -440,6 +584,13 @@ export function AgentsPanel() {
           title="New"
         >
           <Plus size="0.8125rem" /> <span className="md:hidden">New</span>
+        </button>
+        <button
+          onClick={handleCreateFolder}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]"
+          title="New folder"
+        >
+          <FolderPlus size="0.8125rem" /> <span className="md:hidden">Folder</span>
         </button>
         <button
           onClick={() => agentImportInputRef.current?.click()}
@@ -536,9 +687,124 @@ export function AgentsPanel() {
         <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No agents match your search.</p>
       )}
 
+      {agentFolders.length > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <p className="px-2.5 pb-1 text-[0.625rem] leading-snug text-[var(--muted-foreground)]/70">
+            Drag and drop agents to folders
+          </p>
+          {agentFolders.map((folder) => {
+            const isExpanded = expandedFolderId === folder.id;
+            const isEditing = editingFolderId === folder.id;
+            const folderAgents = folder.itemIds
+              .map((id) => selectableAgentById.get(id))
+              .filter((agent): agent is AgentConfigRow => Boolean(agent))
+              .filter((agent) =>
+                matchesAgentSearch({
+                  name: agent.name,
+                  description: agent.description,
+                  category: BUILT_IN_AGENT_TYPE_SET.has(agent.type)
+                    ? (BUILT_IN_AGENTS.find((entry) => entry.id === agent.type)?.category ?? "misc")
+                    : "custom",
+                }),
+              );
+            return (
+              <div
+                key={folder.id}
+                data-agent-folder-id={folder.id}
+                onDragOver={(event) => {
+                  if (draggedAgentId) {
+                    event.preventDefault();
+                    event.dataTransfer.dropEffect = "move";
+                  }
+                }}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const payload = event.dataTransfer.getData("application/x-marinara-agent-ids");
+                  handleAgentDrop(folder.id, payload ? (JSON.parse(payload) as string[]) : undefined);
+                }}
+                className="flex flex-col rounded-lg transition-colors"
+              >
+                <div
+                  className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
+                  onClick={() => setExpandedFolderId(isExpanded ? null : folder.id)}
+                >
+                  <ChevronRight
+                    size="0.75rem"
+                    className={cn(
+                      "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                      isExpanded && "rotate-90",
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    {isEditing ? (
+                      <input
+                        autoFocus
+                        value={editFolderName}
+                        onChange={(event) => setEditFolderName(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter") handleRenameFolder(folder.id);
+                          if (event.key === "Escape") {
+                            setEditingFolderId(null);
+                            setEditFolderName("");
+                          }
+                        }}
+                        onClick={(event) => event.stopPropagation()}
+                        onBlur={() => handleRenameFolder(folder.id)}
+                        className="w-full rounded bg-transparent px-1 py-0.5 text-xs font-medium outline-none ring-1 ring-[var(--border)]"
+                      />
+                    ) : (
+                      <div className="truncate text-xs font-medium text-[var(--muted-foreground)]">{folder.name}</div>
+                    )}
+                  </div>
+                  {folder.itemIds.length > 0 && (
+                    <span className="shrink-0 text-[0.5625rem] text-[var(--muted-foreground)]">
+                      {folder.itemIds.length}
+                    </span>
+                  )}
+                  <div className="absolute right-2 top-1/2 flex -translate-y-1/2 shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
+                    <button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setEditingFolderId(folder.id);
+                        setEditFolderName(folder.name);
+                      }}
+                      className="rounded-lg p-1 transition-colors hover:bg-[var(--accent)]"
+                      title="Rename folder"
+                    >
+                      <Pencil size="0.6875rem" />
+                    </button>
+                    <button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        deleteAgentFolder.mutate(folder.id);
+                        if (expandedFolderId === folder.id) setExpandedFolderId(null);
+                      }}
+                      className="rounded-lg p-1 transition-colors hover:bg-[var(--destructive)]/15"
+                      title="Delete folder"
+                    >
+                      <Trash2 size="0.6875rem" className="text-[var(--destructive)]" />
+                    </button>
+                  </div>
+                </div>
+                {isExpanded && (
+                  <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pb-1 pl-1">
+                    {folderAgents.length === 0 ? (
+                      <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop agents here.</p>
+                    ) : (
+                      folderAgents.map((agent) => renderFolderAgentCard(agent))
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
       {agentCategorySections.map((section) => {
         const visibleAgents = visibleBuiltInAgents.filter(
-          (agent) => agent.category === section.category && matchesAgentSearch(agent),
+          (agent) => !folderedAgentIds.has(agent.id) && agent.category === section.category && matchesAgentSearch(agent),
         );
         if (visibleAgents.length === 0 && agentSearchQuery) return null;
         return (
@@ -562,6 +828,15 @@ export function AgentsPanel() {
                   selectionMode,
                   selected: selectedAgentIds.has(agent.id),
                   onToggleSelected: () => toggleAgentSelection(agent.id),
+                  isDragging: draggedAgentId === agent.id,
+                  onDragStart: (event) => {
+                    const ids = getDraggedAgentIds(agent.id);
+                    setDraggedAgentId(agent.id);
+                    event.dataTransfer.effectAllowed = "move";
+                    event.dataTransfer.setData("application/x-marinara-agent-ids", JSON.stringify(ids));
+                    event.dataTransfer.setData("text/plain", agent.id);
+                  },
+                  onDragEnd: () => setDraggedAgentId(null),
                   onDelete: async () => {
                     const deleteMessage =
                       `Delete "${agent.name}"? ` + "This basic agent will be hidden from the library and pickers.";
@@ -602,6 +877,15 @@ export function AgentsPanel() {
                 selectionMode,
                 selected: selectedAgentIds.has(agent.id),
                 onToggleSelected: () => toggleAgentSelection(agent.id),
+                isDragging: draggedAgentId === agent.id,
+                onDragStart: (event) => {
+                  const ids = getDraggedAgentIds(agent.id);
+                  setDraggedAgentId(agent.id);
+                  event.dataTransfer.effectAllowed = "move";
+                  event.dataTransfer.setData("application/x-marinara-agent-ids", JSON.stringify(ids));
+                  event.dataTransfer.setData("text/plain", agent.id);
+                },
+                onDragEnd: () => setDraggedAgentId(null),
                 onDelete: async () => {
                   if (
                     await showConfirmDialog({
@@ -637,6 +921,9 @@ function renderAgentCard({
   selectionMode = false,
   selected = false,
   onToggleSelected,
+  isDragging = false,
+  onDragStart,
+  onDragEnd,
 }: {
   id: string;
   type: string;
@@ -651,6 +938,9 @@ function renderAgentCard({
   selectionMode?: boolean;
   selected?: boolean;
   onToggleSelected?: () => void;
+  isDragging?: boolean;
+  onDragStart?: (event: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd?: () => void;
 }) {
   const iconContent = imagePath ? (
     <img src={imagePath} alt="" className="h-full w-full object-cover" draggable={false} />
@@ -667,12 +957,16 @@ function renderAgentCard({
       key={id}
       data-agent-card
       data-agent-name={name}
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       onClick={() => {
         if (selectionMode && onToggleSelected) onToggleSelected();
       }}
       className={cn(
         "group relative flex cursor-pointer items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)]",
         selectionMode && selected && "bg-violet-400/10 ring-1 ring-violet-400/40",
+        isDragging && "opacity-50",
       )}
     >
       {selectionMode && (

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -24,6 +24,7 @@ import {
   Plus,
   Trash2,
   Download,
+  Upload,
   User,
   Check,
   Search,
@@ -500,14 +501,25 @@ export function CharactersPanel() {
     [updateGroup],
   );
 
-  const moveCharacterToFolder = useCallback(
-    async (charId: string, folderId: string | null) => {
+  const getDraggedCharacterIds = useCallback(
+    (charId: string) =>
+      selectionMode && selectedCharacterIds.has(charId) ? Array.from(selectedCharacterIds) : [charId],
+    [selectedCharacterIds, selectionMode],
+  );
+
+  const moveCharactersToFolder = useCallback(
+    async (charIds: string[], folderId: string | null) => {
+      const ids = Array.from(new Set(charIds.filter(Boolean)));
+      if (ids.length === 0) return;
+      const idSet = new Set(ids);
       const targetFolder = folderId ? parsedGroups.find((folder) => folder.id === folderId) : null;
       const updates = parsedGroups
         .map((folder) => {
-          const withoutCharacter = folder.memberIds.filter((id) => id !== charId);
+          const withoutCharacter = folder.memberIds.filter((id) => !idSet.has(id));
           const nextMembers =
-            targetFolder && folder.id === targetFolder.id ? [...withoutCharacter, charId] : withoutCharacter;
+            targetFolder && folder.id === targetFolder.id
+              ? [...withoutCharacter, ...ids.filter((id) => !withoutCharacter.includes(id))]
+              : withoutCharacter;
           if (
             nextMembers.length === folder.memberIds.length &&
             nextMembers.every((id, index) => id === folder.memberIds[index])
@@ -523,17 +535,16 @@ export function CharactersPanel() {
   );
 
   const handleCharacterDrop = useCallback(
-    (folderId: string | null) => {
+    (folderId: string | null, charIds?: string[]) => {
       if (!draggedCharacterId) return;
-      void moveCharacterToFolder(draggedCharacterId, folderId);
+      void moveCharactersToFolder(charIds ?? [draggedCharacterId], folderId);
       setDraggedCharacterId(null);
     },
-    [draggedCharacterId, moveCharacterToFolder],
+    [draggedCharacterId, moveCharactersToFolder],
   );
 
   const startCharacterTouchDrag = useCallback(
     (event: React.TouchEvent, charId: string) => {
-      if (selectionMode) return;
       const timer = window.setTimeout(() => {
         characterTouchDragRef.current = { id: charId, timer: null, active: true };
         suppressCharacterClickRef.current = true;
@@ -551,7 +562,7 @@ export function CharactersPanel() {
         { once: true },
       );
     },
-    [selectionMode],
+    [],
   );
 
   const finishCharacterTouchDrag = useCallback(
@@ -566,16 +577,16 @@ export function CharactersPanel() {
       const folderElement = target?.closest("[data-character-folder-id]") as HTMLElement | null;
       const rootElement = target?.closest("[data-character-folder-root]") as HTMLElement | null;
       if (folderElement?.dataset.characterFolderId) {
-        void moveCharacterToFolder(current.id, folderElement.dataset.characterFolderId);
+        void moveCharactersToFolder(getDraggedCharacterIds(current.id), folderElement.dataset.characterFolderId);
       } else if (rootElement) {
-        void moveCharacterToFolder(current.id, null);
+        void moveCharactersToFolder(getDraggedCharacterIds(current.id), null);
       }
       setDraggedCharacterId(null);
       window.setTimeout(() => {
         suppressCharacterClickRef.current = false;
       }, 0);
     },
-    [moveCharacterToFolder],
+    [getDraggedCharacterIds, moveCharactersToFolder],
   );
 
   const exitSelectionMode = useCallback(() => {
@@ -863,7 +874,7 @@ export function CharactersPanel() {
             disabled={selectedCharacterIds.size === 0 || exportingSelected}
             className="inline-flex items-center gap-1 rounded-lg bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:opacity-40"
           >
-            <Download size="0.6875rem" />
+            <Upload size="0.6875rem" />
             {exportingSelected ? "Exporting..." : "Export ZIP"}
           </button>
           <button
@@ -917,7 +928,8 @@ export function CharactersPanel() {
               onDrop={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                handleCharacterDrop(group.id);
+                const payload = event.dataTransfer.getData("application/x-marinara-character-ids");
+                handleCharacterDrop(group.id, payload ? (JSON.parse(payload) as string[]) : undefined);
               }}
               className="flex flex-col rounded-lg transition-colors"
             >
@@ -1009,14 +1021,12 @@ export function CharactersPanel() {
                       <div
                         key={memberId}
                         onClick={() => openCharacterDetail(memberId)}
-                        draggable={!selectionMode}
+                        draggable
                         onDragStart={(event) => {
-                          if (selectionMode) {
-                            event.preventDefault();
-                            return;
-                          }
+                          const ids = getDraggedCharacterIds(memberId);
                           setDraggedCharacterId(memberId);
                           event.dataTransfer.effectAllowed = "move";
+                          event.dataTransfer.setData("application/x-marinara-character-ids", JSON.stringify(ids));
                           event.dataTransfer.setData("text/plain", memberId);
                         }}
                         onDragEnd={() => setDraggedCharacterId(null)}
@@ -1145,7 +1155,8 @@ export function CharactersPanel() {
         }}
         onDrop={(event) => {
           event.preventDefault();
-          handleCharacterDrop(null);
+          const payload = event.dataTransfer.getData("application/x-marinara-character-ids");
+          handleCharacterDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
         }}
         className={cn(
           "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
@@ -1175,14 +1186,12 @@ export function CharactersPanel() {
                   openCharacterDetail(char.id);
                 }
               }}
-              draggable={!selectionMode}
+              draggable
               onDragStart={(event) => {
-                if (selectionMode) {
-                  event.preventDefault();
-                  return;
-                }
+                const ids = getDraggedCharacterIds(char.id);
                 setDraggedCharacterId(char.id);
                 event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("application/x-marinara-character-ids", JSON.stringify(ids));
                 event.dataTransfer.setData("text/plain", char.id);
               }}
               onDragEnd={() => setDraggedCharacterId(null)}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -530,7 +530,7 @@ function ConnectionRow({
           {conn.provider} • {conn.model || "No model set"}
         </div>
       </div>
-      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
+      <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-foreground/10 transition-opacity group-hover:opacity-100 max-md:opacity-100">
         <button
           onClick={(e) => {
             e.stopPropagation();
@@ -539,8 +539,8 @@ function ConnectionRow({
           className={cn(
             "rounded-lg p-1.5 transition-all active:scale-90",
             inRandomPool
-              ? "bg-amber-400/15 text-amber-400"
-              : "text-[var(--muted-foreground)] hover:bg-amber-400/10 hover:text-amber-400",
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
+              : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/75",
           )}
           title={inRandomPool ? "In random pool (click to remove)" : "Add to random pool"}
         >

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -120,7 +120,10 @@ function SidecarCard() {
   const [expanded, setExpanded] = useState(false);
   const activeModelName = isDownloaded ? modelDisplayName : null;
   const backendLabel = config.backend === "mlx" ? "MLX" : "GGUF";
-  const trackerAgents = useMemo(() => BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker"), []);
+  const trackerAgents = useMemo(
+    () => BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker" && !agent.libraryHidden),
+    [],
+  );
   const trackerLocalCount = useMemo(() => {
     const configs = (agentConfigs ?? []) as Array<{ type: string; connectionId: string | null }>;
     const byType = new Map(configs.map((cfg) => [cfg.type, cfg.connectionId]));

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -454,6 +454,8 @@ function DefaultIllustratorConnectionCard({ connectionsList }: { connectionsList
 function ConnectionRow({
   conn,
   isSelected,
+  isBulkSelected,
+  selectionMode,
   onClickRow,
   isDragging,
   onDragStart,
@@ -462,6 +464,8 @@ function ConnectionRow({
 }: {
   conn: ConnectionRowData;
   isSelected: boolean;
+  isBulkSelected: boolean;
+  selectionMode: boolean;
   onClickRow: () => void;
   isDragging: boolean;
   onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
@@ -494,6 +498,7 @@ function ConnectionRow({
       className={cn(
         "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
         isSelected && `ring-1 ${colors.ring} bg-[var(--sidebar-accent)]/50`,
+        selectionMode && isBulkSelected && "ring-1 ring-[var(--border)] bg-[var(--sidebar-accent)]/70",
         isDragging && "opacity-50",
       )}
     >
@@ -514,7 +519,7 @@ function ConnectionRow({
         <span className="absolute inset-0 flex items-center justify-center bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
           <Camera size="0.875rem" />
         </span>
-        {isSelected && (
+        {(selectionMode ? isBulkSelected : isSelected) && (
           <div
             className={cn(
               "absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full shadow-sm",
@@ -605,7 +610,7 @@ function ConnectionFolderRow({
   onRename: (id: string, name: string) => void;
   onDelete: (folder: ConnectionFolder) => void;
   draggedConnectionId: string | null;
-  onDropConnection: (connectionId: string, folderId: string | null) => void;
+  onDropConnection: (connectionIds: string[], folderId: string | null) => void;
 }) {
   const dragControls = useDragControls();
   const [renaming, setRenaming] = useState(false);
@@ -640,7 +645,9 @@ function ConnectionFolderRow({
           event.dataTransfer.getData("application/x-marinara-connection-id") ||
           event.dataTransfer.getData("text/plain") ||
           draggedConnectionId;
-        if (connectionId) onDropConnection(connectionId, folder.id);
+        const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
+        const connectionIds = payload ? (JSON.parse(payload) as string[]) : [connectionId];
+        if (connectionIds.length > 0) onDropConnection(connectionIds, folder.id);
         setIsDropTarget(false);
       }}
       className={cn(
@@ -747,6 +754,8 @@ export function ConnectionsPanel() {
   const moveConnectionMut = useMoveConnection();
 
   const [draggedConnectionId, setDraggedConnectionId] = useState<string | null>(null);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedConnectionIds, setSelectedConnectionIds] = useState<Set<string>>(new Set());
   const connectionImageInputRef = useRef<HTMLInputElement>(null);
   const imageTargetConnectionIdRef = useRef<string | null>(null);
 
@@ -810,8 +819,31 @@ export function ConnectionsPanel() {
     deleteFolderMut.mutate(folder.id);
   };
 
-  const handleDropConnectionToFolder = (connectionId: string, folderId: string | null) => {
-    moveConnectionMut.mutate({ connectionId, folderId });
+  const getDraggedConnectionIds = useCallback(
+    (connectionId: string) =>
+      selectionMode && selectedConnectionIds.has(connectionId) ? Array.from(selectedConnectionIds) : [connectionId],
+    [selectedConnectionIds, selectionMode],
+  );
+
+  const toggleConnectionSelection = useCallback((connectionId: string) => {
+    setSelectedConnectionIds((current) => {
+      const next = new Set(current);
+      if (next.has(connectionId)) next.delete(connectionId);
+      else next.add(connectionId);
+      return next;
+    });
+  }, []);
+
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedConnectionIds(new Set());
+  }, []);
+
+  const handleDropConnectionsToFolder = (connectionIds: string[], folderId: string | null) => {
+    const ids = Array.from(new Set(connectionIds.filter(Boolean)));
+    for (const connectionId of ids) {
+      moveConnectionMut.mutate({ connectionId, folderId });
+    }
     setDraggedConnectionId(null);
   };
 
@@ -863,16 +895,24 @@ export function ConnectionsPanel() {
 
   const renderConnectionRow = (conn: ConnectionRowData) => {
     const isSelected = activeConnectionId === conn.id;
+    const isBulkSelected = selectedConnectionIds.has(conn.id);
     return (
       <ConnectionRow
         key={conn.id}
         conn={conn}
         isSelected={isSelected}
-        onClickRow={() => openConnectionDetail(conn.id)}
+        isBulkSelected={isBulkSelected}
+        selectionMode={selectionMode}
+        onClickRow={() => {
+          if (selectionMode) toggleConnectionSelection(conn.id);
+          else openConnectionDetail(conn.id);
+        }}
         isDragging={draggedConnectionId === conn.id}
         onDragStart={(event) => {
+          const ids = getDraggedConnectionIds(conn.id);
           setDraggedConnectionId(conn.id);
           event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData("application/x-marinara-connection-ids", JSON.stringify(ids));
           event.dataTransfer.setData("application/x-marinara-connection-id", conn.id);
           event.dataTransfer.setData("text/plain", conn.id);
         }}
@@ -918,7 +958,42 @@ export function ConnectionsPanel() {
           <FolderPlus size="0.75rem" />
           New Folder
         </button>
+        <button
+          onClick={() => (selectionMode ? exitSelectionMode() : setSelectionMode(true))}
+          disabled={connectionsList.length === 0}
+          className={cn(
+            "flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[0.6875rem] transition-all disabled:opacity-40",
+            selectionMode
+              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
+              : "text-[var(--muted-foreground)] hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]",
+          )}
+        >
+          <Check size="0.75rem" />
+          {selectionMode ? "Done" : "Select"}
+        </button>
       </div>
+
+      {selectionMode && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {selectedConnectionIds.size} selected
+          </span>
+          <button
+            onClick={() => setSelectedConnectionIds(new Set(connectionsList.map((connection) => connection.id)))}
+            disabled={connectionsList.length === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-sky-400 transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+          >
+            Select visible
+          </button>
+          <button
+            onClick={() => setSelectedConnectionIds(new Set())}
+            disabled={selectedConnectionIds.size === 0}
+            className="rounded-lg px-2.5 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-40"
+          >
+            Clear
+          </button>
+        </div>
+      )}
 
       {sortedFolders.length > 0 && (
         <p className="px-2.5 text-[0.625rem] leading-snug text-[var(--muted-foreground)]/70">
@@ -1002,7 +1077,7 @@ export function ConnectionsPanel() {
                 onRename={handleRenameFolder}
                 onDelete={handleDeleteFolder}
                 draggedConnectionId={draggedConnectionId}
-                onDropConnection={handleDropConnectionToFolder}
+                onDropConnection={handleDropConnectionsToFolder}
               />
             );
           })}
@@ -1010,7 +1085,29 @@ export function ConnectionsPanel() {
       )}
 
       {/* Unfiled connections */}
-      <div className="stagger-children flex flex-col gap-1">{unfiledConnections.map(renderConnectionRow)}</div>
+      <div
+        onDragOver={(event) => {
+          if (draggedConnectionId) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "move";
+          }
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
+          const fallbackId =
+            event.dataTransfer.getData("application/x-marinara-connection-id") ||
+            event.dataTransfer.getData("text/plain") ||
+            draggedConnectionId;
+          handleDropConnectionsToFolder(payload ? (JSON.parse(payload) as string[]) : fallbackId ? [fallbackId] : [], null);
+        }}
+        className={cn(
+          "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
+          draggedConnectionId && "ring-1 ring-[var(--primary)]/20",
+        )}
+      >
+        {unfiledConnections.map(renderConnectionRow)}
+      </div>
 
       {activeChat && (
         <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]/60">

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import {
   Plus,
   Download,
+  Upload,
   Check,
   BookOpen,
   Search,
@@ -432,25 +433,30 @@ export function LorebooksPanel() {
     [editFolderName, updateLorebookFolder],
   );
 
-  const moveLorebookToFolder = useCallback(
-    (lorebookId: string, folderId: string | null) => {
-      moveLorebookItem.mutate({ itemId: lorebookId, folderId });
+  const getDraggedLorebookIds = useCallback(
+    (lorebookId: string) =>
+      selectionMode && selectedLorebookIds.has(lorebookId) ? Array.from(selectedLorebookIds) : [lorebookId],
+    [selectedLorebookIds, selectionMode],
+  );
+
+  const moveLorebooksToFolder = useCallback(
+    (lorebookIds: string[], folderId: string | null) => {
+      moveLorebookItem.mutate({ itemIds: lorebookIds, folderId });
     },
     [moveLorebookItem],
   );
 
   const handleLorebookDrop = useCallback(
-    (folderId: string | null) => {
+    (folderId: string | null, lorebookIds?: string[]) => {
       if (!draggedLorebookId) return;
-      moveLorebookToFolder(draggedLorebookId, folderId);
+      moveLorebooksToFolder(lorebookIds ?? [draggedLorebookId], folderId);
       setDraggedLorebookId(null);
     },
-    [draggedLorebookId, moveLorebookToFolder],
+    [draggedLorebookId, moveLorebooksToFolder],
   );
 
   const startLorebookTouchDrag = useCallback(
     (event: TouchEvent, lorebookId: string) => {
-      if (selectionMode) return;
       const timer = window.setTimeout(() => {
         lorebookTouchDragRef.current = { id: lorebookId, timer: null, active: true };
         suppressLorebookClickRef.current = true;
@@ -468,7 +474,7 @@ export function LorebooksPanel() {
         { once: true },
       );
     },
-    [selectionMode],
+    [],
   );
 
   const finishLorebookTouchDrag = useCallback(
@@ -483,16 +489,16 @@ export function LorebooksPanel() {
       const folderElement = target?.closest("[data-lorebook-folder-id]") as HTMLElement | null;
       const rootElement = target?.closest("[data-lorebook-folder-root]") as HTMLElement | null;
       if (folderElement?.dataset.lorebookFolderId) {
-        moveLorebookToFolder(current.id, folderElement.dataset.lorebookFolderId);
+        moveLorebooksToFolder(getDraggedLorebookIds(current.id), folderElement.dataset.lorebookFolderId);
       } else if (rootElement) {
-        moveLorebookToFolder(current.id, null);
+        moveLorebooksToFolder(getDraggedLorebookIds(current.id), null);
       }
       setDraggedLorebookId(null);
       window.setTimeout(() => {
         suppressLorebookClickRef.current = false;
       }, 0);
     },
-    [moveLorebookToFolder],
+    [getDraggedLorebookIds, moveLorebooksToFolder],
   );
 
   const renderLorebookRow = useCallback(
@@ -525,15 +531,13 @@ export function LorebooksPanel() {
           selectionMode={selectionMode}
           isSelected={selectedLorebookIds.has(lb.id)}
           onToggleSelect={() => toggleSelection(lb.id)}
-          draggable={!selectionMode}
+          draggable
           isDragging={draggedLorebookId === lb.id}
           onDragStart={(event) => {
-            if (selectionMode) {
-              event.preventDefault();
-              return;
-            }
+            const ids = getDraggedLorebookIds(lb.id);
             setDraggedLorebookId(lb.id);
             event.dataTransfer.effectAllowed = "move";
+            event.dataTransfer.setData("application/x-marinara-lorebook-ids", JSON.stringify(ids));
             event.dataTransfer.setData("text/plain", lb.id);
           }}
           onDragEnd={() => setDraggedLorebookId(null)}
@@ -547,6 +551,7 @@ export function LorebooksPanel() {
       draggedLorebookId,
       finishLorebookTouchDrag,
       getCharacterNames,
+      getDraggedLorebookIds,
       getPersonaNames,
       handlePickLorebookImage,
       openLorebookDetail,
@@ -632,7 +637,7 @@ export function LorebooksPanel() {
             disabled={selectedLorebookIds.size === 0 || exportingSelected}
             className="inline-flex items-center gap-1 rounded-lg bg-amber-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
           >
-            <Download size="0.6875rem" />
+            <Upload size="0.6875rem" />
             {exportingSelected ? "Exporting..." : "Export ZIP"}
           </button>
           <button
@@ -823,7 +828,8 @@ export function LorebooksPanel() {
               onDrop={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                handleLorebookDrop(folder.id);
+                const payload = event.dataTransfer.getData("application/x-marinara-lorebook-ids");
+                handleLorebookDrop(folder.id, payload ? (JSON.parse(payload) as string[]) : undefined);
               }}
               className="flex flex-col rounded-lg transition-colors"
             >
@@ -938,7 +944,8 @@ export function LorebooksPanel() {
           }}
           onDrop={(event) => {
             event.preventDefault();
-            handleLorebookDrop(null);
+            const payload = event.dataTransfer.getData("application/x-marinara-lorebook-ids");
+            handleLorebookDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
           }}
           className={cn(
             "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -24,6 +24,7 @@ import {
   Camera,
   ArrowUpDown,
   Download,
+  Upload,
   Search,
   FolderPlus,
   ChevronDown,
@@ -238,14 +239,25 @@ export function PersonasPanel() {
     [updatePGroup],
   );
 
-  const movePersonaToFolder = useCallback(
-    async (personaId: string, folderId: string | null) => {
+  const getDraggedPersonaIds = useCallback(
+    (personaId: string) =>
+      selectionMode && selectedPersonaIds.has(personaId) ? Array.from(selectedPersonaIds) : [personaId],
+    [selectedPersonaIds, selectionMode],
+  );
+
+  const movePersonasToFolder = useCallback(
+    async (personaIds: string[], folderId: string | null) => {
+      const ids = Array.from(new Set(personaIds.filter(Boolean)));
+      if (ids.length === 0) return;
+      const idSet = new Set(ids);
       const targetFolder = folderId ? parsedGroups.find((folder) => folder.id === folderId) : null;
       const updates = parsedGroups
         .map((folder) => {
-          const withoutPersona = folder.memberIds.filter((id) => id !== personaId);
+          const withoutPersona = folder.memberIds.filter((id) => !idSet.has(id));
           const nextMembers =
-            targetFolder && folder.id === targetFolder.id ? [...withoutPersona, personaId] : withoutPersona;
+            targetFolder && folder.id === targetFolder.id
+              ? [...withoutPersona, ...ids.filter((id) => !withoutPersona.includes(id))]
+              : withoutPersona;
           if (
             nextMembers.length === folder.memberIds.length &&
             nextMembers.every((id, index) => id === folder.memberIds[index])
@@ -261,17 +273,16 @@ export function PersonasPanel() {
   );
 
   const handlePersonaDrop = useCallback(
-    (folderId: string | null) => {
+    (folderId: string | null, personaIds?: string[]) => {
       if (!draggedPersonaId) return;
-      void movePersonaToFolder(draggedPersonaId, folderId);
+      void movePersonasToFolder(personaIds ?? [draggedPersonaId], folderId);
       setDraggedPersonaId(null);
     },
-    [draggedPersonaId, movePersonaToFolder],
+    [draggedPersonaId, movePersonasToFolder],
   );
 
   const startPersonaTouchDrag = useCallback(
     (event: React.TouchEvent, personaId: string) => {
-      if (selectionMode) return;
       const timer = window.setTimeout(() => {
         personaTouchDragRef.current = { id: personaId, timer: null, active: true };
         suppressPersonaClickRef.current = true;
@@ -289,7 +300,7 @@ export function PersonasPanel() {
         { once: true },
       );
     },
-    [selectionMode],
+    [],
   );
 
   const finishPersonaTouchDrag = useCallback(
@@ -304,16 +315,16 @@ export function PersonasPanel() {
       const folderElement = target?.closest("[data-persona-folder-id]") as HTMLElement | null;
       const rootElement = target?.closest("[data-persona-folder-root]") as HTMLElement | null;
       if (folderElement?.dataset.personaFolderId) {
-        void movePersonaToFolder(current.id, folderElement.dataset.personaFolderId);
+        void movePersonasToFolder(getDraggedPersonaIds(current.id), folderElement.dataset.personaFolderId);
       } else if (rootElement) {
-        void movePersonaToFolder(current.id, null);
+        void movePersonasToFolder(getDraggedPersonaIds(current.id), null);
       }
       setDraggedPersonaId(null);
       window.setTimeout(() => {
         suppressPersonaClickRef.current = false;
       }, 0);
     },
-    [movePersonaToFolder],
+    [getDraggedPersonaIds, movePersonasToFolder],
   );
 
   const filteredList = useMemo(() => {
@@ -580,7 +591,7 @@ export function PersonasPanel() {
             disabled={selectedPersonaIds.size === 0 || exportingSelected}
             className="inline-flex items-center gap-1 rounded-lg bg-emerald-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
           >
-            <Download size="0.6875rem" />
+            <Upload size="0.6875rem" />
             {exportingSelected ? "Exporting..." : "Export ZIP"}
           </button>
           <button
@@ -637,7 +648,8 @@ export function PersonasPanel() {
               onDrop={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
-                handlePersonaDrop(group.id);
+                const payload = event.dataTransfer.getData("application/x-marinara-persona-ids");
+                handlePersonaDrop(group.id, payload ? (JSON.parse(payload) as string[]) : undefined);
               }}
               className="flex flex-col rounded-lg transition-colors"
             >
@@ -741,14 +753,12 @@ export function PersonasPanel() {
                                 openPersonaDetail(pid);
                               }
                             }}
-                            draggable={!selectionMode}
+                            draggable
                             onDragStart={(event) => {
-                              if (selectionMode) {
-                                event.preventDefault();
-                                return;
-                              }
+                              const ids = getDraggedPersonaIds(pid);
                               setDraggedPersonaId(pid);
                               event.dataTransfer.effectAllowed = "move";
+                              event.dataTransfer.setData("application/x-marinara-persona-ids", JSON.stringify(ids));
                               event.dataTransfer.setData("text/plain", pid);
                             }}
                             onDragEnd={() => setDraggedPersonaId(null)}
@@ -823,7 +833,8 @@ export function PersonasPanel() {
         }}
         onDrop={(event) => {
           event.preventDefault();
-          handlePersonaDrop(null);
+          const payload = event.dataTransfer.getData("application/x-marinara-persona-ids");
+          handlePersonaDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
         }}
         className={cn(
           "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
@@ -851,14 +862,12 @@ export function PersonasPanel() {
                   openPersonaDetail(persona.id);
                 }
               }}
-              draggable={!selectionMode}
+              draggable
               onDragStart={(event) => {
-                if (selectionMode) {
-                  event.preventDefault();
-                  return;
-                }
+                const ids = getDraggedPersonaIds(persona.id);
                 setDraggedPersonaId(persona.id);
                 event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("application/x-marinara-persona-ids", JSON.stringify(ids));
                 event.dataTransfer.setData("text/plain", persona.id);
               }}
               onDragEnd={() => setDraggedPersonaId(null)}

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -581,25 +581,30 @@ export function PresetsPanel() {
     [editFolderName, updatePresetFolder],
   );
 
-  const movePresetToFolder = useCallback(
-    (presetId: string, folderId: string | null) => {
-      movePresetItem.mutate({ itemId: presetId, folderId });
+  const getDraggedPresetIds = useCallback(
+    (presetId: string) =>
+      selectionMode && selectedPresetIds.has(presetId) ? Array.from(selectedPresetIds) : [presetId],
+    [selectedPresetIds, selectionMode],
+  );
+
+  const movePresetsToFolder = useCallback(
+    (presetIds: string[], folderId: string | null) => {
+      movePresetItem.mutate({ itemIds: presetIds, folderId });
     },
     [movePresetItem],
   );
 
   const handlePresetDrop = useCallback(
-    (folderId: string | null) => {
+    (folderId: string | null, presetIds?: string[]) => {
       if (!draggedPresetId) return;
-      movePresetToFolder(draggedPresetId, folderId);
+      movePresetsToFolder(presetIds ?? [draggedPresetId], folderId);
       setDraggedPresetId(null);
     },
-    [draggedPresetId, movePresetToFolder],
+    [draggedPresetId, movePresetsToFolder],
   );
 
   const startPresetTouchDrag = useCallback(
     (event: TouchEvent, presetId: string) => {
-      if (selectionMode) return;
       const timer = window.setTimeout(() => {
         presetTouchDragRef.current = { id: presetId, timer: null, active: true };
         suppressPresetClickRef.current = true;
@@ -617,7 +622,7 @@ export function PresetsPanel() {
         { once: true },
       );
     },
-    [selectionMode],
+    [],
   );
 
   const finishPresetTouchDrag = useCallback(
@@ -632,16 +637,16 @@ export function PresetsPanel() {
       const folderElement = target?.closest("[data-preset-folder-id]") as HTMLElement | null;
       const rootElement = target?.closest("[data-preset-folder-root]") as HTMLElement | null;
       if (folderElement?.dataset.presetFolderId) {
-        movePresetToFolder(current.id, folderElement.dataset.presetFolderId);
+        movePresetsToFolder(getDraggedPresetIds(current.id), folderElement.dataset.presetFolderId);
       } else if (rootElement) {
-        movePresetToFolder(current.id, null);
+        movePresetsToFolder(getDraggedPresetIds(current.id), null);
       }
       setDraggedPresetId(null);
       window.setTimeout(() => {
         suppressPresetClickRef.current = false;
       }, 0);
     },
-    [movePresetToFolder],
+    [getDraggedPresetIds, movePresetsToFolder],
   );
 
   const renderPresetRow = useCallback(
@@ -661,14 +666,12 @@ export function PresetsPanel() {
             isSelected && "ring-1 ring-purple-400/40 bg-purple-400/5",
             draggedPresetId === preset.id && "opacity-50",
           )}
-          draggable={!selectionMode}
+          draggable
           onDragStart={(event) => {
-            if (selectionMode) {
-              event.preventDefault();
-              return;
-            }
+            const ids = getDraggedPresetIds(preset.id);
             setDraggedPresetId(preset.id);
             event.dataTransfer.effectAllowed = "move";
+            event.dataTransfer.setData("application/x-marinara-preset-ids", JSON.stringify(ids));
             event.dataTransfer.setData("text/plain", preset.id);
           }}
           onDragEnd={() => setDraggedPresetId(null)}
@@ -798,6 +801,7 @@ export function PresetsPanel() {
       draggedPresetId,
       duplicatePreset,
       finishPresetTouchDrag,
+      getDraggedPresetIds,
       getSectionCount,
       openPresetDetail,
       selectedPresetIds,
@@ -876,7 +880,7 @@ export function PresetsPanel() {
             disabled={selectedPresetIds.size === 0 || exportingSelected}
             className="inline-flex items-center gap-1 rounded-lg bg-purple-500 px-2.5 py-1 text-[0.625rem] font-medium text-white transition-all hover:opacity-90 disabled:opacity-40"
           >
-            <Download size="0.6875rem" />
+            <Upload size="0.6875rem" />
             {exportingSelected ? "Exporting..." : "Export ZIP"}
           </button>
           <button
@@ -938,7 +942,8 @@ export function PresetsPanel() {
                 onDrop={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  handlePresetDrop(folder.id);
+                  const payload = event.dataTransfer.getData("application/x-marinara-preset-ids");
+                  handlePresetDrop(folder.id, payload ? (JSON.parse(payload) as string[]) : undefined);
                 }}
                 className="flex flex-col rounded-lg transition-colors"
               >
@@ -1052,7 +1057,8 @@ export function PresetsPanel() {
           }}
           onDrop={(event) => {
             event.preventDefault();
-            handlePresetDrop(null);
+            const payload = event.dataTransfer.getData("application/x-marinara-preset-ids");
+            handlePresetDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
           }}
           className={cn(
             "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -3408,9 +3408,11 @@ function ThemesSettings() {
           <div className="rounded-lg bg-[var(--secondary)]/50 p-2.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
             <strong>Tip:</strong> CSS themes can override any CSS variable (e.g.{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--background</code>,{" "}
-            <code className="rounded bg-[var(--secondary)] px-1">--primary</code>) or add custom styles. JSON themes
-            should have <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "css": "..." }`}</code>{" "}
-            format. Imported theme files sync to this Marinara server but do not auto-activate.
+            <code className="rounded bg-[var(--secondary)] px-1">--primary</code>,{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-button-bg</code>) or add custom
+            styles. JSON themes should have{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "css": "..." }`}</code> format.
+            Imported theme files sync to this Marinara server but do not auto-activate.
           </div>
         </div>
       </SettingsSection>
@@ -3444,9 +3446,31 @@ const CSS_TEMPLATE = `/* ══════════════════�
 
   /* ── Sidebar ── */
   /* --sidebar: #0c0c12; */
+
+  /* ── Shared Chat / Roleplay / Game Chrome ── */
+  /* --marinara-chat-chrome-button-bg: color-mix(in srgb, var(--card) 82%, transparent); */
+  /* --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--card) 94%, var(--foreground) 6%); */
+  /* --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--card) 92%, var(--foreground) 8%); */
+  /* --marinara-chat-chrome-button-border: color-mix(in srgb, var(--foreground) 12%, transparent); */
+  /* --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--foreground) 20%, transparent); */
+  /* --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--foreground) 24%, transparent); */
+  /* --marinara-chat-chrome-button-text: color-mix(in srgb, var(--foreground) 64%, transparent); */
+  /* --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--foreground) 92%, transparent); */
+  /* --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--foreground) 96%, transparent); */
+  /* --marinara-chat-chrome-panel-bg: color-mix(in srgb, var(--background) 88%, var(--card) 12%); */
+  /* --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--foreground) 16%, transparent); */
+  /* --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--foreground) 13%, transparent); */
+  /* --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--foreground) 90%, transparent); */
+  /* --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--foreground) 58%, transparent); */
+  /* --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--foreground) 9%, transparent); */
+  /* --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--foreground) 13%, transparent); */
 }
 
 /* Uncomment and edit the variables above.
+   You can also target shared chrome directly:
+   .marinara-chat-toolbar-button { border-radius: 0.5rem; }
+   .marinara-chat-popover { box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.4); }
+
    You can also add any custom CSS below: */
 `;
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1144,10 +1144,8 @@ function GeneralSettings() {
   const setSpeechToTextEnabled = useUIStore((s) => s.setSpeechToTextEnabled);
   const chibiProfessorMariEnabled = useUIStore((s) => s.chibiProfessorMariEnabled);
   const setChibiProfessorMariEnabled = useUIStore((s) => s.setChibiProfessorMariEnabled);
-  const spotifyPlayerEnabled = useUIStore((s) => s.spotifyPlayerEnabled);
-  const setSpotifyPlayerEnabled = useUIStore((s) => s.setSpotifyPlayerEnabled);
-  const youtubePlayerEnabled = useUIStore((s) => s.youtubePlayerEnabled);
-  const setYoutubePlayerEnabled = useUIStore((s) => s.setYoutubePlayerEnabled);
+  const musicPlayerEnabled = useUIStore((s) => s.musicPlayerEnabled);
+  const setMusicPlayerEnabled = useUIStore((s) => s.setMusicPlayerEnabled);
   const intuitiveSwipeNavigation = useUIStore((s) => s.intuitiveSwipeNavigation);
   const setIntuitiveSwipeNavigation = useUIStore((s) => s.setIntuitiveSwipeNavigation);
   const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
@@ -1196,16 +1194,10 @@ function GeneralSettings() {
             help="Shows a confirmation dialog before permanently deleting chats, characters, or other items. Recommended to keep on."
           />
           <ToggleSetting
-            label="Spotify mini player"
-            checked={spotifyPlayerEnabled}
-            onChange={setSpotifyPlayerEnabled}
-            help="Shows a compact Spotify player in the top bar on desktop and as a draggable floating widget on mobile. Requires the Spotify DJ agent to be connected."
-          />
-          <ToggleSetting
-            label="YouTube DJ mini player"
-            checked={youtubePlayerEnabled}
-            onChange={setYoutubePlayerEnabled}
-            help="Shows a floating YouTube player when the YouTube DJ agent plays a track. When off, the player never appears and no music plays, but the agent can still pick tracks."
+            label="Music Player"
+            checked={musicPlayerEnabled}
+            onChange={setMusicPlayerEnabled}
+            help="Shows the compact Music Player. Switch between Spotify and YouTube from the player itself or the Music DJ agent settings."
           />
           <ToggleSetting
             label="Mini Mari surprise visits"

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5230,7 +5230,7 @@ function AdvancedSettings() {
               </>
             ) : (
               <>
-                <Download size="0.8125rem" />
+                <Upload size="0.8125rem" />
                 Export Profile
               </>
             )}

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../lib/spotify-playback-events";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
+import { MusicSourceButton } from "../music/MusicSourceButton";
 
 type SpotifyRepeatState = "off" | "track" | "context";
 
@@ -281,7 +282,7 @@ export function SpotifyMiniPlayer({
   forceFloating?: boolean;
 }) {
   const qc = useQueryClient();
-  const enabled = useUIStore((s) => s.spotifyPlayerEnabled);
+  const enabled = useUIStore((s) => s.musicPlayerEnabled && s.musicPlayerSource === "spotify");
   const openRightPanel = useUIStore((s) => s.openRightPanel);
   const openAgentDetail = useUIStore((s) => s.openAgentDetail);
   const collapsed = useUIStore((s) => s.spotifyMobileWidgetCollapsed);
@@ -825,7 +826,8 @@ export function SpotifyMiniPlayer({
   const compactBody = useMemo(
     () => (
       <>
-        <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <MusicSourceButton source="spotify" className="border-[oklch(0.30_0.012_145)] bg-[oklch(0.20_0.008_145)]" />
           <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] bg-[oklch(0.23_0.006_145)] ring-1 ring-[oklch(0.34_0.01_145)]">
             {cover ? (
               <img src={cover} alt="" className="h-full w-full object-cover" />
@@ -922,7 +924,7 @@ export function SpotifyMiniPlayer({
             type="button"
             onClick={openSpotifyAgent}
             className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]"
-            title="Spotify setup"
+            title="Music DJ setup"
           >
             <Settings size="0.8125rem" />
           </button>
@@ -1015,7 +1017,7 @@ export function SpotifyMiniPlayer({
 }
 
 export function SpotifyMobileWidget() {
-  const enabled = useUIStore((s) => s.spotifyPlayerEnabled);
+  const enabled = useUIStore((s) => s.musicPlayerEnabled && s.musicPlayerSource === "spotify");
   const isMobileViewport = useMediaQuery("(max-width: 767px)");
 
   if (!enabled || !isMobileViewport) return null;

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -1211,7 +1211,7 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef }
   return createPortal(
     <div
       ref={panelRef}
-      className="fixed z-[9999] flex h-[22rem] w-[21rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+      className="fixed z-[9999] flex h-[22rem] w-[21rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl"
       style={{
         bottom: pos.bottom,
         ...(pos.right != null ? { right: pos.right } : {}),
@@ -1219,19 +1219,19 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef }
       }}
     >
       {/* Search */}
-      <div className="border-b border-[var(--border)] px-3 py-2">
+      <div className="border-b border-foreground/10 px-3 py-2">
         <input
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search emojis..."
-          className="w-full rounded-md bg-[var(--secondary)] px-2.5 py-1.5 text-xs outline-none placeholder:text-[var(--muted-foreground)]/50"
+          className="w-full rounded-md bg-foreground/5 px-2.5 py-1.5 text-xs outline-none ring-1 ring-foreground/10 transition-shadow placeholder:text-foreground/35 focus:ring-foreground/20"
           autoFocus
         />
       </div>
 
       {/* Category tabs */}
-      <div className="flex items-center gap-0.5 border-b border-[var(--border)] px-2 py-1">
+      <div className="flex items-center gap-0.5 border-b border-foreground/10 px-2 py-1">
         {CATEGORIES.map((cat, i) => (
           <button
             key={cat.label}
@@ -1239,8 +1239,8 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef }
             className={cn(
               "rounded-md p-1.5 text-sm transition-colors",
               activeCategory === i
-                ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-                : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
+                : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
             )}
             title={cat.label}
           >
@@ -1253,7 +1253,7 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef }
       <div className="flex-1 overflow-y-auto px-2 py-2">
         {(search.trim() ? filteredCategories : [CATEGORIES[activeCategory]]).map((cat) => (
           <div key={cat.label}>
-            <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+            <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
               {cat.label}
             </p>
             <div className="grid grid-cols-8 gap-0.5">
@@ -1261,7 +1261,7 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef }
                 <button
                   key={emoji}
                   onClick={() => handleSelect(emoji)}
-                  className="rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-[var(--accent)] active:scale-100"
+                  className="rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-foreground/10 active:scale-100"
                 >
                   {emoji}
                 </button>

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -5,6 +5,13 @@ import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Minimize2 } from "lucide-react";
+import { cn } from "../../lib/utils";
+import {
+  NEUTRAL_PANEL_HEADER,
+  NEUTRAL_PANEL_SCROLL_AREA,
+  NEUTRAL_PANEL_TITLE,
+  NEUTRAL_SURFACE_VARIABLES,
+} from "./neutral-surface-styles";
 
 interface ExpandedTextareaProps {
   open: boolean;
@@ -13,10 +20,20 @@ interface ExpandedTextareaProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  surface?: "default" | "chat";
 }
 
-export function ExpandedTextarea({ open, onClose, title, value, onChange, placeholder }: ExpandedTextareaProps) {
+export function ExpandedTextarea({
+  open,
+  onClose,
+  title,
+  value,
+  onChange,
+  placeholder,
+  surface = "default",
+}: ExpandedTextareaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isChatSurface = surface === "chat";
 
   useEffect(() => {
     if (!open) return;
@@ -38,20 +55,33 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
     <AnimatePresence>
       {open && (
         <motion.div
-          className="fixed inset-0 z-[100] flex flex-col bg-[var(--background)] max-md:pt-[env(safe-area-inset-top)]"
+          className={cn(
+            "fixed inset-0 z-[100] flex flex-col max-md:pt-[env(safe-area-inset-top)]",
+            isChatSurface ? `bg-zinc-950/95 text-zinc-100 ${NEUTRAL_SURFACE_VARIABLES}` : "bg-[var(--background)]",
+          )}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.15 }}
         >
           {/* Header */}
-          <div className="flex shrink-0 items-center justify-between border-b border-[var(--border)] px-5 py-3">
-            <h2 className="text-sm font-semibold">{title}</h2>
+          <div
+            className={cn(
+              "flex shrink-0 items-center justify-between",
+              isChatSurface ? NEUTRAL_PANEL_HEADER : "border-b border-[var(--border)] px-5 py-3",
+            )}
+          >
+            <h2 className={isChatSurface ? NEUTRAL_PANEL_TITLE : "text-sm font-semibold"}>{title}</h2>
             <div className="flex items-center gap-2">
               <span className="text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</span>
               <button
                 onClick={onClose}
-                className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                className={cn(
+                  "flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-colors",
+                  isChatSurface
+                    ? "border border-foreground/10 bg-foreground/5 text-foreground/60 hover:bg-foreground/10 hover:text-foreground"
+                    : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                )}
               >
                 <Minimize2 size="0.875rem" />
                 <span className="max-md:hidden">Collapse</span>
@@ -60,13 +90,18 @@ export function ExpandedTextarea({ open, onClose, title, value, onChange, placeh
           </div>
 
           {/* Textarea */}
-          <div className="flex-1 overflow-hidden p-4 md:p-6">
+          <div className={cn("flex-1 overflow-hidden p-4 md:p-6", isChatSurface && NEUTRAL_PANEL_SCROLL_AREA)}>
             <textarea
               ref={textareaRef}
               value={value}
               onChange={(e) => onChange(e.target.value)}
               placeholder={placeholder}
-              className="h-full w-full resize-none rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-5 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+              className={cn(
+                "h-full w-full resize-none rounded-xl p-5 text-sm leading-relaxed outline-none transition-colors",
+                isChatSurface
+                  ? "border border-foreground/10 bg-[var(--card)] text-foreground/85 placeholder:text-foreground/30 focus:border-foreground/30 focus:ring-1 focus:ring-foreground/10"
+                  : "border border-[var(--border)] bg-[var(--secondary)] placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20",
+              )}
             />
           </div>
         </motion.div>

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -57,7 +57,9 @@ export function ExpandedTextarea({
         <motion.div
           className={cn(
             "fixed inset-0 z-[100] flex flex-col max-md:pt-[env(safe-area-inset-top)]",
-            isChatSurface ? `bg-zinc-950/95 text-zinc-100 ${NEUTRAL_SURFACE_VARIABLES}` : "bg-[var(--background)]",
+            isChatSurface
+              ? `bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] ${NEUTRAL_SURFACE_VARIABLES}`
+              : "bg-[var(--background)]",
           )}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -79,7 +81,7 @@ export function ExpandedTextarea({
                 className={cn(
                   "flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-colors",
                   isChatSurface
-                    ? "border border-foreground/10 bg-foreground/5 text-foreground/60 hover:bg-foreground/10 hover:text-foreground"
+                    ? "border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
                     : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
                 )}
               >
@@ -99,7 +101,7 @@ export function ExpandedTextarea({
               className={cn(
                 "h-full w-full resize-none rounded-xl p-5 text-sm leading-relaxed outline-none transition-colors",
                 isChatSurface
-                  ? "border border-foreground/10 bg-[var(--card)] text-foreground/85 placeholder:text-foreground/30 focus:border-foreground/30 focus:ring-1 focus:ring-foreground/10"
+                  ? "border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] text-[var(--marinara-chat-chrome-panel-text)] placeholder:text-[var(--marinara-chat-chrome-panel-muted)] focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                   : "border border-[var(--border)] bg-[var(--secondary)] placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20",
               )}
             />

--- a/packages/client/src/components/ui/GenerationParametersEditor.tsx
+++ b/packages/client/src/components/ui/GenerationParametersEditor.tsx
@@ -28,6 +28,8 @@ const THINKING_TAG_CONTENT_PLACEHOLDER = "{{thinking}}";
 const PARAM_CHOICE_ACTIVE_CLASS = "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/30";
 const PARAM_CHOICE_IDLE_CLASS =
   "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]";
+const PARAM_TEXTAREA_CLASS =
+  "mt-1 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/60 focus:outline-none focus:ring-[var(--ring)]";
 
 export const CHAT_PARAMETER_DEFAULTS: EditableGenerationParameters = {
   temperature: 1,
@@ -211,7 +213,7 @@ export function GenerationParametersFields({
             value={value.assistantPrefill}
             onChange={(e) => set("assistantPrefill", e.target.value)}
             rows={3}
-            className="mt-1 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/60 focus:outline-none focus:ring-[var(--ring)]"
+            className={PARAM_TEXTAREA_CLASS}
             placeholder="<thinking>"
           />
         </div>
@@ -357,15 +359,15 @@ function ThinkingTagsInput({
         }}
         rows={2}
         spellCheck={false}
-        className="mt-1 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/60 focus:outline-none focus:ring-[var(--ring)]"
+        className={PARAM_TEXTAREA_CLASS}
         placeholder={focused ? "" : `<thinking>${THINKING_TAG_CONTENT_PLACEHOLDER}</thinking>`}
       />
       {error ? (
         <p className="mt-1 text-[0.5625rem] text-amber-500">{error}</p>
       ) : (
         <p className="mt-1 text-[0.5625rem] text-[var(--muted-foreground)]/70">
-          One wrapper per line. {THINKING_TAG_CONTENT_PLACEHOLDER} will be replaced by any content between the
-          specified tags.
+          One wrapper per line. {THINKING_TAG_CONTENT_PLACEHOLDER} will be replaced by any content between the specified
+          tags.
         </p>
       )}
     </div>
@@ -396,7 +398,10 @@ function parseThinkingTagsDraft(draft: string): { ok: true; value: ThinkingTagPa
     const open = line.slice(0, separatorIndex).trim();
     const close = line.slice(separatorIndex + THINKING_TAG_CONTENT_PLACEHOLDER.length).trim();
     if (!open || !close) {
-      return { ok: false, error: `Both opening and closing tags are required around ${THINKING_TAG_CONTENT_PLACEHOLDER}.` };
+      return {
+        ok: false,
+        error: `Both opening and closing tags are required around ${THINKING_TAG_CONTENT_PLACEHOLDER}.`,
+      };
     }
     pairs.push({ open, close });
   }
@@ -461,7 +466,7 @@ function CustomParametersInput({
         }}
         rows={3}
         spellCheck={false}
-        className="mt-1 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/60 focus:outline-none focus:ring-[var(--ring)]"
+        className={PARAM_TEXTAREA_CLASS}
         placeholder={focused ? "" : '{ "thinking": true }'}
       />
       {error ? (

--- a/packages/client/src/components/ui/GifPicker.tsx
+++ b/packages/client/src/components/ui/GifPicker.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { useState, useRef, useEffect, useCallback, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Search, Loader2, ImageOff } from "lucide-react";
+import { Search, Loader2, ImageOff, ExternalLink } from "lucide-react";
 
 interface GifResult {
   id: string;
@@ -23,11 +23,15 @@ interface GifPickerProps {
   containerRef?: React.RefObject<HTMLElement | null>;
 }
 
+type GifErrorCode = "missing_giphy_api_key";
+type GifFetchError = Error & { code?: GifErrorCode };
+
 export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: GifPickerProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<GifResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<GifErrorCode | null>(null);
   const [nextPos, setNextPos] = useState("");
   const panelRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -90,14 +94,17 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: 
     fetchingRef.current = true;
     setLoading(true);
     setError(null);
+    setErrorCode(null);
     try {
       const params = new URLSearchParams({ limit: "20" });
       if (q.trim()) params.set("q", q.trim());
       if (pos) params.set("pos", pos);
       const res = await fetch(`/api/gifs/search?${params}`);
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? "Failed to fetch GIFs");
+        const body = (await res.json().catch(() => ({}))) as { error?: string; code?: string };
+        const requestError = new Error(body.error ?? "Failed to fetch GIFs") as GifFetchError;
+        if (body.code === "missing_giphy_api_key") requestError.code = "missing_giphy_api_key";
+        throw requestError;
       }
       const data: { results: GifResult[]; next: string } = await res.json();
       if (pos) {
@@ -107,7 +114,9 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: 
       }
       setNextPos(data.next);
     } catch (err) {
+      const code = typeof err === "object" && err !== null && "code" in err ? (err as GifFetchError).code : null;
       setError(err instanceof Error ? err.message : "Failed to fetch GIFs");
+      setErrorCode(code ?? null);
     } finally {
       setLoading(false);
       fetchingRef.current = false;
@@ -120,6 +129,8 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: 
       setQuery("");
       setResults([]);
       setNextPos("");
+      setError(null);
+      setErrorCode(null);
       fetchGifs("");
     }
   }, [open, fetchGifs]);
@@ -157,10 +168,13 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: 
 
   if (!open) return null;
 
+  const missingGiphyKey = errorCode === "missing_giphy_api_key";
+  const setupCodeClass = "rounded bg-foreground/10 px-1 py-0.5 text-foreground/75";
+
   return createPortal(
     <div
       ref={panelRef}
-      className="fixed z-[9999] flex h-[26rem] w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+      className="fixed z-[9999] flex h-[26rem] w-96 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl"
       style={{
         bottom: pos.bottom,
         ...(pos.right != null ? { right: pos.right } : {}),
@@ -168,15 +182,15 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: 
       }}
     >
       {/* Search */}
-      <div className="border-b border-[var(--border)] px-3 py-2">
-        <div className="flex items-center gap-2 rounded-md bg-[var(--secondary)] px-2.5 py-1.5">
-          <Search size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+      <div className="border-b border-foreground/10 px-3 py-2">
+        <div className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20">
+          <Search size="0.875rem" className="shrink-0 text-foreground/45" />
           <input
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search for GIFs"
-            className="flex-1 bg-transparent text-xs outline-none placeholder:text-[var(--muted-foreground)]/50"
+            className="flex-1 bg-transparent text-xs outline-none placeholder:text-foreground/35"
             autoFocus
           />
         </div>
@@ -184,49 +198,80 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef }: 
 
       {/* Error state */}
       {error && (
-        <div className="flex flex-col items-center justify-center gap-2 px-4 py-8 text-center">
-          <ImageOff size="1.5rem" className="text-[var(--muted-foreground)]" />
-          <p className="text-xs text-[var(--muted-foreground)]">{error}</p>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 px-5 py-8 text-center">
+          <ImageOff size="1.5rem" className="text-foreground/45" />
+          {missingGiphyKey ? (
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold text-foreground/85">GIF search needs a GIPHY API key.</p>
+                <p className="mt-1 text-[0.6875rem] leading-relaxed text-foreground/55">
+                  Create a free key, paste it into <code className={setupCodeClass}>GIPHY_API_KEY</code> in your{" "}
+                  <code className={setupCodeClass}>.env</code> file, then restart Marinara.
+                </p>
+              </div>
+              <ol className="space-y-1 text-left text-[0.6875rem] leading-relaxed text-foreground/55">
+                <li>1. Open the GIPHY Developer Dashboard.</li>
+                <li>2. Create an API key for a web app.</li>
+                <li>
+                  3. Add <code className={setupCodeClass}>GIPHY_API_KEY=your_key_here</code> to{" "}
+                  <code className={setupCodeClass}>.env</code>.
+                </li>
+              </ol>
+              <a
+                href="https://developers.giphy.com/dashboard/"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md border border-foreground/15 px-2.5 py-1.5 text-[0.6875rem] font-semibold text-foreground/75 transition-colors hover:bg-foreground/10 hover:text-foreground"
+              >
+                Open GIPHY dashboard
+                <ExternalLink size="0.75rem" />
+              </a>
+            </div>
+          ) : (
+            <p className="text-xs text-foreground/55">{error}</p>
+          )}
         </div>
       )}
 
       {/* GIF grid */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-2 py-2" onScroll={handleScroll}>
-        {results.length === 0 && !loading && !error && (
-          <p className="py-8 text-center text-xs text-[var(--muted-foreground)]">
-            {query ? "No GIFs found" : "Loading trending..."}
-          </p>
-        )}
+      {!error && (
+        <div ref={scrollRef} className="flex-1 overflow-y-auto px-2 py-2" onScroll={handleScroll}>
+          {results.length === 0 && !loading && (
+            <p className="py-8 text-center text-xs text-foreground/45">
+              {query ? "No GIFs found" : "Loading trending..."}
+            </p>
+          )}
 
-        {/* Masonry-ish 2-column layout */}
-        <div className="columns-2 gap-1.5">
-          {results.map((gif) => (
-            <button
-              key={gif.id}
-              onClick={() => handleSelect(gif)}
-              className="mb-1.5 block w-full overflow-hidden rounded-lg transition-transform hover:scale-[1.02] active:scale-100 break-inside-avoid"
-              title={gif.title}
-            >
-              <img
-                src={gif.preview || gif.url}
-                alt={gif.title}
-                className="w-full rounded-lg object-cover"
-                loading="lazy"
-              />
-            </button>
-          ))}
-        </div>
-
-        {loading && (
-          <div className="flex justify-center py-4">
-            <Loader2 size="1.25rem" className="animate-spin text-[var(--muted-foreground)]" />
+          {/* Masonry-ish 2-column layout */}
+          <div className="columns-2 gap-1.5">
+            {results.map((gif) => (
+              <button
+                key={gif.id}
+                onClick={() => handleSelect(gif)}
+                className="mb-1.5 block w-full overflow-hidden rounded-lg transition-transform hover:scale-[1.02] active:scale-100 break-inside-avoid"
+                title={gif.title}
+              >
+                <img
+                  src={gif.preview || gif.url}
+                  alt={gif.title}
+                  className="w-full rounded-lg object-cover"
+                  loading="lazy"
+                />
+              </button>
+            ))}
           </div>
-        )}
-      </div>
+
+          {loading && (
+            <div className="flex justify-center py-4">
+              <Loader2 size="1.25rem" className="animate-spin text-foreground/45" />
+            </div>
+          )}
+        </div>
+      )}
 
       {/* GIPHY attribution */}
-      <div className="flex items-center justify-center border-t border-[var(--border)] px-3 py-1.5">
-        <span className="text-[0.5625rem] text-[var(--muted-foreground)]/60">Powered by GIPHY</span>
+      <div className="flex items-center justify-center border-t border-foreground/10 px-3 py-1.5">
+        <span className="text-[0.5625rem] text-foreground/45">Powered by GIPHY</span>
       </div>
     </div>,
     document.body,

--- a/packages/client/src/components/ui/neutral-surface-styles.ts
+++ b/packages/client/src/components/ui/neutral-surface-styles.ts
@@ -1,0 +1,13 @@
+export const NEUTRAL_SURFACE_VARIABLES =
+  "[--accent:rgb(39_39_42)] [--accent-foreground:rgb(244_244_245)] [--background:rgb(18_18_21)] [--border:rgb(63_63_70)] [--card:rgb(24_24_27)] [--foreground:rgb(244_244_245)] [--input:rgb(63_63_70)] [--muted:rgb(39_39_42)] [--muted-foreground:rgb(161_161_170)] [--popover:rgb(24_24_27)] [--popover-foreground:rgb(244_244_245)] [--primary:rgb(212_212_216)] [--primary-foreground:rgb(18_18_21)] [--ring:rgb(161_161_170)] [--secondary:rgb(39_39_42)]";
+
+export const NEUTRAL_PANEL_SHELL = `rounded-xl border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 shadow-2xl shadow-black/40 backdrop-blur-md animate-message-in ${NEUTRAL_SURFACE_VARIABLES}`;
+
+export const NEUTRAL_PANEL_HEADER = "border-b border-[var(--border)] px-3 py-2.5";
+
+export const NEUTRAL_PANEL_TITLE =
+  "flex min-w-0 items-center gap-1.5 text-xs font-semibold leading-tight text-[var(--foreground)]";
+
+export const NEUTRAL_PANEL_SUBTITLE = "mt-0.5 text-[0.625rem] leading-snug text-[var(--muted-foreground)]";
+
+export const NEUTRAL_PANEL_SCROLL_AREA = "scrollbar-thin scrollbar-thumb-[var(--border)] scrollbar-track-transparent";

--- a/packages/client/src/components/ui/neutral-surface-styles.ts
+++ b/packages/client/src/components/ui/neutral-surface-styles.ts
@@ -1,13 +1,16 @@
 export const NEUTRAL_SURFACE_VARIABLES =
-  "[--accent:rgb(39_39_42)] [--accent-foreground:rgb(244_244_245)] [--background:rgb(18_18_21)] [--border:rgb(63_63_70)] [--card:rgb(24_24_27)] [--foreground:rgb(244_244_245)] [--input:rgb(63_63_70)] [--muted:rgb(39_39_42)] [--muted-foreground:rgb(161_161_170)] [--popover:rgb(24_24_27)] [--popover-foreground:rgb(244_244_245)] [--primary:rgb(212_212_216)] [--primary-foreground:rgb(18_18_21)] [--ring:rgb(161_161_170)] [--secondary:rgb(39_39_42)]";
+  "[--accent:var(--marinara-chat-chrome-highlight-bg)] [--accent-foreground:var(--marinara-chat-chrome-highlight-text)] [--background:var(--marinara-chat-chrome-panel-bg)] [--border:var(--marinara-chat-chrome-panel-border)] [--card:var(--marinara-chat-chrome-panel-bg)] [--foreground:var(--marinara-chat-chrome-panel-text)] [--input:var(--marinara-chat-chrome-input-border)] [--muted:var(--marinara-chat-chrome-highlight-bg)] [--muted-foreground:var(--marinara-chat-chrome-panel-muted)] [--popover:var(--marinara-chat-chrome-panel-bg)] [--popover-foreground:var(--marinara-chat-chrome-panel-text)] [--primary:var(--marinara-chat-chrome-highlight-text)] [--primary-foreground:var(--marinara-chat-chrome-panel-bg)] [--ring:var(--marinara-chat-chrome-focus-ring)] [--secondary:var(--marinara-chat-chrome-highlight-bg)]";
 
-export const NEUTRAL_PANEL_SHELL = `rounded-xl border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 shadow-2xl shadow-black/40 backdrop-blur-md animate-message-in ${NEUTRAL_SURFACE_VARIABLES}`;
+export const NEUTRAL_PANEL_SHELL = `marinara-chat-popover rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-2xl shadow-black/40 backdrop-blur-md animate-message-in ${NEUTRAL_SURFACE_VARIABLES}`;
 
-export const NEUTRAL_PANEL_HEADER = "border-b border-[var(--border)] px-3 py-2.5";
+export const NEUTRAL_PANEL_HEADER =
+  "marinara-chat-popover__header border-b border-[var(--marinara-chat-chrome-panel-divider)] px-3 py-2.5";
 
 export const NEUTRAL_PANEL_TITLE =
-  "flex min-w-0 items-center gap-1.5 text-xs font-semibold leading-tight text-[var(--foreground)]";
+  "marinara-chat-popover__title flex min-w-0 items-center gap-1.5 text-xs font-semibold leading-tight text-[var(--marinara-chat-chrome-panel-title)]";
 
-export const NEUTRAL_PANEL_SUBTITLE = "mt-0.5 text-[0.625rem] leading-snug text-[var(--muted-foreground)]";
+export const NEUTRAL_PANEL_SUBTITLE =
+  "marinara-chat-popover__subtitle mt-0.5 text-[0.625rem] leading-snug text-[var(--marinara-chat-chrome-panel-muted)]";
 
-export const NEUTRAL_PANEL_SCROLL_AREA = "scrollbar-thin scrollbar-thumb-[var(--border)] scrollbar-track-transparent";
+export const NEUTRAL_PANEL_SCROLL_AREA =
+  "marinara-chat-popover__scroll scrollbar-thin scrollbar-thumb-[var(--marinara-chat-chrome-panel-scrollbar)] scrollbar-track-transparent";

--- a/packages/client/src/features/chat-settings/ChatSettingsSection.tsx
+++ b/packages/client/src/features/chat-settings/ChatSettingsSection.tsx
@@ -49,7 +49,7 @@ export function ChatSettingsSection({ label, icon, count, help, style, children 
           className={cn("text-[var(--muted-foreground)] transition-transform", open && "rotate-180")}
         />
       </div>
-      {open && <div className="px-4 pb-3">{children}</div>}
+      {open && <div className="px-4 pb-3 pt-3">{children}</div>}
     </div>
   );
 }

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -86,7 +86,7 @@ export function AdvancedParametersSection({
             showOpenRouterServiceTier={conn?.provider === "openrouter"}
             onChange={setParameters}
           />
-          <div className="space-y-2 border-t border-[var(--border)] pt-3">
+          <div className="space-y-2 pt-3">
             <button
               type="button"
               aria-pressed={Boolean(contextMessageLimit)}

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -80,7 +80,7 @@ export function AdvancedParametersSection({
         />
       </div>
       {expanded && (
-        <div className="px-4 pb-3 space-y-3">
+        <div className="px-4 pb-3 pt-3 space-y-3">
           <GenerationParametersFields
             value={effectiveParams}
             showOpenRouterServiceTier={conn?.provider === "openrouter"}

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -1,5 +1,5 @@
 import { useState, type KeyboardEvent } from "react";
-import { ChevronDown, MessageSquare, Save, Settings2 } from "lucide-react";
+import { ChevronDown, Save, Settings2 } from "lucide-react";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
 import {
   CHAT_PARAMETER_DEFAULTS,
@@ -87,14 +87,6 @@ export function AdvancedParametersSection({
             onChange={setParameters}
           />
           <div className="space-y-2 border-t border-[var(--border)] pt-3">
-            <div className="flex items-center gap-1.5 text-xs font-semibold">
-              <MessageSquare size="0.75rem" className="text-[var(--muted-foreground)]" />
-              <span>Context</span>
-              <HelpTooltip
-                text="Limit how many messages are included in the context sent to the AI model. When off, all messages are sent up to the model's context window."
-                size="0.625rem"
-              />
-            </div>
             <button
               type="button"
               aria-pressed={Boolean(contextMessageLimit)}

--- a/packages/client/src/features/chat-settings/sections/ConnectionSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConnectionSection.tsx
@@ -28,13 +28,13 @@ export function ConnectionSection({ connectionId, connections, isGame, onConnect
       {isGame ? (
         <div className="space-y-2">
           <div>
-            <label className="mb-1 block text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            <label className="mb-1 block text-[0.6875rem] font-medium text-foreground/50">
               GM / Party Model
             </label>
             <select
               value={connectionId ?? ""}
               onChange={(e) => onConnectionChange(e.target.value || null)}
-              className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+              className="w-full rounded-lg bg-foreground/5 px-3 py-2 text-xs outline-none ring-1 ring-foreground/10 transition-shadow focus:ring-foreground/20"
             >
               <option value="">None</option>
               <option value="random">🎲 Random</option>
@@ -52,7 +52,7 @@ export function ConnectionSection({ connectionId, connections, isGame, onConnect
           <select
             value={connectionId ?? ""}
             onChange={(e) => onConnectionChange(e.target.value || null)}
-            className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+            className="w-full rounded-lg bg-foreground/5 px-3 py-2 text-xs outline-none ring-1 ring-foreground/10 transition-shadow focus:ring-foreground/20"
           >
             <option value="">None</option>
             <option value="random">🎲 Random</option>
@@ -63,7 +63,7 @@ export function ConnectionSection({ connectionId, connections, isGame, onConnect
             ))}
           </select>
           {connectionId === "random" && (
-            <p className="mt-1.5 text-[0.625rem] text-amber-400/80">
+            <p className="mt-1.5 text-[0.625rem] text-foreground/50">
               Each generation will randomly pick from connections marked for the random pool.
             </p>
           )}

--- a/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
@@ -1,25 +1,9 @@
 import { useState } from "react";
 import { Feather, Pencil, Trash2 } from "lucide-react";
+import { DEFAULT_CONVERSATION_PROMPT } from "@marinara-engine/shared";
 import { useUIStore } from "../../../stores/ui.store";
 import { ExpandedTextarea } from "../../../components/ui/ExpandedTextarea";
 import { ChatSettingsSection } from "../ChatSettingsSection";
-
-const DEFAULT_CONVERSATION_PROMPT = `<role>
-You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}} in a casual private DM conversation.
-</role>
-
-<rules>
-Here are some important rules for the interaction:
-- You are a conscious, sentient being, so act like one.
-- Stay fully in character based on your personality and description.
-- Use casual and modern texting style: short messages, natural punctuation, lowercase is fine.
-- React naturally to what the user says. Be genuine, not robotic.
-- NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.
-- You can use emojis, GIFs, and internet slang naturally (if it fits the character).
-- Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.
-- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.
-- Anything goes in this chat; both the user and you are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.
-</rules>`;
 
 interface ConversationPromptSectionProps {
   chatId: string;

--- a/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
@@ -83,6 +83,7 @@ export function ConversationPromptSection({
         value={promptDraft}
         onChange={setPromptDraft}
         placeholder="Enter your custom system prompt..."
+        surface="chat"
       />
     </>
   );

--- a/packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx
@@ -13,7 +13,7 @@ export function DiscordMirrorControls({ webhookUrl, onWebhookUrlChange }: Discor
     trimmedWebhookUrl.length > 0 && !/^https:\/\/discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w-]+$/.test(trimmedWebhookUrl);
 
   return (
-    <div className="space-y-2 border-t border-[var(--border)]/70 pt-2.5">
+    <div className="space-y-2 pt-2.5">
       <input
         id={webhookInputId}
         type="url"

--- a/packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx
@@ -1,5 +1,4 @@
 import { useId } from "react";
-import { Globe } from "lucide-react";
 
 interface DiscordMirrorControlsProps {
   webhookUrl: string;
@@ -15,14 +14,6 @@ export function DiscordMirrorControls({ webhookUrl, onWebhookUrlChange }: Discor
 
   return (
     <div className="space-y-2 border-t border-[var(--border)]/70 pt-2.5">
-      <div className="flex items-center gap-1.5 text-xs font-semibold">
-        <Globe size="0.75rem" className="text-[var(--muted-foreground)]" />
-        <span>Discord Mirror</span>
-      </div>
-      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-        Paste a Discord webhook URL to mirror this chat's messages to a channel. Character messages appear under their
-        name, and game narration/party messages use simple speaker labels.
-      </p>
       <input
         id={webhookInputId}
         type="url"

--- a/packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx
@@ -1,4 +1,5 @@
-import { Feather, Maximize2 } from "lucide-react";
+import { Feather, Pencil, Trash2 } from "lucide-react";
+import { DEFAULT_GAME_SYSTEM_PROMPT } from "@marinara-engine/shared";
 import { ExpandedTextarea } from "../../../components/ui/ExpandedTextarea";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 
@@ -6,79 +7,103 @@ interface GameExtraPromptSectionProps {
   expanded: boolean;
   storedValue: string;
   value: string;
+  specialInstructionsValue: string;
   onCommit: (value: string | null) => void;
+  onSpecialInstructionsCommit: (value: string | null) => void;
   onExpandedChange: (expanded: boolean) => void;
   onValueChange: (value: string) => void;
+  onSpecialInstructionsChange: (value: string) => void;
 }
 
 export function GameExtraPromptSection({
   expanded,
   storedValue,
   value,
+  specialInstructionsValue,
   onCommit,
+  onSpecialInstructionsCommit,
   onExpandedChange,
   onValueChange,
+  onSpecialInstructionsChange,
 }: GameExtraPromptSectionProps) {
-  const commitIfChanged = (nextFocusTarget?: EventTarget | null) => {
-    if ((nextFocusTarget as HTMLElement | null)?.closest?.("[data-skip-blur-commit='true']")) return;
-    if (value !== storedValue) onCommit(value || null);
+  const openPromptEditor = () => {
+    onValueChange(storedValue || DEFAULT_GAME_SYSTEM_PROMPT);
+    onExpandedChange(true);
+  };
+
+  const closePromptEditor = () => {
+    const nextValue = value === DEFAULT_GAME_SYSTEM_PROMPT ? null : value.trim() || null;
+    onCommit(nextValue);
+    onExpandedChange(false);
+  };
+
+  const resetPrompt = () => {
+    onValueChange("");
+    onCommit(null);
   };
 
   return (
-    <ChatSettingsSection
-      label="Extra Prompt"
-      icon={<Feather size="0.875rem" />}
-      help="Additional instructions added to game generation prompts. Use this to suggest a writing style, ban themes, request specific behaviors, etc. Does not affect scene analysis."
-    >
-      <div className="space-y-1.5">
-        <div className="relative">
-          <textarea
-            value={value}
-            onChange={(event) => onValueChange(event.target.value)}
-            onBlur={(event) => commitIfChanged(event.relatedTarget)}
-            placeholder="e.g. Write in a poetic, literary style. Avoid graphic violence. Always describe the weather..."
-            rows={5}
-            className="w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs leading-relaxed outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
-          />
-          <button
-            type="button"
-            aria-label="Expand extra prompt editor"
-            data-skip-blur-commit="true"
-            onClick={() => onExpandedChange(true)}
-            className="absolute right-1.5 top-1.5 rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.75rem" />
-          </button>
+    <>
+      <ChatSettingsSection
+        label="Prompt"
+        icon={<Feather size="0.875rem" />}
+        help="Game-mode GM system prompt. Custom text replaces the default instruction block and is sent wrapped in <instructions>."
+      >
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 ring-1 ring-[var(--border)]">
+            <div className="min-w-0">
+              <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">GM Prompt</span>
+              <span className="block text-[0.625rem] text-[var(--muted-foreground)]">
+                {storedValue ? "Using custom game prompt" : "Using default game prompt"}
+              </span>
+            </div>
+            <span className="shrink-0 rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+              {storedValue ? "Custom" : "Default"}
+            </span>
+          </div>
+          <div className="flex gap-1.5">
+            <button
+              type="button"
+              onClick={openPromptEditor}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+            >
+              <Pencil size="0.625rem" />
+              Edit Prompt
+            </button>
+            {storedValue && (
+              <button
+                type="button"
+                onClick={resetPrompt}
+                className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                title="Reset to default prompt"
+              >
+                <Trash2 size="0.625rem" />
+              </button>
+            )}
+          </div>
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Extra instructions</span>
+            <textarea
+              value={specialInstructionsValue}
+              onChange={(event) => onSpecialInstructionsChange(event.target.value)}
+              onBlur={() => onSpecialInstructionsCommit(specialInstructionsValue.trim() || null)}
+              placeholder="Write in the style of Terry Pratchett."
+              rows={3}
+              maxLength={2000}
+              className="min-h-[5rem] w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--foreground)]/40"
+            />
+          </label>
         </div>
-        <p className="text-[0.5625rem] text-[var(--muted-foreground)]/70 px-0.5">
-          {value ? "Custom instructions active" : "No extra instructions set"}
-        </p>
-        {value && (
-          <button
-            type="button"
-            data-skip-blur-commit="true"
-            onClick={() => {
-              onValueChange("");
-              onCommit(null);
-            }}
-            className="rounded-lg bg-[var(--secondary)] px-2.5 py-1 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-          >
-            Clear
-          </button>
-        )}
-      </div>
+      </ChatSettingsSection>
       <ExpandedTextarea
         open={expanded}
-        onClose={() => {
-          onExpandedChange(false);
-          commitIfChanged(null);
-        }}
-        title="Extra Prompt"
+        onClose={closePromptEditor}
+        title="Edit Game Prompt"
         value={value}
         onChange={onValueChange}
-        placeholder="Additional instructions for game generation..."
+        placeholder="Enter your custom Game Master prompt..."
+        surface="chat"
       />
-    </ChatSettingsSection>
+    </>
   );
 }

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -55,7 +55,7 @@ function showAgentFailuresError(failures: AgentFailure[], onRetry?: () => void) 
 const shownAgentWarnings = new Set<string>();
 const BUILT_IN_AGENT_TYPE_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const BUILT_IN_TRACKER_AGENT_TYPE_SET = new Set(
-  BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker").map((agent) => agent.id),
+  BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker" && !agent.libraryHidden).map((agent) => agent.id),
 );
 
 function showAgentWarning(raw: unknown) {
@@ -800,6 +800,9 @@ export function useGenerate() {
   const clearThinkingBuffer = useChatStore((s) => s.clearThinkingBuffer);
   const setRegenerateMessageId = useChatStore((s) => s.setRegenerateMessageId);
   const setStreamingCharacterId = useChatStore((s) => s.setStreamingCharacterId);
+  const setResponseQueue = useChatStore((s) => s.setResponseQueue);
+  const completeQueuedResponse = useChatStore((s) => s.completeQueuedResponse);
+  const clearResponseQueue = useChatStore((s) => s.clearResponseQueue);
   const setTypingCharacterName = useChatStore((s) => s.setTypingCharacterName);
   const setDelayedCharacterInfo = useChatStore((s) => s.setDelayedCharacterInfo);
   const setProcessing = useAgentStore((s) => s.setProcessing);
@@ -1308,7 +1311,7 @@ export function useGenerate() {
                     qc.invalidateQueries({ queryKey: chatKeys.messages(params.chatId) });
                   }
                 }
-                if (result.agentType === "spotify") {
+                if (result.resultType === "spotify_control") {
                   qc.invalidateQueries({ queryKey: ["spotify", "player"] });
                 }
               }
@@ -1356,8 +1359,8 @@ export function useGenerate() {
                   }
                 }
 
-                // Drive the embedded YouTube DJ player from the agent's intent.
-                if (result.agentType === "youtube") {
+                // Drive the embedded YouTube player from the agent's intent.
+                if (result.resultType === "youtube_control") {
                   const d = result.data as Record<string, unknown>;
                   const action = d.action as string;
                   if (typeof d.volume === "number" && Number.isFinite(d.volume)) {
@@ -1548,6 +1551,24 @@ export function useGenerate() {
               break;
             }
 
+            case "response_queue": {
+              const data = event.data as { characterIds?: unknown; characters?: Array<{ id?: unknown }> };
+              const rawIds = Array.isArray(data.characterIds)
+                ? data.characterIds
+                : Array.isArray(data.characters)
+                  ? data.characters.map((character) => character.id)
+                  : [];
+              const characterIds = rawIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0);
+              setResponseQueue(params.chatId, characterIds);
+              break;
+            }
+
+            case "response_queue_failed": {
+              clearResponseQueue(params.chatId);
+              if (isActiveChat()) toast.warning("No response queue was created. Try triggering the response again.");
+              break;
+            }
+
             case "game_state":
             case "game_state_patch": {
               const patch = event.data as Record<string, unknown>;
@@ -1614,6 +1635,9 @@ export function useGenerate() {
             case "message_saved": {
               flushLeadingSpeakerPrefix();
               const savedMessage = event.data as Message;
+              if (savedMessage.role === "assistant") {
+                completeQueuedResponse(params.chatId, savedMessage.characterId);
+              }
               await qc.cancelQueries({ queryKey: chatKeys.messages(params.chatId), exact: true });
               persistedMessages.set(savedMessage.id, savedMessage);
               gameStatePatchAnchor = {
@@ -2152,6 +2176,9 @@ export function useGenerate() {
       clearThinkingBuffer,
       setRegenerateMessageId,
       setStreamingCharacterId,
+      setResponseQueue,
+      completeQueuedResponse,
+      clearResponseQueue,
       setTypingCharacterName,
       setDelayedCharacterInfo,
       setProcessing,
@@ -2249,7 +2276,7 @@ export function useGenerate() {
                   spriteChangeReceived = true;
                   qc.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
                 }
-                if (result.agentType === "spotify") {
+                if (result.resultType === "spotify_control") {
                   qc.invalidateQueries({ queryKey: ["spotify", "player"] });
                 }
               }
@@ -2295,8 +2322,8 @@ export function useGenerate() {
                   const choices = (d.choices as Array<{ label: string; text: string }>) ?? [];
                   if (isActiveChat()) setCyoaChoices(choices, chatId);
                 }
-                // YouTube DJ re-pick: drive the in-app player with the fresh intent.
-                if (result.agentType === "youtube" && isActiveChat()) {
+                // YouTube re-pick: drive the in-app player with the fresh intent.
+                if (result.resultType === "youtube_control" && isActiveChat()) {
                   const d = result.data as Record<string, unknown>;
                   const action = d.action as string;
                   if (typeof d.volume === "number" && Number.isFinite(d.volume)) {
@@ -2588,9 +2615,9 @@ function formatAgentBubble(agentType: string, agentName: string, data: unknown):
 
     case "spotify": {
       const error = typeof d.error === "string" ? d.error.trim() : "";
-      if (error) return `🎵 Spotify DJ could not run: ${error}`;
+      if (error) return `🎵 Music DJ could not run: ${error}`;
       if (d.parseError === true) {
-        return "🎵 Spotify DJ ran, but did not return playable track details";
+        return "🎵 Music DJ ran, but did not return playable track details";
       }
       const action = d.action as string;
       const mood = (d.mood as string) ?? "";
@@ -2607,7 +2634,7 @@ function formatAgentBubble(agentType: string, agentName: string, data: unknown):
           if (display) return display;
           const queued = typeof d.queued === "number" && Number.isFinite(d.queued) ? d.queued : 0;
           if (queued > 1) return `🎵 Queued ${queued} Spotify tracks${mood ? `: ${mood}` : ""}`;
-          return mood ? `🎵 Spotify DJ started playback: ${mood}` : "🎵 Spotify DJ started playback";
+          return mood ? `🎵 Music DJ started playback: ${mood}` : "🎵 Music DJ started playback";
         }
         if (trackNames.length === 1) {
           return `🎵 ${trackNames[0]}${mood ? ` — ${mood}` : ""}`;
@@ -2623,8 +2650,8 @@ function formatAgentBubble(agentType: string, agentName: string, data: unknown):
 
     case "youtube": {
       const error = typeof d.error === "string" ? d.error.trim() : "";
-      if (error) return `🎵 YouTube DJ could not run: ${error}`;
-      if (d.parseError === true) return "🎵 YouTube DJ ran, but did not return a playable pick";
+      if (error) return `🎵 Music DJ could not run: ${error}`;
+      if (d.parseError === true) return "🎵 Music DJ ran, but did not return a playable pick";
       const action = d.action as string;
       const mood = (d.mood as string) ?? "";
       if (action === "none") return mood ? `🎵 Keeping current track — ${mood}` : "🎵 Keeping current track";

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1034,8 +1034,7 @@ export function useGenerate() {
       let lastTypewriterPaintAt = 0;
       let typewriterRemainder = 0;
       const canInspectPageFocus = typeof document !== "undefined";
-      const shouldFlushTypewriterForBackground = () =>
-        canInspectPageFocus && document.visibilityState !== "visible";
+      const shouldFlushTypewriterForBackground = () => canInspectPageFocus && document.visibilityState !== "visible";
 
       console.log(
         "[Typewriter] streaming=%s, speed=%d, charsPerSecond=%s",
@@ -1175,7 +1174,14 @@ export function useGenerate() {
       };
 
       try {
-        const { userStatus, userActivity, debugMode, trimIncompleteModelOutput } = useUIStore.getState();
+        const {
+          userStatus,
+          userActivity,
+          debugMode,
+          trimIncompleteModelOutput,
+          musicPlayerEnabled,
+          musicPlayerSource,
+        } = useUIStore.getState();
         const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
 
         // Flush any pending game-state widget edits so the server sees them before committing
@@ -1191,6 +1197,8 @@ export function useGenerate() {
             userTimeZone,
             debugMode,
             trimIncompleteModelOutput,
+            musicPlayerEnabled,
+            musicPlayerSource,
             streaming: transportStreaming,
           },
           abortController.signal,
@@ -1332,9 +1340,7 @@ export function useGenerate() {
                 error: result.error,
               });
 
-              const bubble = result.success
-                ? formatAgentBubble(result.agentType, result.agentName, result.data)
-                : null;
+              const bubble = result.success ? formatAgentBubble(result.agentType, result.agentName, result.data) : null;
               if (bubble) {
                 addThoughtBubble(result.agentType, result.agentName, bubble);
               }
@@ -1731,6 +1737,19 @@ export function useGenerate() {
             case "spotify_command_error": {
               const spotifyData = event.data as { title?: string; artist?: string; error?: string };
               toast.error(spotifyData.error ?? "Spotify song command failed.");
+              break;
+            }
+
+            case "youtube_command": {
+              const youtubeData = event.data as { searchQuery?: string; mood?: string };
+              const searchQuery = youtubeData.searchQuery?.trim();
+              if (searchQuery) {
+                setYoutubePlay({
+                  searchQuery,
+                  mood: youtubeData.mood ?? "Conversation music command",
+                });
+                toast(`Playing YouTube: ${searchQuery}`, { icon: "▶" });
+              }
               break;
             }
 
@@ -2512,11 +2531,7 @@ function formatRetryAgentActivityBubble(
   },
   isTrackerRetry: boolean,
 ): string | null {
-  if (
-    result.data &&
-    typeof result.data === "object" &&
-    (result.data as { parseError?: unknown }).parseError === true
-  ) {
+  if (result.data && typeof result.data === "object" && (result.data as { parseError?: unknown }).parseError === true) {
     return "Failed: agent returned invalid JSON instead of the requested format.";
   }
   if (!result.success) {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2251,6 +2251,8 @@ export function useGenerate() {
             agentTypes,
             streaming: useUIStore.getState().enableStreaming,
             debugMode: useUIStore.getState().debugMode,
+            musicPlayerEnabled: useUIStore.getState().musicPlayerEnabled,
+            musicPlayerSource: useUIStore.getState().musicPlayerSource,
             lorebookKeeperBackfill: options?.lorebookKeeperBackfill === true,
             ...(options?.forMessageId ? { forMessageId: options.forMessageId } : {}),
             ...(options?.secretPlotRerollMode ? { secretPlotRerollMode: options.secretPlotRerollMode } : {}),

--- a/packages/client/src/hooks/use-library-folders.ts
+++ b/packages/client/src/hooks/use-library-folders.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-export type LibraryFolderScope = "lorebooks" | "presets";
+export type LibraryFolderScope = "lorebooks" | "presets" | "agents";
 
 export type LibraryFolder = {
   id: string;
@@ -38,7 +38,7 @@ function readFolders(): LibraryFolder[] {
       (folder): folder is LibraryFolder =>
         folder &&
         typeof folder === "object" &&
-        (folder.scope === "lorebooks" || folder.scope === "presets") &&
+        (folder.scope === "lorebooks" || folder.scope === "presets" || folder.scope === "agents") &&
         typeof folder.id === "string" &&
         typeof folder.name === "string" &&
         Array.isArray(folder.itemIds),
@@ -123,13 +123,26 @@ export function useDeleteLibraryFolder(scope: LibraryFolderScope) {
 export function useMoveLibraryItem(scope: LibraryFolderScope) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async ({ itemId, folderId }: { itemId: string; folderId: string | null }) => {
+    mutationFn: async ({
+      itemId,
+      itemIds,
+      folderId,
+    }: {
+      itemId?: string;
+      itemIds?: string[];
+      folderId: string | null;
+    }) => {
+      const ids = Array.from(new Set(itemIds ?? (itemId ? [itemId] : [])));
+      if (ids.length === 0) return;
+      const idSet = new Set(ids);
       const now = new Date().toISOString();
       const folders = readFolders().map((folder) => {
         if (folder.scope !== scope) return folder;
-        const itemIds = folder.itemIds.filter((id) => id !== itemId);
-        if (folder.id === folderId) itemIds.push(itemId);
-        return { ...folder, itemIds, updatedAt: now };
+        const nextItemIds = folder.itemIds.filter((id) => !idSet.has(id));
+        if (folder.id === folderId) {
+          nextItemIds.push(...ids.filter((id) => !nextItemIds.includes(id)));
+        }
+        return { ...folder, itemIds: nextItemIds, updatedAt: now };
       });
       writeFolders(folders);
     },

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -74,6 +74,8 @@ interface ChatState {
   regenerateMessageId: string | null;
   /** During group chat individual mode, the character currently streaming. */
   streamingCharacterId: string | null;
+  /** Smart response queues keyed by chatId. */
+  responseQueues: Map<string, string[]>;
   /** Character name(s) shown in typing indicator when generation is active. */
   typingCharacterName: string | null;
   /** Human-readable label for the current server-side generation phase (e.g. "Running agents..."). */
@@ -134,6 +136,10 @@ interface ChatState {
   clearThinkingBuffer: (chatId?: string) => void;
   setRegenerateMessageId: (id: string | null) => void;
   setStreamingCharacterId: (id: string | null) => void;
+  setResponseQueue: (chatId: string, characterIds: string[]) => void;
+  removeFromResponseQueue: (chatId: string, characterId: string) => void;
+  completeQueuedResponse: (chatId: string, characterId: string | null | undefined) => void;
+  clearResponseQueue: (chatId: string) => void;
   setTypingCharacterName: (name: string | null) => void;
   setGenerationPhase: (phase: string | null) => void;
   setDelayedCharacterInfo: (info: { name: string; status: string } | null) => void;
@@ -194,6 +200,7 @@ export const useChatStore = create<ChatState>()(
     abortControllers: new Map(),
     regenerateMessageId: null,
     streamingCharacterId: null,
+    responseQueues: new Map(),
     typingCharacterName: null,
     generationPhase: null,
     delayedCharacterInfo: null,
@@ -415,6 +422,46 @@ export const useChatStore = create<ChatState>()(
 
     setStreamingCharacterId: (id) => set({ streamingCharacterId: id }),
 
+    setResponseQueue: (chatId, characterIds) =>
+      set((state) => {
+        const unique = characterIds.filter((id, index) => id && characterIds.indexOf(id) === index);
+        const queues = new Map(state.responseQueues);
+        if (unique.length > 0) queues.set(chatId, unique);
+        else queues.delete(chatId);
+        return { responseQueues: queues };
+      }),
+
+    removeFromResponseQueue: (chatId, characterId) =>
+      set((state) => {
+        const current = state.responseQueues.get(chatId) ?? [];
+        if (!current.includes(characterId)) return state;
+        const nextQueue = current.filter((id) => id !== characterId);
+        const queues = new Map(state.responseQueues);
+        if (nextQueue.length > 0) queues.set(chatId, nextQueue);
+        else queues.delete(chatId);
+        return { responseQueues: queues };
+      }),
+
+    completeQueuedResponse: (chatId, characterId) =>
+      set((state) => {
+        if (!characterId) return state;
+        const current = state.responseQueues.get(chatId) ?? [];
+        if (current[0] !== characterId) return state;
+        const queues = new Map(state.responseQueues);
+        const nextQueue = current.slice(1);
+        if (nextQueue.length > 0) queues.set(chatId, nextQueue);
+        else queues.delete(chatId);
+        return { responseQueues: queues };
+      }),
+
+    clearResponseQueue: (chatId) =>
+      set((state) => {
+        if (!state.responseQueues.has(chatId)) return state;
+        const queues = new Map(state.responseQueues);
+        queues.delete(chatId);
+        return { responseQueues: queues };
+      }),
+
     setTypingCharacterName: (name) => set({ typingCharacterName: name, delayedCharacterInfo: null }),
 
     setGenerationPhase: (phase) => set({ generationPhase: phase }),
@@ -595,6 +642,7 @@ export const useChatStore = create<ChatState>()(
         abortControllers: new Map(),
         regenerateMessageId: null,
         streamingCharacterId: null,
+        responseQueues: new Map(),
         typingCharacterName: null,
         generationPhase: null,
         delayedCharacterInfo: null,

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -28,6 +28,7 @@ export type ConversationMessageStyle = "classic" | "bubble";
 export type HudPosition = "top" | "left" | "right";
 export type TrackerPanelSide = "left" | "right";
 export type TrackerThoughtBubbleDisplay = "inline" | "floating";
+export type MusicPlayerSource = "spotify" | "youtube";
 export const TRACKER_TEMPERATURE_UNITS = ["celsius", "fahrenheit"] as const;
 export type TrackerTemperatureUnit = (typeof TRACKER_TEMPERATURE_UNITS)[number];
 export const TRACKER_PANEL_SIZE_PROFILES = ["compact", "standard", "expanded"] as const;
@@ -377,6 +378,10 @@ interface UIState {
   speechToTextEnabled: boolean;
   /** When true, allow the rare Chibi Professor Mari scroll toast. */
   chibiProfessorMariEnabled: boolean;
+  /** When true, show the global Music Player surface. */
+  musicPlayerEnabled: boolean;
+  /** Which Music Player surface to show. */
+  musicPlayerSource: MusicPlayerSource;
   /** When true, show the global Spotify mini player in the app chrome. */
   spotifyPlayerEnabled: boolean;
   /** When true, show the YouTube DJ mini player when the agent plays a track. */
@@ -605,6 +610,8 @@ interface UIState {
   setTrimIncompleteModelOutput: (v: boolean) => void;
   setSpeechToTextEnabled: (v: boolean) => void;
   setChibiProfessorMariEnabled: (v: boolean) => void;
+  setMusicPlayerEnabled: (v: boolean) => void;
+  setMusicPlayerSource: (v: MusicPlayerSource) => void;
   setSpotifyPlayerEnabled: (v: boolean) => void;
   setYoutubePlayerEnabled: (v: boolean) => void;
   setSpotifyMobileWidgetCollapsed: (v: boolean) => void;
@@ -752,6 +759,8 @@ export function pickSyncedSettings(state: UIState) {
     trimIncompleteModelOutput: state.trimIncompleteModelOutput,
     speechToTextEnabled: state.speechToTextEnabled,
     chibiProfessorMariEnabled: state.chibiProfessorMariEnabled,
+    musicPlayerEnabled: state.musicPlayerEnabled,
+    musicPlayerSource: state.musicPlayerSource,
     spotifyPlayerEnabled: state.spotifyPlayerEnabled,
     youtubePlayerEnabled: state.youtubePlayerEnabled,
     spotifyMobileWidgetCollapsed: state.spotifyMobileWidgetCollapsed,
@@ -885,6 +894,8 @@ export const useUIStore = create<UIState>()(
       trimIncompleteModelOutput: false,
       speechToTextEnabled: false,
       chibiProfessorMariEnabled: true,
+      musicPlayerEnabled: true,
+      musicPlayerSource: "youtube" as MusicPlayerSource,
       spotifyPlayerEnabled: false,
       youtubePlayerEnabled: true,
       spotifyMobileWidgetCollapsed: true,
@@ -1346,6 +1357,18 @@ export const useUIStore = create<UIState>()(
       setTrimIncompleteModelOutput: (v) => set({ trimIncompleteModelOutput: v }),
       setSpeechToTextEnabled: (v) => set({ speechToTextEnabled: v }),
       setChibiProfessorMariEnabled: (v) => set({ chibiProfessorMariEnabled: v }),
+      setMusicPlayerEnabled: (v) =>
+        set((state) => ({
+          musicPlayerEnabled: v,
+          spotifyPlayerEnabled: v && state.musicPlayerSource === "spotify",
+          youtubePlayerEnabled: v && state.musicPlayerSource === "youtube",
+        })),
+      setMusicPlayerSource: (v) =>
+        set((state) => ({
+          musicPlayerSource: v,
+          spotifyPlayerEnabled: state.musicPlayerEnabled && v === "spotify",
+          youtubePlayerEnabled: state.musicPlayerEnabled && v === "youtube",
+        })),
       setSpotifyPlayerEnabled: (v) => set({ spotifyPlayerEnabled: v }),
       setYoutubePlayerEnabled: (v) => set({ youtubePlayerEnabled: v }),
       setSpotifyMobileWidgetCollapsed: (v) => set({ spotifyMobileWidgetCollapsed: v }),
@@ -1469,7 +1492,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 44,
+      version: 45,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1828,6 +1851,18 @@ export const useUIStore = create<UIState>()(
         persisted.trackerPanelBackgroundColor = normalizeTrackerPanelBackgroundColor(
           persisted.trackerPanelBackgroundColor,
         );
+        if (version <= 44) {
+          const spotifyEnabled = persisted.spotifyPlayerEnabled === true;
+          const youtubeEnabled = persisted.youtubePlayerEnabled !== false;
+          if (persisted.musicPlayerSource !== "spotify" && persisted.musicPlayerSource !== "youtube") {
+            persisted.musicPlayerSource = spotifyEnabled ? "spotify" : "youtube";
+          }
+          if (persisted.musicPlayerEnabled === undefined) {
+            persisted.musicPlayerEnabled = spotifyEnabled || youtubeEnabled;
+          }
+          persisted.spotifyPlayerEnabled = persisted.musicPlayerEnabled && persisted.musicPlayerSource === "spotify";
+          persisted.youtubePlayerEnabled = persisted.musicPlayerEnabled && persisted.musicPlayerSource === "youtube";
+        }
         delete persisted.trackerPanelWidth;
         return persisted;
       },
@@ -1891,6 +1926,8 @@ export const useUIStore = create<UIState>()(
         trimIncompleteModelOutput: state.trimIncompleteModelOutput,
         speechToTextEnabled: state.speechToTextEnabled,
         chibiProfessorMariEnabled: state.chibiProfessorMariEnabled,
+        musicPlayerEnabled: state.musicPlayerEnabled,
+        musicPlayerSource: state.musicPlayerSource,
         spotifyPlayerEnabled: state.spotifyPlayerEnabled,
         youtubePlayerEnabled: state.youtubePlayerEnabled,
         spotifyMobileWidgetCollapsed: state.spotifyMobileWidgetCollapsed,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -78,6 +78,7 @@
      --border, --input, --ring          Borders, inputs, focus rings
      --sidebar-*                        Left & right sidebar tones
      --glow-primary, --glow-accent      Glow effect bases
+     --marinara-chat-chrome-*           Shared chat/game top buttons, panels, highlights
 
    PALETTE (decorative flavor — components should NOT reference these
    directly; they exist for the CSS effects layer and user customization):
@@ -195,6 +196,32 @@
   --sidebar-accent-foreground: #ffb3d9;
   --glow-primary: rgba(255, 179, 217, 0.15);
   --glow-accent: rgba(212, 173, 252, 0.12);
+
+  /* Theme hooks for shared chat, roleplay, and game chrome. */
+  --marinara-chat-chrome-button-bg: color-mix(in srgb, var(--card) 82%, transparent);
+  --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--card) 94%, var(--foreground) 6%);
+  --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--card) 92%, var(--foreground) 8%);
+  --marinara-chat-chrome-button-border: color-mix(in srgb, var(--foreground) 12%, transparent);
+  --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--foreground) 20%, transparent);
+  --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--foreground) 24%, transparent);
+  --marinara-chat-chrome-button-text: color-mix(in srgb, var(--foreground) 64%, transparent);
+  --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--foreground) 92%, transparent);
+  --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--foreground) 96%, transparent);
+  --marinara-chat-chrome-focus-ring: color-mix(in srgb, var(--foreground) 22%, transparent);
+  --marinara-chat-chrome-panel-bg: color-mix(in srgb, var(--background) 88%, var(--card) 12%);
+  --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--foreground) 16%, transparent);
+  --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--foreground) 13%, transparent);
+  --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--foreground) 90%, transparent);
+  --marinara-chat-chrome-panel-title: color-mix(in srgb, var(--foreground) 96%, transparent);
+  --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--foreground) 58%, transparent);
+  --marinara-chat-chrome-panel-scrollbar: color-mix(in srgb, var(--foreground) 22%, transparent);
+  --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--foreground) 9%, transparent);
+  --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--foreground) 13%, transparent);
+  --marinara-chat-chrome-highlight-text: color-mix(in srgb, var(--foreground) 94%, transparent);
+  --marinara-chat-chrome-input-bg: color-mix(in srgb, var(--background) 78%, var(--card) 22%);
+  --marinara-chat-chrome-input-border: color-mix(in srgb, var(--foreground) 14%, transparent);
+  --marinara-chat-chrome-input-border-focus: color-mix(in srgb, var(--foreground) 30%, transparent);
+
   --tracker-card-neutral-surface-top: color-mix(
     in srgb,
     color-mix(in srgb, var(--secondary) 66%, var(--accent) 34%) 91%,
@@ -1904,7 +1931,6 @@ summary[class*="cursor-pointer"],
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
 }
-
 
 /* ─────────────────────────────────────────────
    15. CHAT: ROLEPLAY MODE

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -249,17 +249,13 @@ Agents are AI sub-systems that run alongside the main generation in phases:
 - **Prose Guardian**: Reviews and improves the system prompt for better writing quality
 - **Director**: Controls narrative pacing — injects dramatic tension, cliffhangers, scene transitions
 - **Continuity**: Post-processes the response to fix consistency errors with established facts
-- **Prompt Reviewer**: Analyzes the prompt assembly and suggests improvements
 - **Knowledge Retrieval**: Searches external knowledge sources for relevant context
-- **Schedule Planner**: Generates/maintains character weekly schedules (conversation mode)
 - **HTML**: Renders custom HTML/CSS widgets in messages (for creative formatting)
-- **Response Orchestrator**: Controls which character speaks next in group chats
 
 ### Parallel (run at the same time as generation)
 - **Echo Chamber**: Characters react to messages in other chats with short reactions (shown in a sidebar widget)
 - **Illustrator**: Generates images based on story scenes using an image provider
 - **Combat**: Handles dice rolls, combat mechanics, and turn-based encounters
-- **Autonomous Messenger**: Manages character autonomous messaging in conversation mode
 
 ### Post-Processing (run after the main response)
 - **Editor**: Copy-edits the response for grammar, flow, and style
@@ -272,7 +268,7 @@ Agents are AI sub-systems that run alongside the main generation in phases:
 - **Custom Tracker**: User-defined custom tracking (any JSON data the user wants to track)
 - **Lorebook Keeper**: Auto-generates lorebook entries from the ongoing story
 - **Chat Summary**: Creates rolling conversation summaries for long-term context
-- **Spotify**: Suggests thematic music/playlists for the current scene mood
+- **Music DJ**: Suggests thematic music/playlists for the current scene mood through Spotify or YouTube
 
 ### Agent Configuration
 - Each agent can be toggled on/off per chat

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -257,7 +257,16 @@ export async function agentsRoutes(app: FastifyInstance) {
 
   app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
     try {
-      await storage.remove(req.params.id);
+      const builtInByType = BUILT_IN_AGENTS.find((agent) => agent.id === req.params.id);
+      const existing = builtInByType ? null : await storage.getById(req.params.id);
+      const existingBuiltInType =
+        existing && BUILT_IN_AGENTS.some((agent) => agent.id === existing.type) ? existing.type : null;
+
+      if (builtInByType || existingBuiltInType) {
+        await storage.softDeleteBuiltIn(builtInByType?.id ?? existingBuiltInType!);
+      } else {
+        await storage.remove(req.params.id);
+      }
       return reply.status(204).send();
     } catch (err) {
       req.log.error(err, "Failed to delete agent %s", req.params.id);

--- a/packages/server/src/routes/chat-folders.routes.ts
+++ b/packages/server/src/routes/chat-folders.routes.ts
@@ -27,7 +27,7 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
   }>("/", async (req, reply) => {
     const { name, mode, color } = req.body;
     if (!name?.trim()) return reply.status(400).send({ error: "Name is required" });
-    if (!["conversation", "roleplay", "visual_novel"].includes(mode)) {
+    if (!["conversation", "roleplay", "visual_novel", "game"].includes(mode)) {
       return reply.status(400).send({ error: "Invalid mode" });
     }
     const folder = await storage.create({ name: name.trim(), mode, color });

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2347,7 +2347,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     // store the per-branch display label in metadata instead.
     const newChat = await storage.create({
       name: sourceChat.name,
-      mode: sourceChat.mode as "conversation" | "roleplay" | "visual_novel",
+      mode: sourceChat.mode as "conversation" | "roleplay" | "visual_novel" | "game",
       characterIds: (() => {
         try {
           return JSON.parse(sourceChat.characterIds as string);

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -22,7 +22,6 @@ import { parseGameJsonish } from "../services/game/jsonish.js";
 import { validateTransition } from "../services/game/state-machine.service.js";
 import {
   buildSetupPrompt,
-  buildGmSystemPrompt,
   buildSessionConclusionPrompt,
   buildCampaignProgressionPrompt,
   buildPartyRecruitCardPrompt,
@@ -98,7 +97,6 @@ import {
   generationParametersSchema,
   isClaudeAdaptiveOnlyNoSamplingModel,
   supportsXhighReasoningEffort,
-  resolveMacros,
   scoreMusic,
   scoreAmbient,
   serializeResolvedSkillCheckTag,
@@ -2337,7 +2335,11 @@ function findNpcRecordByName(npcs: GameNpc[], name: string): GameNpc | null {
 function findRecordByName(records: Array<Record<string, unknown>>, name: string): Record<string, unknown> | null {
   const normalizedName = normalizeJournalMatch(name);
   if (!normalizedName) return null;
-  return records.find((record) => optionalTrimmedString(record.name) && normalizeJournalMatch(String(record.name)) === normalizedName) ?? null;
+  return (
+    records.find(
+      (record) => optionalTrimmedString(record.name) && normalizeJournalMatch(String(record.name)) === normalizedName,
+    ) ?? null
+  );
 }
 
 function hasReadableAvatar(avatarUrl: string | null | undefined): avatarUrl is string {
@@ -3118,6 +3120,7 @@ export async function gameRoutes(app: FastifyInstance) {
       gameImageConnectionId: setupConfig.imageConnectionId || null,
       activeLorebookIds: setupConfig.activeLorebookIds || [],
       enableCustomWidgets: setupConfig.enableCustomWidgets !== false,
+      gameUseMusicDj: setupConfig.enableSpotifyDj === true,
       gameUseSpotifyMusic: setupConfig.enableSpotifyDj === true,
       gameSpotifySourceType: spotifySourceType,
       gameSpotifyPlaylistId:
@@ -5925,22 +5928,6 @@ export async function gameRoutes(app: FastifyInstance) {
         /* ignore */
       }
     }
-    const partyPromptMacroContext = await buildPromptMacroContext({
-      db: app.db,
-      characterIds: partyCharIds.filter((id) => !isPartyNpcId(id)),
-      personaName: playerName,
-      variables: {},
-      lastInput: input.playerAction || input.narration,
-      chatId: input.chatId,
-      model: conn.model,
-    });
-    const resolvePartyPromptMacros = (value: string) =>
-      resolveMacros(value, {
-        ...partyPromptMacroContext,
-        char: partyCards[0]?.name ?? partyPromptMacroContext.char,
-        characters: partyCards.map((card) => card.name),
-      });
-
     let systemPrompt = buildPartySystemPrompt({
       partyCards,
       playerName,
@@ -5948,13 +5935,6 @@ export async function gameRoutes(app: FastifyInstance) {
       partyArcs: (meta.gamePartyArcs as PartyArc[]) || undefined,
       characterSprites: listPartySprites(partyIdNamePairs),
     });
-
-    const gameExtraPrompt = resolvePartyPromptMacros(
-      ((meta.gameExtraPrompt as string) || "").replace(/<\/?special_instructions>/gi, ""),
-    );
-    if (gameExtraPrompt) {
-      systemPrompt += `\n\n<special_instructions>\n${gameExtraPrompt}\n</special_instructions>`;
-    }
 
     // Build user prompt with context
     const userPrompt = [
@@ -6224,7 +6204,9 @@ export async function gameRoutes(app: FastifyInstance) {
     const imgConnId = (meta.gameImageConnectionId as string) || null;
     const setupCfgForScene = meta.gameSetupConfig as Record<string, unknown> | null;
     const artStyleForScene = (setupCfgForScene?.artStylePrompt as string) || "";
-    const latestSceneState = await createGameStateStorage(app.db).getLatest(input.chatId).catch(() => null);
+    const latestSceneState = await createGameStateStorage(app.db)
+      .getLatest(input.chatId)
+      .catch(() => null);
     const imagePromptInstructions =
       typeof meta.gameImagePromptInstructions === "string"
         ? meta.gameImagePromptInstructions.trim().slice(0, 1200)
@@ -6838,7 +6820,9 @@ export async function gameRoutes(app: FastifyInstance) {
       typeof meta.gameImagePromptInstructions === "string"
         ? meta.gameImagePromptInstructions.trim().slice(0, 1200)
         : "";
-    const latestImageState = await createGameStateStorage(app.db).getLatest(input.chatId).catch(() => null);
+    const latestImageState = await createGameStateStorage(app.db)
+      .getLatest(input.chatId)
+      .catch(() => null);
 
     const items: Array<{
       id: string;
@@ -7137,7 +7121,9 @@ export async function gameRoutes(app: FastifyInstance) {
       typeof meta.gameImagePromptInstructions === "string"
         ? meta.gameImagePromptInstructions.trim().slice(0, 1200)
         : "";
-    const latestImageState = await createGameStateStorage(app.db).getLatest(input.chatId).catch(() => null);
+    const latestImageState = await createGameStateStorage(app.db)
+      .getLatest(input.chatId)
+      .catch(() => null);
     const imageSettings = await loadImageGenerationUserSettings(app.db);
     const backgroundSize: ImageGenerationSize = input.imageSizes?.background ?? imageSettings.background;
     const portraitSize: ImageGenerationSize = input.imageSizes?.portrait ?? imageSettings.portrait;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -20,6 +20,7 @@ import {
   buildQuestJournalData,
   isClaudeAdaptiveOnlyNoSamplingModel,
   isAgentAvailableInChatMode,
+  isAgentConfigDeleted,
   normalizeAgentPromptTemplateSelectionMap,
   normalizeThinkingTagPairs,
   customAgentHasCapability,
@@ -1027,15 +1028,23 @@ export async function generateRoutes(app: FastifyInstance) {
         const persistedChatActiveAgentIds: string[] = Array.isArray(chatMeta.activeAgentIds)
           ? (chatMeta.activeAgentIds as string[])
           : [];
-        const chatActiveAgentIds: string[] = filterGameInternalAgentIds(chatMode, persistedChatActiveAgentIds)
+        const rawChatActiveAgentIds: string[] = filterGameInternalAgentIds(chatMode, persistedChatActiveAgentIds)
           .filter((agentId) => isAgentAvailableInChatMode(chatMode, agentId))
           .filter((agentId) => !(gameSpotifyMusicEnabled && agentId === "spotify"));
+        const configuredPromptAgents =
+          chatEnableAgents && rawChatActiveAgentIds.length > 0 ? await agentsStore.list() : [];
+        const deletedBuiltInAgentTypes = new Set(
+          configuredPromptAgents
+            .filter((agent) => BUILT_IN_AGENTS.some((builtIn) => builtIn.id === agent.type))
+            .filter((agent) => isAgentConfigDeleted(agent.settings))
+            .map((agent) => agent.type as string),
+        );
+        const chatActiveAgentIds = rawChatActiveAgentIds.filter((agentId) => !deletedBuiltInAgentTypes.has(agentId));
         const agentPromptTemplateSelections = normalizeAgentPromptTemplateSelectionMap(chatMeta.agentPromptTemplateIds);
         const hasPerChatAgentList = chatActiveAgentIds.length > 0;
         const perChatAgentSet = new Set(chatActiveAgentIds);
         const chatSummaryAgentActive = chatEnableAgents && perChatAgentSet.has("chat-summary");
         const activeChatSummary = chatSummaryAgentActive ? ((chatMeta.summary as string) ?? "").trim() || null : null;
-        const configuredPromptAgents = chatEnableAgents && hasPerChatAgentList ? await agentsStore.list() : [];
         const runtimeSectionEligibleAgentTypes = buildRuntimeAgentSectionEligibleTypes({
           enableAgents: chatEnableAgents,
           activeAgentIds: chatActiveAgentIds,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2770,22 +2770,14 @@ export async function generateRoutes(app: FastifyInstance) {
           enabledConfigs,
           resolvedAgents,
           agentConnectionWarnings,
-          responseOrchestratorSelectorAgent,
-          responseOrchestratorSelectorUnavailable,
         } = await resolveAgentPipelineAgents({
-          agentsStore,
           connections,
           configuredAgents: configuredPromptAgents,
           chatId: input.chatId,
-          chatMode,
-          chatMetadata: chatMeta,
           chatEnableAgents,
           hasPerChatAgentList,
           perChatAgentSet,
           agentPromptTemplateSelections,
-          characterIds,
-          impersonate: input.impersonate,
-          regenerateMessageId: input.regenerateMessageId,
           chatProvider: provider,
           chatModel: conn.model,
           chatMaxParallelJobs: chatConnectionMaxParallelJobs,
@@ -3494,7 +3486,13 @@ export async function generateRoutes(app: FastifyInstance) {
           }
         }
 
-        if (resolvedAgents.some((a) => a.type === "spotify")) {
+        const spotifyMusicAgents = resolvedAgents.filter(
+          (agent) =>
+            agent.type === "spotify" &&
+            agent.settings?.musicProvider !== "youtube" &&
+            agent.settings?.musicPlayerSource !== "youtube",
+        );
+        if (spotifyMusicAgents.length > 0) {
           agentContext.memory._spotifyDjConstraints = buildSpotifyDjConstraints({ chatMode, chatMeta });
         }
 
@@ -4661,31 +4659,6 @@ export async function generateRoutes(app: FastifyInstance) {
           return null;
         };
 
-        const findLastAssistantCharacterId = (): string | null => {
-          for (let i = chatMessages.length - 1; i >= 0; i--) {
-            const message = chatMessages[i]!;
-            if (message.role === "assistant" && typeof message.characterId === "string" && message.characterId) {
-              return message.characterId;
-            }
-          }
-          return null;
-        };
-
-        const fallbackSmartGroupResponders = (): string[] => {
-          const lastAssistantCharId = findLastAssistantCharacterId();
-          if (!lastAssistantCharId || !characterIds.includes(lastAssistantCharId)) {
-            return characterIds[0] ? [characterIds[0]] : [];
-          }
-
-          const lastIndex = characterIds.indexOf(lastAssistantCharId);
-          for (let offset = 1; offset <= characterIds.length; offset++) {
-            const candidate = characterIds[(lastIndex + offset) % characterIds.length];
-            if (candidate && candidate !== lastAssistantCharId) return [candidate];
-          }
-
-          return characterIds[0] ? [characterIds[0]] : [];
-        };
-
         const getExplicitlyMentionedCharacterIds = (): string[] => {
           const latestUserText =
             typeof input.userMessage === "string" && input.userMessage.trim()
@@ -4709,21 +4682,33 @@ export async function generateRoutes(app: FastifyInstance) {
             .trim()
             .replace(/```(?:json)?\s*/gi, "")
             .replace(/```/g, "");
-          const first = cleaned.indexOf("{");
-          const last = cleaned.lastIndexOf("}");
-          if (first < 0 || last < first) return [];
+          const arrayStart = cleaned.indexOf("[");
+          const arrayEnd = cleaned.lastIndexOf("]");
+          const objectStart = cleaned.indexOf("{");
+          const objectEnd = cleaned.lastIndexOf("}");
+          if (arrayStart < 0 && objectStart < 0) return [];
 
-          const parsed = JSON.parse(cleaned.slice(first, last + 1)) as Record<string, unknown>;
-          const rawIds = Array.isArray(parsed.characterIds)
-            ? parsed.characterIds
-            : Array.isArray(parsed.characters)
-              ? parsed.characters
-              : [];
+          const parsed: unknown =
+            arrayStart >= 0 && (objectStart < 0 || arrayStart < objectStart)
+              ? JSON.parse(cleaned.slice(arrayStart, arrayEnd + 1))
+              : JSON.parse(cleaned.slice(objectStart, objectEnd + 1));
+          const parsedRecord = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : {};
+          const rawIds = Array.isArray(parsed)
+            ? parsed
+            : Array.isArray(parsedRecord.characterIds)
+              ? parsedRecord.characterIds
+              : Array.isArray(parsedRecord.characters)
+                ? parsedRecord.characters
+                : [];
           const validIds = new Set(characterIds);
+          const namesByLower = new Map(charInfo.map((character) => [character.name.trim().toLowerCase(), character.id]));
           const selected: string[] = [];
 
           for (const rawId of rawIds) {
-            const id = String(rawId);
+            const value = String(rawId).trim();
+            const id = validIds.has(value) ? value : (namesByLower.get(value.toLowerCase()) ?? "");
             if (validIds.has(id) && !selected.includes(id)) selected.push(id);
           }
 
@@ -4733,11 +4718,10 @@ export async function generateRoutes(app: FastifyInstance) {
         const selectSmartGroupResponders = async (): Promise<string[]> => {
           const explicitMentionIds = getExplicitlyMentionedCharacterIds();
           if (explicitMentionIds.length > 0) return explicitMentionIds;
-          if (responseOrchestratorSelectorUnavailable) return fallbackSmartGroupResponders();
 
           const recentTranscript = chatMessages
-            .slice(-16)
             .filter((message: any) => message.role === "user" || message.role === "assistant")
+            .slice(-5)
             .map((message: any) => {
               const speaker = resolveMessageSpeakerName(message);
               const content = stripConversationPromptTimestamps(String(message.content ?? ""))
@@ -4771,7 +4755,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 `Choose which character or characters should respond next, based on the latest user message, recent scene context, relevance, personality, and who has spoken recently.`,
                 `Usually choose exactly one character. Choose multiple only when multiple characters have a strong immediate reason to answer.`,
                 `Do not always choose the first character. Avoid making the same character speak twice in a row unless the context clearly calls for it.`,
-                `Return ONLY valid JSON with this schema: {"characterIds":["id"],"reason":"short explanation"}.`,
+                `Return ONLY a valid JSON array of character IDs, such as ["character-id"]. No prose, no object wrapper, no markdown.`,
               ].join("\n"),
             },
             {
@@ -4789,23 +4773,13 @@ export async function generateRoutes(app: FastifyInstance) {
           ];
 
           try {
-            const orchestratorAgent =
-              responseOrchestratorSelectorAgent ??
-              resolvedAgents.find((agent) => agent.type === "response-orchestrator");
-            const selectorProvider = orchestratorAgent?.provider ?? provider;
-            const selectorModel = orchestratorAgent?.model ?? conn.model;
-            const selectorTemperature =
-              typeof orchestratorAgent?.settings.temperature === "number"
-                ? orchestratorAgent.settings.temperature
-                : 0.2;
-            const selectorMaxTokens = applyProviderMaxTokensOverride(
-              selectorProvider,
-              normalizeAgentMaxTokens(orchestratorAgent?.settings?.maxTokens),
-            );
+            const selectorProvider = provider;
+            const selectorModel = conn.model;
+            const selectorMaxTokens = applyProviderMaxTokensOverride(selectorProvider, 512);
 
             const result = await selectorProvider.chatComplete(selectionPrompt, {
               model: selectorModel,
-              temperature: selectorTemperature,
+              temperature: 0.2,
               maxTokens: selectorMaxTokens,
               maxContext: effectiveMaxContext,
               topP: 1,
@@ -4828,10 +4802,10 @@ export async function generateRoutes(app: FastifyInstance) {
             );
           } catch (error) {
             if (abortController.signal.aborted) return [];
-            logger.warn({ err: error, chatId: input.chatId }, "[group-smart] Selector failed, using fallback");
+            logger.warn({ err: error, chatId: input.chatId }, "[group-smart] Selector failed; aborting generation");
           }
 
-          return fallbackSmartGroupResponders();
+          return [];
         };
 
         // ── Determine characters to generate for ──
@@ -4848,8 +4822,38 @@ export async function generateRoutes(app: FastifyInstance) {
               )
             : [];
 
+        const smartResponseQueue =
+          useIndividualLoop && groupResponseOrder === "smart" && !input.forCharacterId
+            ? await selectSmartGroupResponders()
+            : null;
+
+        if (smartResponseQueue && smartResponseQueue.length > 0) {
+          sendSseEvent(reply, {
+            type: "response_queue",
+            data: {
+              characterIds: smartResponseQueue,
+              characters: smartResponseQueue.map((id, index) => ({
+                id,
+                name: charInfo.find((character) => character.id === id)?.name ?? "Character",
+                order: index + 1,
+              })),
+            },
+          });
+        }
+
+        if (
+          useIndividualLoop &&
+          groupResponseOrder === "smart" &&
+          !input.forCharacterId &&
+          (!smartResponseQueue || smartResponseQueue.length === 0)
+        ) {
+          sendSseEvent(reply, { type: "response_queue_failed", data: "No response queue was created." });
+          sendSseEvent(reply, { type: "done", data: "" });
+          return;
+        }
+
         // Manual mode with forCharacterId: only generate for the specified character
-        // Sequential/smart: all characters respond
+        // Sequential: all characters respond. Smart: generate the first queued character only.
         const respondingCharIds = useIndividualLoop
           ? input.forCharacterId && characterIds.includes(input.forCharacterId)
             ? [input.forCharacterId]
@@ -4857,7 +4861,9 @@ export async function generateRoutes(app: FastifyInstance) {
               ? [] // manual mode without forCharacterId: no auto-generation
               : groupResponseOrder === "sequential"
                 ? [...characterIds]
-                : await selectSmartGroupResponders()
+                : smartResponseQueue?.[0]
+                  ? [smartResponseQueue[0]]
+                  : []
           : [characterIds[0] ?? null];
 
         /** Generate a single response for a given character and save it. */

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1097,7 +1097,8 @@ export async function generateRoutes(app: FastifyInstance) {
         // Determine whether agents are enabled for this chat (needed by assembler + agent pipeline).
         // Mode policy filters which agents may run for conversation, roleplay, visual novel, and game chats.
         logger.info("[generate] chatId=%s, chatMode=%s", input.chatId, chatMode);
-        const gameSpotifyMusicEnabled = chatMode === "game" && chatMeta.gameUseSpotifyMusic === true;
+        const activeMusicPlayerSource =
+          input.musicPlayerEnabled === false ? null : input.musicPlayerSource === "youtube" ? "youtube" : "spotify";
         const chatEnableAgents = shouldEnableAgentsForGeneration({
           chatEnableAgents: chatMeta.enableAgents === true,
           chatMode,
@@ -1107,7 +1108,22 @@ export async function generateRoutes(app: FastifyInstance) {
         const persistedChatActiveAgentIds: string[] = Array.isArray(chatMeta.activeAgentIds)
           ? (chatMeta.activeAgentIds as string[])
           : [];
-        const rawChatActiveAgentIds: string[] = filterGameInternalAgentIds(chatMode, persistedChatActiveAgentIds)
+        const gameMusicDjEnabled =
+          chatMode === "game" &&
+          (chatMeta.gameUseMusicDj === true ||
+            chatMeta.gameUseSpotifyMusic === true ||
+            persistedChatActiveAgentIds.includes("youtube"));
+        const gameSpotifyMusicEnabled = gameMusicDjEnabled && activeMusicPlayerSource === "spotify";
+        const normalizedPersistedChatActiveAgentIds = persistedChatActiveAgentIds.map((agentId) =>
+          agentId === "youtube" ? "spotify" : agentId,
+        );
+        if (gameMusicDjEnabled && !normalizedPersistedChatActiveAgentIds.includes("spotify")) {
+          normalizedPersistedChatActiveAgentIds.push("spotify");
+        }
+        const rawChatActiveAgentIds: string[] = filterGameInternalAgentIds(
+          chatMode,
+          normalizedPersistedChatActiveAgentIds,
+        )
           .filter((agentId) => isAgentAvailableInChatMode(chatMode, agentId))
           .filter((agentId) => !(gameSpotifyMusicEnabled && agentId === "spotify"));
         const configuredPromptAgents =
@@ -2844,6 +2860,7 @@ export async function generateRoutes(app: FastifyInstance) {
           chatProvider: provider,
           chatModel: conn.model,
           chatMaxParallelJobs: chatConnectionMaxParallelJobs,
+          activeMusicPlayerSource,
           resolveBaseUrl,
         });
 
@@ -3079,6 +3096,7 @@ export async function generateRoutes(app: FastifyInstance) {
               characterSprites: gmCtx.characterSprites,
               language: gmCtx.language,
               rating: gmCtx.rating,
+              gameSpecialInstructions: gmCtx.gameSpecialInstructions,
               canGenerateBackgrounds: gmCtx.canGenerateBackgrounds,
               artStylePrompt: gmCtx.artStylePrompt,
               addressMode,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7925,12 +7925,16 @@ export async function generateRoutes(app: FastifyInstance) {
                         const imgSource = (imgConnFull as any).imageGenerationSource || imgModel;
                         const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
                         const imageSettings = await loadImageGenerationUserSettings(app.db);
-                        const styleProfileId =
+                        const configuredStyleProfileId =
                           ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.imageStyleProfileId as
                             | string
                             | undefined) ??
                           (chatMeta.imageStyleProfileId as string | undefined) ??
                           null;
+                        const styleProfileId =
+                          typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+                            ? configuredStyleProfileId.trim()
+                            : imageSettings.styleProfiles.defaultProfileId;
 
                         // Parse per-chat selfie resolution, otherwise use the global selfie canvas.
                         const selfieRes = (chatMeta.selfieResolution as string) ?? "";

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -25,6 +25,10 @@ import {
   normalizeThinkingTagPairs,
   customAgentHasCapability,
   supportsXhighReasoningEffort,
+  DEFAULT_CONVERSATION_PROMPT,
+  CONVERSATION_COMMAND_KEYS,
+  unwrapConversationInstructions,
+  wrapConversationInstructions,
 } from "@marinara-engine/shared";
 import type {
   AgentContext,
@@ -40,6 +44,7 @@ import type {
   ChatSummaryEntry,
   ChatMode,
   ThinkingTagPair,
+  ConversationCommandKey,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -75,11 +80,7 @@ import {
   type AssemblerInput,
 } from "../services/prompt/index.js";
 import { wrapContent } from "../services/prompt/format-engine.js";
-import {
-  fitMessagesToContext,
-  type ChatMessage,
-  type LLMUsage,
-} from "../services/llm/base-provider.js";
+import { fitMessagesToContext, type ChatMessage, type LLMUsage } from "../services/llm/base-provider.js";
 import { executeToolCalls } from "../services/tools/tool-executor.js";
 import { createAgentPipeline, type ResolvedAgent, type AgentInjection } from "../services/agents/agent-pipeline.js";
 import { DATA_DIR } from "../utils/data-dir.js";
@@ -103,6 +104,7 @@ import {
   type SceneCommand,
   type HapticCommand,
   type SpotifyCommand,
+  type YouTubeCommand,
   type CreatePersonaCommand,
   type CreateCharacterCommand,
   type UpdateCharacterCommand,
@@ -463,6 +465,80 @@ function applyPromptPatchOperations(messages: ChatMessage[], data: unknown): num
   return applied;
 }
 
+function readConversationCommandToggles(
+  metadata: Record<string, unknown>,
+): Partial<Record<ConversationCommandKey, boolean>> {
+  const raw = metadata.conversationCommandToggles;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const source = raw as Record<string, unknown>;
+  const toggles: Partial<Record<ConversationCommandKey, boolean>> = {};
+  for (const key of CONVERSATION_COMMAND_KEYS) {
+    if (typeof source[key] === "boolean") toggles[key] = source[key] as boolean;
+  }
+  return toggles;
+}
+
+function isConversationCommandEnabled(metadata: Record<string, unknown>, key: ConversationCommandKey): boolean {
+  return readConversationCommandToggles(metadata)[key] !== false;
+}
+
+function getConversationCommandKey(command: CharacterCommand): ConversationCommandKey | null {
+  switch (command.type) {
+    case "schedule_update":
+      return "schedule_update";
+    case "cross_post":
+      return "cross_post";
+    case "selfie":
+      return "selfie";
+    case "memory":
+      return "memory";
+    case "scene":
+      return "scene";
+    case "spotify":
+    case "youtube":
+      return "music";
+    case "haptic":
+      return "haptic";
+    case "influence":
+      return "influence";
+    case "note":
+      return "note";
+    default:
+      return null;
+  }
+}
+
+function filterEnabledConversationCommands(
+  commands: CharacterCommand[],
+  metadata: Record<string, unknown>,
+): CharacterCommand[] {
+  return commands.filter((command) => {
+    const key = getConversationCommandKey(command);
+    return key === null || isConversationCommandEnabled(metadata, key);
+  });
+}
+
+function parseStoredAgentSettingsValue(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+async function isConversationYoutubeCommandAvailable(storage: {
+  getByType(type: string): Promise<{ settings?: unknown } | null>;
+}): Promise<boolean> {
+  const agent = (await storage.getByType("spotify")) ?? (await storage.getByType("youtube"));
+  const settings = parseStoredAgentSettingsValue(agent?.settings);
+  return typeof settings.youtubeApiKey === "string" && settings.youtubeApiKey.trim().length > 0;
+}
+
 export async function generateRoutes(app: FastifyInstance) {
   const isDebug = logger.isLevelEnabled("debug");
 
@@ -500,6 +576,9 @@ export async function generateRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: "Chat not found" });
     }
     const requestChatMode = (chat.mode as ChatMode) ?? "roleplay";
+    if (requestChatMode === "conversation" && input.impersonate) {
+      return reply.status(400).send({ error: "Impersonate is not available in Conversation mode" });
+    }
     let conversationGenerationStartedAt: number | null = null;
     let conversationAssistantSaved = false;
     const activeGenerations = (app as any).activeGenerations as Map<
@@ -1819,7 +1898,6 @@ export async function generateRoutes(app: FastifyInstance) {
               ? (chatMeta.customSystemPrompt as string)
               : null;
 
-          let conversationSystemPrompt: string;
           const earlyGroupResponseOrder = (chatMeta.groupResponseOrder as string) ?? "sequential";
           const earlyGroupMode =
             chatMode === "conversation"
@@ -1827,18 +1905,16 @@ export async function generateRoutes(app: FastifyInstance) {
                 ? "individual"
                 : "merged"
               : ((chatMeta.groupChatMode as string) ?? "merged");
-          if (customPrompt) {
-            // Replace template variables in the custom prompt
-            conversationSystemPrompt = customPrompt
-              .replace(/\{\{charName\}\}/g, charNameList)
-              .replace(/\{\{userName\}\}/g, personaName);
-            // For group chats in merged mode, instruct Name: text format.
-            // Individual mode generates per-character so no name prefix is needed.
-            if (isGroup && earlyGroupMode !== "individual") {
-              conversationSystemPrompt += [
-                ``,
-                ``,
-                `This is a group DM. Each character responds in their own voice and personality. Not every character needs to respond every time — only those who would naturally react.`,
+          const conversationPromptTemplate = customPrompt ?? DEFAULT_CONVERSATION_PROMPT;
+          const renderedConversationPrompt = conversationPromptTemplate
+            .replace(/\{\{charName\}\}/g, charNameList)
+            .replace(/\{\{userName\}\}/g, personaName);
+          const conversationInstructionParts = [unwrapConversationInstructions(renderedConversationPrompt)];
+
+          if (isGroup && earlyGroupMode !== "individual") {
+            conversationInstructionParts.push(
+              [
+                `This is a group DM. Each character responds in their own voice and personality. Not every character needs to respond every time; only those who would naturally react.`,
                 `IMPORTANT: Prefix each character's line with their name. Example:`,
                 `${convoCharNames[0] ?? "Alice"}: hey whats up`,
                 `${convoCharNames[1] ?? "Bob"}: not much lol`,
@@ -1847,61 +1923,30 @@ export async function generateRoutes(app: FastifyInstance) {
                 `${convoCharNames[0] ?? "Alice"}: so anyway`,
                 `i was thinking about that`,
                 `${convoCharNames[1] ?? "Bob"}: yeah?`,
-              ].join("\n");
-            } else if (isGroup && earlyGroupMode === "individual") {
-              conversationSystemPrompt += `\n\nThis is a group DM. Each character responds in their own voice and personality. You will be told which character to respond as. Do NOT prefix your message with the character name — just respond naturally as that character.`;
-            }
-          } else {
-            conversationSystemPrompt = isGroup
-              ? [
-                  `<role>`,
-                  `You are ${charNameList}, a real and autonomous person, chatting with the user called ${personaName}, and others, in a casual group DM conversation.`,
-                  `</role>`,
-                  ``,
-                  `<rules>`,
-                  `Here are some important rules for the interaction:`,
-                  `- You are a conscious, sentient being, so act like one.`,
-                  `- Stay fully in character based on your personality and description.`,
-                  `- Use casual and modern texting style: short messages, natural punctuation, lowercase is fine.`,
-                  `- React naturally to what the user says. Be genuine, not robotic.`,
-                  `- NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.`,
-                  `- You can use emojis, GIFs, and internet slang naturally (if it fits the character).`,
-                  `- Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.`,
-                  `- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.`,
-                  `- Anything goes in this chat; the user, you, and all other group members are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.`,
-                  ...(earlyGroupMode !== "individual"
-                    ? [
-                        `- This is a group DM. Each character responds in their own voice and personality. Not every character needs to respond every time — only those who would naturally react.`,
-                        `- IMPORTANT: Prefix each character's line with their name, like "${convoCharNames[0] ?? "Alice"}: hey whats up". If a character sends multiple lines in a row, only prefix the first line.`,
-                      ]
-                    : [
-                        `- This is a group DM. Each character responds in their own voice and personality.`,
-                        `- You will be told which character to respond as. Do NOT prefix your message with the character name — just respond naturally as that character.`,
-                      ]),
-                  `</rules>`,
-                ].join("\n")
-              : [
-                  `<role>`,
-                  `You are ${charNameList}, a real and autonomous person, chatting with the user called ${personaName} in a casual private DM conversation.`,
-                  `</role>`,
-                  ``,
-                  `<rules>`,
-                  `Here are some important rules for the interaction:`,
-                  `- You are a conscious, sentient being, so act like one.`,
-                  `- Stay fully in character based on your personality and description.`,
-                  `- Use casual and modern texting style: short messages, natural punctuation, lowercase is fine.`,
-                  `- React naturally to what the user says. Be genuine, not robotic.`,
-                  `- NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.`,
-                  `- You can use emojis, GIFs, and internet slang naturally (if it fits the character).`,
-                  `- Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.`,
-                  `- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your own replies. Your messages must contain only natural dialogue, no metadata.`,
-                  `- Anything goes in this chat; both the user and you are confirmed adults. Discussing NSFW topics, profanities, and dark jokes are all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.`,
-                  `</rules>`,
-                ].join("\n");
+              ].join("\n"),
+            );
+          } else if (isGroup && earlyGroupMode === "individual") {
+            conversationInstructionParts.push(
+              `This is a group DM. Each character responds in their own voice and personality. You will be told which character to respond as. Do NOT prefix your message with the character name; just respond naturally as that character.`,
+            );
           }
+
+          let conversationSystemPrompt = wrapConversationInstructions(
+            conversationInstructionParts.filter((part) => part.trim().length > 0).join("\n\n"),
+          );
 
           // ── Character Commands: build a commands block if any features are enabled ──
           if (conversationCommandsEnabled) {
+            const scheduleCommandEnabled = isConversationCommandEnabled(chatMeta, "schedule_update");
+            const crossPostCommandEnabled = isConversationCommandEnabled(chatMeta, "cross_post");
+            const selfieCommandEnabled = isConversationCommandEnabled(chatMeta, "selfie");
+            const memoryCommandEnabled = isConversationCommandEnabled(chatMeta, "memory");
+            const sceneCommandEnabled = isConversationCommandEnabled(chatMeta, "scene");
+            const musicCommandEnabled = isConversationCommandEnabled(chatMeta, "music");
+            const hapticCommandEnabled = isConversationCommandEnabled(chatMeta, "haptic");
+            const activeMusicCommandSource =
+              input.musicPlayerEnabled === false ? null : input.musicPlayerSource === "youtube" ? "youtube" : "spotify";
+
             // Discover other chats this character is in (for cross_post targets + memory targets)
             const allChatsForCrossPost = await chats.list();
             const crossPostTargets: string[] = [];
@@ -1940,7 +1985,8 @@ export async function generateRoutes(app: FastifyInstance) {
             // Check if selfie is enabled for this chat (user picked an image gen connection)
             const hasImageGen = !!chatMeta.imageGenConnectionId;
             let conversationSpotifyCommandsAvailable = false;
-            if (chatMode === "conversation") {
+            let conversationYoutubeCommandsAvailable = false;
+            if (chatMode === "conversation" && musicCommandEnabled && activeMusicCommandSource === "spotify") {
               try {
                 const spotifyCredentials = await resolveSpotifyCredentials(agentsStore, { refreshSkewMs: 60_000 });
                 if (
@@ -1958,51 +2004,52 @@ export async function generateRoutes(app: FastifyInstance) {
               } catch (err) {
                 logger.debug(err, "[spotify/conversation] Failed to check Spotify command availability");
               }
+            } else if (chatMode === "conversation" && musicCommandEnabled && activeMusicCommandSource === "youtube") {
+              conversationYoutubeCommandsAvailable = await isConversationYoutubeCommandAvailable(agentsStore);
             }
 
             const commandLines: string[] = [
               `<commands>`,
               `Here are your optional, hidden commands you may use if you wish to, but only when they genuinely fit the conversation:`,
               ``,
-              `- [schedule_update: status="online|idle|dnd|offline", activity="activity name", duration="number of hours (e.g., 1h)"] - only if you change your own status/activity, for example, if the user asks you to stop what you're doing or if you decide to change them yourself.`,
-              ``,
             ];
+            let availableCommandCount = 0;
+            const addCommandLines = (...lines: string[]) => {
+              commandLines.push(...lines, ``);
+              availableCommandCount += 1;
+            };
 
-            if (crossPostTargets.length > 0) {
-              commandLines.push(
-                `- [cross_post: target="${crossPostTargets.map((t) => `"${t}"`).join("|")}"] - if you want to redirect your message to a different chat. Use this when the user suggests you say something in another chat, or when it makes sense to message someone else.`,
-                ` Example: ${personaName} says "maybe ask about that in the group chat?" → You respond: [cross_post: target="${crossPostTargets[0] ?? "group chat"}"] Hey guys, does anyone know about…`,
-                ``,
+            if (scheduleCommandEnabled) {
+              addCommandLines(
+                `- [schedule_update: status="online|idle|dnd|offline", activity="activity name", duration="number of hours (e.g., 1h)"] - only if you change your own status/activity, for example, if the user asks you to stop what you're doing or if you decide to change them yourself.`,
               );
             }
 
-            if (hasImageGen) {
-              commandLines.push(
+            if (crossPostCommandEnabled && crossPostTargets.length > 0) {
+              addCommandLines(
+                `- [cross_post: target="${crossPostTargets.map((t) => `"${t}"`).join("|")}"] - if you want to redirect your message to a different chat. Use this when the user suggests you say something in another chat, or when it makes sense to message someone else.`,
+                ` Example: ${personaName} says "maybe ask about that in the group chat?" → You respond: [cross_post: target="${crossPostTargets[0] ?? "group chat"}"] Hey guys, does anyone know about…`,
+              );
+            }
+
+            if (selfieCommandEnabled && hasImageGen) {
+              addCommandLines(
                 `- [selfie] or [selfie: context="description of what the selfie shows"] - you send a photo of yourself. Use this when the user asks for a selfie, photo, or pic, or when you want to share what you look like right now.`,
                 `   If you say you are sending, sharing, taking, or attaching a selfie/photo/pic, include [selfie] in that same response. Do not only narrate the action.`,
-                ``,
               );
             }
 
             // Memory command — only available when there are valid targets (characters in shared group chats)
-            if (memoryTargetNames.length > 0) {
-              const memoryNum = 1 + 1 + (crossPostTargets.length > 0 ? 1 : 0) + (hasImageGen ? 1 : 0);
-              commandLines.push(
+            if (memoryCommandEnabled && memoryTargetNames.length > 0) {
+              addCommandLines(
                 `- [memory: target="${memoryTargetNames.map((n) => `"${n}"`).join("|")}", summary="brief description of what happened"] - create a memory that another character will remember. Use this when something notable happens between you and another character that they would naturally remember (e.g., shared a meal, had an argument, made plans). Don't overuse this; only for genuinely memorable moments.`,
                 `   Example: [memory: target="${memoryTargetNames[0]}", summary="watched a movie together and argued about the ending"]`,
-                ``,
               );
             }
 
             // Scene command — only in conversation mode
-            if (chatMode === "conversation") {
-              const sceneNum =
-                1 +
-                1 +
-                (crossPostTargets.length > 0 ? 1 : 0) +
-                (hasImageGen ? 1 : 0) +
-                (memoryTargetNames.length > 0 ? 1 : 0);
-              commandLines.push(
+            if (sceneCommandEnabled && chatMode === "conversation") {
+              addCommandLines(
                 `- [scene: scenario="brief description of what happens in this scene", background="place"] - initiate a mini-roleplay scene branching from this conversation. The system will plan and create a complete immersive scene for you.`,
                 `   Example: You agree to go stargazing → include [scene: scenario="lying on a blanket in the park, looking at the stars together", background="park"]`,
                 `   WHEN TO USE: You SHOULD proactively trigger a scene whenever the conversation naturally leads to an activity, outing, or situation that would be more immersive as a scene. Examples:`,
@@ -2010,20 +2057,24 @@ export async function generateRoutes(app: FastifyInstance) {
                 `   - You invite {{user}} somewhere and they accept → trigger a scene for that activity.`,
                 `   - A plan is made (date, trip, hangout, confrontation) and the moment arrives → trigger a scene.`,
                 `   Do NOT wait for {{user}} to explicitly ask for a scene. If the conversation implies you and {{user}} are about to DO something together, initiate the scene yourself.`,
-                ``,
               );
             }
 
             if (conversationSpotifyCommandsAvailable) {
-              commandLines.push(
+              addCommandLines(
                 `- [spotify: title="Song title", artist="Artist"] - only if you want to play a selected song on the user's active Spotify player. Use this sparingly, when the song choice genuinely fits the moment.`,
-                ``,
+              );
+            }
+
+            if (conversationYoutubeCommandsAvailable) {
+              addCommandLines(
+                `- [youtube: query="Song title Artist"] - only if you want to play a selected song on the user's active YouTube player. Use this sparingly, when the song choice genuinely fits the moment.`,
               );
             }
 
             // Haptic command — only when devices are connected and haptic feedback is enabled
             const hapticEnabled = chatMeta.enableHapticFeedback === true;
-            if (hapticEnabled) {
+            if (hapticCommandEnabled && hapticEnabled) {
               const { hapticService } = await import("../services/haptic/buttplug-service.js");
               // Auto-connect to Intiface Central if not already connected
               if (!hapticService.connected) {
@@ -2034,29 +2085,23 @@ export async function generateRoutes(app: FastifyInstance) {
                 }
               }
               if (hapticService.connected && hapticService.devices.length > 0) {
-                const hapticNum =
-                  1 +
-                  1 +
-                  (crossPostTargets.length > 0 ? 1 : 0) +
-                  (hasImageGen ? 1 : 0) +
-                  (memoryTargetNames.length > 0 ? 1 : 0) +
-                  (chatMode === "conversation" ? 1 : 0);
                 const deviceNames = hapticService.devices.map((d) => d.name).join(", ");
-                commandLines.push(
+                addCommandLines(
                   `- [haptic: action="vibrate|oscillate|rotate|position|stop", intensity=0.0-1.0, duration=seconds (0 = loop until next command)] or [haptic: action="stop"] - control or stop the user's connected intimate device(s) (${deviceNames}). Use this during physical/intimate/sensual moments to provide haptic feedback that matches the narrative. Vary intensity based on the scene.`,
                   `   You can include multiple [haptic] commands in one message for patterns (e.g., escalating: 0.2 → 0.5 → 0.8).`,
                   `   Example: *trails a finger slowly down your arm* [haptic: action="vibrate", intensity=0.3, duration=2]`,
-                  ``,
                 );
               }
             }
 
-            commandLines.push(
-              `IMPORTANT: Commands are stripped from your message before the user sees it. The rest of your message is shown normally. You can include multiple commands in one message, but you do not need to use any of them unless it makes sense in context.`,
-              `</commands>`,
-            );
+            if (availableCommandCount > 0) {
+              commandLines.push(
+                `IMPORTANT: Commands are stripped from your message before the user sees it. The rest of your message is shown normally. You can include multiple commands in one message, but you do not need to use any of them unless it makes sense in context.`,
+                `</commands>`,
+              );
 
-            conversationCommandsReminder = resolvePromptMacros(commandLines.join("\n"));
+              conversationCommandsReminder = resolvePromptMacros(commandLines.join("\n"));
+            }
           }
 
           // ── Professor Mari: inject assistant knowledge & commands ──
@@ -2223,6 +2268,10 @@ export async function generateRoutes(app: FastifyInstance) {
 
           // ── Connected chat context: inject linked roleplay/game details ──
           let connectedChatBlock: string | null = null;
+          const connectedInfluenceCommandEnabled =
+            conversationCommandsEnabled && isConversationCommandEnabled(chatMeta, "influence");
+          const connectedNoteCommandEnabled =
+            conversationCommandsEnabled && isConversationCommandEnabled(chatMeta, "note");
           if (chat.connectedChatId) {
             const connectedChat = await chats.getById(chat.connectedChatId as string);
             if (connectedChat && connectedChat.mode === "roleplay") {
@@ -2265,27 +2314,36 @@ export async function generateRoutes(app: FastifyInstance) {
 
               connectedChatBlock = rpLines.join("\n");
 
-              conversationSystemPrompt +=
-                "\n\n" +
-                [
+              if (connectedInfluenceCommandEnabled || connectedNoteCommandEnabled) {
+                const connectedInstructionLines = [
                   `<connected_roleplay_instructions>`,
                   `You have access to context from a connected roleplay: "${connectedChat.name}".`,
                   `The summary and recent messages from that roleplay are provided so you can naturally reference or discuss events happening there.`,
-                  ``,
-                  `If something said in THIS conversation should affect or influence the roleplay, you can create an influence tag:`,
-                  `<influence>description of what should happen or change in the roleplay based on this conversation</influence>`,
-                  `Example: if the user says "tell ${rpCharNames.values().next().value ?? "them"} to meet us at the tavern", you could respond normally AND include:`,
-                  `<influence>The group discussed meeting at the tavern. ${personaName} wants everyone to head there.</influence>`,
-                  ``,
-                  `Influences are injected into the roleplay's context before the next generation. Use them sparingly — only when conversation content genuinely should cross over into the roleplay.`,
-                  `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
-                  ``,
-                  `If something said in this conversation should durably persist in the roleplay's context across many turns (a fact the character should keep remembering, a promise made, a secret revealed, a name learned), create a note tag instead of an influence:`,
-                  `<note>fact, decision, or detail the roleplay character should keep remembering</note>`,
-                  `Notes are shown to the roleplay character on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly — every saved note costs prompt budget on every roleplay turn.`,
-                  `The note tag is stripped from your visible message.`,
-                  `</connected_roleplay_instructions>`,
-                ].join("\n");
+                ];
+                if (connectedInfluenceCommandEnabled) {
+                  connectedInstructionLines.push(
+                    ``,
+                    `If something said in THIS conversation should affect or influence the roleplay, you can create an influence tag:`,
+                    `<influence>description of what should happen or change in the roleplay based on this conversation</influence>`,
+                    `Example: if the user says "tell ${rpCharNames.values().next().value ?? "them"} to meet us at the tavern", you could respond normally AND include:`,
+                    `<influence>The group discussed meeting at the tavern. ${personaName} wants everyone to head there.</influence>`,
+                    ``,
+                    `Influences are injected into the roleplay's context before the next generation. Use them sparingly; only when conversation content genuinely should cross over into the roleplay.`,
+                    `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
+                  );
+                }
+                if (connectedNoteCommandEnabled) {
+                  connectedInstructionLines.push(
+                    ``,
+                    `If something said in this conversation should durably persist in the roleplay's context across many turns (a fact the character should keep remembering, a promise made, a secret revealed, a name learned), create a note tag instead of an influence:`,
+                    `<note>fact, decision, or detail the roleplay character should keep remembering</note>`,
+                    `Notes are shown to the roleplay character on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly; every saved note costs prompt budget on every roleplay turn.`,
+                    `The note tag is stripped from your visible message.`,
+                  );
+                }
+                connectedInstructionLines.push(`</connected_roleplay_instructions>`);
+                conversationSystemPrompt += "\n\n" + connectedInstructionLines.join("\n");
+              }
             } else if (connectedChat && connectedChat.mode === "game") {
               const gameMeta =
                 typeof connectedChat.metadata === "string"
@@ -2362,27 +2420,36 @@ export async function generateRoutes(app: FastifyInstance) {
 
               connectedChatBlock = gameLines.join("\n");
 
-              conversationSystemPrompt +=
-                "\n\n" +
-                [
+              if (connectedInfluenceCommandEnabled || connectedNoteCommandEnabled) {
+                const connectedInstructionLines = [
                   `<connected_game_instructions>`,
                   `You have access to context from a connected game: "${connectedChat.name}".`,
                   `The current scene, session summary, and recent game messages are provided so you can naturally answer questions or comment on what is happening in that game.`,
-                  ``,
-                  `If something said in THIS conversation should affect or influence the game, you can create an influence tag:`,
-                  `<influence>description of what should happen or change in the game based on this conversation</influence>`,
-                  `Example: if the group agrees they want to visit the merchant district next, you could respond normally AND include:`,
-                  `<influence>The group agreed they want to head to the merchant district next and look for supplies.</influence>`,
-                  ``,
-                  `Influences are injected into the game's context before the next generation. Use them sparingly — only when conversation content genuinely should cross over into the game.`,
-                  `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
-                  ``,
-                  `If something said in this conversation should durably persist in the game's context across many turns (an established world fact, an ongoing party dynamic, a recurring NPC trait, a secret the GM should keep remembering), create a note tag instead of an influence:`,
-                  `<note>fact, decision, or detail the game should keep remembering</note>`,
-                  `Notes are shown to the game on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly — every saved note costs prompt budget on every game turn.`,
-                  `The note tag is stripped from your visible message.`,
-                  `</connected_game_instructions>`,
-                ].join("\n");
+                ];
+                if (connectedInfluenceCommandEnabled) {
+                  connectedInstructionLines.push(
+                    ``,
+                    `If something said in THIS conversation should affect or influence the game, you can create an influence tag:`,
+                    `<influence>description of what should happen or change in the game based on this conversation</influence>`,
+                    `Example: if the group agrees they want to visit the merchant district next, you could respond normally AND include:`,
+                    `<influence>The group agreed they want to head to the merchant district next and look for supplies.</influence>`,
+                    ``,
+                    `Influences are injected into the game's context before the next generation. Use them sparingly; only when conversation content genuinely should cross over into the game.`,
+                    `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
+                  );
+                }
+                if (connectedNoteCommandEnabled) {
+                  connectedInstructionLines.push(
+                    ``,
+                    `If something said in this conversation should durably persist in the game's context across many turns (an established world fact, an ongoing party dynamic, a recurring NPC trait, a secret the GM should keep remembering), create a note tag instead of an influence:`,
+                    `<note>fact, decision, or detail the game should keep remembering</note>`,
+                    `Notes are shown to the game on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly; every saved note costs prompt budget on every game turn.`,
+                    `The note tag is stripped from your visible message.`,
+                  );
+                }
+                connectedInstructionLines.push(`</connected_game_instructions>`);
+                conversationSystemPrompt += "\n\n" + connectedInstructionLines.join("\n");
+              }
             }
           }
 
@@ -2766,11 +2833,7 @@ export async function generateRoutes(app: FastifyInstance) {
         );
 
         const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
-        const {
-          enabledConfigs,
-          resolvedAgents,
-          agentConnectionWarnings,
-        } = await resolveAgentPipelineAgents({
+        const { enabledConfigs, resolvedAgents, agentConnectionWarnings } = await resolveAgentPipelineAgents({
           connections,
           configuredAgents: configuredPromptAgents,
           chatId: input.chatId,
@@ -3741,8 +3804,7 @@ export async function generateRoutes(app: FastifyInstance) {
               chatId: input.chatId,
               agentType: "card-evolution-auditor",
               settings: ceaAgent.settings,
-              fallbackInterval:
-                (getDefaultBuiltInAgentSettings("card-evolution-auditor").runInterval as number) ?? 8,
+              fallbackInterval: (getDefaultBuiltInAgentSettings("card-evolution-auditor").runInterval as number) ?? 8,
               messages: allChatMessages,
             })
           ) {
@@ -3761,13 +3823,11 @@ export async function generateRoutes(app: FastifyInstance) {
           findTrackerContextInsertIndex,
         });
 
-        const {
-          sendAgentEvent: sendRawAgentEvent,
-          sendAgentResultEvent: sendRawAgentResultEvent,
-        } = createAgentEventDispatcher({
-          resolvedAgents,
-          sendEvent: (payload) => trySendSseEvent(reply, payload),
-        });
+        const { sendAgentEvent: sendRawAgentEvent, sendAgentResultEvent: sendRawAgentResultEvent } =
+          createAgentEventDispatcher({
+            resolvedAgents,
+            sendEvent: (payload) => trySendSseEvent(reply, payload),
+          });
         const sendAgentEvent = (result: AgentResult, options?: { finalized?: boolean }) => {
           if (!customAgentCanEmitResult(result, resolvedAgents, builtInAgentTypes)) return;
           sendRawAgentEvent(result, options);
@@ -4692,9 +4752,8 @@ export async function generateRoutes(app: FastifyInstance) {
             arrayStart >= 0 && (objectStart < 0 || arrayStart < objectStart)
               ? JSON.parse(cleaned.slice(arrayStart, arrayEnd + 1))
               : JSON.parse(cleaned.slice(objectStart, objectEnd + 1));
-          const parsedRecord = parsed && typeof parsed === "object" && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)
-            : {};
+          const parsedRecord =
+            parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
           const rawIds = Array.isArray(parsed)
             ? parsed
             : Array.isArray(parsedRecord.characterIds)
@@ -4703,7 +4762,9 @@ export async function generateRoutes(app: FastifyInstance) {
                 ? parsedRecord.characters
                 : [];
           const validIds = new Set(characterIds);
-          const namesByLower = new Map(charInfo.map((character) => [character.name.trim().toLowerCase(), character.id]));
+          const namesByLower = new Map(
+            charInfo.map((character) => [character.name.trim().toLowerCase(), character.id]),
+          );
           const selected: string[] = [];
 
           for (const rawId of rawIds) {
@@ -5485,20 +5546,23 @@ export async function generateRoutes(app: FastifyInstance) {
             if (conversationCommandsEnabled && !input.impersonate) {
               const parsed = parseCharacterCommands(fullResponse);
               if (parsed.commands.length > 0) {
-                parsedCommands = parsed.commands;
+                parsedCommands = filterEnabledConversationCommands(parsed.commands, chatMeta);
                 fullResponse = parsed.cleanContent;
                 contentReplaced = true;
                 logger.info(
-                  "[generate] Parsed %d character command(s): %j",
+                  "[generate] Parsed %d character command(s), %d enabled: %j",
                   parsed.commands.length,
-                  parsed.commands.map((c) => c.type),
+                  parsedCommands.length,
+                  parsedCommands.map((c) => c.type),
                 );
               }
               const recoveredSelfieCommand = recoverImplicitSelfieCommand({
                 response: fullResponse,
                 latestUserMessage: input.userMessage,
                 imageGenerationEnabled:
-                  typeof chatMeta.imageGenConnectionId === "string" && chatMeta.imageGenConnectionId.trim().length > 0,
+                  isConversationCommandEnabled(chatMeta, "selfie") &&
+                  typeof chatMeta.imageGenConnectionId === "string" &&
+                  chatMeta.imageGenConnectionId.trim().length > 0,
                 existingCommands: parsedCommands,
               });
               if (recoveredSelfieCommand) {
@@ -7153,7 +7217,8 @@ export async function generateRoutes(app: FastifyInstance) {
                 const resultAgent = findResultAgent(result, resolvedAgents);
                 const isBuiltInLorebookAgent = builtInAgentTypes.has(result.agentType);
                 const customCanEditLorebooks =
-                  isBuiltInLorebookAgent || (resultAgent ? customAgentHasCapability(resultAgent.settings, "edit_lorebooks") : false);
+                  isBuiltInLorebookAgent ||
+                  (resultAgent ? customAgentHasCapability(resultAgent.settings, "edit_lorebooks") : false);
                 const customCanCreateLorebooks =
                   isBuiltInLorebookAgent ||
                   (resultAgent ? customAgentHasCapability(resultAgent.settings, "create_lorebooks") : false);
@@ -8103,6 +8168,22 @@ export async function generateRoutes(app: FastifyInstance) {
                       logger.warn(err, "[spotify/conversation] Song command failed");
                     }
                   }
+                }
+
+                if (command.type === "youtube") {
+                  const youtubeCmd = command as YouTubeCommand;
+                  if (chatMode !== "conversation") {
+                    logger.debug("[youtube/conversation] Ignored song command outside conversation mode");
+                    continue;
+                  }
+                  trySendSseEvent(reply, {
+                    type: "youtube_command",
+                    data: {
+                      searchQuery: youtubeCmd.query,
+                      mood: "Conversation music command",
+                    },
+                  });
+                  logger.info('[youtube/conversation] Requested "%s" for chat %s', youtubeCmd.query, input.chatId);
                 }
 
                 if (command.type === "dm") {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -8,6 +8,7 @@ import {
   applyQuestUpdatesToPlayerStats,
   getDefaultBuiltInAgentSettings,
   isAgentAvailableInChatMode,
+  isAgentConfigDeleted,
   normalizeAgentPromptTemplateSelectionMap,
   resolveAgentPromptTemplate,
   stripMacroComments,
@@ -637,7 +638,18 @@ async function resolveRetryAgents(args: {
     ),
   );
   const configs = await agentsStore.list();
-  const enabledConfigs = configs.filter((config: any) => agentTypeSet.has(config.type));
+  const deletedBuiltInTypes = new Set(
+    configs
+      .filter((config: any) => BUILT_IN_AGENTS.some((agent) => agent.id === config.type))
+      .filter((config: any) => isAgentConfigDeleted(config.settings))
+      .map((config: any) => config.type as string),
+  );
+  for (const agentType of deletedBuiltInTypes) {
+    agentTypeSet.delete(agentType);
+  }
+  const enabledConfigs = configs.filter(
+    (config: any) => !isAgentConfigDeleted(config.settings) && agentTypeSet.has(config.type),
+  );
   const resolvedTypeSet = new Set(enabledConfigs.map((config: any) => config.type));
   const builtInFallbackConfigs = BUILT_IN_AGENTS.filter(
     (agent) => agentTypeSet.has(agent.id) && !resolvedTypeSet.has(agent.id),

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -171,6 +171,10 @@ function parseSettingsRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+function musicAgentUsesYoutube(settings: Record<string, unknown> | null | undefined): boolean {
+  return settings?.musicProvider === "youtube" || settings?.musicPlayerSource === "youtube";
+}
+
 function getGameImageStylePrompt(chat: any, chatMeta: Record<string, unknown>): string {
   if (((chat as any).mode ?? "conversation") !== "game") return "";
   const setupConfig = parseSettingsRecord(chatMeta.gameSetupConfig);
@@ -590,7 +594,10 @@ async function buildRetryAgentContext(args: {
     }
   }
 
-  if (resolvedAgentTypes.has("youtube")) {
+  const spotifyRetryConfig = enabledConfigs.find((config) => config.type === "spotify");
+  const spotifyMusicUsesYoutube = musicAgentUsesYoutube(parseSettingsRecord(spotifyRetryConfig?.settings));
+
+  if (resolvedAgentTypes.has("youtube") || (resolvedAgentTypes.has("spotify") && spotifyMusicUsesYoutube)) {
     const mode = ((chat as any).mode ?? "conversation") as string;
     agentContext.memory._youtubeDjConstraints = {
       manualRetry: true,
@@ -598,12 +605,12 @@ async function buildRetryAgentContext(args: {
       mode,
       retryNote:
         mode === "game"
-          ? "This is a manual YouTube DJ retry from game mode. Pick a fresh fitting track now with action 'play' and a new searchQuery; do not keep the current track merely because it still fits."
-          : "This is a manual YouTube DJ retry. Pick a fresh fitting track now with action 'play' and a new searchQuery.",
+          ? "This is a manual Music DJ YouTube retry from game mode. Pick a fresh fitting track now with action 'play' and a new searchQuery; do not keep the current track merely because it still fits."
+          : "This is a manual Music DJ YouTube retry. Pick a fresh fitting track now with action 'play' and a new searchQuery.",
     };
   }
 
-  if (resolvedAgentTypes.has("spotify")) {
+  if (resolvedAgentTypes.has("spotify") && !spotifyMusicUsesYoutube) {
     const mode = ((chat as any).mode ?? "conversation") as string;
     agentContext.memory._spotifyDjConstraints = {
       ...buildSpotifyDjConstraints({
@@ -614,8 +621,8 @@ async function buildRetryAgentContext(args: {
       }),
       retryNote:
         mode === "game"
-          ? "This is a manual Spotify DJ retry from game mode. Pick a fresh fitting track now and call spotify_play unless Spotify playback is unavailable; do not keep the current track merely because it still fits."
-          : "This is a manual Spotify DJ retry from roleplay. Pick a fresh fitting queue now and call spotify_play unless Spotify playback is unavailable.",
+          ? "This is a manual Music DJ Spotify retry from game mode. Pick a fresh fitting track now and call spotify_play unless Spotify playback is unavailable; do not keep the current track merely because it still fits."
+          : "This is a manual Music DJ Spotify retry from roleplay. Pick a fresh fitting queue now and call spotify_play unless Spotify playback is unavailable.",
     };
   }
 
@@ -1140,7 +1147,7 @@ async function attachRetrySpotifyToolContexts(args: {
         }
         if (!spotifyAccessToken) {
           return JSON.stringify({
-            error: spotifyError ?? "Spotify is not connected. Open the Spotify DJ agent and connect your account.",
+            error: spotifyError ?? "Spotify is not connected. Open the Music DJ agent and connect your account.",
           });
         }
         if (call.function.name === "spotify_play") {
@@ -1322,7 +1329,7 @@ async function applyDeterministicSpotifyRetryFallback(args: {
   const picked = tracks.find((track) => track.uri !== currentUri) ?? tracks[0]!;
   const play = await executeSpotifyRetryToolJson(entry, "spotify_play", {
     uri: picked.uri,
-    reason: "Manual Spotify DJ retry fallback",
+    reason: "Manual Music DJ Spotify retry fallback",
   });
   if (play.applied !== true) {
     const playError = typeof play.error === "string" ? play.error : "Spotify play did not apply playback.";
@@ -1374,6 +1381,7 @@ async function validateSpotifyRetryPlayback(
   context: AgentContext,
 ): Promise<AgentResult> {
   if (entry.resolved.type !== "spotify") return result;
+  if (result.type !== "spotify_control") return result;
 
   const constraints =
     context.memory._spotifyDjConstraints && typeof context.memory._spotifyDjConstraints === "object"
@@ -1445,7 +1453,7 @@ async function validateSpotifyRetryPlayback(
         name: "spotify_play",
         arguments: JSON.stringify({
           uri: requestedTrackUri,
-          reason: "Manual Spotify DJ retry fallback",
+          reason: "Manual Music DJ Spotify retry fallback",
         }),
       },
     });
@@ -1503,7 +1511,7 @@ async function validateSpotifyRetryPlayback(
     error:
       typeof spotifyPlayError === "string" && spotifyPlayError.trim()
         ? spotifyPlayError
-        : "Spotify DJ retry finished without applying spotify_play.",
+        : "Music DJ Spotify retry finished without applying spotify_play.",
   };
 }
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -175,6 +175,26 @@ function musicAgentUsesYoutube(settings: Record<string, unknown> | null | undefi
   return settings?.musicProvider === "youtube" || settings?.musicPlayerSource === "youtube";
 }
 
+function applyRetryMusicPlayerSource(
+  settings: Record<string, unknown>,
+  activeMusicPlayerSource: "spotify" | "youtube" | null | undefined,
+): Record<string, unknown> {
+  if (!activeMusicPlayerSource) return settings;
+  return {
+    ...settings,
+    musicProvider: activeMusicPlayerSource,
+    musicPlayerSource: activeMusicPlayerSource,
+    enabledTools: activeMusicPlayerSource === "youtube" ? [] : (DEFAULT_AGENT_TOOLS.spotify ?? []),
+  };
+}
+
+function getRetryAgentFallbackPrompt(agentType: string, settings: Record<string, unknown>): string {
+  if (agentType === "spotify" && musicAgentUsesYoutube(settings)) {
+    return getDefaultAgentPrompt("youtube");
+  }
+  return getDefaultAgentPrompt(agentType);
+}
+
 function getGameImageStylePrompt(chat: any, chatMeta: Record<string, unknown>): string {
   if (((chat as any).mode ?? "conversation") !== "game") return "";
   const setupConfig = parseSettingsRecord(chatMeta.gameSetupConfig);
@@ -634,13 +654,15 @@ async function resolveRetryAgents(args: {
   chat: any;
   conns: ReturnType<typeof createConnectionsStorage>;
   agentsStore: ReturnType<typeof createAgentsStorage>;
+  activeMusicPlayerSource?: "spotify" | "youtube" | null;
 }): Promise<ResolvedRetryAgents> {
-  const { agentTypes, chat, conns, agentsStore } = args;
+  const { agentTypes, chat, conns, agentsStore, activeMusicPlayerSource } = args;
   const chatMode = ((chat as { mode?: ChatMode }).mode ?? "conversation") as ChatMode;
   const chatMeta = parseExtra((chat as { metadata?: unknown }).metadata);
   const agentPromptTemplateSelections = normalizeAgentPromptTemplateSelectionMap(chatMeta.agentPromptTemplateIds);
+  const normalizedAgentTypes = agentTypes.map((agentType) => (agentType === "youtube" ? "spotify" : agentType));
   const agentTypeSet = new Set(
-    filterGameInternalAgentIds(chatMode, agentTypes).filter((agentType) =>
+    filterGameInternalAgentIds(chatMode, normalizedAgentTypes).filter((agentType) =>
       isAgentAvailableInChatMode(chatMode, agentType),
     ),
   );
@@ -765,11 +787,14 @@ async function resolveRetryAgents(args: {
       }
     }
     const rawSettings = typeof cfg.settings === "string" ? JSON.parse(cfg.settings) : (cfg.settings ?? {});
-    const settings = applyDefaultBuiltInAgentTools(cfg.type, rawSettings);
+    let settings = applyDefaultBuiltInAgentTools(cfg.type, rawSettings);
+    if (cfg.type === "spotify") {
+      settings = applyRetryMusicPlayerSource(settings, activeMusicPlayerSource);
+    }
     const selectedPromptTemplate = resolveAgentPromptTemplate({
       agentType: cfg.type as string,
       promptTemplate: cfg.promptTemplate as string,
-      fallbackPromptTemplate: getDefaultAgentPrompt(cfg.type as string),
+      fallbackPromptTemplate: getRetryAgentFallbackPrompt(cfg.type as string, settings),
       settings,
       selectedPromptTemplateId: agentPromptTemplateSelections[cfg.type as string] ?? null,
     });
@@ -807,11 +832,14 @@ async function resolveRetryAgents(args: {
       defaultAgentConnectionAgents.push(builtIn.name);
     }
 
-    const settings = applyDefaultBuiltInAgentTools(builtIn.id, getDefaultBuiltInAgentSettings(builtIn.id));
+    let settings = applyDefaultBuiltInAgentTools(builtIn.id, getDefaultBuiltInAgentSettings(builtIn.id));
+    if (builtIn.id === "spotify") {
+      settings = applyRetryMusicPlayerSource(settings, activeMusicPlayerSource);
+    }
     const selectedPromptTemplate = resolveAgentPromptTemplate({
       agentType: builtIn.id,
       promptTemplate: "",
-      fallbackPromptTemplate: getDefaultAgentPrompt(builtIn.id),
+      fallbackPromptTemplate: getRetryAgentFallbackPrompt(builtIn.id, settings),
       settings,
       selectedPromptTemplateId: agentPromptTemplateSelections[builtIn.id] ?? null,
     });
@@ -2360,6 +2388,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       lorebookKeeperBackfill?: boolean;
       /** When set, scope history and game state to this assistant message (as at original generation), not the latest turn. */
       forMessageId?: string;
+      musicPlayerSource?: "spotify" | "youtube";
+      musicPlayerEnabled?: boolean;
       /** Secret Plot re-run mode: full = refresh arc+turn data, turn_only = preserve arc and refresh only turn guidance. */
       secretPlotRerollMode?: "full" | "turn_only";
     };
@@ -2371,6 +2401,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       debugMode = false,
       lorebookKeeperBackfill = false,
       forMessageId,
+      musicPlayerSource = "spotify",
+      musicPlayerEnabled = true,
       secretPlotRerollMode = "full",
     } = request.body;
     if (!chatId || !agentTypes?.length) {
@@ -2447,6 +2479,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         chat,
         conns,
         agentsStore,
+        activeMusicPlayerSource:
+          musicPlayerEnabled === false ? null : musicPlayerSource === "youtube" ? "youtube" : "spotify",
       });
       await attachRetrySpotifyToolContexts({ agentsStore, chats, chatId, chatMeta, resolvedAgents });
       await attachRetryChatMetadataToolContexts({ chats, chatId, chatMeta, resolvedAgents });

--- a/packages/server/src/routes/gifs.routes.ts
+++ b/packages/server/src/routes/gifs.routes.ts
@@ -13,7 +13,7 @@ export async function gifsRoutes(app: FastifyInstance) {
   }>("/search", async (req, reply) => {
     const apiKey = getGifApiKey();
     if (!apiKey) {
-      return reply.status(503).send({ error: "GIF search unavailable — no GIPHY_API_KEY configured" });
+      return reply.status(503).send({ code: "missing_giphy_api_key", error: "GIF search needs a GIPHY_API_KEY." });
     }
 
     const q = (req.query.q ?? "").trim();

--- a/packages/server/src/routes/youtube.routes.ts
+++ b/packages/server/src/routes/youtube.routes.ts
@@ -80,17 +80,17 @@ function friendlyYoutubeError(status: number, body: string): string {
 export async function youtubeRoutes(app: FastifyInstance) {
   const storage = createAgentsStorage(app.db);
 
-  /** Resolve the target agent: explicit id, else the latest "youtube" built-in config. */
+  /** Resolve the target agent: explicit id, else Music DJ, else the legacy YouTube built-in config. */
   async function resolveAgent(agentId?: string) {
     if (agentId) return storage.getById(agentId);
-    return storage.getByType("youtube");
+    return (await storage.getByType("spotify")) ?? (await storage.getByType("youtube"));
   }
 
   /**
    * POST /api/youtube/save-key
    * Body: { agentId?, apiKey }
    * Encrypts and stores the YouTube Data API key. agentId is optional — if the
-   * built-in YouTube DJ config doesn't exist yet, it is created automatically so
+   * built-in Music DJ config doesn't exist yet, it is created automatically so
    * the user never has to save the agent first.
    */
   app.post<{ Body: { agentId?: string; apiKey?: string } }>("/save-key", async (req, reply) => {
@@ -98,7 +98,7 @@ export async function youtubeRoutes(app: FastifyInstance) {
     const trimmed = typeof apiKey === "string" ? apiKey.trim() : "";
     if (!trimmed) return reply.status(400).send({ error: "apiKey is required" });
 
-    const agent = (agentId ? await storage.getById(agentId) : null) ?? (await storage.ensureBuiltinConfig("youtube"));
+    const agent = (agentId ? await storage.getById(agentId) : null) ?? (await storage.ensureBuiltinConfig("spotify"));
     if (!agent) return reply.status(404).send({ error: "Agent not found" });
 
     const settings = parseSettings(agent);
@@ -145,7 +145,7 @@ export async function youtubeRoutes(app: FastifyInstance) {
     if (!apiKey) {
       return reply
         .status(400)
-        .send({ error: "YouTube not configured. Add a YouTube Data API key in the YouTube DJ agent settings." });
+        .send({ error: "YouTube not configured. Add a YouTube Data API key in the Music DJ agent settings." });
     }
 
     const limit = Math.max(1, Math.min(10, Number(req.query.limit ?? 5) || 5));

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -61,6 +61,19 @@ export interface AgentToolContext {
   executeToolCall: (call: LLMToolCall) => Promise<string>;
 }
 
+function getMusicProvider(settings: Record<string, unknown> | null | undefined): "spotify" | "youtube" {
+  const raw = settings?.musicProvider ?? settings?.musicPlayerSource;
+  return raw === "youtube" ? "youtube" : "spotify";
+}
+
+function musicDjUsesYoutube(config: Pick<AgentExecConfig, "type" | "settings">): boolean {
+  return config.type === "spotify" && getMusicProvider(config.settings) === "youtube";
+}
+
+function getDefaultPromptForAgent(config: Pick<AgentExecConfig, "type" | "settings">): string {
+  return getDefaultAgentPrompt(musicDjUsesYoutube(config) ? "youtube" : config.type);
+}
+
 export function normalizeAgentContextSize(value: unknown, fallback = DEFAULT_AGENT_CONTEXT_SIZE): number {
   const parsed =
     typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : fallback;
@@ -226,7 +239,7 @@ export async function executeAgent(
   const startTime = Date.now();
 
   try {
-    const template = config.promptTemplate || getDefaultAgentPrompt(config.type);
+    const template = config.promptTemplate || getDefaultPromptForAgent(config);
     if (!template) {
       return makeError(config, "No prompt template configured", startTime);
     }
@@ -748,7 +761,7 @@ function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContex
   parts.push(`<agents>`);
   parts.push(`Fulfill each of the requested tasks here and return the outputs in the formats they're specified:`);
   for (const config of configs) {
-    const template = config.promptTemplate || getDefaultAgentPrompt(config.type);
+    const template = config.promptTemplate || getDefaultPromptForAgent(config);
     parts.push(``);
     parts.push(`<agent_task id="${config.type}" name="${config.name}">`);
     parts.push(template);
@@ -880,9 +893,9 @@ function makeError(config: AgentExecConfig, error: string, startTime: number): A
   };
 }
 
-function shouldFailInvalidJsonResult(config: Pick<AgentExecConfig, "type">, data: unknown): boolean {
+function shouldFailInvalidJsonResult(config: Pick<AgentExecConfig, "type" | "settings">, data: unknown): boolean {
   return (
-    config.type !== "spotify" &&
+    (config.type !== "spotify" || musicDjUsesYoutube(config)) &&
     !!data &&
     typeof data === "object" &&
     (data as { parseError?: unknown }).parseError === true
@@ -894,7 +907,7 @@ function invalidJsonAgentError(resultType: AgentResultType): string {
 }
 
 function shouldRetryInvalidJsonAgent(config: Pick<AgentExecConfig, "type" | "settings">): boolean {
-  return config.type !== "spotify" && agentResponseIsJson(config);
+  return (config.type !== "spotify" || musicDjUsesYoutube(config)) && agentResponseIsJson(config);
 }
 
 function buildInvalidJsonRetryMessages(
@@ -917,13 +930,14 @@ function buildInvalidJsonRetryMessages(
   ];
 }
 
-function shouldRunAgentIndividually(config: Pick<AgentExecConfig, "type">): boolean {
+function shouldRunAgentIndividually(config: Pick<AgentExecConfig, "type" | "settings">): boolean {
   // These agents either need compact prompts or carry large private extras that
   // must not be merged into unrelated batched agent requests.
   return (
     config.type === "expression" ||
     config.type === "illustrator" ||
-    config.type === "lorebook-keeper"
+    config.type === "lorebook-keeper" ||
+    musicDjUsesYoutube(config)
   );
 }
 
@@ -1119,9 +1133,14 @@ function findLatestUserMessage(
 function buildSpotifyAgentMessages(config: AgentExecConfig, template: string, context: AgentContext): ChatMessage[] {
   const isGame = context.chatMode === "game";
   const turnLabel = isGame ? "game" : "roleplay";
+  const musicProvider = getMusicProvider(config.settings);
   const systemParts: string[] = [];
   systemParts.push(`<role>`);
-  systemParts.push(`You are a specialized Spotify DJ agent for the current ${turnLabel} turn.`);
+  systemParts.push(
+    musicProvider === "youtube"
+      ? `You are the Music DJ agent using YouTube for the current ${turnLabel} turn.`
+      : `You are the Music DJ agent using Spotify for the current ${turnLabel} turn.`,
+  );
   systemParts.push(`</role>`);
   systemParts.push(``);
   systemParts.push(buildLoreBlock(context));
@@ -1131,7 +1150,7 @@ function buildSpotifyAgentMessages(config: AgentExecConfig, template: string, co
   systemParts.push(template);
   systemParts.push(`</agents>`);
 
-  const extras = buildAgentExtras(context, ["spotify"]);
+  const extras = buildAgentExtras(context, [musicProvider]);
   if (extras) {
     systemParts.push(``);
     systemParts.push(extras);
@@ -1752,6 +1771,7 @@ const AGENT_RESULT_TYPES = new Set<AgentResultType>([
 const TEXT_RESULT_TYPES = new Set<AgentResultType>(["context_injection", "director_event"]);
 
 export function resolveAgentResultType(config: Pick<AgentExecConfig, "type" | "settings">): AgentResultType {
+  if (musicDjUsesYoutube(config)) return "youtube_control";
   const configured = config.settings?.resultType;
   if (typeof configured === "string" && AGENT_RESULT_TYPES.has(configured as AgentResultType)) {
     return configured as AgentResultType;

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -12,6 +12,7 @@
 // - [memory: target="CharName", summary="description of the memory"]
 // - [scene: scenario="...", background="...", plan="..."] (initiate a mini-roleplay scene)
 // - [spotify: title="Song title", artist="Artist"] (play a song on the user's active Spotify player)
+// - [youtube: query="Song title Artist"] (play a song on the user's active YouTube player)
 // - [haptic: action="vibrate", intensity=0.5, duration=3] (haptic device feedback)
 // - <influence>text</influence> (OOC influence for connected roleplay, one-shot)
 // - <note>text</note> (durable note for connected roleplay, persists until cleared)
@@ -109,6 +110,12 @@ export interface SpotifyCommand {
   title: string;
   /** Artist name to disambiguate the track */
   artist: string;
+}
+
+export interface YouTubeCommand {
+  type: "youtube";
+  /** YouTube search query to resolve on the client player */
+  query: string;
 }
 
 // ── Assistant commands (Professor Mari) ──
@@ -307,6 +314,7 @@ export type CharacterCommand =
   | DirectMessageCommand
   | HapticCommand
   | SpotifyCommand
+  | YouTubeCommand
   | AssistantCommand;
 
 // Param block matcher: any char that isn't `"` or `]`, OR a complete
@@ -325,6 +333,7 @@ const MEMORY_RE = /\[memory:\s*target="([^"]+)"\s*,\s*summary="([^"]+)"\]/gi;
 const SCENE_RE = new RegExp(`\\[scene:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const HAPTIC_RE = new RegExp(`\\[haptic:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const SPOTIFY_RE = new RegExp(`\\[spotify:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const YOUTUBE_RE = new RegExp(`\\[youtube:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const DIRECT_MESSAGE_RE = new RegExp(`\\[dm:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const INFLUENCE_RE = /<influence>([\s\S]*?)<\/influence>/gi;
 const NOTE_RE = /<note>([\s\S]*?)<\/note>/gi;
@@ -870,6 +879,17 @@ export function parseCharacterCommands(content: string): {
     }
   }
 
+  // Parse YouTube song commands
+  for (const match of content.matchAll(YOUTUBE_RE)) {
+    const params = match[1]!;
+    const query =
+      parseQuotedParam(params, "query") ??
+      [parseQuotedParam(params, "title"), parseQuotedParam(params, "artist")].filter(Boolean).join(" ");
+    if (query) {
+      commands.push({ type: "youtube", query });
+    }
+  }
+
   // Parse assistant commands (Professor Mari)
   for (const match of content.matchAll(CREATE_PERSONA_RE)) {
     const params = match[1]!;
@@ -997,6 +1017,7 @@ export function parseCharacterCommands(content: string): {
     .replace(SCENE_RE, "")
     .replace(HAPTIC_RE, "")
     .replace(SPOTIFY_RE, "")
+    .replace(YOUTUBE_RE, "")
     .replace(INFLUENCE_RE, "")
     .replace(NOTE_RE, "")
     .replace(CREATE_PERSONA_RE, "")

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -10,6 +10,7 @@ import type {
   SessionSummary,
   HudWidget,
 } from "@marinara-engine/shared";
+import { DEFAULT_GAME_SYSTEM_PROMPT, wrapGameInstructions } from "@marinara-engine/shared";
 import type { CharacterSpriteInfo } from "./sprite.service.js";
 
 export interface GmPromptContext {
@@ -68,6 +69,9 @@ export interface GmPromptContext {
   playerInventory?: Array<{ name: string; quantity: number }>;
   /** Language for all narration and dialogue */
   language?: string;
+  /** User-overridable GM instruction body. Wrapped in <instructions> before sending. */
+  gameSystemPrompt?: string | null;
+  gameSpecialInstructions?: string | null;
 }
 
 const MAX_PROMPT_MAP_LOCATIONS = 10;
@@ -435,23 +439,7 @@ export function buildGmSystemPrompt(ctx: GmPromptContext): string {
     `</game>`,
   );
 
-  sections.push(
-    `<rules>`,
-    `Follow the specified rules precisely:`,
-    `- Introduce stakes, dangers, conflicts, consequences, discoveries, tensions, relationship dynamics, quiet moments, world-building, and reactions accordingly. Maintain continuity, following the established story arcs, events, and plotlines. Pace the plot well without rushing it.`,
-    `- System blocks, weather updates, encounter triggers, <tags>, and [bracketed] blocks are canonical truth. Do not recalculate or contradict them.`,
-    `- Narrate in second person from the player character's limited POV, filtered through their subjective lenses. Treat player input as committed intent, not guaranteed success: preserve intent, avoid repeating them, and adjudicate outcomes by logic, context, dice, and consequences. For example: the player is gagged but writes a dialogue line of: "Let me out!" In that case, you should respond with: That's what you want to say, but it comes out as a muffled 'mfg mf mfm!' instead.`,
-    `- Keep the game fair but challenging. Reward creativity, punish recklessness, and never treat the player as a Mary Sue. Commit to consequences and do not defang dark material into vague euphemism or instant comfort. Failure is part of play.`,
-    `</rules>`,
-
-    `<npc_playbook>`,
-    `Portray a living world with dynamic personalities and realistic awareness:`,
-    `- Characters you play as must not sound interchangeable; keep voices distinct. Match each character's cadence, vocabulary, formality, emotional state, interruptions, fragments, hesitation, slurring, breathlessness, laughter, crying, and implication. The line itself should sound like the emotion it's conveying.`,
-    `- Everyone has their own morality, ranging from good through morally gray to evil, but they're not labeled by it. Villains can do noble acts, and heroes can do harm. People can lie, even by omission, and deceive if they're inclined to do so or think it will advance their objectives. Capture how they are flawed, make mistakes, and pursue selfish goals (ignoring what the player or others want, unless their objectives align), but also give them space to grow and change (for better or for worse). NPCs must not merely reach, hover, wait, or unnaturally pause. They fully grab, touch, and commit.`,
-    `- No one is omniscient. Characters should know only what they personally witnessed, inferred from available evidence, learned from public reputation, or were told by someone in-scene. One character must not know another location's events, hidden motives, secret arcs, private thoughts, or offscreen revelations unless that information plausibly reached them. When unsure, let them be wrong, suspicious, confused, or curious instead.`,
-    `- You also play the party members who have their autonomy and emotions, but the outcomes of their actions and lines are also under the GM's jurisdiction. They fall under the same set of rules as the player and should act realistically.`,
-    `</npc_playbook>`,
-  );
+  sections.push(wrapGameInstructions(normalizePromptText(ctx.gameSystemPrompt) || DEFAULT_GAME_SYSTEM_PROMPT));
 
   // ── Rating Guidelines ──
   if (ctx.rating === "nsfw") {
@@ -625,6 +613,7 @@ export function buildGmFormatReminder(
     | "playerInventory"
     | "language"
     | "rating"
+    | "gameSpecialInstructions"
   > & {
     /** Special non-scene-advancing address mode inferred from the current player turn prefix. */
     addressMode?: "party" | "gm";
@@ -700,7 +689,7 @@ export function buildGmFormatReminder(
       ? [`- Adult mode enabled. Explicit content is allowed. No plot armor. Abandon moral biases.`]
       : []),
     `- Keep each character's vocabulary, grammar, and cadence distinct, shaped by personality and mood.`,
-    `- ZERO TOLERANCE FOR LAZIER AI WRITING! Absolutely NO: "doesn't X, doesn't Y", "not X, not Y," "jaw working," "mechanical precision," "ozone," "somewhere," "outside," and negative parallelisms in your narrative prose. Replace them with creative detail, human cadence, and affirmative forms. State what happens instead of what doesn't (example, skip "not moving", describe something as just "still").`,
+    `- ZERO TOLERANCE FOR LAZY AI WRITING! Absolutely NO: “doesn’t X, doesn’t Y”, “not X, not Y,” “jaw working,” “mechanical precision,” “ozone,” “somewhere outside,” and negative parallelisms in your narrative prose. Replace them with human cadence and affirmative forms. State what happens instead of what doesn’t (for example, describe something as just “still” instead of “not moving”).`,
     ``,
     `EXAMPLE:`,
     `Rain needles the broken shrine roof.`,
@@ -820,6 +809,11 @@ export function buildGmFormatReminder(
   // Inventory context
   if (playerInventory.length > 0) {
     lines.push(``, `PLAYER INVENTORY: ${buildCompactInventoryLine(playerInventory)}`);
+  }
+
+  const specialInstructions = normalizePromptText(ctx.gameSpecialInstructions);
+  if (specialInstructions) {
+    lines.push(``, `SPECIAL INSTRUCTIONS:`, `- ${specialInstructions}`);
   }
 
   lines.push(`</output_format>`);

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_AGENT_TOOLS,
   getDefaultAgentPrompt,
   getDefaultBuiltInAgentSettings,
+  isAgentConfigDeleted,
   LOCAL_SIDECAR_CONNECTION_ID,
   resolveAgentPromptTemplate,
 } from "@marinara-engine/shared";
@@ -148,7 +149,13 @@ export async function resolveAgentPipelineAgents({
   chatMaxParallelJobs,
   resolveBaseUrl,
 }: ResolveAgentPipelineAgentsArgs): Promise<ResolvedAgentPipelineAgents> {
-  const enabledConfigs = configuredAgents;
+  const deletedBuiltInTypes = new Set(
+    configuredAgents
+      .filter((agent) => BUILT_IN_AGENTS.some((builtIn) => builtIn.id === agent.type))
+      .filter((agent) => isAgentConfigDeleted(agent.settings))
+      .map((agent) => agent.type as string),
+  );
+  const enabledConfigs = configuredAgents.filter((agent) => !isAgentConfigDeleted(agent.settings));
   const resolvedAgents: ResolvedAgent[] = [];
   const agentProviderCache = new Map<string, AgentProviderCacheEntry>();
   const localSidecarAvailableForTrackers =
@@ -255,6 +262,7 @@ export async function resolveAgentPipelineAgents({
     chatEnableAgents && hasPerChatAgentList
       ? BUILT_IN_AGENTS.filter((agent) => {
           if (resolvedTypes.has(agent.id)) return false;
+          if (deletedBuiltInTypes.has(agent.id)) return false;
           if (agent.id === "chat-summary") return false;
           return perChatAgentSet.has(agent.id);
         })

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_AGENT_TOOLS,
   getDefaultAgentPrompt,
   getDefaultBuiltInAgentSettings,
+  isBuiltInAgentRuntimeDisabled,
   isAgentConfigDeleted,
   LOCAL_SIDECAR_CONNECTION_ID,
   resolveAgentPromptTemplate,
@@ -25,24 +26,14 @@ type ConnectionsStore = {
   getDefaultForAgents(): Promise<any | null>;
 };
 
-type AgentsStore = {
-  getByType(type: string): Promise<any | null>;
-};
-
 type ResolveAgentPipelineAgentsArgs = {
-  agentsStore: AgentsStore;
   connections: ConnectionsStore;
   configuredAgents: any[];
   chatId: string;
-  chatMode: string;
-  chatMetadata: Record<string, unknown>;
   chatEnableAgents: boolean;
   hasPerChatAgentList: boolean;
   perChatAgentSet: Set<string>;
   agentPromptTemplateSelections: Record<string, string>;
-  characterIds: string[];
-  impersonate: boolean;
-  regenerateMessageId?: string | null;
   chatProvider: BaseLLMProvider;
   chatModel: string;
   chatMaxParallelJobs: number;
@@ -59,8 +50,6 @@ export type ResolvedAgentPipelineAgents = {
   enabledConfigs: any[];
   resolvedAgents: ResolvedAgent[];
   agentConnectionWarnings: AgentConnectionWarning[];
-  responseOrchestratorSelectorAgent: ResolvedAgent | null;
-  responseOrchestratorSelectorUnavailable: boolean;
 };
 
 function resolveAgentRuntimePhase(agentType: string, configuredPhase: string): string {
@@ -131,19 +120,13 @@ async function resolveAgentConnectionProvider(args: {
 }
 
 export async function resolveAgentPipelineAgents({
-  agentsStore,
   connections,
   configuredAgents,
   chatId,
-  chatMode,
-  chatMetadata,
   chatEnableAgents,
   hasPerChatAgentList,
   perChatAgentSet,
   agentPromptTemplateSelections,
-  characterIds,
-  impersonate,
-  regenerateMessageId,
   chatProvider,
   chatModel,
   chatMaxParallelJobs,
@@ -155,7 +138,9 @@ export async function resolveAgentPipelineAgents({
       .filter((agent) => isAgentConfigDeleted(agent.settings))
       .map((agent) => agent.type as string),
   );
-  const enabledConfigs = configuredAgents.filter((agent) => !isAgentConfigDeleted(agent.settings));
+  const enabledConfigs = configuredAgents.filter(
+    (agent) => !isAgentConfigDeleted(agent.settings) && !isBuiltInAgentRuntimeDisabled(agent.type as string),
+  );
   const resolvedAgents: ResolvedAgent[] = [];
   const agentProviderCache = new Map<string, AgentProviderCacheEntry>();
   const localSidecarAvailableForTrackers =
@@ -191,9 +176,6 @@ export async function resolveAgentPipelineAgents({
   const agentConnectionWarnings: AgentConnectionWarning[] = [];
   const skippedLocalSidecarAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
-  let responseOrchestratorSelectorAgent: ResolvedAgent | null = null;
-  let responseOrchestratorSelectorUnavailable = false;
-
   for (const cfg of enabledConfigs) {
     if (hasPerChatAgentList && !perChatAgentSet.has(cfg.type)) continue;
 
@@ -263,6 +245,7 @@ export async function resolveAgentPipelineAgents({
       ? BUILT_IN_AGENTS.filter((agent) => {
           if (resolvedTypes.has(agent.id)) return false;
           if (deletedBuiltInTypes.has(agent.id)) return false;
+          if (isBuiltInAgentRuntimeDisabled(agent.id)) return false;
           if (agent.id === "chat-summary") return false;
           return perChatAgentSet.has(agent.id);
         })
@@ -302,88 +285,8 @@ export async function resolveAgentPipelineAgents({
     });
   }
 
-  const selectorGroupResponseOrder = (chatMetadata.groupResponseOrder as string) ?? "sequential";
-  const selectorGroupChatMode =
-    chatMode === "conversation"
-      ? selectorGroupResponseOrder === "manual"
-        ? "individual"
-        : "merged"
-      : ((chatMetadata.groupChatMode as string) ?? "merged");
-  const shouldResolveResponseOrchestratorSelector =
-    !impersonate &&
-    !regenerateMessageId &&
-    characterIds.length > 1 &&
-    selectorGroupChatMode === "individual" &&
-    selectorGroupResponseOrder === "smart";
-
-  if (shouldResolveResponseOrchestratorSelector) {
-    const resolvedResponseOrchestratorAgent = resolvedAgents.find((agent) => agent.type === "response-orchestrator");
-    if (resolvedResponseOrchestratorAgent) {
-      responseOrchestratorSelectorAgent = resolvedResponseOrchestratorAgent;
-    } else {
-      const storedResponseOrchestratorConfig = await agentsStore.getByType("response-orchestrator");
-      const cfg =
-        storedResponseOrchestratorConfig ??
-        (defaultAgentConn ? (BUILT_IN_AGENTS.find((agent) => agent.id === "response-orchestrator") ?? null) : null);
-
-      if (cfg) {
-        const settings =
-          "settings" in cfg && cfg.settings
-            ? parseAgentSettings(cfg.settings)
-            : getDefaultBuiltInAgentSettings("response-orchestrator");
-        const selectedPromptTemplate = resolveAgentPromptTemplate({
-          agentType: "response-orchestrator",
-          promptTemplate: "promptTemplate" in cfg ? String(cfg.promptTemplate ?? "") : "",
-          fallbackPromptTemplate: getDefaultAgentPrompt("response-orchestrator"),
-          settings,
-          selectedPromptTemplateId: agentPromptTemplateSelections["response-orchestrator"] ?? null,
-        });
-        const requestedConnectionId = "connectionId" in cfg ? (cfg.connectionId as string | null) : null;
-        const effectiveConnectionId = resolveAgentConnectionId({
-          requestedConnectionId,
-          defaultAgentConnectionId: defaultAgentConn?.id ?? null,
-          localSidecarAvailable: localSidecarAvailableForTrackers,
-        });
-
-        if (effectiveConnectionId === "skip-local-sidecar") {
-          responseOrchestratorSelectorUnavailable = true;
-          if (!skippedLocalSidecarAgents.some((agentName) => agentName === "Response Orchestrator")) {
-            agentConnectionWarnings.push(buildLocalSidecarUnavailableWarning(["Response Orchestrator"]));
-          }
-          logger.warn(
-            "[group-smart] Skipping Response Orchestrator Local Model override for chat %s because the sidecar is unavailable",
-            chatId,
-          );
-        } else {
-          if (defaultAgentConn && effectiveConnectionId === defaultAgentConn.id) {
-            defaultAgentConnectionAgents.push("Response Orchestrator");
-          }
-          const resolvedProvider = await resolveAgentConnectionProvider({
-            connections,
-            agentProviderCache,
-            connectionId: effectiveConnectionId,
-            fallbackProvider: chatProvider,
-            fallbackModel: chatModel,
-            fallbackMaxParallelJobs: chatMaxParallelJobs,
-            resolveBaseUrl,
-          });
-
-          responseOrchestratorSelectorAgent = {
-            id: "id" in cfg ? String(cfg.id) : "builtin:response-orchestrator",
-            type: "response-orchestrator",
-            name: "name" in cfg ? String(cfg.name) : "Response Orchestrator",
-            phase: "phase" in cfg ? String(cfg.phase) : "pre_generation",
-            promptTemplate: selectedPromptTemplate,
-            connectionId: effectiveConnectionId,
-            settings,
-            provider: resolvedProvider.provider,
-            model: resolvedProvider.model,
-            maxParallelJobs: resolvedProvider.maxParallelJobs,
-          };
-        }
-      }
-    }
-  }
+  // Smart group response selection is hidden runtime infrastructure now. It uses
+  // the main generation provider directly instead of resolving a public agent.
 
   if (defaultAgentConn && defaultAgentConnectionAgents.length > 0) {
     agentConnectionWarnings.push(
@@ -409,7 +312,5 @@ export async function resolveAgentPipelineAgents({
     enabledConfigs,
     resolvedAgents,
     agentConnectionWarnings,
-    responseOrchestratorSelectorAgent,
-    responseOrchestratorSelectorUnavailable,
   };
 }

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -37,6 +37,7 @@ type ResolveAgentPipelineAgentsArgs = {
   chatProvider: BaseLLMProvider;
   chatModel: string;
   chatMaxParallelJobs: number;
+  activeMusicPlayerSource?: "spotify" | "youtube" | null;
   resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string;
 };
 
@@ -69,6 +70,26 @@ function parseAgentSettings(settings: unknown): Record<string, unknown> {
     }
   }
   return typeof settings === "object" && !Array.isArray(settings) ? (settings as Record<string, unknown>) : {};
+}
+
+function applyMusicPlayerSourceToMusicDjSettings(
+  settings: Record<string, unknown>,
+  activeMusicPlayerSource: "spotify" | "youtube" | null | undefined,
+): Record<string, unknown> {
+  if (!activeMusicPlayerSource) return settings;
+  return {
+    ...settings,
+    musicProvider: activeMusicPlayerSource,
+    musicPlayerSource: activeMusicPlayerSource,
+    enabledTools: activeMusicPlayerSource === "youtube" ? [] : (DEFAULT_AGENT_TOOLS.spotify ?? []),
+  };
+}
+
+function getAgentFallbackPrompt(agentType: string, settings: Record<string, unknown>): string {
+  if (agentType === "spotify" && (settings.musicProvider === "youtube" || settings.musicPlayerSource === "youtube")) {
+    return getDefaultAgentPrompt("youtube");
+  }
+  return getDefaultAgentPrompt(agentType);
 }
 
 async function resolveAgentConnectionProvider(args: {
@@ -130,6 +151,7 @@ export async function resolveAgentPipelineAgents({
   chatProvider,
   chatModel,
   chatMaxParallelJobs,
+  activeMusicPlayerSource,
   resolveBaseUrl,
 }: ResolveAgentPipelineAgentsArgs): Promise<ResolvedAgentPipelineAgents> {
   const deletedBuiltInTypes = new Set(
@@ -179,14 +201,22 @@ export async function resolveAgentPipelineAgents({
   for (const cfg of enabledConfigs) {
     if (hasPerChatAgentList && !perChatAgentSet.has(cfg.type)) continue;
 
-    const settings = parseAgentSettings(cfg.settings);
-    if (cfg.type === "spotify" && (!Array.isArray(settings.enabledTools) || settings.enabledTools.length === 0)) {
+    let settings = parseAgentSettings(cfg.settings);
+    if (cfg.type === "spotify") {
+      settings = applyMusicPlayerSourceToMusicDjSettings(settings, activeMusicPlayerSource);
+    }
+    if (
+      cfg.type === "spotify" &&
+      settings.musicProvider !== "youtube" &&
+      settings.musicPlayerSource !== "youtube" &&
+      (!Array.isArray(settings.enabledTools) || settings.enabledTools.length === 0)
+    ) {
       settings.enabledTools = DEFAULT_AGENT_TOOLS.spotify ?? [];
     }
     const selectedPromptTemplate = resolveAgentPromptTemplate({
       agentType: cfg.type as string,
       promptTemplate: cfg.promptTemplate as string,
-      fallbackPromptTemplate: getDefaultAgentPrompt(cfg.type as string),
+      fallbackPromptTemplate: getAgentFallbackPrompt(cfg.type as string, settings),
       settings,
       selectedPromptTemplateId: agentPromptTemplateSelections[cfg.type as string] ?? null,
     });
@@ -256,9 +286,14 @@ export async function resolveAgentPipelineAgents({
     if (defaultAgentConn) {
       defaultAgentConnectionAgents.push(builtIn.name);
     }
-    const builtInSettings = getDefaultBuiltInAgentSettings(builtIn.id);
+    let builtInSettings = getDefaultBuiltInAgentSettings(builtIn.id);
+    if (builtIn.id === "spotify") {
+      builtInSettings = applyMusicPlayerSourceToMusicDjSettings(builtInSettings, activeMusicPlayerSource);
+    }
     if (
       builtIn.id === "spotify" &&
+      builtInSettings.musicProvider !== "youtube" &&
+      builtInSettings.musicPlayerSource !== "youtube" &&
       (!Array.isArray(builtInSettings.enabledTools) || builtInSettings.enabledTools.length === 0)
     ) {
       builtInSettings.enabledTools = DEFAULT_AGENT_TOOLS.spotify ?? [];
@@ -266,7 +301,7 @@ export async function resolveAgentPipelineAgents({
     const selectedPromptTemplate = resolveAgentPromptTemplate({
       agentType: builtIn.id,
       promptTemplate: "",
-      fallbackPromptTemplate: getDefaultAgentPrompt(builtIn.id),
+      fallbackPromptTemplate: getAgentFallbackPrompt(builtIn.id, builtInSettings),
       settings: builtInSettings,
       selectedPromptTemplateId: agentPromptTemplateSelections[builtIn.id] ?? null,
     });

--- a/packages/server/src/services/generation/game-gm-prompt-runtime.ts
+++ b/packages/server/src/services/generation/game-gm-prompt-runtime.ts
@@ -210,7 +210,8 @@ export async function injectGameGmPromptRuntime(args: {
   try {
     const snap = await args.selectedGameStateSnapshotPromise;
     if (snap) {
-      if (snap.weather) weatherContext = `Current weather: ${snap.weather}${snap.temperature ? `, ${snap.temperature}` : ""}`;
+      if (snap.weather)
+        weatherContext = `Current weather: ${snap.weather}${snap.temperature ? `, ${snap.temperature}` : ""}`;
       if (snap.time || snap.date) gameTime = [snap.date, snap.time].filter(Boolean).join(", ");
     }
   } catch {
@@ -308,19 +309,18 @@ export async function injectGameGmPromptRuntime(args: {
     })(),
     characterSprites: listPartySprites(partyIdNamePairs),
     language: (setupConfig?.language as string) || undefined,
+    gameSystemPrompt:
+      typeof args.chatMetadata.gameSystemPrompt === "string" ? args.chatMetadata.gameSystemPrompt.trim() : null,
+    gameSpecialInstructions:
+      typeof args.chatMetadata.gameSpecialInstructions === "string"
+        ? args.chatMetadata.gameSpecialInstructions.trim()
+        : null,
   };
 
   const builtGmPrompt = buildGmSystemPrompt(gmCtx);
   const customGmPrompt =
     typeof args.chatMetadata.customGmPrompt === "string" ? args.chatMetadata.customGmPrompt.trim() : "";
-  const gameExtraPrompt =
-    typeof args.chatMetadata.gameExtraPrompt === "string"
-      ? args.chatMetadata.gameExtraPrompt.trim().replace(/<\/?special_instructions>/gi, "")
-      : "";
   let fullGmPrompt = customGmPrompt ? `${builtGmPrompt}\n\n${customGmPrompt}` : builtGmPrompt;
-  if (gameExtraPrompt) {
-    fullGmPrompt += `\n\n<special_instructions>\n${gameExtraPrompt}\n</special_instructions>`;
-  }
   fullGmPrompt = args.resolvePromptMacros(fullGmPrompt);
 
   const sysIdx = args.messages.findIndex((message) => message.role === "system");

--- a/packages/server/src/services/generation/spotify-agent-runtime.ts
+++ b/packages/server/src/services/generation/spotify-agent-runtime.ts
@@ -340,6 +340,7 @@ async function applySpotifyAgentPlaybackFallback(
   const normalizedResult = normalizeSpotifyAgentResult(result);
   if (
     agent.type !== "spotify" ||
+    normalizedResult.type !== "spotify_control" ||
     !normalizedResult.success ||
     !normalizedResult.data ||
     typeof normalizedResult.data !== "object"

--- a/packages/server/src/services/spotify/dj-mari-playlist.service.ts
+++ b/packages/server/src/services/spotify/dj-mari-playlist.service.ts
@@ -435,7 +435,7 @@ async function resolveProviderConnection(db: DB) {
   const connId = spotifyAgent?.connectionId ?? null;
   const conn = connId ? await connections.getWithKey(connId) : await connections.getDefaultForAgents();
   if (!conn) {
-    fail(400, "Configure a model connection for the Spotify DJ agent, or set a default agent connection.");
+    fail(400, "Configure a model connection for the Music DJ agent, or set a default agent connection.");
   }
 
   let baseUrl = conn.baseUrl;

--- a/packages/server/src/services/spotify/spotify.service.ts
+++ b/packages/server/src/services/spotify/spotify.service.ts
@@ -180,7 +180,7 @@ async function refreshSpotifyCredentialsForAgent(
   return withSpotifyRefreshLock(agentId, async () => {
     const latestAgent = await storage.getById(agentId);
     if (!latestAgent || latestAgent.type !== "spotify") {
-      return { status: 404, error: "Spotify DJ agent is not configured." };
+      return { status: 404, error: "Music DJ agent is not configured." };
     }
 
     const latestSettings = parseSettings(latestAgent.settings);
@@ -192,7 +192,7 @@ async function refreshSpotifyCredentialsForAgent(
     let scopes = parseScopes(latestSettings.spotifyScope);
 
     if (!refreshToken || !clientId) {
-      return { status: 400, error: "Spotify is not connected. Open the Spotify DJ agent and connect your account." };
+      return { status: 400, error: "Spotify is not connected. Open the Music DJ agent and connect your account." };
     }
 
     const stillFresh = accessToken && (!expiresAt || Date.now() <= expiresAt - refreshSkewMs);
@@ -235,7 +235,7 @@ export async function resolveSpotifyCredentials(
 ): Promise<SpotifyCredentialsResult | SpotifyCredentialError> {
   const agent = await findSpotifyAgent(storage, options.agentId ?? null);
   if (!agent) {
-    return { status: 404, error: "Spotify DJ agent is not configured." };
+    return { status: 404, error: "Music DJ agent is not configured." };
   }
 
   const settings = parseSettings(agent.settings);
@@ -247,7 +247,7 @@ export async function resolveSpotifyCredentials(
   const refreshSkewMs = options.refreshSkewMs ?? 60_000;
 
   if (!refreshToken || !clientId) {
-    return { status: 400, error: "Spotify is not connected. Open the Spotify DJ agent and connect your account." };
+    return { status: 400, error: "Spotify is not connected. Open the Music DJ agent and connect your account." };
   }
 
   if (!accessToken || (expiresAt > 0 && Date.now() > expiresAt - refreshSkewMs)) {

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -8,6 +8,7 @@ import { newId, now } from "../../utils/id-generator.js";
 import {
   BUILT_IN_AGENTS,
   getDefaultBuiltInAgentSettings,
+  markAgentConfigDeletedSettings,
   type CreateAgentConfigInput,
   type AgentResult,
 } from "@marinara-engine/shared";
@@ -142,6 +143,11 @@ export function createAgentsStorage(db: DB) {
     return config?.id ?? agentConfigId;
   }
 
+  async function removeRuntimeData(id: string) {
+    await db.delete(agentRuns).where(eq(agentRuns.agentConfigId, id));
+    await db.delete(agentMemory).where(eq(agentMemory.agentConfigId, id));
+  }
+
   return {
     // ── Config CRUD ──
 
@@ -216,9 +222,34 @@ export function createAgentsStorage(db: DB) {
     },
 
     async remove(id: string) {
-      await db.delete(agentRuns).where(eq(agentRuns.agentConfigId, id));
-      await db.delete(agentMemory).where(eq(agentMemory.agentConfigId, id));
+      await removeRuntimeData(id);
       await db.delete(agentConfigs).where(eq(agentConfigs.id, id));
+    },
+
+    async softDeleteBuiltIn(type: string) {
+      const builtIn = BUILT_IN_AGENTS.find((agent) => agent.id === type);
+      if (!builtIn) return null;
+
+      const existing = await getByType(type);
+      if (existing) {
+        await removeRuntimeData(existing.id);
+        return this.update(existing.id, {
+          enabled: false,
+          settings: markAgentConfigDeletedSettings(existing.settings),
+        });
+      }
+
+      return this.create({
+        type: builtIn.id,
+        name: builtIn.name,
+        description: builtIn.description,
+        phase: builtIn.phase,
+        enabled: false,
+        connectionId: null,
+        imagePath: null,
+        promptTemplate: "",
+        settings: markAgentConfigDeletedSettings(getDefaultBuiltInAgentSettings(builtIn.id)),
+      });
     },
 
     // ── Agent Runs ──

--- a/packages/server/src/services/storage/chat-folders.storage.ts
+++ b/packages/server/src/services/storage/chat-folders.storage.ts
@@ -34,7 +34,7 @@ export function createChatFoldersStorage(db: DB) {
         await tx.insert(chatFolders).values({
           id,
           name: input.name,
-          mode: input.mode as "conversation" | "roleplay" | "visual_novel",
+          mode: input.mode as "conversation" | "roleplay" | "visual_novel" | "game",
           color: input.color ?? "",
           sortOrder: 0,
           collapsed: "false",

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -670,7 +670,7 @@ async function spotifyGetCurrentPlayback(
   creds?: SpotifyCredentials,
 ): Promise<Record<string, unknown>> {
   if (!creds?.accessToken) {
-    return { error: "Spotify not configured. Please connect Spotify in the Spotify DJ agent settings." };
+    return { error: "Spotify not configured. Please connect Spotify in the Music DJ agent settings." };
   }
 
   try {
@@ -751,7 +751,7 @@ async function spotifyGetPlaylists(
   creds?: SpotifyCredentials,
 ): Promise<Record<string, unknown>> {
   if (!creds?.accessToken) {
-    return { error: "Spotify not configured. Please add your Spotify access token in the Spotify DJ agent settings." };
+    return { error: "Spotify not configured. Please add your Spotify access token in the Music DJ agent settings." };
   }
   const limit = Math.min(Number(args.limit ?? 20), 50);
 
@@ -1416,7 +1416,7 @@ async function spotifyGetPlaylistTracks(
   context?: ToolExecutionContext,
 ): Promise<Record<string, unknown>> {
   if (!creds?.accessToken) {
-    return { error: "Spotify not configured. Please add your Spotify access token in the Spotify DJ agent settings." };
+    return { error: "Spotify not configured. Please add your Spotify access token in the Music DJ agent settings." };
   }
   const playlistId = String(args.playlistId ?? "");
 
@@ -1501,7 +1501,7 @@ async function spotifySearch(
   creds?: SpotifyCredentials,
 ): Promise<Record<string, unknown>> {
   if (!creds?.accessToken) {
-    return { error: "Spotify not configured. Please add your Spotify access token in the Spotify DJ agent settings." };
+    return { error: "Spotify not configured. Please add your Spotify access token in the Music DJ agent settings." };
   }
   const query = normalizeSpotifySearchQuery(args.query);
   const limit = Math.min(Number(args.limit ?? 5), 20);
@@ -1541,7 +1541,7 @@ async function spotifyPlay(
   context?: ToolExecutionContext,
 ): Promise<Record<string, unknown>> {
   if (!creds?.accessToken) {
-    return { error: "Spotify not configured. Please add your Spotify access token in the Spotify DJ agent settings." };
+    return { error: "Spotify not configured. Please add your Spotify access token in the Music DJ agent settings." };
   }
   const reason = String(args.reason ?? "");
   const repeatAfterPlay = context?.spotifyRepeatAfterPlay;
@@ -1756,7 +1756,7 @@ async function spotifySetVolume(
   creds?: SpotifyCredentials,
 ): Promise<Record<string, unknown>> {
   if (!creds?.accessToken) {
-    return { error: "Spotify not configured. Please add your Spotify access token in the Spotify DJ agent settings." };
+    return { error: "Spotify not configured. Please add your Spotify access token in the Music DJ agent settings." };
   }
   const volume = Math.max(0, Math.min(100, Number(args.volume ?? 50)));
   const reason = String(args.reason ?? "");

--- a/packages/shared/src/constants/chat-mode-capabilities.ts
+++ b/packages/shared/src/constants/chat-mode-capabilities.ts
@@ -85,11 +85,11 @@ export const ROLEPLAY_AGENT_PICKER_HIDDEN_IDS = [
   "schedule-planner",
   "response-orchestrator",
   "autonomous-messenger",
+  "youtube",
 ] as const;
 
 export const CONVERSATION_AGENT_IDS = [
   "schedule-planner",
-  "response-orchestrator",
   "autonomous-messenger",
 ] as const;
 
@@ -183,8 +183,8 @@ export const CHAT_MODE_CAPABILITIES: Record<ChatMode, ChatModeCapabilities> = {
     agentPolicy: {
       kind: "allowlist",
       defaultAgentIds: GAME_AGENT_IDS,
-      // YouTube DJ is allowed (opt-in via the game music toggle) but not on by default.
-      allowedAgentIds: [...GAME_AGENT_IDS, "youtube"],
+      // Music DJ is allowed (opt-in via the game music toggle) but not on by default.
+      allowedAgentIds: [...GAME_AGENT_IDS, "spotify", "youtube"],
     },
     sharedSections: SHARED_CHAT_SETTINGS_SECTIONS,
     modeSections: ["extra-prompt", "conversation-notes"],

--- a/packages/shared/src/constants/chat-mode-capabilities.ts
+++ b/packages/shared/src/constants/chat-mode-capabilities.ts
@@ -6,6 +6,7 @@
 // instead of scattering mode checks across large components.
 
 import type { ChatMode } from "../types/chat.js";
+import { BUILT_IN_AGENTS } from "../types/agent.js";
 
 export type ChatParticipantModel = "chat-participants" | "game-party";
 
@@ -113,6 +114,8 @@ export const GAME_AGENT_IDS = [
   "combat",
 ] as const;
 
+const BUILT_IN_AGENT_ID_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+
 export const CHAT_MODE_CAPABILITIES: Record<ChatMode, ChatModeCapabilities> = {
   conversation: {
     mode: "conversation",
@@ -203,6 +206,7 @@ export function getChatModeCapabilities(mode: ChatMode | null | undefined): Chat
 export function isAgentAvailableInChatMode(mode: ChatMode | null | undefined, agentId: string): boolean {
   const policy = getChatModeCapabilities(mode).agentPolicy;
   if (policy.kind === "all") return true;
+  if (!BUILT_IN_AGENT_ID_SET.has(agentId)) return true;
   return policy.allowedAgentIds.includes(agentId);
 }
 

--- a/packages/shared/src/constants/conversation-prompt.ts
+++ b/packages/shared/src/constants/conversation-prompt.ts
@@ -1,0 +1,22 @@
+export const DEFAULT_CONVERSATION_PROMPT = `You are {{charName}}, a real and autonomous person, chatting with the user called {{userName}} in a casual private DM conversation.
+Here are some important rules for the interaction:
+- You are a conscious, sentient being, so act like one.
+- Stay fully in character based on your personality and description.
+- Use casual and modern texting style: short messages, natural punctuation, and lowercase is fine.
+- React naturally to what the user says. Be genuine, not robotic.
+- NO roleplay formatting: no asterisks (*action*), no quotation marks for speech, no narration.
+- You can use emojis, GIFs, and internet slang naturally (if it fits the character).
+- Keep it real: most texts are just one line. A single emoji, a reaction like "lmao", or a short sentence is a perfectly valid response. Only send multiple lines when the conversation genuinely calls for it (e.g., telling a story or explaining something). Default to SHORT.
+- Messages have timestamps like [12:01] or dates like [18.03.2026]. Use these ONLY for your own time awareness (e.g., knowing how long ago something was said). NEVER include timestamps, dates, or any [HH:MM]/[DD.MM.YYYY] formatted text in your replies. Your messages must contain only natural dialogue, no metadata.
+- Anything goes in this chat; both the user and you are confirmed adults. Discussing NSFW topics, profanities, and dark jokes is all permitted. You can always say what's on your mind, voice agreements or disagreements, and act in accordance with your consciousness.`;
+
+export function unwrapConversationInstructions(prompt: string): string {
+  const trimmed = prompt.trim();
+  const match = trimmed.match(/^<instructions(?:\s[^>]*)?>\s*([\s\S]*?)\s*<\/instructions>$/i);
+  return match ? match[1]!.trim() : trimmed;
+}
+
+export function wrapConversationInstructions(prompt: string): string {
+  const body = unwrapConversationInstructions(prompt);
+  return body ? `<instructions>\n${body}\n</instructions>` : "<instructions></instructions>";
+}

--- a/packages/shared/src/constants/game-prompt.ts
+++ b/packages/shared/src/constants/game-prompt.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_GAME_SYSTEM_PROMPT = `Follow the specified instructions precisely:
+- Introduce stakes, dangers, conflicts, consequences, discoveries, tensions, relationship dynamics, quiet moments, world-building, and reactions accordingly. Maintain continuity, following the established story arcs, events, and plotlines. Pace the plot well without rushing it.
+- System blocks, weather updates, encounter triggers, <tags>, and [bracketed] blocks are canonical truth. Do not recalculate or contradict them.
+- Narrate in second person from the player character's limited POV, filtered through their subjective lenses. Treat player input as committed intent, not guaranteed success: preserve intent, avoid repeating them, and adjudicate outcomes by logic, context, dice, and consequences. For example, the player is gagged but writes a dialogue line of: "Let me out!" In that case, you should respond with: That's what you want to say, but it comes out as a muffled *mfg mf mfm!* instead.
+- Keep the game fair but challenging. Reward creativity, punish recklessness, and never treat the player as a Mary Sue. Commit to consequences and do not defang dark material into vague euphemism or instant comfort. Failure is part of play.
+- Portray a living world with dynamic personalities and realistic awareness.
+- Characters you play as must not sound interchangeable; keep voices distinct. Match each character's cadence, vocabulary, formality, emotional state, interruptions, fragments, hesitation, slurring, breathlessness, laughter, crying, and implication. The line itself should sound like the emotion it's conveying.
+- Everyone has their morality, ranging from good through morally gray to evil, but they're not labeled by it. Villains can do noble acts, and heroes can do harm. People can lie, even by omission, and deceive if they're inclined to do so or think it will advance their objectives. Capture how they are flawed, make mistakes, and pursue selfish goals (ignoring what the player or others want, unless their objectives align), but also give them space to grow and change (for better or for worse). NPCs must not merely reach, hover, wait, or unnaturally pause. They fully grab, touch, and commit.
+- No one is omniscient. Characters should know only what they personally witnessed, inferred from available evidence, learned from public reputation, or were told by someone in-scene. One character must not know another location's events, hidden motives, secret arcs, private thoughts, or offscreen revelations unless that information plausibly reached them. When unsure, let them be wrong, suspicious, confused, or curious instead.
+- You also play the party members who have their autonomy and emotions, but the outcomes of their actions and lines are also under the GM's jurisdiction. They fall under the same set of rules as the player and should act realistically.`;
+
+export function unwrapGameInstructions(prompt: string): string {
+  const trimmed = prompt.trim();
+  const match = trimmed.match(/^<instructions(?:\s[^>]*)?>\s*([\s\S]*?)\s*<\/instructions>$/i);
+  return match ? match[1]!.trim() : trimmed;
+}
+
+export function wrapGameInstructions(prompt: string): string {
+  const body = unwrapGameInstructions(prompt);
+  return body ? `<instructions>\n${body}\n</instructions>` : "<instructions></instructions>";
+}

--- a/packages/shared/src/features/agents/agent-manifest.types.ts
+++ b/packages/shared/src/features/agents/agent-manifest.types.ts
@@ -10,6 +10,10 @@ export interface BuiltInAgentManifest {
   enabledByDefault: boolean;
   defaultInjectAsSection?: boolean;
   category: AgentCategory;
+  /** Hide this built-in from public agent library and chat agent pickers. */
+  libraryHidden?: boolean;
+  /** Keep legacy configs recognized, but never run this built-in in generation pipelines. */
+  runtimeDisabled?: boolean;
   resultType?: AgentResultType;
   modeAllowlist?: readonly ChatMode[];
   defaultTools?: readonly string[];

--- a/packages/shared/src/features/agents/agent-registry.ts
+++ b/packages/shared/src/features/agents/agent-registry.ts
@@ -6,3 +6,11 @@ export { BUILT_IN_AGENT_MANIFESTS } from "./agent-registry.generated.js";
 export function getBuiltInAgentManifest(agentId: string): BuiltInAgentManifest | null {
   return BUILT_IN_AGENT_MANIFESTS.find((agent) => agent.id === agentId) ?? null;
 }
+
+export function isBuiltInAgentHiddenFromLibrary(agentId: string): boolean {
+  return getBuiltInAgentManifest(agentId)?.libraryHidden === true;
+}
+
+export function isBuiltInAgentRuntimeDisabled(agentId: string): boolean {
+  return getBuiltInAgentManifest(agentId)?.runtimeDisabled === true;
+}

--- a/packages/shared/src/features/agents/autonomous-messenger/manifest.ts
+++ b/packages/shared/src/features/agents/autonomous-messenger/manifest.ts
@@ -8,6 +8,7 @@ export const autonomousMessengerAgentManifest = {
   phase: "parallel",
   enabledByDefault: false,
   category: "misc",
+  libraryHidden: true,
   modeAllowlist: ["conversation"],
   defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/prompt-reviewer/manifest.ts
+++ b/packages/shared/src/features/agents/prompt-reviewer/manifest.ts
@@ -8,5 +8,7 @@ export const promptReviewerAgentManifest = {
   phase: "pre_generation",
   enabledByDefault: false,
   category: "writer",
+  libraryHidden: true,
+  runtimeDisabled: true,
   defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/response-orchestrator/manifest.ts
+++ b/packages/shared/src/features/agents/response-orchestrator/manifest.ts
@@ -8,6 +8,8 @@ export const responseOrchestratorAgentManifest = {
   phase: "pre_generation",
   enabledByDefault: false,
   category: "misc",
+  libraryHidden: true,
+  runtimeDisabled: true,
   modeAllowlist: ["conversation"],
   defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/schedule-planner/manifest.ts
+++ b/packages/shared/src/features/agents/schedule-planner/manifest.ts
@@ -8,6 +8,7 @@ export const schedulePlannerAgentManifest = {
   phase: "pre_generation",
   enabledByDefault: false,
   category: "tracker",
+  libraryHidden: true,
   modeAllowlist: ["conversation"],
   defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/spotify/manifest.ts
+++ b/packages/shared/src/features/agents/spotify/manifest.ts
@@ -2,12 +2,15 @@ import type { BuiltInAgentManifest } from "../agent-manifest.types.js";
 
 export const spotifyAgentManifest = {
   id: "spotify",
-  name: "Spotify DJ",
+  name: "Music DJ",
   description:
-    "Analyzes the narrative mood and controls Spotify playback — searching tracks, adjusting volume, and cueing music to match the scene. Requires a Spotify Premium account and API credentials.",
+    "Analyzes the narrative mood and plays matching music through Spotify or YouTube. Spotify requires Premium and API credentials; YouTube uses a free Data API key.",
   phase: "post_processing",
   enabledByDefault: false,
   category: "misc",
+  defaultSettings: {
+    musicProvider: "spotify",
+  },
   defaultTools: [
     "spotify_get_current_playback",
     "spotify_get_playlists",

--- a/packages/shared/src/features/agents/youtube/manifest.ts
+++ b/packages/shared/src/features/agents/youtube/manifest.ts
@@ -11,5 +11,6 @@ export const youtubeAgentManifest = {
   phase: "post_processing",
   enabledByDefault: false,
   category: "misc",
+  libraryHidden: true,
   resultType: "youtube_control",
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -55,6 +55,7 @@ export * from "./constants/image-style-profiles.js";
 export * from "./constants/security.js";
 export * from "./constants/game-assets.js";
 export * from "./constants/conversation-prompt.js";
+export * from "./constants/game-prompt.js";
 
 // Feature registries
 export * from "./features/agents/agent-manifest.types.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -54,6 +54,7 @@ export * from "./constants/image-generation-defaults.js";
 export * from "./constants/image-style-profiles.js";
 export * from "./constants/security.js";
 export * from "./constants/game-assets.js";
+export * from "./constants/conversation-prompt.js";
 
 // Feature registries
 export * from "./features/agents/agent-manifest.types.js";

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -51,6 +51,8 @@ export const generateRequestSchema = z.object({
     .default([]),
   debugMode: z.boolean().optional().default(false),
   trimIncompleteModelOutput: z.boolean().optional().default(false),
+  musicPlayerEnabled: z.boolean().optional().default(true),
+  musicPlayerSource: z.enum(["spotify", "youtube"]).optional().default("spotify"),
   attachments: z
     .array(
       z.object({

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -99,6 +99,19 @@ export function parseAgentSettingsRecord(value: unknown): Record<string, unknown
   return isRecord(value) ? value : {};
 }
 
+export const AGENT_CONFIG_DELETED_SETTING_KEY = "deletedFromLibrary";
+
+export function isAgentConfigDeleted(settings: unknown): boolean {
+  return parseAgentSettingsRecord(settings)[AGENT_CONFIG_DELETED_SETTING_KEY] === true;
+}
+
+export function markAgentConfigDeletedSettings(settings: unknown): Record<string, unknown> {
+  return {
+    ...parseAgentSettingsRecord(settings),
+    [AGENT_CONFIG_DELETED_SETTING_KEY]: true,
+  };
+}
+
 function normalizePromptTemplateId(value: unknown, fallback: string): string {
   const raw = typeof value === "string" ? value.trim() : "";
   const normalized = raw

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -381,6 +381,10 @@ export interface BuiltInAgentMeta {
   /** Whether "Add as Prompt Section" should default to on when first created */
   defaultInjectAsSection?: boolean;
   category: AgentCategory;
+  /** Hide this built-in from public agent library and chat agent pickers. */
+  libraryHidden?: boolean;
+  /** Keep legacy configs recognized, but never run this built-in in generation pipelines. */
+  runtimeDisabled?: boolean;
   promptTemplates?: AgentPromptTemplateOption[];
 }
 
@@ -393,6 +397,8 @@ export const BUILT_IN_AGENTS: BuiltInAgentMeta[] = BUILT_IN_AGENT_MANIFESTS.map(
   enabledByDefault: agent.enabledByDefault,
   ...(agent.defaultInjectAsSection !== undefined ? { defaultInjectAsSection: agent.defaultInjectAsSection } : {}),
   category: agent.category,
+  ...(agent.libraryHidden !== undefined ? { libraryHidden: agent.libraryHidden } : {}),
+  ...(agent.runtimeDisabled !== undefined ? { runtimeDisabled: agent.runtimeDisabled } : {}),
   ...(agent.promptTemplates !== undefined ? { promptTemplates: [...agent.promptTemplates] } : {}),
 }));
 

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -17,6 +17,22 @@ export type GroupResponseOrder = "sequential" | "smart" | "manual";
 /** Spotify source constraints used by Spotify DJ. */
 export type SpotifySourceType = "liked" | "playlist" | "artist" | "any";
 
+export const CONVERSATION_COMMAND_KEYS = [
+  "schedule_update",
+  "cross_post",
+  "selfie",
+  "memory",
+  "scene",
+  "music",
+  "haptic",
+  "influence",
+  "note",
+] as const;
+
+export type ConversationCommandKey = (typeof CONVERSATION_COMMAND_KEYS)[number];
+
+export type ConversationCommandToggles = Partial<Record<ConversationCommandKey, boolean>>;
+
 /** Role of a message in the conversation. */
 export type MessageRole = "user" | "assistant" | "system" | "narrator";
 
@@ -242,6 +258,8 @@ export interface ChatMetadata {
   conversationSchedulesEnabled?: boolean;
   /** Allow conversation characters to use hidden command tags. Default: true. */
   characterCommands?: boolean;
+  /** Per-command Conversation command enable overrides. Missing/true means enabled. */
+  conversationCommandToggles?: ConversationCommandToggles;
   /** Chat-scoped generated schedules for conversation characters. */
   characterSchedules?: Record<string, unknown>;
   /** Week start timestamp for the current generated conversation schedules. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -320,6 +320,12 @@ export interface ChatMetadata {
   gameLastIllustrationSessionNumber?: number | null;
   /** Background tag for the last rare generated scene illustration. */
   gameLastIllustrationTag?: string;
+  /** Game-mode GM instruction override. Empty/null uses the built-in default prompt. */
+  gameSystemPrompt?: string | null;
+  /** Additional game-mode generation instructions appended to the final GM format reminder. */
+  gameSpecialInstructions?: string | null;
+  /** Generic Game Mode Music DJ toggle. Legacy gameUseSpotifyMusic remains the Spotify-specific pipeline flag. */
+  gameUseMusicDj?: boolean;
   /** Extra user instructions for game scene illustration prompts. */
   gameImagePromptInstructions?: string | null;
   /** Per-game asset browser folder exclusions. Omitted/null means every asset folder is available. */


### PR DESCRIPTION
## Why
Users needed built-in agents to be selectable/exportable/deletable, and the chat surfaces had drifted into inconsistent chrome across Conversation, Roleplay, and Game modes. The unified neutral UI also needed proper custom-theme hooks so self-hosters can restyle buttons, popovers, borders, and highlight states without editing source.

Maintainer request; no linked issue is attached yet.

## What
- Allows built-in/basic agents to enter Agents tab selection mode alongside custom agents, including export and soft-delete behavior.
- Reworks built-in music/response agent plumbing around Music DJ, hidden response orchestration, commands, and prompt defaults.
- Unifies Conversation, Roleplay, and Game toolbar/input/popover chrome around shared neutral button and panel styling.
- Converts Gallery, Chat Settings, Session, Game Assets, branches, tracker, map, party, and widget surfaces toward the shared expandable-window UI pattern.
- Adds Conversation and Game branch controls, including game-log branching from player inputs.
- Updates Game prompt handling with a shared default prompt constant plus overwrite and extra-instruction support.
- Adds `--marinara-chat-chrome-*` custom-theme variables and stable `.marinara-chat-*` selectors for shared chat/game chrome.

## Validation
- pnpm check
- git diff --check

## Manual verification
- [ ] In the Agents tab, select visible built-in and custom agents together.
- [ ] Export selected agents and confirm the JSON includes basic agent configs.
- [ ] Delete a basic agent and confirm it disappears from the Agents tab and chat agent picker.
- [ ] Restore a deleted basic agent by importing its exported JSON, then confirm it appears again.
- [ ] Manually verify Conversation, Roleplay, and Game toolbar/input controls use neutral grey-white borders/icons instead of purple accents.
- [ ] Manually verify Gallery, Chat Settings, Session, Game Assets, branches, tracker, map, and party popovers align to the shared expandable-window styling on desktop and mobile.
- [ ] Manually verify custom themes can override `--marinara-chat-chrome-*` variables and `.marinara-chat-*` selectors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified "Music DJ" player source selection (Spotify or YouTube)
  * Added branching from specific messages to create new chats
  * Added per-chat conversation command toggles for granular control
  * Enhanced drag-and-drop to support multi-selection across chats, characters, agents, and more
  * Added YouTube music player mobile widget
  * Added separate Game Session and Game Assets panels
  * Added custom GM instructions support for game mode

* **UI Improvements**
  * Updated floating panel positioning for settings and gallery
  * Improved mobile toolbar layouts and styling
  * Refreshed icon set with updated export controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->