### PR TITLE
feat(chat): apply character creator-notes CSS in chat (card theming)

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -76,6 +76,8 @@ import { HomeCreditsModal } from "./HomeCreditsModal";
 import { HomeProfessorMariChat } from "./HomeProfessorMariChat";
 import { NewChatConnectionGate } from "./NewChatConnectionGate";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
+import { CreatorNotesCssInjector, type CardCssMode } from "./CreatorNotesCssInjector";
+import type { ChatModeFilter } from "../../lib/card-css";
 
 export type { CharacterMap };
 
@@ -552,6 +554,22 @@ export function ChatArea() {
 
   const updateMeta = useUpdateChatMetadata();
   const summaryContextSize: number = (chatMeta.summaryContextSize as number) ?? 50;
+
+  // Creator-notes card CSS: resolve the per-chat mode (default "chat") and map
+  // the chat mode onto the @chat-mode filter surface (visual novel shares the
+  // roleplay surface). One injector element, reused across every render path.
+  const cardCssMode: CardCssMode =
+    chatMeta.cardCssMode === "disabled" || chatMeta.cardCssMode === "exclusive" ? chatMeta.cardCssMode : "chat";
+  const cardCssChatMode: ChatModeFilter =
+    chatMode === "conversation" ? "conversation" : chatMode === "game" ? "game" : "roleplay";
+  const cardCssInjector = (
+    <CreatorNotesCssInjector
+      characterIds={chatCharIds}
+      allCharacters={allCharacters as CharacterRow[] | undefined}
+      mode={cardCssMode}
+      chatMode={cardCssChatMode}
+    />
+  );
 
   // Sync translation config from chat metadata to the translation store
   useEffect(() => {
@@ -2024,6 +2042,7 @@ export function ChatArea() {
   if (chatMode === "conversation") {
     return (
       <>
+        {cardCssInjector}
         <Suspense fallback={surfaceFallback}>
           <ChatConversationSurface
             activeChatId={activeChatId}
@@ -2108,6 +2127,7 @@ export function ChatArea() {
 
   return (
     <>
+      {cardCssInjector}
       <Suspense fallback={surfaceFallback}>
         <ChatRoleplaySurface
           activeChatId={activeChatId}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -559,7 +559,7 @@ export function ChatArea() {
   // the chat mode onto the @chat-mode filter surface (visual novel shares the
   // roleplay surface). One injector element, reused across every render path.
   const cardCssMode: CardCssMode =
-    chatMeta.cardCssMode === "disabled" || chatMeta.cardCssMode === "exclusive" ? chatMeta.cardCssMode : "chat";
+    chatMeta.cardCssMode === "exclusive" || chatMeta.cardCssMode === "chat" ? chatMeta.cardCssMode : "disabled";
   const cardCssChatMode: ChatModeFilter =
     chatMode === "conversation" ? "conversation" : chatMode === "game" ? "game" : "roleplay";
   const cardCssInjector = (

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1623,6 +1623,7 @@ export const ChatMessage = memo(function ChatMessage({
             "mari-message mari-message-narrator rpg-narrator-msg group mb-4 px-2",
             multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/5 ring-2 ring-[var(--destructive)]/50",
           )}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleRoleplayDoubleClick}
         >
@@ -1694,6 +1695,7 @@ export const ChatMessage = memo(function ChatMessage({
           )}
           data-message-id={message.id}
           data-message-role={message.role}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleRoleplayDoubleClick}
           style={roleplayAvatarScaleStyle}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -516,8 +516,37 @@ function extractChatStyleBlocks(html: string): { html: string; css: string } {
   return { html: withoutStyles, css: cssBlocks.join("\n") };
 }
 
+/** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
+function decodeCssEscapes(input: string): string {
+  return input.replace(/\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g, (_m, hex: string | undefined, ch: string | undefined) => {
+    if (hex) {
+      const cp = parseInt(hex, 16);
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+    }
+    return ch ?? "";
+  });
+}
+
+// Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
+// scanner steps over them, leaving their contents untouched.
+const STRING_OR_ESCAPE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\\(?:[0-9a-fA-F]{1,6}\s?|[\s\S])/g;
+
+// Canonicalize CSS escapes that spell a token character (ASCII letter, `@`, or `-`) so the
+// literal-text guards in sanitizeChatCss can't be bypassed by escaping (e.g. `\75rl(` → `url(`,
+// `po\73ition` → `position`, `\40 import` → `@import`). Escapes resolving to digits/punctuation
+// and all string contents are preserved so benign selectors like `.\32 xl` and `.w-1\/2` stay exact.
+function canonicalizeKeywordEscapes(css: string): string {
+  return css.replace(STRING_OR_ESCAPE, (match: string, stringLiteral: string | undefined) => {
+    if (stringLiteral !== undefined) return stringLiteral;
+    const decoded = decodeCssEscapes(match);
+    return /^[-A-Za-z@]$/.test(decoded) ? decoded : match;
+  });
+}
+
 function sanitizeChatCss(css: string): string {
-  return css
+  // Normalize escaped keyword characters first so every literal-text guard below sees the tokens a
+  // browser would actually parse. Without this, CSS escapes (`\75rl(`, `po\73ition`) slip past.
+  return canonicalizeKeywordEscapes(css)
     .replace(/<\/?style\b[^>]*>/gi, "")
     .replace(/@import\s+[^;]+;?/gi, "")
     .replace(/@namespace\s+[^;]+;?/gi, "")

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1002,7 +1002,11 @@ export function ChatRoleplaySurface({
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
-      <div className="rpg-chat-area mari-chat-area relative flex flex-1 flex-col overflow-hidden">
+      <div
+        className="rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
+        data-chat-mode="roleplay"
+        style={{ isolation: "isolate" }}
+      >
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay absolute inset-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0" />

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -33,6 +33,7 @@ import {
   Maximize2,
   Vibrate,
   Feather,
+  Paintbrush,
   Activity,
   Puzzle,
   Save,
@@ -108,6 +109,7 @@ import {
   stepCadenceValue,
 } from "../../lib/agent-cadence";
 import { getCharacterTitle, parseCharacterDisplayData } from "../../lib/character-display";
+import { extractCreatorNotesCss } from "../../lib/creator-notes-css";
 import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { useUIStore } from "../../stores/ui.store";
 import {
@@ -310,6 +312,7 @@ const CHAT_SETTINGS_ORDER = {
   advancedParameters: -1100,
   persona: -1000,
   characters: -900,
+  cardTheming: -850,
   groupChat: -800,
   connectedChat: -700,
   connectedNotes: -690,
@@ -530,6 +533,30 @@ export function ChatSettingsDrawer({
     () => (typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {})),
     [chat.metadata],
   );
+
+  // Creator-notes card CSS: the current per-chat mode (default "chat"), and
+  // whether any active character actually ships CSS — the Card Theming control
+  // only appears when one does, so it never clutters chats it can't affect.
+  const cardCssMode: "disabled" | "exclusive" | "chat" =
+    metadata.cardCssMode === "disabled" || metadata.cardCssMode === "exclusive" ? metadata.cardCssMode : "chat";
+  const activeCardsHaveCss = useMemo(() => {
+    if (!allCharacters) return false;
+    const byId = new Map((allCharacters as Array<{ id: string; data: unknown }>).map((c) => [c.id, c]));
+    return chatCharIds.some((id) => {
+      const row = byId.get(id);
+      if (!row) return false;
+      let parsed: Record<string, unknown>;
+      try {
+        if (typeof row.data === "string") parsed = JSON.parse(row.data) as Record<string, unknown>;
+        else if (row.data && typeof row.data === "object") parsed = row.data as Record<string, unknown>;
+        else return false;
+      } catch {
+        return false;
+      }
+      const notes = (parsed as { creator_notes?: string }).creator_notes;
+      return typeof notes === "string" && extractCreatorNotesCss(notes).css.trim().length > 0;
+    });
+  }, [allCharacters, chatCharIds]);
   const conversationCommandToggles = useMemo(
     () => readConversationCommandToggles(metadata.conversationCommandToggles),
     [metadata.conversationCommandToggles],
@@ -3015,6 +3042,61 @@ export function ChatSettingsDrawer({
               customPrompt={(metadata.customSystemPrompt as string) ?? ""}
               onCustomPromptChange={(id, customSystemPrompt) => updateMeta.mutate({ id, customSystemPrompt })}
             />
+          )}
+
+          {/* Card Theming — only shown when an active character ships creator-notes CSS */}
+          {activeCardsHaveCss && (
+            <Section
+              style={{ order: CHAT_SETTINGS_ORDER.cardTheming }}
+              label="Card Theming"
+              icon={<Paintbrush size="0.875rem" />}
+              help="Apply CSS embedded in a character's Creator Notes. Exclusive keeps each character's styling to their own messages; Chat applies it to the whole area."
+            >
+              <div className="space-y-2">
+                <div className="flex rounded-lg ring-1 ring-[var(--border)]">
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, cardCssMode: "disabled" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-l-lg",
+                      cardCssMode === "disabled"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Disabled
+                  </button>
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, cardCssMode: "exclusive" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors",
+                      cardCssMode === "exclusive"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Exclusive
+                  </button>
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, cardCssMode: "chat" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-r-lg",
+                      cardCssMode === "chat"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Chat
+                  </button>
+                </div>
+                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                  {cardCssMode === "disabled"
+                    ? "Card CSS is off — no character styling is applied."
+                    : cardCssMode === "exclusive"
+                      ? "Each character's CSS only affects their own messages."
+                      : "All card CSS affects the entire chat area, including UI elements."}
+                </p>
+              </div>
+            </Section>
           )}
 
           {/* Group Chat Settings — only when 2+ characters, game mode handles it internally */}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -538,7 +538,7 @@ export function ChatSettingsDrawer({
   // whether any active character actually ships CSS — the Card Theming control
   // only appears when one does, so it never clutters chats it can't affect.
   const cardCssMode: "disabled" | "exclusive" | "chat" =
-    metadata.cardCssMode === "disabled" || metadata.cardCssMode === "exclusive" ? metadata.cardCssMode : "chat";
+    metadata.cardCssMode === "exclusive" || metadata.cardCssMode === "chat" ? metadata.cardCssMode : "disabled";
   const activeCardsHaveCss = useMemo(() => {
     if (!allCharacters) return false;
     const byId = new Map((allCharacters as Array<{ id: string; data: unknown }>).map((c) => [c.id, c]));

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -674,6 +674,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
         data-message-id={message.id}
         data-message-role={message.role}
+        data-card-css={message.characterId ?? undefined}
         onClick={handleMobileTap}
       >
         {isBubbleStyle ? <ConversationMessageBubble ctx={ctx} /> : <ConversationMessageLine ctx={ctx} />}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -854,7 +854,11 @@ export function ConversationView({
   }, [visiblePartCounts]);
 
   return (
-    <div className="mari-chat-area relative flex flex-1 flex-col overflow-hidden" style={gradientStyle}>
+    <div
+      className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
+      data-chat-mode="conversation"
+      style={{ ...gradientStyle, isolation: "isolate" }}
+    >
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}

--- a/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
+++ b/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
@@ -33,9 +33,10 @@ const SCOPE_SELECTOR = ".mari-card-css";
 /**
  * Pulls `<style>` blocks out of every active character's `creator_notes`,
  * sanitizes + scopes them per the selected mode, and injects the combined CSS
- * into the document head inside an `@layer card-css` so it loses specificity
- * ties to app styles. A single shared `<style>` node is reused/cleared as the
- * active set or mode changes.
+ * into the document head. The CSS is injected unlayered so its scoped selectors
+ * can override the app's own (partly unlayered) message styling; the sanitizer
+ * and per-card scope keep it from reaching anything outside the chat. A single
+ * shared `<style>` node is reused/cleared as the active set or mode changes.
  */
 export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, chatMode }: CreatorNotesCssInjectorProps) {
   const scopedCss = useMemo(() => {
@@ -81,7 +82,13 @@ export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, cha
     }
 
     if (cssChunks.length === 0) return "";
-    return `@layer card-css {\n${cssChunks.join("\n")}\n}`;
+    // Injected unlayered (not wrapped in @layer): the app styles some message
+    // elements with unlayered rules (e.g. `.mari-message-content { color }` in
+    // globals.css), and any @layer always loses to unlayered rules — which would
+    // silently neuter most card theming. The scoped selectors above are specific
+    // enough to win on their own, while the sanitizer + per-card scope keep card
+    // CSS contained to the chat.
+    return cssChunks.join("\n");
   }, [characterIds, allCharacters, mode, chatMode]);
 
   useEffect(() => {

--- a/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
+++ b/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
@@ -1,0 +1,110 @@
+// ──────────────────────────────────────────────
+// CreatorNotesCssInjector — extracts CSS from the
+// active characters' creator_notes, sanitizes +
+// scopes it, and injects a single <style> element
+// into <head>. Renders nothing.
+// ──────────────────────────────────────────────
+import { useEffect, useMemo } from "react";
+import { extractCreatorNotesCss } from "../../lib/creator-notes-css";
+import { scopeChatCss, filterCssByMode, type ChatModeFilter } from "../../lib/card-css";
+
+export type CardCssMode = "disabled" | "exclusive" | "chat";
+
+type CharacterRow = {
+  id: string;
+  /** Raw character-card payload — a JSON string or an already-parsed object. */
+  data: unknown;
+};
+
+interface CreatorNotesCssInjectorProps {
+  /** IDs of the characters active in this chat. */
+  characterIds: string[];
+  /** Catalog rows for resolving each character's card data. */
+  allCharacters: CharacterRow[] | undefined;
+  /** Injection mode: disabled | exclusive (per-character) | chat (whole area). */
+  mode: CardCssMode;
+  /** Current chat surface — drives `@chat-mode` filtering. */
+  chatMode: ChatModeFilter;
+}
+
+const STYLE_ELEMENT_ID = "marinara-card-css";
+const SCOPE_SELECTOR = ".mari-card-css";
+
+/**
+ * Pulls `<style>` blocks out of every active character's `creator_notes`,
+ * sanitizes + scopes them per the selected mode, and injects the combined CSS
+ * into the document head inside an `@layer card-css` so it loses specificity
+ * ties to app styles. A single shared `<style>` node is reused/cleared as the
+ * active set or mode changes.
+ */
+export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, chatMode }: CreatorNotesCssInjectorProps) {
+  const scopedCss = useMemo(() => {
+    if (mode === "disabled" || !allCharacters || characterIds.length === 0) return "";
+
+    const charMap = new Map<string, CharacterRow>();
+    for (const char of allCharacters) {
+      charMap.set(char.id, char);
+    }
+
+    const cssChunks: string[] = [];
+    for (const charId of characterIds) {
+      const row = charMap.get(charId);
+      if (!row) continue;
+
+      let parsed: Record<string, unknown>;
+      try {
+        if (typeof row.data === "string") {
+          parsed = JSON.parse(row.data) as Record<string, unknown>;
+        } else if (row.data && typeof row.data === "object") {
+          parsed = row.data as Record<string, unknown>;
+        } else {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      const creatorNotes = (parsed as { creator_notes?: string }).creator_notes;
+      if (!creatorNotes) continue;
+
+      const { css: rawCss } = extractCreatorNotesCss(creatorNotes);
+      if (!rawCss) continue;
+
+      // Keep only rules that target the active surface (@chat-mode blocks).
+      const css = filterCssByMode(rawCss, chatMode);
+      if (!css.trim()) continue;
+
+      // Exclusive → scope to this character's own messages; chat → whole area.
+      const scope = mode === "exclusive" ? `${SCOPE_SELECTOR} [data-card-css="${charId}"]` : SCOPE_SELECTOR;
+      const scoped = scopeChatCss(css, scope);
+      if (scoped) cssChunks.push(scoped);
+    }
+
+    if (cssChunks.length === 0) return "";
+    return `@layer card-css {\n${cssChunks.join("\n")}\n}`;
+  }, [characterIds, allCharacters, mode, chatMode]);
+
+  useEffect(() => {
+    let styleEl = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+
+    if (!scopedCss) {
+      if (styleEl) styleEl.textContent = "";
+      return;
+    }
+
+    if (!styleEl) {
+      styleEl = document.createElement("style");
+      styleEl.id = STYLE_ELEMENT_ID;
+      document.head.appendChild(styleEl);
+    }
+
+    styleEl.textContent = scopedCss;
+
+    return () => {
+      const el = document.getElementById(STYLE_ELEMENT_ID);
+      if (el) el.textContent = "";
+    };
+  }, [scopedCss]);
+
+  return null;
+}

--- a/packages/client/src/lib/card-css.ts
+++ b/packages/client/src/lib/card-css.ts
@@ -1,0 +1,578 @@
+// ──────────────────────────────────────────────
+// Card CSS — sanitize + scope creator-notes CSS
+// ──────────────────────────────────────────────
+//
+// Locks down untrusted card CSS (no network/script, no scope escape, no
+// theme-token override) and scopes every rule under a per-card selector.
+// Consumed by CreatorNotesCssInjector. This is distinct from the inline
+// message-CSS helpers in ChatMessage.tsx, which sanitize the author's own
+// inline <style> blocks rather than CSS imported from a character card.
+//
+// SECURITY: this is the shared card-CSS sanitizer — keep it in sync with
+// upstream hardening of the same logic.
+
+export type ChatModeFilter = "roleplay" | "conversation" | "game";
+
+const CHAT_MODE_RE = /@chat-mode\s+(roleplay|conversation|game)\s*\{/gi;
+
+function findCssBlockEnd(css: string, bodyStart: number): { end: number; closed: boolean } {
+  let depth = 1;
+  let i = bodyStart;
+  let quote: string | null = null;
+  let escaped = false;
+  let inComment = false;
+
+  while (i < css.length && depth > 0) {
+    const ch = css[i]!;
+    const next = css[i + 1];
+    if (inComment) {
+      if (ch === "*" && next === "/") {
+        inComment = false;
+        i += 2;
+      } else {
+        i++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inComment = true;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    i++;
+  }
+
+  return { end: i, closed: depth === 0 };
+}
+
+/**
+ * Filter CSS by `@chat-mode <mode> { ... }` blocks.
+ *
+ * - `@chat-mode conversation { ... }` → included only in conversation mode
+ * - `@chat-mode roleplay { ... }` → included only in roleplay mode
+ * - `@chat-mode game { ... }` → included only in game mode
+ * - CSS outside any `@chat-mode` block → included in ALL modes
+ *
+ * Card creators use this to target styles to specific surfaces while
+ * keeping a shared base that applies everywhere.
+ */
+export function filterCssByMode(css: string, chatMode: ChatModeFilter): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  CHAT_MODE_RE.lastIndex = 0;
+
+  while ((match = CHAT_MODE_RE.exec(css)) !== null) {
+    // Emit any CSS between the last block and this one (unscoped = all modes)
+    if (match.index > cursor) {
+      chunks.push(css.slice(cursor, match.index));
+    }
+
+    const targetMode = match[1].toLowerCase();
+    const bodyStart = match.index + match[0].length;
+
+    const block = findCssBlockEnd(css, bodyStart);
+    const body = css.slice(bodyStart, block.closed ? block.end - 1 : block.end);
+    cursor = block.end;
+    CHAT_MODE_RE.lastIndex = block.end;
+
+    if (targetMode === chatMode) {
+      chunks.push(body);
+    }
+  }
+
+  // Trailing CSS after the last @chat-mode block (unscoped = all modes)
+  if (cursor < css.length) {
+    chunks.push(css.slice(cursor));
+  }
+
+  return chunks.join("\n");
+}
+
+/** Theme tokens that card CSS must never override. */
+const THEME_TOKEN_BLOCKLIST = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--destructive-foreground",
+  "--border",
+  "--input",
+  "--ring",
+  "--radius",
+  "--sidebar-background",
+  "--sidebar-foreground",
+  "--sidebar-primary",
+  "--sidebar-primary-foreground",
+  "--sidebar-accent",
+  "--sidebar-accent-foreground",
+  "--sidebar-border",
+  "--sidebar-ring",
+  "--color-background",
+  "--color-foreground",
+  "--color-card",
+  "--color-primary",
+  "--color-secondary",
+  "--color-muted",
+  "--color-accent",
+  "--color-destructive",
+  "--color-border",
+  "--color-input",
+  "--color-ring",
+];
+
+/** Strip CSS comments */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function sanitizeContentText(text: string): string {
+  const stripped = text.replace(/[<>]/g, "");
+  return stripped.length > 200 ? stripped.slice(0, 200) : stripped;
+}
+
+function sanitizeContentQuotedSegments(value: string): string {
+  return value.replace(/(['"])((?:\\.|(?!\1)[\s\S])*)\1/g, (_match, quote: string, text: string) => {
+    return `${quote}${sanitizeContentText(text)}${quote}`;
+  });
+}
+
+const CONTENT_TOKEN_RE =
+  /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|(?:counter|counters|attr)\s*\([^)]*\)|open-quote|close-quote|no-open-quote|no-close-quote|none|normal)\s*/gi;
+
+function isAllowedContentExpression(value: string): boolean {
+  return value.replace(CONTENT_TOKEN_RE, "").trim().length === 0;
+}
+
+function matchContentPropertyColon(css: string, index: number): number | null {
+  if (css.slice(index, index + "content".length).toLowerCase() !== "content") return null;
+  if (index > 0 && /[-_A-Za-z0-9]/.test(css[index - 1]!)) return null;
+  let cursor = index + "content".length;
+  while (cursor < css.length && /\s/.test(css[cursor]!)) cursor++;
+  return css[cursor] === ":" ? cursor : null;
+}
+
+function findDeclarationEnd(css: string, valueStart: number): { valueEnd: number; terminator: string } {
+  let quote: string | null = null;
+  let escaped = false;
+  for (let cursor = valueStart; cursor < css.length; cursor++) {
+    const ch = css[cursor]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ";" || ch === "}") return { valueEnd: cursor, terminator: ch };
+  }
+  return { valueEnd: css.length, terminator: "" };
+}
+
+function sanitizeContentDeclarationValue(value: string, terminator: string): string {
+  const normalized = value.trim();
+  // Allow empty string content (pseudo-element clearing)
+  if (/^(['"])\s*\1$/.test(normalized)) {
+    return `content: ${normalized}${terminator}`;
+  }
+  // Allow quoted text with sanitization
+  const quoted = normalized.match(/^(['"])(.*)\1$/);
+  if (quoted) {
+    return `content: "${sanitizeContentText(quoted[2])}"${terminator}`;
+  }
+  // Allow CSS functions like counter(), attr(), etc.
+  if (isAllowedContentExpression(normalized)) {
+    return `content: ${sanitizeContentQuotedSegments(normalized)}${terminator}`;
+  }
+  return `content: ''${terminator}`;
+}
+
+function sanitizeContentDeclarations(css: string): string {
+  let result = "";
+  let lastAppend = 0;
+  let cursor = 0;
+  let quote: string | null = null;
+  let escaped = false;
+
+  while (cursor < css.length) {
+    const ch = css[cursor]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      cursor++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      cursor++;
+      continue;
+    }
+
+    const colonIndex = matchContentPropertyColon(css, cursor);
+    if (colonIndex !== null) {
+      const valueStart = colonIndex + 1;
+      const { valueEnd, terminator } = findDeclarationEnd(css, valueStart);
+      result += css.slice(lastAppend, cursor);
+      result += sanitizeContentDeclarationValue(css.slice(valueStart, valueEnd), terminator);
+      cursor = valueEnd + (terminator ? 1 : 0);
+      lastAppend = cursor;
+      continue;
+    }
+    cursor++;
+  }
+
+  return result + css.slice(lastAppend);
+}
+
+/** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
+function decodeCssEscapes(input: string): string {
+  return input.replace(
+    /\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g,
+    (_m, hex: string | undefined, ch: string | undefined) => {
+      if (hex) {
+        const cp = parseInt(hex, 16);
+        return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+      }
+      return ch ?? "";
+    },
+  );
+}
+
+// Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
+// scanner steps over them, leaving their contents untouched.
+const STRING_OR_ESCAPE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\\(?:[0-9a-fA-F]{1,6}\s?|[\s\S])/g;
+
+/**
+ * Canonicalize CSS escapes that spell a token character, so the literal-text guards in
+ * sanitizeChatCss can't be evaded by escaping. CSS escapes are decoded by the engine, so
+ * `po\73ition` is `position`, `\75rl(` is `url(`, `\40 import` is `@import`, and
+ * `\2d-background` is `--background` — and the raw-text regexes below would otherwise miss
+ * every one of them.
+ *
+ * We decode escapes resolving to ASCII letters, `@`, or `-`. Letters and `@` spell the keyword
+ * guards (url, @import, @font-face, :has, position, content…). `-` is included because the only
+ * punctuation-led forbidden tokens are hyphen-prefixed identifiers — custom-property / theme
+ * tokens (`--…`) and the `-moz-binding` vendor prefix; no benign card CSS escapes a hyphen
+ * (hyphens never need escaping in identifiers), so decoding it stays equivalent.
+ *
+ * Escapes resolving to other punctuation or digits are left byte-exact. They legitimately appear
+ * in selectors (`.\32 xl`, `.w-1\/2`) where decoding would change meaning, and — crucially — they
+ * cannot disguise a forbidden token: by CSS/HTML tokenization an escaped `:` / `!` / `/` becomes
+ * an identifier character, not a declaration separator, an `!important` delimiter, or a `</style`
+ * breakout. Escapes inside string literals are always preserved.
+ */
+function canonicalizeKeywordEscapes(css: string): string {
+  return css.replace(STRING_OR_ESCAPE, (match: string, stringLiteral: string | undefined) => {
+    if (stringLiteral !== undefined) return stringLiteral;
+    const decoded = decodeCssEscapes(match);
+    return /^[-A-Za-z@]$/.test(decoded) ? decoded : match;
+  });
+}
+
+/**
+ * Strip the CSS constructs that are dangerous no matter where the CSS is injected:
+ * network exfiltration (url()/@import/@namespace/@font-face), script execution
+ * (expression()/javascript:/vbscript:/behavior/-moz-binding), and browsing-history
+ * probing (:visited).
+ *
+ * Unlike scoped card CSS, app-level theme and extension CSS is allowed to override
+ * theme tokens, use !important, and position elements — so it must be run through
+ * THIS function rather than sanitizeChatCss, which additionally applies card-only
+ * scope/theme-protection passes that would neuter a legitimate theme.
+ */
+export function stripDangerousCss(css: string): string {
+  let out = stripComments(css);
+
+  // ── Escape normalization ──
+  // Canonicalize escaped keyword characters up front so every literal-text guard below sees the
+  // tokens a browser would actually parse (e.g. `\75rl(` → `url(`, `po\73ition` → `position`).
+  // Benign escapes in selectors (digits/punctuation) and string contents are preserved (#1989).
+  out = canonicalizeKeywordEscapes(out);
+
+  // ── Network exfiltration prevention ──
+  // Strip ALL url() except data: URIs for images and fonts (no external network requests).
+  // Allowed MIME prefixes are intentionally narrow: image/*, font/*, and the font-specific
+  // application/font* and application/x-font* (no generic application/octet-stream).
+  out = out.replace(
+    /url\s*\(\s*(['"]?)\s*(?!['"]?\s*data:(?:image\/|font\/|application\/(?:font|x-font)))[^)]*\)/gi,
+    "url(about:invalid)",
+  );
+  // Strip @import (network request + CSS injection)
+  out = out.replace(/@import\b[^;]*;/gi, "");
+  // Strip @namespace
+  out = out.replace(/@namespace\b[^;]*;/gi, "");
+  // Keep an @font-face block only if every source is a FONT data: URI. The block must carry
+  // at least one url() (an empty url() set would otherwise pass vacuously), every url() must
+  // be a font data: URI, and local() sources are rejected — they reference installed fonts
+  // (non-data, usable for fingerprinting) and fall outside the documented "embedded data:
+  // fonts only" contract. External URLs were already neutralized to url(about:invalid) above,
+  // and image/* data URIs (allowed for general url() use) are not valid font sources.
+  out = out.replace(/@font-face\s*\{[^}]*\}/gi, (block) => {
+    const urls = block.match(/url\s*\([^)]*\)/gi) ?? [];
+    const allFontData =
+      urls.length > 0 &&
+      urls.every((u) => /url\s*\(\s*(['"]?)\s*data:(?:font\/|application\/(?:font|x-font))/i.test(u));
+    const hasLocalSource = /\blocal\s*\(/i.test(block);
+    return allFontData && !hasLocalSource ? block : "";
+  });
+
+  // ── Script/expression injection ──
+  out = out.replace(/expression\s*\([^)]*\)/gi, "");
+  out = out.replace(/javascript\s*:/gi, "");
+  out = out.replace(/vbscript\s*:/gi, "");
+  out = out.replace(/behavior\s*:[^;]*/gi, "");
+  out = out.replace(/-moz-binding\s*:[^;]*/gi, "");
+
+  // ── History probing ──
+  // Strip :visited — can detect browsing history via style differences
+  out = out.replace(/:visited/gi, ":link");
+
+  return out;
+}
+
+/**
+ * Remove dangerous constructs from CSS and additionally lock it down for use as
+ * scoped card CSS.
+ *
+ * Security model: card CSS is untrusted user content shared between users.
+ * A malicious card creator must not be able to:
+ * - Make network requests (data exfiltration, IP tracking)
+ * - Escape the scoped container to style/probe app UI
+ * - Override application theme tokens
+ * - Inject phishing content via `content` property
+ * - Cause denial-of-service via resource-heavy rules
+ */
+function sanitizeChatCss(css: string): string {
+  let out = stripDangerousCss(css);
+
+  // ── Scope escape prevention ──
+  // Strip :has() — can probe elements outside the scoped container
+  out = out.replace(/:has\s*\([^)]*\)/gi, "");
+  // Convert position:fixed to position:absolute (prevent viewport overlays)
+  out = out.replace(/position\s*:\s*fixed/gi, "position:absolute");
+
+  // ── Content injection prevention ──
+  // Allow content property with sanitized text (for decorative labels in card CSS).
+  // Strip HTML-like characters and cap length to prevent phishing/UI spoofing.
+  out = sanitizeContentDeclarations(out);
+  // Strip </style (prevent injection breakout)
+  out = out.replace(/<\/style/gi, "");
+
+  // ── Theme protection ──
+  // Strip theme token declarations
+  out = out.replace(
+    new RegExp(
+      `(${THEME_TOKEN_BLOCKLIST.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*:[^;]*;?`,
+      "gi",
+    ),
+    "",
+  );
+  // Strip !important (prevent overriding app styles)
+  out = out.replace(/!important/gi, "");
+
+  return out;
+}
+
+/**
+ * Stable, short, non-cryptographic hash (FNV-1a, base36). Used only to salt
+ * generated identifiers so they can't collide between independent card CSS
+ * specimens — it does not need to be secure, just deterministic.
+ */
+function hashCss(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Scope CSS rules under a given selector.
+ * - Sanitizes input
+ * - Namespaces @keyframes with "mc-" prefix
+ * - Rewrites :root, html, body to the scope selector
+ * - Prefixes all other selectors with the scope selector
+ */
+export function scopeChatCss(css: string, scopeSelector: string): string {
+  let sanitized = sanitizeChatCss(css);
+
+  // Namespace @keyframes: @keyframes foo -> @keyframes mc-foo
+  sanitized = sanitized.replace(/@keyframes\s+([^\s{]+)/gi, (_match, name: string) => {
+    return `@keyframes mc-${name}`;
+  });
+
+  // Rewrite animation-name references too
+  sanitized = sanitized.replace(/animation(?:-name)?\s*:[^;{}]*/gi, (match) => {
+    // For each animation name token that isn't a keyword, prefix with mc-
+    return match.replace(/:\s*([^;{}]*)/, (_, value: string) => {
+      const prefixed = value.replace(/(?:^|,\s*)([a-zA-Z_][\w-]*)/g, (full, name: string) => {
+        const keywords = new Set([
+          "none",
+          "initial",
+          "inherit",
+          "unset",
+          "infinite",
+          "alternate",
+          "reverse",
+          "alternate-reverse",
+          "normal",
+          "forwards",
+          "backwards",
+          "both",
+          "running",
+          "paused",
+          "ease",
+          "ease-in",
+          "ease-out",
+          "ease-in-out",
+          "linear",
+          "step-start",
+          "step-end",
+        ]);
+        if (keywords.has(name) || /^\d/.test(name)) return full;
+        return full.replace(name, `mc-${name}`);
+      });
+      return `: ${prefixed}`;
+    });
+  });
+
+  // Namespace @font-face families so an embedded font can't override an app-wide
+  // family (e.g. "Inter") outside the card. We rewrite the declared family in each
+  // kept @font-face block to a unique "mc-font-*" name, then rewrite the
+  // font-family / font references that point at it — mirroring @keyframes handling.
+  //
+  // @font-face rules are global (they can't be scoped under a selector), so the
+  // namespaced name is salted with a per-card hash (scope + source). Without the
+  // salt, two different cards that both embed `font-family: Inter` would both map to
+  // `mc-font-Inter` and silently clobber each other in the global cascade. The salt
+  // is stable per card, so multiple faces of the same family within one card
+  // (regular/bold/italic) still share a name and remain a single family.
+  const fontSalt = hashCss(`${scopeSelector}\\0${css}`);
+  const fontFamilyMap = new Map<string, string>();
+  sanitized = sanitized.replace(/@font-face\s*\{([^}]*)\}/gi, (_block, body: string) => {
+    const newBody = body.replace(
+      /(font-family\s*:\s*)("[^"]*"|'[^']*'|[^;]+)/i,
+      (_decl, prefix: string, rawValue: string) => {
+        const name = rawValue
+          .trim()
+          .replace(/^['"]|['"]$/g, "")
+          .trim();
+        if (!name) return `${prefix}${rawValue}`;
+        const namespaced = `mc-font-${name.replace(/[^a-zA-Z0-9_-]+/g, "-")}-${fontSalt}`;
+        fontFamilyMap.set(name.toLowerCase(), namespaced);
+        return `${prefix}"${namespaced}"`;
+      },
+    );
+    return `@font-face {${newBody}}`;
+  });
+  if (fontFamilyMap.size > 0) {
+    sanitized = sanitized.replace(/\bfont(?:-family)?\s*:\s*([^;{}]+)/gi, (decl: string, value: string) => {
+      let next = value;
+      for (const [orig, namespaced] of fontFamilyMap) {
+        const escaped = orig.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // quoted family occurrences: 'Inter' / "Inter"
+        next = next.replace(new RegExp(`(['"])${escaped}\\1`, "gi"), `"${namespaced}"`);
+        // unquoted single-token occurrences in a family list
+        next = next.replace(new RegExp(`(^|,|\\s)${escaped}(?=\\s*(?:,|$))`, "gi"), `$1"${namespaced}"`);
+      }
+      return decl.slice(0, decl.length - value.length) + next;
+    });
+  }
+
+  // Split into rules and scope selectors
+  const result: string[] = [];
+  // Simple rule-level split: find selector { ... } blocks
+  const ruleRe = /([^{}]+)\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}/g;
+  let ruleMatch: RegExpExecArray | null;
+
+  while ((ruleMatch = ruleRe.exec(sanitized)) !== null) {
+    const selector = ruleMatch[1].trim();
+    const body = ruleMatch[2];
+
+    // Skip @keyframes — already namespaced, don't prefix their contents
+    if (/^@keyframes\s/i.test(selector)) {
+      result.push(`${selector} {${body}}`);
+      continue;
+    }
+
+    // Skip @font-face — contains declarations, not nested rules
+    if (/^@font-face$/i.test(selector)) {
+      result.push(`${selector} {${body}}`);
+      continue;
+    }
+
+    // Handle @media and other at-rules that wrap rulesets
+    if (/^@/.test(selector)) {
+      // Recursively scope the inner rules
+      const innerScoped = scopeChatCss(body, scopeSelector);
+      result.push(`${selector} {${innerScoped}}`);
+      continue;
+    }
+
+    // Scope each selector in the comma-separated list
+    const scopedSelectors = selector.split(",").map((sel) => {
+      const s = sel.trim();
+      // :root, html, body -> scopeSelector (targets the scope element itself)
+      if (/^(:root|html|body)$/i.test(s)) return scopeSelector;
+      // Starts with :root, html, body (descendant or chained) -> replace prefix with scope
+      if (/^(:root|html|body)[\s:.[]/i.test(s)) return s.replace(/^(:root|html|body)/i, scopeSelector);
+      // [data-card-css] alone -> scopeSelector (self-reference in exclusive mode)
+      if (/^\[data-card-css\]$/i.test(s)) return scopeSelector;
+      // [data-card-css] with descendant -> replace with scope
+      if (/^\[data-card-css\]\s/i.test(s)) return s.replace(/^\[data-card-css\]/i, scopeSelector);
+      // [data-card-css] with chained pseudo-classes or attribute selectors
+      // e.g. [data-card-css]:not([data-grouped]), [data-card-css][data-grouped]
+      // In exclusive mode the scope IS the element, so chain on it.
+      // In chat mode the scope is a container, so keep as descendant (default).
+      if (/^\[data-card-css\][:[.]/.test(s) && scopeSelector.includes("[data-card-css=")) {
+        return s.replace(/^\[data-card-css\]/i, scopeSelector);
+      }
+      // Otherwise prefix
+      return `${scopeSelector} ${s}`;
+    });
+
+    result.push(`${scopedSelectors.join(", ")} {${body}}`);
+  }
+
+  return result.join("\n");
+}

--- a/packages/client/src/lib/creator-notes-css.ts
+++ b/packages/client/src/lib/creator-notes-css.ts
@@ -1,0 +1,23 @@
+// ──────────────────────────────────────────────
+// Creator-notes CSS — pull <style> blocks out of a
+// character card's creator_notes field.
+// ──────────────────────────────────────────────
+
+const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+/**
+ * Split a character's `creator_notes` into its embedded CSS and the remaining
+ * note text. Card authors wrap custom styling in `<style>…</style>` blocks;
+ * this lifts every block out so the CSS can be sanitized + scoped separately
+ * (see {@link file://./card-css.ts}) and the prose shown on its own.
+ */
+export function extractCreatorNotesCss(creatorNotes: string): { css: string; text: string } {
+  const cssBlocks: string[] = [];
+  const text = creatorNotes
+    .replace(STYLE_BLOCK_RE, (_match, css: string) => {
+      cssBlocks.push(css);
+      return "";
+    })
+    .trim();
+  return { css: cssBlocks.join("\n"), text };
+}

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -215,8 +215,9 @@ export interface ChatMetadata {
   spritePosition?: SpriteSide;
   /**
    * How creator-notes card CSS is applied in this chat:
-   * "disabled" (none), "exclusive" (each character's CSS only styles their own
-   * messages), or "chat" (all card CSS styles the whole chat area — default).
+   * "exclusive" (each character's CSS only styles their own messages) or "chat"
+   * (all card CSS styles the whole chat area). Defaults to "disabled" (off) —
+   * card styling is opt-in per chat.
    */
   cardCssMode?: "disabled" | "exclusive" | "chat";
   /** Display scale for roleplay Expression Engine sprites. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -213,6 +213,12 @@ export interface ChatMetadata {
   spriteDisplayModes?: Array<"expressions" | "full-body">;
   /** Preferred sidebar / default layout side for chat sprites. */
   spritePosition?: SpriteSide;
+  /**
+   * How creator-notes card CSS is applied in this chat:
+   * "disabled" (none), "exclusive" (each character's CSS only styles their own
+   * messages), or "chat" (all card CSS styles the whole chat area — default).
+   */
+  cardCssMode?: "disabled" | "exclusive" | "chat";
   /** Display scale for roleplay Expression Engine sprites. */
   spriteScale?: number;
   /** Display opacity for roleplay Expression Engine sprites. */


### PR DESCRIPTION
## Linked issue

Closes #2579

> Stacked on #2586 (card-CSS sanitizer hardening). Until #2586 merges, this PR's diff includes that commit; it will be rebased onto `staging` once #2586 lands. The two are otherwise independent — this feature ships its own self-contained card-CSS sanitizer (`lib/card-css.ts`).

## Why this change

Character cards can ship custom CSS in their `creator_notes` (a long-standing card convention), but staging has no way to apply it — so imported cards that rely on creator-notes styling render plain. This ports the creator-notes card-CSS feature (source: #1748) so a card's embedded styling actually shows in chat, with a per-chat control over how aggressively it applies and a hardened sanitizer so untrusted card CSS can't exfiltrate data, escape its scope, or override the app theme.

## What changed

- **`lib/card-css.ts`** — sanitizes + scopes untrusted card CSS: strips network/script vectors, removes `:has()` / `position: fixed` / history-probing, blocks theme-token overrides and `!important`, namespaces `@keyframes` and `@font-face` (anti-collision salted), recurses into `@media`, canonicalizes CSS escape sequences so the literal-text guards can't be evaded, and rewrites every selector under a per-card scope. Plus `filterCssByMode` for `@chat-mode` surface targeting.
- **`lib/creator-notes-css.ts`** — lifts `<style>` blocks out of `creator_notes`.
- **`CreatorNotesCssInjector`** — for the chat's active characters, extracts → filters → scopes → injects one `<style id="marinara-card-css">` into `<head>`, **unlayered** so its scoped selectors override the app's own message styling (the app sets some message styles with unlayered rules that beat any `@layer` — wrapping card CSS in a layer silently neutered most theming; the sanitizer + per-card scope still contain it). Mounted in `ChatArea` for the roleplay + conversation surfaces.
- **`ChatMetadata.cardCssMode`** — new per-chat tri-state: `disabled` (default — card styling is opt-in per chat) / `exclusive` (each character's CSS only styles their own messages) / `chat` (whole area).
- **Card Theming control** — a segmented selector in the chat settings drawer, shown only when an active character actually ships creator-notes CSS.
- **Scope markers** — `.mari-card-css` + `data-chat-mode` on the roleplay + conversation surface containers; `data-card-css={characterId}` on the message wrappers.

Game mode is intentionally out of scope here (its surface and narration log have a distinct structure and stacking); a follow-up can extend the same markers to it.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Already run (automated): client typecheck (`tsc -b`), client lint (`eslint`), and server typecheck all pass. Full `pnpm check` and the in-app checks below still need a human.

Please manually verify in the app:
- Add a `<style>…</style>` block to a character's **Creator Notes** (e.g. `<style>.mari-message-bubble { border: 2px solid hotpink; }</style>`), open a chat with that character, and confirm the **Card Theming** section appears in chat settings and the styling shows.
- Switch the mode: **Disabled** removes all card styling; **Exclusive** styles only that character's messages; **Chat** styles the whole area. Confirm the mode persists across a reload (it is per-chat metadata).
- In a 2+ character chat, confirm **Exclusive** keeps each card's CSS to its own messages (no bleed between characters).
- Security spot-checks — confirm these are neutralized: a `url(http://…)` background (no outbound request), a `--primary: red` override (app theme unchanged), a `position: fixed` overlay, a `:has()` probe, and an escaped evasion such as `po\73ition: fixed`.
- Confirm a normal chat with no card CSS is visually unchanged, and that the roleplay, conversation, and visual-novel surfaces all behave.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

To be added: screenshots of the Card Theming control and a card's CSS applied in chat (disabled / exclusive / chat).
