### PR TITLE
feat(lorebooks): duplicate lorebook entry

### DIFF
--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -18,6 +18,7 @@ import {
   CheckCircle2,
   CheckSquare2,
   CircleDashed,
+  Copy,
   FileText,
   GripVertical,
   Hash,
@@ -34,7 +35,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { useUpdateLorebookEntry, useDeleteLorebookEntry } from "../../hooks/use-lorebooks";
+import { useUpdateLorebookEntry, useDeleteLorebookEntry, useDuplicateLorebookEntry } from "../../hooks/use-lorebooks";
 import type {
   LorebookEntry,
   LorebookFilterMode,
@@ -193,6 +194,7 @@ export function LorebookEntryRow({
 }: Props) {
   const updateEntry = useUpdateLorebookEntry();
   const deleteEntry = useDeleteLorebookEntry();
+  const duplicateEntry = useDuplicateLorebookEntry();
 
   // ── Inline-control optimistic state ──
   // We keep a local mirror of the entry's fields so the inputs feel snappy
@@ -316,6 +318,14 @@ export function LorebookEntryRow({
       deleteEntry.mutate({ lorebookId, entryId: entry.id });
     },
     [lorebookId, entry.id, deleteEntry],
+  );
+
+  const handleDuplicate = useCallback(
+    (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      duplicateEntry.mutate({ lorebookId, entry });
+    },
+    [lorebookId, entry, duplicateEntry],
   );
 
   const showDepthInput = localPosition === 2;
@@ -699,6 +709,18 @@ export function LorebookEntryRow({
           <Hash size="0.5625rem" />
           {estimateTokens(entry.content).toLocaleString()}
         </span>
+
+        {/* Duplicate button (visible on hover, always on mobile) */}
+        <button
+          type="button"
+          aria-label="Duplicate entry"
+          title="Duplicate entry"
+          disabled={duplicateEntry.isPending}
+          onClick={handleDuplicate}
+          className="shrink-0 rounded p-1 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] group-hover:opacity-100 disabled:cursor-not-allowed max-md:opacity-100"
+        >
+          <Copy size="0.75rem" />
+        </button>
 
         {/* Delete button (visible on hover, always on mobile) */}
         <button

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -320,9 +320,12 @@ export function LorebookEntryRow({
     [lorebookId, entry.id, deleteEntry],
   );
 
+  const duplicateDisabled = duplicateEntry.isPending || updateEntry.isPending;
+
   const handleDuplicate = useCallback(
     (e: ReactMouseEvent) => {
       e.stopPropagation();
+      if (duplicateDisabled) return;
       // Clone from the row's current inline state (not the prop snapshot) so an edit made
       // just before duplicating isn't dropped while its update/refetch is still in flight.
       const { constant, selective } = statusToFlags(localStatus);
@@ -330,7 +333,7 @@ export function LorebookEntryRow({
         lorebookId,
         entry: {
           ...entry,
-          name: localName,
+          name: localName.trim() || entry.name,
           enabled: localEnabled,
           constant,
           selective,
@@ -354,6 +357,7 @@ export function LorebookEntryRow({
       localProbability,
       localUseRegex,
       duplicateEntry,
+      duplicateDisabled,
     ],
   );
 
@@ -744,7 +748,7 @@ export function LorebookEntryRow({
           type="button"
           aria-label="Duplicate entry"
           title="Duplicate entry"
-          disabled={duplicateEntry.isPending}
+          disabled={duplicateDisabled}
           onClick={handleDuplicate}
           className="shrink-0 rounded p-1 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] group-hover:opacity-100 disabled:cursor-not-allowed max-md:opacity-100"
         >

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -323,9 +323,38 @@ export function LorebookEntryRow({
   const handleDuplicate = useCallback(
     (e: ReactMouseEvent) => {
       e.stopPropagation();
-      duplicateEntry.mutate({ lorebookId, entry });
+      // Clone from the row's current inline state (not the prop snapshot) so an edit made
+      // just before duplicating isn't dropped while its update/refetch is still in flight.
+      const { constant, selective } = statusToFlags(localStatus);
+      duplicateEntry.mutate({
+        lorebookId,
+        entry: {
+          ...entry,
+          name: localName,
+          enabled: localEnabled,
+          constant,
+          selective,
+          position: localPosition,
+          depth: localDepth,
+          order: localOrder,
+          probability: localProbability === 100 ? null : localProbability,
+          useRegex: localUseRegex,
+        },
+      });
     },
-    [lorebookId, entry, duplicateEntry],
+    [
+      lorebookId,
+      entry,
+      localName,
+      localEnabled,
+      localStatus,
+      localPosition,
+      localDepth,
+      localOrder,
+      localProbability,
+      localUseRegex,
+      duplicateEntry,
+    ],
   );
 
   const showDepthInput = localPosition === 2;

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -197,6 +197,26 @@ export function useDeleteLorebookEntry() {
   });
 }
 
+export function useDuplicateLorebookEntry() {
+  const qc = useQueryClient();
+  return useMutation({
+    // Clone every field through the create path. The create schema drops server-managed
+    // fields (id/createdAt/updatedAt) and the route re-derives lorebookId, so each other
+    // field — keys, filters, position/depth/order, timing, etc. — carries over verbatim.
+    mutationFn: ({ lorebookId, entry }: { lorebookId: string; entry: LorebookEntry }) => {
+      const clone: Record<string, unknown> = { ...entry, name: `${entry.name} (Copy)` };
+      delete clone.id;
+      delete clone.createdAt;
+      delete clone.updatedAt;
+      return api.post<LorebookEntry>(`/lorebooks/${lorebookId}/entries`, clone);
+    },
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+    },
+  });
+}
+
 export function useBulkCreateEntries() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Linked issue

Closes #2578

## Why this change

- Re-creating a near-identical lorebook entry by hand — re-typing its keys, filters, injection/activation settings, and content — is tedious. A one-click **Duplicate** is a pure QoL win and fully additive (no existing behavior changes). Ports the entry-duplication feature from `refactor` #2157.

## What changed

- **`useDuplicateLorebookEntry`** (`hooks/use-lorebooks.ts`) — clones an entry through the existing `POST /lorebooks/:id/entries` create path. The create schema drops server-managed `id`/`createdAt`/`updatedAt` and the route re-derives `lorebookId`, so the name gets a `" (Copy)"` suffix and **every other field carries over verbatim** (keys/secondaryKeys, all character/tag/trigger filters, position/depth/order, probability, timing, grouping, role, embedding, activation conditions). Invalidates the same queries as `useCreateLorebookEntry`.
- **Duplicate button** (`components/lorebooks/LorebookEntryRow.tsx`) — a `Copy`-icon button in the per-row actions, immediately left of delete. Mirrors delete's hover-reveal pattern (always visible on mobile), neutral styling, disabled while the clone is in flight.

**No backend changes** — lorebook entries have no managed on-disk asset, so duplication is a pure client-side row clone over the existing create endpoint.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `tsc -b` + ESLint pass for the client.
- opened a lorebook with an entry that has keys/filters/content set, clicked the new Copy button, and confirmed a `"… (Copy)"` entry appears with all those fields carried over
- confirmed the original is untouched and the button is disabled mid-clone.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Assessment: additive QoL — no docs/version changes expected.

## UI evidence (if applicable)

Screenshots to follow.

<img width="616" height="89" alt="{24689666-1BA3-4B65-B4B7-D590DE57520E}" src="https://github.com/user-attachments/assets/d46143c6-5b26-4134-b8c6-964d08ff2bc6" />

<img width="636" height="489" alt="{CCCA7CB8-6305-422F-B8B6-1A523979D03E}" src="https://github.com/user-attachments/assets/39512123-b86a-4335-a3b4-5e9879116764" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now duplicate lorebook entries directly from the entry row. Duplicated entries automatically append "(Copy)" to the original name while preserving all other details. The duplicate button appears on hover or in mobile view and is disabled while the operation is processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->