### PR TITLE
fix: neutralize game party sheet text

### DIFF
--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -19,6 +19,7 @@ import {
   Zap,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import { NEUTRAL_SURFACE_VARIABLES } from "../ui/neutral-surface-styles";
 
 export interface GameCharacterSheetGameCard {
   shortDescription: string;
@@ -389,7 +390,10 @@ export function GameCharacterSheet({
       onClick={onClose}
     >
       <div
-        className="relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-zinc-700/80 bg-zinc-950/95 shadow-2xl"
+        className={cn(
+          NEUTRAL_SURFACE_VARIABLES,
+          "relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-zinc-700/80 bg-zinc-950/95 shadow-2xl",
+        )}
         onClick={(e) => e.stopPropagation()}
       >
         {(onSave || onRegenerate) && (

--- a/packages/client/src/components/game/GamePartySidebar.tsx
+++ b/packages/client/src/components/game/GamePartySidebar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { Users, Send, ChevronLeft, ChevronRight, Swords, Heart, Sparkles } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { AnimatedText } from "./AnimatedText";
+import { NEUTRAL_SURFACE_VARIABLES } from "../ui/neutral-surface-styles";
 
 interface PartyChatMessage {
   id: string;
@@ -160,7 +161,12 @@ export function GamePartySidebar({
 
           {/* RPG character card */}
           {selectedCard && (
-            <div className="border-b border-[var(--border)] bg-[var(--secondary)]/55 px-2 py-2">
+            <div
+              className={cn(
+                NEUTRAL_SURFACE_VARIABLES,
+                "border-b border-[var(--border)] bg-[var(--secondary)]/55 px-2 py-2",
+              )}
+            >
               <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/80 shadow-lg">
                 {/* Card header with avatar + name */}
                 <div className="relative border-b border-[var(--border)] bg-[var(--secondary)]/45 px-2.5 py-2">


### PR DESCRIPTION
## What changed

- Neutralized inherited game party character card and sheet text colors by applying the shared neutral surface variables inside the party card surfaces.
- Keeps explicit semantic colors for things like HP, strengths, weaknesses, and mood indicators.

## Why

- The game party card and character sheet still inherited purple text and control colors after the broader chat UI neutralization pass.

## Validation

- pnpm check

## Manual verification

- [ ] Manually verify the Game mode party card and character sheet no longer show purple description, edit, or close controls.
