### PR TITLE
feat(chat): card-CSS theming hooks (typing indicator + message grouping)

### DIFF
--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -12,12 +12,18 @@ Paste a `<style>` block into your character's **Creator Notes** field (in the ch
 <style>
   [data-card-css] {
     border-left: 3px solid #ff69b4;
-    background: linear-gradient(90deg, rgba(255, 105, 180, 0.08) 0%, transparent 40%);
+  }
+  [data-card-css] .mari-message-name {
+    color: #ff8fd4;
+    text-shadow: 0 0 8px rgba(255, 105, 180, 0.5);
+  }
+  [data-card-css] .mari-message-content {
+    color: #ffd6f0;
   }
 </style>
 ```
 
-This gives your character a pink accent on their messages.
+This gives the character a pink accent border, a glowing pink name, and soft pink message text — and it works in both roleplay and conversation.
 
 > Card theming is **off by default**. Open **Chat Settings → Card Theming** and pick a mode (it only appears once an active character actually has CSS in its creator notes). See the modes below.
 
@@ -30,7 +36,7 @@ When a character with CSS in their creator notes is active, Marinara:
 1. Extracts every `<style>` block from the creator notes,
 2. Sanitizes the CSS (strips anything dangerous — see [What You Cannot Style](#what-you-cannot-style)),
 3. Scopes it so it can only affect the chat, and
-4. Injects it into the page inside an `@layer card-css` layer.
+4. Injects it into the page so its scoped selectors override the app's own message styling.
 
 Users choose how it's applied via **Chat Settings → Card Theming** (per chat):
 
@@ -127,6 +133,23 @@ Roleplay messages can contain HTML, so you have the most creative freedom — st
 | `[data-grouped]`                                | Present on consecutive (continuation) messages from the same character              |
 
 Works well: HTML structures, CSS animations (`@keyframes`, transitions), pseudo-elements (`::before`/`::after`), backgrounds, borders, shadows, gradients, and custom fonts (system/web-safe stacks, or embedded `@font-face` with font `data:` URIs).
+
+**Example — style the message itself (no custom HTML needed):**
+
+```css
+[data-card-css] .mari-message-bubble {
+  border: 1px solid rgba(255, 105, 180, 0.4);
+  border-radius: 12px;
+  background: rgba(255, 105, 180, 0.08);
+}
+[data-card-css] .mari-message-name {
+  color: #ff8fd4;
+  text-shadow: 0 0 8px rgba(255, 105, 180, 0.5);
+}
+[data-card-css] .mari-message-content {
+  color: #ffe3f4;
+}
+```
 
 ### Conversation Mode
 
@@ -234,7 +257,7 @@ These are stripped by the sanitizer for security:
 | `!important`                    | Stripped, so card CSS can't force-override app styles.                                                                                                                                                                           |
 | App theme tokens                | Declarations like `--primary: blue` or `--background: red` are stripped so card CSS can't repaint the app UI.                                                                                                                    |
 
-Because card CSS is injected in an `@layer card-css` layer, a rule that fights a style the app already applies may not win — prefer properties the UI doesn't already set (borders, shadows, backgrounds the element lacks, opacity, custom colors).
+Card CSS is injected with scoped selectors that out-specify the app's own message styles, so it can recolor text, swap backgrounds, change borders and fonts, and so on within the chat. The only things it can't override are what the sanitizer strips (above), anything outside the chat scope, and styles the app applies inline or with `!important` (for example your global chat font color/size) — card CSS can't use `!important` itself.
 
 **Custom fonts** — embed with base64 `data:` URIs, or use system/web-safe stacks:
 

--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -1,0 +1,329 @@
+# Card CSS Theming Guide
+
+Give your characters a unique visual identity in chat. This guide covers how to embed custom CSS in your character cards so their messages look exactly the way you want — safely scoped so a card can only ever style the chat, never the rest of the app.
+
+---
+
+## Quick Start
+
+Paste a `<style>` block into your character's **Creator Notes** field (in the character editor) and save. When that character is active in a chat, Marinara extracts and applies the CSS automatically.
+
+```html
+<style>
+  [data-card-css] {
+    border-left: 3px solid #ff69b4;
+    background: linear-gradient(90deg, rgba(255, 105, 180, 0.08) 0%, transparent 40%);
+  }
+</style>
+```
+
+This gives your character a pink accent on their messages.
+
+> Card theming is **off by default**. Open **Chat Settings → Card Theming** and pick a mode (it only appears once an active character actually has CSS in its creator notes). See the modes below.
+
+---
+
+## How It Works
+
+When a character with CSS in their creator notes is active, Marinara:
+
+1. Extracts every `<style>` block from the creator notes,
+2. Sanitizes the CSS (strips anything dangerous — see [What You Cannot Style](#what-you-cannot-style)),
+3. Scopes it so it can only affect the chat, and
+4. Injects it into the page inside an `@layer card-css` layer.
+
+Users choose how it's applied via **Chat Settings → Card Theming** (per chat):
+
+| Mode                   | What it does                                         |
+| ---------------------- | ---------------------------------------------------- |
+| **Disabled** (default) | No card CSS is applied — the character looks default |
+| **Exclusive**          | Each character's CSS only affects their own messages |
+| **Chat**               | All card CSS affects the entire chat area            |
+
+**Exclusive** suits group chats where each character has its own look. **Chat** suits single-character experiences where the card themes the whole chat surface.
+
+---
+
+## The one scoping rule that matters
+
+Your CSS is rewritten so it can only reach the chat. _How_ it's rewritten depends on the mode, and this trips people up:
+
+- **Chat mode** scopes everything under the chat area (`.mari-card-css`). A selector like `.mari-message` matches normally — it's something _inside_ the area.
+- **Exclusive mode** scopes everything under _each of your character's own message elements_. Those elements are the ones carrying `data-card-css`. **A class on that same element (e.g. `.mari-message`, or `.mari-typing-indicator`) will not match it in Exclusive** — only things _inside_ it will.
+
+So the portable rule:
+
+> **Use `[data-card-css]` to style the message element itself, and normal class selectors for everything inside it.**
+
+`[data-card-css]` is rewritten to "this character's message" in Exclusive and "the chat area" in Chat, so it works in both modes. (`:root` and `body` are rewritten to the scope the same way.)
+
+```css
+[data-card-css] {
+  /* the message wrapper (Exclusive) or the chat area (Chat) */
+}
+[data-card-css] .mari-message-body {
+  /* the bubble inside it — matches in both modes */
+}
+```
+
+If you write `.mari-message { … }` and it works in Chat but vanishes in Exclusive, this is why — switch it to `[data-card-css] { … }`.
+
+---
+
+## Mode-Specific CSS with `@chat-mode`
+
+Different chat surfaces render differently. Wrap rules in `@chat-mode` blocks to target a specific surface; CSS outside any block applies everywhere.
+
+```html
+<style>
+  /* Applies in ALL modes */
+  .note-box {
+    border: 1px solid #0f0;
+    background: #000;
+  }
+
+  /* Only in Roleplay mode */
+  @chat-mode roleplay {
+    .camera-view {
+      border: 2px solid rgba(0, 255, 0, 0.3);
+      box-shadow: 0 0 20px rgba(0, 255, 0, 0.4);
+    }
+  }
+
+  /* Only in Conversation mode */
+  @chat-mode conversation {
+    [data-card-css] {
+      border-left: 2px solid #00ff00;
+      border-radius: 1rem;
+      padding: 0.75rem;
+      background: rgba(0, 30, 0, 0.8);
+    }
+  }
+</style>
+```
+
+Standard `@media` queries work normally inside `@chat-mode` blocks for responsive layouts.
+
+> **Game mode** does not apply card CSS yet — a `@chat-mode game { … }` block is harmless but currently has no effect.
+
+---
+
+## What You Can Style
+
+### Roleplay Mode
+
+Roleplay messages can contain HTML, so you have the most creative freedom — style the message HTML your card (or your regex scripts) produces.
+
+| Selector                                        | What it targets                                                                     |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `[data-card-css]`                               | The message wrapper (this character's messages in Exclusive; the chat area in Chat) |
+| `:root` / `body`                                | Rewritten to the scope automatically — same as `[data-card-css]`                    |
+| `.mari-message`                                 | A message container                                                                 |
+| `.mari-message-narrator`                        | Narrator messages                                                                   |
+| `.mari-message-assistant`                       | Character messages                                                                  |
+| `.mari-message-user`                            | User messages                                                                       |
+| `.mari-message-bubble`, `.mari-message-content` | The bubble and the text container                                                   |
+| Any custom class                                | Classes your message HTML injects (e.g. `.camera-view`, `.terminal-window`)         |
+| `[data-grouped]`                                | Present on consecutive (continuation) messages from the same character              |
+
+Works well: HTML structures, CSS animations (`@keyframes`, transitions), pseudo-elements (`::before`/`::after`), backgrounds, borders, shadows, gradients, and custom fonts (system/web-safe stacks, or embedded `@font-face` with font `data:` URIs).
+
+### Conversation Mode
+
+Conversation messages render as text + markdown. Theming here styles the existing message elements.
+
+| Selector                                    | What it targets                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `[data-card-css]`                           | The message wrapper — your main target                                                           |
+| `[data-card-css] .mari-message-body`        | The bubble container — background, border, corners, shadows                                      |
+| `[data-card-css] .mari-message-meta`        | The header row (name + timestamp)                                                                |
+| `[data-card-css] .mari-message-name`        | The display name                                                                                 |
+| `[data-card-css] .mari-message-timestamp`   | The timestamp                                                                                    |
+| `[data-card-css] .mari-message-content`     | The text container                                                                               |
+| `[data-card-css] .mari-message-avatar`      | The avatar column; `.mari-message-avatar > div` is the avatar circle                             |
+| `[data-card-css] p`, `[data-card-css] span` | Paragraphs and inline spans in the text                                                          |
+| `[data-grouped]`                            | Continuation messages — use `[data-card-css]:not([data-grouped])` for the first message in a run |
+
+**Example — message bubble:**
+
+```css
+@chat-mode conversation {
+  [data-card-css] .mari-message-body {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    border: 1px solid rgba(100, 149, 237, 0.3);
+    border-radius: 1rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+  [data-card-css] .mari-message-name {
+    color: #6495ed;
+    text-shadow: 0 0 8px rgba(100, 149, 237, 0.5);
+  }
+  [data-card-css] .mari-message-content p {
+    color: #e0e0ff;
+    font-family: Georgia, serif;
+  }
+}
+```
+
+#### Typing Indicator
+
+While a character generates a reply, Marinara shows a "_(name) is typing…_" row (in conversation mode, classic message style). It's themeable:
+
+| Selector                 | What it targets                                                          |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `.mari-typing-indicator` | The indicator row                                                        |
+| `.mari-typing-dots`      | The animated dots wrapper — style the dots with `.mari-typing-dots span` |
+| `.mari-typing-text`      | The "(name) is typing…" label                                            |
+
+The character's name is also exposed on the row as a `data-typing-name` attribute, so you can compose your own label with `content: attr(data-typing-name)`.
+
+> **Scoping note (Exclusive mode):** `data-card-css` sits **on** the `.mari-typing-indicator` row itself. So target the row with **no space** (`[data-card-css].mari-typing-indicator`) and its children **with a space** (`[data-card-css] .mari-typing-text`) — the same rule as messages above.
+
+```css
+@chat-mode conversation {
+  /* recolor the label + dots */
+  [data-card-css] .mari-typing-text {
+    color: #c77b92;
+    font-style: italic;
+  }
+  [data-card-css] .mari-typing-dots span {
+    background: #e3a8bd;
+  }
+
+  /* or replace the label entirely, name included */
+  [data-card-css] .mari-typing-text {
+    display: none;
+  }
+  [data-card-css].mari-typing-indicator::after {
+    content: attr(data-typing-name) " is cooking up a reply…";
+    font-style: italic;
+    color: #c77b92;
+  }
+}
+```
+
+#### Avatar
+
+The conversation avatar is a 40px circle — reshape it with pure CSS:
+
+```css
+@chat-mode conversation {
+  [data-card-css] .mari-message-avatar > div {
+    border-radius: 8px; /* square it off — 0 = sharp, 50% = circle */
+    box-shadow: 0 0 0 3px #fff; /* white sticker border */
+  }
+}
+```
+
+> Swapping the avatar _image_ per character (emoji / sprite / gallery / hide) is a separate upcoming feature — see issue #2592. The CSS reshaping above works today.
+
+---
+
+## What You Cannot Style
+
+These are stripped by the sanitizer for security:
+
+| Blocked                         | Why                                                                                                                                                                                                                              |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url(https://…)`                | Prevents network requests that could track users or exfiltrate data. Only `url(data:…)` is allowed, for inline images and embedded fonts.                                                                                        |
+| `@font-face` with external URLs | Only `data:` font sources (`font/*`, `application/font*`, `application/x-font*`) are kept; the embedded family name is auto-namespaced so it can't override app fonts, and your `font-family` references are rewritten to match. |
+| `@import`                       | Prevents loading external stylesheets.                                                                                                                                                                                           |
+| `:has()` selectors              | Prevents probing elements outside the chat.                                                                                                                                                                                      |
+| `content:` with HTML            | Decorative text is allowed, but `<` and `>` are stripped and text is capped at 200 chars. CSS functions like `attr()` and `counter()` are permitted (e.g. `content: attr(data-typing-name)`).                                    |
+| `position: fixed`               | Converted to `position: absolute` to prevent full-screen overlays.                                                                                                                                                               |
+| `!important`                    | Stripped, so card CSS can't force-override app styles.                                                                                                                                                                           |
+| App theme tokens                | Declarations like `--primary: blue` or `--background: red` are stripped so card CSS can't repaint the app UI.                                                                                                                    |
+
+Because card CSS is injected in an `@layer card-css` layer, a rule that fights a style the app already applies may not win — prefer properties the UI doesn't already set (borders, shadows, backgrounds the element lacks, opacity, custom colors).
+
+**Custom fonts** — embed with base64 `data:` URIs, or use system/web-safe stacks:
+
+```css
+@font-face {
+  font-family: "MyFont";
+  src: url(data:font/woff2;base64,d09GMgAB...) format("woff2");
+}
+font-family: "Courier New", Consolas, monospace;
+```
+
+---
+
+## Tips for Card Creators
+
+1. **Use `[data-card-css]` as your root selector.** It works in both Exclusive and Chat modes (see [the scoping rule](#the-one-scoping-rule-that-matters)).
+2. **Use `@chat-mode` blocks** so your card looks intentional in both roleplay and conversation, not just the surface you tested.
+3. **Test in light and dark themes.** Use `rgba()` colors so they blend with any background.
+4. **Keep animations subtle** — prefer `transition` over heavy `animation` for lower-end devices.
+5. **Don't depend on internal utility classes.** Stick to the documented selectors (`[data-card-css]`, `.mari-message-body`, `.mari-message-name`, `.mari-message-content`, `.mari-typing-*`, `p`, `span`); other class names can change between versions.
+6. **Use `@media (max-width: 768px)`** for phones and narrow windows.
+7. **Theme the "typing…" state** — a little `.mari-typing-text` / `.mari-typing-dots span` styling goes a long way.
+
+---
+
+## Using an AI Assistant to Create Card CSS
+
+If you'd rather not hand-write CSS, ask an AI assistant. A prompt template:
+
+> I'm creating a character card for Marinara Engine (an AI chat app). The card has a "Creator Notes" field where I can embed `<style>` blocks. I need CSS that themes the character's messages.
+>
+> **Character concept:** [describe the aesthetic — e.g. "cyberpunk hacker, neon-green terminal vibes" or "soft cottagecore fairy, pink pastels"]
+>
+> **Technical constraints:**
+>
+> - Use `[data-card-css]` for the message wrapper element (it works in both "Exclusive" and "Chat" scoping modes); use normal class selectors for things inside it.
+> - `[data-card-css] .mari-message-body` = the bubble (background / border / corners); `[data-card-css] .mari-message-content` = the text area; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar > div` = the avatar circle (override `border-radius`); `[data-card-css] p` = text paragraphs.
+> - Style the "typing…" indicator via `[data-card-css] .mari-typing-text` and `[data-card-css] .mari-typing-dots span` (the name is available as `attr(data-typing-name)`).
+> - Wrap roleplay-only CSS in `@chat-mode roleplay { … }` and conversation-only CSS in `@chat-mode conversation { … }`; CSS outside these applies everywhere.
+> - `url(https://…)`, `@import`, `:has()`, and `!important` are blocked; `position: fixed` becomes `absolute`; app theme tokens (`--primary`, etc.) are stripped. Use `url(data:…)` and `rgba()` colors.
+> - `[data-grouped]` marks continuation messages — use `:not([data-grouped])` for first-in-group.
+>
+> Output a single `<style>` block I can paste into the Creator Notes field.
+
+**After generating:** paste into Creator Notes → open a chat with the character → Chat Settings → Card Theming → set **Exclusive** → send a test message → try switching Exclusive ↔ Chat to compare.
+
+---
+
+## Example: Multi-Mode Card CSS
+
+```html
+<style>
+  /* Shared animation */
+  @keyframes glow-pulse {
+    0%,
+    100% {
+      box-shadow: 0 0 8px rgba(0, 255, 0, 0.2);
+    }
+    50% {
+      box-shadow: 0 0 16px rgba(0, 255, 0, 0.4);
+    }
+  }
+
+  /* Roleplay: immersive */
+  @chat-mode roleplay {
+    .terminal-window {
+      background: #1a1a1a;
+      border: 1px solid #0f0;
+      border-radius: 8px;
+      animation: glow-pulse 3s ease-in-out infinite;
+    }
+  }
+
+  /* Conversation: clean bubbles */
+  @chat-mode conversation {
+    [data-card-css] .mari-message-body {
+      background: linear-gradient(135deg, rgba(0, 30, 0, 0.85), rgba(0, 15, 0, 0.7));
+      border: 1px solid rgba(0, 255, 0, 0.3);
+      border-radius: 1rem;
+    }
+    [data-card-css] .mari-message-name {
+      color: #00ff00;
+      text-shadow: 0 0 8px rgba(0, 255, 0, 0.6);
+      font-family: "Courier New", monospace;
+    }
+    [data-card-css] .mari-message-content p {
+      font-family: "Courier New", monospace;
+      color: #c0ffc0;
+    }
+  }
+</style>
+```

--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -113,7 +113,7 @@ Wrap rules in `@chat-mode` blocks to target a specific surface; CSS outside any 
 
 Standard `@media` queries work normally inside `@chat-mode` blocks for responsive layouts.
 
-> **Game mode** does not apply card CSS yet — a `@chat-mode game { … }` block is harmless but has no effect.
+> **Game mode** has baseline support: in **Chat** mode, card CSS reaches the whole game surface (scoped to `.mari-card-css`), so `[data-card-css] { … }` themes the game area and `@chat-mode game { … }` targets it specifically. Game uses its own layout — the message-bubble hooks above don't exist there, so target broadly (e.g. the area background). Per-character (Exclusive) scoping of game narration is a planned enhancement, not in yet.
 
 ---
 

--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -1,21 +1,27 @@
 # Card CSS Theming Guide
 
-Give your characters a unique visual identity in chat. This guide covers how to embed custom CSS in your character cards so their messages look exactly the way you want — safely scoped so a card can only ever style the chat, never the rest of the app.
+Give your characters a unique visual identity in chat. Embed CSS in a character's **Creator Notes** and Marinara applies it to that character's messages — safely scoped so a card can only ever style the chat, never the rest of the app.
+
+Every selector and example below is written against the real chat DOM and has the cascade working in its favor, so they actually take effect (not just compile).
 
 ---
 
 ## Quick Start
 
-Paste a `<style>` block into your character's **Creator Notes** field (in the character editor) and save. When that character is active in a chat, Marinara extracts and applies the CSS automatically.
+Paste a `<style>` block into your character's **Creator Notes** field and save. Then open a chat with that character, open **Chat Settings → Card Theming**, and switch the mode on (it defaults to **Disabled** and only appears once an active character has CSS).
 
 ```html
 <style>
-  [data-card-css] {
-    border-left: 3px solid #ff69b4;
+  /* the visible message bubble (bubble style + roleplay) */
+  [data-card-css] .mari-message-bubble {
+    background: linear-gradient(135deg, #2a1240, #3a1030);
+    border: 1px solid #ff66cc;
+    border-radius: 14px;
   }
+  /* the name and text (works in every message style) */
   [data-card-css] .mari-message-name {
     color: #ff8fd4;
-    text-shadow: 0 0 8px rgba(255, 105, 180, 0.5);
+    text-shadow: 0 0 8px rgba(255, 102, 204, 0.6);
   }
   [data-card-css] .mari-message-content {
     color: #ffd6f0;
@@ -23,9 +29,9 @@ Paste a `<style>` block into your character's **Creator Notes** field (in the ch
 </style>
 ```
 
-This gives the character a pink accent border, a glowing pink name, and soft pink message text — and it works in both roleplay and conversation.
+The character's bubble turns a purple gradient with a pink border, their name glows pink, and their text goes soft pink.
 
-> Card theming is **off by default**. Open **Chat Settings → Card Theming** and pick a mode (it only appears once an active character actually has CSS in its creator notes). See the modes below.
+> **Sanity check:** if you want a single undeniable test, use `[data-card-css] .mari-message-bubble { background: hotpink; }` — the bubble should turn bright pink immediately.
 
 ---
 
@@ -52,57 +58,54 @@ Users choose how it's applied via **Chat Settings → Card Theming** (per chat):
 
 ## The one scoping rule that matters
 
-Your CSS is rewritten so it can only reach the chat. _How_ it's rewritten depends on the mode, and this trips people up:
+Your CSS is rewritten so it can only reach the chat. _How_ it's rewritten depends on the mode:
 
-- **Chat mode** scopes everything under the chat area (`.mari-card-css`). A selector like `.mari-message` matches normally — it's something _inside_ the area.
-- **Exclusive mode** scopes everything under _each of your character's own message elements_. Those elements are the ones carrying `data-card-css`. **A class on that same element (e.g. `.mari-message`, or `.mari-typing-indicator`) will not match it in Exclusive** — only things _inside_ it will.
+- **Chat mode** scopes everything under the chat area (`.mari-card-css`). `.mari-message-bubble` matches normally — it's inside the area.
+- **Exclusive mode** scopes everything under _each of your character's own message elements_ (the ones carrying `data-card-css`). A class on that same element can't match it as a descendant — only things _inside_ it can.
 
 So the portable rule:
 
-> **Use `[data-card-css]` to style the message element itself, and normal class selectors for everything inside it.**
+> **Use `[data-card-css]` to style the message element itself, and normal class selectors for everything inside it** (`.mari-message-bubble`, `.mari-message-content`, `.mari-message-name`, …).
 
-`[data-card-css]` is rewritten to "this character's message" in Exclusive and "the chat area" in Chat, so it works in both modes. (`:root` and `body` are rewritten to the scope the same way.)
+`[data-card-css]` is rewritten to "this character's message" in Exclusive and "the chat area" in Chat, so it works in both. The inner-element selectors (with a space) work the same in both modes.
 
 ```css
 [data-card-css] {
-  /* the message wrapper (Exclusive) or the chat area (Chat) */
+  /* the message row itself — good for a left-accent border */
+  border-left: 3px solid #ff66cc;
 }
-[data-card-css] .mari-message-body {
-  /* the bubble inside it — matches in both modes */
+[data-card-css] .mari-message-bubble {
+  /* the visible bubble inside it */
+  border-radius: 14px;
 }
 ```
-
-If you write `.mari-message { … }` and it works in Chat but vanishes in Exclusive, this is why — switch it to `[data-card-css] { … }`.
 
 ---
 
 ## Mode-Specific CSS with `@chat-mode`
 
-Different chat surfaces render differently. Wrap rules in `@chat-mode` blocks to target a specific surface; CSS outside any block applies everywhere.
+Wrap rules in `@chat-mode` blocks to target a specific surface; CSS outside any block applies everywhere.
 
 ```html
 <style>
   /* Applies in ALL modes */
-  .note-box {
-    border: 1px solid #0f0;
-    background: #000;
+  [data-card-css] .mari-message-name {
+    color: #00ff95;
   }
 
   /* Only in Roleplay mode */
   @chat-mode roleplay {
-    .camera-view {
-      border: 2px solid rgba(0, 255, 0, 0.3);
-      box-shadow: 0 0 20px rgba(0, 255, 0, 0.4);
+    [data-card-css] .mari-message-bubble {
+      border: 1px solid rgba(0, 255, 149, 0.4);
+      box-shadow: 0 0 16px rgba(0, 255, 149, 0.25);
     }
   }
 
   /* Only in Conversation mode */
   @chat-mode conversation {
-    [data-card-css] {
-      border-left: 2px solid #00ff00;
+    [data-card-css] .mari-message-bubble {
+      background: rgba(0, 40, 28, 0.9);
       border-radius: 1rem;
-      padding: 0.75rem;
-      background: rgba(0, 30, 0, 0.8);
     }
   }
 </style>
@@ -110,135 +113,78 @@ Different chat surfaces render differently. Wrap rules in `@chat-mode` blocks to
 
 Standard `@media` queries work normally inside `@chat-mode` blocks for responsive layouts.
 
-> **Game mode** does not apply card CSS yet — a `@chat-mode game { … }` block is harmless but currently has no effect.
+> **Game mode** does not apply card CSS yet — a `@chat-mode game { … }` block is harmless but has no effect.
 
 ---
 
 ## What You Can Style
 
-### Roleplay Mode
+The chat DOM is the same skeleton in roleplay and conversation. These are the elements card CSS can target. (Internal Tailwind utility classes are **not** documented hooks — they change between versions; stick to the `mari-*` classes and `data-*` attributes below.)
 
-Roleplay messages can contain HTML, so you have the most creative freedom — style the message HTML your card (or your regex scripts) produces.
+| Selector                                  | What it targets                                                                                                |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `[data-card-css]`                         | The whole message **row** (the scope element) — left/edge accents, or the chat area in Chat mode               |
+| `[data-card-css] .mari-message-bubble`    | The **visible bubble** — background, border, corners, shadow. _(Bubble style + roleplay.)_                     |
+| `[data-card-css] .mari-message-content`   | The **message text**. In bubble style this is the bubble element itself, so it also takes background/border    |
+| `[data-card-css] .mari-message-name`      | The character's display **name**                                                                               |
+| `[data-card-css] .mari-message-meta`      | The header row holding the name + timestamp                                                                    |
+| `[data-card-css] .mari-message-timestamp` | The timestamp                                                                                                  |
+| `[data-card-css] .mari-message-avatar`    | The avatar column; `.mari-message-avatar > div` is the avatar **circle** (override `border-radius` to reshape) |
+| `[data-card-css] .mari-message-narrator`  | Narrator messages (roleplay)                                                                                   |
+| `[data-card-css] .mari-message-user`      | User messages — `.mari-message-assistant` for character messages                                               |
+| `[data-card-css] p`, `… span`             | Paragraphs and inline spans inside the text                                                                    |
+| `[data-grouped]`                          | Continuation messages from the same character — use `[data-card-css]:not([data-grouped])` for first-in-group   |
 
-| Selector                                        | What it targets                                                                     |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `[data-card-css]`                               | The message wrapper (this character's messages in Exclusive; the chat area in Chat) |
-| `:root` / `body`                                | Rewritten to the scope automatically — same as `[data-card-css]`                    |
-| `.mari-message`                                 | A message container                                                                 |
-| `.mari-message-narrator`                        | Narrator messages                                                                   |
-| `.mari-message-assistant`                       | Character messages                                                                  |
-| `.mari-message-user`                            | User messages                                                                       |
-| `.mari-message-bubble`, `.mari-message-content` | The bubble and the text container                                                   |
-| Any custom class                                | Classes your message HTML injects (e.g. `.camera-view`, `.terminal-window`)         |
-| `[data-grouped]`                                | Present on consecutive (continuation) messages from the same character              |
+> **Bubble vs classic:** the **bubble** conversation style is what `.mari-message-bubble` targets. In the **classic** (flat) conversation style there's no bubble element — style `.mari-message-content` (text) and `[data-card-css]` (row) instead. Roleplay always has a bubble.
 
-Works well: HTML structures, CSS animations (`@keyframes`, transitions), pseudo-elements (`::before`/`::after`), backgrounds, borders, shadows, gradients, and custom fonts (system/web-safe stacks, or embedded `@font-face` with font `data:` URIs).
-
-**Example — style the message itself (no custom HTML needed):**
+**Example — a styled conversation/roleplay bubble:**
 
 ```css
 [data-card-css] .mari-message-bubble {
-  border: 1px solid rgba(255, 105, 180, 0.4);
-  border-radius: 12px;
-  background: rgba(255, 105, 180, 0.08);
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  border: 1px solid rgba(100, 149, 237, 0.35);
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
 }
 [data-card-css] .mari-message-name {
-  color: #ff8fd4;
-  text-shadow: 0 0 8px rgba(255, 105, 180, 0.5);
+  color: #6495ed;
+  text-shadow: 0 0 8px rgba(100, 149, 237, 0.5);
 }
 [data-card-css] .mari-message-content {
-  color: #ffe3f4;
+  font-family: Georgia, serif;
 }
 ```
 
-### Conversation Mode
+### Typing Indicator
 
-Conversation messages render as text + markdown. Theming here styles the existing message elements.
+While a character generates a reply, conversation mode (classic message style) shows a "_(name) is typing…_" row:
 
-| Selector                                    | What it targets                                                                                  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `[data-card-css]`                           | The message wrapper — your main target                                                           |
-| `[data-card-css] .mari-message-body`        | The bubble container — background, border, corners, shadows                                      |
-| `[data-card-css] .mari-message-meta`        | The header row (name + timestamp)                                                                |
-| `[data-card-css] .mari-message-name`        | The display name                                                                                 |
-| `[data-card-css] .mari-message-timestamp`   | The timestamp                                                                                    |
-| `[data-card-css] .mari-message-content`     | The text container                                                                               |
-| `[data-card-css] .mari-message-avatar`      | The avatar column; `.mari-message-avatar > div` is the avatar circle                             |
-| `[data-card-css] p`, `[data-card-css] span` | Paragraphs and inline spans in the text                                                          |
-| `[data-grouped]`                            | Continuation messages — use `[data-card-css]:not([data-grouped])` for the first message in a run |
-
-**Example — message bubble:**
+| Selector                                 | What it targets                                              |
+| ---------------------------------------- | ------------------------------------------------------------ |
+| `[data-card-css] .mari-typing-text`      | The "(name) is typing…" label                                |
+| `[data-card-css] .mari-typing-dots span` | The animated dots                                            |
+| `[data-card-css] .mari-typing-indicator` | The row itself (also carries the name as `data-typing-name`) |
 
 ```css
-@chat-mode conversation {
-  [data-card-css] .mari-message-body {
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-    border: 1px solid rgba(100, 149, 237, 0.3);
-    border-radius: 1rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
-  [data-card-css] .mari-message-name {
-    color: #6495ed;
-    text-shadow: 0 0 8px rgba(100, 149, 237, 0.5);
-  }
-  [data-card-css] .mari-message-content p {
-    color: #e0e0ff;
-    font-family: Georgia, serif;
-  }
+[data-card-css] .mari-typing-text {
+  color: #ff66cc;
+  font-style: italic;
+}
+[data-card-css] .mari-typing-dots span {
+  background: #ff66cc;
 }
 ```
 
-#### Typing Indicator
+### Avatar
 
-While a character generates a reply, Marinara shows a "_(name) is typing…_" row (in conversation mode, classic message style). It's themeable:
-
-| Selector                 | What it targets                                                          |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `.mari-typing-indicator` | The indicator row                                                        |
-| `.mari-typing-dots`      | The animated dots wrapper — style the dots with `.mari-typing-dots span` |
-| `.mari-typing-text`      | The "(name) is typing…" label                                            |
-
-The character's name is also exposed on the row as a `data-typing-name` attribute, so you can compose your own label with `content: attr(data-typing-name)`.
-
-> **Scoping note (Exclusive mode):** `data-card-css` sits **on** the `.mari-typing-indicator` row itself. So target the row with **no space** (`[data-card-css].mari-typing-indicator`) and its children **with a space** (`[data-card-css] .mari-typing-text`) — the same rule as messages above.
+The avatar is a circle by default — reshape and ring it with pure CSS:
 
 ```css
-@chat-mode conversation {
-  /* recolor the label + dots */
-  [data-card-css] .mari-typing-text {
-    color: #c77b92;
-    font-style: italic;
-  }
-  [data-card-css] .mari-typing-dots span {
-    background: #e3a8bd;
-  }
-
-  /* or replace the label entirely, name included */
-  [data-card-css] .mari-typing-text {
-    display: none;
-  }
-  [data-card-css].mari-typing-indicator::after {
-    content: attr(data-typing-name) " is cooking up a reply…";
-    font-style: italic;
-    color: #c77b92;
-  }
+[data-card-css] .mari-message-avatar > div {
+  border-radius: 6px; /* 0 = sharp corners, 50% = back to a circle */
+  box-shadow: 0 0 0 2px #ff66cc;
 }
 ```
-
-#### Avatar
-
-The conversation avatar is a 40px circle — reshape it with pure CSS:
-
-```css
-@chat-mode conversation {
-  [data-card-css] .mari-message-avatar > div {
-    border-radius: 8px; /* square it off — 0 = sharp, 50% = circle */
-    box-shadow: 0 0 0 3px #fff; /* white sticker border */
-  }
-}
-```
-
-> Swapping the avatar _image_ per character (emoji / sprite / gallery / hide) is a separate upcoming feature — see issue #2592. The CSS reshaping above works today.
 
 ---
 
@@ -246,18 +192,18 @@ The conversation avatar is a 40px circle — reshape it with pure CSS:
 
 These are stripped by the sanitizer for security:
 
-| Blocked                         | Why                                                                                                                                                                                                                              |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url(https://…)`                | Prevents network requests that could track users or exfiltrate data. Only `url(data:…)` is allowed, for inline images and embedded fonts.                                                                                        |
-| `@font-face` with external URLs | Only `data:` font sources (`font/*`, `application/font*`, `application/x-font*`) are kept; the embedded family name is auto-namespaced so it can't override app fonts, and your `font-family` references are rewritten to match. |
-| `@import`                       | Prevents loading external stylesheets.                                                                                                                                                                                           |
-| `:has()` selectors              | Prevents probing elements outside the chat.                                                                                                                                                                                      |
-| `content:` with HTML            | Decorative text is allowed, but `<` and `>` are stripped and text is capped at 200 chars. CSS functions like `attr()` and `counter()` are permitted (e.g. `content: attr(data-typing-name)`).                                    |
-| `position: fixed`               | Converted to `position: absolute` to prevent full-screen overlays.                                                                                                                                                               |
-| `!important`                    | Stripped, so card CSS can't force-override app styles.                                                                                                                                                                           |
-| App theme tokens                | Declarations like `--primary: blue` or `--background: red` are stripped so card CSS can't repaint the app UI.                                                                                                                    |
+| Blocked                         | Why                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `url(https://…)`                | No network requests (tracking / exfiltration). Only `url(data:…)` is allowed, for inline images/fonts   |
+| `@font-face` with external URLs | Only `data:` font sources are kept; the family name is auto-namespaced so it can't override app fonts   |
+| `@import`                       | No loading external stylesheets                                                                         |
+| `:has()` selectors              | Can't probe elements outside the chat                                                                   |
+| `content:` with HTML            | Decorative text allowed, but `<`/`>` are stripped and capped at 200 chars; `attr()`/`counter()` allowed |
+| `position: fixed`               | Converted to `position: absolute` (no full-screen overlays)                                             |
+| `!important`                    | Stripped, so card CSS can't force-override app styles                                                   |
+| App theme tokens                | `--primary`, `--background`, etc. are stripped so card CSS can't repaint the app UI                     |
 
-Card CSS is injected with scoped selectors that out-specify the app's own message styles, so it can recolor text, swap backgrounds, change borders and fonts, and so on within the chat. The only things it can't override are what the sanitizer strips (above), anything outside the chat scope, and styles the app applies inline or with `!important` (for example your global chat font color/size) — card CSS can't use `!important` itself.
+Card CSS is injected with scoped selectors that out-specify the app's own message styles, so it wins for colors, backgrounds, borders, fonts, and so on within the chat. The only things it can't beat are what the sanitizer strips (above), anything outside the chat scope, and styles the app applies inline or with `!important` (for example your global chat font color/size in Settings).
 
 **Custom fonts** — embed with base64 `data:` URIs, or use system/web-safe stacks:
 
@@ -271,82 +217,127 @@ font-family: "Courier New", Consolas, monospace;
 
 ---
 
-## Tips for Card Creators
+## Exclusive vs Chat: choosing a scope
 
-1. **Use `[data-card-css]` as your root selector.** It works in both Exclusive and Chat modes (see [the scoping rule](#the-one-scoping-rule-that-matters)).
-2. **Use `@chat-mode` blocks** so your card looks intentional in both roleplay and conversation, not just the surface you tested.
-3. **Test in light and dark themes.** Use `rgba()` colors so they blend with any background.
-4. **Keep animations subtle** — prefer `transition` over heavy `animation` for lower-end devices.
-5. **Don't depend on internal utility classes.** Stick to the documented selectors (`[data-card-css]`, `.mari-message-body`, `.mari-message-name`, `.mari-message-content`, `.mari-typing-*`, `p`, `span`); other class names can change between versions.
-6. **Use `@media (max-width: 768px)`** for phones and narrow windows.
-7. **Theme the "typing…" state** — a little `.mari-typing-text` / `.mari-typing-dots span` styling goes a long way.
+- **Exclusive** — `[data-card-css]` is _this character's messages_. Best for group chats and per-character identity. CSS targeting elements _inside_ the message works the same as in Chat.
+- **Chat** — `[data-card-css]` is the _whole chat area_. Best for 1-on-1 cards that want to theme the background/atmosphere, not just message bubbles.
+
+Build with `[data-card-css] .mari-message-…` selectors and your card works correctly in both.
+
+---
+
+## Tips
+
+1. **Style the bubble with `.mari-message-bubble`, not `[data-card-css]`** — the latter is the full-width row, so a background on it is mostly invisible.
+2. **Use `rgba()`** so colors blend on both light and dark themes.
+3. **Keep animations subtle** — prefer `transition` over heavy `animation` on lower-end devices.
+4. **Use `@media (max-width: 768px)`** for phones.
+5. **Don't depend on Tailwind utility classes** — only the documented `mari-*` hooks are stable.
+
+---
+
+## Showcase: "Eldritch Grimoire" — the full extent
+
+A deliberately extravagant card that uses nearly every hook: an animated glowing bubble, a runic corner sigil, a glowing uppercase name, themed serif text, a reshaped/ringed avatar, and an eerie typing indicator. Paste it whole, set the mode to **Exclusive** (or **Chat**), and watch.
+
+```html
+<style>
+  /* ── animated arcane glow for the bubble ── */
+  @keyframes grimoire-pulse {
+    0%,
+    100% {
+      box-shadow:
+        0 0 12px rgba(168, 85, 247, 0.35),
+        inset 0 0 18px rgba(80, 0, 60, 0.5);
+    }
+    50% {
+      box-shadow:
+        0 0 24px rgba(220, 38, 120, 0.55),
+        inset 0 0 26px rgba(120, 0, 80, 0.6);
+    }
+  }
+
+  /* ── the visible message bubble ── */
+  [data-card-css] .mari-message-bubble {
+    background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
+    border: 1px solid rgba(220, 38, 120, 0.45);
+    border-radius: 4px 16px 16px 16px;
+    animation: grimoire-pulse 4s ease-in-out infinite;
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* a faint rune in the corner, drawn with a pseudo-element */
+  [data-card-css] .mari-message-bubble::before {
+    content: "✦";
+    position: absolute;
+    top: 1px;
+    right: 7px;
+    font-size: 0.7rem;
+    color: rgba(220, 38, 120, 0.55);
+    text-shadow: 0 0 6px rgba(220, 38, 120, 0.9);
+  }
+
+  /* ── glowing serif message text ── */
+  [data-card-css] .mari-message-content {
+    color: #f3d7ff;
+    text-shadow: 0 0 2px rgba(168, 85, 247, 0.4);
+    font-family: "Iowan Old Style", Georgia, "Times New Roman", serif;
+  }
+
+  /* ── the character's name — glowing crimson rune-caps ── */
+  [data-card-css] .mari-message-name {
+    color: #ff5c8a;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    text-shadow:
+      0 0 8px rgba(255, 92, 138, 0.7),
+      0 0 16px rgba(168, 85, 247, 0.45);
+  }
+
+  /* ── reshape + ring the avatar ── */
+  [data-card-css] .mari-message-avatar > div {
+    border-radius: 7px;
+    box-shadow:
+      0 0 0 2px rgba(220, 38, 120, 0.6),
+      0 0 14px rgba(168, 85, 247, 0.5);
+    filter: saturate(1.2) contrast(1.05);
+  }
+
+  /* ── eerie typing indicator (conversation, classic style) ── */
+  [data-card-css] .mari-typing-text {
+    color: #ff5c8a;
+    font-style: italic;
+    letter-spacing: 0.05em;
+    text-shadow: 0 0 8px rgba(255, 92, 138, 0.6);
+  }
+  [data-card-css] .mari-typing-dots span {
+    background: #ff5c8a;
+    box-shadow: 0 0 6px rgba(255, 92, 138, 0.85);
+  }
+</style>
+```
+
+Everything in it is sanitizer-safe (no external `url()`, no `!important`, no theme tokens, `position: relative`/`absolute` only). Swap the colors and the `content` glyph to make it your own.
 
 ---
 
 ## Using an AI Assistant to Create Card CSS
 
-If you'd rather not hand-write CSS, ask an AI assistant. A prompt template:
+A prompt template if you'd rather not hand-write CSS:
 
-> I'm creating a character card for Marinara Engine (an AI chat app). The card has a "Creator Notes" field where I can embed `<style>` blocks. I need CSS that themes the character's messages.
+> I'm creating a character card for Marinara Engine (an AI chat app). The card has a "Creator Notes" field where I can embed `<style>` blocks. Write CSS that themes the character's messages.
 >
-> **Character concept:** [describe the aesthetic — e.g. "cyberpunk hacker, neon-green terminal vibes" or "soft cottagecore fairy, pink pastels"]
+> **Character concept:** [describe the aesthetic]
 >
 > **Technical constraints:**
 >
-> - Use `[data-card-css]` for the message wrapper element (it works in both "Exclusive" and "Chat" scoping modes); use normal class selectors for things inside it.
-> - `[data-card-css] .mari-message-body` = the bubble (background / border / corners); `[data-card-css] .mari-message-content` = the text area; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar > div` = the avatar circle (override `border-radius`); `[data-card-css] p` = text paragraphs.
-> - Style the "typing…" indicator via `[data-card-css] .mari-typing-text` and `[data-card-css] .mari-typing-dots span` (the name is available as `attr(data-typing-name)`).
-> - Wrap roleplay-only CSS in `@chat-mode roleplay { … }` and conversation-only CSS in `@chat-mode conversation { … }`; CSS outside these applies everywhere.
-> - `url(https://…)`, `@import`, `:has()`, and `!important` are blocked; `position: fixed` becomes `absolute`; app theme tokens (`--primary`, etc.) are stripped. Use `url(data:…)` and `rgba()` colors.
+> - Use `[data-card-css]` for the message row (works in both "Exclusive" and "Chat" modes); use normal class selectors for things inside it.
+> - `[data-card-css] .mari-message-bubble` = the visible bubble (background / border / corners / shadow); `[data-card-css] .mari-message-content` = the text; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar > div` = the avatar circle.
+> - Style the typing indicator via `[data-card-css] .mari-typing-text` and `[data-card-css] .mari-typing-dots span`.
+> - Wrap roleplay-only CSS in `@chat-mode roleplay { … }`, conversation-only in `@chat-mode conversation { … }`; CSS outside applies everywhere.
+> - Blocked: `url(https://…)`, `@import`, `:has()`, `!important`, app theme tokens (`--primary`, etc.). `position: fixed` becomes `absolute`. Use `url(data:…)` and `rgba()` colors.
 > - `[data-grouped]` marks continuation messages — use `:not([data-grouped])` for first-in-group.
 >
-> Output a single `<style>` block I can paste into the Creator Notes field.
-
-**After generating:** paste into Creator Notes → open a chat with the character → Chat Settings → Card Theming → set **Exclusive** → send a test message → try switching Exclusive ↔ Chat to compare.
-
----
-
-## Example: Multi-Mode Card CSS
-
-```html
-<style>
-  /* Shared animation */
-  @keyframes glow-pulse {
-    0%,
-    100% {
-      box-shadow: 0 0 8px rgba(0, 255, 0, 0.2);
-    }
-    50% {
-      box-shadow: 0 0 16px rgba(0, 255, 0, 0.4);
-    }
-  }
-
-  /* Roleplay: immersive */
-  @chat-mode roleplay {
-    .terminal-window {
-      background: #1a1a1a;
-      border: 1px solid #0f0;
-      border-radius: 8px;
-      animation: glow-pulse 3s ease-in-out infinite;
-    }
-  }
-
-  /* Conversation: clean bubbles */
-  @chat-mode conversation {
-    [data-card-css] .mari-message-body {
-      background: linear-gradient(135deg, rgba(0, 30, 0, 0.85), rgba(0, 15, 0, 0.7));
-      border: 1px solid rgba(0, 255, 0, 0.3);
-      border-radius: 1rem;
-    }
-    [data-card-css] .mari-message-name {
-      color: #00ff00;
-      text-shadow: 0 0 8px rgba(0, 255, 0, 0.6);
-      font-family: "Courier New", monospace;
-    }
-    [data-card-css] .mari-message-content p {
-      font-family: "Courier New", monospace;
-      color: #c0ffc0;
-    }
-  }
-</style>
-```
+> Output a single `<style>` block I can paste into Creator Notes.

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1973,6 +1973,7 @@ export function ChatArea() {
     return (
       <Suspense fallback={surfaceFallback}>
         <>
+          {cardCssInjector}
           <GameSurface
             activeChatId={activeChatId}
             chat={chat!}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -76,6 +76,8 @@ import { HomeCreditsModal } from "./HomeCreditsModal";
 import { HomeProfessorMariChat } from "./HomeProfessorMariChat";
 import { NewChatConnectionGate } from "./NewChatConnectionGate";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
+import { CreatorNotesCssInjector, type CardCssMode } from "./CreatorNotesCssInjector";
+import type { ChatModeFilter } from "../../lib/card-css";
 
 export type { CharacterMap };
 
@@ -552,6 +554,22 @@ export function ChatArea() {
 
   const updateMeta = useUpdateChatMetadata();
   const summaryContextSize: number = (chatMeta.summaryContextSize as number) ?? 50;
+
+  // Creator-notes card CSS: resolve the per-chat mode (default "chat") and map
+  // the chat mode onto the @chat-mode filter surface (visual novel shares the
+  // roleplay surface). One injector element, reused across every render path.
+  const cardCssMode: CardCssMode =
+    chatMeta.cardCssMode === "disabled" || chatMeta.cardCssMode === "exclusive" ? chatMeta.cardCssMode : "chat";
+  const cardCssChatMode: ChatModeFilter =
+    chatMode === "conversation" ? "conversation" : chatMode === "game" ? "game" : "roleplay";
+  const cardCssInjector = (
+    <CreatorNotesCssInjector
+      characterIds={chatCharIds}
+      allCharacters={allCharacters as CharacterRow[] | undefined}
+      mode={cardCssMode}
+      chatMode={cardCssChatMode}
+    />
+  );
 
   // Sync translation config from chat metadata to the translation store
   useEffect(() => {
@@ -2024,6 +2042,7 @@ export function ChatArea() {
   if (chatMode === "conversation") {
     return (
       <>
+        {cardCssInjector}
         <Suspense fallback={surfaceFallback}>
           <ChatConversationSurface
             activeChatId={activeChatId}
@@ -2108,6 +2127,7 @@ export function ChatArea() {
 
   return (
     <>
+      {cardCssInjector}
       <Suspense fallback={surfaceFallback}>
         <ChatRoleplaySurface
           activeChatId={activeChatId}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -559,7 +559,7 @@ export function ChatArea() {
   // the chat mode onto the @chat-mode filter surface (visual novel shares the
   // roleplay surface). One injector element, reused across every render path.
   const cardCssMode: CardCssMode =
-    chatMeta.cardCssMode === "disabled" || chatMeta.cardCssMode === "exclusive" ? chatMeta.cardCssMode : "chat";
+    chatMeta.cardCssMode === "exclusive" || chatMeta.cardCssMode === "chat" ? chatMeta.cardCssMode : "disabled";
   const cardCssChatMode: ChatModeFilter =
     chatMode === "conversation" ? "conversation" : chatMode === "game" ? "game" : "roleplay";
   const cardCssInjector = (

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1852,7 +1852,7 @@ export const ChatMessage = memo(function ChatMessage({
             {/* Message bubble */}
             <div
               className={cn(
-                "mari-message-bubble relative overflow-hidden rounded-2xl shadow-lg shadow-black/20",
+                "mari-message-bubble mari-rp-bubble relative overflow-hidden rounded-2xl shadow-lg shadow-black/20",
                 isUser
                   ? "rounded-tr-sm text-neutral-100 ring-1 ring-white/10"
                   : "rounded-tl-sm text-white/90 ring-1 ring-white/8",
@@ -1862,10 +1862,15 @@ export const ChatMessage = memo(function ChatMessage({
                 isHiddenFromAI && "ring-amber-300/35 saturate-75",
                 editing && "w-full",
               )}
-              style={{
-                ...messageTextStyle,
-                backgroundColor: roleplayBubbleBg,
-              }}
+              style={
+                {
+                  ...messageTextStyle,
+                  // Pass the per-character/default color as a var rather than
+                  // an inline `background` so card CSS can override the bubble
+                  // (inline styles beat every selector). Applied by `.mari-rp-bubble`.
+                  "--mari-rp-bubble-bg": roleplayBubbleBg,
+                } as React.CSSProperties
+              }
             >
               {showRoleplayAvatarPanel ? (
                 <div className={cn("flex min-h-full items-stretch", isUser && "flex-row-reverse")}>

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1623,6 +1623,7 @@ export const ChatMessage = memo(function ChatMessage({
             "mari-message mari-message-narrator rpg-narrator-msg group mb-4 px-2",
             multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/5 ring-2 ring-[var(--destructive)]/50",
           )}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleRoleplayDoubleClick}
         >
@@ -1694,6 +1695,7 @@ export const ChatMessage = memo(function ChatMessage({
           )}
           data-message-id={message.id}
           data-message-role={message.role}
+          data-card-css={message.characterId ?? undefined}
           onClick={handleMobileTap}
           onDoubleClick={handleRoleplayDoubleClick}
           style={roleplayAvatarScaleStyle}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -516,8 +516,37 @@ function extractChatStyleBlocks(html: string): { html: string; css: string } {
   return { html: withoutStyles, css: cssBlocks.join("\n") };
 }
 
+/** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
+function decodeCssEscapes(input: string): string {
+  return input.replace(/\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g, (_m, hex: string | undefined, ch: string | undefined) => {
+    if (hex) {
+      const cp = parseInt(hex, 16);
+      return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+    }
+    return ch ?? "";
+  });
+}
+
+// Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
+// scanner steps over them, leaving their contents untouched.
+const STRING_OR_ESCAPE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\\(?:[0-9a-fA-F]{1,6}\s?|[\s\S])/g;
+
+// Canonicalize CSS escapes that spell a token character (ASCII letter, `@`, or `-`) so the
+// literal-text guards in sanitizeChatCss can't be bypassed by escaping (e.g. `\75rl(` → `url(`,
+// `po\73ition` → `position`, `\40 import` → `@import`). Escapes resolving to digits/punctuation
+// and all string contents are preserved so benign selectors like `.\32 xl` and `.w-1\/2` stay exact.
+function canonicalizeKeywordEscapes(css: string): string {
+  return css.replace(STRING_OR_ESCAPE, (match: string, stringLiteral: string | undefined) => {
+    if (stringLiteral !== undefined) return stringLiteral;
+    const decoded = decodeCssEscapes(match);
+    return /^[-A-Za-z@]$/.test(decoded) ? decoded : match;
+  });
+}
+
 function sanitizeChatCss(css: string): string {
-  return css
+  // Normalize escaped keyword characters first so every literal-text guard below sees the tokens a
+  // browser would actually parse. Without this, CSS escapes (`\75rl(`, `po\73ition`) slip past.
+  return canonicalizeKeywordEscapes(css)
     .replace(/<\/?style\b[^>]*>/gi, "")
     .replace(/@import\s+[^;]+;?/gi, "")
     .replace(/@namespace\s+[^;]+;?/gi, "")

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1002,7 +1002,11 @@ export function ChatRoleplaySurface({
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
-      <div className="rpg-chat-area mari-chat-area relative flex flex-1 flex-col overflow-hidden">
+      <div
+        className="rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
+        data-chat-mode="roleplay"
+        style={{ isolation: "isolate" }}
+      >
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay absolute inset-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0" />

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -33,6 +33,7 @@ import {
   Maximize2,
   Vibrate,
   Feather,
+  Paintbrush,
   Activity,
   Puzzle,
   Save,
@@ -108,6 +109,7 @@ import {
   stepCadenceValue,
 } from "../../lib/agent-cadence";
 import { getCharacterTitle, parseCharacterDisplayData } from "../../lib/character-display";
+import { extractCreatorNotesCss } from "../../lib/creator-notes-css";
 import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { useUIStore } from "../../stores/ui.store";
 import {
@@ -310,6 +312,7 @@ const CHAT_SETTINGS_ORDER = {
   advancedParameters: -1100,
   persona: -1000,
   characters: -900,
+  cardTheming: -850,
   groupChat: -800,
   connectedChat: -700,
   connectedNotes: -690,
@@ -530,6 +533,30 @@ export function ChatSettingsDrawer({
     () => (typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {})),
     [chat.metadata],
   );
+
+  // Creator-notes card CSS: the current per-chat mode (default "chat"), and
+  // whether any active character actually ships CSS — the Card Theming control
+  // only appears when one does, so it never clutters chats it can't affect.
+  const cardCssMode: "disabled" | "exclusive" | "chat" =
+    metadata.cardCssMode === "disabled" || metadata.cardCssMode === "exclusive" ? metadata.cardCssMode : "chat";
+  const activeCardsHaveCss = useMemo(() => {
+    if (!allCharacters) return false;
+    const byId = new Map((allCharacters as Array<{ id: string; data: unknown }>).map((c) => [c.id, c]));
+    return chatCharIds.some((id) => {
+      const row = byId.get(id);
+      if (!row) return false;
+      let parsed: Record<string, unknown>;
+      try {
+        if (typeof row.data === "string") parsed = JSON.parse(row.data) as Record<string, unknown>;
+        else if (row.data && typeof row.data === "object") parsed = row.data as Record<string, unknown>;
+        else return false;
+      } catch {
+        return false;
+      }
+      const notes = (parsed as { creator_notes?: string }).creator_notes;
+      return typeof notes === "string" && extractCreatorNotesCss(notes).css.trim().length > 0;
+    });
+  }, [allCharacters, chatCharIds]);
   const conversationCommandToggles = useMemo(
     () => readConversationCommandToggles(metadata.conversationCommandToggles),
     [metadata.conversationCommandToggles],
@@ -3015,6 +3042,61 @@ export function ChatSettingsDrawer({
               customPrompt={(metadata.customSystemPrompt as string) ?? ""}
               onCustomPromptChange={(id, customSystemPrompt) => updateMeta.mutate({ id, customSystemPrompt })}
             />
+          )}
+
+          {/* Card Theming — only shown when an active character ships creator-notes CSS */}
+          {activeCardsHaveCss && (
+            <Section
+              style={{ order: CHAT_SETTINGS_ORDER.cardTheming }}
+              label="Card Theming"
+              icon={<Paintbrush size="0.875rem" />}
+              help="Apply CSS embedded in a character's Creator Notes. Exclusive keeps each character's styling to their own messages; Chat applies it to the whole area."
+            >
+              <div className="space-y-2">
+                <div className="flex rounded-lg ring-1 ring-[var(--border)]">
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, cardCssMode: "disabled" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-l-lg",
+                      cardCssMode === "disabled"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Disabled
+                  </button>
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, cardCssMode: "exclusive" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors",
+                      cardCssMode === "exclusive"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Exclusive
+                  </button>
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, cardCssMode: "chat" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-r-lg",
+                      cardCssMode === "chat"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Chat
+                  </button>
+                </div>
+                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                  {cardCssMode === "disabled"
+                    ? "Card CSS is off — no character styling is applied."
+                    : cardCssMode === "exclusive"
+                      ? "Each character's CSS only affects their own messages."
+                      : "All card CSS affects the entire chat area, including UI elements."}
+                </p>
+              </div>
+            </Section>
           )}
 
           {/* Group Chat Settings — only when 2+ characters, game mode handles it internally */}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -538,7 +538,7 @@ export function ChatSettingsDrawer({
   // whether any active character actually ships CSS — the Card Theming control
   // only appears when one does, so it never clutters chats it can't affect.
   const cardCssMode: "disabled" | "exclusive" | "chat" =
-    metadata.cardCssMode === "disabled" || metadata.cardCssMode === "exclusive" ? metadata.cardCssMode : "chat";
+    metadata.cardCssMode === "exclusive" || metadata.cardCssMode === "chat" ? metadata.cardCssMode : "disabled";
   const activeCardsHaveCss = useMemo(() => {
     if (!allCharacters) return false;
     const byId = new Map((allCharacters as Array<{ id: string; data: unknown }>).map((c) => [c.id, c]));

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -674,6 +674,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         )}
         data-message-id={message.id}
         data-message-role={message.role}
+        data-card-css={message.characterId ?? undefined}
         onClick={handleMobileTap}
       >
         {isBubbleStyle ? <ConversationMessageBubble ctx={ctx} /> : <ConversationMessageLine ctx={ctx} />}

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -675,6 +675,7 @@ export const ConversationMessage = memo(function ConversationMessage({
         data-message-id={message.id}
         data-message-role={message.role}
         data-card-css={message.characterId ?? undefined}
+        data-grouped={isGrouped || undefined}
         onClick={handleMobileTap}
       >
         {isBubbleStyle ? <ConversationMessageBubble ctx={ctx} /> : <ConversationMessageLine ctx={ctx} />}

--- a/packages/client/src/components/chat/ConversationMessageGrouped.tsx
+++ b/packages/client/src/components/chat/ConversationMessageGrouped.tsx
@@ -84,6 +84,8 @@ export function ConversationMessageGrouped({
         isStreaming && "bg-[var(--secondary)]/20",
         multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
       )}
+      data-card-css={message.characterId ?? undefined}
+      data-grouped={isGrouped || undefined}
       onClick={handleMobileTap}
     >
       {/* Multi-select checkbox */}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -854,7 +854,11 @@ export function ConversationView({
   }, [visiblePartCounts]);
 
   return (
-    <div className="mari-chat-area relative flex flex-1 flex-col overflow-hidden" style={gradientStyle}>
+    <div
+      className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
+      data-chat-mode="conversation"
+      style={{ ...gradientStyle, isolation: "isolate" }}
+    >
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -289,6 +289,9 @@ export function ConversationView({
     return "Character";
   }, [characterMap, characterNames, chatCharIds, streamingCharacterId, typingCharacterName]);
   const liveTypingVerb = liveTypingName.includes(",") || liveTypingName.includes(" & ") ? "are" : "is";
+  // Single typer → tag the typing row so exclusive-mode card CSS can target it via
+  // `[data-card-css="<id>"] .mari-typing-*`. Multiple/unknown typers stay untagged.
+  const typingCardCssId = streamingCharacterId ?? (chatCharIds.length === 1 ? chatCharIds[0] : undefined);
 
   // Track whether the current generation has produced any content. When the stream
   // buffer clears (stream finished) but isStreaming hasn't cleared yet, this ref lets
@@ -1172,8 +1175,12 @@ export function ConversationView({
 
         {/* Typing indicator — classic mode only; bubble regen uses the draft row instead */}
         {showTypingIndicator && (
-          <div className="flex items-center gap-2 px-4 py-1.5 text-[0.8125rem] text-[var(--text-secondary)]">
-            <span className="flex gap-0.5">
+          <div
+            className="mari-typing-indicator flex items-center gap-2 px-4 py-1.5 text-[0.8125rem] text-[var(--text-secondary)]"
+            data-typing-name={liveTypingName}
+            data-card-css={typingCardCssId}
+          >
+            <span className="mari-typing-dots flex gap-0.5">
               <span
                 className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
                 style={{ animationDelay: "0ms" }}
@@ -1187,7 +1194,7 @@ export function ConversationView({
                 style={{ animationDelay: "300ms" }}
               />
             </span>
-            <span className="italic">
+            <span className="mari-typing-text italic">
               {liveTypingName} {liveTypingVerb} typing...
             </span>
           </div>

--- a/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
+++ b/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
@@ -33,9 +33,10 @@ const SCOPE_SELECTOR = ".mari-card-css";
 /**
  * Pulls `<style>` blocks out of every active character's `creator_notes`,
  * sanitizes + scopes them per the selected mode, and injects the combined CSS
- * into the document head inside an `@layer card-css` so it loses specificity
- * ties to app styles. A single shared `<style>` node is reused/cleared as the
- * active set or mode changes.
+ * into the document head. The CSS is injected unlayered so its scoped selectors
+ * can override the app's own (partly unlayered) message styling; the sanitizer
+ * and per-card scope keep it from reaching anything outside the chat. A single
+ * shared `<style>` node is reused/cleared as the active set or mode changes.
  */
 export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, chatMode }: CreatorNotesCssInjectorProps) {
   const scopedCss = useMemo(() => {
@@ -81,7 +82,13 @@ export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, cha
     }
 
     if (cssChunks.length === 0) return "";
-    return `@layer card-css {\n${cssChunks.join("\n")}\n}`;
+    // Injected unlayered (not wrapped in @layer): the app styles some message
+    // elements with unlayered rules (e.g. `.mari-message-content { color }` in
+    // globals.css), and any @layer always loses to unlayered rules — which would
+    // silently neuter most card theming. The scoped selectors above are specific
+    // enough to win on their own, while the sanitizer + per-card scope keep card
+    // CSS contained to the chat.
+    return cssChunks.join("\n");
   }, [characterIds, allCharacters, mode, chatMode]);
 
   useEffect(() => {

--- a/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
+++ b/packages/client/src/components/chat/CreatorNotesCssInjector.tsx
@@ -1,0 +1,110 @@
+// ──────────────────────────────────────────────
+// CreatorNotesCssInjector — extracts CSS from the
+// active characters' creator_notes, sanitizes +
+// scopes it, and injects a single <style> element
+// into <head>. Renders nothing.
+// ──────────────────────────────────────────────
+import { useEffect, useMemo } from "react";
+import { extractCreatorNotesCss } from "../../lib/creator-notes-css";
+import { scopeChatCss, filterCssByMode, type ChatModeFilter } from "../../lib/card-css";
+
+export type CardCssMode = "disabled" | "exclusive" | "chat";
+
+type CharacterRow = {
+  id: string;
+  /** Raw character-card payload — a JSON string or an already-parsed object. */
+  data: unknown;
+};
+
+interface CreatorNotesCssInjectorProps {
+  /** IDs of the characters active in this chat. */
+  characterIds: string[];
+  /** Catalog rows for resolving each character's card data. */
+  allCharacters: CharacterRow[] | undefined;
+  /** Injection mode: disabled | exclusive (per-character) | chat (whole area). */
+  mode: CardCssMode;
+  /** Current chat surface — drives `@chat-mode` filtering. */
+  chatMode: ChatModeFilter;
+}
+
+const STYLE_ELEMENT_ID = "marinara-card-css";
+const SCOPE_SELECTOR = ".mari-card-css";
+
+/**
+ * Pulls `<style>` blocks out of every active character's `creator_notes`,
+ * sanitizes + scopes them per the selected mode, and injects the combined CSS
+ * into the document head inside an `@layer card-css` so it loses specificity
+ * ties to app styles. A single shared `<style>` node is reused/cleared as the
+ * active set or mode changes.
+ */
+export function CreatorNotesCssInjector({ characterIds, allCharacters, mode, chatMode }: CreatorNotesCssInjectorProps) {
+  const scopedCss = useMemo(() => {
+    if (mode === "disabled" || !allCharacters || characterIds.length === 0) return "";
+
+    const charMap = new Map<string, CharacterRow>();
+    for (const char of allCharacters) {
+      charMap.set(char.id, char);
+    }
+
+    const cssChunks: string[] = [];
+    for (const charId of characterIds) {
+      const row = charMap.get(charId);
+      if (!row) continue;
+
+      let parsed: Record<string, unknown>;
+      try {
+        if (typeof row.data === "string") {
+          parsed = JSON.parse(row.data) as Record<string, unknown>;
+        } else if (row.data && typeof row.data === "object") {
+          parsed = row.data as Record<string, unknown>;
+        } else {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      const creatorNotes = (parsed as { creator_notes?: string }).creator_notes;
+      if (!creatorNotes) continue;
+
+      const { css: rawCss } = extractCreatorNotesCss(creatorNotes);
+      if (!rawCss) continue;
+
+      // Keep only rules that target the active surface (@chat-mode blocks).
+      const css = filterCssByMode(rawCss, chatMode);
+      if (!css.trim()) continue;
+
+      // Exclusive → scope to this character's own messages; chat → whole area.
+      const scope = mode === "exclusive" ? `${SCOPE_SELECTOR} [data-card-css="${charId}"]` : SCOPE_SELECTOR;
+      const scoped = scopeChatCss(css, scope);
+      if (scoped) cssChunks.push(scoped);
+    }
+
+    if (cssChunks.length === 0) return "";
+    return `@layer card-css {\n${cssChunks.join("\n")}\n}`;
+  }, [characterIds, allCharacters, mode, chatMode]);
+
+  useEffect(() => {
+    let styleEl = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+
+    if (!scopedCss) {
+      if (styleEl) styleEl.textContent = "";
+      return;
+    }
+
+    if (!styleEl) {
+      styleEl = document.createElement("style");
+      styleEl.id = STYLE_ELEMENT_ID;
+      document.head.appendChild(styleEl);
+    }
+
+    styleEl.textContent = scopedCss;
+
+    return () => {
+      const el = document.getElementById(STYLE_ELEMENT_ID);
+      if (el) el.textContent = "";
+    };
+  }, [scopedCss]);
+
+  return null;
+}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -8306,7 +8306,7 @@ export function GameSurface({
   );
 
   return (
-    <div className="relative flex h-full overflow-hidden bg-black">
+    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" data-chat-mode="game">
       <GameTransitionManager gameState={gameState} location={gameSnapshot?.location ?? null}>
         <DirectionEngine
           directions={activeDirections}

--- a/packages/client/src/lib/card-css.ts
+++ b/packages/client/src/lib/card-css.ts
@@ -1,0 +1,578 @@
+// ──────────────────────────────────────────────
+// Card CSS — sanitize + scope creator-notes CSS
+// ──────────────────────────────────────────────
+//
+// Locks down untrusted card CSS (no network/script, no scope escape, no
+// theme-token override) and scopes every rule under a per-card selector.
+// Consumed by CreatorNotesCssInjector. This is distinct from the inline
+// message-CSS helpers in ChatMessage.tsx, which sanitize the author's own
+// inline <style> blocks rather than CSS imported from a character card.
+//
+// SECURITY: this is the shared card-CSS sanitizer — keep it in sync with
+// upstream hardening of the same logic.
+
+export type ChatModeFilter = "roleplay" | "conversation" | "game";
+
+const CHAT_MODE_RE = /@chat-mode\s+(roleplay|conversation|game)\s*\{/gi;
+
+function findCssBlockEnd(css: string, bodyStart: number): { end: number; closed: boolean } {
+  let depth = 1;
+  let i = bodyStart;
+  let quote: string | null = null;
+  let escaped = false;
+  let inComment = false;
+
+  while (i < css.length && depth > 0) {
+    const ch = css[i]!;
+    const next = css[i + 1];
+    if (inComment) {
+      if (ch === "*" && next === "/") {
+        inComment = false;
+        i += 2;
+      } else {
+        i++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      i++;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inComment = true;
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      i++;
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    i++;
+  }
+
+  return { end: i, closed: depth === 0 };
+}
+
+/**
+ * Filter CSS by `@chat-mode <mode> { ... }` blocks.
+ *
+ * - `@chat-mode conversation { ... }` → included only in conversation mode
+ * - `@chat-mode roleplay { ... }` → included only in roleplay mode
+ * - `@chat-mode game { ... }` → included only in game mode
+ * - CSS outside any `@chat-mode` block → included in ALL modes
+ *
+ * Card creators use this to target styles to specific surfaces while
+ * keeping a shared base that applies everywhere.
+ */
+export function filterCssByMode(css: string, chatMode: ChatModeFilter): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  CHAT_MODE_RE.lastIndex = 0;
+
+  while ((match = CHAT_MODE_RE.exec(css)) !== null) {
+    // Emit any CSS between the last block and this one (unscoped = all modes)
+    if (match.index > cursor) {
+      chunks.push(css.slice(cursor, match.index));
+    }
+
+    const targetMode = match[1].toLowerCase();
+    const bodyStart = match.index + match[0].length;
+
+    const block = findCssBlockEnd(css, bodyStart);
+    const body = css.slice(bodyStart, block.closed ? block.end - 1 : block.end);
+    cursor = block.end;
+    CHAT_MODE_RE.lastIndex = block.end;
+
+    if (targetMode === chatMode) {
+      chunks.push(body);
+    }
+  }
+
+  // Trailing CSS after the last @chat-mode block (unscoped = all modes)
+  if (cursor < css.length) {
+    chunks.push(css.slice(cursor));
+  }
+
+  return chunks.join("\n");
+}
+
+/** Theme tokens that card CSS must never override. */
+const THEME_TOKEN_BLOCKLIST = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--card-foreground",
+  "--primary",
+  "--primary-foreground",
+  "--secondary",
+  "--secondary-foreground",
+  "--muted",
+  "--muted-foreground",
+  "--accent",
+  "--accent-foreground",
+  "--destructive",
+  "--destructive-foreground",
+  "--border",
+  "--input",
+  "--ring",
+  "--radius",
+  "--sidebar-background",
+  "--sidebar-foreground",
+  "--sidebar-primary",
+  "--sidebar-primary-foreground",
+  "--sidebar-accent",
+  "--sidebar-accent-foreground",
+  "--sidebar-border",
+  "--sidebar-ring",
+  "--color-background",
+  "--color-foreground",
+  "--color-card",
+  "--color-primary",
+  "--color-secondary",
+  "--color-muted",
+  "--color-accent",
+  "--color-destructive",
+  "--color-border",
+  "--color-input",
+  "--color-ring",
+];
+
+/** Strip CSS comments */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function sanitizeContentText(text: string): string {
+  const stripped = text.replace(/[<>]/g, "");
+  return stripped.length > 200 ? stripped.slice(0, 200) : stripped;
+}
+
+function sanitizeContentQuotedSegments(value: string): string {
+  return value.replace(/(['"])((?:\\.|(?!\1)[\s\S])*)\1/g, (_match, quote: string, text: string) => {
+    return `${quote}${sanitizeContentText(text)}${quote}`;
+  });
+}
+
+const CONTENT_TOKEN_RE =
+  /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|(?:counter|counters|attr)\s*\([^)]*\)|open-quote|close-quote|no-open-quote|no-close-quote|none|normal)\s*/gi;
+
+function isAllowedContentExpression(value: string): boolean {
+  return value.replace(CONTENT_TOKEN_RE, "").trim().length === 0;
+}
+
+function matchContentPropertyColon(css: string, index: number): number | null {
+  if (css.slice(index, index + "content".length).toLowerCase() !== "content") return null;
+  if (index > 0 && /[-_A-Za-z0-9]/.test(css[index - 1]!)) return null;
+  let cursor = index + "content".length;
+  while (cursor < css.length && /\s/.test(css[cursor]!)) cursor++;
+  return css[cursor] === ":" ? cursor : null;
+}
+
+function findDeclarationEnd(css: string, valueStart: number): { valueEnd: number; terminator: string } {
+  let quote: string | null = null;
+  let escaped = false;
+  for (let cursor = valueStart; cursor < css.length; cursor++) {
+    const ch = css[cursor]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ";" || ch === "}") return { valueEnd: cursor, terminator: ch };
+  }
+  return { valueEnd: css.length, terminator: "" };
+}
+
+function sanitizeContentDeclarationValue(value: string, terminator: string): string {
+  const normalized = value.trim();
+  // Allow empty string content (pseudo-element clearing)
+  if (/^(['"])\s*\1$/.test(normalized)) {
+    return `content: ${normalized}${terminator}`;
+  }
+  // Allow quoted text with sanitization
+  const quoted = normalized.match(/^(['"])(.*)\1$/);
+  if (quoted) {
+    return `content: "${sanitizeContentText(quoted[2])}"${terminator}`;
+  }
+  // Allow CSS functions like counter(), attr(), etc.
+  if (isAllowedContentExpression(normalized)) {
+    return `content: ${sanitizeContentQuotedSegments(normalized)}${terminator}`;
+  }
+  return `content: ''${terminator}`;
+}
+
+function sanitizeContentDeclarations(css: string): string {
+  let result = "";
+  let lastAppend = 0;
+  let cursor = 0;
+  let quote: string | null = null;
+  let escaped = false;
+
+  while (cursor < css.length) {
+    const ch = css[cursor]!;
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      cursor++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      cursor++;
+      continue;
+    }
+
+    const colonIndex = matchContentPropertyColon(css, cursor);
+    if (colonIndex !== null) {
+      const valueStart = colonIndex + 1;
+      const { valueEnd, terminator } = findDeclarationEnd(css, valueStart);
+      result += css.slice(lastAppend, cursor);
+      result += sanitizeContentDeclarationValue(css.slice(valueStart, valueEnd), terminator);
+      cursor = valueEnd + (terminator ? 1 : 0);
+      lastAppend = cursor;
+      continue;
+    }
+    cursor++;
+  }
+
+  return result + css.slice(lastAppend);
+}
+
+/** Decode CSS escape sequences (`\XX` hex, `\c` literal) to the characters a browser parses. */
+function decodeCssEscapes(input: string): string {
+  return input.replace(
+    /\\(?:([0-9a-fA-F]{1,6})\s?|([\s\S]))/g,
+    (_m, hex: string | undefined, ch: string | undefined) => {
+      if (hex) {
+        const cp = parseInt(hex, 16);
+        return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : "";
+      }
+      return ch ?? "";
+    },
+  );
+}
+
+// Match a quoted string (group 1) OR a single CSS escape sequence. Strings come first so the
+// scanner steps over them, leaving their contents untouched.
+const STRING_OR_ESCAPE = /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\\(?:[0-9a-fA-F]{1,6}\s?|[\s\S])/g;
+
+/**
+ * Canonicalize CSS escapes that spell a token character, so the literal-text guards in
+ * sanitizeChatCss can't be evaded by escaping. CSS escapes are decoded by the engine, so
+ * `po\73ition` is `position`, `\75rl(` is `url(`, `\40 import` is `@import`, and
+ * `\2d-background` is `--background` — and the raw-text regexes below would otherwise miss
+ * every one of them.
+ *
+ * We decode escapes resolving to ASCII letters, `@`, or `-`. Letters and `@` spell the keyword
+ * guards (url, @import, @font-face, :has, position, content…). `-` is included because the only
+ * punctuation-led forbidden tokens are hyphen-prefixed identifiers — custom-property / theme
+ * tokens (`--…`) and the `-moz-binding` vendor prefix; no benign card CSS escapes a hyphen
+ * (hyphens never need escaping in identifiers), so decoding it stays equivalent.
+ *
+ * Escapes resolving to other punctuation or digits are left byte-exact. They legitimately appear
+ * in selectors (`.\32 xl`, `.w-1\/2`) where decoding would change meaning, and — crucially — they
+ * cannot disguise a forbidden token: by CSS/HTML tokenization an escaped `:` / `!` / `/` becomes
+ * an identifier character, not a declaration separator, an `!important` delimiter, or a `</style`
+ * breakout. Escapes inside string literals are always preserved.
+ */
+function canonicalizeKeywordEscapes(css: string): string {
+  return css.replace(STRING_OR_ESCAPE, (match: string, stringLiteral: string | undefined) => {
+    if (stringLiteral !== undefined) return stringLiteral;
+    const decoded = decodeCssEscapes(match);
+    return /^[-A-Za-z@]$/.test(decoded) ? decoded : match;
+  });
+}
+
+/**
+ * Strip the CSS constructs that are dangerous no matter where the CSS is injected:
+ * network exfiltration (url()/@import/@namespace/@font-face), script execution
+ * (expression()/javascript:/vbscript:/behavior/-moz-binding), and browsing-history
+ * probing (:visited).
+ *
+ * Unlike scoped card CSS, app-level theme and extension CSS is allowed to override
+ * theme tokens, use !important, and position elements — so it must be run through
+ * THIS function rather than sanitizeChatCss, which additionally applies card-only
+ * scope/theme-protection passes that would neuter a legitimate theme.
+ */
+export function stripDangerousCss(css: string): string {
+  let out = stripComments(css);
+
+  // ── Escape normalization ──
+  // Canonicalize escaped keyword characters up front so every literal-text guard below sees the
+  // tokens a browser would actually parse (e.g. `\75rl(` → `url(`, `po\73ition` → `position`).
+  // Benign escapes in selectors (digits/punctuation) and string contents are preserved (#1989).
+  out = canonicalizeKeywordEscapes(out);
+
+  // ── Network exfiltration prevention ──
+  // Strip ALL url() except data: URIs for images and fonts (no external network requests).
+  // Allowed MIME prefixes are intentionally narrow: image/*, font/*, and the font-specific
+  // application/font* and application/x-font* (no generic application/octet-stream).
+  out = out.replace(
+    /url\s*\(\s*(['"]?)\s*(?!['"]?\s*data:(?:image\/|font\/|application\/(?:font|x-font)))[^)]*\)/gi,
+    "url(about:invalid)",
+  );
+  // Strip @import (network request + CSS injection)
+  out = out.replace(/@import\b[^;]*;/gi, "");
+  // Strip @namespace
+  out = out.replace(/@namespace\b[^;]*;/gi, "");
+  // Keep an @font-face block only if every source is a FONT data: URI. The block must carry
+  // at least one url() (an empty url() set would otherwise pass vacuously), every url() must
+  // be a font data: URI, and local() sources are rejected — they reference installed fonts
+  // (non-data, usable for fingerprinting) and fall outside the documented "embedded data:
+  // fonts only" contract. External URLs were already neutralized to url(about:invalid) above,
+  // and image/* data URIs (allowed for general url() use) are not valid font sources.
+  out = out.replace(/@font-face\s*\{[^}]*\}/gi, (block) => {
+    const urls = block.match(/url\s*\([^)]*\)/gi) ?? [];
+    const allFontData =
+      urls.length > 0 &&
+      urls.every((u) => /url\s*\(\s*(['"]?)\s*data:(?:font\/|application\/(?:font|x-font))/i.test(u));
+    const hasLocalSource = /\blocal\s*\(/i.test(block);
+    return allFontData && !hasLocalSource ? block : "";
+  });
+
+  // ── Script/expression injection ──
+  out = out.replace(/expression\s*\([^)]*\)/gi, "");
+  out = out.replace(/javascript\s*:/gi, "");
+  out = out.replace(/vbscript\s*:/gi, "");
+  out = out.replace(/behavior\s*:[^;]*/gi, "");
+  out = out.replace(/-moz-binding\s*:[^;]*/gi, "");
+
+  // ── History probing ──
+  // Strip :visited — can detect browsing history via style differences
+  out = out.replace(/:visited/gi, ":link");
+
+  return out;
+}
+
+/**
+ * Remove dangerous constructs from CSS and additionally lock it down for use as
+ * scoped card CSS.
+ *
+ * Security model: card CSS is untrusted user content shared between users.
+ * A malicious card creator must not be able to:
+ * - Make network requests (data exfiltration, IP tracking)
+ * - Escape the scoped container to style/probe app UI
+ * - Override application theme tokens
+ * - Inject phishing content via `content` property
+ * - Cause denial-of-service via resource-heavy rules
+ */
+function sanitizeChatCss(css: string): string {
+  let out = stripDangerousCss(css);
+
+  // ── Scope escape prevention ──
+  // Strip :has() — can probe elements outside the scoped container
+  out = out.replace(/:has\s*\([^)]*\)/gi, "");
+  // Convert position:fixed to position:absolute (prevent viewport overlays)
+  out = out.replace(/position\s*:\s*fixed/gi, "position:absolute");
+
+  // ── Content injection prevention ──
+  // Allow content property with sanitized text (for decorative labels in card CSS).
+  // Strip HTML-like characters and cap length to prevent phishing/UI spoofing.
+  out = sanitizeContentDeclarations(out);
+  // Strip </style (prevent injection breakout)
+  out = out.replace(/<\/style/gi, "");
+
+  // ── Theme protection ──
+  // Strip theme token declarations
+  out = out.replace(
+    new RegExp(
+      `(${THEME_TOKEN_BLOCKLIST.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\s*:[^;]*;?`,
+      "gi",
+    ),
+    "",
+  );
+  // Strip !important (prevent overriding app styles)
+  out = out.replace(/!important/gi, "");
+
+  return out;
+}
+
+/**
+ * Stable, short, non-cryptographic hash (FNV-1a, base36). Used only to salt
+ * generated identifiers so they can't collide between independent card CSS
+ * specimens — it does not need to be secure, just deterministic.
+ */
+function hashCss(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Scope CSS rules under a given selector.
+ * - Sanitizes input
+ * - Namespaces @keyframes with "mc-" prefix
+ * - Rewrites :root, html, body to the scope selector
+ * - Prefixes all other selectors with the scope selector
+ */
+export function scopeChatCss(css: string, scopeSelector: string): string {
+  let sanitized = sanitizeChatCss(css);
+
+  // Namespace @keyframes: @keyframes foo -> @keyframes mc-foo
+  sanitized = sanitized.replace(/@keyframes\s+([^\s{]+)/gi, (_match, name: string) => {
+    return `@keyframes mc-${name}`;
+  });
+
+  // Rewrite animation-name references too
+  sanitized = sanitized.replace(/animation(?:-name)?\s*:[^;{}]*/gi, (match) => {
+    // For each animation name token that isn't a keyword, prefix with mc-
+    return match.replace(/:\s*([^;{}]*)/, (_, value: string) => {
+      const prefixed = value.replace(/(?:^|,\s*)([a-zA-Z_][\w-]*)/g, (full, name: string) => {
+        const keywords = new Set([
+          "none",
+          "initial",
+          "inherit",
+          "unset",
+          "infinite",
+          "alternate",
+          "reverse",
+          "alternate-reverse",
+          "normal",
+          "forwards",
+          "backwards",
+          "both",
+          "running",
+          "paused",
+          "ease",
+          "ease-in",
+          "ease-out",
+          "ease-in-out",
+          "linear",
+          "step-start",
+          "step-end",
+        ]);
+        if (keywords.has(name) || /^\d/.test(name)) return full;
+        return full.replace(name, `mc-${name}`);
+      });
+      return `: ${prefixed}`;
+    });
+  });
+
+  // Namespace @font-face families so an embedded font can't override an app-wide
+  // family (e.g. "Inter") outside the card. We rewrite the declared family in each
+  // kept @font-face block to a unique "mc-font-*" name, then rewrite the
+  // font-family / font references that point at it — mirroring @keyframes handling.
+  //
+  // @font-face rules are global (they can't be scoped under a selector), so the
+  // namespaced name is salted with a per-card hash (scope + source). Without the
+  // salt, two different cards that both embed `font-family: Inter` would both map to
+  // `mc-font-Inter` and silently clobber each other in the global cascade. The salt
+  // is stable per card, so multiple faces of the same family within one card
+  // (regular/bold/italic) still share a name and remain a single family.
+  const fontSalt = hashCss(`${scopeSelector}\\0${css}`);
+  const fontFamilyMap = new Map<string, string>();
+  sanitized = sanitized.replace(/@font-face\s*\{([^}]*)\}/gi, (_block, body: string) => {
+    const newBody = body.replace(
+      /(font-family\s*:\s*)("[^"]*"|'[^']*'|[^;]+)/i,
+      (_decl, prefix: string, rawValue: string) => {
+        const name = rawValue
+          .trim()
+          .replace(/^['"]|['"]$/g, "")
+          .trim();
+        if (!name) return `${prefix}${rawValue}`;
+        const namespaced = `mc-font-${name.replace(/[^a-zA-Z0-9_-]+/g, "-")}-${fontSalt}`;
+        fontFamilyMap.set(name.toLowerCase(), namespaced);
+        return `${prefix}"${namespaced}"`;
+      },
+    );
+    return `@font-face {${newBody}}`;
+  });
+  if (fontFamilyMap.size > 0) {
+    sanitized = sanitized.replace(/\bfont(?:-family)?\s*:\s*([^;{}]+)/gi, (decl: string, value: string) => {
+      let next = value;
+      for (const [orig, namespaced] of fontFamilyMap) {
+        const escaped = orig.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        // quoted family occurrences: 'Inter' / "Inter"
+        next = next.replace(new RegExp(`(['"])${escaped}\\1`, "gi"), `"${namespaced}"`);
+        // unquoted single-token occurrences in a family list
+        next = next.replace(new RegExp(`(^|,|\\s)${escaped}(?=\\s*(?:,|$))`, "gi"), `$1"${namespaced}"`);
+      }
+      return decl.slice(0, decl.length - value.length) + next;
+    });
+  }
+
+  // Split into rules and scope selectors
+  const result: string[] = [];
+  // Simple rule-level split: find selector { ... } blocks
+  const ruleRe = /([^{}]+)\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}/g;
+  let ruleMatch: RegExpExecArray | null;
+
+  while ((ruleMatch = ruleRe.exec(sanitized)) !== null) {
+    const selector = ruleMatch[1].trim();
+    const body = ruleMatch[2];
+
+    // Skip @keyframes — already namespaced, don't prefix their contents
+    if (/^@keyframes\s/i.test(selector)) {
+      result.push(`${selector} {${body}}`);
+      continue;
+    }
+
+    // Skip @font-face — contains declarations, not nested rules
+    if (/^@font-face$/i.test(selector)) {
+      result.push(`${selector} {${body}}`);
+      continue;
+    }
+
+    // Handle @media and other at-rules that wrap rulesets
+    if (/^@/.test(selector)) {
+      // Recursively scope the inner rules
+      const innerScoped = scopeChatCss(body, scopeSelector);
+      result.push(`${selector} {${innerScoped}}`);
+      continue;
+    }
+
+    // Scope each selector in the comma-separated list
+    const scopedSelectors = selector.split(",").map((sel) => {
+      const s = sel.trim();
+      // :root, html, body -> scopeSelector (targets the scope element itself)
+      if (/^(:root|html|body)$/i.test(s)) return scopeSelector;
+      // Starts with :root, html, body (descendant or chained) -> replace prefix with scope
+      if (/^(:root|html|body)[\s:.[]/i.test(s)) return s.replace(/^(:root|html|body)/i, scopeSelector);
+      // [data-card-css] alone -> scopeSelector (self-reference in exclusive mode)
+      if (/^\[data-card-css\]$/i.test(s)) return scopeSelector;
+      // [data-card-css] with descendant -> replace with scope
+      if (/^\[data-card-css\]\s/i.test(s)) return s.replace(/^\[data-card-css\]/i, scopeSelector);
+      // [data-card-css] with chained pseudo-classes or attribute selectors
+      // e.g. [data-card-css]:not([data-grouped]), [data-card-css][data-grouped]
+      // In exclusive mode the scope IS the element, so chain on it.
+      // In chat mode the scope is a container, so keep as descendant (default).
+      if (/^\[data-card-css\][:[.]/.test(s) && scopeSelector.includes("[data-card-css=")) {
+        return s.replace(/^\[data-card-css\]/i, scopeSelector);
+      }
+      // Otherwise prefix
+      return `${scopeSelector} ${s}`;
+    });
+
+    result.push(`${scopedSelectors.join(", ")} {${body}}`);
+  }
+
+  return result.join("\n");
+}

--- a/packages/client/src/lib/creator-notes-css.ts
+++ b/packages/client/src/lib/creator-notes-css.ts
@@ -1,0 +1,23 @@
+// ──────────────────────────────────────────────
+// Creator-notes CSS — pull <style> blocks out of a
+// character card's creator_notes field.
+// ──────────────────────────────────────────────
+
+const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+
+/**
+ * Split a character's `creator_notes` into its embedded CSS and the remaining
+ * note text. Card authors wrap custom styling in `<style>…</style>` blocks;
+ * this lifts every block out so the CSS can be sanitized + scoped separately
+ * (see {@link file://./card-css.ts}) and the prose shown on its own.
+ */
+export function extractCreatorNotesCss(creatorNotes: string): { css: string; text: string } {
+  const cssBlocks: string[] = [];
+  const text = creatorNotes
+    .replace(STYLE_BLOCK_RE, (_match, css: string) => {
+      cssBlocks.push(css);
+      return "";
+    })
+    .trim();
+  return { css: cssBlocks.join("\n"), text };
+}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1972,6 +1972,14 @@ summary[class*="cursor-pointer"],
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
 }
 
+/* Roleplay message bubble background. Applied here (via a class + the
+   `--mari-rp-bubble-bg` variable the bubble sets) instead of inline, so card
+   CSS (`.mari-card-css .mari-message-bubble { background: … }`) can override it
+   — an inline background would otherwise beat every card selector. */
+.mari-rp-bubble {
+  background-color: var(--mari-rp-bubble-bg);
+}
+
 /* ─────────────────────────────────────────────
    15. CHAT: ROLEPLAY MODE
    ───────────────────────────────────────────── */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -215,8 +215,9 @@ export interface ChatMetadata {
   spritePosition?: SpriteSide;
   /**
    * How creator-notes card CSS is applied in this chat:
-   * "disabled" (none), "exclusive" (each character's CSS only styles their own
-   * messages), or "chat" (all card CSS styles the whole chat area — default).
+   * "exclusive" (each character's CSS only styles their own messages) or "chat"
+   * (all card CSS styles the whole chat area). Defaults to "disabled" (off) —
+   * card styling is opt-in per chat.
    */
   cardCssMode?: "disabled" | "exclusive" | "chat";
   /** Display scale for roleplay Expression Engine sprites. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -213,6 +213,12 @@ export interface ChatMetadata {
   spriteDisplayModes?: Array<"expressions" | "full-body">;
   /** Preferred sidebar / default layout side for chat sprites. */
   spritePosition?: SpriteSide;
+  /**
+   * How creator-notes card CSS is applied in this chat:
+   * "disabled" (none), "exclusive" (each character's CSS only styles their own
+   * messages), or "chat" (all card CSS styles the whole chat area — default).
+   */
+  cardCssMode?: "disabled" | "exclusive" | "chat";
   /** Display scale for roleplay Expression Engine sprites. */
   spriteScale?: number;
   /** Display opacity for roleplay Expression Engine sprites. */


### PR DESCRIPTION
## Linked issue

Closes #2580

> Stacked on #2590 (creator-notes card-CSS injection) — these hooks are inert without it. Until #2590 merges, this PR's diff includes the #2586 + #2590 commits; it will be rebased onto `staging` as those land. The conversation **avatar override** also bundled into the source feature is split out to #2592.

## Why this change

#2590 lets a character's creator-notes CSS style its messages, but two surfaces have no hooks for authors to target: the **typing indicator** and **grouped (consecutive) messages**. This adds the minimal markup hooks so card CSS can style those too — e.g. a custom "… is typing" treatment, or a distinct look for the first message in a run vs its continuations.

## What changed

- **Typing indicator** (`ConversationView`, classic mode): the row now carries `.mari-typing-indicator` / `.mari-typing-dots` / `.mari-typing-text` class hooks and `data-typing-name` (usable as `content: attr(data-typing-name)`). When a single character is typing, the row also gets `data-card-css={characterId}` so exclusive-mode CSS can target it via `[data-card-css="<id>"] .mari-typing-*`.
- **Message grouping**: the standard message wrapper (`ConversationMessage`) and the grouped multi-speaker layout (`ConversationMessageGrouped`) carry `data-grouped` on continuation messages, so authors can target first-in-group with `[data-card-css]:not([data-grouped])` and continuations with `[data-grouped]`. The grouped layout also gains the `data-card-css` scope it was previously missing.
- **Game-mode baseline** — the game surface is scoped (`.mari-card-css` + `data-chat-mode="game"`) and the injector mounts there, so **Chat**-mode card CSS reaches the game area and `@chat-mode game` targets it. Game uses its own layout, so the message hooks don't apply there; per-character (Exclusive) narration scoping is a noted follow-up.
- **Authoring guide** — `docs/card-css-theming-guide.md`, written against staging's **real** chat DOM (every selector verified), with a smoking-gun test, the `[data-card-css]`-for-the-element vs class-for-children convention, `@chat-mode` targeting, the sanitizer limits, and a full "Eldritch Grimoire" showcase.
- **Cascade fix** (carried from #2590): card CSS is injected **unlayered**, so its scoped selectors actually override the app's own message styling — a prior `@layer card-css` wrapper lost to the app's unlayered rules and silently neutered most theming.

The hook changes are additive markup (no default-render change); the cascade fix is what makes card CSS visibly take effect.

**Out of scope (intentionally):**
- The multi-typer, exclusive-mode *standalone typing-row split* (each styled character gets an isolated row) — a niche refinement; the single-typer path above covers the common case.
- The N-bubble *grouping collapse* into one seamless `.mari-message-group` — staging renders grouped messages flat, and collapsing would change default rendering.
- The **conversation avatar override** (hide / emoji / sprite / gallery) — a large, independent feature split to #2592.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Already run (automated): client typecheck (`tsc -b`) and client lint (`eslint`) pass. Full `pnpm check` and the in-app checks below still need a human.

Please manually verify in the app (conversation mode, with a card that has creator-notes CSS and Card Theming enabled):
- **Typing indicator** — with `<style>.mari-typing-text { color: hotpink; font-weight: bold; }</style>` in a card's Creator Notes, send a message and confirm the "… is typing" row restyles while the reply streams. Confirm a normal chat's typing row is unchanged when no card CSS targets it.
- **Grouping** — with `<style>[data-grouped] { opacity: 0.6; }</style>`, send two quick consecutive messages from the same character and confirm the continuation dims while the first stays full. Confirm `[data-card-css]:not([data-grouped])` targets only first-in-group.
- Confirm grouped multi-speaker messages (Name: text format / merged group chat) now pick up exclusive-mode card CSS (they were unscoped before).
- Confirm default rendering (no card CSS) is visually identical to before, in both classic and bubble conversation styles.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

To be added: before/after of a card styling the typing indicator + grouped continuation messages.
