### PR TITLE
Unify chat chrome theming controls

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -15,6 +15,7 @@ import { useUIStore } from "./stores/ui.store";
 import { useSidecarStore } from "./stores/sidecar.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
+import { getCssColorFallback, isCssGradient } from "./lib/css-colors";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
 import { useLegacyExtensionMigration } from "./hooks/use-extensions";
 import { useSettingsSync } from "./hooks/use-settings-sync";
@@ -91,6 +92,7 @@ export function App() {
   const language = useUIStore((s) => s.language);
   const visualTheme = useUIStore((s) => s.visualTheme);
   const fontFamily = useUIStore((s) => s.fontFamily);
+  const appAccentColor = useUIStore((s) => s.appAccentColor);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
   useLegacyThemeMigration();
   useLegacyExtensionMigration();
@@ -149,6 +151,26 @@ export function App() {
     document.documentElement.dataset.theme = theme;
     document.documentElement.style.colorScheme = theme;
   }, [theme]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const accent = appAccentColor.trim();
+    if (accent) {
+      if (isCssGradient(accent)) {
+        root.style.setProperty("--marinara-chat-chrome-accent", getCssColorFallback(accent, "#d4d4d4"));
+        root.style.setProperty("--marinara-chat-chrome-accent-gradient", accent);
+        root.dataset.marinaraChatChromeAccentMode = "gradient";
+      } else {
+        root.style.setProperty("--marinara-chat-chrome-accent", accent);
+        root.style.removeProperty("--marinara-chat-chrome-accent-gradient");
+        delete root.dataset.marinaraChatChromeAccentMode;
+      }
+    } else {
+      root.style.removeProperty("--marinara-chat-chrome-accent");
+      root.style.removeProperty("--marinara-chat-chrome-accent-gradient");
+      delete root.dataset.marinaraChatChromeAccentMode;
+    }
+  }, [appAccentColor]);
 
   // Apply visual theme (default / sillytavern) to the document root
   useEffect(() => {

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -26,6 +26,7 @@ import { showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
 import { getChatDisplayName } from "../../lib/chat-display";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
+import { getChatToolbarButtonClass } from "./ChatToolbarControls";
 import {
   ROLEPLAY_POPOVER_SCROLL_AREA,
   ROLEPLAY_POPOVER_SHELL,
@@ -216,8 +217,16 @@ export function ChatBranchSelector({
 
   const branchLabel = currentBranch?.name ?? activeChatName ?? "Current branch";
   const roleplayMinimal = variant === "roleplay" && !compact;
-  const buttonClassName =
-    "marinara-chat-toolbar-button border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
+  const branchButtonSizeClassName = compact
+    ? "relative h-8 w-8"
+    : roleplayMinimal
+      ? "h-8 min-w-14"
+      : "max-w-[min(15rem,calc(100vw-9rem))]";
+  const branchButtonContentClassName = compact
+    ? undefined
+    : roleplayMinimal
+      ? "justify-start gap-1.5 px-2 py-1 text-left"
+      : "justify-start gap-2 px-2.5 py-1.5 text-left";
   const badgeClassName = "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-muted)]";
 
   return (
@@ -230,17 +239,12 @@ export function ChatBranchSelector({
           setOpen((value) => !value);
         }}
         aria-label={isLoading ? "Switch branch" : `Switch branch (${branchCount} branches)`}
-        className={cn(
-          compact
-            ? "relative flex h-8 w-8 items-center justify-center rounded-lg backdrop-blur-sm transition-colors"
-            : roleplayMinimal
-              ? "flex h-8 min-w-14 items-center gap-1.5 rounded-lg px-2 py-1 text-left backdrop-blur-sm transition-colors"
-              : "flex max-w-[min(15rem,calc(100vw-9rem))] items-center gap-2 rounded-lg px-2.5 py-1.5 text-left backdrop-blur-sm transition-colors",
-          buttonClassName,
-          open &&
-            "marinara-chat-toolbar-button--active border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]",
-          className,
-        )}
+        className={getChatToolbarButtonClass({
+          className: cn(branchButtonContentClassName, className),
+          compact,
+          open,
+          sizeClassName: branchButtonSizeClassName,
+        })}
         title="Switch branch"
       >
         <GitBranch size="0.8125rem" className="shrink-0" />

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -17,6 +17,7 @@ type ChatToolbarButtonClassInput = {
   className?: string;
   compact?: boolean;
   open?: boolean;
+  sizeClassName?: string;
 };
 
 export function getChatToolbarButtonClass({
@@ -24,9 +25,11 @@ export function getChatToolbarButtonClass({
   className,
   compact = false,
   open = false,
+  sizeClassName,
 }: ChatToolbarButtonClassInput = {}) {
   return cn(
-    "marinara-chat-toolbar-button flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
+    "marinara-chat-toolbar-button flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
+    sizeClassName ?? "h-8 w-8",
     compact ? "p-1" : "p-1.5",
     (active || open) &&
       "marinara-chat-toolbar-button--active border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]",

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -92,7 +92,9 @@ function CornerPicker({ current, onChange }: { current: EchoChamberSide; onChang
           onClick={() => onChange(c)}
           className={cn(
             "h-[0.4375rem] w-[0.4375rem] rounded-[0.09375rem] transition-colors",
-            c === current ? "bg-white/70" : "bg-white/15 hover:bg-white/30",
+            c === current
+              ? "bg-[var(--marinara-chat-chrome-button-text-hover)]"
+              : "bg-[var(--marinara-chat-chrome-highlight-bg)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)]",
           )}
           title={c.replace("-", " ")}
         />
@@ -334,7 +336,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
           </span>
           Echo
           {visibleMessages.length > 0 && (
-            <span className="ml-0.5 text-[0.5625rem] font-normal text-white/25">{visibleMessages.length}</span>
+            <span className="ml-0.5 text-[0.5625rem] font-normal text-[var(--marinara-chat-chrome-panel-muted)]">
+              {visibleMessages.length}
+            </span>
           )}
         </span>
         <div className="flex items-center gap-1.5">
@@ -351,7 +355,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
                   /* best-effort */
                 }
               }}
-              className="rounded p-0.5 text-white/20 transition-colors hover:bg-white/10 hover:text-white/50"
+              className="rounded p-0.5 text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
               title="Clear messages"
             >
               <Trash2 size="0.5625rem" />
@@ -363,7 +367,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
           </span>
           <button
             onClick={toggleEchoChamber}
-            className="rounded p-0.5 text-white/20 transition-colors hover:bg-white/10 hover:text-white/50"
+            className="rounded p-0.5 text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
           >
             <X size="0.625rem" />
           </button>
@@ -373,7 +377,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       {/* Scrollable message area */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-2 pb-1.5 scrollbar-thin">
         {visibleMessages.length === 0 ? (
-          <p className="py-1.5 text-center text-[0.625rem] text-white/25">Waiting for reactions…</p>
+          <p className="py-1.5 text-center text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)]">
+            Waiting for reactions…
+          </p>
         ) : (
           <div className="flex flex-col gap-0.5">
             {visibleMessages.map((msg, i) => (
@@ -381,8 +387,10 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
                 <span className={cn("text-[0.6875rem] font-bold", nameColorMap.get(msg.characterName))}>
                   {msg.characterName}
                 </span>
-                <span className="text-[0.6875rem] text-white/30">: </span>
-                <span className="text-[0.6875rem] leading-snug text-white/60">{msg.reaction}</span>
+                <span className="text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-muted)]">: </span>
+                <span className="text-[0.6875rem] leading-snug text-[var(--marinara-chat-chrome-panel-text)]">
+                  {msg.reaction}
+                </span>
               </div>
             ))}
           </div>

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -34,15 +34,16 @@ interface SearchResult {
 
 let ytApiPromise: Promise<void> | null = null;
 
-const MUSIC_NEUTRAL_BORDER_CLASS = "border-[oklch(0.30_0.012_145)]";
-const MUSIC_NEUTRAL_BG_CLASS = "bg-[oklch(0.16_0.006_145)]";
-const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[oklch(0.20_0.008_145)]";
-const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[oklch(0.23_0.006_145)]";
-const MUSIC_NEUTRAL_TEXT_CLASS = "text-[oklch(0.96_0.006_145)]";
-const MUSIC_NEUTRAL_MUTED_CLASS = "text-[oklch(0.72_0.012_145)]";
-const MUSIC_NEUTRAL_ICON_CLASS = "text-[oklch(0.70_0.012_145)]";
-const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[oklch(0.28_0.01_145)]";
-const MUSIC_NEUTRAL_PROGRESS_FILL_CLASS = "bg-[oklch(0.96_0.006_145)]";
+const MUSIC_NEUTRAL_BORDER_CLASS = "border-[var(--marinara-chat-chrome-panel-border)]";
+const MUSIC_NEUTRAL_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-bg)]";
+const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-bg)]";
+const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[var(--marinara-chat-chrome-highlight-bg)]";
+const MUSIC_NEUTRAL_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-title)]";
+const MUSIC_NEUTRAL_MUTED_CLASS = "text-[var(--marinara-chat-chrome-panel-muted)]";
+const MUSIC_NEUTRAL_ICON_CLASS = "text-[var(--marinara-chat-chrome-button-text)]";
+const MUSIC_NEUTRAL_ICON_HOVER_CLASS = "hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
+const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-divider)]";
+const MUSIC_NEUTRAL_PROGRESS_FILL_CLASS = "bg-[var(--marinara-chat-chrome-accent)]";
 const YOUTUBE_LOGO_CLASS = "text-[oklch(0.62_0.16_25)]";
 const MOBILE_WIDGET_COLLAPSED_SIZE = 48;
 const MOBILE_WIDGET_EXPANDED_MAX_WIDTH = 320;
@@ -92,7 +93,10 @@ function getMobileWidgetStyle(
 
 function getMobileExpandedPanelStyle(position: { x: number; y: number }): CSSProperties {
   if (typeof window === "undefined") return {};
-  const width = Math.min(MOBILE_WIDGET_EXPANDED_MAX_WIDTH, window.innerWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER);
+  const width = Math.min(
+    MOBILE_WIDGET_EXPANDED_MAX_WIDTH,
+    window.innerWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER,
+  );
   return {
     width,
     maxWidth: `calc(100vw - ${MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER}px)`,
@@ -212,9 +216,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
       setLoading(true);
       setError(null);
       try {
-        const res = await api.get<{ results: SearchResult[] }>(
-          `/youtube/search?q=${encodeURIComponent(query)}`,
-        );
+        const res = await api.get<{ results: SearchResult[] }>(`/youtube/search?q=${encodeURIComponent(query)}`);
         const top = res.results?.[0];
         if (!top) {
           if (!cancelled) setError(`No YouTube results for "${query}"`);
@@ -344,15 +346,12 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
   const compactBody = (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <MusicSourceButton
-          source="youtube"
-          className={cn(MUSIC_NEUTRAL_BORDER_CLASS, MUSIC_NEUTRAL_BUTTON_BG_CLASS)}
-        />
+        <MusicSourceButton source="youtube" className={cn(MUSIC_NEUTRAL_BORDER_CLASS, MUSIC_NEUTRAL_BUTTON_BG_CLASS)} />
         <div
           className={cn(
             "flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1",
             MUSIC_NEUTRAL_TILE_BG_CLASS,
-            "ring-[oklch(0.34_0.01_145)]",
+            "ring-[var(--marinara-chat-chrome-panel-border)]",
           )}
         >
           {loading ? (
@@ -370,16 +369,14 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
           >
             {displayTitle}
           </p>
-          <p className={cn("truncate text-[0.5625rem] leading-tight", MUSIC_NEUTRAL_MUTED_CLASS)}>
-            {displaySubtitle}
-          </p>
+          <p className={cn("truncate text-[0.5625rem] leading-tight", MUSIC_NEUTRAL_MUTED_CLASS)}>{displaySubtitle}</p>
         </div>
       </div>
       {nowPlaying && (
         <button
           type="button"
           onClick={togglePlay}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[oklch(0.96_0.006_145)] text-[oklch(0.16_0.006_145)] shadow-[0_1px_8px_rgba(255,255,255,0.10)] transition-transform hover:scale-105 active:scale-95"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--marinara-chat-chrome-button-text-active)] text-[var(--marinara-chat-chrome-panel-bg)] shadow-[0_1px_8px_rgba(255,255,255,0.10)] transition-transform hover:scale-105 active:scale-95"
           aria-label={paused ? "Play" : "Pause"}
         >
           {paused ? <Play size="0.8125rem" className="translate-x-px" /> : <Pause size="0.8125rem" />}
@@ -390,8 +387,9 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
           type="button"
           onClick={() => setShowVideo((v) => !v)}
           className={cn(
-            "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:text-[oklch(0.96_0.006_145)] active:scale-90",
+            "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors active:scale-90",
             MUSIC_NEUTRAL_ICON_CLASS,
+            MUSIC_NEUTRAL_ICON_HOVER_CLASS,
           )}
           aria-label={showVideo ? "Hide video" : "Show video"}
         >
@@ -403,8 +401,9 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
           type="button"
           onClick={close}
           className={cn(
-            "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:text-[oklch(0.96_0.006_145)] active:scale-90",
+            "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors active:scale-90",
             MUSIC_NEUTRAL_ICON_CLASS,
+            MUSIC_NEUTRAL_ICON_HOVER_CLASS,
           )}
           aria-label="Stop"
         >
@@ -420,9 +419,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
         "fixed top-14 z-40 w-[calc(100vw-1rem)] max-w-80 overflow-hidden rounded-xl border shadow-[0_18px_50px_rgba(0,0,0,0.35)] transition-opacity",
         MUSIC_NEUTRAL_BORDER_CLASS,
         MUSIC_NEUTRAL_BG_CLASS,
-        active && hasPlayerContent && showVideo
-          ? "left-2 opacity-100"
-          : "pointer-events-none -left-[9999px] opacity-0",
+        active && hasPlayerContent && showVideo ? "left-2 opacity-100" : "pointer-events-none -left-[9999px] opacity-0",
       )}
     >
       {/* The IFrame player lives here; YT injects the iframe into this host. */}
@@ -493,8 +490,9 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
                       setCollapsed(true);
                     }}
                     className={cn(
-                      "rounded-full p-1 transition-colors hover:text-[oklch(0.96_0.006_145)]",
+                      "rounded-full p-1 transition-colors",
                       MUSIC_NEUTRAL_ICON_CLASS,
+                      MUSIC_NEUTRAL_ICON_HOVER_CLASS,
                     )}
                     title="Close player"
                   >

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -20,6 +20,7 @@ import { useBackgroundAutonomousPolling } from "../../hooks/use-background-auton
 import { useClearAutonomousUnread } from "../../hooks/use-chats";
 import { useIdleDetection } from "../../hooks/use-idle-detection";
 import { usePageActivity } from "../../hooks/use-page-activity";
+import { getCssBackgroundStyle } from "../../lib/css-colors";
 import { cn } from "../../lib/utils";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { motion, AnimatePresence } from "framer-motion";
@@ -182,6 +183,9 @@ export function AppShell() {
   const trackerPanelWidth = getTrackerPanelWidthForProfile(trackerPanelSizeProfile);
   const trackerPanelHasCustomBackground =
     trackerPanelBackgroundColor.trim().toLowerCase() !== TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR;
+  const trackerPanelBackgroundStyle = trackerPanelHasCustomBackground
+    ? getCssBackgroundStyle(trackerPanelBackgroundColor)
+    : undefined;
 
   // Track mobile breakpoint for right-panel animation strategy
   const [isMobile, setIsMobile] = useState(() => typeof window !== "undefined" && window.innerWidth < 768);
@@ -684,7 +688,7 @@ export function AppShell() {
           ...(side === "left"
             ? { left: sidebarOpen ? liveSidebarWidth + RESIZER_HITBOX : 0 }
             : { right: rightPanelOpen ? liveRightPanelWidth + RESIZER_HITBOX : 0 }),
-          ...(trackerPanelHasCustomBackground ? { backgroundColor: trackerPanelBackgroundColor } : {}),
+          ...(trackerPanelBackgroundStyle ?? {}),
         }}
       >
         <div className="mari-tracker-panel-scroll max-h-[inherit] overflow-x-hidden overflow-y-auto">
@@ -825,7 +829,7 @@ export function AppShell() {
                 "mari-tracker-panel !fixed inset-y-0 z-50 w-[calc(100vw-0.5rem)] max-w-[24rem] overflow-hidden bg-zinc-950/95 pt-[env(safe-area-inset-top)] shadow-2xl ring-1 ring-zinc-700/80 backdrop-blur-xl",
                 trackerPanelSide === "left" ? "left-0" : "right-0",
               )}
-              style={trackerPanelHasCustomBackground ? { backgroundColor: trackerPanelBackgroundColor } : undefined}
+              style={trackerPanelBackgroundStyle}
             >
               <Suspense fallback={<SidePanelFallback />}>
                 <TrackerDataSidebar fillHeight />

--- a/packages/client/src/components/music/MusicSourceButton.tsx
+++ b/packages/client/src/components/music/MusicSourceButton.tsx
@@ -25,13 +25,7 @@ function YouTubeGlyph({ className }: { className?: string }) {
   );
 }
 
-export function MusicSourceGlyph({
-  source,
-  className,
-}: {
-  source: MusicPlayerSource;
-  className?: string;
-}) {
+export function MusicSourceGlyph({ source, className }: { source: MusicPlayerSource; className?: string }) {
   return source === "spotify" ? (
     <SpotifyGlyph className={cn("h-4 w-4 [--music-glyph-stroke:#06110a]", className)} />
   ) : (
@@ -39,13 +33,7 @@ export function MusicSourceGlyph({
   );
 }
 
-export function MusicSourceButton({
-  source,
-  className,
-}: {
-  source: MusicPlayerSource;
-  className?: string;
-}) {
+export function MusicSourceButton({ source, className }: { source: MusicPlayerSource; className?: string }) {
   const setMusicPlayerSource = useUIStore((s) => s.setMusicPlayerSource);
   const nextSource: MusicPlayerSource = source === "spotify" ? "youtube" : "spotify";
 
@@ -57,7 +45,7 @@ export function MusicSourceButton({
         setMusicPlayerSource(nextSource);
       }}
       className={cn(
-        "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 transition-colors hover:bg-white/10 active:scale-95",
+        "marinara-chat-toolbar-button inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] active:scale-95",
         className,
         source === "spotify" ? "text-[#1DB954]" : "text-[oklch(0.62_0.16_25)]",
       )}

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -198,7 +198,7 @@ export function AgentsPanel() {
   const [editFolderName, setEditFolderName] = useState("");
   const [draggedAgentId, setDraggedAgentId] = useState<string | null>(null);
 
-  const agentConfigRows = useMemo(() => ((agentConfigs ?? []) as AgentConfigRow[]), [agentConfigs]);
+  const agentConfigRows = useMemo(() => (agentConfigs ?? []) as AgentConfigRow[], [agentConfigs]);
   const visibleAgentConfigs = useMemo(
     () => agentConfigRows.filter((config) => !isAgentConfigDeleted(config.settings)),
     [agentConfigRows],
@@ -265,11 +265,26 @@ export function AgentsPanel() {
         }),
     )
     .sort((a, b) => a.name.localeCompare(b.name));
+  const visibleFolderAgentIds = agentFolders.flatMap((folder) => {
+    if (folder.id !== expandedFolderId) return [];
+    return folder.itemIds.filter((id) => {
+      const agent = selectableAgentById.get(id);
+      if (!agent) return false;
+      return matchesAgentSearch({
+        name: agent.name,
+        description: agent.description,
+        category: BUILT_IN_AGENT_TYPE_SET.has(agent.type)
+          ? (BUILT_IN_AGENTS.find((entry) => entry.id === agent.type)?.category ?? "misc")
+          : "custom",
+      });
+    });
+  });
   const visibleSelectableAgentIds = [
     ...visibleBuiltInAgents
       .filter((agent) => !folderedAgentIds.has(agent.id) && matchesAgentSearch(agent))
       .map((agent) => agent.id),
     ...visibleCustomAgents.map((agent) => agent.id),
+    ...visibleFolderAgentIds,
   ];
   const hasVisibleAgents =
     agentCategorySections.some((section) =>
@@ -368,8 +383,7 @@ export function AgentsPanel() {
     if (ids.length === 0) return;
     const agentNoun = ids.length === 1 ? "agent" : "agents";
     const deleteMessage =
-      `Delete ${ids.length} selected ${agentNoun}? ` +
-      "Basic agents will be hidden from the library and pickers.";
+      `Delete ${ids.length} selected ${agentNoun}? ` + "Basic agents will be hidden from the library and pickers.";
 
     if (
       !(await showConfirmDialog({
@@ -804,7 +818,8 @@ export function AgentsPanel() {
 
       {agentCategorySections.map((section) => {
         const visibleAgents = visibleBuiltInAgents.filter(
-          (agent) => !folderedAgentIds.has(agent.id) && agent.category === section.category && matchesAgentSearch(agent),
+          (agent) =>
+            !folderedAgentIds.has(agent.id) && agent.category === section.category && matchesAgentSearch(agent),
         );
         if (visibleAgents.length === 0 && agentSearchQuery) return null;
         return (

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -543,27 +543,24 @@ export function CharactersPanel() {
     [draggedCharacterId, moveCharactersToFolder],
   );
 
-  const startCharacterTouchDrag = useCallback(
-    (event: React.TouchEvent, charId: string) => {
-      const timer = window.setTimeout(() => {
-        characterTouchDragRef.current = { id: charId, timer: null, active: true };
-        suppressCharacterClickRef.current = true;
-        setDraggedCharacterId(charId);
-      }, 450);
-      characterTouchDragRef.current = { id: charId, timer, active: false };
-      event.currentTarget.addEventListener(
-        "touchcancel",
-        () => {
-          const current = characterTouchDragRef.current;
-          if (current?.timer) window.clearTimeout(current.timer);
-          characterTouchDragRef.current = null;
-          setDraggedCharacterId(null);
-        },
-        { once: true },
-      );
-    },
-    [],
-  );
+  const startCharacterTouchDrag = useCallback((event: React.TouchEvent, charId: string) => {
+    const timer = window.setTimeout(() => {
+      characterTouchDragRef.current = { id: charId, timer: null, active: true };
+      suppressCharacterClickRef.current = true;
+      setDraggedCharacterId(charId);
+    }, 450);
+    characterTouchDragRef.current = { id: charId, timer, active: false };
+    event.currentTarget.addEventListener(
+      "touchcancel",
+      () => {
+        const current = characterTouchDragRef.current;
+        if (current?.timer) window.clearTimeout(current.timer);
+        characterTouchDragRef.current = null;
+        setDraggedCharacterId(null);
+      },
+      { once: true },
+    );
+  }, []);
 
   const finishCharacterTouchDrag = useCallback(
     (event: React.TouchEvent) => {
@@ -1017,10 +1014,28 @@ export function CharactersPanel() {
                   {group.memberIds.map((memberId) => {
                     const member = charMap.get(memberId);
                     if (!member) return null;
+                    const isBulkSelected = selectedCharacterIds.has(memberId);
+                    const memberTitle = getCharacterTitle(member);
                     return (
                       <div
                         key={memberId}
-                        onClick={() => openCharacterDetail(memberId)}
+                        onClick={() => {
+                          if (suppressCharacterClickRef.current) return;
+                          if (selectionMode) {
+                            toggleSelection(memberId);
+                            return;
+                          }
+                          openCharacterDetail(memberId);
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key !== "Enter" && e.key !== " ") return;
+                          e.preventDefault();
+                          if (selectionMode) {
+                            toggleSelection(memberId);
+                            return;
+                          }
+                          openCharacterDetail(memberId);
+                        }}
                         draggable
                         onDragStart={(event) => {
                           const ids = getDraggedCharacterIds(memberId);
@@ -1045,8 +1060,32 @@ export function CharactersPanel() {
                             altGreetings: (fullMember?.parsed?.alternate_greetings ?? []) as string[],
                           });
                         }}
-                        className="group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]"
+                        role="button"
+                        tabIndex={0}
+                        className={cn(
+                          "group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]",
+                          selectionMode && isBulkSelected && "bg-[var(--primary)]/8 ring-1 ring-[var(--primary)]/40",
+                          draggedCharacterId === memberId && "opacity-50",
+                        )}
                       >
+                        {selectionMode && (
+                          <button
+                            type="button"
+                            aria-label={isBulkSelected ? "Deselect character" : "Select character"}
+                            className={cn(
+                              "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                              isBulkSelected
+                                ? "border-[var(--primary)] bg-[var(--primary)] text-white"
+                                : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                            )}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleSelection(memberId);
+                            }}
+                          >
+                            <Check size="0.75rem" />
+                          </button>
+                        )}
                         <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-pink-400 to-rose-500 text-white">
                           <div className="absolute inset-0 overflow-hidden rounded-lg">
                             {member.avatarPath ? (
@@ -1073,41 +1112,45 @@ export function CharactersPanel() {
                         </div>
                         <div className="min-w-0 flex-1">
                           <span className="block truncate text-[0.6875rem]">{member.name}</span>
-                          {getCharacterTitle(member) && (
+                          {memberTitle && (
                             <span className="block truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
-                              {getCharacterTitle(member)}
+                              {memberTitle}
                             </span>
                           )}
                         </div>
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const fullMember = parsedCharacters.find((c) => c.id === memberId);
-                            handleStartNewChat(
-                              memberId,
-                              member.name,
-                              fullMember?.parsed?.first_mes as string | undefined,
-                              (fullMember?.parsed?.alternate_greetings ?? []) as string[],
-                            );
-                          }}
-                          disabled={isStartingChat}
-                          className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--primary)]/10 hover:text-[var(--primary)] group-hover/member:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 max-md:opacity-100"
-                          title="Start New Chat"
-                          aria-label={`Start New Chat with ${member.name}`}
-                        >
-                          <MessageCircle size="0.6875rem" />
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            toggleGroupMember(group.id, memberId, group.memberIds);
-                          }}
-                          className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
-                          title="Remove from folder"
-                        >
-                          <UserMinus size="0.6875rem" className="text-[var(--destructive)]" />
-                        </button>
+                        {!selectionMode && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                const fullMember = parsedCharacters.find((c) => c.id === memberId);
+                                handleStartNewChat(
+                                  memberId,
+                                  member.name,
+                                  fullMember?.parsed?.first_mes as string | undefined,
+                                  (fullMember?.parsed?.alternate_greetings ?? []) as string[],
+                                );
+                              }}
+                              disabled={isStartingChat}
+                              className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--primary)]/10 hover:text-[var(--primary)] group-hover/member:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 max-md:opacity-100"
+                              title="Start New Chat"
+                              aria-label={`Start New Chat with ${member.name}`}
+                            >
+                              <MessageCircle size="0.6875rem" />
+                            </button>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleGroupMember(group.id, memberId, group.memberIds);
+                              }}
+                              className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
+                              title="Remove from folder"
+                            >
+                              <UserMinus size="0.6875rem" className="text-[var(--destructive)]" />
+                            </button>
+                          </>
+                        )}
                       </div>
                     );
                   })}

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -281,27 +281,24 @@ export function PersonasPanel() {
     [draggedPersonaId, movePersonasToFolder],
   );
 
-  const startPersonaTouchDrag = useCallback(
-    (event: React.TouchEvent, personaId: string) => {
-      const timer = window.setTimeout(() => {
-        personaTouchDragRef.current = { id: personaId, timer: null, active: true };
-        suppressPersonaClickRef.current = true;
-        setDraggedPersonaId(personaId);
-      }, 450);
-      personaTouchDragRef.current = { id: personaId, timer, active: false };
-      event.currentTarget.addEventListener(
-        "touchcancel",
-        () => {
-          const current = personaTouchDragRef.current;
-          if (current?.timer) window.clearTimeout(current.timer);
-          personaTouchDragRef.current = null;
-          setDraggedPersonaId(null);
-        },
-        { once: true },
-      );
-    },
-    [],
-  );
+  const startPersonaTouchDrag = useCallback((event: React.TouchEvent, personaId: string) => {
+    const timer = window.setTimeout(() => {
+      personaTouchDragRef.current = { id: personaId, timer: null, active: true };
+      suppressPersonaClickRef.current = true;
+      setDraggedPersonaId(personaId);
+    }, 450);
+    personaTouchDragRef.current = { id: personaId, timer, active: false };
+    event.currentTarget.addEventListener(
+      "touchcancel",
+      () => {
+        const current = personaTouchDragRef.current;
+        if (current?.timer) window.clearTimeout(current.timer);
+        personaTouchDragRef.current = null;
+        setDraggedPersonaId(null);
+      },
+      { once: true },
+    );
+  }, []);
 
   const finishPersonaTouchDrag = useCallback(
     (event: React.TouchEvent) => {
@@ -740,16 +737,25 @@ export function PersonasPanel() {
                       {group.memberIds.map((pid) => {
                         const p = personaMap.get(pid);
                         if (!p) return null;
+                        const isBulkSelected = selectedPersonaIds.has(pid);
                         return (
                           <div
                             key={pid}
                             onClick={() => {
                               if (suppressPersonaClickRef.current) return;
+                              if (selectionMode) {
+                                toggleSelection(pid);
+                                return;
+                              }
                               openPersonaDetail(pid);
                             }}
                             onKeyDown={(e) => {
                               if (e.key === "Enter" || e.key === " ") {
                                 e.preventDefault();
+                                if (selectionMode) {
+                                  toggleSelection(pid);
+                                  return;
+                                }
                                 openPersonaDetail(pid);
                               }
                             }}
@@ -768,9 +774,28 @@ export function PersonasPanel() {
                             tabIndex={0}
                             className={cn(
                               "group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 text-xs transition-all hover:bg-[var(--sidebar-accent)]",
+                              selectionMode && isBulkSelected && "bg-emerald-400/8 ring-1 ring-emerald-400/40",
                               draggedPersonaId === pid && "opacity-50",
                             )}
                           >
+                            {selectionMode && (
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleSelection(pid);
+                                }}
+                                className={cn(
+                                  "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                                  isBulkSelected
+                                    ? "border-emerald-400 bg-emerald-400 text-white"
+                                    : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                                )}
+                                aria-label={isBulkSelected ? "Deselect persona" : "Select persona"}
+                              >
+                                <Check size="0.75rem" />
+                              </button>
+                            )}
                             <div className="relative flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-emerald-400 to-teal-500 text-white">
                               {p.avatarPath ? (
                                 <img
@@ -784,16 +809,18 @@ export function PersonasPanel() {
                               )}
                             </div>
                             <span className="min-w-0 flex-1 truncate">{p.name}</span>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                toggleGroupMember(group.id, pid, group.memberIds);
-                              }}
-                              className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)] group-hover/member:opacity-100 max-md:opacity-100"
-                              title="Remove from folder"
-                            >
-                              <UserMinus size="0.625rem" />
-                            </button>
+                            {!selectionMode && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleGroupMember(group.id, pid, group.memberIds);
+                                }}
+                                className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)] group-hover/member:opacity-100 max-md:opacity-100"
+                                title="Remove from folder"
+                              >
+                                <UserMinus size="0.625rem" />
+                              </button>
+                            )}
                           </div>
                         );
                       })}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import {
   TRACKER_DATA_PANEL_SECTIONS,
   TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR,
   useUIStore,
+  getDefaultAppAccentColor,
   getTrackerPanelWidthForProfile,
   type ConversationMessageStyle,
   type GameDialogueDisplayMode,
@@ -840,14 +841,6 @@ function TrackerPanelAppearanceDrawer({
 }) {
   const [drawerOpen, setDrawerOpen] = useState(true);
   const drawerId = React.useId();
-  const handleTrackerPanelBackgroundColorChange = useCallback(
-    (color: string) => {
-      setTrackerPanelBackgroundColor(
-        color.trim().toLowerCase().startsWith("linear-gradient") ? TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR : color,
-      );
-    },
-    [setTrackerPanelBackgroundColor],
-  );
 
   const toggleTrackerPanel = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -933,10 +926,11 @@ function TrackerPanelAppearanceDrawer({
           <div className="mt-2">
             <ColorPicker
               value={trackerPanelBackgroundColor}
-              onChange={handleTrackerPanelBackgroundColorChange}
+              onChange={setTrackerPanelBackgroundColor}
+              gradient
               compact
               label="Panel background"
-              helpText="Pick the Tracker panel and tracker section background color. CSS color values are accepted."
+              helpText="Pick the Tracker panel and tracker section background. CSS colors and gradients are accepted."
               emptyText={`Default ${TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR}`}
               clearLabel="Reset"
             />
@@ -1718,6 +1712,8 @@ function GameAssetsSettings() {
 function AppearanceSettings() {
   const theme = useUIStore((s) => s.theme);
   const setTheme = useUIStore((s) => s.setTheme);
+  const appAccentColor = useUIStore((s) => s.appAccentColor);
+  const setAppAccentColor = useUIStore((s) => s.setAppAccentColor);
   const visualTheme = useUIStore((s) => s.visualTheme);
   const setVisualTheme = useUIStore((s) => s.setVisualTheme);
   const chatBackground = useUIStore((s) => s.chatBackground);
@@ -1934,6 +1930,16 @@ function AppearanceSettings() {
               <option value="light">Light</option>
             </select>
           </label>
+
+          <ColorPicker
+            value={appAccentColor || getDefaultAppAccentColor(theme)}
+            onChange={setAppAccentColor}
+            gradient
+            compact
+            label="Accent Color"
+            helpText="Colors the shared chat, roleplay, and game chrome: toolbar icons, button borders, focus rings, highlights, and panel outlines. Gradients unlock rainbow accents."
+            clearLabel="Use scheme default"
+          />
 
           <label className="flex flex-col gap-1">
             <span className="text-xs font-medium inline-flex items-center gap-1">
@@ -3411,6 +3417,8 @@ function ThemesSettings() {
             <strong>Tip:</strong> CSS themes can override any CSS variable (e.g.{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--background</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--primary</code>,{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-accent</code>,{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-accent-gradient</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-button-bg</code>) or add custom
             styles. JSON themes should have{" "}
             <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "css": "..." }`}</code> format.
@@ -3450,22 +3458,24 @@ const CSS_TEMPLATE = `/* ══════════════════�
   /* --sidebar: #0c0c12; */
 
   /* ── Shared Chat / Roleplay / Game Chrome ── */
+  /* --marinara-chat-chrome-accent: var(--foreground); */
+  /* --marinara-chat-chrome-accent-gradient: linear-gradient(90deg, var(--marinara-chat-chrome-accent), var(--marinara-chat-chrome-accent)); */
   /* --marinara-chat-chrome-button-bg: color-mix(in srgb, var(--card) 82%, transparent); */
   /* --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--card) 94%, var(--foreground) 6%); */
   /* --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--card) 92%, var(--foreground) 8%); */
-  /* --marinara-chat-chrome-button-border: color-mix(in srgb, var(--foreground) 12%, transparent); */
-  /* --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--foreground) 20%, transparent); */
-  /* --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--foreground) 24%, transparent); */
-  /* --marinara-chat-chrome-button-text: color-mix(in srgb, var(--foreground) 64%, transparent); */
-  /* --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--foreground) 92%, transparent); */
-  /* --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--foreground) 96%, transparent); */
+  /* --marinara-chat-chrome-button-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 12%, transparent); */
+  /* --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 20%, transparent); */
+  /* --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 24%, transparent); */
+  /* --marinara-chat-chrome-button-text: color-mix(in srgb, var(--marinara-chat-chrome-accent) 64%, transparent); */
+  /* --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 92%, transparent); */
+  /* --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 96%, transparent); */
   /* --marinara-chat-chrome-panel-bg: color-mix(in srgb, var(--background) 88%, var(--card) 12%); */
-  /* --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--foreground) 16%, transparent); */
-  /* --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--foreground) 13%, transparent); */
+  /* --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 16%, transparent); */
+  /* --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent); */
   /* --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--foreground) 90%, transparent); */
   /* --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--foreground) 58%, transparent); */
-  /* --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--foreground) 9%, transparent); */
-  /* --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--foreground) 13%, transparent); */
+  /* --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--marinara-chat-chrome-accent) 9%, transparent); */
+  /* --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent); */
 }
 
 /* Uncomment and edit the variables above.

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -136,6 +136,18 @@ const spotifyKeys = {
 
 const SPOTIFY_GREEN_CLASS = "text-[oklch(0.72_0.18_145)]";
 const SPOTIFY_GREEN_BG_CLASS = "bg-[oklch(0.72_0.18_145)]";
+const MUSIC_PLAYER_BORDER_CLASS = "border-[var(--marinara-chat-chrome-panel-border)]";
+const MUSIC_PLAYER_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-bg)]";
+const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-bg)]";
+const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[var(--marinara-chat-chrome-highlight-bg)]";
+const MUSIC_PLAYER_TILE_RING_CLASS = "ring-[var(--marinara-chat-chrome-panel-border)]";
+const MUSIC_PLAYER_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-title)]";
+const MUSIC_PLAYER_MUTED_CLASS = "text-[var(--marinara-chat-chrome-panel-muted)]";
+const MUSIC_PLAYER_ICON_CLASS = "text-[var(--marinara-chat-chrome-button-text)]";
+const MUSIC_PLAYER_ICON_HOVER_CLASS = "hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
+const MUSIC_PLAYER_ACTION_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-text-active)]";
+const MUSIC_PLAYER_ACTION_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-bg)]";
+const MUSIC_PLAYER_PROGRESS_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-divider)]";
 const REPEAT_TRACK_END_GRACE_MS = 15_000;
 const REPEAT_TRACK_REPLAY_COOLDOWN_MS = 8_000;
 const MANUAL_CONTROL_REPEAT_SUPPRESS_MS = 15_000;
@@ -751,12 +763,12 @@ export function SpotifyMiniPlayer({
   const spotifyVolumeStyle: RangeCssProperties = useMemo(
     () => ({
       "--range-progress": `${volumeDraft}%`,
-      "--range-track-color": "oklch(0.36 0.006 145)",
-      "--range-fill-color": "oklch(0.96 0.006 145)",
-      "--range-thumb-color": "oklch(0.96 0.006 145)",
+      "--range-track-color": "var(--marinara-chat-chrome-panel-divider)",
+      "--range-fill-color": "var(--marinara-chat-chrome-button-text-active)",
+      "--range-thumb-color": "var(--marinara-chat-chrome-button-text-active)",
       "--range-thumb-size": "0.6875rem",
       "--range-track-height": "0.25rem",
-      "--range-thumb-shadow": "0 0 0 0.125rem oklch(0.16 0.006 145)",
+      "--range-thumb-shadow": "0 0 0 0.125rem var(--marinara-chat-chrome-panel-bg)",
     }),
     [volumeDraft],
   );
@@ -769,7 +781,11 @@ export function SpotifyMiniPlayer({
       return (
         <button
           type="button"
-          className="flex w-full shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-left text-[oklch(0.70_0.012_145)] transition-colors hover:bg-[oklch(0.22_0.008_145)] hover:text-[oklch(0.96_0.006_145)]"
+          className={cn(
+            "flex w-full shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)]",
+            MUSIC_PLAYER_ICON_CLASS,
+            MUSIC_PLAYER_ICON_HOVER_CLASS,
+          )}
           onPointerDown={stopPointer}
           onPointerMove={stopPointer}
           onPointerUp={stopPointer}
@@ -798,7 +814,9 @@ export function SpotifyMiniPlayer({
           type="button"
           onClick={toggleMute}
           className={cn(
-            "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]",
+            "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors",
+            MUSIC_PLAYER_ICON_CLASS,
+            MUSIC_PLAYER_ICON_HOVER_CLASS,
             volumeMuted && SPOTIFY_GREEN_CLASS,
           )}
           title={volumeMuted ? "Restore volume" : "Mute"}
@@ -827,8 +845,14 @@ export function SpotifyMiniPlayer({
     () => (
       <>
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <MusicSourceButton source="spotify" className="border-[oklch(0.30_0.012_145)] bg-[oklch(0.20_0.008_145)]" />
-          <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] bg-[oklch(0.23_0.006_145)] ring-1 ring-[oklch(0.34_0.01_145)]">
+          <MusicSourceButton source="spotify" className={cn(MUSIC_PLAYER_BORDER_CLASS, MUSIC_PLAYER_BUTTON_BG_CLASS)} />
+          <div
+            className={cn(
+              "flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1",
+              MUSIC_PLAYER_TILE_BG_CLASS,
+              MUSIC_PLAYER_TILE_RING_CLASS,
+            )}
+          >
             {cover ? (
               <img src={cover} alt="" className="h-full w-full object-cover" />
             ) : (
@@ -836,10 +860,10 @@ export function SpotifyMiniPlayer({
             )}
           </div>
           <div className="min-w-0">
-            <p className="truncate text-[0.6875rem] font-semibold leading-tight text-[oklch(0.96_0.006_145)]">
+            <p className={cn("truncate text-[0.6875rem] font-semibold leading-tight", MUSIC_PLAYER_TEXT_CLASS)}>
               {title}
             </p>
-            <p className="truncate text-[0.5625rem] leading-tight text-[oklch(0.72_0.012_145)]">{subtitle}</p>
+            <p className={cn("truncate text-[0.5625rem] leading-tight", MUSIC_PLAYER_MUTED_CLASS)}>{subtitle}</p>
           </div>
         </div>
 
@@ -848,7 +872,9 @@ export function SpotifyMiniPlayer({
             type="button"
             onClick={() => handleShufflePress({ shuffle: shuffleActive, smartShuffle: smartShuffleActive, deviceId })}
             className={cn(
-              "relative inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]",
+              "relative inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+              MUSIC_PLAYER_ICON_CLASS,
+              MUSIC_PLAYER_ICON_HOVER_CLASS,
               shuffleEnabled && SPOTIFY_GREEN_CLASS,
             )}
             aria-pressed={shuffleEnabled}
@@ -859,7 +885,11 @@ export function SpotifyMiniPlayer({
           <button
             type="button"
             onClick={() => runControl.mutate({ type: "previous", deviceId })}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.82_0.01_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]"
+            className={cn(
+              "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+              MUSIC_PLAYER_ICON_CLASS,
+              MUSIC_PLAYER_ICON_HOVER_CLASS,
+            )}
             title="Previous"
           >
             <SkipBack size="0.8125rem" />
@@ -867,7 +897,11 @@ export function SpotifyMiniPlayer({
           <button
             type="button"
             onClick={() => void handlePlayPause()}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[oklch(0.96_0.006_145)] text-[oklch(0.16_0.006_145)] shadow-[0_1px_8px_rgba(29,185,84,0.18)] transition-transform hover:scale-105 active:scale-95"
+            className={cn(
+              "inline-flex h-7 w-7 items-center justify-center rounded-full shadow-[0_1px_8px_rgba(29,185,84,0.18)] transition-transform hover:scale-105 active:scale-95",
+              MUSIC_PLAYER_ACTION_BG_CLASS,
+              MUSIC_PLAYER_ACTION_TEXT_CLASS,
+            )}
             title={player?.isPlaying ? "Pause" : "Play"}
           >
             {playPauseBusy ? (
@@ -881,7 +915,11 @@ export function SpotifyMiniPlayer({
           <button
             type="button"
             onClick={() => runControl.mutate({ type: "next", deviceId })}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.82_0.01_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]"
+            className={cn(
+              "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+              MUSIC_PLAYER_ICON_CLASS,
+              MUSIC_PLAYER_ICON_HOVER_CLASS,
+            )}
             title="Next"
           >
             <SkipForward size="0.8125rem" />
@@ -890,7 +928,9 @@ export function SpotifyMiniPlayer({
             type="button"
             onClick={() => runControl.mutate({ type: "repeat", state: getNextRepeatState(repeatState), deviceId })}
             className={cn(
-              "inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]",
+              "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+              MUSIC_PLAYER_ICON_CLASS,
+              MUSIC_PLAYER_ICON_HOVER_CLASS,
               repeatState !== "off" && SPOTIFY_GREEN_CLASS,
             )}
             aria-pressed={repeatState !== "off"}
@@ -902,7 +942,11 @@ export function SpotifyMiniPlayer({
             type="button"
             onClick={() => createDjMariPlaylist.mutate()}
             disabled={createDjMariPlaylist.isPending}
-            className="inline-flex h-7 min-w-7 items-center justify-center rounded-full px-1.5 text-[0.625rem] font-black leading-none text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)] disabled:cursor-wait disabled:opacity-80"
+            className={cn(
+              "inline-flex h-7 min-w-7 items-center justify-center rounded-full px-1.5 text-[0.625rem] font-black leading-none transition-colors disabled:cursor-wait disabled:opacity-80",
+              MUSIC_PLAYER_ICON_CLASS,
+              MUSIC_PLAYER_ICON_HOVER_CLASS,
+            )}
             title="DJ Mari composes a playlist for you!"
             aria-label="DJ Mari composes a playlist for you!"
           >
@@ -914,7 +958,11 @@ export function SpotifyMiniPlayer({
               onClick={() =>
                 runControl.mutate({ type: "transfer", deviceId: sdkDeviceId, play: player?.isPlaying === true })
               }
-              className="hidden h-7 w-7 items-center justify-center rounded-full text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)] sm:inline-flex"
+              className={cn(
+                "hidden h-7 w-7 items-center justify-center rounded-full transition-colors sm:inline-flex",
+                MUSIC_PLAYER_ICON_CLASS,
+                MUSIC_PLAYER_ICON_HOVER_CLASS,
+              )}
               title="Use Marinara player"
             >
               <Laptop size="0.8125rem" />
@@ -923,7 +971,11 @@ export function SpotifyMiniPlayer({
           <button
             type="button"
             onClick={openSpotifyAgent}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[oklch(0.70_0.012_145)] transition-colors hover:text-[oklch(0.96_0.006_145)]"
+            className={cn(
+              "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+              MUSIC_PLAYER_ICON_CLASS,
+              MUSIC_PLAYER_ICON_HOVER_CLASS,
+            )}
             title="Music DJ setup"
           >
             <Settings size="0.8125rem" />
@@ -968,17 +1020,28 @@ export function SpotifyMiniPlayer({
         onPointerCancel={endDrag}
       >
         {collapsed ? (
-          <div className="flex h-12 w-12 items-center justify-center rounded-full border border-[oklch(0.30_0.012_145)] bg-[oklch(0.16_0.006_145)] text-[oklch(0.72_0.18_145)] shadow-lg backdrop-blur-xl">
+          <div
+            className={cn(
+              "flex h-12 w-12 items-center justify-center rounded-full border shadow-lg backdrop-blur-xl",
+              MUSIC_PLAYER_BORDER_CLASS,
+              MUSIC_PLAYER_BG_CLASS,
+              SPOTIFY_GREEN_CLASS,
+            )}
+          >
             <Music2 size="1.125rem" />
           </div>
         ) : (
           <div
-            className="rounded-xl border border-[oklch(0.30_0.012_145)] bg-[oklch(0.16_0.006_145)] p-2 shadow-2xl backdrop-blur-xl"
+            className={cn(
+              "rounded-xl border p-2 shadow-2xl backdrop-blur-xl",
+              MUSIC_PLAYER_BORDER_CLASS,
+              MUSIC_PLAYER_BG_CLASS,
+            )}
             style={mobileExpandedPanelStyle}
           >
             <div className="mb-1 flex items-center gap-1">
-              <GripVertical size="0.875rem" className="text-[oklch(0.70_0.012_145)]" />
-              <span className="flex-1 truncate text-[0.625rem] font-medium text-[oklch(0.70_0.012_145)]">
+              <GripVertical size="0.875rem" className={MUSIC_PLAYER_ICON_CLASS} />
+              <span className={cn("flex-1 truncate text-[0.625rem] font-medium", MUSIC_PLAYER_ICON_CLASS)}>
                 {player?.device?.name ?? "Spotify"}
               </span>
               <button
@@ -991,7 +1054,7 @@ export function SpotifyMiniPlayer({
                   event.stopPropagation();
                   setCollapsed(true);
                 }}
-                className="rounded-full p-1 text-[oklch(0.70_0.012_145)] hover:text-[oklch(0.96_0.006_145)]"
+                className={cn("rounded-full p-1", MUSIC_PLAYER_ICON_CLASS, MUSIC_PLAYER_ICON_HOVER_CLASS)}
                 title="Close player"
               >
                 <X size="0.875rem" />
@@ -1006,10 +1069,21 @@ export function SpotifyMiniPlayer({
   }
 
   return (
-    <div className="relative hidden h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border border-[oklch(0.30_0.012_145)] bg-[oklch(0.16_0.006_145)] px-2.5 md:flex">
+    <div
+      className={cn(
+        "relative hidden h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border px-2.5 md:flex",
+        MUSIC_PLAYER_BORDER_CLASS,
+        MUSIC_PLAYER_BG_CLASS,
+      )}
+    >
       {compactBody}
       <div className="hidden w-24 lg:flex">{volumeControls}</div>
-      <div className="pointer-events-none absolute bottom-0 left-3 right-3 h-px overflow-hidden rounded-full bg-[oklch(0.28_0.01_145)]">
+      <div
+        className={cn(
+          "pointer-events-none absolute bottom-0 left-3 right-3 h-px overflow-hidden rounded-full",
+          MUSIC_PLAYER_PROGRESS_BG_CLASS,
+        )}
+      >
         <div className={cn("h-full rounded-full", SPOTIFY_GREEN_BG_CLASS)} style={{ width: `${progressPercent}%` }} />
       </div>
     </div>

--- a/packages/client/src/components/ui/ColorPicker.tsx
+++ b/packages/client/src/components/ui/ColorPicker.tsx
@@ -4,6 +4,7 @@
 import { useState, useRef, useCallback, useEffect, type ReactNode } from "react";
 import { Pipette, Sparkles, X, Plus, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { isCssGradient, RAINBOW_GRADIENT_PRESET } from "../../lib/css-colors";
 
 interface ColorPickerProps {
   value: string;
@@ -50,6 +51,7 @@ const PRESETS = [
 
 /** Preset gradients */
 const GRADIENT_PRESETS = [
+  RAINBOW_GRADIENT_PRESET,
   "linear-gradient(90deg, #ff6b6b, #ffd93d)",
   "linear-gradient(90deg, #a29bfe, #fd79a8)",
   "linear-gradient(90deg, #6c5ce7, #00cec9)",
@@ -90,7 +92,7 @@ export function ColorPicker({
   clearLabel = "Clear",
   headerAction,
 }: ColorPickerProps) {
-  const isGradient = value.startsWith("linear-gradient");
+  const isGradient = isCssGradient(value);
   const [mode, setMode] = useState<"solid" | "gradient">(isGradient ? "gradient" : "solid");
   const [gradientStops, setGradientStops] = useState<string[]>(
     isGradient ? parseGradientStops(value) : ["#ff6b6b", "#ffd93d"],
@@ -102,7 +104,7 @@ export function ColorPicker({
 
   // Sync value → local state when value changes externally
   useEffect(() => {
-    if (value.startsWith("linear-gradient")) {
+    if (isCssGradient(value)) {
       setMode("gradient");
       setGradientStops(parseGradientStops(value));
       const angleMatch = value.match(/linear-gradient\((\d+)deg/);
@@ -165,7 +167,7 @@ export function ColorPicker({
   }, [onChange]);
 
   const displayStyle = value
-    ? value.startsWith("linear-gradient")
+    ? isCssGradient(value)
       ? { background: value }
       : { backgroundColor: value }
     : { backgroundColor: "transparent" };
@@ -272,7 +274,7 @@ export function ColorPicker({
                   <span
                     className="h-6 w-6 shrink-0 rounded-md ring-1 ring-[var(--border)]"
                     style={{
-                      backgroundColor: value && !value.startsWith("linear-gradient") ? value : "#6c5ce7",
+                      backgroundColor: value && !isCssGradient(value) ? value : "#6c5ce7",
                     }}
                   />
                   <span className="min-w-0 text-xs font-medium text-[var(--foreground)]">Pick color</span>
@@ -281,7 +283,7 @@ export function ColorPicker({
                     ref={nativeRef}
                     type="color"
                     aria-label={`Pick ${label} color`}
-                    value={value && !value.startsWith("linear-gradient") ? getNativeColorValue(value) : "#6c5ce7"}
+                    value={value && !isCssGradient(value) ? getNativeColorValue(value) : "#6c5ce7"}
                     onChange={(e) => handleSolidChange(e.target.value)}
                     className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                   />
@@ -291,7 +293,7 @@ export function ColorPicker({
                   <span className="block text-[0.625rem] font-medium text-[var(--muted-foreground)]">Hex / CSS</span>
                   <input
                     aria-label={`${label} hex or CSS color`}
-                    value={value && !value.startsWith("linear-gradient") ? value : ""}
+                    value={value && !isCssGradient(value) ? value : ""}
                     onChange={(e) => handleSolidChange(e.target.value)}
                     placeholder="#hex or color name"
                     className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-1.5 font-mono text-xs outline-none transition-colors focus:border-[var(--primary)]/50"
@@ -409,6 +411,7 @@ export function ColorPicker({
                         value === g && "ring-2 ring-[var(--primary)] scale-105",
                       )}
                       style={{ background: g }}
+                      title={g === RAINBOW_GRADIENT_PRESET ? "Gay RGB rainbow" : g}
                     />
                   ))}
                 </div>

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties } from "react";
 import { TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR, useUIStore } from "../../../stores/ui.store";
 import { useChatStore } from "../../../stores/chat.store";
 import { useGameStatePatcher } from "../../../hooks/use-game-state-patcher";
+import { getCssBackgroundStyle, getCssColorFallback, isCssGradient } from "../../../lib/css-colors";
 import { cn } from "../../../lib/utils";
 import { useTrackerGameState } from "../hooks/use-tracker-game-state";
 import { useTrackerPanelModel } from "../hooks/use-tracker-panel-model";
@@ -12,6 +13,7 @@ import { TrackerSidebarHeader } from "./TrackerSidebarHeader";
 
 const TRACKER_PANEL_NEUTRAL_VARS =
   "[--accent:rgb(39_39_42)] [--accent-foreground:rgb(244_244_245)] [--background:rgb(18_18_21)] [--border:rgb(63_63_70)] [--card:rgb(24_24_27)] [--foreground:rgb(244_244_245)] [--input:rgb(63_63_70)] [--muted:rgb(39_39_42)] [--muted-foreground:rgb(161_161_170)] [--popover:rgb(24_24_27)] [--popover-foreground:rgb(244_244_245)] [--primary:rgb(212_212_216)] [--primary-foreground:rgb(18_18_21)] [--ring:rgb(161_161_170)] [--secondary:rgb(39_39_42)] [--tracker-panel-card-background:color-mix(in_srgb,var(--background)_22%,transparent)] [--tracker-panel-section-background:color-mix(in_srgb,var(--card)_6%,transparent)]";
+type TrackerPanelSurfaceStyle = CSSProperties & Record<`--${string}`, string>;
 
 export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolean } = {}) {
   const activeChatId = useChatStore((s) => s.activeChatId);
@@ -53,20 +55,26 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
   const showTrackerSections = !!activeChatId && !isLoadingGameState && !!currentGameState && hasFixedTrackerPanel;
   const trackerPanelHasCustomBackground =
     trackerPanelBackgroundColor.trim().toLowerCase() !== TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR;
-  const trackerPanelSurfaceStyle = trackerPanelHasCustomBackground
-    ? ({
-        backgroundColor: trackerPanelBackgroundColor,
-        "--background": trackerPanelBackgroundColor,
-        "--card": trackerPanelBackgroundColor,
-        "--muted": `color-mix(in srgb, ${trackerPanelBackgroundColor} 82%, var(--foreground) 18%)`,
-        "--popover": trackerPanelBackgroundColor,
-        "--secondary": `color-mix(in srgb, ${trackerPanelBackgroundColor} 86%, var(--foreground) 14%)`,
-        "--tracker-card-neutral-material": `color-mix(in srgb, ${trackerPanelBackgroundColor} 90%, var(--foreground) 10%)`,
-        "--tracker-card-neutral-surface-bottom": `color-mix(in srgb, ${trackerPanelBackgroundColor} 96%, var(--foreground) 4%)`,
-        "--tracker-card-neutral-surface-top": `color-mix(in srgb, ${trackerPanelBackgroundColor} 92%, var(--foreground) 8%)`,
-        "--tracker-panel-card-background": `color-mix(in srgb, ${trackerPanelBackgroundColor} 88%, var(--foreground) 12%)`,
-        "--tracker-panel-section-background": trackerPanelBackgroundColor,
-      } as CSSProperties)
+  const trackerPanelBackgroundFallback = getCssColorFallback(
+    trackerPanelBackgroundColor,
+    TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR,
+  );
+  const trackerPanelSurfaceStyle: TrackerPanelSurfaceStyle | undefined = trackerPanelHasCustomBackground
+    ? {
+        ...getCssBackgroundStyle(trackerPanelBackgroundColor),
+        "--background": trackerPanelBackgroundFallback,
+        "--card": trackerPanelBackgroundFallback,
+        "--muted": `color-mix(in srgb, ${trackerPanelBackgroundFallback} 82%, var(--foreground) 18%)`,
+        "--popover": trackerPanelBackgroundFallback,
+        "--secondary": `color-mix(in srgb, ${trackerPanelBackgroundFallback} 86%, var(--foreground) 14%)`,
+        "--tracker-card-neutral-material": `color-mix(in srgb, ${trackerPanelBackgroundFallback} 90%, var(--foreground) 10%)`,
+        "--tracker-card-neutral-surface-bottom": `color-mix(in srgb, ${trackerPanelBackgroundFallback} 96%, var(--foreground) 4%)`,
+        "--tracker-card-neutral-surface-top": `color-mix(in srgb, ${trackerPanelBackgroundFallback} 92%, var(--foreground) 8%)`,
+        "--tracker-panel-card-background": `color-mix(in srgb, ${trackerPanelBackgroundFallback} 88%, var(--foreground) 12%)`,
+        "--tracker-panel-section-background": isCssGradient(trackerPanelBackgroundColor)
+          ? trackerPanelBackgroundColor
+          : trackerPanelBackgroundFallback,
+      }
     : undefined;
 
   return (

--- a/packages/client/src/lib/css-colors.ts
+++ b/packages/client/src/lib/css-colors.ts
@@ -1,0 +1,20 @@
+export const RAINBOW_GRADIENT_PRESET =
+  "linear-gradient(90deg, #ff4d6d, #ff9f1c, #ffe66d, #2ec4b6, #3a86ff, #8338ec, #ff4d6d)";
+
+const CSS_GRADIENT_RE = /\b(?:linear|radial|conic|repeating-linear|repeating-radial|repeating-conic)-gradient\(/i;
+const HEX_COLOR_RE = /#[0-9a-f]{3,8}\b/i;
+
+export function isCssGradient(value: string | null | undefined): value is string {
+  return typeof value === "string" && CSS_GRADIENT_RE.test(value.trim());
+}
+
+export function getCssColorFallback(value: string | null | undefined, fallback: string) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) return fallback;
+  if (!isCssGradient(trimmed)) return trimmed;
+  return trimmed.match(HEX_COLOR_RE)?.[0] ?? fallback;
+}
+
+export function getCssBackgroundStyle(value: string) {
+  return isCssGradient(value) ? { background: value } : { backgroundColor: value };
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -82,6 +82,8 @@ export const TRACKER_PANEL_WIDTH_DEFAULT = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.sta
 export const TRACKER_PANEL_WIDTH_MIN = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.compact;
 export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expanded;
 export const TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR = "#09090b";
+export const DEFAULT_APP_ACCENT_DARK = "#d4d4d4";
+export const DEFAULT_APP_ACCENT_LIGHT = "#1a1025";
 const IMAGE_DIMENSION_MIN = 64;
 const IMAGE_DIMENSION_MAX = 4096;
 const GAME_SETUP_LEARNED_LIMIT = 60;
@@ -117,6 +119,14 @@ const DEFAULT_SUMMARY_POPOVER_SETTINGS: SummaryPopoverSettings = {
   hideSummarisedMessages: false,
   collapseHiddenMessages: false,
 };
+
+export function getDefaultAppAccentColor(theme: "dark" | "light") {
+  return theme === "light" ? DEFAULT_APP_ACCENT_LIGHT : DEFAULT_APP_ACCENT_DARK;
+}
+
+function normalizeAppAccentColor(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
 
 function clampImageDimension(value: number) {
   const rounded = Number.isFinite(value) ? Math.round(value) : 0;
@@ -286,6 +296,7 @@ interface UIState {
   settingsTab: string;
   modal: { type: string; props?: Record<string, unknown> } | null;
   theme: "dark" | "light";
+  appAccentColor: string;
   chatBackground: string | null;
   /** Native blur applied to selected chat/game background images, in px. */
   chatBackgroundBlur: number;
@@ -540,6 +551,7 @@ interface UIState {
   openModal: (type: string, props?: Record<string, unknown>) => void;
   closeModal: () => void;
   setTheme: (theme: "dark" | "light") => void;
+  setAppAccentColor: (color: string) => void;
   setChatBackground: (url: string | null) => void;
   setChatBackgroundBlur: (v: number) => void;
   openCharacterDetail: (id: string) => void;
@@ -719,6 +731,7 @@ export function pickSyncedSettings(state: UIState) {
     trackerPanelCollapsedSections: state.trackerPanelCollapsedSections,
     trackerPanelSectionOrder: state.trackerPanelSectionOrder,
     theme: state.theme,
+    appAccentColor: state.appAccentColor,
     chatBackground: state.chatBackground,
     chatBackgroundBlur: state.chatBackgroundBlur,
     language: state.language,
@@ -836,6 +849,7 @@ export const useUIStore = create<UIState>()(
       settingsTab: "general",
       modal: null,
       theme: "dark" as const,
+      appAccentColor: "",
       chatBackground: null,
       chatBackgroundBlur: 0,
       characterDetailId: null,
@@ -1025,6 +1039,7 @@ export const useUIStore = create<UIState>()(
       openModal: (type, props) => set({ modal: { type, props } }),
       closeModal: () => set({ modal: null }),
       setTheme: (theme) => set({ theme }),
+      setAppAccentColor: (color) => set({ appAccentColor: normalizeAppAccentColor(color) }),
       setChatBackground: (url) => set({ chatBackground: url }),
       setChatBackgroundBlur: (v) => set({ chatBackgroundBlur: Math.max(0, Math.min(24, Math.round(v))) }),
       openCharacterDetail: (id) =>
@@ -1492,7 +1507,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 45,
+      version: 46,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1863,6 +1878,10 @@ export const useUIStore = create<UIState>()(
           persisted.spotifyPlayerEnabled = persisted.musicPlayerEnabled && persisted.musicPlayerSource === "spotify";
           persisted.youtubePlayerEnabled = persisted.musicPlayerEnabled && persisted.musicPlayerSource === "youtube";
         }
+        if (version <= 45) {
+          persisted.appAccentColor = normalizeAppAccentColor(persisted.appAccentColor);
+        }
+        persisted.appAccentColor = normalizeAppAccentColor(persisted.appAccentColor);
         delete persisted.trackerPanelWidth;
         return persisted;
       },
@@ -1883,6 +1902,7 @@ export const useUIStore = create<UIState>()(
         trackerPanelCollapsedSections: state.trackerPanelCollapsedSections,
         trackerPanelSectionOrder: state.trackerPanelSectionOrder,
         theme: state.theme,
+        appAccentColor: state.appAccentColor,
         chatBackground: state.chatBackground,
         chatBackgroundBlur: state.chatBackgroundBlur,
         fontSize: state.fontSize,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -55,6 +55,8 @@
    QUICK CUSTOMIZATION GUIDE
    ─────────────────────────
    • Change the app's accent color → edit --primary in §2
+   • Change chat toolbar/panel accents → edit --marinara-chat-chrome-accent in §2
+   • Change rainbow chrome accents → edit --marinara-chat-chrome-accent-gradient in §2
    • Change the background color   → edit --background in §2
    • Change the font               → edit --font-y2k in §2
    • Change the cursor SVG         → edit --cursor-pink in §2
@@ -79,6 +81,8 @@
      --sidebar-*                        Left & right sidebar tones
      --glow-primary, --glow-accent      Glow effect bases
      --marinara-chat-chrome-*           Shared chat/game top buttons, panels, highlights
+     --marinara-chat-chrome-accent      Shared chrome icon, border, ring, and highlight color
+     --marinara-chat-chrome-accent-gradient  Optional gradient for rainbow chrome accents
 
    PALETTE (decorative flavor — components should NOT reference these
    directly; they exist for the CSS effects layer and user customization):
@@ -198,29 +202,35 @@
   --glow-accent: rgba(212, 173, 252, 0.12);
 
   /* Theme hooks for shared chat, roleplay, and game chrome. */
+  --marinara-chat-chrome-accent: var(--foreground);
+  --marinara-chat-chrome-accent-gradient: linear-gradient(
+    90deg,
+    var(--marinara-chat-chrome-accent),
+    var(--marinara-chat-chrome-accent)
+  );
   --marinara-chat-chrome-button-bg: color-mix(in srgb, var(--card) 82%, transparent);
   --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--card) 94%, var(--foreground) 6%);
   --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--card) 92%, var(--foreground) 8%);
-  --marinara-chat-chrome-button-border: color-mix(in srgb, var(--foreground) 12%, transparent);
-  --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--foreground) 20%, transparent);
-  --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--foreground) 24%, transparent);
-  --marinara-chat-chrome-button-text: color-mix(in srgb, var(--foreground) 64%, transparent);
-  --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--foreground) 92%, transparent);
-  --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--foreground) 96%, transparent);
-  --marinara-chat-chrome-focus-ring: color-mix(in srgb, var(--foreground) 22%, transparent);
+  --marinara-chat-chrome-button-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 12%, transparent);
+  --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 20%, transparent);
+  --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 24%, transparent);
+  --marinara-chat-chrome-button-text: color-mix(in srgb, var(--marinara-chat-chrome-accent) 64%, transparent);
+  --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 92%, transparent);
+  --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 96%, transparent);
+  --marinara-chat-chrome-focus-ring: color-mix(in srgb, var(--marinara-chat-chrome-accent) 22%, transparent);
   --marinara-chat-chrome-panel-bg: color-mix(in srgb, var(--background) 88%, var(--card) 12%);
-  --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--foreground) 16%, transparent);
-  --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--foreground) 13%, transparent);
+  --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 16%, transparent);
+  --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent);
   --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--foreground) 90%, transparent);
   --marinara-chat-chrome-panel-title: color-mix(in srgb, var(--foreground) 96%, transparent);
   --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--foreground) 58%, transparent);
-  --marinara-chat-chrome-panel-scrollbar: color-mix(in srgb, var(--foreground) 22%, transparent);
-  --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--foreground) 9%, transparent);
-  --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--foreground) 13%, transparent);
-  --marinara-chat-chrome-highlight-text: color-mix(in srgb, var(--foreground) 94%, transparent);
+  --marinara-chat-chrome-panel-scrollbar: color-mix(in srgb, var(--marinara-chat-chrome-accent) 22%, transparent);
+  --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--marinara-chat-chrome-accent) 9%, transparent);
+  --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent);
+  --marinara-chat-chrome-highlight-text: color-mix(in srgb, var(--marinara-chat-chrome-accent) 94%, transparent);
   --marinara-chat-chrome-input-bg: color-mix(in srgb, var(--background) 78%, var(--card) 22%);
-  --marinara-chat-chrome-input-border: color-mix(in srgb, var(--foreground) 14%, transparent);
-  --marinara-chat-chrome-input-border-focus: color-mix(in srgb, var(--foreground) 30%, transparent);
+  --marinara-chat-chrome-input-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 14%, transparent);
+  --marinara-chat-chrome-input-border-focus: color-mix(in srgb, var(--marinara-chat-chrome-accent) 30%, transparent);
 
   --tracker-card-neutral-surface-top: color-mix(
     in srgb,
@@ -457,6 +467,36 @@
 }
 
 /* ─────────────────────────────────────────────
+   4a. SHARED CHROME GRADIENT ACCENTS
+   ───────────────────────────────────────────── */
+[data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button {
+  border-color: transparent;
+  background:
+    linear-gradient(var(--marinara-chat-chrome-button-bg), var(--marinara-chat-chrome-button-bg)) padding-box,
+    var(--marinara-chat-chrome-accent-gradient) border-box;
+}
+
+[data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button:hover {
+  background:
+    linear-gradient(var(--marinara-chat-chrome-button-bg-hover), var(--marinara-chat-chrome-button-bg-hover))
+      padding-box,
+    var(--marinara-chat-chrome-accent-gradient) border-box;
+}
+
+[data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button--active {
+  border-color: transparent;
+  background: var(--marinara-chat-chrome-accent-gradient);
+  color: oklch(0.17 0.02 300);
+}
+
+[data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-popover {
+  border-color: transparent;
+  background:
+    linear-gradient(var(--marinara-chat-chrome-panel-bg), var(--marinara-chat-chrome-panel-bg)) padding-box,
+    var(--marinara-chat-chrome-accent-gradient) border-box;
+}
+
+/* ─────────────────────────────────────────────
    5. BASE RESET & BODY
    ───────────────────────────────────────────── */
 * {
@@ -566,39 +606,39 @@ input[type="range"]:disabled {
 }
 
 input[type="range"].mari-spotify-volume-slider {
-  --range-track-color: oklch(0.36 0.006 145);
-  --range-fill-color: oklch(0.96 0.006 145);
-  --range-thumb-color: oklch(0.96 0.006 145);
+  --range-track-color: var(--marinara-chat-chrome-panel-divider);
+  --range-fill-color: var(--marinara-chat-chrome-button-text-active);
+  --range-thumb-color: var(--marinara-chat-chrome-button-text-active);
   --range-thumb-size: 0.6875rem;
   --range-track-height: 0.25rem;
-  --range-thumb-shadow: 0 0 0 0.125rem oklch(0.16 0.006 145);
-  accent-color: oklch(0.96 0.006 145);
+  --range-thumb-shadow: 0 0 0 0.125rem var(--marinara-chat-chrome-panel-bg);
+  accent-color: var(--marinara-chat-chrome-button-text-active);
 }
 
 input[type="range"].mari-spotify-volume-slider::-webkit-slider-runnable-track {
   background: linear-gradient(
     to right,
-    oklch(0.96 0.006 145) 0%,
-    oklch(0.96 0.006 145) var(--range-progress),
-    oklch(0.36 0.006 145) var(--range-progress),
-    oklch(0.36 0.006 145) 100%
+    var(--range-fill-color) 0%,
+    var(--range-fill-color) var(--range-progress),
+    var(--range-track-color) var(--range-progress),
+    var(--range-track-color) 100%
   );
 }
 
 input[type="range"].mari-spotify-volume-slider::-moz-range-track {
-  background: oklch(0.36 0.006 145);
+  background: var(--range-track-color);
 }
 
 input[type="range"].mari-spotify-volume-slider::-moz-range-progress {
-  background: oklch(0.96 0.006 145);
+  background: var(--range-fill-color);
 }
 
 input[type="range"].mari-spotify-volume-slider::-webkit-slider-thumb {
-  background: oklch(0.96 0.006 145);
+  background: var(--range-thumb-color);
 }
 
 input[type="range"].mari-spotify-volume-slider::-moz-range-thumb {
-  background: oklch(0.96 0.006 145);
+  background: var(--range-thumb-color);
 }
 
 @font-face {


### PR DESCRIPTION
Summary:
- Route branch controls through the shared chat toolbar button class and keep chat/game top buttons on common chrome tokens.
- Add customizable accent color support, including rainbow gradient accents, and apply it to button borders, icons, highlights, tracker panels, and popovers.
- Fix light color scheme coverage for Echo Chamber and Music Player surfaces, including Spotify/YouTube player chrome.
- Allow foldered library items to remain selectable for multi-item handling.

Validation run:
- pnpm check
- git diff --check

Manual verification still recommended:
- Manually verify Conversation, Roleplay, and Game top buttons in dark/light schemes.
- Manually verify accent color and rainbow gradient presets in Settings > Appearance.
- Manually verify Spotify/YouTube mini-player backgrounds in light mode.

Issue note:
- No linked issue was provided for this maintainer-requested UI pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app accent color customization in appearance settings
  * Added selection mode for bulk operations on agents, characters, and personas
  * Improved folder member visibility in agent panel when expanded

* **Improvements**
  * Enhanced UI styling consistency with CSS variables across chat and music components
  * Improved gradient detection and support in color picker
  * Refined tracker panel background styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->