### PR TITLE
Add tracker field locks

### DIFF
--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -34,6 +34,7 @@ import {
   getTemperatureKeywordHint,
   parseTemperatureValue,
 } from "../../features/tracker-panel/lib/world-state-display";
+import { TrackerLockProvider } from "../../features/tracker-panel/components/TrackerLockContext";
 import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
 import { getChatToolbarButtonClass } from "./ChatToolbarControls";
 import type {
@@ -45,6 +46,7 @@ import type {
   CustomTrackerField,
   Message,
 } from "@marinara-engine/shared";
+import { toggleTrackerFieldLock } from "@marinara-engine/shared";
 import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store";
 
 const ACTIONS_DROPDOWN_WIDTH_PX = 288;
@@ -103,6 +105,7 @@ export function RoleplayHUD({
   injectionSourceMessages,
 }: RoleplayHUDProps & { mobileCompact?: boolean }) {
   const [agentsOpen, setAgentsOpen] = useState(false);
+  const [lockMode, setLockMode] = useState(false);
   const gameState = useGameStateStore((s) => s.current);
   const gameStateRefreshing = useGameStateStore((s) => s.isRefreshing);
   const setGameState = useGameStateStore((s) => s.setGameState);
@@ -192,6 +195,7 @@ export function RoleplayHUD({
         status: "",
       },
       personaStats: [],
+      fieldLocks: null,
     };
     discardPendingGameStatePatch(chatId);
     const prev = useGameStateStore.getState().current;
@@ -225,6 +229,13 @@ export function RoleplayHUD({
   const inventory = playerStats?.inventory ?? [];
   const activeQuests = playerStats?.activeQuests ?? [];
   const customTrackerFields = playerStats?.customTrackerFields ?? [];
+  const fieldLocks = gameState?.fieldLocks ?? null;
+  const toggleFieldLock = useCallback(
+    (key: string) => {
+      patchField("fieldLocks", toggleTrackerFieldLock(fieldLocks, key));
+    },
+    [fieldLocks, patchField],
+  );
   const hasPersonaStatsTracker = enabledAgentTypes.has("persona-stats");
   const hasPlayerTrackerSections =
     hasPersonaStatsTracker ||
@@ -236,13 +247,19 @@ export function RoleplayHUD({
   // If mobileCompact, widgets are even narrower and action buttons are not cut off
 
   return (
-    <div
-      className={cn(
-        "rpg-hud",
-        isVertical ? "flex flex-col items-center gap-1.5" : "flex items-center gap-1.5",
-        mobileCompact && "flex-1 min-w-0",
-      )}
+    <TrackerLockProvider
+      fieldLocks={fieldLocks}
+      lockMode={lockMode}
+      onSetLockMode={setLockMode}
+      onToggleFieldLock={toggleFieldLock}
     >
+      <div
+        className={cn(
+          "rpg-hud",
+          isVertical ? "flex flex-col items-center gap-1.5" : "flex items-center gap-1.5",
+          mobileCompact && "flex-1 min-w-0",
+        )}
+      >
       {trackerPanelEnabled && !trackerPanelOpen && <TrackerPanelToggleButton onToggle={toggleTrackerPanel} />}
 
       {/* Actions (Agents + Clear) */}
@@ -426,7 +443,8 @@ export function RoleplayHUD({
           )}
         </div>
       )}
-    </div>
+      </div>
+    </TrackerLockProvider>
   );
 }
 
@@ -1200,7 +1218,10 @@ function InventoryWidget({
         className="w-64 max-h-80 overflow-y-auto"
       >
         <Suspense fallback={<DeferredHUDPanelFallback label="Loading inventory…" />}>
-          <InventoryPanel items={items} onUpdate={onUpdate} />
+          <InventoryPanel
+            items={items}
+            onUpdate={onUpdate}
+          />
         </Suspense>
       </WidgetPopover>
     </div>

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -16,6 +16,7 @@ import {
   Clock,
   CloudSun,
   ImagePlus,
+  Lock,
   MapPin,
   Package,
   Pencil,
@@ -27,6 +28,7 @@ import {
   Target,
   Thermometer,
   Trash2,
+  Unlock,
   Users,
   X,
   RefreshCw,
@@ -42,6 +44,19 @@ import type {
   PresentCharacter,
   QuestProgress,
 } from "@marinara-engine/shared";
+import {
+  characterStatTrackerLockKey,
+  characterTrackerLockKey,
+  customTrackerLockKey,
+  inventoryTrackerLockKey,
+  isTrackerFieldLocked,
+  personaStatTrackerLockKey,
+  personaStatusTrackerLockKey,
+  questObjectiveTrackerLockKey,
+  questTrackerLockKey,
+  worldTrackerLockKey,
+} from "@marinara-engine/shared";
+import { useTrackerLockContext } from "../../features/tracker-panel/components/TrackerLockContext";
 
 interface CombinedPlayerPanelProps {
   showPersona: boolean;
@@ -99,6 +114,79 @@ const TRACKER_SECTION_TITLE =
   "text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider flex items-center gap-1";
 const TRACKER_SECTION_ACTION =
   "flex items-center gap-0.5 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]";
+const HUD_LOCKED_FIELD_CLASS =
+  "bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] ring-1 ring-[color-mix(in_srgb,var(--foreground)_30%,transparent)]";
+const HUD_LOCKED_FIELD_INSET_CLASS =
+  "bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] ring-1 ring-inset ring-[color-mix(in_srgb,var(--foreground)_30%,transparent)]";
+
+function HudFieldLockButton({
+  locked,
+  onToggle,
+  label,
+  persistentLocked = true,
+  className,
+}: {
+  locked?: boolean;
+  onToggle?: () => void;
+  label: string;
+  persistentLocked?: boolean;
+  className?: string;
+}) {
+  const { lockMode } = useTrackerLockContext();
+  if (!lockMode) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      title={locked ? "Unlock field" : "Lock field"}
+      aria-label={`${locked ? "Unlock" : "Lock"} ${label}`}
+      aria-pressed={locked}
+      className={cn(
+        "flex h-4 w-4 shrink-0 items-center justify-center rounded text-[var(--muted-foreground)]/55 opacity-70 ring-1 ring-transparent transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90 max-md:opacity-100",
+        locked && "text-[var(--foreground)]/80 ring-[var(--foreground)]/20",
+        locked && persistentLocked && "opacity-100",
+        className,
+      )}
+    >
+      {locked ? <Lock size="0.5625rem" /> : <Unlock size="0.5625rem" />}
+    </button>
+  );
+}
+
+function HudLockModeToggle() {
+  const { lockMode, onSetLockMode } = useTrackerLockContext();
+  if (!onSetLockMode) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSetLockMode(!lockMode)}
+      title={lockMode ? "Exit lock mode" : "Enter lock mode"}
+      aria-label={lockMode ? "Exit HUD lock mode" : "Enter HUD lock mode"}
+      aria-pressed={!!lockMode}
+      className={cn(
+        "flex h-5 w-5 shrink-0 items-center justify-center rounded p-0.5 transition-all active:scale-90",
+        lockMode
+          ? "bg-[var(--foreground)]/12 text-[var(--foreground)] ring-1 ring-[var(--foreground)]/24"
+          : "text-[var(--muted-foreground)]/50 ring-1 ring-transparent hover:bg-[var(--accent)] hover:text-[var(--foreground)] hover:ring-[var(--border)]",
+      )}
+    >
+      {lockMode ? <Lock size="0.625rem" /> : <Unlock size="0.625rem" />}
+    </button>
+  );
+}
+
+function useHudFieldLockResolver() {
+  const { fieldLocks, onToggleFieldLock } = useTrackerLockContext();
+  return useCallback(
+    (key: string) => ({
+      locked: isTrackerFieldLocked(fieldLocks, key),
+      onToggle: () => onToggleFieldLock?.(key),
+    }),
+    [fieldLocks, onToggleFieldLock],
+  );
+}
 
 export function CombinedPlayerPanel({
   showPersona,
@@ -188,6 +276,8 @@ export function CombinedPlayerPanel({
     next[idx] = updated;
     onUpdateCustomTracker(next);
   };
+  const lockFor = useHudFieldLockResolver();
+  const personaStatusLock = lockFor(personaStatusTrackerLockKey());
 
   return (
     <>
@@ -195,17 +285,25 @@ export function CombinedPlayerPanel({
         <span className={ROLEPLAY_POPOVER_TITLE}>
           <Swords size="0.625rem" className="text-orange-400/80" /> Trackers
         </span>
-        <button
-          onClick={onClose}
-          className="text-[var(--muted-foreground)]/50 hover:text-[var(--foreground)] transition-colors"
-        >
-          <X size="0.75rem" />
-        </button>
+        <span className="flex items-center gap-1">
+          <HudLockModeToggle />
+          <button
+            onClick={onClose}
+            className="text-[var(--muted-foreground)]/50 transition-colors hover:text-[var(--foreground)]"
+          >
+            <X size="0.75rem" />
+          </button>
+        </span>
       </div>
       <div className="overflow-y-auto max-h-[min(calc(75vh-2rem),30rem)] divide-y divide-[var(--border)]">
         {showPersona && (
           <div className="p-2">
-            <PersonaStatusField value={personaStatus} onSave={onUpdatePersonaStatus} />
+            <PersonaStatusField
+              value={personaStatus}
+              onSave={onUpdatePersonaStatus}
+              locked={personaStatusLock.locked}
+              onToggleLock={personaStatusLock.onToggle}
+            />
             <div className="flex items-center justify-between px-1 pb-1">
               <span className="text-[0.625rem] font-semibold text-[var(--muted-foreground)] uppercase tracking-wider">
                 Persona Stats
@@ -219,15 +317,26 @@ export function CombinedPlayerPanel({
             </div>
             <div className="space-y-2">
               {personaStats.length === 0 && <div className={EMPTY_STATE}>No stats tracked</div>}
-              {personaStats.map((bar, idx) => (
-                <StatBarEditable
-                  key={bar.name}
-                  stat={bar}
-                  onUpdateName={(name) => updateBar(idx, "name", name)}
-                  onUpdateValue={(value) => updateBar(idx, "value", value)}
-                  onUpdateMax={(value) => updateBar(idx, "max", value)}
-                />
-              ))}
+              {personaStats.map((bar, idx) => {
+                const nameLock = lockFor(personaStatTrackerLockKey(idx, "name"));
+                const valueLock = lockFor(personaStatTrackerLockKey(idx, "value"));
+                const maxLock = lockFor(personaStatTrackerLockKey(idx, "max"));
+                return (
+                  <StatBarEditable
+                    key={bar.name}
+                    stat={bar}
+                    onUpdateName={(name) => updateBar(idx, "name", name)}
+                    onUpdateValue={(value) => updateBar(idx, "value", value)}
+                    onUpdateMax={(value) => updateBar(idx, "max", value)}
+                    nameLocked={nameLock.locked}
+                    valueLocked={valueLock.locked}
+                    maxLocked={maxLock.locked}
+                    onToggleNameLock={nameLock.onToggle}
+                    onToggleValueLock={valueLock.onToggle}
+                    onToggleMaxLock={maxLock.onToggle}
+                  />
+                );
+              })}
             </div>
           </div>
         )}
@@ -255,20 +364,31 @@ export function CombinedPlayerPanel({
             </div>
             <div className="space-y-2">
               {characters.length === 0 && <div className={EMPTY_STATE}>No characters in scene</div>}
-              {characters.map((char, idx) => (
-                <div key={char.characterId ?? idx} className="rounded-lg bg-[var(--muted)]/20 p-2 space-y-1">
-                  <div className="flex items-center gap-1.5">
+              {characters.map((char, idx) => {
+                const emojiLock = lockFor(characterTrackerLockKey(char, idx, "emoji"));
+                const nameLock = lockFor(characterTrackerLockKey(char, idx, "name"));
+                const moodLock = lockFor(characterTrackerLockKey(char, idx, "mood"));
+                const appearanceLock = lockFor(characterTrackerLockKey(char, idx, "appearance"));
+                const outfitLock = lockFor(characterTrackerLockKey(char, idx, "outfit"));
+                const thoughtsLock = lockFor(characterTrackerLockKey(char, idx, "thoughts"));
+                return (
+                  <div key={char.characterId ?? idx} className="rounded-lg bg-[var(--muted)]/20 p-2 space-y-1">
+                  <div className="group/field flex items-center gap-1.5">
                     <InlineEdit
                       value={char.emoji || "👤"}
                       onSave={(value) => updateCharacter(idx, { ...char, emoji: value })}
                       className="w-8 text-center !text-sm"
+                      locked={emojiLock.locked}
                     />
+                    <HudFieldLockButton {...emojiLock} label={`${char.name || "character"} emoji`} />
                     <InlineEdit
                       value={char.name}
                       onSave={(value) => updateCharacter(idx, { ...char, name: value })}
                       className="flex-1 !font-medium"
                       placeholder="Name"
+                      locked={nameLock.locked}
                     />
+                    <HudFieldLockButton {...nameLock} label={`${char.name || "character"} name`} />
                     <button
                       onClick={() => removeCharacter(idx)}
                       className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
@@ -282,45 +402,62 @@ export function CombinedPlayerPanel({
                       label="Mood"
                       value={char.mood}
                       onSave={(value) => updateCharacter(idx, { ...char, mood: value })}
+                      locked={moodLock.locked}
+                      onToggleLock={moodLock.onToggle}
                     />
                     <LabeledEdit
                       label="Look"
                       value={char.appearance ?? ""}
                       onSave={(value) => updateCharacter(idx, { ...char, appearance: value || null })}
+                      locked={appearanceLock.locked}
+                      onToggleLock={appearanceLock.onToggle}
                     />
                     <LabeledEdit
                       label="Outfit"
                       value={char.outfit ?? ""}
                       onSave={(value) => updateCharacter(idx, { ...char, outfit: value || null })}
+                      locked={outfitLock.locked}
+                      onToggleLock={outfitLock.onToggle}
                     />
                     <LabeledEdit
                       label="Thinks"
                       value={char.thoughts ?? ""}
                       onSave={(value) => updateCharacter(idx, { ...char, thoughts: value || null })}
+                      locked={thoughtsLock.locked}
+                      onToggleLock={thoughtsLock.onToggle}
                     />
                   </div>
                   {char.stats?.length > 0 && (
                     <div className="space-y-1 pt-1 border-t border-[var(--border)]">
-                      {char.stats.map((stat, statIndex) => (
-                        <StatBarEditable
-                          key={stat.name}
-                          stat={stat}
-                          onUpdateValue={(value) => {
-                            const next = [...(char.stats ?? [])];
-                            next[statIndex] = { ...next[statIndex]!, value };
-                            updateCharacter(idx, { ...char, stats: next });
-                          }}
-                          onUpdateMax={(value) => {
-                            const next = [...(char.stats ?? [])];
-                            next[statIndex] = { ...next[statIndex]!, max: value };
-                            updateCharacter(idx, { ...char, stats: next });
-                          }}
-                        />
-                      ))}
+                      {char.stats.map((stat, statIndex) => {
+                        const valueLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "value"));
+                        const maxLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "max"));
+                        return (
+                          <StatBarEditable
+                            key={stat.name}
+                            stat={stat}
+                            onUpdateValue={(value) => {
+                              const next = [...(char.stats ?? [])];
+                              next[statIndex] = { ...next[statIndex]!, value };
+                              updateCharacter(idx, { ...char, stats: next });
+                            }}
+                            onUpdateMax={(value) => {
+                              const next = [...(char.stats ?? [])];
+                              next[statIndex] = { ...next[statIndex]!, max: value };
+                              updateCharacter(idx, { ...char, stats: next });
+                            }}
+                            valueLocked={valueLock.locked}
+                            maxLocked={maxLock.locked}
+                            onToggleValueLock={valueLock.onToggle}
+                            onToggleMaxLock={maxLock.onToggle}
+                          />
+                        );
+                      })}
                     </div>
                   )}
                 </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}
@@ -331,40 +468,50 @@ export function CombinedPlayerPanel({
               <span className={TRACKER_SECTION_TITLE}>
                 <Package size="0.5625rem" className="text-amber-400/80" /> Inventory ({inventory.length})
               </span>
-              <button
-                onClick={addItem}
-                className={TRACKER_SECTION_ACTION}
-              >
+              <button onClick={addItem} className={TRACKER_SECTION_ACTION}>
                 <Plus size="0.625rem" /> Add
               </button>
             </div>
             <div className="space-y-1">
               {inventory.length === 0 && <div className={EMPTY_STATE}>Inventory empty</div>}
-              {inventory.map((item, idx) => (
-                <div key={idx} className="flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5">
-                  <Package size="0.625rem" className="shrink-0 text-amber-400/60" />
-                  <InlineEdit
-                    value={item.name}
-                    onSave={(value) => updateItem(idx, { ...item, name: value })}
-                    className="flex-1"
-                    placeholder="Item name"
-                  />
-                  <input
-                    type="number"
-                    value={item.quantity}
-                    onChange={(e) => updateItem(idx, { ...item, quantity: Math.max(0, Number(e.target.value)) })}
-                    className="w-8 bg-transparent text-center text-[0.5625rem] text-[var(--foreground)]/60 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                    title="Quantity"
-                  />
-                  <button
-                    onClick={() => removeItem(idx)}
-                    className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
-                    title="Remove item"
+              {inventory.map((item, idx) => {
+                const nameLock = lockFor(inventoryTrackerLockKey(idx, "name"));
+                const quantityLock = lockFor(inventoryTrackerLockKey(idx, "quantity"));
+                return (
+                  <div
+                    key={idx}
+                    className="group/field flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5"
                   >
-                    <X size="0.5625rem" />
-                  </button>
-                </div>
-              ))}
+                    <Package size="0.625rem" className="shrink-0 text-amber-400/60" />
+                    <InlineEdit
+                      value={item.name}
+                      onSave={(value) => updateItem(idx, { ...item, name: value })}
+                      className="flex-1"
+                      placeholder="Item name"
+                      locked={nameLock.locked}
+                    />
+                    <HudFieldLockButton {...nameLock} label={`${item.name || "item"} name`} />
+                    <input
+                      type="number"
+                      value={item.quantity}
+                      onChange={(e) => updateItem(idx, { ...item, quantity: Math.max(0, Number(e.target.value)) })}
+                      className={cn(
+                        "w-8 rounded bg-transparent text-center text-[0.5625rem] text-[var(--foreground)]/60 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
+                        quantityLock.locked && HUD_LOCKED_FIELD_CLASS,
+                      )}
+                      title="Quantity"
+                    />
+                    <HudFieldLockButton {...quantityLock} label={`${item.name || "item"} quantity`} />
+                    <button
+                      onClick={() => removeItem(idx)}
+                      className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
+                      title="Remove item"
+                    >
+                      <X size="0.5625rem" />
+                    </button>
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}
@@ -382,10 +529,7 @@ export function CombinedPlayerPanel({
                   busy={isTrackerRetryBusy}
                   title="Re-run quest tracker only"
                 />
-                <button
-                  onClick={addQuest}
-                  className={TRACKER_SECTION_ACTION}
-                >
+                <button onClick={addQuest} className={TRACKER_SECTION_ACTION}>
                   <Plus size="0.625rem" /> Add
                 </button>
               </span>
@@ -396,6 +540,7 @@ export function CombinedPlayerPanel({
                 <QuestCardEditable
                   key={quest.questEntryId || idx}
                   quest={quest}
+                  questIndex={idx}
                   onUpdate={(updatedQuest) => updateQuest(idx, updatedQuest)}
                   onRemove={() => removeQuest(idx)}
                 />
@@ -408,7 +553,8 @@ export function CombinedPlayerPanel({
           <div className="p-2">
             <div className="flex items-center justify-between px-1 pb-1">
               <span className={TRACKER_SECTION_TITLE}>
-                <SlidersHorizontal size="0.5625rem" className="text-cyan-400/80" /> Custom ({customTrackerFields.length})
+                <SlidersHorizontal size="0.5625rem" className="text-cyan-400/80" />{" "}
+                {`Custom (${customTrackerFields.length})`}
               </span>
               <span className="flex items-center gap-1">
                 <TrackerSectionRefresh
@@ -417,41 +563,57 @@ export function CombinedPlayerPanel({
                   busy={isTrackerRetryBusy}
                   title="Re-run custom tracker only"
                 />
-                <button
-                  onClick={addCustomField}
-                  className={TRACKER_SECTION_ACTION}
-                >
+                <button onClick={addCustomField} className={TRACKER_SECTION_ACTION}>
                   <Plus size="0.625rem" /> Add
                 </button>
               </span>
             </div>
             <div className="space-y-1">
               {customTrackerFields.length === 0 && <div className={EMPTY_STATE}>No fields tracked</div>}
-              {customTrackerFields.map((field, idx) => (
-                <div key={idx} className="flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5">
-                  <SlidersHorizontal size="0.625rem" className="shrink-0 text-cyan-400/60" />
-                  <InlineEdit
-                    value={field.name}
-                    onSave={(value) => updateCustomField(idx, { ...field, name: value })}
-                    className="flex-1 min-w-0"
-                    placeholder="Field name"
-                  />
-                  <span className="text-[var(--muted-foreground)]/40 text-[0.5rem]">=</span>
-                  <InlineEdit
-                    value={field.value}
-                    onSave={(value) => updateCustomField(idx, { ...field, value })}
-                    className="flex-1 min-w-0"
-                    placeholder="Value"
-                  />
-                  <button
-                    onClick={() => removeCustomField(idx)}
-                    className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
-                    title="Remove field"
+              {customTrackerFields.map((field, idx) => {
+                const nameLock = lockFor(customTrackerLockKey(idx, "name"));
+                const valueLock = lockFor(customTrackerLockKey(idx, "value"));
+                const toggleValueLock = () => {
+                  if (field.locked) updateCustomField(idx, { ...field, locked: false });
+                  if (valueLock.locked || !field.locked) valueLock.onToggle();
+                };
+                return (
+                  <div
+                    key={idx}
+                    className="group/field flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5"
                   >
-                    <X size="0.5625rem" />
-                  </button>
-                </div>
-              ))}
+                    <SlidersHorizontal size="0.625rem" className="shrink-0 text-cyan-400/60" />
+                    <InlineEdit
+                      value={field.name}
+                      onSave={(value) => updateCustomField(idx, { ...field, name: value })}
+                      className="flex-1 min-w-0"
+                      placeholder="Field name"
+                      locked={nameLock.locked}
+                    />
+                    <HudFieldLockButton {...nameLock} label={`${field.name || "field"} name`} />
+                    <span className="text-[var(--muted-foreground)]/40 text-[0.5rem]">=</span>
+                    <InlineEdit
+                      value={field.value}
+                      onSave={(value) => updateCustomField(idx, { ...field, value })}
+                      className="flex-1 min-w-0"
+                      placeholder="Value"
+                      locked={valueLock.locked || field.locked}
+                    />
+                    <HudFieldLockButton
+                      locked={valueLock.locked || field.locked}
+                      onToggle={toggleValueLock}
+                      label={`${field.name || "field"} value`}
+                    />
+                    <button
+                      onClick={() => removeCustomField(idx)}
+                      className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
+                      title="Remove field"
+                    >
+                      <X size="0.5625rem" />
+                    </button>
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}
@@ -485,34 +647,53 @@ export function PersonaStatsPanel({
   const removeBar = (idx: number) => {
     onUpdate(bars.filter((_, index) => index !== idx));
   };
+  const lockFor = useHudFieldLockResolver();
+  const statusLock = lockFor(personaStatusTrackerLockKey());
 
   return (
     <>
       <div className="border-b border-[var(--border)] p-2">
-        <PersonaStatusField value={status} onSave={onUpdateStatus} />
-      </div>
-      <div className={cn(ROLEPLAY_POPOVER_HEADER, "flex items-center justify-between")}>
-        <span className={ROLEPLAY_POPOVER_TITLE}>
-          Persona Stats
-        </span>
-        <TrackerSectionRefresh
-          agentType="persona-stats"
-          onRerunSingleTracker={onRerunSingleTracker}
-          busy={isTrackerRetryBusy}
-          title="Re-run persona tracker (stats + inventory)"
+        <PersonaStatusField
+          value={status}
+          onSave={onUpdateStatus}
+          locked={statusLock.locked}
+          onToggleLock={statusLock.onToggle}
         />
       </div>
-      <div className="p-2 space-y-2">
-        {bars.map((bar, idx) => (
-          <StatBarEditable
-            key={bar.name}
-            stat={bar}
-            onUpdateName={(name) => updateBar(idx, "name", name)}
-            onUpdateValue={(value) => updateBar(idx, "value", value)}
-            onUpdateMax={(value) => updateBar(idx, "max", value)}
-            onRemove={() => removeBar(idx)}
+      <div className={cn(ROLEPLAY_POPOVER_HEADER, "flex items-center justify-between")}>
+        <span className={ROLEPLAY_POPOVER_TITLE}>Persona Stats</span>
+        <span className="flex items-center gap-1">
+          <TrackerSectionRefresh
+            agentType="persona-stats"
+            onRerunSingleTracker={onRerunSingleTracker}
+            busy={isTrackerRetryBusy}
+            title="Re-run persona tracker (stats + inventory)"
           />
-        ))}
+          <HudLockModeToggle />
+        </span>
+      </div>
+      <div className="p-2 space-y-2">
+        {bars.map((bar, idx) => {
+          const nameLock = lockFor(personaStatTrackerLockKey(idx, "name"));
+          const valueLock = lockFor(personaStatTrackerLockKey(idx, "value"));
+          const maxLock = lockFor(personaStatTrackerLockKey(idx, "max"));
+          return (
+            <StatBarEditable
+              key={bar.name}
+              stat={bar}
+              onUpdateName={(name) => updateBar(idx, "name", name)}
+              onUpdateValue={(value) => updateBar(idx, "value", value)}
+              onUpdateMax={(value) => updateBar(idx, "max", value)}
+              onRemove={() => removeBar(idx)}
+              nameLocked={nameLock.locked}
+              valueLocked={valueLock.locked}
+              maxLocked={maxLock.locked}
+              onToggleNameLock={nameLock.onToggle}
+              onToggleValueLock={valueLock.onToggle}
+              onToggleMaxLock={maxLock.onToggle}
+            />
+          );
+        })}
       </div>
     </>
   );
@@ -610,6 +791,7 @@ export function CharactersPanel({
     next[idx] = updated;
     onUpdate(next);
   };
+  const lockFor = useHudFieldLockResolver();
 
   return (
     <>
@@ -624,6 +806,7 @@ export function CharactersPanel({
             busy={isTrackerRetryBusy}
             title="Re-run character tracker only"
           />
+          <HudLockModeToggle />
           {trackerConfig && (
             <button
               onClick={toggleAutoGenerate}
@@ -649,9 +832,15 @@ export function CharactersPanel({
       </div>
       <div className="p-2 space-y-2">
         {characters.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>No characters in scene</div>}
-        {characters.map((char, idx) => (
-          <div key={char.characterId ?? idx} className="rounded-lg bg-[var(--muted)]/20 p-2 space-y-1">
-            <div className="flex items-center gap-1.5">
+        {characters.map((char, idx) => {
+          const nameLock = lockFor(characterTrackerLockKey(char, idx, "name"));
+          const moodLock = lockFor(characterTrackerLockKey(char, idx, "mood"));
+          const appearanceLock = lockFor(characterTrackerLockKey(char, idx, "appearance"));
+          const outfitLock = lockFor(characterTrackerLockKey(char, idx, "outfit"));
+          const thoughtsLock = lockFor(characterTrackerLockKey(char, idx, "thoughts"));
+          return (
+            <div key={char.characterId ?? idx} className="rounded-lg bg-[var(--muted)]/20 p-2 space-y-1">
+            <div className="group/field flex items-center gap-1.5">
               {/* Avatar circle or emoji fallback */}
               {char.avatarPath ? (
                 <button
@@ -681,7 +870,9 @@ export function CharactersPanel({
                 onSave={(value) => updateCharacter(idx, { ...char, name: value })}
                 className="flex-1 !font-medium"
                 placeholder="Name"
+                locked={nameLock.locked}
               />
+              <HudFieldLockButton {...nameLock} label={`${char.name || "character"} name`} />
               <button
                 onClick={() => removeCharacter(idx)}
                 className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
@@ -695,45 +886,62 @@ export function CharactersPanel({
                 label="Mood"
                 value={char.mood}
                 onSave={(value) => updateCharacter(idx, { ...char, mood: value })}
+                locked={moodLock.locked}
+                onToggleLock={moodLock.onToggle}
               />
               <LabeledEdit
                 label="Look"
                 value={char.appearance ?? ""}
                 onSave={(value) => updateCharacter(idx, { ...char, appearance: value || null })}
+                locked={appearanceLock.locked}
+                onToggleLock={appearanceLock.onToggle}
               />
               <LabeledEdit
                 label="Outfit"
                 value={char.outfit ?? ""}
                 onSave={(value) => updateCharacter(idx, { ...char, outfit: value || null })}
+                locked={outfitLock.locked}
+                onToggleLock={outfitLock.onToggle}
               />
               <LabeledEdit
                 label="Thinks"
                 value={char.thoughts ?? ""}
                 onSave={(value) => updateCharacter(idx, { ...char, thoughts: value || null })}
+                locked={thoughtsLock.locked}
+                onToggleLock={thoughtsLock.onToggle}
               />
             </div>
             {char.stats?.length > 0 && (
               <div className="space-y-1 pt-1 border-t border-[var(--border)]">
-                {char.stats.map((stat, statIndex) => (
-                  <StatBarEditable
-                    key={stat.name}
-                    stat={stat}
-                    onUpdateValue={(value) => {
-                      const next = [...(char.stats ?? [])];
-                      next[statIndex] = { ...next[statIndex]!, value };
-                      updateCharacter(idx, { ...char, stats: next });
-                    }}
-                    onUpdateMax={(value) => {
-                      const next = [...(char.stats ?? [])];
-                      next[statIndex] = { ...next[statIndex]!, max: value };
-                      updateCharacter(idx, { ...char, stats: next });
-                    }}
-                  />
-                ))}
+                {char.stats.map((stat, statIndex) => {
+                  const valueLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "value"));
+                  const maxLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "max"));
+                  return (
+                    <StatBarEditable
+                      key={stat.name}
+                      stat={stat}
+                      onUpdateValue={(value) => {
+                        const next = [...(char.stats ?? [])];
+                        next[statIndex] = { ...next[statIndex]!, value };
+                        updateCharacter(idx, { ...char, stats: next });
+                      }}
+                      onUpdateMax={(value) => {
+                        const next = [...(char.stats ?? [])];
+                        next[statIndex] = { ...next[statIndex]!, max: value };
+                        updateCharacter(idx, { ...char, stats: next });
+                      }}
+                      valueLocked={valueLock.locked}
+                      maxLocked={maxLock.locked}
+                      onToggleValueLock={valueLock.onToggle}
+                      onToggleMaxLock={maxLock.onToggle}
+                    />
+                  );
+                })}
               </div>
             )}
           </div>
-        ))}
+          );
+        })}
       </div>
       {/* Hidden file input for avatar upload */}
       <input
@@ -756,7 +964,10 @@ interface InventoryPanelProps {
   onUpdate: (items: InventoryItem[]) => void;
 }
 
-export function InventoryPanel({ items, onUpdate }: InventoryPanelProps) {
+export function InventoryPanel({
+  items,
+  onUpdate,
+}: InventoryPanelProps) {
   const addItem = () => {
     onUpdate([...items, { name: "New Item", description: "", quantity: 1, location: "on_person" }]);
   };
@@ -770,6 +981,7 @@ export function InventoryPanel({ items, onUpdate }: InventoryPanelProps) {
     next[idx] = updated;
     onUpdate(next);
   };
+  const lockFor = useHudFieldLockResolver();
 
   return (
     <>
@@ -777,40 +989,50 @@ export function InventoryPanel({ items, onUpdate }: InventoryPanelProps) {
         <span className={ROLEPLAY_POPOVER_TITLE}>
           <Package size="0.625rem" className="text-amber-400/80" /> Inventory ({items.length})
         </span>
-        <button
-          onClick={addItem}
-          className={TRACKER_SECTION_ACTION}
-        >
-          <Plus size="0.625rem" /> Add
-        </button>
+        <span className="flex items-center gap-1">
+          <HudLockModeToggle />
+          <button onClick={addItem} className={TRACKER_SECTION_ACTION}>
+            <Plus size="0.625rem" /> Add
+          </button>
+        </span>
       </div>
       <div className="p-2 space-y-1">
         {items.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>Inventory empty</div>}
-        {items.map((item, idx) => (
-          <div key={idx} className="flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5">
-            <Package size="0.625rem" className="shrink-0 text-amber-400/60" />
-            <InlineEdit
-              value={item.name}
-              onSave={(value) => updateItem(idx, { ...item, name: value })}
-              className="flex-1 min-w-0"
-              placeholder="Item name"
-            />
-            <input
-              type="number"
-              value={item.quantity}
-              onChange={(e) => updateItem(idx, { ...item, quantity: Math.max(0, Number(e.target.value)) })}
-              className="w-8 bg-transparent text-center text-[0.5625rem] text-[var(--foreground)]/60 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-              title="Quantity"
-            />
-            <button
-              onClick={() => removeItem(idx)}
-              className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
-              title="Remove item"
-            >
-              <X size="0.5625rem" />
-            </button>
-          </div>
-        ))}
+        {items.map((item, idx) => {
+          const nameLock = lockFor(inventoryTrackerLockKey(idx, "name"));
+          const quantityLock = lockFor(inventoryTrackerLockKey(idx, "quantity"));
+          return (
+            <div key={idx} className="group/field flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5">
+              <Package size="0.625rem" className="shrink-0 text-amber-400/60" />
+              <InlineEdit
+                value={item.name}
+                onSave={(value) => updateItem(idx, { ...item, name: value })}
+                className="flex-1 min-w-0"
+                placeholder="Item name"
+                locked={nameLock.locked}
+              />
+              <HudFieldLockButton {...nameLock} label={`${item.name || "item"} name`} />
+              <input
+                type="number"
+                value={item.quantity}
+                onChange={(e) => updateItem(idx, { ...item, quantity: Math.max(0, Number(e.target.value)) })}
+                className={cn(
+                  "w-8 rounded bg-transparent text-center text-[0.5625rem] text-[var(--foreground)]/60 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
+                  quantityLock.locked && HUD_LOCKED_FIELD_CLASS,
+                )}
+                title="Quantity"
+              />
+              <HudFieldLockButton {...quantityLock} label={`${item.name || "item"} quantity`} />
+              <button
+                onClick={() => removeItem(idx)}
+                className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
+                title="Remove item"
+              >
+                <X size="0.5625rem" />
+              </button>
+            </div>
+          );
+        })}
       </div>
     </>
   );
@@ -823,7 +1045,12 @@ interface QuestsPanelProps {
   isTrackerRetryBusy?: boolean;
 }
 
-export function QuestsPanel({ quests, onUpdate, onRerunSingleTracker, isTrackerRetryBusy }: QuestsPanelProps) {
+export function QuestsPanel({
+  quests,
+  onUpdate,
+  onRerunSingleTracker,
+  isTrackerRetryBusy,
+}: QuestsPanelProps) {
   const addQuest = () => {
     onUpdate([
       ...quests,
@@ -860,10 +1087,8 @@ export function QuestsPanel({ quests, onUpdate, onRerunSingleTracker, isTrackerR
             busy={isTrackerRetryBusy}
             title="Re-run quest tracker only"
           />
-          <button
-            onClick={addQuest}
-            className={TRACKER_SECTION_ACTION}
-          >
+          <HudLockModeToggle />
+          <button onClick={addQuest} className={TRACKER_SECTION_ACTION}>
             <Plus size="0.625rem" /> Add
           </button>
         </span>
@@ -874,6 +1099,7 @@ export function QuestsPanel({ quests, onUpdate, onRerunSingleTracker, isTrackerR
           <QuestCardEditable
             key={quest.questEntryId || idx}
             quest={quest}
+            questIndex={idx}
             onUpdate={(updatedQuest) => updateQuest(idx, updatedQuest)}
             onRemove={() => removeQuest(idx)}
           />
@@ -909,6 +1135,7 @@ export function CustomTrackerPanel({
     next[idx] = updated;
     onUpdate(next);
   };
+  const lockFor = useHudFieldLockResolver();
 
   return (
     <>
@@ -923,41 +1150,58 @@ export function CustomTrackerPanel({
             busy={isTrackerRetryBusy}
             title="Re-run custom tracker only"
           />
-          <button
-            onClick={addField}
-            className={TRACKER_SECTION_ACTION}
-          >
+          <HudLockModeToggle />
+          <button onClick={addField} className={TRACKER_SECTION_ACTION}>
             <Plus size="0.625rem" /> Add
           </button>
         </span>
       </div>
       <div className="p-2 space-y-1">
         {fields.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>No fields tracked — add one above</div>}
-        {fields.map((field, idx) => (
-          <div key={idx} className="flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5">
-            <SlidersHorizontal size="0.625rem" className="shrink-0 text-cyan-400/60" />
-            <InlineEdit
-              value={field.name}
-              onSave={(value) => updateField(idx, { ...field, name: value })}
-              className="flex-1 min-w-0"
-              placeholder="Field name"
-            />
-            <span className="text-[var(--muted-foreground)]/40 text-[0.5rem]">=</span>
-            <InlineEdit
-              value={field.value}
-              onSave={(value) => updateField(idx, { ...field, value })}
-              className="flex-1 min-w-0"
-              placeholder="Value"
-            />
-            <button
-              onClick={() => removeField(idx)}
-              className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
-              title="Remove field"
+        {fields.map((field, idx) => {
+          const nameLock = lockFor(customTrackerLockKey(idx, "name"));
+          const valueLock = lockFor(customTrackerLockKey(idx, "value"));
+          const toggleValueLock = () => {
+            if (field.locked) updateField(idx, { ...field, locked: false });
+            if (valueLock.locked || !field.locked) valueLock.onToggle();
+          };
+          return (
+            <div
+              key={idx}
+              className="group/field flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5"
             >
-              <X size="0.5625rem" />
-            </button>
-          </div>
-        ))}
+              <SlidersHorizontal size="0.625rem" className="shrink-0 text-cyan-400/60" />
+              <InlineEdit
+                value={field.name}
+                onSave={(value) => updateField(idx, { ...field, name: value })}
+                className="flex-1 min-w-0"
+                placeholder="Field name"
+                locked={nameLock.locked}
+              />
+              <HudFieldLockButton {...nameLock} label={`${field.name || "field"} name`} />
+              <span className="text-[var(--muted-foreground)]/40 text-[0.5rem]">=</span>
+              <InlineEdit
+                value={field.value}
+                onSave={(value) => updateField(idx, { ...field, value })}
+                className="flex-1 min-w-0"
+                placeholder="Value"
+                locked={valueLock.locked || field.locked}
+              />
+              <HudFieldLockButton
+                locked={valueLock.locked || field.locked}
+                onToggle={toggleValueLock}
+                label={`${field.name || "field"} value`}
+              />
+              <button
+                onClick={() => removeField(idx)}
+                className="text-[var(--muted-foreground)]/40 hover:text-red-500 transition-colors shrink-0"
+                title="Remove field"
+              >
+                <X size="0.5625rem" />
+              </button>
+            </div>
+          );
+        })}
       </div>
     </>
   );
@@ -1000,6 +1244,13 @@ export function CombinedWorldPanel({
   onRerunSingleTracker,
   isTrackerRetryBusy,
 }: CombinedWorldPanelProps) {
+  const lockFor = useHudFieldLockResolver();
+  const locationLock = lockFor(worldTrackerLockKey("location"));
+  const dateLock = lockFor(worldTrackerLockKey("date"));
+  const timeLock = lockFor(worldTrackerLockKey("time"));
+  const weatherLock = lockFor(worldTrackerLockKey("weather"));
+  const temperatureLock = lockFor(worldTrackerLockKey("temperature"));
+
   return (
     <>
       <div className={cn(ROLEPLAY_POPOVER_HEADER, "flex items-center justify-between")}>
@@ -1013,6 +1264,7 @@ export function CombinedWorldPanel({
             busy={isTrackerRetryBusy}
             title="Re-run world state tracker only"
           />
+          <HudLockModeToggle />
           <button
             onClick={onClose}
             className="text-[var(--muted-foreground)]/50 hover:text-[var(--foreground)] transition-colors"
@@ -1028,6 +1280,8 @@ export function CombinedWorldPanel({
           value={location}
           onSave={onSaveLocation}
           accent="text-[var(--foreground)]/80"
+          locked={locationLock.locked}
+          onToggleLock={locationLock.onToggle}
         />
         <WorldFieldRow
           icon={<CalendarDays size="0.8125rem" className="text-[var(--muted-foreground)]" />}
@@ -1035,6 +1289,8 @@ export function CombinedWorldPanel({
           value={date}
           onSave={onSaveDate}
           accent="text-[var(--foreground)]"
+          locked={dateLock.locked}
+          onToggleLock={dateLock.onToggle}
         />
         <WorldFieldRow
           icon={<Clock size="0.8125rem" className="text-amber-400" />}
@@ -1042,6 +1298,8 @@ export function CombinedWorldPanel({
           value={time}
           onSave={onSaveTime}
           accent="text-[var(--foreground)]/80"
+          locked={timeLock.locked}
+          onToggleLock={timeLock.onToggle}
         />
         <WorldFieldRow
           icon={<span className="text-sm leading-none">{weatherEmoji}</span>}
@@ -1049,6 +1307,8 @@ export function CombinedWorldPanel({
           value={weather}
           onSave={onSaveWeather}
           accent="text-[var(--foreground)]/80"
+          locked={weatherLock.locked}
+          onToggleLock={weatherLock.onToggle}
         />
         <WorldFieldRow
           icon={<Thermometer size="0.8125rem" className={tempColor} />}
@@ -1056,6 +1316,8 @@ export function CombinedWorldPanel({
           value={temperature}
           onSave={onSaveTemperature}
           accent="text-[var(--foreground)]"
+          locked={temperatureLock.locked}
+          onToggleLock={temperatureLock.onToggle}
         />
       </div>
     </>
@@ -1175,21 +1437,30 @@ function InlineEdit({
   placeholder,
   className,
   scrollOnHover = false,
+  showEditHint = true,
+  locked = false,
 }: {
   value: string;
   onSave: (v: string) => void;
   placeholder?: string;
   className?: string;
   scrollOnHover?: boolean;
+  showEditHint?: boolean;
+  locked?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const ref = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const scrollFieldRef = useRef<HTMLSpanElement>(null);
+  const scrollMeasureRef = useRef<HTMLSpanElement>(null);
   const lastTapRef = useRef(0);
   const isTouchRef = useRef(false);
   const [showTip, setShowTip] = useState(false);
+  const [scrollActive, setScrollActive] = useState(false);
   const tipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const canScroll = scrollOnHover && !!value;
+  const shouldScroll = canScroll && (scrollActive || showTip);
 
   useEffect(() => {
     if (editing) ref.current?.focus();
@@ -1201,14 +1472,35 @@ function InlineEdit({
     };
   }, []);
 
+  useEffect(() => {
+    setScrollActive(false);
+    setShowTip(false);
+  }, [value, scrollOnHover]);
+
   const commit = () => {
     const trimmed = draft.trim();
     if (trimmed !== value) onSave(trimmed);
     setEditing(false);
   };
 
+  const measureScrollOverflow = () => {
+    if (!canScroll) return false;
+    const field = scrollFieldRef.current;
+    const measure = scrollMeasureRef.current;
+    if (!field || !measure) return false;
+
+    const nextScrollActive = measure.scrollWidth > field.clientWidth + 1;
+    setScrollActive((previous) => (previous === nextScrollActive ? previous : nextScrollActive));
+    return nextScrollActive;
+  };
+
+  const resetScrollOverflow = () => {
+    setScrollActive((previous) => (previous ? false : previous));
+  };
+
   const handleTouchStart = () => {
     isTouchRef.current = true;
+    measureScrollOverflow();
   };
 
   const handleClick = () => {
@@ -1225,7 +1517,7 @@ function InlineEdit({
       if (tipTimerRef.current) clearTimeout(tipTimerRef.current);
       setDraft(value);
       setEditing(true);
-    } else {
+    } else if (measureScrollOverflow()) {
       setShowTip(true);
       if (tipTimerRef.current) clearTimeout(tipTimerRef.current);
       tipTimerRef.current = setTimeout(() => setShowTip(false), 2500);
@@ -1246,6 +1538,7 @@ function InlineEdit({
         onBlur={commit}
         className={cn(
           "rounded border border-[var(--border)] bg-[var(--muted)]/20 px-1.5 py-0.5 text-[0.625rem] text-[var(--foreground)] outline-none focus:border-[var(--foreground)]/30",
+          locked && HUD_LOCKED_FIELD_CLASS,
           className,
         )}
         placeholder={placeholder}
@@ -1258,20 +1551,35 @@ function InlineEdit({
       ref={buttonRef}
       onClick={handleClick}
       onTouchStart={handleTouchStart}
+      onMouseEnter={measureScrollOverflow}
+      onFocus={measureScrollOverflow}
+      onMouseLeave={resetScrollOverflow}
+      onBlur={resetScrollOverflow}
       title={value || undefined}
       aria-label={value || placeholder}
       className={cn(
-        "group relative flex items-center gap-1 text-left hover:bg-[var(--muted)]/20 rounded px-0.5 transition-colors min-w-0",
+        "group relative flex min-w-0 items-center overflow-hidden rounded px-0.5 text-left transition-colors hover:bg-[var(--muted)]/20",
+        locked && HUD_LOCKED_FIELD_CLASS,
         className,
       )}
     >
       <span
+        ref={scrollFieldRef}
         className={cn(
-          "text-[0.625rem] text-[var(--foreground)]/70 overflow-hidden whitespace-nowrap scrollbar-hide min-w-0",
-          scrollOnHover && value && "roleplay-hud-scroll-field",
+          "min-w-0 flex-1 overflow-hidden whitespace-nowrap scrollbar-hide text-[0.625rem] text-[var(--foreground)]/70",
+          shouldScroll && "roleplay-hud-scroll-field",
         )}
       >
-        {scrollOnHover && value ? (
+        {canScroll && (
+          <span
+            ref={scrollMeasureRef}
+            aria-hidden="true"
+            className="pointer-events-none invisible absolute left-0 top-0 block w-max max-w-none whitespace-nowrap"
+          >
+            {value}
+          </span>
+        )}
+        {canScroll && shouldScroll ? (
           <span className={cn("roleplay-hud-scroll-track", showTip && "roleplay-hud-scroll-track--active")}>
             <span className="pr-6">{value}</span>
             <span className="pr-6" aria-hidden>
@@ -1282,20 +1590,36 @@ function InlineEdit({
           value || <span className="italic text-[var(--muted-foreground)]/50">{placeholder ?? "—"}</span>
         )}
       </span>
-      <Pencil size="0.4375rem" className="opacity-0 group-hover:opacity-40 shrink-0 transition-opacity" />
+      {showEditHint && (
+        <Pencil
+          size="0.4375rem"
+          className="pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-40"
+        />
+      )}
       <InlinePreviewPortal open={showTip} value={value} anchorRef={buttonRef} />
     </button>
   );
 }
 
-function PersonaStatusField({ value, onSave }: { value: string; onSave?: (v: string) => void }) {
+function PersonaStatusField({
+  value,
+  onSave,
+  locked,
+  onToggleLock,
+}: {
+  value: string;
+  onSave?: (v: string) => void;
+  locked?: boolean;
+  onToggleLock?: () => void;
+}) {
   return (
     <div className="mb-2 rounded-lg border border-[var(--border)]/60 bg-[var(--muted)]/10 px-2 py-1.5">
-      <div className="mb-0.5 flex items-center gap-1.5">
+      <div className="group/field mb-0.5 flex items-center gap-1.5">
         <Sparkles size="0.5625rem" className="text-[var(--muted-foreground)]/60" />
         <span className="text-[0.5625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]/70">
           Current Status
         </span>
+        <HudFieldLockButton locked={locked} onToggle={onToggleLock} label="persona status" />
       </div>
       <InlineEdit
         value={value}
@@ -1303,6 +1627,7 @@ function PersonaStatusField({ value, onSave }: { value: string; onSave?: (v: str
         className="w-full !text-[0.6875rem] !text-[var(--foreground)]/85"
         placeholder="Status not tracked"
         scrollOnHover
+        locked={locked}
       />
     </div>
   );
@@ -1314,55 +1639,85 @@ function StatBarEditable({
   onUpdateValue,
   onUpdateMax,
   onRemove,
+  nameLocked,
+  valueLocked,
+  maxLocked,
+  onToggleNameLock,
+  onToggleValueLock,
+  onToggleMaxLock,
 }: {
   stat: CharacterStat;
   onUpdateName?: (name: string) => void;
   onUpdateValue: (v: number) => void;
   onUpdateMax: (v: number) => void;
   onRemove?: () => void;
+  nameLocked?: boolean;
+  valueLocked?: boolean;
+  maxLocked?: boolean;
+  onToggleNameLock?: () => void;
+  onToggleValueLock?: () => void;
+  onToggleMaxLock?: () => void;
 }) {
+  const { lockMode } = useTrackerLockContext();
   const pct = stat.max > 0 ? Math.min(100, Math.max(0, (stat.value / stat.max) * 100)) : 0;
+  const removeButton = onRemove ? (
+    <button
+      type="button"
+      onClick={onRemove}
+      title="Remove stat"
+      aria-label={`Remove ${stat.name || "stat"}`}
+      className={cn(
+        "flex h-4 w-4 items-center justify-center rounded bg-[var(--popover)]/90 text-[var(--muted-foreground)]/45 shadow-sm ring-1 ring-[var(--border)]/70 transition-all hover:text-[var(--destructive)] hover:opacity-100 focus-visible:opacity-100",
+        lockMode ? "shrink-0 opacity-70" : "absolute -right-1 -top-1 opacity-0 group-hover/stat:opacity-80 max-md:opacity-80",
+      )}
+    >
+      <Trash2 size="0.5625rem" />
+    </button>
+  ) : null;
 
   return (
     <div className="group/stat relative">
       <div className="flex items-center justify-between mb-0.5">
         {onUpdateName ? (
-          <InlineEdit
-            value={stat.name}
-            onSave={onUpdateName}
-            className="!text-[0.625rem] !font-medium !text-[var(--foreground)]/80"
-            placeholder="Stat name"
-          />
+          <span className="group/field flex min-w-0 items-center gap-1">
+            <InlineEdit
+              value={stat.name}
+              onSave={onUpdateName}
+              className="!text-[0.625rem] !font-medium !text-[var(--foreground)]/80"
+              placeholder="Stat name"
+              locked={nameLocked}
+            />
+            <HudFieldLockButton locked={nameLocked} onToggle={onToggleNameLock} label={`${stat.name || "stat"} name`} />
+          </span>
         ) : (
           <span className="text-[0.625rem] font-medium text-[var(--foreground)]/80">{stat.name}</span>
         )}
-        <div className="flex items-center gap-0.5 shrink-0 text-[0.5625rem] text-[var(--muted-foreground)]/60">
+        <div className="group/field flex items-center gap-0.5 shrink-0 text-[0.5625rem] text-[var(--muted-foreground)]/60">
           <input
             type="number"
             value={stat.value}
             onChange={(e) => onUpdateValue(Number(e.target.value))}
-            className="w-12 bg-transparent text-right outline-none text-[var(--foreground)]/80 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            className={cn(
+              "w-12 rounded bg-transparent text-right outline-none text-[var(--foreground)]/80 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
+              valueLocked && HUD_LOCKED_FIELD_CLASS,
+            )}
           />
+          <HudFieldLockButton locked={valueLocked} onToggle={onToggleValueLock} label={`${stat.name || "stat"} value`} />
           <span>/</span>
           <input
             type="number"
             value={stat.max}
             onChange={(e) => onUpdateMax(Number(e.target.value))}
-            className="w-12 bg-transparent outline-none text-[var(--foreground)]/80 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+            className={cn(
+              "w-12 rounded bg-transparent outline-none text-[var(--foreground)]/80 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
+              maxLocked && HUD_LOCKED_FIELD_CLASS,
+            )}
           />
+          <HudFieldLockButton locked={maxLocked} onToggle={onToggleMaxLock} label={`${stat.name || "stat"} max`} />
+          {lockMode && removeButton}
         </div>
       </div>
-      {onRemove && (
-        <button
-          type="button"
-          onClick={onRemove}
-          title="Remove stat"
-          aria-label={`Remove ${stat.name || "stat"}`}
-          className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded bg-[var(--popover)]/90 text-[var(--muted-foreground)]/45 opacity-0 shadow-sm ring-1 ring-[var(--border)]/70 transition-all hover:text-[var(--destructive)] hover:opacity-100 focus-visible:opacity-100 group-hover/stat:opacity-80 max-md:opacity-80"
-        >
-          <Trash2 size="0.5625rem" />
-        </button>
-      )}
+      {!lockMode && removeButton}
       <div className="h-1.5 rounded-full bg-[var(--muted)]/30 overflow-hidden">
         <div
           className="h-full rounded-full transition-all duration-500"
@@ -1375,10 +1730,12 @@ function StatBarEditable({
 
 function QuestCardEditable({
   quest,
+  questIndex,
   onUpdate,
   onRemove,
 }: {
   quest: QuestProgress;
+  questIndex: number;
   onUpdate: (q: QuestProgress) => void;
   onRemove: () => void;
 }) {
@@ -1407,13 +1764,17 @@ function QuestCardEditable({
 
   const completed = quest.objectives.filter((objective) => objective.completed).length;
   const total = quest.objectives.length;
+  const lockFor = useHudFieldLockResolver();
+  const questCompletedLock = lockFor(questTrackerLockKey(quest, questIndex, "completed"));
+  const questNameLock = lockFor(questTrackerLockKey(quest, questIndex, "name"));
 
   return (
     <div className="rounded-lg bg-[var(--muted)]/20 p-2">
-      <div className="flex items-center gap-1.5">
+      <div className="group/field flex items-center gap-1.5">
         <button
           onClick={() => onUpdate({ ...quest, completed: !quest.completed })}
           title={quest.completed ? "Mark incomplete" : "Mark complete"}
+          className={cn("rounded-sm", questCompletedLock.locked && HUD_LOCKED_FIELD_CLASS)}
         >
           {quest.completed ? (
             <CheckCircle2 size="0.6875rem" className="text-emerald-400 shrink-0" />
@@ -1421,12 +1782,18 @@ function QuestCardEditable({
             <Target size="0.6875rem" className="text-amber-400 shrink-0" />
           )}
         </button>
+        <HudFieldLockButton
+          {...questCompletedLock}
+          label={`${quest.name || "quest"} completion`}
+        />
         <InlineEdit
           value={quest.name}
           onSave={(value) => onUpdate({ ...quest, name: value })}
           className={cn("flex-1 !font-medium", quest.completed && "line-through opacity-50")}
           placeholder="Quest name"
+          locked={questNameLock.locked}
         />
+        <HudFieldLockButton {...questNameLock} label={`${quest.name || "quest"} name`} />
         {total > 0 && (
           <span className="text-[0.5625rem] text-[var(--muted-foreground)]/60">
             {completed}/{total}
@@ -1442,29 +1809,39 @@ function QuestCardEditable({
       </div>
       {!quest.completed && (
         <div className="mt-1 space-y-0.5 pl-4">
-          {quest.objectives.map((objective, idx) => (
-            <div key={idx} className="group flex items-center gap-1 text-[0.5625rem]">
-              <button onClick={() => toggleObjective(idx)}>
-                {objective.completed ? (
-                  <CheckCircle2 size="0.5rem" className="text-emerald-400/60 shrink-0" />
-                ) : (
-                  <Circle size="0.5rem" className="text-[var(--muted-foreground)]/40 shrink-0" />
-                )}
-              </button>
-              <InlineEdit
-                value={objective.text}
-                onSave={(value) => updateObjectiveText(idx, value)}
-                className={cn("flex-1", objective.completed && "line-through opacity-50")}
-                placeholder="Objective"
-              />
-              <button
-                onClick={() => removeObjective(idx)}
-                className="opacity-0 group-hover:opacity-100 text-[var(--muted-foreground)]/40 hover:text-red-500 transition-all shrink-0"
-              >
-                <X size="0.4375rem" />
-              </button>
-            </div>
-          ))}
+          {quest.objectives.map((objective, idx) => {
+            const completedLock = lockFor(questObjectiveTrackerLockKey(quest, questIndex, idx, "completed"));
+            const textLock = lockFor(questObjectiveTrackerLockKey(quest, questIndex, idx, "text"));
+            return (
+              <div key={idx} className="group group/field flex items-center gap-1 text-[0.5625rem]">
+                <button
+                  onClick={() => toggleObjective(idx)}
+                  className={cn("rounded-sm", completedLock.locked && HUD_LOCKED_FIELD_CLASS)}
+                >
+                  {objective.completed ? (
+                    <CheckCircle2 size="0.5rem" className="text-emerald-400/60 shrink-0" />
+                  ) : (
+                    <Circle size="0.5rem" className="text-[var(--muted-foreground)]/40 shrink-0" />
+                  )}
+                </button>
+                <HudFieldLockButton {...completedLock} label="objective completion" />
+                <InlineEdit
+                  value={objective.text}
+                  onSave={(value) => updateObjectiveText(idx, value)}
+                  className={cn("flex-1", objective.completed && "line-through opacity-50")}
+                  placeholder="Objective"
+                  locked={textLock.locked}
+                />
+                <HudFieldLockButton {...textLock} label="objective text" />
+                <button
+                  onClick={() => removeObjective(idx)}
+                  className="opacity-0 group-hover:opacity-100 text-[var(--muted-foreground)]/40 hover:text-red-500 transition-all shrink-0"
+                >
+                  <X size="0.4375rem" />
+                </button>
+              </div>
+            );
+          })}
           <button
             onClick={addObjective}
             className="flex items-center gap-0.5 text-[0.5rem] text-[var(--muted-foreground)]/40 hover:text-[var(--muted-foreground)] transition-colors mt-0.5"
@@ -1477,11 +1854,45 @@ function QuestCardEditable({
   );
 }
 
-function LabeledEdit({ label, value, onSave }: { label: string; value: string; onSave: (v: string) => void }) {
+function LabeledEdit({
+  label,
+  value,
+  onSave,
+  locked,
+  onToggleLock,
+}: {
+  label: string;
+  value: string;
+  onSave: (v: string) => void;
+  locked?: boolean;
+  onToggleLock?: () => void;
+}) {
+  const { lockMode } = useTrackerLockContext();
+
   return (
-    <div className="flex items-center gap-1">
-      <span className="text-[0.5625rem] text-[var(--muted-foreground)]/60 w-10 shrink-0">{label}</span>
-      <InlineEdit value={value} onSave={onSave} className="flex-1 min-w-0" placeholder="—" scrollOnHover />
+    <div className="group/field relative grid grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-1">
+      <span
+        className={cn(
+          "relative flex w-10 min-w-0 shrink-0 items-center text-[0.5625rem] text-[var(--muted-foreground)]/60",
+          lockMode && "pr-3",
+        )}
+      >
+        <span className="min-w-0 truncate">{label}</span>
+        <HudFieldLockButton
+          locked={locked}
+          onToggle={onToggleLock}
+          label={label}
+          className="absolute right-0 top-1/2 h-3.5 w-3.5 -translate-y-1/2 bg-[var(--popover)]/85 shadow-sm"
+        />
+      </span>
+      <InlineEdit
+        value={value}
+        onSave={onSave}
+        className="min-w-0"
+        placeholder="—"
+        scrollOnHover
+        locked={locked}
+      />
     </div>
   );
 }
@@ -1492,12 +1903,16 @@ function WorldFieldRow({
   value,
   onSave,
   accent,
+  locked,
+  onToggleLock,
 }: {
   icon: ReactNode;
   label: string;
   value: string;
   onSave: (v: string) => void;
   accent: string;
+  locked?: boolean;
+  onToggleLock?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -1517,7 +1932,12 @@ function WorldFieldRow({
   };
 
   return (
-    <div className="flex items-center gap-2.5 px-3 py-2 group/row hover:bg-[var(--muted)]/20 transition-colors">
+    <div
+      className={cn(
+        "group/row group/field flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-[var(--muted)]/20",
+        locked && "bg-[color-mix(in_srgb,var(--foreground)_5%,transparent)]",
+      )}
+    >
       <div className="shrink-0 w-5 flex items-center justify-center">{icon}</div>
       <div className="flex-1 min-w-0">
         <div className="text-[0.5625rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]/60 mb-0.5">
@@ -1534,7 +1954,8 @@ function WorldFieldRow({
             }}
             onBlur={commit}
             className={cn(
-              "w-full bg-transparent text-[0.6875rem] font-medium outline-none placeholder:text-[var(--muted-foreground)]/40",
+              "w-full rounded bg-transparent px-1 py-0.5 text-[0.6875rem] font-medium outline-none placeholder:text-[var(--muted-foreground)]/40",
+              locked && HUD_LOCKED_FIELD_CLASS,
               accent,
             )}
             placeholder={label}
@@ -1543,8 +1964,9 @@ function WorldFieldRow({
           <button
             onClick={() => setEditing(true)}
             className={cn(
-              "w-full text-left text-[0.6875rem] font-medium truncate",
+              "w-full truncate rounded px-1 py-0.5 text-left text-[0.6875rem] font-medium",
               value ? "text-[var(--foreground)]/80" : "text-[var(--muted-foreground)]/50 italic",
+              locked && HUD_LOCKED_FIELD_INSET_CLASS,
             )}
           >
             {value || `Set ${label.toLowerCase()}…`}
@@ -1560,6 +1982,7 @@ function WorldFieldRow({
           <Pencil size="0.625rem" />
         </button>
       )}
+      <HudFieldLockButton locked={locked} onToggle={onToggleLock} label={label.toLowerCase()} />
     </div>
   );
 }

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -1,4 +1,5 @@
-import { useState, type CSSProperties } from "react";
+import { useCallback, useState, type CSSProperties } from "react";
+import { toggleTrackerFieldLock } from "@marinara-engine/shared";
 import { TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR, useUIStore } from "../../../stores/ui.store";
 import { useChatStore } from "../../../stores/chat.store";
 import { useGameStatePatcher } from "../../../hooks/use-game-state-patcher";
@@ -10,6 +11,7 @@ import { EmptySection } from "./controls/SectionControls";
 import { TrackerSectionList } from "./TrackerSectionList";
 import { TrackerSkeleton } from "./TrackerSkeleton";
 import { TrackerSidebarHeader } from "./TrackerSidebarHeader";
+import { TrackerLockProvider } from "./TrackerLockContext";
 
 const TRACKER_PANEL_NEUTRAL_VARS =
   "[--accent:rgb(39_39_42)] [--accent-foreground:rgb(244_244_245)] [--background:rgb(18_18_21)] [--border:rgb(63_63_70)] [--card:rgb(24_24_27)] [--foreground:rgb(244_244_245)] [--input:rgb(63_63_70)] [--muted:rgb(39_39_42)] [--muted-foreground:rgb(161_161_170)] [--popover:rgb(24_24_27)] [--popover-foreground:rgb(244_244_245)] [--primary:rgb(212_212_216)] [--primary-foreground:rgb(18_18_21)] [--ring:rgb(161_161_170)] [--secondary:rgb(39_39_42)] [--tracker-panel-card-background:color-mix(in_srgb,var(--background)_22%,transparent)] [--tracker-panel-section-background:color-mix(in_srgb,var(--card)_6%,transparent)]";
@@ -51,6 +53,11 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
   });
   const [deleteMode, setDeleteMode] = useState(false);
   const [addMode, setAddMode] = useState(false);
+  const [lockMode, setLockMode] = useState(false);
+  const fieldLocks = currentGameState?.fieldLocks ?? null;
+  const toggleFieldLock = useCallback((key: string) => {
+    patchField("fieldLocks", toggleTrackerFieldLock(fieldLocks, key));
+  }, [fieldLocks, patchField]);
   const hasFixedTrackerPanel = orderedTrackerSections.length > 0;
   const showTrackerSections = !!activeChatId && !isLoadingGameState && !!currentGameState && hasFixedTrackerPanel;
   const trackerPanelHasCustomBackground =
@@ -90,60 +97,67 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
       style={trackerPanelSurfaceStyle}
     >
       <div className="pointer-events-none absolute inset-0 z-0 opacity-[0.08] [background-image:linear-gradient(color-mix(in_srgb,var(--foreground)_12%,transparent)_1px,transparent_1px),linear-gradient(90deg,color-mix(in_srgb,var(--foreground)_9%,transparent)_1px,transparent_1px)] [background-size:8px_8px]" />
-      <TrackerSidebarHeader
-        trackerPanelSide={trackerPanelSide}
-        sizeProfile={trackerPanelSizeProfile}
-        addMode={addMode}
-        deleteMode={deleteMode}
-        onSetAddMode={setAddMode}
-        onSetDeleteMode={setDeleteMode}
-        onSetSide={setTrackerPanelSide}
-        onSetSizeProfile={setTrackerPanelSizeProfile}
-        onClose={() => setTrackerPanelOpen(false)}
-      />
+      <TrackerLockProvider
+        fieldLocks={fieldLocks}
+        lockMode={lockMode}
+        onSetLockMode={setLockMode}
+        onToggleFieldLock={toggleFieldLock}
+      >
+        <TrackerSidebarHeader
+          trackerPanelSide={trackerPanelSide}
+          sizeProfile={trackerPanelSizeProfile}
+          addMode={addMode}
+          deleteMode={deleteMode}
+          onSetAddMode={setAddMode}
+          onSetDeleteMode={setDeleteMode}
+          onSetSide={setTrackerPanelSide}
+          onSetSizeProfile={setTrackerPanelSizeProfile}
+          onClose={() => setTrackerPanelOpen(false)}
+        />
 
-      <div className={cn("relative z-10", fillHeight && "min-h-0 flex-1 overflow-y-auto")}>
-        {showTrackerSections ? (
-          <TrackerSectionList
-            activeChatId={activeChatId}
-            activePersona={activePersona}
-            autoGenerateCharacterAvatars={autoGenerateCharacterAvatars}
-            characterSpriteLookup={characterSpriteLookup}
-            characterTrackerConfig={characterTrackerConfig}
-            characterTrackerSettings={characterTrackerSettings}
-            currentGameState={currentGameState}
-            enabledAgentTypes={enabledAgentTypes}
-            expressionSpritesEnabled={expressionSpritesEnabled}
-            featuredCharacterCardKeys={featuredCharacterCardKeys}
-            flushPatch={flushPatch}
-            gameStateRefreshing={gameStateRefreshing}
-            orderedTrackerSections={orderedTrackerSections}
-            patchField={patchField}
-            patchPlayerStats={patchPlayerStats}
-            resolveSpriteCharacterId={resolveSpriteCharacterId}
-            spriteExpressions={spriteExpressions}
-            trackerPanelCollapsedSections={trackerPanelCollapsedSections}
-            trackerPanelSide={trackerPanelSide}
-            trackerPanelSizeProfile={trackerPanelSizeProfile}
-            trackerPanelThoughtBubbleDisplay={trackerPanelThoughtBubbleDisplay}
-            trackerPanelDockedThoughtsAlwaysVisible={trackerPanelDockedThoughtsAlwaysVisible}
-            trackerTemperatureUnit={trackerTemperatureUnit}
-            toggleTrackerPanelSectionCollapsed={toggleTrackerPanelSectionCollapsed}
-            deleteMode={deleteMode}
-            addMode={addMode}
-          />
-        ) : null}
+        <div className={cn("relative z-10", fillHeight && "min-h-0 flex-1 overflow-y-auto")}>
+          {showTrackerSections ? (
+            <TrackerSectionList
+              activeChatId={activeChatId}
+              activePersona={activePersona}
+              autoGenerateCharacterAvatars={autoGenerateCharacterAvatars}
+              characterSpriteLookup={characterSpriteLookup}
+              characterTrackerConfig={characterTrackerConfig}
+              characterTrackerSettings={characterTrackerSettings}
+              currentGameState={currentGameState}
+              enabledAgentTypes={enabledAgentTypes}
+              expressionSpritesEnabled={expressionSpritesEnabled}
+              featuredCharacterCardKeys={featuredCharacterCardKeys}
+              flushPatch={flushPatch}
+              gameStateRefreshing={gameStateRefreshing}
+              orderedTrackerSections={orderedTrackerSections}
+              patchField={patchField}
+              patchPlayerStats={patchPlayerStats}
+              resolveSpriteCharacterId={resolveSpriteCharacterId}
+              spriteExpressions={spriteExpressions}
+              trackerPanelCollapsedSections={trackerPanelCollapsedSections}
+              trackerPanelSide={trackerPanelSide}
+              trackerPanelSizeProfile={trackerPanelSizeProfile}
+              trackerPanelThoughtBubbleDisplay={trackerPanelThoughtBubbleDisplay}
+              trackerPanelDockedThoughtsAlwaysVisible={trackerPanelDockedThoughtsAlwaysVisible}
+              trackerTemperatureUnit={trackerTemperatureUnit}
+              toggleTrackerPanelSectionCollapsed={toggleTrackerPanelSectionCollapsed}
+              deleteMode={deleteMode}
+              addMode={addMode}
+            />
+          ) : null}
 
-        {!activeChatId ? (
-          <EmptySection>Select a chat to view tracker data.</EmptySection>
-        ) : isLoadingGameState ? (
-          <TrackerSkeleton />
-        ) : !currentGameState ? (
-          <EmptySection>No tracker data yet.</EmptySection>
-        ) : !hasFixedTrackerPanel ? (
-          <EmptySection>No enabled tracker panels.</EmptySection>
-        ) : null}
-      </div>
+          {!activeChatId ? (
+            <EmptySection>Select a chat to view tracker data.</EmptySection>
+          ) : isLoadingGameState ? (
+            <TrackerSkeleton />
+          ) : !currentGameState ? (
+            <EmptySection>No tracker data yet.</EmptySection>
+          ) : !hasFixedTrackerPanel ? (
+            <EmptySection>No enabled tracker panels.</EmptySection>
+          ) : null}
+        </div>
+      </TrackerLockProvider>
     </section>
   );
 }

--- a/packages/client/src/features/tracker-panel/components/TrackerLockContext.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerLockContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
+import { isTrackerFieldLocked, type TrackerFieldLocks } from "@marinara-engine/shared";
+
+interface TrackerLockContextValue {
+  fieldLocks?: TrackerFieldLocks | null;
+  lockMode: boolean;
+  onSetLockMode?: (enabled: boolean) => void;
+  onToggleFieldLock?: (key: string) => void;
+}
+
+const TrackerLockContext = createContext<TrackerLockContextValue>({ lockMode: false });
+
+export function TrackerLockProvider({
+  children,
+  fieldLocks,
+  lockMode,
+  onSetLockMode,
+  onToggleFieldLock,
+}: TrackerLockContextValue & { children: ReactNode }) {
+  const value = useMemo(
+    () => ({ fieldLocks, lockMode, onSetLockMode, onToggleFieldLock }),
+    [fieldLocks, lockMode, onSetLockMode, onToggleFieldLock],
+  );
+  return <TrackerLockContext.Provider value={value}>{children}</TrackerLockContext.Provider>;
+}
+
+export function useTrackerLockContext() {
+  return useContext(TrackerLockContext);
+}
+
+export function useTrackerFieldLock(key: string | undefined) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const onToggleLock = useCallback(() => {
+    if (key) onToggleFieldLock?.(key);
+  }, [key, onToggleFieldLock]);
+  return {
+    locked: key ? isTrackerFieldLocked(fieldLocks, key) : false,
+    lockMode,
+    onToggleLock: key && onToggleFieldLock ? onToggleLock : undefined,
+  };
+}

--- a/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
@@ -1,8 +1,9 @@
-import { PanelLeft, PanelRight, Plus, Trash2 } from "lucide-react";
+import { Lock, PanelLeft, PanelRight, Plus, Trash2, Unlock } from "lucide-react";
 import { TrackerPanelIcon } from "../../../components/ui/TrackerPanelIcon";
 import { TrackerSizeTierIcon } from "../../../components/ui/TrackerSizeTierIcon";
 import type { TrackerPanelSide, TrackerPanelSizeProfile } from "../../../stores/ui.store";
 import { cn } from "../../../lib/utils";
+import { useTrackerLockContext } from "./TrackerLockContext";
 
 const TRACKER_PANEL_SIZE_SEQUENCE: TrackerPanelSizeProfile[] = ["compact", "standard", "expanded"];
 const TRACKER_PANEL_SIZE_LABELS: Record<TrackerPanelSizeProfile, string> = {
@@ -31,6 +32,7 @@ export function TrackerSidebarHeader({
   onSetSizeProfile: (profile: TrackerPanelSizeProfile) => void;
   onClose: () => void;
 }) {
+  const { lockMode, onSetLockMode } = useTrackerLockContext();
   const sizeIndex = Math.max(0, TRACKER_PANEL_SIZE_SEQUENCE.indexOf(sizeProfile));
   const nextSizeProfile = TRACKER_PANEL_SIZE_SEQUENCE[(sizeIndex + 1) % TRACKER_PANEL_SIZE_SEQUENCE.length]!;
   const sizeLabel = TRACKER_PANEL_SIZE_LABELS[sizeProfile];
@@ -55,7 +57,10 @@ export function TrackerSidebarHeader({
         onClick={() => {
           const nextAddMode = !addMode;
           onSetAddMode(nextAddMode);
-          if (nextAddMode) onSetDeleteMode(false);
+          if (nextAddMode) {
+            onSetDeleteMode(false);
+            onSetLockMode?.(false);
+          }
         }}
         title={addMode ? "Exit add mode" : "Enter add mode"}
         aria-label={addMode ? "Exit tracker add mode" : "Enter tracker add mode"}
@@ -72,9 +77,34 @@ export function TrackerSidebarHeader({
       <button
         type="button"
         onClick={() => {
+          const nextLockMode = !lockMode;
+          onSetLockMode?.(nextLockMode);
+          if (nextLockMode) {
+            onSetAddMode(false);
+            onSetDeleteMode(false);
+          }
+        }}
+        title={lockMode ? "Exit lock mode" : "Enter lock mode"}
+        aria-label={lockMode ? "Exit tracker lock mode" : "Enter tracker lock mode"}
+        aria-pressed={lockMode}
+        className={cn(
+          "flex h-6 w-6 items-center justify-center rounded-sm transition-all ring-1 active:scale-90",
+          lockMode
+            ? "bg-[var(--foreground)]/12 text-[var(--foreground)] ring-[var(--foreground)]/24"
+            : "text-[var(--muted-foreground)]/55 ring-transparent hover:bg-[var(--accent)] hover:text-[var(--muted-foreground)] hover:ring-[var(--border)]",
+        )}
+      >
+        {lockMode ? <Lock size="0.75rem" /> : <Unlock size="0.75rem" />}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
           const nextDeleteMode = !deleteMode;
           onSetDeleteMode(nextDeleteMode);
-          if (nextDeleteMode) onSetAddMode(false);
+          if (nextDeleteMode) {
+            onSetAddMode(false);
+            onSetLockMode?.(false);
+          }
         }}
         title={deleteMode ? "Exit delete mode" : "Enter delete mode"}
         aria-label={deleteMode ? "Exit tracker delete mode" : "Enter tracker delete mode"}

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterThoughtBubbles.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterThoughtBubbles.tsx
@@ -5,6 +5,7 @@ import type { TrackerPanelSide } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 import { InlineEdit } from "../controls/InlineControls";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 
 type ThoughtBubbleSize = "short" | "medium" | "long";
 
@@ -138,11 +139,14 @@ function ThoughtBubble({
   value,
   onSave,
   tailSide = "left",
+  lockKey,
 }: {
   value: string | null | undefined;
   onSave?: (value: string) => void;
   tailSide?: "left" | "right";
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const tailOnLeft = tailSide === "left";
   const thoughtText = visibleText(value, "Thoughts").replace(/\s+/g, " ");
   const thoughtBubbleSize = getThoughtBubbleSize(thoughtText);
@@ -226,6 +230,7 @@ function ThoughtBubble({
               previewLineCount={thoughtTextFit.previewLineCount}
               previewClassName={thoughtTextFit.previewClassName}
               previewStyle={thoughtTextStyle}
+              {...lock}
             />
           ) : (
             <p
@@ -253,6 +258,7 @@ export function InlineThoughtBubble({
   surfaceClassName,
   tailSide = "right",
   variant = "default",
+  lockKey,
 }: {
   value: string | null | undefined;
   onSave?: (value: string) => void;
@@ -261,7 +267,9 @@ export function InlineThoughtBubble({
   surfaceClassName?: string;
   tailSide?: "left" | "right";
   variant?: "default" | "featured";
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const tailOnLeft = tailSide === "left";
   const thoughtText = visibleText(value, "Thoughts").replace(/\s+/g, " ");
   const thoughtTextFit = getThoughtTextFit(thoughtText, getThoughtBubbleSize(thoughtText));
@@ -340,6 +348,7 @@ export function InlineThoughtBubble({
               previewLineCount={previewLineCount}
               previewClassName={thoughtTextFit.previewClassName}
               previewStyle={thoughtTextStyle}
+              {...lock}
             />
           ) : (
             <p
@@ -366,12 +375,14 @@ export function ExternalThoughtBubble({
   onSave,
   panelSide,
   bubbleRef,
+  lockKey,
 }: {
   anchorRef: RefObject<HTMLElement | null>;
   value: string | null | undefined;
   onSave?: (value: string) => void;
   panelSide: TrackerPanelSide;
   bubbleRef?: RefObject<HTMLDivElement | null>;
+  lockKey?: string;
 }) {
   const reducedMotion = useReducedMotion();
   const [position, setPosition] = useState<{
@@ -465,7 +476,12 @@ export function ExternalThoughtBubble({
         transformOrigin: position.outsideSide === "left" ? "right 1.5rem" : "left 1.5rem",
       }}
     >
-      <ThoughtBubble value={value} onSave={onSave} tailSide={position.outsideSide === "left" ? "right" : "left"} />
+      <ThoughtBubble
+        value={value}
+        onSave={onSave}
+        tailSide={position.outsideSide === "left" ? "right" : "left"}
+        lockKey={lockKey}
+      />
     </motion.div>,
     document.body,
   );

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
 import { Eye, HeartPulse, Maximize2, Shirt, X } from "lucide-react";
-import type { PresentCharacter } from "@marinara-engine/shared";
+import {
+  characterCustomFieldTrackerLockKey,
+  characterStatTrackerLockKey,
+  characterTrackerLockKey,
+  isTrackerFieldLocked,
+  type PresentCharacter,
+} from "@marinara-engine/shared";
 import type {
   TrackerPanelSide,
   TrackerPanelSizeProfile,
@@ -17,6 +23,7 @@ import {
 } from "../controls/TrackerProfileChrome";
 import { StatList } from "../controls/StatList";
 import { FeaturedCharacterTrackerCard } from "./FeaturedCharacterTrackerCard";
+import { useTrackerFieldLock, useTrackerLockContext } from "../TrackerLockContext";
 import { CharacterTrackerAvatar } from "./CharacterTrackerAvatar";
 import {
   COMPACT_CHARACTER_MOOD_EDIT_CLASS,
@@ -78,10 +85,13 @@ function CompactCharacterNameplate({ children }: { children: ReactNode }) {
 function CompactThoughtBubble({
   value,
   onSave,
+  lockKey,
 }: {
   value: string | null | undefined;
   onSave?: (value: string) => void;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const thoughtText = visibleText(value, "Thoughts").replace(/\s+/g, " ");
 
   return (
@@ -97,8 +107,8 @@ function CompactThoughtBubble({
               className="min-h-4 w-full min-w-0 px-0 py-0 text-[0.59375rem] font-medium italic leading-[1.05] [--foreground:color-mix(in_srgb,var(--tracker-profile-text)_90%,var(--tracker-profile-accent-solid)_10%)] [--muted-foreground:color-mix(in_srgb,var(--tracker-profile-muted-text)_82%,var(--tracker-profile-accent-solid)_18%)] hover:bg-[var(--tracker-profile-accent-solid)]/10"
               showEditHint={false}
               previewLineCount={3}
-              editHintMode="overlay"
               previewClassName="tracking-[0]"
+              {...lock}
             />
           ) : (
             <p className="line-clamp-3 break-words text-[0.59375rem] font-medium italic leading-[1.05] tracking-[0] text-[color-mix(in_srgb,var(--tracker-profile-text)_90%,var(--tracker-profile-accent-solid)_10%)]">
@@ -125,6 +135,7 @@ export function CharacterTrackerCard({
   action,
   onUpdate,
   onRemove,
+  characterIndex = 0,
   deleteMode = false,
   addMode = false,
   featured = false,
@@ -144,12 +155,14 @@ export function CharacterTrackerCard({
   action?: ReactNode;
   onUpdate?: (character: PresentCharacter) => void;
   onRemove?: () => void;
+  characterIndex?: number;
   deleteMode?: boolean;
   addMode?: boolean;
   featured?: boolean;
   onToggleFeatured?: () => void;
   onUploadAvatar?: () => void;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
   if (featured) {
     return (
       <FeaturedCharacterTrackerCard
@@ -166,6 +179,7 @@ export function CharacterTrackerCard({
         action={action}
         onUpdate={onUpdate}
         onRemove={onRemove}
+        characterIndex={characterIndex}
         deleteMode={deleteMode}
         addMode={addMode}
         onToggleFeatured={onToggleFeatured}
@@ -243,6 +257,13 @@ export function CharacterTrackerCard({
             showEditHint={false}
             fitPreview
             fitMinScale={0.58}
+            locked={isTrackerFieldLocked(fieldLocks, characterTrackerLockKey(character, characterIndex, "name"))}
+            lockMode={lockMode}
+            onToggleLock={
+              onToggleFieldLock
+                ? () => onToggleFieldLock(characterTrackerLockKey(character, characterIndex, "name"))
+                : undefined
+            }
           />
         ) : (
           <FittedText
@@ -280,6 +301,7 @@ export function CharacterTrackerCard({
             <CompactThoughtBubble
               value={character.thoughts}
               onSave={onUpdate ? (thoughts) => onUpdate({ ...character, thoughts: thoughts || null }) : undefined}
+              lockKey={characterTrackerLockKey(character, characterIndex, "thoughts")}
             />
           )}
           {!showThoughts && <div className={CHARACTER_HEADER_FILLER_CLASS} />}
@@ -298,6 +320,7 @@ export function CharacterTrackerCard({
               tone="mood"
               readable={readableDetailRows}
               valueClassName={onUpdate ? COMPACT_CHARACTER_MOOD_EDIT_CLASS : COMPACT_CHARACTER_MOOD_STATIC_CLASS}
+              lockKey={characterTrackerLockKey(character, characterIndex, "mood")}
             />
           )}
           {showAppearance && (
@@ -309,6 +332,7 @@ export function CharacterTrackerCard({
               onSave={onUpdate ? (appearance) => onUpdate({ ...character, appearance: appearance || null }) : undefined}
               tone="appearance"
               readable={readableDetailRows}
+              lockKey={characterTrackerLockKey(character, characterIndex, "appearance")}
             />
           )}
           {showOutfit && (
@@ -320,6 +344,7 @@ export function CharacterTrackerCard({
               onSave={onUpdate ? (outfit) => onUpdate({ ...character, outfit: outfit || null }) : undefined}
               tone="outfit"
               readable={readableDetailRows}
+              lockKey={characterTrackerLockKey(character, characterIndex, "outfit")}
             />
           )}
         </div>
@@ -334,6 +359,7 @@ export function CharacterTrackerCard({
             nameMode="truncate"
             deleteMode={deleteMode}
             addMode={addMode}
+            getLockKey={(statIndex, field) => characterStatTrackerLockKey(character, characterIndex, statIndex, field)}
           />
         </div>
       )}
@@ -349,6 +375,17 @@ export function CharacterTrackerCard({
                   placeholder="Field"
                   className="min-w-0 px-0.5 py-0 font-medium"
                   scrollOnHover
+                  locked={isTrackerFieldLocked(
+                    fieldLocks,
+                    characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"),
+                  )}
+                  lockMode={lockMode}
+                  onToggleLock={
+                    onToggleFieldLock
+                      ? () =>
+                          onToggleFieldLock(characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"))
+                      : undefined
+                  }
                 />
               ) : (
                 <span className="truncate font-medium text-[color:var(--tracker-profile-muted-text)]">{name}</span>
@@ -361,7 +398,19 @@ export function CharacterTrackerCard({
                   className="min-w-0 px-0.5 py-0"
                   scrollOnHover={!readableCustomFields}
                   twoLinePreview={readableCustomFields}
-                  editHintMode={readableCustomFields ? "overlay" : "inline"}
+                  locked={isTrackerFieldLocked(
+                    fieldLocks,
+                    characterCustomFieldTrackerLockKey(character, characterIndex, name, "value"),
+                  )}
+                  lockMode={lockMode}
+                  onToggleLock={
+                    onToggleFieldLock
+                      ? () =>
+                          onToggleFieldLock(
+                            characterCustomFieldTrackerLockKey(character, characterIndex, name, "value"),
+                          )
+                      : undefined
+                  }
                 />
               ) : (
                 <span

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerField.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerField.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 import { InlineEdit } from "../controls/InlineControls";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 
 export type CompactCharacterFieldTone = "mood" | "appearance" | "outfit" | "thoughts";
 
@@ -35,6 +36,7 @@ export function CompactCharacterField({
   readable = false,
   className,
   valueClassName,
+  lockKey,
 }: {
   icon: ReactNode;
   accessibleLabel: string;
@@ -45,7 +47,9 @@ export function CompactCharacterField({
   readable?: boolean;
   className?: string;
   valueClassName?: string;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   if (!onSave && !value) return null;
   const toneClasses = COMPACT_CHARACTER_FIELD_TONE_CLASSES[tone];
 
@@ -81,8 +85,8 @@ export function CompactCharacterField({
           )}
           scrollOnHover={!readable}
           twoLinePreview={readable}
-          editHintMode={readable ? "overlay" : "inline"}
           showEditHint={false}
+          {...lock}
         />
       ) : (
         <span

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterFields.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterFields.tsx
@@ -1,6 +1,10 @@
 import { type ReactNode } from "react";
 import { Eye, HeartPulse, Shirt } from "lucide-react";
-import type { CharacterStat, PresentCharacter } from "@marinara-engine/shared";
+import {
+  characterTrackerLockKey,
+  type CharacterStat,
+  type PresentCharacter,
+} from "@marinara-engine/shared";
 import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
 import type { TrackerStatDensity } from "../../tracker-panel.types";
@@ -8,11 +12,13 @@ import { visibleText } from "../../lib/tracker-display";
 import { InlineEdit } from "../controls/InlineControls";
 import { StatList } from "../controls/StatList";
 import { TRACKER_PROFILE_FIELD_TILE_CLASS } from "../controls/TrackerProfileChrome";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 
 const FEATURED_FIELD_LIST_CLASS = "relative z-[1] grid h-full min-h-0 grid-cols-1 gap-1 overflow-hidden p-1";
 const FEATURED_FIELD_ICON_CLASS =
   "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[color-mix(in_srgb,var(--tracker-profile-icon)_58%,var(--tracker-profile-text)_42%)] opacity-[0.82] ring-1 ring-inset ring-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_18%,transparent)] transition-colors before:absolute before:inset-[3px] before:rounded-full before:bg-[color-mix(in_srgb,var(--tracker-profile-accent-solid)_3%,transparent)] before:content-[''] group-hover/field:text-[color-mix(in_srgb,var(--tracker-profile-icon)_78%,var(--tracker-profile-text)_22%)] group-hover/field:ring-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_34%,transparent)] group-hover/field:before:bg-[color-mix(in_srgb,var(--tracker-profile-accent-solid)_6%,transparent)] [&>svg]:relative [&>svg]:z-[1] [&>svg]:stroke-[1.85]";
 type FeaturedFieldTone = "mood" | "appearance" | "outfit";
+type FeaturedCharacterFieldKey = "mood" | "appearance" | "outfit";
 const FEATURED_FIELD_ICON_TONE_CLASS = {
   mood: "text-[color-mix(in_srgb,var(--tracker-profile-icon)_70%,var(--tracker-profile-text)_30%)] before:bg-[color-mix(in_srgb,var(--tracker-profile-accent-solid)_4%,transparent)] group-hover/field:text-[color-mix(in_srgb,var(--tracker-profile-icon)_84%,var(--tracker-profile-text)_16%)]",
   appearance:
@@ -54,6 +60,7 @@ function FeaturedFieldTile({
   readable = false,
   sizeProfile,
   tone,
+  lockKey,
 }: {
   icon: ReactNode;
   accessibleLabel: string;
@@ -63,7 +70,9 @@ function FeaturedFieldTile({
   readable?: boolean;
   sizeProfile: TrackerPanelSizeProfile;
   tone: FeaturedFieldTone;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const displayValue = visibleText(value, placeholder);
   const textClass = FEATURED_FIELD_TEXT_CLASS_BY_PROFILE[sizeProfile];
   const previewLines = FEATURED_FIELD_PREVIEW_LINES_BY_PROFILE[sizeProfile];
@@ -86,10 +95,10 @@ function FeaturedFieldTile({
             "w-full min-w-0 self-center px-0 py-0 text-[color:var(--tracker-profile-text)] hover:bg-[var(--accent)]/25",
             readable ? textClass : "h-4 text-[0.625rem] leading-4",
           )}
-          editHintMode={readable ? "overlay" : "inline"}
           scrollOnHover={!readable}
           twoLinePreview={readable}
           previewLineCount={previewLines}
+          {...lock}
         />
       ) : (
         <span
@@ -112,11 +121,13 @@ export function FeaturedFieldList({
   onUpdate,
   readableRows = true,
   sizeProfile,
+  characterIndex,
 }: {
   character: PresentCharacter;
   onUpdate?: (character: PresentCharacter) => void;
   readableRows?: boolean;
   sizeProfile: TrackerPanelSizeProfile;
+  characterIndex: number;
 }) {
   const fields = [
     {
@@ -165,6 +176,7 @@ export function FeaturedFieldList({
           readable={readableRows}
           sizeProfile={sizeProfile}
           tone={field.tone}
+          lockKey={characterTrackerLockKey(character, characterIndex, field.key as FeaturedCharacterFieldKey)}
         />
       ))}
     </div>
@@ -181,6 +193,7 @@ export function FeaturedStatGrid({
   scrollable,
   wideColumns,
   className,
+  getLockKey,
 }: {
   stats: CharacterStat[];
   onUpdate?: (stats: CharacterStat[]) => void;
@@ -191,6 +204,7 @@ export function FeaturedStatGrid({
   scrollable: boolean;
   wideColumns?: boolean;
   className?: string;
+  getLockKey?: (index: number, field: "name" | "value" | "max") => string;
 }) {
   return (
     <div className={cn(FEATURED_STAT_SHELF_CLASS, scrollable ? "overflow-y-auto" : "overflow-y-hidden", className)}>
@@ -207,6 +221,7 @@ export function FeaturedStatGrid({
           wideColumns={wideColumns}
           showWideColumnGhost={wideColumns}
           visualTone="instrument"
+          getLockKey={getLockKey}
         />
       </div>
     </div>

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterNameplate.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterNameplate.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, type RefObject } from "react";
 import { Brain, Minimize2 } from "lucide-react";
-import type { PresentCharacter } from "@marinara-engine/shared";
+import { characterTrackerLockKey, type PresentCharacter } from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import type { TrackerProfileSide } from "../../lib/tracker-profile-layout";
 import {
@@ -20,6 +20,7 @@ export function FeaturedCharacterNameplate({
   onToggleThoughts,
   onToggleFeatured,
   action,
+  characterIndex,
 }: {
   character: PresentCharacter;
   onUpdate?: (character: PresentCharacter) => void;
@@ -30,7 +31,9 @@ export function FeaturedCharacterNameplate({
   onToggleThoughts?: () => void;
   onToggleFeatured?: () => void;
   action?: ReactNode;
+  characterIndex: number;
 }) {
+  const nameLockKey = characterTrackerLockKey(character, characterIndex, "name");
   const thoughtButtonLabel = thoughtsOpen ? "Stop reading thoughts" : "Read thoughts";
   const thoughtControl =
     hasThoughtsControl && onToggleThoughts ? (
@@ -79,6 +82,7 @@ export function FeaturedCharacterNameplate({
       primaryControl={thoughtControl}
       primaryControlSide={thoughtControlSide}
       secondaryControls={headerControls}
+      lockKey={nameLockKey}
     />
   );
 }

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { X } from "lucide-react";
-import type { PresentCharacter } from "@marinara-engine/shared";
+import {
+  characterCustomFieldTrackerLockKey,
+  characterStatTrackerLockKey,
+  characterTrackerLockKey,
+  isTrackerFieldLocked,
+  type PresentCharacter,
+} from "@marinara-engine/shared";
 import type {
   TrackerPanelSide,
   TrackerPanelSizeProfile,
@@ -38,6 +44,7 @@ import { FeaturedFieldList, FeaturedStatGrid } from "./FeaturedCharacterFields";
 import { FeaturedCharacterNameplate } from "./FeaturedCharacterNameplate";
 import { FeaturedCharacterPortrait } from "./FeaturedCharacterPortrait";
 import { ExternalThoughtBubble, InlineThoughtBubble } from "./CharacterThoughtBubbles";
+import { useTrackerLockContext } from "../TrackerLockContext";
 
 const FEATURED_CARD_CLASS = cn(
   TRACKER_PROFILE_CARD_FRAME_CLASS,
@@ -76,6 +83,7 @@ export function FeaturedCharacterTrackerCard({
   action,
   onUpdate,
   onRemove,
+  characterIndex = 0,
   deleteMode,
   addMode,
   onToggleFeatured,
@@ -94,11 +102,13 @@ export function FeaturedCharacterTrackerCard({
   action?: ReactNode;
   onUpdate?: (character: PresentCharacter) => void;
   onRemove?: () => void;
+  characterIndex?: number;
   deleteMode: boolean;
   addMode: boolean;
   onToggleFeatured?: () => void;
   onUploadAvatar?: () => void;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
   const thoughtAnchorRef = useRef<HTMLDivElement | null>(null);
   const thoughtBubbleRef = useRef<HTMLDivElement | null>(null);
   const thoughtControlRef = useRef<HTMLButtonElement | null>(null);
@@ -239,6 +249,7 @@ export function FeaturedCharacterTrackerCard({
           onToggleThoughts={canToggleThoughts ? () => setThoughtsOpen((open) => !open) : undefined}
           onToggleFeatured={onToggleFeatured}
           action={action}
+          characterIndex={characterIndex}
         />
         <div aria-hidden="true" className={FEATURED_COCKPIT_SHELF_CLASS}>
           <div className={TRACKER_PROFILE_SURFACE_TEXTURE_CLASS} />
@@ -282,6 +293,7 @@ export function FeaturedCharacterTrackerCard({
               surfaceClassName={FEATURED_DOCKED_THOUGHT_SURFACE_CLASS}
               tailSide={featuredPortraitSide}
               variant="featured"
+              lockKey={characterTrackerLockKey(character, characterIndex, "thoughts")}
             />
           )}
           <div className={FEATURED_DETAILS_FIELDS_CLASS}>
@@ -290,6 +302,7 @@ export function FeaturedCharacterTrackerCard({
               onUpdate={onUpdate}
               readableRows={!showDockedThoughts}
               sizeProfile={trackerPanelSizeProfile}
+              characterIndex={characterIndex}
             />
           </div>
         </div>
@@ -305,6 +318,7 @@ export function FeaturedCharacterTrackerCard({
             scrollable={characterStatsOverflowPortrait}
             wideColumns={useFeaturedStatColumns}
             className={FEATURED_STAT_BAND_CLASS}
+            getLockKey={(statIndex, field) => characterStatTrackerLockKey(character, characterIndex, statIndex, field)}
           />
         )}
       </div>
@@ -316,6 +330,7 @@ export function FeaturedCharacterTrackerCard({
           value={character.thoughts}
           onSave={onUpdate ? (thoughts) => onUpdate({ ...character, thoughts: thoughts || null }) : undefined}
           panelSide={trackerPanelSide}
+          lockKey={characterTrackerLockKey(character, characterIndex, "thoughts")}
         />
       )}
 
@@ -330,6 +345,17 @@ export function FeaturedCharacterTrackerCard({
                   placeholder="Field"
                   className="min-w-0 px-0.5 py-0 font-medium"
                   scrollOnHover
+                  locked={isTrackerFieldLocked(
+                    fieldLocks,
+                    characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"),
+                  )}
+                  lockMode={lockMode}
+                  onToggleLock={
+                    onToggleFieldLock
+                      ? () =>
+                          onToggleFieldLock(characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"))
+                      : undefined
+                  }
                 />
               ) : (
                 <span className="truncate font-medium text-[color:var(--tracker-profile-muted-text)]">{name}</span>
@@ -341,6 +367,19 @@ export function FeaturedCharacterTrackerCard({
                   placeholder="Value"
                   className="min-w-0 px-0.5 py-0"
                   scrollOnHover
+                  locked={isTrackerFieldLocked(
+                    fieldLocks,
+                    characterCustomFieldTrackerLockKey(character, characterIndex, name, "value"),
+                  )}
+                  lockMode={lockMode}
+                  onToggleLock={
+                    onToggleFieldLock
+                      ? () =>
+                          onToggleFieldLock(
+                            characterCustomFieldTrackerLockKey(character, characterIndex, name, "value"),
+                          )
+                      : undefined
+                  }
                 />
               ) : (
                 <span className="min-w-0 truncate text-[color:var(--tracker-profile-text)]">{value}</span>

--- a/packages/client/src/features/tracker-panel/components/controls/InlineControls.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/InlineControls.tsx
@@ -87,7 +87,6 @@ export function InlineEdit({
   fullPreview = false,
   scrollOnHover = false,
   showEditHint = true,
-  editHintMode = "inline",
   twoLinePreview = false,
   threeLinePreview = false,
   previewLineCount,
@@ -96,6 +95,9 @@ export function InlineEdit({
   fitPreview = false,
   fitMinScale = 0.62,
   fitAlign = "left",
+  locked = false,
+  lockMode = false,
+  onToggleLock,
 }: {
   value: string | number | null | undefined;
   onSave: (value: string) => void;
@@ -106,7 +108,6 @@ export function InlineEdit({
   fullPreview?: boolean;
   scrollOnHover?: boolean;
   showEditHint?: boolean;
-  editHintMode?: "inline" | "overlay";
   twoLinePreview?: boolean;
   threeLinePreview?: boolean;
   previewLineCount?: 2 | 3 | 4 | "full";
@@ -115,6 +116,9 @@ export function InlineEdit({
   fitPreview?: boolean;
   fitMinScale?: number;
   fitAlign?: "left" | "center" | "right";
+  locked?: boolean;
+  lockMode?: boolean;
+  onToggleLock?: () => void;
 }) {
   const currentValue = value === null || value === undefined ? "" : String(value);
   const previewText = currentValue || placeholder;
@@ -128,6 +132,7 @@ export function InlineEdit({
   const scrollFieldRef = useRef<HTMLSpanElement>(null);
   const scrollMeasureRef = useRef<HTMLSpanElement>(null);
   const committedRef = useRef(false);
+  const lockToggleActive = lockMode && !!onToggleLock;
 
   useEffect(() => {
     if (!editing) setDraft(currentValue);
@@ -192,16 +197,28 @@ export function InlineEdit({
   return (
     <button
       type="button"
-      onClick={() => setEditing(true)}
+      onClick={() => {
+        if (lockToggleActive) {
+          onToggleLock?.();
+          return;
+        }
+        setEditing(true);
+      }}
       onMouseEnter={measureScrollOverflow}
       onFocus={measureScrollOverflow}
       onMouseLeave={resetScrollOverflow}
       onBlur={resetScrollOverflow}
-      title={title ?? currentValue}
+      title={lockToggleActive ? (locked ? "Unlock field" : "Lock field") : (title ?? currentValue)}
+      aria-label={
+        lockToggleActive ? `${locked ? "Unlock" : "Lock"} ${(title ?? currentValue) || placeholder}` : undefined
+      }
+      aria-pressed={lockToggleActive ? locked : undefined}
       className={cn(
         "group group/inline relative flex min-w-0 rounded px-0.5 text-left transition-colors hover:bg-[var(--accent)]/55",
-        editHintMode === "inline" && "gap-1",
         multilinePreviewLineCount ? "items-start overflow-hidden" : "items-center",
+        locked &&
+          "bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] text-[var(--foreground)] ring-1 ring-[color-mix(in_srgb,var(--foreground)_30%,transparent)]",
+        lockToggleActive && "cursor-pointer [@media(pointer:coarse)]:min-h-[1.75rem]",
         className,
       )}
       style={style}
@@ -265,15 +282,14 @@ export function InlineEdit({
           )}
         </span>
       )}
-      <Pencil
-        size="0.5625rem"
-        className={cn(
-          "shrink-0 text-[color:var(--tracker-inline-muted,var(--muted-foreground))] opacity-0 transition-opacity group-hover/inline:opacity-60",
-          (!showEditHint || fullPreview) && "hidden",
-          (useHoverScroll || editHintMode === "overlay") &&
-            "pointer-events-none absolute right-0.5 top-1/2 -translate-y-1/2",
-        )}
-      />
+      {!(lockMode || locked) && (
+        <Pencil
+          className={cn(
+            "pointer-events-none absolute right-0.5 top-1/2 h-2.5 w-2.5 -translate-y-1/2 shrink-0 text-[color:var(--tracker-inline-muted,var(--muted-foreground))] opacity-0 transition-opacity group-hover/inline:opacity-60",
+            (!showEditHint || fullPreview) && "hidden",
+          )}
+        />
+      )}
     </button>
   );
 }
@@ -284,14 +300,43 @@ export function InlineNumber({
   className,
   min,
   title,
+  locked = false,
+  lockMode = false,
+  onToggleLock,
 }: {
   value: number;
   onChange: (value: number) => void;
   className?: string;
   min?: number;
   title?: string;
+  locked?: boolean;
+  lockMode?: boolean;
+  onToggleLock?: () => void;
 }) {
   const width = getNumberValueWidth(value);
+
+  if (lockMode && onToggleLock) {
+    return (
+      <button
+        type="button"
+        onClick={onToggleLock}
+        title={locked ? "Unlock field" : "Lock field"}
+        aria-label={`${locked ? "Unlock" : "Lock"} ${title?.toLowerCase() ?? "field"}`}
+        aria-pressed={locked}
+        style={{ width }}
+        className={cn(
+          "inline-flex min-w-0 items-center justify-end rounded bg-transparent px-0 py-0.5 text-right text-[0.625rem] tabular-nums text-[color:var(--tracker-inline-number,var(--tracker-inline-foreground,var(--foreground)))] outline-none ring-1 transition-colors hover:bg-[var(--accent)]/45 focus:ring-[var(--border)]",
+          locked
+            ? "bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] ring-1 ring-[color-mix(in_srgb,var(--foreground)_30%,transparent)]"
+            : "opacity-90 ring-transparent hover:ring-[var(--border)]/60",
+          className,
+          "[@media(pointer:coarse)]:min-h-[1.75rem]",
+        )}
+      >
+        <span>{Number.isFinite(value) ? value : 0}</span>
+      </button>
+    );
+  }
 
   return (
     <input
@@ -306,6 +351,8 @@ export function InlineNumber({
       style={{ width }}
       className={cn(
         "rounded bg-transparent px-1 py-0.5 text-right text-[0.625rem] tabular-nums text-[color:var(--tracker-inline-number,var(--tracker-inline-foreground,var(--foreground)))] outline-none transition-colors hover:bg-[var(--accent)]/45 focus:bg-[var(--background)] focus:ring-1 focus:ring-[var(--border)] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+        locked &&
+          "bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] ring-1 ring-[color-mix(in_srgb,var(--foreground)_30%,transparent)]",
         className,
       )}
     />

--- a/packages/client/src/features/tracker-panel/components/controls/StatList.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/StatList.tsx
@@ -1,5 +1,5 @@
 import { X } from "lucide-react";
-import type { CharacterStat } from "@marinara-engine/shared";
+import { isTrackerFieldLocked, type CharacterStat } from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import { TRACKER_BAR, TRACKER_TEXT_ROW } from "../../lib/tracker-panel.constants";
 import type { TrackerStatDensity, TrackerStatDisplayScale } from "../../tracker-panel.types";
@@ -7,6 +7,7 @@ import { visibleText } from "../../lib/tracker-display";
 import { getStatPercent, getTrackerStatDisplayScale } from "../../lib/tracker-stat-layout";
 import { FittedText, InlineAddRow, InlineEdit, InlineNumber } from "./InlineControls";
 import { EmptySection } from "./SectionControls";
+import { useTrackerLockContext } from "../TrackerLockContext";
 
 type StatListVisualTone = "plain" | "instrument";
 
@@ -66,6 +67,13 @@ function StatBar({
   compactNameRhythm = false,
   wideColumnCell = false,
   visualTone = "plain",
+  nameLocked,
+  valueLocked,
+  maxLocked,
+  lockMode,
+  onToggleNameLock,
+  onToggleValueLock,
+  onToggleMaxLock,
 }: {
   stat: CharacterStat;
   onUpdateName?: (name: string) => void;
@@ -81,6 +89,13 @@ function StatBar({
   compactNameRhythm?: boolean;
   wideColumnCell?: boolean;
   visualTone?: StatListVisualTone;
+  nameLocked?: boolean;
+  valueLocked?: boolean;
+  maxLocked?: boolean;
+  lockMode?: boolean;
+  onToggleNameLock?: () => void;
+  onToggleValueLock?: () => void;
+  onToggleMaxLock?: () => void;
 }) {
   const percent = getStatPercent(stat);
   const isCompact = density === "compact";
@@ -197,7 +212,9 @@ function StatBar({
             scrollOnHover={nameMode === "scroll"}
             fitPreview={nameMode === "truncate"}
             fitMinScale={0.56}
-            editHintMode="overlay"
+            locked={nameLocked}
+            lockMode={lockMode}
+            onToggleLock={onToggleNameLock}
           />
         ) : nameMode === "truncate" ? (
           <FittedText
@@ -221,11 +238,28 @@ function StatBar({
         )}
         {onUpdateValue && onUpdateMax ? (
           <div className={valueGroupClass}>
-            <InlineNumber value={stat.value} onChange={onUpdateValue} title="Value" className={valueInputClass} />
+            <InlineNumber
+              value={stat.value}
+              onChange={onUpdateValue}
+              title="Value"
+              className={valueInputClass}
+              locked={valueLocked}
+              lockMode={lockMode}
+              onToggleLock={onToggleValueLock}
+            />
             <span className="px-px text-[color:color-mix(in_srgb,var(--tracker-profile-number-text)_58%,transparent)]">
               /
             </span>
-            <InlineNumber value={stat.max} onChange={onUpdateMax} min={0} title="Max" className={valueInputClass} />
+            <InlineNumber
+              value={stat.max}
+              onChange={onUpdateMax}
+              min={0}
+              title="Max"
+              className={valueInputClass}
+              locked={maxLocked}
+              lockMode={lockMode}
+              onToggleLock={onToggleMaxLock}
+            />
           </div>
         ) : (
           <div className={valueGroupClass} title={`${stat.value} / ${stat.max}`}>
@@ -274,6 +308,7 @@ export function StatList({
   fillWideColumns = false,
   showWideColumnGhost = false,
   visualTone = "plain",
+  getLockKey,
 }: {
   stats: CharacterStat[];
   onUpdate?: (stats: CharacterStat[]) => void;
@@ -289,7 +324,9 @@ export function StatList({
   fillWideColumns?: boolean;
   showWideColumnGhost?: boolean;
   visualTone?: StatListVisualTone;
+  getLockKey?: (index: number, field: "name" | "value" | "max") => string;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
   if (stats.length === 0) {
     return onAdd && addMode ? (
       <InlineAddRow onClick={onAdd} title="Add stat" className="border-t-0" />
@@ -307,6 +344,8 @@ export function StatList({
     if (!onUpdate) return;
     onUpdate(stats.filter((_, statIndex) => statIndex !== index));
   };
+  const buildLockToggle = (index: number, field: "name" | "value" | "max") =>
+    getLockKey && onToggleFieldLock ? () => onToggleFieldLock(getLockKey(index, field)) : undefined;
   const displayScale = getTrackerStatDisplayScale(
     stats.length,
     density,
@@ -358,6 +397,13 @@ export function StatList({
             compactNameRhythm={compactNameRhythm}
             wideColumnCell={wideColumnCell}
             visualTone={visualTone}
+            nameLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "name")) : false}
+            valueLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "value")) : false}
+            maxLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "max")) : false}
+            lockMode={lockMode}
+            onToggleNameLock={buildLockToggle(index, "name")}
+            onToggleValueLock={buildLockToggle(index, "value")}
+            onToggleMaxLock={buildLockToggle(index, "max")}
           />
         ))}
         {shouldRenderWideColumnGhost && (

--- a/packages/client/src/features/tracker-panel/components/controls/TrackerProfileNameplate.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/TrackerProfileNameplate.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 import { getOppositeTrackerProfileSide, type TrackerProfileSide } from "../../lib/tracker-profile-layout";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 import { FittedText, InlineEdit } from "./InlineControls";
 
 const NAMEPLATE_CLASS = cn(
@@ -123,6 +124,7 @@ export function TrackerProfileNameplate({
   secondaryControlsSide,
   className,
   nameClassName,
+  lockKey,
 }: {
   value: string | null | undefined;
   placeholder: string;
@@ -133,7 +135,9 @@ export function TrackerProfileNameplate({
   secondaryControlsSide?: TrackerProfileSide;
   className?: string;
   nameClassName?: string;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const displayValue = visibleText(value, placeholder);
   const hasPrimaryControl = !!primaryControl;
   const hasSecondaryControls = !!secondaryControls;
@@ -193,6 +197,7 @@ export function TrackerProfileNameplate({
           fitPreview
           fitAlign="center"
           fitMinScale={0.6}
+          {...lock}
         />
       ) : (
         <FittedText

--- a/packages/client/src/features/tracker-panel/components/sections/CharacterTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/CharacterTrackerPanel.tsx
@@ -115,6 +115,7 @@ export function CharacterTrackerPanel({
         dockedThoughtsAlwaysVisible={dockedThoughtsAlwaysVisible}
         onUpdate={(updated) => onUpdateCharacter(index, updated)}
         onRemove={() => onRemoveCharacter(index)}
+        characterIndex={index}
         deleteMode={deleteMode}
         addMode={addMode}
         featured={featured}

--- a/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
@@ -1,12 +1,13 @@
 import type { ReactNode } from "react";
 import { SlidersHorizontal, X } from "lucide-react";
-import type { CustomTrackerField } from "@marinara-engine/shared";
+import { customTrackerLockKey, isTrackerFieldLocked, type CustomTrackerField } from "@marinara-engine/shared";
 import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 import { InlineEdit } from "../controls/InlineControls";
 import { TrackerReadabilityVeil } from "../controls/TrackerProfileChrome";
 import { AddRowButton, EmptySection, SectionHeader } from "../controls/SectionControls";
+import { useTrackerLockContext } from "../TrackerLockContext";
 
 function isLongCustomField(field: CustomTrackerField): boolean {
   const name = visibleText(field.name, "");
@@ -35,6 +36,7 @@ function CustomFieldList({
   deleteMode?: boolean;
   trackerPanelSizeProfile: TrackerPanelSizeProfile;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
   if (fields.length === 0 && !onUpdate) return <EmptySection>No custom stats tracked.</EmptySection>;
   const readableValues = trackerPanelSizeProfile !== "compact";
   const useFieldColumns = shouldUseCustomFieldColumns(fields, trackerPanelSizeProfile);
@@ -66,6 +68,13 @@ function CustomFieldList({
             const valueText = visibleText(field.value, "");
             const valueIsLong = valueText.length > 18 || valueText.includes(" ");
             const valueAlignment = allowWrap && valueIsLong ? "text-left" : "text-right tabular-nums";
+            const valueLockKey = customTrackerLockKey(index, "value");
+            const valueLocked = isTrackerFieldLocked(fieldLocks, valueLockKey);
+            const toggleValueLock = () => {
+              // Migrate the deprecated per-field flag into the shared lock map on first toggle.
+              if (field.locked) updateField(index, { ...field, locked: false });
+              if (valueLocked || !field.locked) onToggleFieldLock?.(valueLockKey);
+            };
             return (
               <div
                 key={`${field.name}-${index}`}
@@ -81,7 +90,8 @@ function CustomFieldList({
                     fields.length % 2 === 1 &&
                     index === fields.length - 1 &&
                     "@min-[300px]:col-span-2",
-                  deleteMode && "pr-5",
+                  onUpdate && "pr-5",
+                  deleteMode && "pr-9",
                 )}
               >
                 {onUpdate ? (
@@ -90,10 +100,12 @@ function CustomFieldList({
                     onSave={(name) => updateField(index, { ...field, name: name || "Field" })}
                     placeholder="Field"
                     className={cn("min-w-0 px-0.5 py-0 font-medium", allowWrap && "min-h-5")}
-                    editHintMode={allowWrap ? "overlay" : "inline"}
                     previewLineCount={allowWrap ? 2 : undefined}
                     scrollOnHover={!allowWrap}
                     showEditHint={false}
+                    locked={isTrackerFieldLocked(fieldLocks, customTrackerLockKey(index, "name"))}
+                    lockMode={lockMode}
+                    onToggleLock={() => onToggleFieldLock?.(customTrackerLockKey(index, "name"))}
                   />
                 ) : (
                   <span
@@ -116,10 +128,12 @@ function CustomFieldList({
                       allowWrap ? "min-h-5 justify-start leading-[1.15]" : "justify-end",
                     )}
                     twoLinePreview={allowWrap}
-                    editHintMode={allowWrap ? "overlay" : "inline"}
                     previewLineCount={allowWrap ? 2 : undefined}
                     scrollOnHover={!allowWrap}
                     showEditHint={false}
+                    locked={valueLocked || field.locked}
+                    lockMode={lockMode}
+                    onToggleLock={toggleValueLock}
                   />
                 ) : (
                   <span
@@ -132,16 +146,20 @@ function CustomFieldList({
                     {visibleText(field.value, "Empty")}
                   </span>
                 )}
-                {onUpdate && deleteMode && (
-                  <button
-                    type="button"
-                    onClick={() => removeField(index)}
-                    className="absolute right-1 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90"
-                    title="Remove field"
-                    aria-label={`Remove ${visibleText(field.name, "field")}`}
-                  >
-                    <X size="0.5625rem" />
-                  </button>
+                {onUpdate && (
+                  <span className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
+                    {deleteMode && (
+                      <button
+                        type="button"
+                        onClick={() => removeField(index)}
+                        className="flex h-4 w-4 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90"
+                        title="Remove field"
+                        aria-label={`Remove ${visibleText(field.name, "field")}`}
+                      >
+                        <X size="0.5625rem" />
+                      </button>
+                    )}
+                  </span>
                 )}
               </div>
             );

--- a/packages/client/src/features/tracker-panel/components/sections/PersonaInventoryRow.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/PersonaInventoryRow.tsx
@@ -1,22 +1,28 @@
 import { X } from "lucide-react";
-import type { InventoryItem } from "@marinara-engine/shared";
+import { inventoryTrackerLockKey, isTrackerFieldLocked, type InventoryItem } from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 import { InlineEdit, InlineNumber } from "../controls/InlineControls";
+import { useTrackerLockContext } from "../TrackerLockContext";
 
 export function PersonaInventoryRow({
   item,
+  itemIndex,
   onUpdate,
   onRemove,
   deleteMode,
   fullWidth = false,
 }: {
   item: InventoryItem;
+  itemIndex: number;
   onUpdate: (item: InventoryItem) => void;
   onRemove: () => void;
   deleteMode: boolean;
   fullWidth?: boolean;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const nameLockKey = inventoryTrackerLockKey(itemIndex, "name");
+  const quantityLockKey = inventoryTrackerLockKey(itemIndex, "quantity");
   return (
     <div
       className={cn(
@@ -34,6 +40,9 @@ export function PersonaInventoryRow({
           title={visibleText(item.name, "Item")}
           scrollOnHover
           showEditHint={false}
+          locked={isTrackerFieldLocked(fieldLocks, nameLockKey)}
+          lockMode={lockMode}
+          onToggleLock={() => onToggleFieldLock?.(nameLockKey)}
         />
         <div className="flex h-4 min-w-0 items-center justify-end">
           <InlineNumber
@@ -42,6 +51,9 @@ export function PersonaInventoryRow({
             min={0}
             className="justify-self-end px-0 text-right text-[0.625rem] leading-4 text-[color:var(--tracker-profile-number-text)] hover:bg-transparent focus:bg-transparent focus:ring-0"
             title={`${item.name} quantity`}
+            locked={isTrackerFieldLocked(fieldLocks, quantityLockKey)}
+            lockMode={lockMode}
+            onToggleLock={() => onToggleFieldLock?.(quantityLockKey)}
           />
         </div>
       </div>

--- a/packages/client/src/features/tracker-panel/components/sections/PersonaTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/PersonaTrackerPanel.tsx
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { HeartPulse, Package, Sparkles } from "lucide-react";
 import type { CharacterStat, InventoryItem, Persona } from "@marinara-engine/shared";
+import {
+  isTrackerFieldLocked,
+  personaStatTrackerLockKey,
+  personaStatusTrackerLockKey,
+} from "@marinara-engine/shared";
 import type { TrackerPanelSide, TrackerPanelSizeProfile } from "../../../../stores/ui.store";
 import {
   characterKeys,
@@ -51,6 +56,7 @@ import {
 } from "../controls/TrackerProfileChrome";
 import { AddRowButton, SectionHeader } from "../controls/SectionControls";
 import { StatList } from "../controls/StatList";
+import { useTrackerLockContext } from "../TrackerLockContext";
 import { PersonaInventoryRow } from "./PersonaInventoryRow";
 import { PersonaPortraitStage } from "./PersonaPortraitStage";
 
@@ -132,6 +138,7 @@ export function PersonaInventoryPanel({
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
   const queryClient = useQueryClient();
   const updatePersona = useUpdatePersona();
   const personaPortraitSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -272,6 +279,7 @@ export function PersonaInventoryPanel({
             <PersonaInventoryRow
               key={`${item.name}-${index}`}
               item={item}
+              itemIndex={index}
               onUpdate={(updated) => onUpdateInventoryItem(index, updated)}
               onRemove={() => onRemoveInventoryItem(index)}
               deleteMode={deleteMode}
@@ -376,6 +384,7 @@ export function PersonaInventoryPanel({
                         wideColumns={useExpandedPersonaStatColumns}
                         fillWideColumns={useExpandedPersonaStatColumns}
                         visualTone="instrument"
+                        getLockKey={(index, field) => personaStatTrackerLockKey(index, field)}
                       />
                     )}
                   </div>
@@ -411,6 +420,9 @@ export function PersonaInventoryPanel({
                     scrollOnHover={trackerPanelSizeProfile === "compact"}
                     previewLineCount={trackerPanelSizeProfile === "compact" ? undefined : 2}
                     showEditHint={false}
+                    locked={isTrackerFieldLocked(fieldLocks, personaStatusTrackerLockKey())}
+                    lockMode={lockMode}
+                    onToggleLock={() => onToggleFieldLock?.(personaStatusTrackerLockKey())}
                   />
                 </div>
                 {!showInventoryInStatColumn && renderInventoryShelf("lower-deck")}

--- a/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
@@ -1,17 +1,21 @@
 import { Clock } from "lucide-react";
 import { cn } from "../../../../lib/utils";
 import { getWorldDateDisplay, getWorldTimeDisplay, type WorldDateDisplay } from "../../lib/world-state-display";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
 
 export function WorldDateTile({
   value,
   display = getWorldDateDisplay(value),
   onSave,
+  lockKey,
 }: {
   value: string | null | undefined;
   display?: WorldDateDisplay;
   onSave?: (value: string) => void;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const isFreeformDate = display.kind === "freeform";
 
   return (
@@ -29,6 +33,7 @@ export function WorldDateTile({
         )}
         inputClassName="text-center"
         showEditHint={false}
+        {...lock}
       >
         {isFreeformDate ? (
           <>
@@ -93,10 +98,13 @@ function WorldClockFace({ hour, minute }: { hour: number | null; minute: number 
 export function WorldTimeTile({
   value,
   onSave,
+  lockKey,
 }: {
   value: string | null | undefined;
   onSave?: (value: string) => void;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const display = getWorldTimeDisplay(value);
   return (
     <WorldTileShell label="Time">
@@ -108,6 +116,7 @@ export function WorldTimeTile({
         className="grid grid-rows-[minmax(0,1fr)_0.625rem] px-1 pb-0.5 pt-0.5 text-center"
         inputClassName="text-center"
         showEditHint={false}
+        {...lock}
       >
         <div className="flex min-h-0 items-center justify-center overflow-visible">
           <WorldClockFace hour={display.hour} minute={display.minute} />

--- a/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Pencil } from "lucide-react";
+import { Lock, Pencil, Unlock } from "lucide-react";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 
@@ -38,6 +38,9 @@ export function WorldRenderedEdit({
   inputClassName,
   showEditHint = true,
   editHintClassName,
+  locked = false,
+  lockMode = false,
+  onToggleLock,
   children,
 }: {
   label: string;
@@ -48,6 +51,9 @@ export function WorldRenderedEdit({
   inputClassName?: string;
   showEditHint?: boolean;
   editHintClassName?: string;
+  locked?: boolean;
+  lockMode?: boolean;
+  onToggleLock?: () => void;
   children: ReactNode;
 }) {
   const currentValue = value === null || value === undefined ? "" : String(value);
@@ -56,6 +62,7 @@ export function WorldRenderedEdit({
   const inputRef = useRef<HTMLInputElement>(null);
   const committedRef = useRef(false);
   const title = `${label}: ${visibleText(value)}`;
+  const lockToggleActive = lockMode && !!onToggleLock;
 
   useEffect(() => {
     if (!editing) setDraft(currentValue);
@@ -111,16 +118,45 @@ export function WorldRenderedEdit({
   return (
     <button
       type="button"
-      onClick={() => setEditing(true)}
-      title={title}
-      aria-label={`${title}. Click to edit.`}
+      onClick={() => {
+        if (lockToggleActive) {
+          onToggleLock?.();
+          return;
+        }
+        setEditing(true);
+      }}
+      title={lockToggleActive ? (locked ? `Unlock ${label.toLowerCase()}` : `Lock ${label.toLowerCase()}`) : title}
+      aria-label={
+        lockToggleActive
+          ? `${locked ? "Unlock" : "Lock"} ${label.toLowerCase()}`
+          : `${title}. Click to edit.`
+      }
+      aria-pressed={lockToggleActive ? locked : undefined}
       className={cn(
         "group/world-edit relative h-full w-full min-w-0 text-left transition-colors hover:bg-[var(--accent)]/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[var(--border)]",
+        locked &&
+          "bg-[color-mix(in_srgb,var(--foreground)_8%,transparent)] ring-1 ring-inset ring-[color-mix(in_srgb,var(--foreground)_30%,transparent)]",
         className,
       )}
     >
       {children}
-      {showEditHint && (
+      {(lockMode || locked) && (
+        <span
+          className={cn(
+            "pointer-events-none absolute right-0.5 top-0.5 z-[12] flex h-3.5 w-3.5 items-center justify-center rounded-[2px] bg-[var(--background)]/58 shadow-[0_0_6px_color-mix(in_srgb,var(--foreground)_10%,transparent)] ring-1 ring-[var(--border)] transition-opacity duration-150 [@media(pointer:coarse)]:h-4 [@media(pointer:coarse)]:w-4",
+            locked ? "text-[var(--foreground)] opacity-90" : "text-[var(--muted-foreground)] opacity-50",
+            editHintClassName,
+          )}
+          aria-hidden="true"
+        >
+          {locked ? (
+            <Lock className="h-2.5 w-2.5 [@media(pointer:coarse)]:h-3 [@media(pointer:coarse)]:w-3" />
+          ) : (
+            <Unlock className="h-2.5 w-2.5 [@media(pointer:coarse)]:h-3 [@media(pointer:coarse)]:w-3" />
+          )}
+        </span>
+      )}
+      {showEditHint && !lockMode && !locked && (
         <span
           className={cn(
             "pointer-events-none absolute right-0.5 top-0.5 z-[12] flex h-3 w-3 translate-y-0.5 items-center justify-center rounded-[2px] bg-[var(--background)]/58 text-[var(--muted-foreground)] opacity-0 shadow-[0_0_6px_color-mix(in_srgb,var(--foreground)_10%,transparent)] ring-1 ring-[var(--border)] transition-[opacity,transform] duration-150 group-hover/world-edit:translate-y-0 group-hover/world-edit:opacity-70 group-focus-visible/world-edit:translate-y-0 group-focus-visible/world-edit:opacity-80 max-md:translate-y-0 max-md:opacity-45",

--- a/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
@@ -4,6 +4,7 @@ import { cn } from "../../../../lib/utils";
 import { getTemperatureColor, getTemperatureGaugeDisplay, getWeatherEmoji } from "../../lib/world-state-display";
 import { visibleText } from "../../lib/tracker-display";
 import { FittedText } from "../controls/InlineControls";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
 
 export function WorldForecastTile({
@@ -13,6 +14,8 @@ export function WorldForecastTile({
   trackerTemperatureUnit,
   onSaveWeather,
   onSaveTemperature,
+  weatherLockKey,
+  temperatureLockKey,
 }: {
   weather: string | null | undefined;
   temperature: string | null | undefined;
@@ -20,7 +23,11 @@ export function WorldForecastTile({
   trackerTemperatureUnit: TrackerTemperatureUnit;
   onSaveWeather?: (value: string) => void;
   onSaveTemperature?: (value: string) => void;
+  weatherLockKey?: string;
+  temperatureLockKey?: string;
 }) {
+  const weatherLock = useTrackerFieldLock(weatherLockKey);
+  const temperatureLock = useTrackerFieldLock(temperatureLockKey);
   const weatherText = visibleText(weather, "Set weather");
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
   const useHorizontalTempRail = trackerPanelSizeProfile !== "compact";
@@ -62,6 +69,7 @@ export function WorldForecastTile({
               ? "right-[4.45rem] @min-[7rem]:right-[4.6rem] @min-[10rem]:right-[4.7rem] @min-[14rem]:right-[4.8rem]"
               : "right-[2.45rem] @min-[7rem]:right-[2.65rem] @min-[10rem]:right-[2.95rem] @min-[14rem]:right-[3.25rem]",
           )}
+          {...weatherLock}
         >
           <WorldWeatherLabel text={weatherText} trackerPanelSizeProfile={trackerPanelSizeProfile} />
         </WorldRenderedEdit>
@@ -86,6 +94,7 @@ export function WorldForecastTile({
             )}
             inputClassName={cn("text-center text-[0.625rem]", useHorizontalTempRail && "text-[0.6875rem]")}
             showEditHint={false}
+            {...temperatureLock}
           >
             <span
               className={cn(

--- a/packages/client/src/features/tracker-panel/components/sections/WorldLocationPlate.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldLocationPlate.tsx
@@ -2,17 +2,21 @@ import { MapPin } from "lucide-react";
 import { cn } from "../../../../lib/utils";
 import { getLocationPinColor } from "../../lib/world-state-display";
 import { visibleText } from "../../lib/tracker-display";
+import { useTrackerFieldLock } from "../TrackerLockContext";
 import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
 
 export function WorldLocationPlate({
   value,
   onSave,
   className,
+  lockKey,
 }: {
   value: string | null | undefined;
   onSave?: (value: string) => void;
   className?: string;
+  lockKey?: string;
 }) {
+  const lock = useTrackerFieldLock(lockKey);
   const locationText = visibleText(value, "Set location");
   const compactLocationText = locationText.length > 34;
 
@@ -26,6 +30,7 @@ export function WorldLocationPlate({
         className="relative z-[1] grid grid-cols-[1.7rem_minmax(0,1fr)] items-center gap-1 px-1 py-1 text-left @min-[380px]:grid-cols-[1.9rem_minmax(0,1fr)] @min-[380px]:px-1.5"
         inputClassName="text-center text-[0.75rem]"
         editHintClassName="right-1 top-1"
+        {...lock}
       >
         <div className="relative flex h-full min-h-[1.625rem] w-full items-center justify-center overflow-hidden rounded-[3px] bg-[color-mix(in_srgb,var(--background)_34%,transparent)] ring-1 ring-[var(--border)]/24 @min-[380px]:min-h-[1.8rem]">
           <div className="pointer-events-none absolute inset-0 opacity-[0.17] [background-image:radial-gradient(circle,color-mix(in_srgb,var(--foreground)_44%,transparent)_0.75px,transparent_1px)] [background-size:4px_4px]" />

--- a/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { MapPin } from "lucide-react";
-import type { GameState } from "@marinara-engine/shared";
+import { worldTrackerLockKey, type GameState } from "@marinara-engine/shared";
 import type { GameStatePatchField } from "../../../../hooks/use-game-state-patcher";
 import type { TrackerPanelSizeProfile, TrackerTemperatureUnit } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
@@ -66,8 +66,13 @@ export function WorldStatePanel({
             value={state?.date}
             display={dateDisplay}
             onSave={(value) => onSaveField("date", value || null)}
+            lockKey={worldTrackerLockKey("date")}
           />
-          <WorldTimeTile value={state?.time} onSave={(value) => onSaveField("time", value || null)} />
+          <WorldTimeTile
+            value={state?.time}
+            onSave={(value) => onSaveField("time", value || null)}
+            lockKey={worldTrackerLockKey("time")}
+          />
           <WorldForecastTile
             weather={state?.weather}
             temperature={state?.temperature}
@@ -75,11 +80,14 @@ export function WorldStatePanel({
             trackerTemperatureUnit={trackerTemperatureUnit}
             onSaveWeather={(value) => onSaveField("weather", value || null)}
             onSaveTemperature={(value) => onSaveField("temperature", value || null)}
+            weatherLockKey={worldTrackerLockKey("weather")}
+            temperatureLockKey={worldTrackerLockKey("temperature")}
           />
           <WorldLocationPlate
             value={state?.location}
             onSave={(value) => onSaveField("location", value || null)}
             className="col-span-3 @min-[380px]:col-span-1"
+            lockKey={worldTrackerLockKey("location")}
           />
         </div>
       )}

--- a/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestBoard.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestBoard.tsx
@@ -59,6 +59,7 @@ export function QuestBoard({
               <QuestRow
                 key={`${quest.questEntryId}-${index}`}
                 quest={quest}
+                questIndex={index}
                 onUpdate={(updated) => onUpdateQuest(index, updated)}
                 onRemove={() => onRemoveQuest(index)}
                 deleteMode={deleteMode}

--- a/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestObjectiveRow.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestObjectiveRow.tsx
@@ -1,8 +1,9 @@
-import { CheckCircle2, Circle, X } from "lucide-react";
-import type { QuestProgress } from "@marinara-engine/shared";
+import { CheckCircle2, Circle, Lock, Unlock, X } from "lucide-react";
+import { isTrackerFieldLocked, type QuestProgress } from "@marinara-engine/shared";
 import { cn } from "../../../../../lib/utils";
 import { visibleText } from "../../../lib/tracker-display";
 import { InlineEdit } from "../../controls/InlineControls";
+import { useTrackerLockContext } from "../../TrackerLockContext";
 
 type QuestObjective = QuestProgress["objectives"][number];
 
@@ -28,6 +29,8 @@ export function QuestObjectiveRow({
   onToggle,
   onUpdateText,
   onRemove,
+  textLockKey,
+  completedLockKey,
 }: {
   objective: QuestObjective;
   deleteMode: boolean;
@@ -38,7 +41,12 @@ export function QuestObjectiveRow({
   onToggle?: () => void;
   onUpdateText?: (text: string) => void;
   onRemove?: () => void;
+  textLockKey: string;
+  completedLockKey: string;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const textLocked = isTrackerFieldLocked(fieldLocks, textLockKey);
+  const completedLocked = isTrackerFieldLocked(fieldLocks, completedLockKey);
   return (
     <div
       className={cn(
@@ -50,12 +58,44 @@ export function QuestObjectiveRow({
       {onToggle ? (
         <button
           type="button"
-          onClick={onToggle}
-          className={cn(OBJECTIVE_TOGGLE_BUTTON_CLASS, wrapsText && "mt-px", objective.completed && "text-emerald-300")}
-          title={objective.completed ? "Mark incomplete" : "Mark complete"}
-          aria-label={objective.completed ? "Mark objective incomplete" : "Mark objective complete"}
+          onClick={lockMode ? () => onToggleFieldLock?.(completedLockKey) : onToggle}
+          className={cn(
+            OBJECTIVE_TOGGLE_BUTTON_CLASS,
+            wrapsText && "mt-px",
+            objective.completed && !lockMode && "text-emerald-300",
+            completedLocked && "ring-1 ring-emerald-300/35",
+          )}
+          title={
+            lockMode
+              ? completedLocked
+                ? "Unlock objective completion"
+                : "Lock objective completion"
+              : objective.completed
+                ? "Mark incomplete"
+                : "Mark complete"
+          }
+          aria-label={
+            lockMode
+              ? completedLocked
+                ? "Unlock objective completion"
+                : "Lock objective completion"
+              : objective.completed
+                ? "Mark objective incomplete"
+                : "Mark objective complete"
+          }
+          aria-pressed={lockMode ? completedLocked : undefined}
         >
-          {objective.completed ? <CheckCircle2 size="0.6875rem" /> : <Circle size="0.6875rem" />}
+          {lockMode ? (
+            completedLocked ? (
+              <Lock size="0.6875rem" />
+            ) : (
+              <Unlock size="0.6875rem" />
+            )
+          ) : objective.completed ? (
+            <CheckCircle2 size="0.6875rem" />
+          ) : (
+            <Circle size="0.6875rem" />
+          )}
         </button>
       ) : objective.completed ? (
         <CheckCircle2 size="0.6875rem" className={cn("shrink-0 text-emerald-300", wrapsText && "mt-0.5")} />
@@ -70,12 +110,14 @@ export function QuestObjectiveRow({
           title={`Objective: ${visibleText(objective.text, "Objective")}`}
           showEditHint={false}
           previewLineCount={previewLineCount}
-          editHintMode={wrapsText ? "overlay" : "inline"}
           className={cn(
             OBJECTIVE_EDIT_CLASS,
             wrapsText ? OBJECTIVE_EDIT_WRAPPED_CLASS : OBJECTIVE_EDIT_SINGLE_LINE_CLASS,
             objective.completed && "line-through opacity-60",
           )}
+          locked={textLocked}
+          lockMode={lockMode}
+          onToggleLock={() => onToggleFieldLock?.(textLockKey)}
         />
       ) : (
         <span

--- a/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestRow.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestRow.tsx
@@ -1,9 +1,15 @@
-import { CheckCircle2, Plus, Target, X } from "lucide-react";
-import type { QuestProgress } from "@marinara-engine/shared";
+import { CheckCircle2, Lock, Plus, Target, Unlock, X } from "lucide-react";
+import {
+  isTrackerFieldLocked,
+  questObjectiveTrackerLockKey,
+  questTrackerLockKey,
+  type QuestProgress,
+} from "@marinara-engine/shared";
 import { cn } from "../../../../../lib/utils";
 import { TRACKER_BAR } from "../../../lib/tracker-panel.constants";
 import { visibleText } from "../../../lib/tracker-display";
 import { InlineEdit } from "../../controls/InlineControls";
+import { useTrackerLockContext } from "../../TrackerLockContext";
 import { getQuestTextWrapClass, type QuestTextLineCount } from "./quest-layout";
 import { QuestObjectiveRow } from "./QuestObjectiveRow";
 
@@ -33,6 +39,7 @@ const ADD_OBJECTIVE_BUTTON_CLASS =
 
 export function QuestRow({
   quest,
+  questIndex,
   onUpdate,
   onRemove,
   deleteMode = false,
@@ -40,12 +47,14 @@ export function QuestRow({
   textLineCount = 1,
 }: {
   quest: QuestProgress;
+  questIndex: number;
   onUpdate?: (quest: QuestProgress) => void;
   onRemove?: () => void;
   deleteMode?: boolean;
   addMode?: boolean;
   textLineCount?: QuestTextLineCount;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
   const completed = quest.objectives.filter((objective) => objective.completed).length;
   const totalObjectives = quest.objectives.length;
   const completionPercent = quest.completed ? 100 : totalObjectives > 0 ? (completed / totalObjectives) * 100 : 0;
@@ -54,6 +63,9 @@ export function QuestRow({
     ? "grid-cols-[0.875rem_minmax(0,1fr)_1rem]"
     : "grid-cols-[0.875rem_minmax(0,1fr)]";
   const questTitle = visibleText(quest.name, "Quest");
+  const questCompletedLockKey = questTrackerLockKey(quest, questIndex, "completed");
+  const questNameLockKey = questTrackerLockKey(quest, questIndex, "name");
+  const questCompletedLocked = isTrackerFieldLocked(fieldLocks, questCompletedLockKey);
   const wrapsText = textLineCount > 1;
   const previewLineCount: 2 | 3 | undefined = textLineCount === 1 ? undefined : textLineCount;
   const wrapClass = getQuestTextWrapClass(textLineCount);
@@ -85,12 +97,49 @@ export function QuestRow({
         {onUpdate && (
           <button
             type="button"
-            onClick={() => onUpdate({ ...quest, completed: !quest.completed })}
-            className={cn(QUEST_TOGGLE_BUTTON_CLASS, quest.completed && "text-emerald-300")}
-            title={quest.completed ? "Mark incomplete" : "Mark complete"}
-            aria-label={quest.completed ? "Mark quest incomplete" : "Mark quest complete"}
+            onClick={() =>
+              lockMode
+                ? onToggleFieldLock?.(questCompletedLockKey)
+                : onUpdate({ ...quest, completed: !quest.completed })
+            }
+            className={cn(
+              QUEST_TOGGLE_BUTTON_CLASS,
+              quest.completed && !lockMode && "text-emerald-300",
+              questCompletedLocked && "ring-1 ring-emerald-300/35",
+            )}
+            title={
+              lockMode
+                ? questCompletedLocked
+                  ? "Unlock quest completion"
+                  : "Lock quest completion"
+                : quest.completed
+                  ? "Mark incomplete"
+                  : "Mark complete"
+            }
+            aria-label={
+              lockMode
+                ? questCompletedLocked
+                  ? "Unlock quest completion"
+                  : "Lock quest completion"
+                : quest.completed
+                  ? "Mark quest incomplete"
+                  : "Mark quest complete"
+            }
+            aria-pressed={
+              lockMode ? questCompletedLocked : undefined
+            }
           >
-            {quest.completed ? <CheckCircle2 size="0.75rem" /> : <Target size="0.75rem" />}
+            {lockMode ? (
+              questCompletedLocked ? (
+                <Lock size="0.75rem" />
+              ) : (
+                <Unlock size="0.75rem" />
+              )
+            ) : quest.completed ? (
+              <CheckCircle2 size="0.75rem" />
+            ) : (
+              <Target size="0.75rem" />
+            )}
           </button>
         )}
         {!onUpdate && (
@@ -107,12 +156,14 @@ export function QuestRow({
             showEditHint={false}
             fitPreview={!wrapsText}
             previewLineCount={previewLineCount}
-            editHintMode={wrapsText ? "overlay" : "inline"}
             className={cn(
               QUEST_TITLE_EDIT_CLASS,
               wrapsText ? QUEST_TITLE_EDIT_WRAPPED_CLASS : QUEST_TITLE_EDIT_SINGLE_LINE_CLASS,
               quest.completed && "line-through opacity-60",
             )}
+            locked={isTrackerFieldLocked(fieldLocks, questNameLockKey)}
+            lockMode={lockMode}
+            onToggleLock={() => onToggleFieldLock?.(questNameLockKey)}
           />
         ) : (
           <div
@@ -164,6 +215,8 @@ export function QuestRow({
               onToggle={onUpdate ? () => toggleObjective(index) : undefined}
               onUpdateText={onUpdate ? (text) => updateObjective(index, text) : undefined}
               onRemove={onUpdate && deleteMode ? () => removeObjective(index) : undefined}
+              textLockKey={questObjectiveTrackerLockKey(quest, questIndex, index, "text")}
+              completedLockKey={questObjectiveTrackerLockKey(quest, questIndex, index, "completed")}
             />
           ))}
           {onUpdate && addMode && (

--- a/packages/client/src/features/tracker-panel/lib/tracker-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-display.ts
@@ -10,5 +10,5 @@ export function clampNumber(value: number, min: number, max: number) {
 
 export function getNumberValueWidth(value: number) {
   const text = Number.isFinite(value) ? String(value) : "0";
-  return `${Math.min(7, Math.max(1.15, text.length + 0.35))}ch`;
+  return `${Math.min(7, Math.max(1.15, text.length + 0.1))}ch`;
 }

--- a/packages/client/src/hooks/use-game-state-patcher.ts
+++ b/packages/client/src/hooks/use-game-state-patcher.ts
@@ -11,7 +11,8 @@ export type GameStatePatchField =
   | "temperature"
   | "presentCharacters"
   | "playerStats"
-  | "personaStats";
+  | "personaStats"
+  | "fieldLocks";
 
 type GameStatePatch = Partial<Record<GameStatePatchField, unknown>>;
 type GameStatePatchTarget = {
@@ -67,6 +68,7 @@ function createEmptyGameState(chatId: string): GameState {
     recentEvents: [],
     playerStats: null,
     personaStats: null,
+    fieldLocks: null,
     createdAt: "",
   };
 }

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -13,6 +13,7 @@ import { agentKeys } from "./use-agents";
 import type { PendingCardUpdate } from "../stores/agent.store";
 import {
   applyQuestUpdatesToPlayerStats,
+  applyTrackerFieldLocksToGameStatePatch,
   BUILT_IN_AGENTS,
   createInlineThinkingStreamFilter,
   EDITABLE_CHARACTER_CARD_FIELDS,
@@ -759,10 +760,11 @@ function applyGameStatePatchToStore(
   const current = useGameStateStore.getState().current;
 
   if (current?.chatId === chatId) {
-    const merged = { ...current, ...patch, chatId, ...(anchor ?? {}) };
-    if (patch.playerStats && typeof patch.playerStats === "object" && current.playerStats) {
-      const mergedPS = { ...current.playerStats, ...(patch.playerStats as object) };
-      const patchPS = patch.playerStats as Record<string, unknown>;
+    const lockedPatch = applyTrackerFieldLocksToGameStatePatch(patch, current);
+    const merged = { ...current, ...lockedPatch, chatId, ...(anchor ?? {}) };
+    if (lockedPatch.playerStats && typeof lockedPatch.playerStats === "object" && current.playerStats) {
+      const mergedPS = { ...current.playerStats, ...(lockedPatch.playerStats as object) };
+      const patchPS = lockedPatch.playerStats as Record<string, unknown>;
       if (
         Array.isArray(patchPS.activeQuests) &&
         patchPS.activeQuests.length === 0 &&
@@ -818,7 +820,6 @@ export function useGenerate() {
   const enqueuePendingCardUpdate = useAgentStore((s) => s.enqueuePendingCardUpdate);
   const setFailedAgentFailures = useAgentStore((s) => s.setFailedAgentFailures);
   const clearFailedAgentTypes = useAgentStore((s) => s.clearFailedAgentTypes);
-  const setGameState = useGameStateStore((s) => s.setGameState);
 
   const generate = useCallback(
     async (params: {
@@ -1430,11 +1431,8 @@ export function useGenerate() {
                   };
                   const questMerge = applyQuestUpdatesToPlayerStats(existing, updates);
                   const quests = questMerge.quests;
-                  const merged = cur
-                    ? { ...cur, playerStats: questMerge.playerStats }
-                    : { playerStats: questMerge.playerStats };
                   console.warn(`[Agent] Quest merge result — activeQuests:`, quests);
-                  setGameState(merged as any);
+                  applyGameStatePatchToStore(params.chatId, { playerStats: questMerge.playerStats });
                 } else {
                   console.warn(`[Agent] Quest agent returned success but 0 updates — data shape:`, Object.keys(qd));
                 }
@@ -2300,7 +2298,6 @@ export function useGenerate() {
       enqueuePendingCardUpdate,
       clearFailedAgentTypes,
       setFailedAgentFailures,
-      setGameState,
     ],
   );
 
@@ -2462,10 +2459,7 @@ export function useGenerate() {
                       status: "",
                     };
                     const questMerge = applyQuestUpdatesToPlayerStats(existing, updates);
-                    const merged = cur
-                      ? { ...cur, playerStats: questMerge.playerStats }
-                      : { playerStats: questMerge.playerStats };
-                    setGameState(merged as any);
+                    applyGameStatePatchToStore(chatId, { playerStats: questMerge.playerStats });
                   }
                 }
               }
@@ -2597,7 +2591,6 @@ export function useGenerate() {
       setYoutubeVolume,
       setFailedAgentFailures,
       setProcessing,
-      setGameState,
       qc,
     ],
   );

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -338,6 +338,7 @@ const CREATE_TABLES: string[] = [
     recent_events TEXT NOT NULL DEFAULT '[]',
     player_stats TEXT,
     persona_stats TEXT,
+    field_locks TEXT,
     committed INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL
   )`,
@@ -530,6 +531,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   {
     table: "game_state_snapshots",
     column: "manual_overrides",
+    definition: "TEXT",
+  },
+  {
+    table: "game_state_snapshots",
+    column: "field_locks",
     definition: "TEXT",
   },
   {

--- a/packages/server/src/db/schema/game-state.ts
+++ b/packages/server/src/db/schema/game-state.ts
@@ -27,6 +27,8 @@ export const gameStateSnapshots = sqliteTable("game_state_snapshots", {
 
   /** JSON object of manually-edited fields — keys are field names, values are the user-set values. */
   manualOverrides: text("manual_overrides"),
+  /** JSON object of tracker field lock keys → enabled. */
+  fieldLocks: text("field_locks"),
 
   /** Whether this snapshot has been "committed" (user sent a follow-up message). */
   committed: integer("committed").notNull().default(0),

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -20,6 +20,9 @@ import {
   stripMacroComments,
   summariesPatchSchema,
   coerceGameStateTextValue,
+  formatCustomTrackerFieldForPrompt,
+  normalizeTrackerFieldLocks,
+  parseTrackerFieldLocks,
 } from "@marinara-engine/shared";
 import type {
   CharacterData,
@@ -313,7 +316,7 @@ function formatPeekTrackerContextBlock(args: {
       }
 
       if (hasCustomTracker && Array.isArray(stats?.customTrackerFields) && stats.customTrackerFields.length > 0) {
-        const customLines = stats.customTrackerFields.map((f: any) => `- ${f.name}: ${f.value}`);
+        const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
         trackerParts.push(wrapContent(customLines.join("\n"), "Custom Tracker", wrapFormat));
       }
     } catch {
@@ -1261,6 +1264,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     const presentCharacters = JSON.parse((row.presentCharacters as string) ?? "[]") as Array<Record<string, unknown>>;
     const playerStats = row.playerStats ? JSON.parse(row.playerStats as string) : null;
     const personaStats = row.personaStats ? JSON.parse(row.personaStats as string) : null;
+    const storedManualOverrides = row.manualOverrides ? (JSON.parse(row.manualOverrides as string) as Record<string, string>) : null;
+    const fieldLocks = parseTrackerFieldLocks(row.fieldLocks);
 
     // ── Enrich present characters with avatar paths ──
     // Match NPC names against the chat's known character cards, then fall back to stored NPC avatars on disk.
@@ -1327,7 +1332,8 @@ export async function chatsRoutes(app: FastifyInstance) {
       recentEvents: JSON.parse((row.recentEvents as string) ?? "[]"),
       playerStats,
       personaStats,
-      manualOverrides: row.manualOverrides ? JSON.parse(row.manualOverrides as string) : null,
+      manualOverrides: storedManualOverrides,
+      fieldLocks,
       createdAt: row.createdAt,
     };
   });
@@ -1355,6 +1361,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       presentCharacters: any[];
       playerStats: any;
       personaStats: any[];
+      fieldLocks: Record<string, boolean> | null;
     }> = {};
     if (body.date !== undefined) fields.date = coerceGameStateTextValue(body.date);
     if (body.time !== undefined) fields.time = coerceGameStateTextValue(body.time);
@@ -1364,6 +1371,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (body.presentCharacters !== undefined) fields.presentCharacters = body.presentCharacters as any[];
     if (body.playerStats !== undefined) fields.playerStats = body.playerStats;
     if (body.personaStats !== undefined) fields.personaStats = body.personaStats as any[];
+    if (body.fieldLocks !== undefined) fields.fieldLocks = normalizeTrackerFieldLocks(body.fieldLocks);
     // Target the same snapshot the GET endpoint returns — the one for the last
     // assistant message's active swipe — so edits persist to the row the user
     // actually sees. Falls back to updateLatest when no messages exist yet.
@@ -1425,6 +1433,7 @@ export async function chatsRoutes(app: FastifyInstance) {
           recentEvents: [],
           playerStats: (fields.playerStats as any) ?? null,
           personaStats: (fields.personaStats as any) ?? null,
+          fieldLocks: normalizeTrackerFieldLocks(fields.fieldLocks),
         },
         Object.keys(manualOverrides).length > 0 ? manualOverrides : null,
       );
@@ -2439,6 +2448,7 @@ export async function chatsRoutes(app: FastifyInstance) {
                   : typeof snapshot.personaStats === "string"
                     ? JSON.parse(snapshot.personaStats)
                     : snapshot.personaStats,
+              fieldLocks: parseTrackerFieldLocks(snapshot.fieldLocks),
               committed: (snapshot.committed as any) === 1,
             } as any,
             overrides,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -22,6 +22,7 @@ import {
   isAgentConfigDeleted,
   normalizeAgentPromptTemplateSelectionMap,
   normalizeThinkingTagPairs,
+  applyTrackerFieldLocksToGameStatePatch,
   customAgentHasCapability,
   supportsXhighReasoningEffort,
   DEFAULT_CONVERSATION_PROMPT,
@@ -165,6 +166,8 @@ import {
   appendReadableAttachmentsToContent,
   buildUserMessageRegenerationPromptFromSource,
   buildUserMessageRegenerationSourceMessage,
+  buildLockedPlayerStatsArrayPatch,
+  buildLockedPersonaTrackerPatch,
   extractImageAttachmentDataUrls,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
@@ -173,6 +176,7 @@ import {
   parseExtra,
   parseStoredGenerationParameters,
   parseGameStateRow,
+  parseSnapshotPlayerStats,
   preserveTrackerCharacterUiFields,
   prefixGroupIndividualHistorySpeakers,
   resolveActiveCharacterIds,
@@ -5317,7 +5321,12 @@ export async function generateRoutes(app: FastifyInstance) {
                           if (u.type === "location_change") updates.location = u.value;
                           if (u.type === "time_advance") updates.time = u.value;
                           if (Object.keys(updates).length > 0) {
-                            await gameStateStore.updateLatest(input.chatId, updates);
+                            const lockedUpdates = applyTrackerFieldLocksToGameStatePatch(
+                              updates,
+                              parseGameStateRow(latest as Record<string, unknown>),
+                            );
+                            await gameStateStore.updateLatest(input.chatId, lockedUpdates);
+                            Object.assign(updates, lockedUpdates);
                           }
                           // Send game_state_patch so HUD updates live
                           logger.debug("[game_state_patch] tool update_game_state: %j", updates);
@@ -5889,17 +5898,22 @@ export async function generateRoutes(app: FastifyInstance) {
                       const persistedMsg = refreshedMsg ?? savedMsg;
                       if (latestLocation && persistedMsg?.id) {
                         const persistedSwipeIndex = persistedMsg.activeSwipeIndex ?? 0;
+                        const targetSnapshot =
+                          (await gameStateStore.getByMessage(persistedMsg.id, persistedSwipeIndex)) ??
+                          baseGameStateSnapshot;
+                        const locationPatch = applyTrackerFieldLocksToGameStatePatch(
+                          { location: latestLocation },
+                          targetSnapshot ? parseGameStateRow(targetSnapshot as Record<string, unknown>) : null,
+                        );
                         await gameStateStore.updateByMessage(
                           persistedMsg.id,
                           persistedSwipeIndex,
                           input.chatId,
-                          {
-                            location: latestLocation,
-                          },
+                          locationPatch,
                           undefined,
                           { baseSnapshot: baseGameStateSnapshot },
                         );
-                        sendSseEvent(reply, { type: "game_state_patch", data: { location: latestLocation } });
+                        sendSseEvent(reply, { type: "game_state_patch", data: locationPatch });
                       }
 
                       logger.info(
@@ -6729,12 +6743,12 @@ export async function generateRoutes(app: FastifyInstance) {
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
 
                 // Build the new snapshot from agent output, falling back to previous snapshot.
-                const newDate = coerceGameStateTextValue(gs.date) ?? coerceGameStateTextValue(prevSnap?.date);
-                const newTime = coerceGameStateTextValue(gs.time) ?? coerceGameStateTextValue(prevSnap?.time);
-                const newLocation =
+                let newDate = coerceGameStateTextValue(gs.date) ?? coerceGameStateTextValue(prevSnap?.date);
+                let newTime = coerceGameStateTextValue(gs.time) ?? coerceGameStateTextValue(prevSnap?.time);
+                let newLocation =
                   coerceGameStateTextValue(gs.location) ?? coerceGameStateTextValue(prevSnap?.location);
-                const newWeather = coerceGameStateTextValue(gs.weather) ?? coerceGameStateTextValue(prevSnap?.weather);
-                const newTemperature =
+                let newWeather = coerceGameStateTextValue(gs.weather) ?? coerceGameStateTextValue(prevSnap?.weather);
+                let newTemperature =
                   coerceGameStateTextValue(gs.temperature) ?? coerceGameStateTextValue(prevSnap?.temperature);
 
                 // The world-state agent ONLY produces date/time/location/weather/temperature
@@ -6762,6 +6776,24 @@ export async function generateRoutes(app: FastifyInstance) {
                     ? JSON.parse(prevSnap.playerStats)
                     : prevSnap.playerStats
                   : null;
+                const currentGameStateForLocks = prevSnap
+                  ? parseGameStateRow(prevSnap as Record<string, unknown>)
+                  : null;
+                const lockedWorldStatePatch = applyTrackerFieldLocksToGameStatePatch(
+                  {
+                    date: newDate,
+                    time: newTime,
+                    location: newLocation,
+                    weather: newWeather,
+                    temperature: newTemperature,
+                  },
+                  currentGameStateForLocks,
+                );
+                newDate = coerceGameStateTextValue(lockedWorldStatePatch.date);
+                newTime = coerceGameStateTextValue(lockedWorldStatePatch.time);
+                newLocation = coerceGameStateTextValue(lockedWorldStatePatch.location);
+                newWeather = coerceGameStateTextValue(lockedWorldStatePatch.weather);
+                newTemperature = coerceGameStateTextValue(lockedWorldStatePatch.temperature);
                 logger.info(
                   `[generate] world-state snapshot: chars=${snapshotChars.length} (prev), personaStats=${snapshotPersonaStats ? "present" : "null"} (prev)`,
                 );
@@ -6779,6 +6811,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     recentEvents: (gs.recentEvents as string[]) ?? [],
                     playerStats: snapshotPlayerStats,
                     personaStats: snapshotPersonaStats,
+                    fieldLocks: currentGameStateForLocks?.fieldLocks ?? null,
                   },
                   null, // manual overrides are one-shot — never carry forward
                 );
@@ -6842,7 +6875,7 @@ export async function generateRoutes(app: FastifyInstance) {
             ) {
               try {
                 const ctData = result.data as Record<string, unknown>;
-                const chars = (ctData.presentCharacters as any[]) ?? [];
+                let chars = (ctData.presentCharacters as any[]) ?? [];
                 const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                 const previousCharacterSnapshot =
                   snapBeforeUpdate ??
@@ -6854,6 +6887,16 @@ export async function generateRoutes(app: FastifyInstance) {
                     : previousCharacterSnapshot.presentCharacters
                   : [];
                 preserveTrackerCharacterUiFields(chars, oldChars);
+                const characterLockState = previousCharacterSnapshot
+                  ? parseGameStateRow(previousCharacterSnapshot as Record<string, unknown>)
+                  : null;
+                const lockedCharacterPatch = applyTrackerFieldLocksToGameStatePatch(
+                  { presentCharacters: chars },
+                  characterLockState,
+                );
+                chars = Array.isArray(lockedCharacterPatch.presentCharacters)
+                  ? lockedCharacterPatch.presentCharacters
+                  : chars;
 
                 // ── Enrich with avatar paths ──
                 // 1. Match against known character records in this chat
@@ -6933,6 +6976,11 @@ export async function generateRoutes(app: FastifyInstance) {
                             | undefined) ??
                           (chatMeta.imageStyleProfileId as string | undefined) ??
                           null;
+                        const generatedAvatarPaths = new Map<string, string>();
+                        const avatarMatchKey = (character: Record<string, unknown>) =>
+                          String(character.characterId ?? character.name ?? "")
+                            .trim()
+                            .toLowerCase();
 
                         for (const npc of charsNeedingAvatars) {
                           try {
@@ -6974,27 +7022,54 @@ export async function generateRoutes(app: FastifyInstance) {
 
                             // Update the character's avatarPath and stream to client
                             npc.avatarPath = `/api/avatars/npc/${input.chatId}/${safeName}.png`;
+                            const key = avatarMatchKey(npc);
+                            if (key) generatedAvatarPaths.set(key, npc.avatarPath);
                             logger.info(`[character-tracker] Generated avatar for NPC "${npcName}"`);
                           } catch (err) {
                             logger.warn(err, '[character-tracker] Failed to generate avatar for "%s"', npc.name);
                           }
                         }
 
+                        if (generatedAvatarPaths.size === 0) return;
+
                         // Re-persist with avatar paths and notify client
+                        const latestAvatarSnapshot =
+                          (await gameStateStore.getByMessage(messageId, targetSwipeIndex)) ?? baseGameStateSnapshot;
+                        const latestAvatarState = latestAvatarSnapshot
+                          ? parseGameStateRow(latestAvatarSnapshot as Record<string, unknown>)
+                          : null;
+                        const currentCharacters = Array.isArray(latestAvatarState?.presentCharacters)
+                          ? latestAvatarState.presentCharacters
+                          : chars;
+                        const mergedAvatarCharacters = currentCharacters.map((character: any) => {
+                          const avatarPath = generatedAvatarPaths.get(avatarMatchKey(character));
+                          return avatarPath ? { ...character, avatarPath } : character;
+                        });
+                        const lockedAvatarPatch = applyTrackerFieldLocksToGameStatePatch(
+                          { presentCharacters: mergedAvatarCharacters },
+                          latestAvatarState,
+                        );
+                        const presentCharacters = Array.isArray(lockedAvatarPatch.presentCharacters)
+                          ? lockedAvatarPatch.presentCharacters
+                          : mergedAvatarCharacters;
+
                         await gameStateStore.updateByMessage(
                           messageId,
                           targetSwipeIndex,
                           input.chatId,
                           {
-                            presentCharacters: chars,
+                            presentCharacters,
                           },
                           undefined,
                           { baseSnapshot: baseGameStateSnapshot },
                         );
                         try {
-                          logger.debug("[game_state_patch] character-tracker (avatar update): %d chars", chars.length);
+                          logger.debug(
+                            "[game_state_patch] character-tracker (avatar update): %d chars",
+                            presentCharacters.length,
+                          );
                           reply.raw.write(
-                            `data: ${JSON.stringify({ type: "game_state_patch", data: { presentCharacters: chars } })}\n\n`,
+                            `data: ${JSON.stringify({ type: "game_state_patch", data: { presentCharacters } })}\n\n`,
                           );
                         } catch {
                           /* stream closed */
@@ -7086,44 +7161,33 @@ export async function generateRoutes(app: FastifyInstance) {
                   });
                   snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                 }
-                if (snap) {
-                  const updates: Record<string, unknown> = {};
-                  if (bars.length > 0) updates.personaStats = JSON.stringify(bars);
-                  // Merge status + inventory into playerStats
-                  const existingPS = snap.playerStats
-                    ? typeof snap.playerStats === "string"
-                      ? JSON.parse(snap.playerStats)
-                      : snap.playerStats
-                    : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
-                  const mergedPS = { ...existingPS };
-                  if (status) mergedPS.status = status;
-                  if (inventory.length > 0) mergedPS.inventory = inventory;
-                  updates.playerStats = JSON.stringify(mergedPS);
+                const personaPatch = buildLockedPersonaTrackerPatch({
+                  stats: bars,
+                  status,
+                  inventory,
+                  snapshot: snap,
+                  lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+                });
+                if (snap && Object.keys(personaPatch.updates).length > 0) {
                   await app.db
                     .update(gameStateSnapshotsTable)
-                    .set(updates)
+                    .set(personaPatch.updates)
                     .where(eq(gameStateSnapshotsTable.id, snap.id));
                 }
-                const patchData: Record<string, unknown> = {};
-                if (bars.length > 0) patchData.personaStats = bars;
-                if (status || inventory.length > 0) {
-                  patchData.playerStats = {
-                    status: status || undefined,
-                    inventory: inventory.length > 0 ? inventory : undefined,
-                  };
+                if (personaPatch.changed) {
+                  logger.debug("[game_state_patch] persona-stats: %j", personaPatch.patch);
+                  reply.raw.write(`data: ${JSON.stringify({ type: "game_state_patch", data: personaPatch.patch })}\n\n`);
                 }
-                logger.debug("[game_state_patch] persona-stats: %j", patchData);
-                reply.raw.write(`data: ${JSON.stringify({ type: "game_state_patch", data: patchData })}\n\n`);
 
                 // Auto-populate journal: inventory changes
-                if (inventory.length > 0) {
+                if (snap && personaPatch.inventory.length > 0) {
                   const existingInv = snap?.playerStats
                     ? typeof snap.playerStats === "string"
                       ? ((JSON.parse(snap.playerStats) as any).inventory ?? [])
                       : ((snap.playerStats as any).inventory ?? [])
                     : [];
                   const oldNames = new Set((existingInv as any[]).map((i: any) => i.name));
-                  for (const item of inventory) {
+                  for (const item of personaPatch.inventory) {
                     if (!oldNames.has(item.name)) {
                       updateJournal(app.db, input.chatId, (j) =>
                         addInventoryEntry(j, item.name, "acquired", item.quantity ?? 1),
@@ -7146,8 +7210,8 @@ export async function generateRoutes(app: FastifyInstance) {
             ) {
               try {
                 const ctData = result.data as Record<string, unknown>;
-                const fields = (ctData.fields as any[]) ?? [];
-                if (fields.length > 0) {
+                const rawFields = (ctData.fields as any[]) ?? [];
+                if (rawFields.length > 0) {
                   // Ensure a snapshot exists for this (messageId, swipeIndex)
                   let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   if (!snap) {
@@ -7156,22 +7220,24 @@ export async function generateRoutes(app: FastifyInstance) {
                     });
                     snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   }
-                  const existingPS = snap?.playerStats
-                    ? typeof snap.playerStats === "string"
-                      ? JSON.parse(snap.playerStats)
-                      : snap.playerStats
-                    : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
-                  const mergedPS = { ...existingPS, customTrackerFields: fields };
-                  if (snap) {
+                  const customTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
+                    field: "customTrackerFields",
+                    values: rawFields,
+                    snapshot: snap,
+                    lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+                  });
+                  if (snap && customTrackerPatch.changed) {
                     await app.db
                       .update(gameStateSnapshotsTable)
-                      .set({ playerStats: JSON.stringify(mergedPS) })
+                      .set({ playerStats: JSON.stringify(customTrackerPatch.playerStats) })
                       .where(eq(gameStateSnapshotsTable.id, snap.id));
                   }
-                  logger.debug("[game_state_patch] custom-tracker: %j", fields);
-                  reply.raw.write(
-                    `data: ${JSON.stringify({ type: "game_state_patch", data: { playerStats: { customTrackerFields: fields } } })}\n\n`,
-                  );
+                  if (customTrackerPatch.changed) {
+                    logger.debug("[game_state_patch] custom-tracker: %j", customTrackerPatch.values);
+                    reply.raw.write(
+                      `data: ${JSON.stringify({ type: "game_state_patch", data: customTrackerPatch.patch })}\n\n`,
+                    );
+                  }
                 }
               } catch {
                 // Non-critical
@@ -7204,28 +7270,29 @@ export async function generateRoutes(app: FastifyInstance) {
                     });
                     snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   }
-                  const existingPS = snap?.playerStats
-                    ? typeof snap.playerStats === "string"
-                      ? JSON.parse(snap.playerStats)
-                      : snap.playerStats
-                    : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
+                  const existingPS = parseSnapshotPlayerStats(snap);
                   const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates, {
                     autoRemoveFullyCompleted: true,
                   });
-                  const { quests } = questMerge;
+                  const questTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
+                    field: "activeQuests",
+                    values: questMerge.quests,
+                    snapshot: snap,
+                    lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+                    basePlayerStats: questMerge.playerStats,
+                  });
 
                   // Only persist + send if quests actually changed
-                  if (questMerge.changed) {
-                    const mergedPS = questMerge.playerStats;
+                  if (questMerge.changed && questTrackerPatch.changed) {
                     if (snap) {
                       await app.db
                         .update(gameStateSnapshotsTable)
-                        .set({ playerStats: JSON.stringify(mergedPS) })
+                        .set({ playerStats: JSON.stringify(questTrackerPatch.playerStats) })
                         .where(eq(gameStateSnapshotsTable.id, snap.id));
                     }
-                    logger.debug("[game_state_patch] quests: %j", quests);
+                    logger.debug("[game_state_patch] quests: %j", questTrackerPatch.values);
                     reply.raw.write(
-                      `data: ${JSON.stringify({ type: "game_state_patch", data: { playerStats: { activeQuests: quests } } })}\n\n`,
+                      `data: ${JSON.stringify({ type: "game_state_patch", data: questTrackerPatch.patch })}\n\n`,
                     );
 
                     // Auto-populate journal: quest updates

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -3,6 +3,7 @@ import {
   findKnownModel,
   LOCAL_SIDECAR_CONNECTION_ID,
   isClaudeAdaptiveOnlyNoSamplingModel,
+  formatCustomTrackerFieldForPrompt,
   supportsXhighReasoningEffort,
   resolveMacros,
   stripMacroComments,
@@ -195,7 +196,7 @@ function formatTrackersContextBlock(args: {
         trackerParts.push(wrapContent(statLines.join("\n"), "Stats", wrapFormat));
       }
       if (Array.isArray(stats.customTrackerFields) && stats.customTrackerFields.length > 0) {
-        const customLines = stats.customTrackerFields.map((f: any) => `- ${f.name}: ${f.value}`);
+        const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
         trackerParts.push(wrapContent(customLines.join("\n"), "Custom Tracker", wrapFormat));
       }
     } catch {

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1,9 +1,15 @@
+import { isDeepStrictEqual } from "node:util";
 import {
   PROVIDERS,
+  applyTrackerFieldLocksToGameStatePatch,
   generationParametersSchema,
   normalizeThinkingTagPairs,
+  parseTrackerFieldLocks,
+  type CharacterStat,
   type GameState,
   type GenerationParameters,
+  type InventoryItem,
+  type PlayerStats,
 } from "@marinara-engine/shared";
 import { wrapContent } from "../../services/prompt/format-engine.js";
 
@@ -29,6 +35,10 @@ export type PromptAttachment = {
   galleryId?: string | null;
 };
 
+function createEmptyPlayerStats(): PlayerStats {
+  return { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
+}
+
 const TEXT_ATTACHMENT_CHAR_LIMIT = 60_000;
 const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
 const TEXT_ATTACHMENT_EXTENSIONS = new Set([
@@ -46,6 +56,136 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function extractPatchRecord(patch: Record<string, unknown>, field: string): Record<string, unknown> | null {
+  const value = patch[field];
+  return isPlainRecord(value) ? value : null;
+}
+
+function extractPatchArray<T>(patch: Record<string, unknown>, field: string, fallback: T[]): T[] {
+  const value = patch[field];
+  return Array.isArray(value) ? (value as T[]) : fallback;
+}
+
+function extractPlayerStatsPatch(patch: Record<string, unknown>): Record<string, unknown> {
+  return extractPatchRecord(patch, "playerStats") ?? {};
+}
+
+function extractPlayerStatsPatchArray<T>(
+  patch: Record<string, unknown>,
+  field: keyof PlayerStats,
+  fallback: T[],
+): T[] {
+  const value = extractPlayerStatsPatch(patch)[field];
+  return Array.isArray(value) ? (value as T[]) : fallback;
+}
+
+type PlayerStatsArrayField = {
+  [K in keyof PlayerStats]-?: NonNullable<PlayerStats[K]> extends unknown[] ? K : never;
+}[keyof PlayerStats];
+
+export function buildLockedPlayerStatsArrayPatch<T>({
+  field,
+  values,
+  snapshot,
+  lockState,
+  basePlayerStats,
+}: {
+  field: PlayerStatsArrayField;
+  values: T[];
+  snapshot: { playerStats?: unknown } | null | undefined;
+  lockState: GameState | null | undefined;
+  basePlayerStats?: PlayerStats;
+}) {
+  const existingPlayerStats = parseSnapshotPlayerStats(snapshot);
+  const lockedPatch = applyTrackerFieldLocksToGameStatePatch({ playerStats: { [field]: values } }, lockState);
+  const lockedValues = extractPlayerStatsPatchArray<T>(lockedPatch, field, values);
+  const playerStats = { ...(basePlayerStats ?? existingPlayerStats), [field]: lockedValues };
+  const existingValues = existingPlayerStats[field];
+  const changed = !isDeepStrictEqual(lockedValues, Array.isArray(existingValues) ? existingValues : []);
+  const patch = {
+    playerStats: { [field]: lockedValues },
+  } as { playerStats: Partial<Record<PlayerStatsArrayField, T[]>> };
+  return { changed, patch, playerStats, values: lockedValues };
+}
+
+function parseSnapshotPersonaStats(snapshot: { personaStats?: unknown } | null | undefined): CharacterStat[] {
+  const raw = snapshot?.personaStats;
+  if (!raw) return [];
+  try {
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    return Array.isArray(parsed) ? (parsed as CharacterStat[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function buildLockedPersonaTrackerPatch({
+  stats,
+  status,
+  inventory,
+  snapshot,
+  lockState,
+}: {
+  stats: CharacterStat[];
+  status: string;
+  inventory: InventoryItem[];
+  snapshot: { personaStats?: unknown; playerStats?: unknown } | null | undefined;
+  lockState: GameState | null | undefined;
+}) {
+  const rawPatch: Record<string, unknown> = {};
+  if (stats.length > 0) rawPatch.personaStats = stats;
+
+  const rawPlayerStatsPatch: Record<string, unknown> = {};
+  if (status) rawPlayerStatsPatch.status = status;
+  if (inventory.length > 0) rawPlayerStatsPatch.inventory = inventory;
+  if (Object.keys(rawPlayerStatsPatch).length > 0) rawPatch.playerStats = rawPlayerStatsPatch;
+
+  const patch = applyTrackerFieldLocksToGameStatePatch(rawPatch, lockState);
+  const updates: Record<string, string> = {};
+  const existingPersonaStats = parseSnapshotPersonaStats(snapshot);
+  const existingPlayerStats = parseSnapshotPlayerStats(snapshot);
+
+  const lockedPersonaStats = extractPatchArray<CharacterStat>(patch, "personaStats", []);
+  const personaStatsChanged =
+    Array.isArray(patch.personaStats) && !isDeepStrictEqual(lockedPersonaStats, existingPersonaStats);
+  if (personaStatsChanged) updates.personaStats = JSON.stringify(lockedPersonaStats);
+
+  const lockedPlayerStatsPatch = extractPlayerStatsPatch(patch);
+  const playerStats = { ...existingPlayerStats };
+  let hasPlayerStatsPatch = false;
+  if (Object.prototype.hasOwnProperty.call(lockedPlayerStatsPatch, "status")) {
+    playerStats.status = typeof lockedPlayerStatsPatch.status === "string" ? lockedPlayerStatsPatch.status : "";
+    hasPlayerStatsPatch = true;
+  }
+  if (Array.isArray(lockedPlayerStatsPatch.inventory)) {
+    playerStats.inventory = lockedPlayerStatsPatch.inventory as InventoryItem[];
+    hasPlayerStatsPatch = true;
+  }
+
+  const playerStatsChanged = hasPlayerStatsPatch && !isDeepStrictEqual(playerStats, existingPlayerStats);
+  if (playerStatsChanged) updates.playerStats = JSON.stringify(playerStats);
+
+  return {
+    changed: personaStatsChanged || playerStatsChanged,
+    inventory: Array.isArray(lockedPlayerStatsPatch.inventory)
+      ? (lockedPlayerStatsPatch.inventory as InventoryItem[])
+      : [],
+    patch,
+    updates,
+  };
+}
+
+export function parseSnapshotPlayerStats(snapshot: { playerStats?: unknown } | null | undefined): PlayerStats {
+  const raw = snapshot?.playerStats;
+  if (!raw) return createEmptyPlayerStats();
+  try {
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    return isPlainRecord(parsed) ? (parsed as unknown as PlayerStats) : createEmptyPlayerStats();
+  } catch {
+    return createEmptyPlayerStats();
+  }
 }
 
 export function shouldAbortOnPassiveGenerationDisconnect(args: { chatMode: string; impersonate?: boolean }): boolean {
@@ -821,6 +961,11 @@ export function preserveTrackerCharacterUiFields(
 
 /** Parse game state JSON fields from a DB row. */
 export function parseGameStateRow(row: Record<string, unknown>): GameState {
+  const manualOverrides =
+    row.manualOverrides && typeof row.manualOverrides === "string"
+      ? (JSON.parse(row.manualOverrides) as Record<string, string>)
+      : null;
+  const fieldLocks = parseTrackerFieldLocks(row.fieldLocks);
   return {
     id: row.id as string,
     chatId: row.chatId as string,
@@ -835,6 +980,8 @@ export function parseGameStateRow(row: Record<string, unknown>): GameState {
     recentEvents: JSON.parse((row.recentEvents as string) ?? "[]"),
     playerStats: row.playerStats ? JSON.parse(row.playerStats as string) : null,
     personaStats: row.personaStats ? JSON.parse(row.personaStats as string) : null,
+    manualOverrides,
+    fieldLocks,
     createdAt: row.createdAt as string,
   };
 }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_AGENT_TOOLS,
   getDefaultAgentPrompt,
   applyQuestUpdatesToPlayerStats,
+  applyTrackerFieldLocksToGameStatePatch,
   getDefaultBuiltInAgentSettings,
   isAgentAvailableInChatMode,
   isAgentConfigDeleted,
@@ -45,9 +46,12 @@ import { getCharacterDescriptionWithExtensions } from "../../services/prompt/ind
 import { syncGameMapMetaPartyPosition } from "../../services/game/map-position.service.js";
 import { gameStateSnapshots as gameStateSnapshotsTable } from "../../db/schema/index.js";
 import {
+  buildLockedPlayerStatsArrayPatch,
+  buildLockedPersonaTrackerPatch,
   isMessageHiddenFromAI,
   parseExtra,
   parseGameStateRow,
+  parseSnapshotPlayerStats,
   preserveTrackerCharacterUiFields,
   resolveActiveCharacterIds,
   resolveBaseUrl,
@@ -1881,18 +1885,23 @@ async function applyRetryResultEffects(args: {
         if (gs.location != null) worldStatePatch.location = gs.location as string;
         if (gs.weather != null) worldStatePatch.weather = gs.weather as string;
         if (gs.temperature != null) worldStatePatch.temperature = gs.temperature as string;
+        const lockSnapshot = (await loadRetryTargetGameStateSnapshot()) ?? (await loadRetryBaseGameStateSnapshot());
+        const lockedWorldStatePatch = applyTrackerFieldLocksToGameStatePatch(
+          worldStatePatch,
+          lockSnapshot ? parseGameStateRow(lockSnapshot as Record<string, unknown>) : null,
+        );
         if (Object.keys(worldStatePatch).length > 0) {
           await gameStateStore.updateByMessage(
             retryMessageId,
             retrySwipeIndex,
             chatId,
-            worldStatePatch as any,
+            lockedWorldStatePatch as any,
             undefined,
             { baseSnapshot: await loadRetryBaseGameStateSnapshot() },
           );
         }
 
-        const nextLocation = typeof worldStatePatch.location === "string" ? worldStatePatch.location : null;
+        const nextLocation = typeof lockedWorldStatePatch.location === "string" ? lockedWorldStatePatch.location : null;
         const existingGameMap = (chatMeta.gameMap as GameMap | null) ?? null;
         const syncedMeta = syncGameMapMetaPartyPosition(chatMeta, nextLocation);
         const syncedGameMap = (syncedMeta.gameMap as GameMap | null) ?? null;
@@ -1902,7 +1911,7 @@ async function applyRetryResultEffects(args: {
           sendSseEvent(reply, { type: "game_map_update", data: syncedGameMap });
         }
 
-        sendSseEvent(reply, { type: "game_state_patch", data: worldStatePatch });
+        sendSseEvent(reply, { type: "game_state_patch", data: lockedWorldStatePatch });
       } catch {
         // Non-critical patching failure.
       }
@@ -1954,7 +1963,7 @@ async function applyRetryResultEffects(args: {
     ) {
       try {
         const ctData = result.data as Record<string, unknown>;
-        const presentCharacters = (ctData.presentCharacters as any[]) ?? [];
+        let presentCharacters = (ctData.presentCharacters as any[]) ?? [];
         const previousSnapshot = await loadRetryTargetGameStateSnapshot();
         let previousCharacters: any[] = [];
         if (previousSnapshot?.presentCharacters) {
@@ -1969,6 +1978,13 @@ async function applyRetryResultEffects(args: {
           }
         }
         preserveTrackerCharacterUiFields(presentCharacters, previousCharacters);
+        const lockedCharacterPatch = applyTrackerFieldLocksToGameStatePatch(
+          { presentCharacters },
+          previousSnapshot ? parseGameStateRow(previousSnapshot as Record<string, unknown>) : null,
+        );
+        presentCharacters = Array.isArray(lockedCharacterPatch.presentCharacters)
+          ? lockedCharacterPatch.presentCharacters
+          : presentCharacters;
         await gameStateStore.updateByMessage(
           retryMessageId,
           retrySwipeIndex,
@@ -1992,29 +2008,24 @@ async function applyRetryResultEffects(args: {
         const status = (psData.status as string) ?? "";
         const inventory = (psData.inventory as any[]) ?? [];
         const latest = await loadRetryTargetGameStateSnapshot();
+        const personaPatch = buildLockedPersonaTrackerPatch({
+          stats: bars,
+          status,
+          inventory,
+          snapshot: latest,
+          lockState: latest ? parseGameStateRow(latest as Record<string, unknown>) : null,
+        });
         if (latest) {
-          const updates: Record<string, unknown> = {};
-          if (bars.length > 0) updates.personaStats = JSON.stringify(bars);
-          const existingPS = latest.playerStats
-            ? typeof latest.playerStats === "string"
-              ? JSON.parse(latest.playerStats)
-              : latest.playerStats
-            : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
-          const mergedPS = { ...existingPS };
-          if (status) mergedPS.status = status;
-          if (inventory.length > 0) mergedPS.inventory = inventory;
-          updates.playerStats = JSON.stringify(mergedPS);
-          await app.db.update(gameStateSnapshotsTable).set(updates).where(eq(gameStateSnapshotsTable.id, latest.id));
+          if (Object.keys(personaPatch.updates).length > 0) {
+            await app.db
+              .update(gameStateSnapshotsTable)
+              .set(personaPatch.updates)
+              .where(eq(gameStateSnapshotsTable.id, latest.id));
+          }
         }
-        const patchData: Record<string, unknown> = {};
-        if (bars.length > 0) patchData.personaStats = bars;
-        if (status || inventory.length > 0) {
-          patchData.playerStats = {
-            status: status || undefined,
-            inventory: inventory.length > 0 ? inventory : undefined,
-          };
+        if (personaPatch.changed) {
+          sendSseEvent(reply, { type: "game_state_patch", data: personaPatch.patch });
         }
-        sendSseEvent(reply, { type: "game_state_patch", data: patchData });
       } catch {
         // Non-critical patching failure.
       }
@@ -2091,22 +2102,23 @@ async function applyRetryResultEffects(args: {
         );
         if (updates.length > 0) {
           const snap = await loadRetryTargetGameStateSnapshot();
-          const existingPS = snap?.playerStats
-            ? typeof snap.playerStats === "string"
-              ? JSON.parse(snap.playerStats)
-              : snap.playerStats
-            : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
+          const existingPS = parseSnapshotPlayerStats(snap);
           const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates);
-          const { quests } = questMerge;
-          if (questMerge.changed) {
-            const mergedPS = questMerge.playerStats;
+          const questTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
+            field: "activeQuests",
+            values: questMerge.quests,
+            snapshot: snap,
+            lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+            basePlayerStats: questMerge.playerStats,
+          });
+          if (questMerge.changed && questTrackerPatch.changed) {
             if (snap) {
               await app.db
                 .update(gameStateSnapshotsTable)
-                .set({ playerStats: JSON.stringify(mergedPS) })
+                .set({ playerStats: JSON.stringify(questTrackerPatch.playerStats) })
                 .where(eq(gameStateSnapshotsTable.id, snap.id));
             }
-            sendSseEvent(reply, { type: "game_state_patch", data: { playerStats: { activeQuests: quests } } });
+            sendSseEvent(reply, { type: "game_state_patch", data: questTrackerPatch.patch });
           }
         }
       } catch (err) {
@@ -2154,22 +2166,24 @@ async function applyRetryResultEffects(args: {
     if (result.success && result.type === "custom_tracker_update" && result.data && typeof result.data === "object") {
       try {
         const ctData = result.data as Record<string, unknown>;
-        const fields = (ctData.fields as any[]) ?? [];
-        if (fields.length > 0) {
+        const rawFields = (ctData.fields as any[]) ?? [];
+        if (rawFields.length > 0) {
           const snap = await loadRetryTargetGameStateSnapshot();
-          if (snap) {
-            const existingPS = snap.playerStats
-              ? typeof snap.playerStats === "string"
-                ? JSON.parse(snap.playerStats)
-                : snap.playerStats
-              : { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
-            const mergedPS = { ...existingPS, customTrackerFields: fields };
+          const customTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
+            field: "customTrackerFields",
+            values: rawFields,
+            snapshot: snap,
+            lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+          });
+          if (snap && customTrackerPatch.changed) {
             await app.db
               .update(gameStateSnapshotsTable)
-              .set({ playerStats: JSON.stringify(mergedPS) })
+              .set({ playerStats: JSON.stringify(customTrackerPatch.playerStats) })
               .where(eq(gameStateSnapshotsTable.id, snap.id));
           }
-          sendSseEvent(reply, { type: "game_state_patch", data: { playerStats: { customTrackerFields: fields } } });
+          if (customTrackerPatch.changed) {
+            sendSseEvent(reply, { type: "game_state_patch", data: customTrackerPatch.patch });
+          }
         }
       } catch {
         // Non-critical patching failure.

--- a/packages/server/src/services/generation/committed-tracker-context.ts
+++ b/packages/server/src/services/generation/committed-tracker-context.ts
@@ -1,4 +1,4 @@
-import { compactQuestProgressForContext } from "@marinara-engine/shared";
+import { compactQuestProgressForContext, formatCustomTrackerFieldForPrompt } from "@marinara-engine/shared";
 import { wrapContent } from "../prompt/format-engine.js";
 
 type WrapFormat = "xml" | "markdown" | "none";
@@ -129,7 +129,7 @@ export function injectCommittedTrackerContext(args: {
       }
 
       if (hasCustomTracker && Array.isArray(stats.customTrackerFields) && stats.customTrackerFields.length > 0) {
-        const customLines = stats.customTrackerFields.map((field: any) => `- ${field.name}: ${field.value}`);
+        const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
         trackerParts.push(wrapContent(customLines.join("\n"), "Custom Tracker", args.wrapFormat));
       }
     }

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -3,7 +3,11 @@
 // sections into actual content at assembly time.
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
-import { resolveCharacterScopedMacros, stripMacroComments } from "@marinara-engine/shared";
+import {
+  formatCustomTrackerFieldForPrompt,
+  resolveCharacterScopedMacros,
+  stripMacroComments,
+} from "@marinara-engine/shared";
 import type {
   CharacterMacroProfile,
   MarkerConfig,
@@ -586,7 +590,7 @@ async function expandWorldStateAgent(ctx: MarkerContext): Promise<ExpandedMarker
       statParts.push(`Stats:\n${statLines.join("\n")}`);
     }
     if (hasCustomTracker && Array.isArray(stats.customTrackerFields) && stats.customTrackerFields.length > 0) {
-      const customLines = stats.customTrackerFields.map((f: any) => `- ${f.name}: ${f.value}`);
+      const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
       statParts.push(`Custom:\n${customLines.join("\n")}`);
     }
     if (statParts.length > 0) parts.push(statParts.join("\n"));

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -5,11 +5,33 @@ import { eq, and, ne, desc, inArray } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
 import { gameStateSnapshots } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
-import { coerceGameStateTextValue, type GameState } from "@marinara-engine/shared";
+import {
+  coerceGameStateTextValue,
+  normalizeTrackerFieldLocks,
+  parseTrackerFieldLocks,
+  trackerFieldLocksAreEmpty,
+  type GameState,
+  type TrackerFieldLocks,
+} from "@marinara-engine/shared";
 
 export type GameStateVisibleAnchor = { messageId: string; swipeIndex: number };
 
 const MANUAL_OVERRIDE_FIELDS = ["date", "time", "location", "weather", "temperature"] as const;
+
+type GameStateUpdateFields = Partial<
+  Pick<
+    GameState,
+    | "date"
+    | "time"
+    | "location"
+    | "weather"
+    | "temperature"
+    | "presentCharacters"
+    | "playerStats"
+    | "personaStats"
+    | "fieldLocks"
+  >
+>;
 
 function coerceSnapshotTextFields(fields: Partial<Pick<GameState, (typeof MANUAL_OVERRIDE_FIELDS)[number]>>) {
   return {
@@ -19,6 +41,30 @@ function coerceSnapshotTextFields(fields: Partial<Pick<GameState, (typeof MANUAL
     weather: coerceGameStateTextValue(fields.weather),
     temperature: coerceGameStateTextValue(fields.temperature),
   };
+}
+
+function parseStoredManualOverrides(value: unknown): Record<string, string> | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, string>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, string>) : null;
+}
+
+function serializeManualOverrides(manualOverrides: Record<string, string> | null | undefined) {
+  return manualOverrides && Object.keys(manualOverrides).length > 0 ? JSON.stringify(manualOverrides) : null;
+}
+
+function serializeFieldLocks(fieldLocks: TrackerFieldLocks | null | undefined) {
+  const normalized = normalizeTrackerFieldLocks(fieldLocks);
+  return trackerFieldLocksAreEmpty(normalized) ? null : JSON.stringify(normalized);
 }
 
 export function createGameStateStorage(db: DB) {
@@ -206,7 +252,8 @@ export function createGameStateStorage(db: DB) {
         recentEvents: JSON.stringify(state.recentEvents),
         playerStats: state.playerStats ? JSON.stringify(state.playerStats) : null,
         personaStats: state.personaStats ? JSON.stringify(state.personaStats) : null,
-        manualOverrides: manualOverrides ? JSON.stringify(manualOverrides) : null,
+        manualOverrides: serializeManualOverrides(manualOverrides),
+        fieldLocks: serializeFieldLocks(state.fieldLocks),
         committed: state.committed ? 1 : 0,
         createdAt: now(),
       });
@@ -215,19 +262,7 @@ export function createGameStateStorage(db: DB) {
 
     async updateLatest(
       chatId: string,
-      fields: Partial<
-        Pick<
-          GameState,
-          | "date"
-          | "time"
-          | "location"
-          | "weather"
-          | "temperature"
-          | "presentCharacters"
-          | "playerStats"
-          | "personaStats"
-        >
-      >,
+      fields: GameStateUpdateFields,
       /** When true, the edited fields are also recorded as manual overrides. */
       manual?: boolean,
     ) {
@@ -254,19 +289,7 @@ export function createGameStateStorage(db: DB) {
       messageId: string,
       swipeIndex: number,
       chatId: string,
-      fields: Partial<
-        Pick<
-          GameState,
-          | "date"
-          | "time"
-          | "location"
-          | "weather"
-          | "temperature"
-          | "presentCharacters"
-          | "playerStats"
-          | "personaStats"
-        >
-      >,
+      fields: GameStateUpdateFields,
       manual?: boolean,
       options?: { baseSnapshot?: typeof gameStateSnapshots.$inferSelect | null },
     ) {
@@ -311,6 +334,7 @@ export function createGameStateStorage(db: DB) {
             ? JSON.parse(latest.personaStats)
             : latest.personaStats
           : null,
+        fieldLocks: parseTrackerFieldLocks(latest?.fieldLocks),
       };
 
       // Apply the incoming fields on top of the cloned base
@@ -322,6 +346,7 @@ export function createGameStateStorage(db: DB) {
       if (fields.presentCharacters !== undefined) baseState.presentCharacters = fields.presentCharacters as any;
       if (fields.playerStats !== undefined) baseState.playerStats = fields.playerStats as any;
       if (fields.personaStats !== undefined) baseState.personaStats = fields.personaStats as any;
+      if (fields.fieldLocks !== undefined) baseState.fieldLocks = normalizeTrackerFieldLocks(fields.fieldLocks);
 
       const manualOverrides = manual
         ? MANUAL_OVERRIDE_FIELDS.reduce<Record<string, string>>((acc, key) => {
@@ -339,19 +364,7 @@ export function createGameStateStorage(db: DB) {
     /** Internal: apply field updates + optional manual-override tracking to a snapshot row. */
     async _applyUpdate(
       row: typeof gameStateSnapshots.$inferSelect,
-      fields: Partial<
-        Pick<
-          GameState,
-          | "date"
-          | "time"
-          | "location"
-          | "weather"
-          | "temperature"
-          | "presentCharacters"
-          | "playerStats"
-          | "personaStats"
-        >
-      >,
+      fields: GameStateUpdateFields,
       manual?: boolean,
     ) {
       const updates: Record<string, unknown> = {};
@@ -365,24 +378,30 @@ export function createGameStateStorage(db: DB) {
         updates.playerStats = fields.playerStats ? JSON.stringify(fields.playerStats) : null;
       if (fields.personaStats !== undefined)
         updates.personaStats = fields.personaStats ? JSON.stringify(fields.personaStats) : null;
-      if (Object.keys(updates).length === 0) return row;
 
-      // Merge manual override tracking
       if (manual) {
-        const existing: Record<string, string> = row.manualOverrides ? JSON.parse(row.manualOverrides as string) : {};
+        const storedOverrides = parseStoredManualOverrides(row.manualOverrides) ?? {};
+
         for (const key of MANUAL_OVERRIDE_FIELDS) {
           if (fields[key] !== undefined) {
             const text = coerceGameStateTextValue(fields[key]);
             // Setting a field to null/empty removes the override so the agent can update it again
             if (!text) {
-              delete existing[key];
+              delete storedOverrides[key];
             } else {
-              existing[key] = text;
+              storedOverrides[key] = text;
             }
           }
         }
-        updates.manualOverrides = Object.keys(existing).length > 0 ? JSON.stringify(existing) : null;
+
+        updates.manualOverrides = serializeManualOverrides(storedOverrides);
       }
+
+      if (fields.fieldLocks !== undefined) {
+        updates.fieldLocks = serializeFieldLocks(fields.fieldLocks);
+      }
+
+      if (Object.keys(updates).length === 0) return row;
 
       await db.update(gameStateSnapshots).set(updates).where(eq(gameStateSnapshots.id, row.id));
       return { ...row, ...updates };

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -299,14 +299,15 @@ Schema:
 6. Track inventory faithfully. Items gained, lost, used, consumed, or traded must update immediately; unchanged items stay as they were.`,
 
   /* ────────────────────────────────────────── */
-  "custom-tracker": `Track only the user's custom fields after the latest assistant message. Current fields live in <current_game_state> under playerStats.customTrackerFields as { name, value } objects.
+  "custom-tracker": `Track only the user's custom fields after the latest assistant message. Current fields live in <current_game_state> under playerStats.customTrackerFields as { name, value, locked? } objects.
 Respond ONLY with valid JSON.
 Rules:
 1. Output ALL fields, including unchanged ones. Omitting a field deletes it.
 2. Update only values the latest narrative changes. If nothing relevant happened, keep previous values exactly.
-3. Do not add, rename, or remove fields.
-4. Values are always strings. Store numbers as strings (for example "150").
-5. Changes must be proportional and realistic.
+3. If a field is locked or marked "(locked)", copy its previous value exactly. Do not change, omit, rename, remove, or unlock locked fields.
+4. Do not add, rename, or remove fields.
+5. Values are always strings. Store numbers as strings (for example "150").
+6. Changes must be proportional and realistic.
 Schema:
 {
   "fields": [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -74,6 +74,8 @@ export * from "./utils/generation-guide.js";
 export * from "./utils/lorebook-keyword-matching.js";
 export * from "./utils/regex-safety.js";
 export * from "./utils/game-state-text.js";
+export * from "./utils/custom-tracker-fields.js";
+export * from "./utils/tracker-field-locks.js";
 export * from "./utils/chat-summary-entries.js";
 export * from "./utils/quest-state.js";
 export * from "./utils/quote-format.js";

--- a/packages/shared/src/types/game-state.ts
+++ b/packages/shared/src/types/game-state.ts
@@ -3,6 +3,8 @@
 // ──────────────────────────────────────────────
 
 /** Complete game state snapshot, linked to a message. */
+export type TrackerFieldLocks = Record<string, boolean>;
+
 export interface GameState {
   id: string;
   chatId: string;
@@ -35,6 +37,9 @@ export interface GameState {
 
   /** JSON object of manually-edited field names → values. Carried forward across agent snapshots. */
   manualOverrides?: Record<string, string> | null;
+
+  /** JSON object of tracker field lock keys → enabled. Carried forward across agent snapshots. */
+  fieldLocks?: TrackerFieldLocks | null;
 
   createdAt: string;
 }
@@ -79,6 +84,8 @@ export interface CharacterStat {
 export interface CustomTrackerField {
   name: string;
   value: string;
+  /** @deprecated Use GameState.fieldLocks for persisted per-cell tracker locks. */
+  locked?: boolean;
 }
 
 /** Player-specific stats and inventory. */

--- a/packages/shared/src/utils/custom-tracker-fields.ts
+++ b/packages/shared/src/utils/custom-tracker-fields.ts
@@ -1,0 +1,10 @@
+import type { CustomTrackerField } from "../types/game-state.js";
+
+export function formatCustomTrackerFieldForPrompt(field: unknown): string {
+  if (!field || typeof field !== "object" || Array.isArray(field)) return "- Field: ";
+  const trackerField = field as Partial<CustomTrackerField>;
+  const name = typeof trackerField.name === "string" ? trackerField.name : "Field";
+  const value = typeof trackerField.value === "string" ? trackerField.value : "";
+  const lockLabel = trackerField.locked === true ? " (locked)" : "";
+  return `- ${name}: ${value}${lockLabel}`;
+}

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -1,0 +1,487 @@
+import type {
+  CharacterStat,
+  CustomTrackerField,
+  GameState,
+  InventoryItem,
+  PlayerStats,
+  PresentCharacter,
+  QuestProgress,
+  TrackerFieldLocks,
+} from "../types/game-state.js";
+
+type WorldTrackerField = "date" | "time" | "location" | "weather" | "temperature";
+type TextCharacterField = "emoji" | "name" | "mood" | "appearance" | "outfit" | "thoughts";
+type StatField = "name" | "value" | "max";
+type InventoryField = "name" | "quantity" | "description" | "location";
+type QuestField = "name" | "completed" | "currentStage";
+type QuestObjectiveField = "text" | "completed";
+type CustomTrackerFieldKey = "name" | "value";
+
+const PLAYER_STATS_FALLBACK: PlayerStats = {
+  stats: [],
+  attributes: null,
+  skills: {},
+  inventory: [],
+  activeQuests: [],
+  status: "",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function encodeSegment(value: string | number | null | undefined) {
+  const text = String(value ?? "").trim();
+  return encodeURIComponent(text || "_").replace(/\./g, "%2E");
+}
+
+function normalizeComparableText(value: unknown) {
+  return typeof value === "string" ? value.normalize("NFKC").trim().toLowerCase().replace(/\s+/g, " ") : "";
+}
+
+export function normalizeTrackerFieldLocks(value: unknown): TrackerFieldLocks {
+  if (!isRecord(value)) return {};
+  const locks: TrackerFieldLocks = {};
+  for (const [key, enabled] of Object.entries(value)) {
+    if (!key || enabled !== true) continue;
+    locks[key] = true;
+  }
+  return locks;
+}
+
+export function parseTrackerFieldLocks(value: unknown): TrackerFieldLocks {
+  if (typeof value === "string") {
+    try {
+      return normalizeTrackerFieldLocks(JSON.parse(value));
+    } catch {
+      return {};
+    }
+  }
+  return normalizeTrackerFieldLocks(value);
+}
+
+export function trackerFieldLocksAreEmpty(locks: TrackerFieldLocks | null | undefined) {
+  return !locks || !Object.values(locks).some(Boolean);
+}
+
+export function isTrackerFieldLocked(locks: TrackerFieldLocks | null | undefined, key: string) {
+  return locks?.[key] === true;
+}
+
+export function toggleTrackerFieldLock(locks: TrackerFieldLocks | null | undefined, key: string) {
+  const next = normalizeTrackerFieldLocks(locks);
+  if (next[key]) {
+    delete next[key];
+  } else {
+    next[key] = true;
+  }
+  return next;
+}
+
+export function worldTrackerLockKey(field: WorldTrackerField) {
+  return `world.${field}`;
+}
+
+export function personaStatusTrackerLockKey() {
+  return "persona.status";
+}
+
+export function personaStatTrackerLockKey(index: number, field: StatField) {
+  return `persona.stats.${index}.${field}`;
+}
+
+export function inventoryTrackerLockKey(index: number, field: InventoryField) {
+  return `player.inventory.${index}.${field}`;
+}
+
+function characterLockRef(character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined, index: number) {
+  const id = typeof character?.characterId === "string" ? character.characterId.trim() : "";
+  if (id) return `id:${encodeSegment(id)}`;
+  const name = typeof character?.name === "string" ? character.name.trim() : "";
+  if (name) return `name:${encodeSegment(name)}`;
+  // Last-resort index locks follow position for unnamed generated rows.
+  return `index:${index}`;
+}
+
+export function characterTrackerLockKey(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  index: number,
+  field: TextCharacterField,
+) {
+  return `characters.${characterLockRef(character, index)}.${field}`;
+}
+
+export function characterStatTrackerLockKey(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  characterIndex: number,
+  statIndex: number,
+  field: StatField,
+) {
+  return `characters.${characterLockRef(character, characterIndex)}.stats.${statIndex}.${field}`;
+}
+
+export function characterCustomFieldTrackerLockKey(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  characterIndex: number,
+  fieldName: string,
+  field: CustomTrackerFieldKey,
+) {
+  return `characters.${characterLockRef(character, characterIndex)}.custom.${encodeSegment(fieldName)}.${field}`;
+}
+
+function questLockRef(quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined, index: number) {
+  const id = typeof quest?.questEntryId === "string" ? quest.questEntryId.trim() : "";
+  if (id) return `id:${encodeSegment(id)}`;
+  const name = typeof quest?.name === "string" ? quest.name.trim() : "";
+  if (name) return `name:${encodeSegment(name)}`;
+  // Last-resort index locks follow position for unnamed generated rows.
+  return `index:${index}`;
+}
+
+export function questTrackerLockKey(
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  index: number,
+  field: QuestField,
+) {
+  return `quests.${questLockRef(quest, index)}.${field}`;
+}
+
+export function questObjectiveTrackerLockKey(
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  questIndex: number,
+  objectiveIndex: number,
+  field: QuestObjectiveField,
+) {
+  return `quests.${questLockRef(quest, questIndex)}.objectives.${objectiveIndex}.${field}`;
+}
+
+export function customTrackerLockKey(index: number, field: CustomTrackerFieldKey) {
+  return `player.custom.${index}.${field}`;
+}
+
+function normalizeEffectiveTrackerFieldLocks(
+  value: TrackerFieldLocks | null | undefined,
+  currentState: GameState | null | undefined,
+) {
+  const locks = normalizeTrackerFieldLocks(value);
+  const legacyFields = currentState?.playerStats?.customTrackerFields;
+  if (!Array.isArray(legacyFields)) return locks;
+  legacyFields.forEach((field, index) => {
+    if (field?.locked === true) locks[customTrackerLockKey(index, "value")] = true;
+  });
+  return locks;
+}
+
+function hasLockWithPrefix(locks: TrackerFieldLocks, prefix: string) {
+  return Object.keys(locks).some((key) => locks[key] === true && key.startsWith(prefix));
+}
+
+function getPlayerStats(state: GameState | null | undefined): PlayerStats {
+  return state?.playerStats ?? PLAYER_STATS_FALLBACK;
+}
+
+function findCurrentCharacterIndex(
+  next: Partial<PresentCharacter>,
+  currentCharacters: PresentCharacter[],
+  fallbackIndex: number,
+) {
+  const id = typeof next.characterId === "string" ? next.characterId.trim() : "";
+  if (id) {
+    const byId = currentCharacters.findIndex((character) => character.characterId === id);
+    if (byId >= 0) return byId;
+  }
+  const name = normalizeComparableText(next.name);
+  if (name) {
+    const byName = currentCharacters.findIndex((character) => normalizeComparableText(character.name) === name);
+    if (byName >= 0) return byName;
+  }
+  return fallbackIndex < currentCharacters.length ? fallbackIndex : -1;
+}
+
+function findCurrentQuestIndex(next: Partial<QuestProgress>, currentQuests: QuestProgress[], fallbackIndex: number) {
+  const id = typeof next.questEntryId === "string" ? next.questEntryId.trim() : "";
+  if (id) {
+    const byId = currentQuests.findIndex((quest) => quest.questEntryId === id);
+    if (byId >= 0) return byId;
+  }
+  const name = normalizeComparableText(next.name);
+  if (name) {
+    const byName = currentQuests.findIndex((quest) => normalizeComparableText(quest.name) === name);
+    if (byName >= 0) return byName;
+  }
+  return fallbackIndex < currentQuests.length ? fallbackIndex : -1;
+}
+
+function findCurrentNamedIndex<T extends { name?: string }>(
+  next: Partial<T>,
+  current: T[],
+  fallbackIndex: number,
+  usedCurrent: Set<number>,
+) {
+  const name = normalizeComparableText(next.name);
+  if (name) {
+    const byName = current.findIndex((item, index) => !usedCurrent.has(index) && normalizeComparableText(item.name) === name);
+    if (byName >= 0) return byName;
+  }
+  return fallbackIndex < current.length && !usedCurrent.has(fallbackIndex) ? fallbackIndex : -1;
+}
+
+function mergeNamedRowsWithLocks<T extends { name?: string }>(
+  nextRows: T[],
+  currentRows: T[] | null | undefined,
+  locks: TrackerFieldLocks,
+  {
+    mergeRow,
+    prefixFor,
+  }: {
+    mergeRow: (nextRow: T, currentRow: T, currentIndex: number) => T;
+    prefixFor: (currentIndex: number) => string;
+  },
+) {
+  const current = currentRows ?? [];
+  const usedCurrent = new Set<number>();
+  const merged = nextRows.map((row, index) => {
+    const currentIndex = findCurrentNamedIndex(row, current, index, usedCurrent);
+    const currentRow = currentIndex >= 0 ? current[currentIndex] : null;
+    if (!currentRow) return row;
+    usedCurrent.add(currentIndex);
+    return mergeRow(row, currentRow, currentIndex);
+  });
+  for (let index = 0; index < current.length; index += 1) {
+    if (usedCurrent.has(index)) continue;
+    if (hasLockWithPrefix(locks, prefixFor(index))) merged.push(current[index]!);
+  }
+  return merged;
+}
+
+function mergeStatsWithLocks(
+  nextStats: CharacterStat[],
+  currentStats: CharacterStat[] | null | undefined,
+  locks: TrackerFieldLocks,
+  keyFor: (index: number, field: StatField) => string,
+) {
+  return mergeNamedRowsWithLocks(nextStats, currentStats, locks, {
+    mergeRow: (stat, currentStat, currentIndex) => {
+      const next = { ...stat };
+      if (isTrackerFieldLocked(locks, keyFor(currentIndex, "name"))) next.name = currentStat.name;
+      if (isTrackerFieldLocked(locks, keyFor(currentIndex, "value"))) next.value = currentStat.value;
+      if (isTrackerFieldLocked(locks, keyFor(currentIndex, "max"))) next.max = currentStat.max;
+      return next;
+    },
+    prefixFor: (index) => keyFor(index, "name").replace(/\.name$/, "."),
+  });
+}
+
+function mergeInventoryWithLocks(
+  nextItems: InventoryItem[],
+  currentItems: InventoryItem[] | null | undefined,
+  locks: TrackerFieldLocks,
+) {
+  return mergeNamedRowsWithLocks(nextItems, currentItems, locks, {
+    mergeRow: (item, currentItem, currentIndex) => {
+      const next = { ...item };
+      for (const field of ["name", "quantity", "description", "location"] as const) {
+        if (isTrackerFieldLocked(locks, inventoryTrackerLockKey(currentIndex, field))) {
+          next[field] = currentItem[field] as never;
+        }
+      }
+      return next;
+    },
+    prefixFor: (index) => `player.inventory.${index}.`,
+  });
+}
+
+function mergeCustomTrackerFieldsWithGenericLocks(
+  nextFields: CustomTrackerField[],
+  currentFields: CustomTrackerField[] | null | undefined,
+  locks: TrackerFieldLocks,
+) {
+  return mergeNamedRowsWithLocks(nextFields, currentFields, locks, {
+    mergeRow: (field, currentField, currentIndex) => {
+      const next = { ...field };
+      if (isTrackerFieldLocked(locks, customTrackerLockKey(currentIndex, "name"))) next.name = currentField.name;
+      if (isTrackerFieldLocked(locks, customTrackerLockKey(currentIndex, "value"))) next.value = currentField.value;
+      return next;
+    },
+    prefixFor: (index) => `player.custom.${index}.`,
+  });
+}
+
+function mergeQuestObjectivesWithLocks(
+  nextObjectives: QuestProgress["objectives"],
+  currentObjectives: QuestProgress["objectives"] | null | undefined,
+  locks: TrackerFieldLocks,
+  quest: QuestProgress,
+  questIndex: number,
+) {
+  const current = currentObjectives ?? [];
+  const merged = nextObjectives.map((objective, index) => {
+    const currentObjective = current[index];
+    if (!currentObjective) return objective;
+    const next = { ...objective };
+    if (isTrackerFieldLocked(locks, questObjectiveTrackerLockKey(quest, questIndex, index, "text"))) {
+      next.text = currentObjective.text;
+    }
+    if (isTrackerFieldLocked(locks, questObjectiveTrackerLockKey(quest, questIndex, index, "completed"))) {
+      next.completed = currentObjective.completed;
+    }
+    return next;
+  });
+  for (let index = nextObjectives.length; index < current.length; index += 1) {
+    const prefix = questObjectiveTrackerLockKey(quest, questIndex, index, "text").replace(/\.text$/, ".");
+    if (hasLockWithPrefix(locks, prefix)) merged.push(current[index]!);
+  }
+  return merged;
+}
+
+function mergeQuestsWithLocks(
+  nextQuests: QuestProgress[],
+  currentQuests: QuestProgress[] | null | undefined,
+  locks: TrackerFieldLocks,
+) {
+  const current = currentQuests ?? [];
+  const usedCurrent = new Set<number>();
+  const merged = nextQuests.map((quest, index) => {
+    const currentIndex = findCurrentQuestIndex(quest, current, index);
+    const currentQuest = currentIndex >= 0 ? current[currentIndex] : null;
+    if (!currentQuest) return quest;
+    usedCurrent.add(currentIndex);
+    const next = { ...quest };
+    if (isTrackerFieldLocked(locks, questTrackerLockKey(currentQuest, currentIndex, "name"))) {
+      next.name = currentQuest.name;
+    }
+    if (isTrackerFieldLocked(locks, questTrackerLockKey(currentQuest, currentIndex, "completed"))) {
+      next.completed = currentQuest.completed;
+    }
+    if (isTrackerFieldLocked(locks, questTrackerLockKey(currentQuest, currentIndex, "currentStage"))) {
+      next.currentStage = currentQuest.currentStage;
+    }
+    if (Array.isArray(next.objectives)) {
+      next.objectives = mergeQuestObjectivesWithLocks(next.objectives, currentQuest.objectives, locks, currentQuest, currentIndex);
+    }
+    return next;
+  });
+  current.forEach((quest, index) => {
+    if (usedCurrent.has(index)) return;
+    if (hasLockWithPrefix(locks, `quests.${questLockRef(quest, index)}.`)) merged.push(quest);
+  });
+  return merged;
+}
+
+function mergeCharacterCustomFieldsWithLocks(
+  nextFields: Record<string, string> | null | undefined,
+  currentFields: Record<string, string> | null | undefined,
+  locks: TrackerFieldLocks,
+  character: PresentCharacter,
+  characterIndex: number,
+): Record<string, string> | undefined {
+  let next = nextFields ? { ...nextFields } : null;
+  const current = currentFields ?? {};
+  let hasLockedField = false;
+  for (const [name, value] of Object.entries(current)) {
+    const nameLocked = isTrackerFieldLocked(
+      locks,
+      characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"),
+    );
+    const valueLocked = isTrackerFieldLocked(
+      locks,
+      characterCustomFieldTrackerLockKey(character, characterIndex, name, "value"),
+    );
+    if (nameLocked || valueLocked) {
+      hasLockedField = true;
+      const nextValue = (next ?? {})[name];
+      (next ??= {})[name] = valueLocked ? value : typeof nextValue === "string" ? nextValue : value;
+    }
+  }
+  return nextFields || hasLockedField ? (next ?? undefined) : undefined;
+}
+
+function mergeCharactersWithLocks(
+  nextCharacters: PresentCharacter[],
+  currentCharacters: PresentCharacter[] | null | undefined,
+  locks: TrackerFieldLocks,
+) {
+  const current = currentCharacters ?? [];
+  const usedCurrent = new Set<number>();
+  const merged = nextCharacters.map((character, index) => {
+    const currentIndex = findCurrentCharacterIndex(character, current, index);
+    const currentCharacter = currentIndex >= 0 ? current[currentIndex] : null;
+    if (!currentCharacter) return character;
+    usedCurrent.add(currentIndex);
+    const next = { ...character };
+    for (const field of ["emoji", "name", "mood", "appearance", "outfit", "thoughts"] as const) {
+      if (isTrackerFieldLocked(locks, characterTrackerLockKey(currentCharacter, currentIndex, field))) {
+        next[field] = currentCharacter[field] as never;
+      }
+    }
+    if (Array.isArray(next.stats)) {
+      next.stats = mergeStatsWithLocks(next.stats, currentCharacter.stats, locks, (statIndex, field) =>
+        characterStatTrackerLockKey(currentCharacter, currentIndex, statIndex, field),
+      );
+    }
+    const customFields = mergeCharacterCustomFieldsWithLocks(
+      next.customFields,
+      currentCharacter.customFields,
+      locks,
+      currentCharacter,
+      currentIndex,
+    );
+    if (customFields !== undefined) next.customFields = customFields;
+    return next;
+  });
+  current.forEach((character, index) => {
+    if (usedCurrent.has(index)) return;
+    if (hasLockWithPrefix(locks, `characters.${characterLockRef(character, index)}.`)) merged.push(character);
+  });
+  return merged;
+}
+
+export function applyTrackerFieldLocksToGameStatePatch<T extends Record<string, unknown>>(
+  patch: T,
+  currentState: GameState | null | undefined,
+  fieldLocks: TrackerFieldLocks | null | undefined = currentState?.fieldLocks,
+): T {
+  const locks = normalizeEffectiveTrackerFieldLocks(fieldLocks, currentState);
+  if (trackerFieldLocksAreEmpty(locks) || !currentState) return patch;
+
+  const next = { ...patch } as Record<string, unknown>;
+  for (const field of ["date", "time", "location", "weather", "temperature"] as const) {
+    if (field in next && isTrackerFieldLocked(locks, worldTrackerLockKey(field))) {
+      next[field] = currentState[field];
+    }
+  }
+
+  if (Array.isArray(next.presentCharacters)) {
+    next.presentCharacters = mergeCharactersWithLocks(next.presentCharacters as PresentCharacter[], currentState.presentCharacters, locks);
+  }
+
+  if (Array.isArray(next.personaStats)) {
+    next.personaStats = mergeStatsWithLocks(next.personaStats as CharacterStat[], currentState.personaStats, locks, (index, field) =>
+      personaStatTrackerLockKey(index, field),
+    );
+  }
+
+  if (isRecord(next.playerStats)) {
+    const currentPlayerStats = getPlayerStats(currentState);
+    const playerStatsPatch = { ...next.playerStats } as Partial<PlayerStats>;
+    if ("status" in playerStatsPatch && isTrackerFieldLocked(locks, personaStatusTrackerLockKey())) {
+      playerStatsPatch.status = currentPlayerStats.status;
+    }
+    if (Array.isArray(playerStatsPatch.inventory)) {
+      playerStatsPatch.inventory = mergeInventoryWithLocks(playerStatsPatch.inventory, currentPlayerStats.inventory, locks);
+    }
+    if (Array.isArray(playerStatsPatch.activeQuests)) {
+      playerStatsPatch.activeQuests = mergeQuestsWithLocks(playerStatsPatch.activeQuests, currentPlayerStats.activeQuests, locks);
+    }
+    if (Array.isArray(playerStatsPatch.customTrackerFields)) {
+      playerStatsPatch.customTrackerFields = mergeCustomTrackerFieldsWithGenericLocks(
+        playerStatsPatch.customTrackerFields,
+        currentPlayerStats.customTrackerFields,
+        locks,
+      );
+    }
+    next.playerStats = playerStatsPatch;
+  }
+
+  return next as T;
+}


### PR DESCRIPTION
## Linked issue

No linked issue yet. A feature request should be opened before this leaves draft.

## Why this change

- Users need tracker values they manually edit to stay stable when generation or tracker agents produce new game-state patches.
- Field locks need to be enforced by code, not only by prompting, so locked values survive model output that tries to overwrite them.

## What changed

- Added persisted `fieldLocks` support on game-state snapshots, stored through the existing manual-overrides payload.
- Added shared lock-key helpers and server/client lock enforcement so generated patches restore locked values before persistence, SSE streaming, or client store merges.
- Added lock controls across RoleplayHUD and Tracker Sidebar user-editable fields.
- Preserved legacy custom-tracker `locked` values and made them unlockable through the new UI.
- Fixed lock preservation for chat branching and empty locked world fields.
- Reduced repeated locked-patch extraction in generation and retry-agent routes.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/shared lint` passed.
- `pnpm --filter @marinara-engine/client lint` passed.
- `pnpm --filter @marinara-engine/client build` passed.
- `git diff --check` passed.
- `pnpm --filter @marinara-engine/server lint` and `pnpm check` are blocked by existing `packages/server/src/services/professor-mari/workspace-agent.service.ts` TypeScript errors for missing `@earendil-works/*` modules and implicit anys.
- Browser visual smoke was not completed in-session because the in-app browser target was unavailable.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No screenshots captured in-session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* **Field Locking in Tracker Widgets**: Lock individual tracker fields (character stats, inventory items, world state data, quests, objectives, custom fields) to prevent accidental modifications. Toggle lock mode in the tracker sidebar to enable per-field locking with visual lock/unlock indicators across all editable fields. Locked fields persist across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->