### PR TITLE
ON HOLD feat(chat): add conversation presence card

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -75,7 +75,7 @@ import { RecentChats } from "./RecentChats";
 import { HomeCreditsModal } from "./HomeCreditsModal";
 import { HomeProfessorMariChat } from "./HomeProfessorMariChat";
 import { NewChatConnectionGate } from "./NewChatConnectionGate";
-import { ChatCommonOverlays } from "./ChatCommonOverlays";
+import { ChatCommonOverlays, type ChatSettingsInitialSection } from "./ChatCommonOverlays";
 
 export type { CharacterMap };
 
@@ -83,6 +83,8 @@ const BUILT_IN_AGENT_ID_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const BUILT_IN_TRACKER_AGENT_ID_SET = new Set(
   BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker" && !agent.libraryHidden).map((agent) => agent.id),
 );
+
+type OpenSettingsOptions = { initialSection?: ChatSettingsInitialSection };
 
 const normalizeSpriteDisplayValue = (value: unknown, fallback: number, min: number, max: number): number => {
   const numeric = typeof value === "number" ? value : Number(value);
@@ -238,6 +240,7 @@ export function ChatArea() {
   // skip the entry animation to avoid a visible flash on refetch.
   const hasAnimatedRef = useRef(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsInitialSection, setSettingsInitialSection] = useState<ChatSettingsInitialSection>(null);
   const [filesOpen, setFilesOpen] = useState(false);
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [settingsAnchor, setSettingsAnchor] = useState<FloatingPanelAnchor>(null);
@@ -269,8 +272,9 @@ export function ChatArea() {
     };
   }, []);
   const handleOpenSettingsPanel = useCallback(
-    (event?: ReactMouseEvent<HTMLElement>) => {
+    (event?: ReactMouseEvent<HTMLElement>, options?: OpenSettingsOptions) => {
       setSettingsAnchor(readFloatingPanelAnchor(event));
+      setSettingsInitialSection(options?.initialSection ?? null);
       setSettingsOpen(true);
     },
     [readFloatingPanelAnchor],
@@ -285,6 +289,7 @@ export function ChatArea() {
   const handleCloseSettingsPanel = useCallback(() => {
     setSettingsOpen(false);
     setSettingsAnchor(null);
+    setSettingsInitialSection(null);
   }, []);
   const handleCloseGalleryPanel = useCallback(() => {
     setGalleryOpen(false);
@@ -1977,6 +1982,7 @@ export function ChatArea() {
             activeChatId={activeChatId}
             settingsOpen={settingsOpen}
             settingsAnchor={settingsAnchor}
+            settingsInitialSection={settingsInitialSection}
             filesOpen={filesOpen}
             galleryOpen={galleryOpen}
             galleryAnchor={galleryAnchor}
@@ -2044,6 +2050,7 @@ export function ChatArea() {
             sceneInfo={conversationSceneInfo}
             settingsOpen={settingsOpen}
             settingsAnchor={settingsAnchor}
+            settingsInitialSection={settingsInitialSection}
             galleryOpen={galleryOpen}
             galleryAnchor={galleryAnchor}
             wizardOpen={wizardOpen}

--- a/packages/client/src/components/chat/ChatCommonOverlays.tsx
+++ b/packages/client/src/components/chat/ChatCommonOverlays.tsx
@@ -31,6 +31,7 @@ const PeekPromptModal = lazy(async () => {
 
 type ChatData = ComponentProps<typeof ChatSettingsDrawer>["chat"];
 export type ChatFloatingPanelAnchor = { right: number; top: number } | null;
+export type ChatSettingsInitialSection = ComponentProps<typeof ChatSettingsDrawer>["initialSection"];
 
 type SharedSceneSettingsProps = {
   spriteArrangeMode: boolean;
@@ -178,6 +179,7 @@ type ChatCommonOverlaysProps = {
   activeChatId: string;
   settingsOpen: boolean;
   settingsAnchor: ChatFloatingPanelAnchor;
+  settingsInitialSection?: ChatSettingsInitialSection;
   filesOpen: boolean;
   galleryOpen: boolean;
   galleryAnchor: ChatFloatingPanelAnchor;
@@ -213,6 +215,7 @@ export function ChatCommonOverlays({
   activeChatId,
   settingsOpen,
   settingsAnchor,
+  settingsInitialSection,
   filesOpen,
   galleryOpen,
   galleryAnchor,
@@ -251,6 +254,7 @@ export function ChatCommonOverlays({
               open={settingsOpen}
               onClose={onCloseSettings}
               anchor={settingsAnchor}
+              initialSection={settingsInitialSection}
               spriteArrangeMode={sceneSettings.spriteArrangeMode}
               onToggleSpriteArrange={sceneSettings.onToggleSpriteArrange}
               onResetSpritePlacements={sceneSettings.onResetSpritePlacements}

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -36,6 +36,7 @@ type ConversationSurfaceProps = {
   sceneInfo?: SceneInfo;
   settingsOpen: boolean;
   settingsAnchor: ComponentProps<typeof ChatCommonOverlays>["settingsAnchor"];
+  settingsInitialSection?: ComponentProps<typeof ChatCommonOverlays>["settingsInitialSection"];
   galleryOpen: boolean;
   galleryAnchor: ComponentProps<typeof ChatCommonOverlays>["galleryAnchor"];
   wizardOpen: boolean;
@@ -99,6 +100,7 @@ export function ChatConversationSurface({
   sceneInfo,
   settingsOpen,
   settingsAnchor,
+  settingsInitialSection,
   galleryOpen,
   galleryAnchor,
   wizardOpen,
@@ -187,6 +189,7 @@ export function ChatConversationSurface({
         activeChatId={activeChatId}
         settingsOpen={settingsOpen}
         settingsAnchor={settingsAnchor}
+        settingsInitialSection={settingsInitialSection}
         filesOpen={false}
         galleryOpen={galleryOpen}
         galleryAnchor={galleryAnchor}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -189,6 +189,7 @@ interface ChatSettingsDrawerProps {
   open: boolean;
   onClose: () => void;
   anchor?: { right: number; top: number } | null;
+  initialSection?: "autonomous" | null;
   spriteArrangeMode?: boolean;
   onToggleSpriteArrange?: () => void;
   onResetSpritePlacements?: () => void;
@@ -465,12 +466,14 @@ export function ChatSettingsDrawer({
   open,
   onClose,
   anchor,
+  initialSection,
   spriteArrangeMode = false,
   onToggleSpriteArrange,
   onResetSpritePlacements,
   onSpriteSideChange,
 }: ChatSettingsDrawerProps) {
   const qc = useQueryClient();
+  const scheduleControlsRef = useRef<HTMLDivElement | null>(null);
   const updateChat = useUpdateChat();
   const updateMeta = useUpdateChatMetadata();
   const updateAgentConfig = useUpdateAgent();
@@ -549,6 +552,15 @@ export function ChatSettingsDrawer({
   );
   const supportsCharacterActivityToggle = chatCharIds.length > 1 && !isGame;
   const isSceneChat = metadata.sceneStatus === "active" || typeof metadata.sceneOriginChatId === "string";
+
+  useEffect(() => {
+    if (!open || initialSection !== "autonomous" || !isConversation) return;
+    const frame = window.requestAnimationFrame(() => {
+      scheduleControlsRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [initialSection, isConversation, open]);
+
   const hasGeneratedConversationSchedules =
     !!metadata.characterSchedules &&
     typeof metadata.characterSchedules === "object" &&
@@ -3268,12 +3280,14 @@ export function ChatSettingsDrawer({
 
           {/* Autonomous Messaging — conversation mode only */}
           {isConversation && (
-            <Section
-              label="Autonomous Messaging"
-              icon={<Bot size="0.875rem" />}
-              help="Characters can message you unprompted based on their personality, your status, and optional schedules. Chatty characters will reach out sooner when you're inactive."
-            >
-              <div className="space-y-2">
+            <div>
+              <Section
+                label="Autonomous Messaging"
+                icon={<Bot size="0.875rem" />}
+                help="Characters can message you unprompted based on their personality, your status, and optional schedules. Chatty characters will reach out sooner when you're inactive."
+                initialOpen={initialSection === "autonomous"}
+              >
+                <div className="space-y-2">
                 {/* Enable autonomous messages toggle */}
                 <button
                   onClick={() => {
@@ -3417,60 +3431,63 @@ export function ChatSettingsDrawer({
                   </div>
                 </button>
 
-                {/* Schedule status */}
-                <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2.5">
-                  <div className="flex-1 min-w-0">
-                    <span className="text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
-                      {!conversationSchedulesEnabled
-                        ? "Schedules are off: autonomy uses talkativeness and your status."
-                        : hasGeneratedConversationSchedules
-                          ? "Schedules generated — status is derived from character routines."
-                          : "Schedules enabled — generate routines when you're ready."}
-                    </span>
-                    <p className="text-[0.59375rem] text-[var(--muted-foreground)]/60 mt-0.5">
-                      {conversationSchedulesEnabled
-                        ? "Schedules refresh only after you enable or regenerate them."
-                        : "Turn schedules on if you want availability and busy delays to matter."}
-                    </p>
-                  </div>
-                  <button
-                    onClick={async () => {
-                      if (!conversationSchedulesEnabled) {
-                        updateMeta.mutate({ id: chat.id, conversationSchedulesEnabled: true });
-                      }
-                      await generateConversationSchedules(true);
-                    }}
-                    disabled={isRegeneratingSchedules || chatCharIds.length === 0}
-                    className={cn(
-                      "flex items-center gap-1 rounded-md px-2 py-1 text-[0.625rem] font-medium transition-colors",
-                      isRegeneratingSchedules || chatCharIds.length === 0
-                        ? "cursor-not-allowed text-[var(--muted-foreground)]/60"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                    )}
-                    title={isRegeneratingSchedules ? "Regenerating schedules…" : "Generate schedules"}
-                  >
-                    <RefreshCw size="0.6875rem" className={cn(isRegeneratingSchedules && "animate-spin")} />
-                    {isRegeneratingSchedules
-                      ? "Regenerating…"
-                      : hasGeneratedConversationSchedules
-                        ? "Regenerate"
-                        : "Generate"}
-                  </button>
-                </div>
+                  <div ref={scheduleControlsRef} className="scroll-mt-2 space-y-2">
+                    {/* Schedule status */}
+                    <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2.5">
+                      <div className="flex-1 min-w-0">
+                        <span className="text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
+                          {!conversationSchedulesEnabled
+                            ? "Schedules are off: autonomy uses talkativeness and your status."
+                            : hasGeneratedConversationSchedules
+                              ? "Schedules generated — status is derived from character routines."
+                              : "Schedules enabled — generate routines when you're ready."}
+                        </span>
+                        <p className="text-[0.59375rem] text-[var(--muted-foreground)]/60 mt-0.5">
+                          {conversationSchedulesEnabled
+                            ? "Schedules refresh only after you enable or regenerate them."
+                            : "Turn schedules on if you want availability and busy delays to matter."}
+                        </p>
+                      </div>
+                      <button
+                        onClick={async () => {
+                          if (!conversationSchedulesEnabled) {
+                            updateMeta.mutate({ id: chat.id, conversationSchedulesEnabled: true });
+                          }
+                          await generateConversationSchedules(true);
+                        }}
+                        disabled={isRegeneratingSchedules || chatCharIds.length === 0}
+                        className={cn(
+                          "flex items-center gap-1 rounded-md px-2 py-1 text-[0.625rem] font-medium transition-colors",
+                          isRegeneratingSchedules || chatCharIds.length === 0
+                            ? "cursor-not-allowed text-[var(--muted-foreground)]/60"
+                            : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                        )}
+                        title={isRegeneratingSchedules ? "Regenerating schedules…" : "Generate schedules"}
+                      >
+                        <RefreshCw size="0.6875rem" className={cn(isRegeneratingSchedules && "animate-spin")} />
+                        {isRegeneratingSchedules
+                          ? "Regenerating…"
+                          : hasGeneratedConversationSchedules
+                            ? "Regenerate"
+                            : "Generate"}
+                      </button>
+                    </div>
 
-                {/* Schedule editor per character */}
-                {conversationSchedulesEnabled && hasGeneratedConversationSchedules && (
-                  <ScheduleEditor
-                    characterSchedules={metadata.characterSchedules}
-                    chatCharIds={chatCharIds}
-                    charNameMap={charNameMap}
-                    onSave={(updated) => {
-                      updateMeta.mutate({ id: chat.id, characterSchedules: updated });
-                    }}
-                  />
-                )}
-              </div>
-            </Section>
+                    {/* Schedule editor per character */}
+                    {conversationSchedulesEnabled && hasGeneratedConversationSchedules && (
+                      <ScheduleEditor
+                        characterSchedules={metadata.characterSchedules}
+                        chatCharIds={chatCharIds}
+                        charNameMap={charNameMap}
+                        onSave={(updated) => {
+                          updateMeta.mutate({ id: chat.id, characterSchedules: updated });
+                        }}
+                      />
+                    )}
+                  </div>
+                </div>
+              </Section>
+            </div>
           )}
 
           {/* Commands — conversation mode only */}

--- a/packages/client/src/components/chat/ConversationPresenceCard.tsx
+++ b/packages/client/src/components/chat/ConversationPresenceCard.tsx
@@ -1,0 +1,662 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { createPortal } from "react-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { Activity, ChevronDown, RotateCcw } from "lucide-react";
+import type {
+  ConversationManualPresenceStatus,
+  ConversationPresenceStatus,
+  ConversationStatusOverride,
+  Message,
+} from "@marinara-engine/shared";
+import type { CharacterMap } from "./chat-area.types";
+import { getChatToolbarButtonClass } from "./ChatToolbarControls";
+import {
+  ROLEPLAY_POPOVER_HEADER,
+  ROLEPLAY_POPOVER_SCROLL_AREA,
+  ROLEPLAY_POPOVER_SHELL,
+  ROLEPLAY_POPOVER_SUBTITLE,
+  ROLEPLAY_POPOVER_TITLE,
+} from "./roleplay-popover-styles";
+import { characterKeys } from "../../hooks/use-characters";
+import { useUpdateChatMetadata } from "../../hooks/use-chats";
+import { api } from "../../lib/api-client";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import { useChatStore, type DelayedCharacterInfo } from "../../stores/chat.store";
+
+type ScheduleBlockLike = {
+  time?: string;
+  activity?: string;
+  status?: ConversationPresenceStatus;
+};
+
+type WeekScheduleLike = {
+  weekStart?: string;
+  days?: Record<string, ScheduleBlockLike[]>;
+};
+
+type PresenceCharacter = {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  avatarCrop?: AvatarCropValue | null;
+  status: ConversationPresenceStatus;
+  activity: string;
+  scheduledStatus: ConversationPresenceStatus;
+  scheduledActivity: string;
+  override?: ConversationStatusOverride;
+  nextBlock: ScheduleBlockLike | null;
+  lastContact: string;
+};
+
+interface ConversationPresenceCardProps {
+  chatId: string;
+  chatMeta: Record<string, any>;
+  chatCharIds: string[];
+  characterMap: CharacterMap;
+  messages: Message[] | undefined;
+  onOpenSettings: (event?: ReactMouseEvent<HTMLElement>, options?: { initialSection?: "autonomous" | null }) => void;
+}
+
+const PRESENCE_OPTIONS: Array<{
+  status: ConversationManualPresenceStatus;
+  label: string;
+}> = [
+  { status: "online", label: "Available" },
+  { status: "idle", label: "Away" },
+  { status: "dnd", label: "Busy" },
+  { status: "offline", label: "Offline" },
+];
+
+const DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+function statusColor(status?: ConversationPresenceStatus | string) {
+  const resolved = status ?? "online";
+  return resolved === "online"
+    ? "bg-green-500"
+    : resolved === "idle"
+      ? "bg-yellow-500"
+      : resolved === "dnd"
+        ? "bg-red-500"
+        : "bg-gray-400";
+}
+
+function statusLabel(status?: ConversationPresenceStatus | string) {
+  return status === "idle" ? "Away" : status === "dnd" ? "Busy" : status === "offline" ? "Offline" : "Available";
+}
+
+function toManualPresenceStatus(status: ConversationPresenceStatus): ConversationManualPresenceStatus {
+  return status;
+}
+
+function parseConversationStatusOverrides(value: unknown): Record<string, ConversationStatusOverride> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([, override]) => {
+      if (!override || typeof override !== "object" || Array.isArray(override)) return false;
+      const status = (override as Record<string, unknown>).status;
+      return status === "online" || status === "idle" || status === "dnd" || status === "offline";
+    }),
+  ) as Record<string, ConversationStatusOverride>;
+}
+
+function parseCharacterSchedules(value: unknown): Record<string, WeekScheduleLike> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, WeekScheduleLike>;
+}
+
+function getActiveOverride(override: ConversationStatusOverride | undefined, now = new Date()) {
+  if (!override) return undefined;
+  if (override.expiresAt) {
+    const expiresAt = new Date(override.expiresAt).getTime();
+    if (Number.isFinite(expiresAt) && expiresAt <= now.getTime()) return undefined;
+  }
+  return override;
+}
+
+function getCurrentScheduleBlock(schedule: WeekScheduleLike | undefined, now = new Date()) {
+  const daySchedule = schedule?.days?.[DAY_NAMES[(now.getDay() + 6) % 7]!];
+  if (!daySchedule?.length) return null;
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  for (const block of daySchedule) {
+    const [startStr, endStr] = (block.time ?? "").split("-");
+    if (!startStr || !endStr) continue;
+    const [startHour, startMinute] = startStr.split(":").map(Number);
+    const [endHour, endMinute] = endStr.split(":").map(Number);
+    const start = (startHour ?? 0) * 60 + (startMinute ?? 0);
+    const end = (endHour ?? 0) * 60 + (endMinute ?? 0);
+    if (start <= currentMinutes && currentMinutes < end) return block;
+    if (start > end && (currentMinutes >= start || currentMinutes < end)) return block;
+  }
+  return null;
+}
+
+function getNextScheduleBlock(schedule: WeekScheduleLike | undefined, now = new Date()) {
+  const daySchedule = schedule?.days?.[DAY_NAMES[(now.getDay() + 6) % 7]!];
+  if (!daySchedule?.length) return null;
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+  return daySchedule.find((block) => {
+    const startStr = (block.time ?? "").split("-")[0];
+    if (!startStr) return false;
+    const [startHour, startMinute] = startStr.split(":").map(Number);
+    return (startHour ?? 0) * 60 + (startMinute ?? 0) > currentMinutes;
+  }) ?? null;
+}
+
+function getRelativeTimeLabel(value: string | undefined) {
+  if (!value) return "No contact yet";
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) return "No contact yet";
+  const minutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60_000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function getManualOverrideDurationLabel(override: ConversationStatusOverride | undefined, now = new Date()) {
+  if (!override?.expiresAt) return "until reset";
+  const expiresAt = new Date(override.expiresAt);
+  const timestamp = expiresAt.getTime();
+  if (!Number.isFinite(timestamp)) return "until reset";
+  const timeLabel = expiresAt.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  if (expiresAt.toDateString() === now.toDateString()) return `until ${timeLabel}`;
+  const dateLabel = expiresAt.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return `until ${dateLabel} ${timeLabel}`;
+}
+
+function describeScheduleBlock(block: ScheduleBlockLike | null) {
+  if (!block) return "No later block today";
+  const parts = [block.time, block.activity].filter((part): part is string => !!part?.trim());
+  return parts.length > 0 ? parts.join(" - ") : statusLabel(block.status);
+}
+
+function removeCharacterFromDelayedInfo(info: DelayedCharacterInfo | null, characterId: string) {
+  if (!info) return null;
+  if (!info.characterIds && !info.characters) return info;
+  const nextCharacterIds = info.characterIds?.filter((id) => id !== characterId);
+  const nextCharacters = info.characters?.filter((character) => character.id !== characterId);
+  if (info.characters && (nextCharacters?.length ?? 0) === 0) return null;
+  if ((nextCharacterIds?.length ?? 0) === 0 && (nextCharacters?.length ?? 0) === 0) return null;
+  const nextName = nextCharacters?.length
+    ? nextCharacters.length === 1
+      ? nextCharacters[0]!.name
+      : nextCharacters.map((character) => character.name).join(", ")
+    : info.name;
+  const nextStatus =
+    nextCharacters?.length && nextCharacters.some((character) => character.status === "dnd")
+      ? "dnd"
+      : nextCharacters?.length && nextCharacters.some((character) => character.status === "idle")
+        ? "idle"
+        : (nextCharacters?.[0]?.status ?? info.status);
+  return {
+    ...info,
+    name: nextName,
+    status: nextStatus,
+    ...(nextCharacterIds ? { characterIds: nextCharacterIds } : {}),
+    ...(nextCharacters ? { characters: nextCharacters } : {}),
+  };
+}
+
+export function ConversationPresenceCard({
+  chatId,
+  chatMeta,
+  chatCharIds,
+  characterMap,
+  messages,
+  onOpenSettings,
+}: ConversationPresenceCardProps) {
+  const qc = useQueryClient();
+  const updateChatMetadata = useUpdateChatMetadata();
+  const [presenceCardOpen, setPresenceCardOpen] = useState(false);
+  const [presenceStatusMenu, setPresenceStatusMenu] = useState<{ characterId: string; left: number; top: number } | null>(null);
+  const presenceCardRef = useRef<HTMLDivElement>(null);
+  const presenceStatusMenuRef = useRef<HTMLDivElement>(null);
+  const metadataStatusOverrides = useMemo(
+    () => parseConversationStatusOverrides(chatMeta.conversationStatusOverrides),
+    [chatMeta.conversationStatusOverrides],
+  );
+  const [optimisticStatusOverrides, setOptimisticStatusOverrides] = useState<Record<
+    string,
+    ConversationStatusOverride
+  > | null>(null);
+  const [draftPresenceActivities, setDraftPresenceActivities] = useState<Record<string, string>>({});
+  const statusOverrides = optimisticStatusOverrides ?? metadataStatusOverrides;
+  const characterSchedules = useMemo(() => parseCharacterSchedules(chatMeta.characterSchedules), [chatMeta.characterSchedules]);
+  const presenceCharacters = useMemo(() => {
+    return chatCharIds
+      .map((id) => {
+        const character = characterMap.get(id);
+        if (!character) return null;
+        const schedule = characterSchedules[id];
+        const scheduledBlock = getCurrentScheduleBlock(schedule);
+        const nextBlock = getNextScheduleBlock(schedule);
+        const activeOverride = getActiveOverride(statusOverrides[id]);
+        const scheduledStatus = scheduledBlock?.status ?? character.conversationStatus ?? "online";
+        const scheduledActivity = scheduledBlock?.activity ?? character.conversationActivity ?? (schedule ? "free time" : "");
+        const effectiveStatus = activeOverride?.status ?? scheduledStatus;
+        const effectiveActivity = activeOverride && typeof activeOverride.activity === "string"
+          ? activeOverride.activity.trim()
+          : scheduledActivity;
+        const lastContactMessage = [...(messages ?? [])]
+          .reverse()
+          .find((msg) => msg.role === "assistant" && (msg.characterId === id || chatCharIds.length === 1));
+        return {
+          id,
+          name: character.name,
+          avatarUrl: character.avatarUrl,
+          avatarCrop: character.avatarCrop,
+          status: effectiveStatus,
+          activity: effectiveActivity,
+          scheduledStatus,
+          scheduledActivity,
+          override: activeOverride,
+          nextBlock,
+          lastContact: getRelativeTimeLabel(lastContactMessage?.createdAt),
+        };
+      })
+      .filter(Boolean) as PresenceCharacter[];
+  }, [characterMap, characterSchedules, chatCharIds, messages, statusOverrides]);
+
+  const hasManualPresenceState = presenceCharacters.some((character) => {
+    const draftActivity = draftPresenceActivities[character.id];
+    return !!character.override || (typeof draftActivity === "string" && draftActivity.trim() !== (character.activity ?? "").trim());
+  });
+
+  const syncConversationStatus = useCallback(async () => {
+    try {
+      await api.get(`/conversation/status/${chatId}`);
+      qc.invalidateQueries({ queryKey: characterKeys.list() });
+    } catch {
+      /* non-critical */
+    }
+  }, [chatId, qc]);
+
+  const clearDelayedPresenceForCharacter = useCallback((characterId: string) => {
+    const chatState = useChatStore.getState();
+    // An online manual override only clears the matching character from any pending busy/away banner.
+    const currentDelayed = chatState.perChatDelayed.get(chatId) ?? null;
+    const nextDelayed = removeCharacterFromDelayedInfo(currentDelayed, characterId);
+    chatState.setPerChatDelayed(chatId, nextDelayed);
+    if (chatState.activeChatId === chatId) {
+      const nextActiveDelayed = removeCharacterFromDelayedInfo(chatState.delayedCharacterInfo, characterId);
+      chatState.setDelayedCharacterInfo(nextActiveDelayed);
+    }
+  }, [chatId]);
+
+  const updatePresenceOverride = useCallback(
+    async (
+      characterId: string,
+      status: ConversationManualPresenceStatus | null,
+      activity?: string,
+      statusAfterClear?: ConversationPresenceStatus,
+    ) => {
+      const previousOverrides = statusOverrides;
+      const nextOverrides = { ...statusOverrides };
+      if (status) {
+        const previousActivity = nextOverrides[characterId]?.activity ?? activity ?? "";
+        nextOverrides[characterId] = {
+          status,
+          activity: typeof activity === "string" ? activity.trim() : previousActivity,
+          createdAt: new Date().toISOString(),
+        };
+      } else {
+        delete nextOverrides[characterId];
+        setDraftPresenceActivities((current) => {
+          const next = { ...current };
+          delete next[characterId];
+          return next;
+        });
+      }
+      setOptimisticStatusOverrides(nextOverrides);
+      try {
+        await updateChatMetadata.mutateAsync({
+          id: chatId,
+          conversationStatusOverrides: Object.keys(nextOverrides).length > 0 ? nextOverrides : null,
+        });
+        await syncConversationStatus();
+        if (status === "online" || (!status && statusAfterClear === "online")) {
+          clearDelayedPresenceForCharacter(characterId);
+        }
+      } catch {
+        setOptimisticStatusOverrides(previousOverrides);
+      }
+    },
+    [chatId, clearDelayedPresenceForCharacter, statusOverrides, syncConversationStatus, updateChatMetadata],
+  );
+
+  const updatePresenceActivity = useCallback(
+    async (
+      characterId: string,
+      activity: string,
+      currentStatus: ConversationPresenceStatus,
+      currentActivity: string,
+    ) => {
+      const currentOverride = statusOverrides[characterId];
+      if (!currentOverride && currentActivity.trim() === activity.trim()) return;
+      if (currentOverride && (currentOverride.activity ?? "") === activity.trim()) return;
+      const previousOverrides = statusOverrides;
+      const nextOverrides = {
+        ...statusOverrides,
+        [characterId]: {
+          ...currentOverride,
+          status: currentOverride?.status ?? toManualPresenceStatus(currentStatus),
+          activity: activity.trim(),
+          createdAt: currentOverride?.createdAt ?? new Date().toISOString(),
+        },
+      };
+      setOptimisticStatusOverrides(nextOverrides);
+      try {
+        await updateChatMetadata.mutateAsync({
+          id: chatId,
+          conversationStatusOverrides: nextOverrides,
+        });
+        await syncConversationStatus();
+      } catch {
+        setOptimisticStatusOverrides(previousOverrides);
+      }
+    },
+    [chatId, statusOverrides, syncConversationStatus, updateChatMetadata],
+  );
+
+  useEffect(() => {
+    if (!chatId) return;
+    const refreshStatus = async () => {
+      if (document.hidden) return;
+      try {
+        await api.get(`/conversation/status/${chatId}`);
+        qc.invalidateQueries({ queryKey: characterKeys.list() });
+      } catch {
+        /* non-critical */
+      }
+    };
+    void refreshStatus();
+    const timer = setInterval(refreshStatus, 60_000);
+    return () => clearInterval(timer);
+  }, [chatId, qc]);
+
+  useEffect(() => {
+    setPresenceCardOpen(false);
+    setPresenceStatusMenu(null);
+    setOptimisticStatusOverrides(null);
+    setDraftPresenceActivities({});
+  }, [chatId]);
+
+  useEffect(() => {
+    setOptimisticStatusOverrides(null);
+  }, [chatMeta.conversationStatusOverrides]);
+
+  useEffect(() => {
+    if (!presenceCardOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!presenceCardRef.current?.contains(target) && !presenceStatusMenuRef.current?.contains(target)) {
+        setPresenceCardOpen(false);
+        setPresenceStatusMenu(null);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPresenceStatusMenu(null);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [presenceCardOpen]);
+
+  if (presenceCharacters.length === 0) return <div />;
+
+  const identityPillClass = getChatToolbarButtonClass({
+    compact: true,
+    className:
+      "w-auto min-w-0 max-w-[min(20rem,calc(100vw-8rem))] justify-start gap-2 px-2.5 text-[var(--foreground)]/80 hover:text-[var(--foreground)]/90",
+  });
+  const avatarShellClass = "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]/80";
+  const avatarFallbackClass =
+    "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--foreground)]/10 text-[0.5rem] font-bold text-[var(--foreground)]/70 ring-1 ring-[var(--border)]/80";
+  const renderAvatar = (character: PresenceCharacter, dotSize = "h-2 w-2", showDot = true) => (
+    <div className="relative flex-shrink-0">
+      {character.avatarUrl ? (
+        <span className={avatarShellClass}>
+          <img
+            src={character.avatarUrl}
+            alt={character.name}
+            className="h-full w-full object-cover"
+            style={getAvatarCropStyle(character.avatarCrop)}
+          />
+        </span>
+      ) : (
+        <div className={avatarFallbackClass}>{character.name[0] ?? "?"}</div>
+      )}
+      {showDot && (
+        <span
+          className={`absolute -bottom-0.5 -right-0.5 ${dotSize} rounded-full ring-[1.5px] ring-[var(--card)] ${statusColor(character.status)}`}
+        />
+      )}
+    </div>
+  );
+  const primaryCharacter = presenceCharacters[0]!;
+  const title = presenceCharacters
+    .map((character) => [character.name, statusLabel(character.status), character.activity].filter(Boolean).join(": "))
+    .join(", ");
+
+  return (
+    <div ref={presenceCardRef} className="relative min-w-0">
+      <button
+        type="button"
+        className={identityPillClass}
+        title={title}
+        aria-expanded={presenceCardOpen}
+        onClick={() => {
+          const nextOpen = !presenceCardOpen;
+          setPresenceCardOpen(nextOpen);
+          if (!nextOpen) setPresenceStatusMenu(null);
+        }}
+      >
+        {presenceCharacters.length === 1 ? (
+          renderAvatar(primaryCharacter)
+        ) : (
+          <div
+            className="relative flex-shrink-0"
+            style={{ width: `${Math.min(presenceCharacters.length, 3) * 12 + 8}px`, height: 20 }}
+          >
+            {presenceCharacters.slice(0, 3).map((character, index) => (
+              <div key={character.id} className="absolute top-0" style={{ left: index * 12 }}>
+                {renderAvatar(character, "h-1.5 w-1.5")}
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="flex min-w-0 flex-col text-left leading-tight">
+          <span className="truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">
+            {presenceCharacters.length <= 2
+              ? presenceCharacters.map((character) => character.name).join(" & ")
+              : `${primaryCharacter.name} + ${presenceCharacters.length - 1}`}
+          </span>
+          <span className="truncate text-[0.5625rem] text-[var(--foreground)]/50">
+            {hasManualPresenceState ? "Manual" : primaryCharacter.activity}
+          </span>
+        </div>
+        <ChevronDown
+          size="0.75rem"
+          className={`ml-0.5 flex-shrink-0 text-[var(--foreground)]/45 transition-transform ${presenceCardOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {presenceCardOpen && (
+        <div
+          className={`${ROLEPLAY_POPOVER_SHELL} absolute left-0 top-full z-30 mt-2 w-[min(28rem,calc(100vw-1rem))] overflow-hidden max-sm:fixed max-sm:left-2 max-sm:right-2 max-sm:top-14 max-sm:w-auto`}
+        >
+          <div className={`${ROLEPLAY_POPOVER_HEADER} flex items-center justify-between gap-2`}>
+            <div className="min-w-0">
+              <div className={ROLEPLAY_POPOVER_TITLE}>
+                <Activity size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                Presence
+              </div>
+              <div className={ROLEPLAY_POPOVER_SUBTITLE}>Adjust manual status here, schedule edits live in Chat Settings.</div>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setPresenceCardOpen(false);
+                setPresenceStatusMenu(null);
+                onOpenSettings(undefined, { initialSection: "autonomous" });
+              }}
+              className="rounded px-1.5 py-0.5 text-[0.625rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+            >
+              Edit schedules
+            </button>
+          </div>
+          <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "max-h-[min(22rem,70vh)] overflow-y-auto p-1.5")}>
+            {presenceCharacters.map((character) => {
+              const displayStatus = character.status;
+              const draftActivity = draftPresenceActivities[character.id];
+              const inputValue = draftActivity ?? character.activity ?? "";
+              const hasDraftActivity = typeof draftActivity === "string" && draftActivity.trim() !== (character.activity ?? "").trim();
+              const isManualPresence = !!character.override || hasDraftActivity;
+              const manualDuration = character.override ? getManualOverrideDurationLabel(character.override) : "editing";
+              return (
+                <div key={character.id} className="rounded-lg px-2.5 py-2 transition-colors hover:bg-[var(--accent)]/20">
+                  <div className="flex min-w-0 items-start gap-2">
+                    {renderAvatar(character, "h-2 w-2", false)}
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate text-[0.75rem] font-semibold">{character.name}</span>
+                        {isManualPresence && (
+                          <span
+                            className="shrink-0 rounded-full bg-[var(--primary)]/10 px-1.5 py-0.5 text-[0.5625rem] font-semibold uppercase tracking-[0.1em] text-[var(--primary)]"
+                            title={character.override ? `Manual override ${manualDuration}` : "Manual edit saves on blur"}
+                          >
+                            Manual {manualDuration}
+                          </span>
+                        )}
+                        {isManualPresence && (
+                          <button
+                            type="button"
+                            aria-label={`Reset manual presence for ${character.name}`}
+                            title="Reset manual presence"
+                            disabled={updateChatMetadata.isPending}
+                            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:pointer-events-none disabled:opacity-35 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+                            // Keep reset from triggering the input blur-save before the override clears.
+                            onMouseDown={(event) => event.preventDefault()}
+                            onClick={() => {
+                              if (character.override) {
+                                void updatePresenceOverride(character.id, null, undefined, character.scheduledStatus);
+                                return;
+                              }
+                              setDraftPresenceActivities((current) => {
+                                const next = { ...current };
+                                delete next[character.id];
+                                return next;
+                              });
+                            }}
+                          >
+                            <RotateCcw size="0.7rem" aria-hidden="true" />
+                          </button>
+                        )}
+                        <span className="ml-auto shrink-0 text-[0.625rem] text-[var(--muted-foreground)]/80">
+                          Last contact {character.lastContact}
+                        </span>
+                      </div>
+                      <div className="mt-1 grid min-w-0 grid-cols-[1.5rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
+                        <button
+                          type="button"
+                          disabled={updateChatMetadata.isPending}
+                          aria-label={`Set ${character.name} presence status`}
+                          aria-expanded={presenceStatusMenu?.characterId === character.id}
+                          aria-haspopup="menu"
+                          title={statusLabel(displayStatus)}
+                          className="flex h-6 w-6 shrink-0 items-center justify-center self-start rounded-md border border-[var(--border)] bg-[var(--secondary)]/70 transition-colors hover:bg-[var(--accent)] disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+                          onClick={(event) => {
+                            const rect = event.currentTarget.getBoundingClientRect();
+                            setPresenceStatusMenu((current) =>
+                              current?.characterId === character.id
+                                ? null
+                                : {
+                                    characterId: character.id,
+                                    left: Math.max(4, Math.min(rect.left, window.innerWidth - 132)),
+                                    top: Math.max(4, Math.min(rect.bottom + 4, window.innerHeight - 116)),
+                                  },
+                            );
+                          }}
+                        >
+                          <span className={`h-2 w-2 rounded-full ${statusColor(displayStatus)}`} />
+                        </button>
+                        <div className="flex min-w-0 items-center overflow-hidden rounded-md border border-[var(--border)] bg-[var(--secondary)]/70 transition-colors focus-within:border-[var(--primary)]/50">
+                          <input
+                            aria-label={`Current status text for ${character.name}`}
+                            value={inputValue}
+                            disabled={updateChatMetadata.isPending}
+                            onChange={(event) =>
+                              setDraftPresenceActivities((current) => ({
+                                ...current,
+                                [character.id]: event.target.value,
+                              }))
+                            }
+                            onBlur={(event) =>
+                              void updatePresenceActivity(character.id, event.target.value, character.status, character.activity)
+                            }
+                            onKeyDown={(event) => {
+                              if (event.key !== "Enter") return;
+                              event.preventDefault();
+                              event.currentTarget.blur();
+                            }}
+                            placeholder="Current status"
+                            className="min-w-0 flex-1 bg-transparent px-2 py-1 text-[0.6875rem] leading-tight text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/45 disabled:opacity-60"
+                          />
+                        </div>
+                        <span className="pt-0.5 font-semibold text-[var(--foreground)]/75">Next</span>
+                        <span className="min-w-0 break-words pt-0.5">{describeScheduleBlock(character.nextBlock)}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      {presenceCardOpen &&
+        presenceStatusMenu &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={presenceStatusMenuRef}
+            role="menu"
+            className="fixed z-[9999] min-w-32 rounded-lg border border-[var(--border)] bg-[var(--card)] p-1 shadow-xl"
+            style={{ left: presenceStatusMenu.left, top: presenceStatusMenu.top }}
+          >
+            {PRESENCE_OPTIONS.map((option) => {
+              const character = presenceCharacters.find((item) => item.id === presenceStatusMenu.characterId);
+              const currentValue = character ? draftPresenceActivities[character.id] ?? character.activity ?? "" : "";
+              const selectedStatus = character?.override?.status ?? character?.status ?? "online";
+              return (
+                <button
+                  key={option.status}
+                  type="button"
+                  role="menuitem"
+                  disabled={updateChatMetadata.isPending || !character}
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[0.6875rem] font-medium transition-colors disabled:opacity-60 ${
+                    selectedStatus === option.status
+                      ? "bg-[var(--primary)]/12 text-[var(--foreground)]"
+                      : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                  }`}
+                  onClick={() => {
+                    if (!character) return;
+                    setPresenceStatusMenu(null);
+                    void updatePresenceOverride(character.id, option.status, currentValue);
+                  }}
+                >
+                  <span className={`h-2 w-2 rounded-full ${statusColor(option.status)}`} />
+                  <span>{option.label}</span>
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -13,22 +13,19 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, ChevronUp, Settings2, Image as ImageIcon, ArrowRightLeft } from "lucide-react";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
 import { ChatBranchSelector } from "./ChatBranchSelector";
 import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
-import { ChatToolbarButton, ChatToolbarMenu, getChatToolbarButtonClass } from "./ChatToolbarControls";
+import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
+import { ConversationPresenceCard } from "./ConversationPresenceCard";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playNotificationPing } from "../../lib/notification-sound";
-import { getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { getTranscriptRenderWindow, TRANSCRIPT_RENDER_WINDOW_STEP } from "../../lib/transcript-render-window";
-import { characterKeys } from "../../hooks/use-characters";
-import { api } from "../../lib/api-client";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
 import type { Message } from "@marinara-engine/shared";
 
@@ -60,7 +57,7 @@ interface ConversationViewProps {
   onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
   onPeekPrompt: () => void;
   lastAssistantMessageId: string | null;
-  onOpenSettings: (event?: ReactMouseEvent<HTMLElement>) => void;
+  onOpenSettings: (event?: ReactMouseEvent<HTMLElement>, options?: { initialSection?: "autonomous" | null }) => void;
   onOpenGallery: (event?: ReactMouseEvent<HTMLElement>) => void;
   onBranch?: (messageId: string) => void;
   multiSelectMode?: boolean;
@@ -268,7 +265,6 @@ export function ConversationView({
   onConcludeScene,
   onAbandonScene,
 }: ConversationViewProps) {
-  const qc = useQueryClient();
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreaming = useChatStore((s) => s.isStreaming) && streamingChatId === chatId;
   const isStreamCommitted = useChatStore((s) => s.committedStreamChatIds.has(chatId));
@@ -316,25 +312,6 @@ export function ConversationView({
     (conversationMessageStyle === "bubble" || !!streamBuffer || !!thinkingBuffer);
   const showTypingIndicator =
     hasLiveStream && !delayedCharacterInfo && !streamBuffer && !thinkingBuffer && conversationMessageStyle !== "bubble";
-
-  // ── Periodic status refresh (every 60s) ──
-  // Keeps status dots in sync with the character's schedule regardless of autonomous messaging
-  useEffect(() => {
-    if (!chatId) return;
-    const refreshStatus = async () => {
-      // Skip while tab is hidden to avoid a burst of requests on return
-      if (document.hidden) return;
-      try {
-        await api.get(`/conversation/status/${chatId}`);
-        qc.invalidateQueries({ queryKey: characterKeys.list() });
-      } catch {
-        /* non-critical */
-      }
-    };
-    void refreshStatus();
-    const timer = setInterval(refreshStatus, 60_000);
-    return () => clearInterval(timer);
-  }, [chatId, qc]);
 
   // Per-scheme conversation gradient from settings.
   // When a scheme's values are still the defaults (user hasn't customized), use
@@ -860,112 +837,14 @@ export function ConversationView({
         {/* Floating header — character info + action buttons */}
         <div className="sticky top-0 z-10 flex items-center justify-between px-4 py-2">
           {/* Character identity pill */}
-          {(() => {
-            const chars = chatCharIds.map((id) => characterMap.get(id)).filter(Boolean) as Array<{
-              name: string;
-              avatarUrl: string | null;
-              avatarCrop?: AvatarCropValue | null;
-              conversationStatus?: "online" | "idle" | "dnd" | "offline";
-              conversationActivity?: string;
-            }>;
-            if (chars.length === 0) return <div />;
-
-            const statusColor = (s?: string) => {
-              const st = s ?? "online";
-              return st === "online"
-                ? "bg-green-500"
-                : st === "idle"
-                  ? "bg-yellow-500"
-                  : st === "dnd"
-                    ? "bg-red-500"
-                    : "bg-gray-400";
-            };
-            const identityPillClass = getChatToolbarButtonClass({
-              compact: true,
-              className:
-                "w-auto min-w-0 max-w-[min(20rem,calc(100vw-8rem))] justify-start gap-2 px-2.5 text-[var(--foreground)]/80 hover:text-[var(--foreground)]/90",
-            });
-            const avatarShellClass =
-              "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]/80";
-            const avatarFallbackClass =
-              "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--foreground)]/10 text-[0.5rem] font-bold text-[var(--foreground)]/70 ring-1 ring-[var(--border)]/80";
-
-            if (chars.length === 1) {
-              const c = chars[0]!;
-              return (
-                <div
-                  className={identityPillClass}
-                  title={c.conversationActivity ? `${c.name}: ${c.conversationActivity}` : c.name}
-                >
-                  <div className="relative flex-shrink-0">
-                    {c.avatarUrl ? (
-                      <span className={avatarShellClass}>
-                        <img
-                          src={c.avatarUrl}
-                          alt={c.name}
-                          className="h-full w-full object-cover"
-                          style={getAvatarCropStyle(c.avatarCrop)}
-                        />
-                      </span>
-                    ) : (
-                      <div className={avatarFallbackClass}>{c.name[0]}</div>
-                    )}
-                    <span
-                      className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-[1.5px] ring-[var(--card)] ${statusColor(c.conversationStatus)}`}
-                    />
-                  </div>
-                  <div className="flex min-w-0 flex-col leading-tight">
-                    <span className="truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">{c.name}</span>
-                    {c.conversationActivity && (
-                      <span className="truncate text-[0.5625rem] text-[var(--foreground)]/50">
-                        {c.conversationActivity}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              );
-            }
-
-            // Multiple characters — show stacked avatars + names
-            return (
-              <div
-                className={identityPillClass}
-                title={chars
-                  .map((c) => (c.conversationActivity ? `${c.name}: ${c.conversationActivity}` : c.name))
-                  .join(", ")}
-              >
-                <div
-                  className="relative flex-shrink-0"
-                  style={{ width: `${Math.min(chars.length, 3) * 12 + 8}px`, height: 20 }}
-                >
-                  {chars.slice(0, 3).map((c, i) => (
-                    <div key={i} className="absolute top-0" style={{ left: i * 12 }}>
-                      <div className="relative">
-                        {c.avatarUrl ? (
-                          <span className={avatarShellClass}>
-                            <img
-                              src={c.avatarUrl}
-                              alt={c.name}
-                              className="h-full w-full object-cover"
-                              style={getAvatarCropStyle(c.avatarCrop)}
-                            />
-                          </span>
-                        ) : (
-                          <div className={avatarFallbackClass}>{c.name[0]}</div>
-                        )}
-                        <span
-                          className={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-[1px] ring-[var(--card)] ${statusColor(c.conversationStatus)}`}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-                <span className="min-w-0 truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">
-                  {chars.length <= 2 ? chars.map((c) => c.name).join(" & ") : `${chars[0]!.name} + ${chars.length - 1}`}
-                </span>
-              </div>
-            );
-          })()}
+          <ConversationPresenceCard
+            chatId={chatId}
+            chatMeta={chatMeta}
+            chatCharIds={chatCharIds}
+            characterMap={characterMap}
+            messages={messages}
+            onOpenSettings={onOpenSettings}
+          />
 
           <ChatToolbarMenu desktopChildren={renderToolbarActions()} mobileChildren={renderToolbarActions(true)} />
         </div>

--- a/packages/client/src/features/chat-settings/ChatSettingsSection.tsx
+++ b/packages/client/src/features/chat-settings/ChatSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode, type KeyboardEvent } from "react";
+import { useEffect, useState, type CSSProperties, type ReactNode, type KeyboardEvent } from "react";
 import { ChevronDown } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../../components/ui/HelpTooltip";
@@ -8,12 +8,16 @@ interface ChatSettingsSectionProps {
   icon?: ReactNode;
   count?: number;
   help?: string;
+  initialOpen?: boolean;
   style?: CSSProperties;
   children: ReactNode;
 }
 
-export function ChatSettingsSection({ label, icon, count, help, style, children }: ChatSettingsSectionProps) {
-  const [open, setOpen] = useState(false);
+export function ChatSettingsSection({ label, icon, count, help, initialOpen = false, style, children }: ChatSettingsSectionProps) {
+  const [open, setOpen] = useState(initialOpen);
+  useEffect(() => {
+    if (initialOpen) setOpen(true);
+  }, [initialOpen]);
   const toggleOpen = () => setOpen((o) => !o);
   const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.target !== event.currentTarget) return;

--- a/packages/client/src/hooks/use-autonomous-messaging.ts
+++ b/packages/client/src/hooks/use-autonomous-messaging.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 // Polls the server to check if any character should send an
 // unprompted message based on user inactivity and character schedules.
-// Also handles busy delays and triggers generation.
+// Triggers generation when the server says a character should speak.
 
 import { useEffect, useRef, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -20,12 +20,6 @@ interface AutonomousCheckResult {
   characterIds: string[];
   reason: string;
   inactivityMs: number;
-}
-
-interface BusyDelayResult {
-  delayMs: number;
-  status: string;
-  activity: string;
 }
 
 /**
@@ -138,22 +132,6 @@ export function useAutonomousMessaging(
         if (result.shouldTrigger && result.characterIds.length > 0) {
           const characterId = result.characterIds[0]!;
 
-          // Check for busy delay
-          const delay = await api.post<BusyDelayResult>("/conversation/busy-delay", { chatId, characterId });
-
-          if (delay.delayMs > 0) {
-            // Wait for the busy delay, then generate
-            busyTimerRef.current = setTimeout(() => {
-              // Re-check guards after delay — user may have started a manual generation
-              if (generatingRef.current || useChatStore.getState().abortControllers.has(chatId)) {
-                schedulePoll();
-                return;
-              }
-              triggerAutonomousGeneration(characterId);
-            }, delay.delayMs);
-            return; // Don't schedule next poll until generation completes
-          }
-
           await triggerAutonomousGeneration(characterId);
           return; // Generation will schedule next poll when done
         }
@@ -172,6 +150,7 @@ export function useAutonomousMessaging(
         produced = await generate({
           chatId,
           connectionId: null,
+          forCharacterId: characterId,
         });
         if (produced) {
           // Re-sort sidebar so this chat floats to the top

--- a/packages/client/src/hooks/use-background-autonomous.ts
+++ b/packages/client/src/hooks/use-background-autonomous.ts
@@ -11,7 +11,7 @@ import type { AvatarCropValue } from "../lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "../lib/api-client";
-import { useChatStore } from "../stores/chat.store";
+import { useChatStore, type DelayedCharacterInfo } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
 import { showConversationLocalNotification } from "../lib/local-notifications";
 import { playNotificationPing } from "../lib/notification-sound";
@@ -26,12 +26,6 @@ interface AutonomousCheckResult {
   generationStartedAt?: number;
 }
 
-interface BusyDelayResult {
-  delayMs: number;
-  status: string;
-  activity: string;
-}
-
 interface RawChat {
   id: string;
   name: string;
@@ -43,6 +37,35 @@ interface RawCharacter {
   id: string;
   data?: string | { name?: string };
   avatarPath?: string | null;
+}
+
+type StreamEvent = { type: string; data?: unknown; [key: string]: unknown };
+
+function parseDelayedEvent(event: StreamEvent): DelayedCharacterInfo {
+  const delayedNames = Array.isArray(event.characters)
+    ? event.characters.filter((name): name is string => typeof name === "string")
+    : [];
+  const delayedIds = Array.isArray(event.characterIds)
+    ? event.characterIds.filter((id): id is string => typeof id === "string" && id.length > 0)
+    : [];
+  const delayedCharacters = Array.isArray(event.characterStatuses)
+    ? event.characterStatuses.flatMap((item) => {
+        if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+        const character = item as Record<string, unknown>;
+        if (typeof character.id !== "string" || typeof character.name !== "string") return [];
+        const status = typeof character.status === "string" ? character.status : "idle";
+        return [{ id: character.id, name: character.name, status }];
+      })
+    : [];
+  const delayedLabel = delayedNames.length === 1 ? delayedNames[0]! : delayedNames.join(", ") || "Character";
+  const delayedStatus = typeof event.status === "string" ? event.status : "idle";
+
+  return {
+    name: delayedLabel,
+    status: delayedStatus,
+    ...(delayedIds.length ? { characterIds: delayedIds } : {}),
+    ...(delayedCharacters.length ? { characters: delayedCharacters } : {}),
+  };
 }
 
 /**
@@ -62,13 +85,13 @@ function parseMeta(chat: RawChat): Record<string, unknown> {
 export function useBackgroundAutonomousPolling() {
   const qc = useQueryClient();
   const pollTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const busyDelayTimers = useRef<Map<ReturnType<typeof setTimeout>, { chatId: string; startedAt?: number }>>(new Map());
+  const generationControllersRef = useRef<Map<string, { controller: AbortController; startedAt?: number }>>(new Map());
   const generatingForRef = useRef<Set<string>>(new Set());
   const mountedRef = useRef(true);
 
   useEffect(() => {
     mountedRef.current = true;
-    const delayTimers = busyDelayTimers.current;
+    const generationControllers = generationControllersRef.current;
 
     const poll = async () => {
       if (!mountedRef.current) return;
@@ -136,17 +159,14 @@ export function useBackgroundAutonomousPolling() {
             const characterId = result.characterIds[0]!;
             const generationStartedAt = result.generationStartedAt;
 
-            // Check busy delay
-            const delay = await api.post<BusyDelayResult>("/conversation/busy-delay", { chatId: chat.id, characterId });
-
-            // Generate in background (after optional delay)
             generatingForRef.current.add(chat.id);
             const doGenerate = async () => {
               let receivedTokens = false;
               let shouldClearAutonomousFlag = true;
+              const abortController = new AbortController();
               try {
                 // Re-check guard — a generation may have started for this chat
-                // during the busy delay.
+                // after the autonomous check returned.
                 if (useChatStore.getState().abortControllers.has(chat.id)) {
                   shouldClearAutonomousFlag = false;
                   generatingForRef.current.delete(chat.id);
@@ -159,13 +179,36 @@ export function useBackgroundAutonomousPolling() {
                   return;
                 }
 
+                generationControllers.set(chat.id, { controller: abortController, startedAt: generationStartedAt });
+                useChatStore.getState().setAbortController(chat.id, abortController);
+
                 // Use streamEvents to drain the SSE — tokens aren't needed for background chats
-                for await (const _event of api.streamEvents("/generate", {
-                  chatId: chat.id,
-                  connectionId: null,
-                  streaming: useUIStore.getState().enableStreaming,
-                })) {
-                  if ((_event as { type: string }).type === "token") receivedTokens = true;
+                for await (const rawEvent of api.streamEvents(
+                  "/generate",
+                  {
+                    chatId: chat.id,
+                    connectionId: null,
+                    forCharacterId: characterId,
+                    streaming: useUIStore.getState().enableStreaming,
+                  },
+                  abortController.signal,
+                )) {
+                  const event = rawEvent as StreamEvent;
+                  if (event.type === "delayed") {
+                    const delayedInfo = parseDelayedEvent(event);
+                    useChatStore.getState().setPerChatDelayed(chat.id, delayedInfo);
+                    if (useChatStore.getState().activeChatId === chat.id) {
+                      useChatStore.getState().setDelayedCharacterInfo(delayedInfo);
+                    }
+                    qc.invalidateQueries({ queryKey: characterKeys.list() });
+                  }
+                  if (event.type === "token") {
+                    receivedTokens = true;
+                    useChatStore.getState().setPerChatDelayed(chat.id, null);
+                    if (useChatStore.getState().activeChatId === chat.id) {
+                      useChatStore.getState().setDelayedCharacterInfo(null);
+                    }
+                  }
                 }
 
                 // Only notify if the generation actually produced a message
@@ -227,6 +270,10 @@ export function useBackgroundAutonomousPolling() {
               } catch {
                 // generation failed — non-critical
               } finally {
+                useChatStore.getState().setPerChatDelayed(chat.id, null);
+                if (useChatStore.getState().activeChatId === chat.id) {
+                  useChatStore.getState().setDelayedCharacterInfo(null);
+                }
                 if (!receivedTokens && shouldClearAutonomousFlag) {
                   try {
                     await api.post("/conversation/autonomous/clear-in-progress", {
@@ -237,19 +284,17 @@ export function useBackgroundAutonomousPolling() {
                     /* non-critical */
                   }
                 }
+                if (useChatStore.getState().abortControllers.get(chat.id) === abortController) {
+                  useChatStore.getState().setAbortController(chat.id, null);
+                }
+                if (useChatStore.getState().activeChatId === chat.id) {
+                  useChatStore.getState().setStreaming(false, chat.id);
+                }
+                generationControllers.delete(chat.id);
                 generatingForRef.current.delete(chat.id);
               }
             };
-
-            if (delay.delayMs > 0) {
-              const timerId = setTimeout(() => {
-                busyDelayTimers.current.delete(timerId);
-                doGenerate();
-              }, delay.delayMs);
-              busyDelayTimers.current.set(timerId, { chatId: chat.id, startedAt: generationStartedAt });
-            } else {
-              doGenerate();
-            }
+            doGenerate();
           }
         } catch {
           // Check failed — skip this chat, try next
@@ -271,16 +316,21 @@ export function useBackgroundAutonomousPolling() {
     return () => {
       mountedRef.current = false;
       clearTimeout(pollTimerRef.current);
-      for (const [timer, lock] of delayTimers) {
-        clearTimeout(timer);
+      for (const [chatId, generation] of generationControllers) {
+        generation.controller.abort();
+        useChatStore.getState().setAbortController(chatId, null);
+        if (useChatStore.getState().activeChatId === chatId) {
+          useChatStore.getState().setStreaming(false, chatId);
+        }
+        useChatStore.getState().setPerChatDelayed(chatId, null);
         void api
           .post("/conversation/autonomous/clear-in-progress", {
-            chatId: lock.chatId,
-            startedAt: lock.startedAt,
+            chatId,
+            startedAt: generation.startedAt,
           })
           .catch(() => {});
       }
-      delayTimers.clear();
+      generationControllers.clear();
     };
   }, [qc]); // Only depends on qc (which is stable) — timer lifecycle is self-managed
 }

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2004,11 +2004,27 @@ export function useGenerate() {
             case "delayed": {
               // Character is busy (DND/idle) — show waiting indicator
               const delayedNames = (event as any).characters as string[] | undefined;
+              const delayedIds = ((event as any).characterIds as unknown[] | undefined)?.filter(
+                (id): id is string => typeof id === "string" && id.length > 0,
+              );
+              const delayedCharacters = ((event as any).characterStatuses as unknown[] | undefined)?.flatMap((item) => {
+                if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+                const character = item as Record<string, unknown>;
+                if (typeof character.id !== "string" || typeof character.name !== "string") return [];
+                const status = typeof character.status === "string" ? character.status : "idle";
+                return [{ id: character.id, name: character.name, status }];
+              });
               const delayedLabel =
                 delayedNames?.length === 1 ? delayedNames[0] : (delayedNames?.join(", ") ?? "Character");
               const delayedStatus = ((event as any).status as string) ?? "idle";
-              useChatStore.getState().setPerChatDelayed(params.chatId, { name: delayedLabel, status: delayedStatus });
-              if (isActiveChat()) setDelayedCharacterInfo({ name: delayedLabel, status: delayedStatus });
+              const delayedInfo = {
+                name: delayedLabel,
+                status: delayedStatus,
+                ...(delayedIds?.length ? { characterIds: delayedIds } : {}),
+                ...(delayedCharacters?.length ? { characters: delayedCharacters } : {}),
+              };
+              useChatStore.getState().setPerChatDelayed(params.chatId, delayedInfo);
+              if (isActiveChat()) setDelayedCharacterInfo(delayedInfo);
               // Refresh character data so sidebar status dots update immediately
               qc.invalidateQueries({ queryKey: characterKeys.list() });
               break;

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -13,6 +13,13 @@ const DRAFTS_KEY = "marinara-input-drafts";
 
 type NotificationAvatarCrop = AvatarCropValue | null;
 
+export interface DelayedCharacterInfo {
+  name: string;
+  status: string;
+  characterIds?: string[];
+  characters?: Array<{ id: string; name: string; status: string }>;
+}
+
 /** Read drafts from localStorage so typed input survives reloads, tab closes, and app restarts. */
 function loadDrafts(): Map<string, string> {
   try {
@@ -81,11 +88,11 @@ interface ChatState {
   /** Human-readable label for the current server-side generation phase (e.g. "Running agents..."). */
   generationPhase: string | null;
   /** Character name + status shown during DND/idle delay (before generation starts). */
-  delayedCharacterInfo: { name: string; status: string } | null;
+  delayedCharacterInfo: DelayedCharacterInfo | null;
   /** Per-chat typing state so switching chats restores the correct indicator. */
   perChatTyping: Map<string, string>;
   /** Per-chat delayed state so switching chats restores the correct indicator. */
-  perChatDelayed: Map<string, { name: string; status: string }>;
+  perChatDelayed: Map<string, DelayedCharacterInfo>;
   swipeIndex: Map<string, number>; // messageId → active swipe index
   /** When true, ChatArea should open the settings drawer on next render. */
   shouldOpenSettings: boolean;
@@ -142,9 +149,9 @@ interface ChatState {
   clearResponseQueue: (chatId: string) => void;
   setTypingCharacterName: (name: string | null) => void;
   setGenerationPhase: (phase: string | null) => void;
-  setDelayedCharacterInfo: (info: { name: string; status: string } | null) => void;
+  setDelayedCharacterInfo: (info: DelayedCharacterInfo | null) => void;
   setPerChatTyping: (chatId: string, name: string | null) => void;
-  setPerChatDelayed: (chatId: string, info: { name: string; status: string } | null) => void;
+  setPerChatDelayed: (chatId: string, info: DelayedCharacterInfo | null) => void;
   clearPerChatState: (chatId: string) => void;
   setSwipeIndex: (messageId: string, index: number) => void;
   setShouldOpenSettings: (v: boolean) => void;
@@ -478,7 +485,7 @@ export const useChatStore = create<ChatState>()(
         return { perChatTyping: m, perChatDelayed: d };
       }),
 
-    setPerChatDelayed: (chatId: string, info: { name: string; status: string } | null) =>
+    setPerChatDelayed: (chatId: string, info: DelayedCharacterInfo | null) =>
       set((state) => {
         const d = new Map(state.perChatDelayed);
         if (info) d.set(chatId, info);

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -11,10 +11,10 @@ import { createCharactersStorage } from "../services/storage/characters.storage.
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { PROVIDERS } from "@marinara-engine/shared";
-import type { CharacterData } from "@marinara-engine/shared";
+import type { CharacterData, ConversationStatusOverride } from "@marinara-engine/shared";
 import {
   generateCharacterSchedule,
-  getCurrentStatus,
+  getEffectiveCurrentStatus,
   scheduleNeedsRefresh,
   getMonday,
   getBusyDelay,
@@ -53,6 +53,17 @@ function areConversationSchedulesEnabled(meta: Record<string, unknown>): boolean
 
 function getEnabledConversationSchedules(meta: Record<string, unknown>): CharacterSchedules {
   return areConversationSchedulesEnabled(meta) && hasSchedules(meta.characterSchedules) ? meta.characterSchedules : {};
+}
+
+function getConversationStatusOverrides(meta: Record<string, unknown>): Record<string, ConversationStatusOverride> {
+  if (!meta.conversationStatusOverrides || typeof meta.conversationStatusOverrides !== "object") return {};
+  return Object.fromEntries(
+    Object.entries(meta.conversationStatusOverrides as Record<string, unknown>).filter(([, value]) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+      const status = (value as Record<string, unknown>).status;
+      return status === "online" || status === "idle" || status === "dnd" || status === "offline";
+    }),
+  ) as Record<string, ConversationStatusOverride>;
 }
 
 type AutonomousUserStatus = "active" | "idle" | "dnd";
@@ -362,7 +373,7 @@ export async function conversationRoutes(app: FastifyInstance) {
           const charRow = await chars.getById(charId);
           if (charRow) {
             const charData = JSON.parse(charRow.data as string) as CharacterData;
-            const { status } = getCurrentStatus(mergedShared);
+            const { status } = getEffectiveCurrentStatus(mergedShared, getConversationStatusOverrides(meta)[charId]);
             const extensions = { ...(charData.extensions ?? {}), conversationStatus: status };
             await chars.update(charId, { extensions } as Partial<CharacterData>, undefined, {
               skipVersionSnapshot: true,
@@ -413,7 +424,7 @@ export async function conversationRoutes(app: FastifyInstance) {
         newSchedules[charId] = fullSchedule;
 
         // Update character's conversationStatus to match current schedule
-        const { status } = getCurrentStatus(fullSchedule);
+        const { status } = getEffectiveCurrentStatus(fullSchedule, getConversationStatusOverrides(meta)[charId]);
         const extensions = { ...(charData.extensions ?? {}), conversationStatus: status };
         await chars.update(charId, { extensions } as Partial<CharacterData>, undefined, {
           skipVersionSnapshot: true,
@@ -487,32 +498,47 @@ export async function conversationRoutes(app: FastifyInstance) {
     const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(req.params.chatId);
     const characterIds: string[] =
       typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : chat.characterIds;
+    const meta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+    const statusOverrides = getConversationStatusOverrides(meta);
 
     const now = new Date();
-    const statuses: Record<string, { status: string; activity: string; schedule?: WeekSchedule }> = {};
+    const statuses: Record<
+      string,
+      { status: string; activity: string; schedule?: WeekSchedule; override?: ConversationStatusOverride }
+    > = {};
 
     for (const charId of characterIds) {
       const schedule = schedules[charId];
       if (!schedule) {
+        const { status, activity, override } = getEffectiveCurrentStatus(
+          null,
+          statusOverrides[charId],
+          now,
+          "",
+        );
         const charRow = await chars.getById(charId);
         if (charRow) {
           const charData = JSON.parse(charRow.data as string) as CharacterData;
           const currentExtensions = (charData.extensions as Record<string, unknown> | undefined) ?? {};
-          if (currentExtensions.conversationStatus !== "online" || currentExtensions.conversationActivity != null) {
+          if (currentExtensions.conversationStatus !== status || currentExtensions.conversationActivity !== activity) {
             const extensions: Record<string, unknown> = {
               ...currentExtensions,
-              conversationStatus: "online",
-              conversationActivity: undefined,
+              conversationStatus: status,
+              conversationActivity: activity,
             };
             await chars.update(charId, { extensions } as Partial<CharacterData>, undefined, {
               skipVersionSnapshot: true,
             });
           }
         }
-        statuses[charId] = { status: "online", activity: "unknown (no schedule)" };
+        statuses[charId] = { status, activity, override };
         continue;
       }
-      const { status, activity } = getCurrentStatus(schedule, now);
+      const { status, activity, override } = getEffectiveCurrentStatus(
+        schedule,
+        statusOverrides[charId],
+        now,
+      );
 
       // Sync the character's conversationStatus in the database
       const charRow = await chars.getById(charId);
@@ -533,7 +559,7 @@ export async function conversationRoutes(app: FastifyInstance) {
         }
       }
 
-      statuses[charId] = { status, activity, schedule };
+      statuses[charId] = { status, activity, schedule, override };
     }
 
     return reply.send({ statuses, needsRefresh: Object.values(schedules).some((s) => scheduleNeedsRefresh(s)) });
@@ -611,12 +637,13 @@ export async function conversationRoutes(app: FastifyInstance) {
         userStatus,
       );
     }
+    const statusOverrides = getConversationStatusOverrides(meta);
 
     // Update each character's conversationStatus to match current schedule
     for (const cid of characterIds) {
       const schedule = schedules[cid];
       if (!schedule) continue;
-      const { status } = getCurrentStatus(schedule);
+      const { status } = getEffectiveCurrentStatus(schedule, statusOverrides[cid]);
       const charRow = await chars.getById(cid);
       if (!charRow) continue;
       const charData = JSON.parse(charRow.data as string);
@@ -648,6 +675,7 @@ export async function conversationRoutes(app: FastifyInstance) {
 
     const result = checkAutonomousMessaging(chatId, filteredSchedules, isGroup, {
       maxFollowups: req.body.maxFollowups,
+      statusOverrides,
     });
 
     if (result.shouldTrigger) {
@@ -655,26 +683,38 @@ export async function conversationRoutes(app: FastifyInstance) {
       return reply.send({ ...result, generationStartedAt });
     }
 
-    // ── Offline catch-up: if any character is now online and last messages are from user ──
+    if (result.reason === "generation_in_progress") {
+      return reply.send(result);
+    }
+
+    // ── Offline catch-up: if any character is available and last messages are from user ──
     // This catches the case where user sent messages while character was offline.
     // Now that they're online, trigger a catch-up generation.
     if (hasRoutineSchedules) {
-      const onlineCharIds = characterIds.filter((cid) => {
-        const schedule = schedules[cid];
-        if (!schedule) return true; // No schedule = assume online
-        const { status } = getCurrentStatus(schedule);
-        return status !== "offline";
+      const onlineCandidates = Object.entries(filteredSchedules).flatMap(([cid, schedule]) => {
+        const { status, override } = getEffectiveCurrentStatus(schedule, statusOverrides[cid]);
+        // Away/busy should not fire immediate catch-up; their normal autonomy delay still applies.
+        return status === "online" ? [{ cid, override }] : [];
       });
 
-      if (onlineCharIds.length > 0 && messages.length > 0) {
+      if (onlineCandidates.length > 0 && messages.length > 0) {
         // Check if the last message (or consecutive last messages) are all from the user
         const last = messages[messages.length - 1]!;
         if (last.role === "user") {
+          onlineCandidates.sort((a, b) => {
+            const aManualOnline = a.override?.status === "online" ? 1 : 0;
+            const bManualOnline = b.override?.status === "online" ? 1 : 0;
+            if (aManualOnline !== bManualOnline) return bManualOnline - aManualOnline;
+            const aCreatedAt = new Date(a.override?.createdAt ?? "").getTime();
+            const bCreatedAt = new Date(b.override?.createdAt ?? "").getTime();
+            return (Number.isFinite(bCreatedAt) ? bCreatedAt : 0) - (Number.isFinite(aCreatedAt) ? aCreatedAt : 0);
+          });
+
           // Character is online but hasn't responded — trigger catch-up
           const generationStartedAt = markGenerationInProgress(chatId);
           return reply.send({
             shouldTrigger: true,
-            characterIds: onlineCharIds.slice(0, 1), // Pick first online character
+            characterIds: [onlineCandidates[0]!.cid],
             reason: "user_inactivity",
             inactivityMs: 0,
             generationStartedAt,
@@ -710,12 +750,16 @@ export async function conversationRoutes(app: FastifyInstance) {
 
     const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(chatId);
     const schedule = schedules[characterId];
+    const statusOverrides = getConversationStatusOverrides(
+      typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {}),
+    );
 
     if (!schedule) {
-      return reply.send({ delayMs: 0, status: "online", activity: "unknown" });
+      const { status, activity } = getEffectiveCurrentStatus(null, statusOverrides[characterId], undefined, "");
+      return reply.send({ delayMs: getBusyDelay(status), status, activity });
     }
 
-    const { status, activity } = getCurrentStatus(schedule);
+    const { status, activity } = getEffectiveCurrentStatus(schedule, statusOverrides[characterId]);
     const delayMs = getBusyDelay(status, schedule);
 
     return reply.send({ delayMs, status, activity });
@@ -745,14 +789,23 @@ export async function conversationRoutes(app: FastifyInstance) {
       return reply.send({ shouldTrigger: false, characterIds: [], reason: "exchanges_disabled", inactivityMs: 0 });
     }
 
+    if (meta.sceneStatus === "active") {
+      return reply.send({ shouldTrigger: false, characterIds: [], reason: "scene_active", inactivityMs: 0 });
+    }
+
     const schedules: CharacterSchedules = await chats.inheritFreshConversationSchedules(chatId);
+    const sceneBusyCharIds: string[] = meta.sceneBusyCharIds ?? [];
+    const filteredSchedules = { ...schedules };
+    for (const busyId of sceneBusyCharIds) {
+      delete filteredSchedules[busyId];
+    }
     const messages = await chats.listMessages(chatId);
     initializeActivityFromMessages(
       chatId,
       messages as Array<{ role: string; createdAt?: string; characterId?: string | null }>,
     );
 
-    const result = checkCharacterExchange(chatId, lastSpeakerCharId, schedules);
+    const result = checkCharacterExchange(chatId, lastSpeakerCharId, filteredSchedules, getConversationStatusOverrides(meta));
     if (result.shouldTrigger) {
       markGenerationInProgress(chatId);
     }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -281,6 +281,7 @@ import {
 import {
   areConversationSchedulesEnabled,
   getEnabledConversationSchedules,
+  parseConversationStatusOverrides,
   parsePromptPresetChoices,
 } from "../services/generation/conversation-context-utils.js";
 import { recoverImplicitSelfieCommand } from "../services/generation/selfie-command-recovery.js";
@@ -1499,6 +1500,7 @@ export async function generateRoutes(app: FastifyInstance) {
               string,
               import("../services/conversation/schedule.service.js").WeekSchedule
             >;
+          const statusOverrides = parseConversationStatusOverrides(chatMeta.conversationStatusOverrides);
           const convoCharInfo: {
             charId: string;
             name: string;
@@ -1512,22 +1514,25 @@ export async function generateRoutes(app: FastifyInstance) {
               const d = JSON.parse(charRow.data as string);
               // Schedules are chat-scoped. If this chat has no schedule for the character,
               // don't inherit a stale conversationStatus from some other chat.
-              let status = "online";
-              let activity = "";
+              const schedSvc = await import("../services/conversation/schedule.service.js");
+              const override = statusOverrides[cid];
+              const derived = schedSvc.getEffectiveCurrentStatus(undefined, override, promptNow, "");
+              let status = derived.status;
+              let activity = derived.activity;
               let todaySchedule = "";
               const schedule = schedules[cid];
               if (schedule) {
-                const schedSvc = await import("../services/conversation/schedule.service.js");
-                const derived = schedSvc.getCurrentStatus(schedule, promptNow);
+                const derived = schedSvc.getEffectiveCurrentStatus(schedule, override, promptNow);
                 status = derived.status;
                 activity = derived.activity;
                 todaySchedule = schedSvc.getTodaySchedule(schedule, promptNow);
-                // Sync status to character DB so sidebar/header dots stay in sync
-                const prevStatus = d.extensions?.conversationStatus;
-                if (prevStatus !== status) {
-                  const extensions = { ...(d.extensions ?? {}), conversationStatus: status };
-                  await chars.update(cid, { extensions } as any).catch(() => {});
-                }
+              }
+              // Sync status to character DB so sidebar/header dots stay in sync
+              const prevStatus = d.extensions?.conversationStatus;
+              const prevActivity = d.extensions?.conversationActivity;
+              if (prevStatus !== status || prevActivity !== activity) {
+                const extensions = { ...(d.extensions ?? {}), conversationStatus: status, conversationActivity: activity };
+                await chars.update(cid, { extensions } as any).catch(() => {});
               }
               convoCharInfo.push({ charId: cid, name: d.name ?? "Unknown", status, activity, todaySchedule });
             }
@@ -1548,6 +1553,7 @@ export async function generateRoutes(app: FastifyInstance) {
               : convoCharInfo;
           const respondingConvoCharInfo = scopedConvoCharInfo.length > 0 ? scopedConvoCharInfo : convoCharInfo;
           const respondingConvoCharNames = respondingConvoCharInfo.map((c) => c.name);
+          const respondingConvoCharIds = respondingConvoCharInfo.map((c) => c.charId);
 
           // ── Offline skip: if ALL characters are offline, don't generate ──
           // The user message is already saved. When the character comes back online,
@@ -1585,7 +1591,18 @@ export async function generateRoutes(app: FastifyInstance) {
             if (delayMs > 0) {
               // Send "delayed" event first — client shows "will respond in a moment" / "when they're back"
               reply.raw.write(
-                `data: ${JSON.stringify({ type: "delayed", characters: respondingConvoCharNames, status: worstStatus, delayMs })}\n\n`,
+                `data: ${JSON.stringify({
+                  type: "delayed",
+                  characters: respondingConvoCharNames,
+                  characterIds: respondingConvoCharIds,
+                  characterStatuses: respondingConvoCharInfo.map((character) => ({
+                    id: character.charId,
+                    name: character.name,
+                    status: character.status,
+                  })),
+                  status: worstStatus,
+                  delayMs,
+                })}\n\n`,
               );
               await new Promise((r) => setTimeout(r, delayMs));
 
@@ -6060,7 +6077,7 @@ export async function generateRoutes(app: FastifyInstance) {
         } else {
           // Single/merged: one generation
           sendProgress("generating");
-          let targetCharId = characterIds[0] ?? null;
+          let targetCharId = promptTargetCharacterId ?? characterIds[0] ?? null;
           const sentMessages = [...finalMessages];
 
           if (generationGuideInstruction) {

--- a/packages/server/src/services/conversation/autonomous.service.ts
+++ b/packages/server/src/services/conversation/autonomous.service.ts
@@ -5,7 +5,8 @@
 // should send autonomous messages. Also handles character-to-character
 // exchanges in group chats.
 
-import { getCurrentStatus, type WeekSchedule } from "./schedule.service.js";
+import type { ConversationStatusOverride } from "@marinara-engine/shared";
+import { getEffectiveCurrentStatus, type WeekSchedule } from "./schedule.service.js";
 
 // ── Types ──
 
@@ -15,7 +16,7 @@ export interface AutonomousCheckResult {
   /** Which character(s) should send a message */
   characterIds: string[];
   /** Why this was triggered */
-  reason: "user_inactivity" | "character_exchange" | "none";
+  reason: "user_inactivity" | "character_exchange" | "none" | "generation_in_progress";
   /** How long the user has been inactive (ms) */
   inactivityMs: number;
 }
@@ -182,7 +183,7 @@ export function checkAutonomousMessaging(
   chatId: string,
   characterSchedules: Record<string, WeekSchedule>,
   isGroupChat: boolean,
-  opts: { maxFollowups?: number } = {},
+  opts: { maxFollowups?: number; statusOverrides?: Record<string, ConversationStatusOverride> } = {},
 ): AutonomousCheckResult {
   const noTrigger: AutonomousCheckResult = {
     shouldTrigger: false,
@@ -199,7 +200,7 @@ export function checkAutonomousMessaging(
     if (Date.now() - state.generationInProgressSince > GENERATION_TIMEOUT_MS) {
       state.generationInProgressSince = null;
     } else {
-      return noTrigger;
+      return { ...noTrigger, reason: "generation_in_progress" };
     }
   }
 
@@ -216,7 +217,7 @@ export function checkAutonomousMessaging(
   const maxFollowups = Math.max(1, Math.min(3, Math.floor(opts.maxFollowups ?? 3)));
 
   for (const [charId, schedule] of Object.entries(characterSchedules)) {
-    const { status } = getCurrentStatus(schedule);
+    const { status } = getEffectiveCurrentStatus(schedule, opts.statusOverrides?.[charId]);
 
     // Can't send if offline or sleeping
     if (status === "offline") continue;
@@ -291,6 +292,7 @@ export function checkCharacterExchange(
   chatId: string,
   lastSpeakerCharId: string,
   characterSchedules: Record<string, WeekSchedule>,
+  statusOverrides: Record<string, ConversationStatusOverride> = {},
 ): AutonomousCheckResult {
   const noTrigger: AutonomousCheckResult = {
     shouldTrigger: false,
@@ -305,7 +307,7 @@ export function checkCharacterExchange(
     if (Date.now() - state.generationInProgressSince > GENERATION_TIMEOUT_MS) {
       state.generationInProgressSince = null;
     } else {
-      return noTrigger;
+      return { ...noTrigger, reason: "generation_in_progress" };
     }
   }
 
@@ -318,7 +320,7 @@ export function checkCharacterExchange(
   for (const [charId, schedule] of Object.entries(characterSchedules)) {
     if (charId === lastSpeakerCharId) continue;
 
-    const { status } = getCurrentStatus(schedule);
+    const { status } = getEffectiveCurrentStatus(schedule, statusOverrides[charId]);
     if (status === "offline") continue;
     if (status === "dnd") continue; // Busy characters don't join casual exchanges
 

--- a/packages/server/src/services/conversation/schedule.service.ts
+++ b/packages/server/src/services/conversation/schedule.service.ts
@@ -6,6 +6,7 @@
 
 import { createLLMProvider } from "../llm/provider-registry.js";
 import type { BaseLLMProvider } from "../llm/base-provider.js";
+import type { ConversationPresenceStatus, ConversationStatusOverride } from "@marinara-engine/shared";
 
 // ── Types ──
 
@@ -16,7 +17,7 @@ export interface ScheduleBlock {
   /** What the character is doing */
   activity: string;
   /** Derived status for this block */
-  status: "online" | "idle" | "dnd" | "offline";
+  status: ConversationPresenceStatus;
 }
 
 /** One day of a character's schedule */
@@ -43,11 +44,17 @@ export interface CharacterSchedules {
   [characterId: string]: WeekSchedule;
 }
 
+export interface CurrentConversationStatus {
+  status: ConversationPresenceStatus;
+  activity: string;
+  override?: ConversationStatusOverride;
+}
+
 // ── Constants ──
 
 const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
-const STATUS_KEYWORDS: Record<string, "online" | "idle" | "dnd" | "offline"> = {
+const STATUS_KEYWORDS: Record<string, ConversationPresenceStatus> = {
   sleep: "offline",
   sleeping: "offline",
   nap: "offline",
@@ -275,7 +282,7 @@ function inferStatusFromActivity(activity: string): "online" | "idle" | "dnd" | 
 export function getCurrentStatus(
   schedule: WeekSchedule,
   now: Date = new Date(),
-): { status: "online" | "idle" | "dnd" | "offline"; activity: string } {
+): { status: ConversationPresenceStatus; activity: string } {
   const dayName = DAYS[(now.getDay() + 6) % 7]!; // JS Sunday=0, we want Monday=0
   const daySchedule = schedule.days[dayName];
   if (!daySchedule || daySchedule.length === 0) {
@@ -304,6 +311,35 @@ export function getCurrentStatus(
   }
 
   return { status: "online", activity: "free time" };
+}
+
+function isManualPresenceStatus(value: unknown): value is ConversationStatusOverride["status"] {
+  return value === "online" || value === "idle" || value === "dnd" || value === "offline";
+}
+
+function getActiveStatusOverride(
+  override: ConversationStatusOverride | null | undefined,
+  now: Date,
+): ConversationStatusOverride | null {
+  if (!override || !isManualPresenceStatus(override.status)) return null;
+  if (override.expiresAt) {
+    const expiresAt = new Date(override.expiresAt).getTime();
+    if (Number.isFinite(expiresAt) && expiresAt <= now.getTime()) return null;
+  }
+  return override;
+}
+
+export function getEffectiveCurrentStatus(
+  schedule: WeekSchedule | null | undefined,
+  override: ConversationStatusOverride | null | undefined,
+  now: Date = new Date(),
+  fallbackActivity = "free time",
+): CurrentConversationStatus {
+  const scheduled = schedule ? getCurrentStatus(schedule, now) : { status: "online" as const, activity: fallbackActivity };
+  const activeOverride = getActiveStatusOverride(override, now);
+  if (!activeOverride) return scheduled;
+  const activity = typeof activeOverride.activity === "string" ? activeOverride.activity.trim() : scheduled.activity;
+  return { status: activeOverride.status, activity, override: activeOverride };
 }
 
 /**
@@ -342,7 +378,7 @@ export function getMonday(date: Date = new Date()): Date {
  * Returns 0 for online characters, 2-5 minutes for busy characters.
  */
 function getConfiguredResponseDelayMinutes(
-  status: "online" | "idle" | "dnd" | "offline",
+  status: ConversationPresenceStatus,
   schedule?: Pick<WeekSchedule, "idleResponseDelayMinutes" | "dndResponseDelayMinutes">,
 ): number | null {
   const rawValue =
@@ -358,7 +394,7 @@ function getConfiguredResponseDelayMinutes(
 }
 
 function getConfiguredResponseDelay(
-  status: "online" | "idle" | "dnd" | "offline",
+  status: ConversationPresenceStatus,
   schedule?: Pick<WeekSchedule, "idleResponseDelayMinutes" | "dndResponseDelayMinutes">,
 ): number {
   const overrideMinutes = getConfiguredResponseDelayMinutes(status, schedule);
@@ -379,7 +415,7 @@ function getConfiguredResponseDelay(
 }
 
 export function getBusyDelay(
-  status: "online" | "idle" | "dnd" | "offline",
+  status: ConversationPresenceStatus,
   schedule?: Pick<WeekSchedule, "idleResponseDelayMinutes" | "dndResponseDelayMinutes">,
 ): number {
   return getConfiguredResponseDelay(status, schedule);

--- a/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
+++ b/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
@@ -87,6 +87,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
       payload: {
         chatId,
         connectionId: null,
+        forCharacterId: characterId,
         streaming: false,
         userStatus: "idle",
         userActivity: "away or offline",

--- a/packages/server/src/services/generation/conversation-context-utils.ts
+++ b/packages/server/src/services/generation/conversation-context-utils.ts
@@ -1,5 +1,18 @@
+import type { ConversationStatusOverride } from "@marinara-engine/shared";
+
 export function hasConversationSchedules(value: unknown): value is Record<string, any> {
   return !!value && typeof value === "object" && Object.keys(value as Record<string, unknown>).length > 0;
+}
+
+export function parseConversationStatusOverrides(value: unknown): Record<string, ConversationStatusOverride> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter(([, override]) => {
+      if (!override || typeof override !== "object" || Array.isArray(override)) return false;
+      const status = (override as Record<string, unknown>).status;
+      return status === "online" || status === "idle" || status === "dnd" || status === "offline";
+    }),
+  ) as Record<string, ConversationStatusOverride>;
 }
 
 export function parsePromptPresetChoices(value: unknown): Record<string, string | string[]> | null {

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -43,6 +43,17 @@ export type ConversationCommandKey = (typeof CONVERSATION_COMMAND_KEYS)[number];
 
 export type ConversationCommandToggles = Partial<Record<ConversationCommandKey, boolean>>;
 
+export type ConversationPresenceStatus = "online" | "idle" | "dnd" | "offline";
+
+export type ConversationManualPresenceStatus = ConversationPresenceStatus;
+
+export interface ConversationStatusOverride {
+  status: ConversationManualPresenceStatus;
+  activity?: string | null;
+  createdAt: string;
+  expiresAt?: string | null;
+}
+
 /** Role of a message in the conversation. */
 export type MessageRole = "user" | "assistant" | "system" | "narrator";
 
@@ -290,6 +301,8 @@ export interface ChatMetadata {
   conversationCommandToggles?: ConversationCommandToggles;
   /** Chat-scoped generated schedules for conversation characters. */
   characterSchedules?: Record<string, unknown>;
+  /** Chat-scoped manual status overrides for conversation characters. */
+  conversationStatusOverrides?: Record<string, ConversationStatusOverride>;
   /** Week start timestamp for the current generated conversation schedules. */
   scheduleWeekStart?: string;
   /** Chat-scoped selfie prompt-builder template. Empty/null uses the global/default prompt. */


### PR DESCRIPTION
ON HOLD till I try something different with schedules.

<!-- Target branch: `staging` -->
<!-- The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Related to #2595

## Why this change

- Conversation chats currently hide character availability and activity too deeply, especially in group chats where autonomous replies, delayed responses, and offline behavior need to map to the character expected to respond.
- Users need compact per-chat presence controls without editing global character data or duplicating the full schedule editor in the chat chrome.

## What changed

- Added a compact conversation presence card/popover for current status, manual activity overrides, reset, and schedule editing entry.
- Added per-chat conversation status overrides, including manual Offline, and server-side effective status resolution.
- Wired effective presence into autonomous messaging, busy-delay, offline handling, generation context, and selected-character targeting.
- Preserved per-character delayed state so changing one character back to Available clears only that pending response.
- Deep-linked Chat Settings to the Autonomous Messaging schedule controls.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated local validation passed: `pnpm check`, `git diff --check`, focused presence API smoke, focused catch-up target API smoke, and expanded temporary presence logic matrix.
- Focused temporary logic matrix passed for effective status overrides, manual Offline, expired overrides, direct delays, autonomous eligibility, group targeting, exchange eligibility, generation-in-progress gating, and follow-up caps.
- Focused API smoke confirmed manual-online catch-up targeting prefers a manually returned character over another scheduled-online group member.
- Code-path review confirms changing a manual status only patches chat metadata, syncs `/conversation/status/:chatId`, and optionally clears matching delayed UI; it does not directly call `/generate`.
- Code-path review confirms active/background autonomous generation still starts only after `/conversation/autonomous/check` or `/conversation/autonomous/exchange` returns a target character.
- Manual browser verification still needed: presence card closed/open states on desktop and mobile.
- Manual browser verification still needed: manual status text saves on blur and Enter.
- Manual browser verification still needed: manual Offline prevents generation and Reset restores schedule behavior.
- Manual browser verification still needed: autonomous generation targets the selected character in group conversations.
- Manual browser verification still needed: delayed indicators clear only for the matching character.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)
