### PR TITLE
fix(chat): harden card CSS sanitizer against escape-sequence evasion

### DIFF
--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -516,8 +516,37 @@ function extractChatStyleBlocks(html: string): { html: string; css: string } {
   return { html: withoutStyles, css: cssBlocks.join("\n") };
 }
 
+/** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
+function decodeCssEscapes(input: string): string {
+  return input.replace(/\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g, (_m, hex: string | undefined, ch: string | undefined) => {
+    if (hex) {
+      const cp = parseInt(hex, 16);
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+    }
+    return ch ?? "";
+  });
+}
+
+// Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
+// scanner steps over them, leaving their contents untouched.
+const STRING_OR_ESCAPE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\\(?:[0-9a-fA-F]{1,6}\s?|[\s\S])/g;
+
+// Canonicalize CSS escapes that spell a token character (ASCII letter, `@`, or `-`) so the
+// literal-text guards in sanitizeChatCss can't be bypassed by escaping (e.g. `\75rl(` → `url(`,
+// `po\73ition` → `position`, `\40 import` → `@import`). Escapes resolving to digits/punctuation
+// and all string contents are preserved so benign selectors like `.\32 xl` and `.w-1\/2` stay exact.
+function canonicalizeKeywordEscapes(css: string): string {
+  return css.replace(STRING_OR_ESCAPE, (match: string, stringLiteral: string | undefined) => {
+    if (stringLiteral !== undefined) return stringLiteral;
+    const decoded = decodeCssEscapes(match);
+    return /^[-A-Za-z@]$/.test(decoded) ? decoded : match;
+  });
+}
+
 function sanitizeChatCss(css: string): string {
-  return css
+  // Normalize escaped keyword characters first so every literal-text guard below sees the tokens a
+  // browser would actually parse. Without this, CSS escapes (`\75rl(`, `po\73ition`) slip past.
+  return canonicalizeKeywordEscapes(css)
     .replace(/<\/?style\b[^>]*>/gi, "")
     .replace(/@import\s+[^;]+;?/gi, "")
     .replace(/@namespace\s+[^;]+;?/gi, "")


### PR DESCRIPTION
> **Draft.** Security hardening; `tsc` + ESLint pass and the bypass/benign cases are unit-verified (see notes). Independent of the gallery PRs — branches off `staging`.

## Linked issue

Closes #2577

## Why this change

- `staging` renders creator card CSS through an inline `<style>` sanitizer in `ChatMessage.tsx` that is a **regex blocklist over raw text**. The CSS engine decodes escape sequences (`\XX` hex, `\c`), so a guard matching literal keyword text can be bypassed by spelling the token with escapes — e.g. `\75rl(//evil)` evades the `url()` guard, `po\73ition` / `expre\73sion(` / `@\69mport` / `beha\76ior:` all slip past. This is the same gap #2020 fixed on `refactor`; porting it closes it on `staging`.

## What changed

- Add `canonicalizeKeywordEscapes()` (with `decodeCssEscapes()` + a `STRING_OR_ESCAPE` scanner) and run it at the **top** of `sanitizeChatCss`, before the existing guards.
- It decodes escapes that resolve to ASCII letters, `@`, or `-`, so the literal-text guards see the tokens the browser would actually parse.
- It **preserves** escapes resolving to digits/punctuation and all escape sequences inside string literals, so benign selectors like `.\32 xl` and `.w-1\/2` and legit `content: "…"` strings stay byte-exact.
- No behavior change for well-formed CSS; confined to the sanitizer.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated: `tsc -b` + ESLint pass for the client. Ran the exact ported sanitizer logic against a bypass/benign matrix — **7/7**: escaped `expression()`, `javascript:`, `@import`, `behavior:`, and a non-https escaped `url()` are all neutralized; a digit-escape selector (`.\32 xl`) and an escape inside a string literal are preserved unchanged.

To verify manually in-browser (TO-DO): put card CSS like `.x{ ba\63kground: \75rl(//example.test/p.png) }` in a character's creator notes and confirm no external request is made / the rule is neutralized, and that a normal Tailwind-ish selector with an escaped digit still renders.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Assessment (please confirm): internal hardening — no docs/version changes expected.

## UI evidence (if applicable)

N/A — no visual change for well-formed CSS.
