### PR TITLE
Lock tracker emoji edits and prune stale locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Added
+
+- Added tracker field locks for editable Roleplay HUD and Tracker Panel fields so manually pinned tracker values survive generated game-state updates.
+
 ### Changed
 
 - Moved AI-assisted character, persona, lorebook, preset creation, and preset review workflows to Professor Mari.

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -35,6 +35,7 @@ import {
   parseTemperatureValue,
 } from "../../features/tracker-panel/lib/world-state-display";
 import { TrackerLockProvider } from "../../features/tracker-panel/components/TrackerLockContext";
+import { useTrackerFieldLockUpdater } from "../../features/tracker-panel/hooks/use-tracker-field-lock-updater";
 import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
 import { getChatToolbarButtonClass } from "./ChatToolbarControls";
 import type {
@@ -46,10 +47,15 @@ import type {
   CustomTrackerField,
   Message,
 } from "@marinara-engine/shared";
-import { toggleTrackerFieldLock } from "@marinara-engine/shared";
+import {
+  inventoryTrackerLockPrefix,
+  removeTrackerArrayItemLocks,
+  toggleTrackerFieldLock,
+} from "@marinara-engine/shared";
 import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store";
 
 const ACTIONS_DROPDOWN_WIDTH_PX = 288;
+const EMPTY_INVENTORY: InventoryItem[] = [];
 
 interface RoleplayHUDProps {
   chatId: string;
@@ -226,15 +232,27 @@ export function RoleplayHUD({
   const personaStatBars = gameState?.personaStats ?? [];
   const playerStats = gameState?.playerStats ?? null;
   const personaStatus = playerStats?.status ?? "";
-  const inventory = playerStats?.inventory ?? [];
+  const inventory = playerStats?.inventory ?? EMPTY_INVENTORY;
   const activeQuests = playerStats?.activeQuests ?? [];
   const customTrackerFields = playerStats?.customTrackerFields ?? [];
   const fieldLocks = gameState?.fieldLocks ?? null;
+  const updateFieldLocks = useTrackerFieldLockUpdater({ chatId, fieldLocks, patchField });
+  const updateInventoryItems = useCallback(
+    (items: InventoryItem[]) => patchPlayerStats("inventory", items),
+    [patchPlayerStats],
+  );
+  const removeInventoryItem = useCallback(
+    (index: number) => {
+      updateInventoryItems(inventory.filter((_, itemIndex) => itemIndex !== index));
+      updateFieldLocks((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), index));
+    },
+    [inventory, updateFieldLocks, updateInventoryItems],
+  );
   const toggleFieldLock = useCallback(
     (key: string) => {
-      patchField("fieldLocks", toggleTrackerFieldLock(fieldLocks, key));
+      updateFieldLocks((locks) => toggleTrackerFieldLock(locks, key));
     },
-    [fieldLocks, patchField],
+    [updateFieldLocks],
   );
   const hasPersonaStatsTracker = enabledAgentTypes.has("persona-stats");
   const hasPlayerTrackerSections =
@@ -252,6 +270,7 @@ export function RoleplayHUD({
       lockMode={lockMode}
       onSetLockMode={setLockMode}
       onToggleFieldLock={toggleFieldLock}
+      onUpdateFieldLocks={updateFieldLocks}
     >
       <div
         className={cn(
@@ -321,7 +340,8 @@ export function RoleplayHUD({
               characters={presentCharacters}
               onUpdateCharacters={(chars) => patchField("presentCharacters", chars)}
               inventory={inventory}
-              onUpdateInventory={(items) => patchPlayerStats("inventory", items)}
+              onUpdateInventory={updateInventoryItems}
+              onRemoveInventoryItem={removeInventoryItem}
               quests={activeQuests}
               onUpdateQuests={(q) => patchPlayerStats("activeQuests", q)}
               customTrackerFields={customTrackerFields}
@@ -399,7 +419,8 @@ export function RoleplayHUD({
           {hasPersonaStatsTracker && (
             <InventoryWidget
               items={inventory}
-              onUpdate={(items) => patchPlayerStats("inventory", items)}
+              onUpdate={updateInventoryItems}
+              onRemoveItem={removeInventoryItem}
               layout={layout}
             />
           )}
@@ -723,6 +744,7 @@ function CombinedPlayerWidget({
   onUpdateCharacters,
   inventory,
   onUpdateInventory,
+  onRemoveInventoryItem,
   quests,
   onUpdateQuests,
   customTrackerFields,
@@ -743,6 +765,7 @@ function CombinedPlayerWidget({
   onUpdateCharacters: (chars: PresentCharacter[]) => void;
   inventory: InventoryItem[];
   onUpdateInventory: (items: InventoryItem[]) => void;
+  onRemoveInventoryItem?: (index: number) => void;
   quests: QuestProgress[];
   onUpdateQuests: (quests: QuestProgress[]) => void;
   customTrackerFields: CustomTrackerField[];
@@ -788,6 +811,7 @@ function CombinedPlayerWidget({
             onUpdateCharacters={onUpdateCharacters}
             inventory={inventory}
             onUpdateInventory={onUpdateInventory}
+            onRemoveInventoryItem={onRemoveInventoryItem}
             quests={quests}
             onUpdateQuests={onUpdateQuests}
             customTrackerFields={customTrackerFields}
@@ -1151,10 +1175,12 @@ function CustomTrackerWidget({
 function InventoryWidget({
   items,
   onUpdate,
+  onRemoveItem,
   layout = "top",
 }: {
   items: InventoryItem[];
   onUpdate: (items: InventoryItem[]) => void;
+  onRemoveItem?: (index: number) => void;
   layout?: HudPosition;
 }) {
   const [open, setOpen] = useState(false);
@@ -1221,6 +1247,7 @@ function InventoryWidget({
           <InventoryPanel
             items={items}
             onUpdate={onUpdate}
+            onRemoveItem={onRemoveItem}
           />
         </Suspense>
       </WidgetPopover>

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -47,13 +47,20 @@ import type {
 import {
   characterStatTrackerLockKey,
   characterTrackerLockKey,
+  customTrackerLockPrefix,
   customTrackerLockKey,
+  inventoryTrackerLockPrefix,
   inventoryTrackerLockKey,
   isTrackerFieldLocked,
+  personaStatsTrackerLockPrefix,
   personaStatTrackerLockKey,
   personaStatusTrackerLockKey,
+  questObjectivesTrackerLockPrefix,
   questObjectiveTrackerLockKey,
   questTrackerLockKey,
+  removeTrackerArrayItemLocks,
+  removeTrackerCharacterLocks,
+  removeTrackerQuestLocks,
   worldTrackerLockKey,
 } from "@marinara-engine/shared";
 import { useTrackerLockContext } from "../../features/tracker-panel/components/TrackerLockContext";
@@ -71,6 +78,7 @@ interface CombinedPlayerPanelProps {
   onUpdateCharacters: (chars: PresentCharacter[]) => void;
   inventory: InventoryItem[];
   onUpdateInventory: (items: InventoryItem[]) => void;
+  onRemoveInventoryItem?: (index: number) => void;
   quests: QuestProgress[];
   onUpdateQuests: (quests: QuestProgress[]) => void;
   customTrackerFields: CustomTrackerField[];
@@ -201,6 +209,7 @@ export function CombinedPlayerPanel({
   onUpdateCharacters,
   inventory,
   onUpdateInventory,
+  onRemoveInventoryItem,
   quests,
   onUpdateQuests,
   customTrackerFields,
@@ -209,6 +218,7 @@ export function CombinedPlayerPanel({
   onRerunSingleTracker,
   isTrackerRetryBusy,
 }: CombinedPlayerPanelProps) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const updateBar = (idx: number, field: "value" | "max" | "name", val: number | string) => {
     const next = [...personaStats];
     next[idx] = { ...next[idx]!, [field]: val };
@@ -231,7 +241,11 @@ export function CombinedPlayerPanel({
       },
     ]);
   };
-  const removeCharacter = (idx: number) => onUpdateCharacters(characters.filter((_, i) => i !== idx));
+  const removeCharacter = (idx: number) => {
+    const removed = characters[idx];
+    if (removed) onUpdateFieldLocks?.((locks) => removeTrackerCharacterLocks(locks, removed, idx));
+    onUpdateCharacters(characters.filter((_, i) => i !== idx));
+  };
   const updateCharacter = (idx: number, updated: PresentCharacter) => {
     const next = [...characters];
     next[idx] = updated;
@@ -241,7 +255,14 @@ export function CombinedPlayerPanel({
   const addItem = () => {
     onUpdateInventory([...inventory, { name: "New Item", description: "", quantity: 1, location: "on_person" }]);
   };
-  const removeItem = (idx: number) => onUpdateInventory(inventory.filter((_, i) => i !== idx));
+  const removeItem = (idx: number) => {
+    if (onRemoveInventoryItem) {
+      onRemoveInventoryItem(idx);
+      return;
+    }
+    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), idx));
+    onUpdateInventory(inventory.filter((_, i) => i !== idx));
+  };
   const updateItem = (idx: number, updated: InventoryItem) => {
     const next = [...inventory];
     next[idx] = updated;
@@ -260,7 +281,11 @@ export function CombinedPlayerPanel({
       },
     ]);
   };
-  const removeQuest = (idx: number) => onUpdateQuests(quests.filter((_, i) => i !== idx));
+  const removeQuest = (idx: number) => {
+    const removed = quests[idx];
+    if (removed) onUpdateFieldLocks?.((locks) => removeTrackerQuestLocks(locks, removed, idx));
+    onUpdateQuests(quests.filter((_, i) => i !== idx));
+  };
   const updateQuest = (idx: number, updated: QuestProgress) => {
     const next = [...quests];
     next[idx] = updated;
@@ -270,7 +295,10 @@ export function CombinedPlayerPanel({
   const addCustomField = () => {
     onUpdateCustomTracker([...customTrackerFields, { name: "New Field", value: "" }]);
   };
-  const removeCustomField = (idx: number) => onUpdateCustomTracker(customTrackerFields.filter((_, i) => i !== idx));
+  const removeCustomField = (idx: number) => {
+    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, customTrackerLockPrefix(), idx));
+    onUpdateCustomTracker(customTrackerFields.filter((_, i) => i !== idx));
+  };
   const updateCustomField = (idx: number, updated: CustomTrackerField) => {
     const next = [...customTrackerFields];
     next[idx] = updated;
@@ -639,12 +667,14 @@ export function PersonaStatsPanel({
   onRerunSingleTracker,
   isTrackerRetryBusy,
 }: PersonaStatsPanelProps) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const updateBar = (idx: number, field: "value" | "max" | "name", val: number | string) => {
     const next = [...bars];
     next[idx] = { ...next[idx]!, [field]: val };
     onUpdate(next);
   };
   const removeBar = (idx: number) => {
+    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, personaStatsTrackerLockPrefix(), idx));
     onUpdate(bars.filter((_, index) => index !== idx));
   };
   const lockFor = useHudFieldLockResolver();
@@ -714,6 +744,7 @@ export function CharactersPanel({
   onRerunSingleTracker,
   isTrackerRetryBusy,
 }: CharactersPanelProps) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadIdx, setUploadIdx] = useState<number | null>(null);
 
@@ -783,6 +814,8 @@ export function CharactersPanel({
   };
 
   const removeCharacter = (idx: number) => {
+    const removed = characters[idx];
+    if (removed) onUpdateFieldLocks?.((locks) => removeTrackerCharacterLocks(locks, removed, idx));
     onUpdate(characters.filter((_, i) => i !== idx));
   };
 
@@ -833,6 +866,7 @@ export function CharactersPanel({
       <div className="p-2 space-y-2">
         {characters.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>No characters in scene</div>}
         {characters.map((char, idx) => {
+          const emojiLock = lockFor(characterTrackerLockKey(char, idx, "emoji"));
           const nameLock = lockFor(characterTrackerLockKey(char, idx, "name"));
           const moodLock = lockFor(characterTrackerLockKey(char, idx, "mood"));
           const appearanceLock = lockFor(characterTrackerLockKey(char, idx, "appearance"));
@@ -865,6 +899,14 @@ export function CharactersPanel({
                   <ImagePlus size="0.75rem" />
                 </button>
               )}
+              <InlineEdit
+                value={char.emoji || "👤"}
+                onSave={(value) => updateCharacter(idx, { ...char, emoji: value || "👤" })}
+                className="h-8 w-8 shrink-0 justify-center text-center !text-sm"
+                placeholder="👤"
+                locked={emojiLock.locked}
+              />
+              <HudFieldLockButton {...emojiLock} label={`${char.name || "character"} emoji`} />
               <InlineEdit
                 value={char.name}
                 onSave={(value) => updateCharacter(idx, { ...char, name: value })}
@@ -962,17 +1004,25 @@ export function CharactersPanel({
 interface InventoryPanelProps {
   items: InventoryItem[];
   onUpdate: (items: InventoryItem[]) => void;
+  onRemoveItem?: (index: number) => void;
 }
 
 export function InventoryPanel({
   items,
   onUpdate,
+  onRemoveItem,
 }: InventoryPanelProps) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const addItem = () => {
     onUpdate([...items, { name: "New Item", description: "", quantity: 1, location: "on_person" }]);
   };
 
   const removeItem = (idx: number) => {
+    if (onRemoveItem) {
+      onRemoveItem(idx);
+      return;
+    }
+    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), idx));
     onUpdate(items.filter((_, i) => i !== idx));
   };
 
@@ -1051,6 +1101,7 @@ export function QuestsPanel({
   onRerunSingleTracker,
   isTrackerRetryBusy,
 }: QuestsPanelProps) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const addQuest = () => {
     onUpdate([
       ...quests,
@@ -1065,6 +1116,8 @@ export function QuestsPanel({
   };
 
   const removeQuest = (idx: number) => {
+    const removed = quests[idx];
+    if (removed) onUpdateFieldLocks?.((locks) => removeTrackerQuestLocks(locks, removed, idx));
     onUpdate(quests.filter((_, i) => i !== idx));
   };
 
@@ -1122,11 +1175,13 @@ export function CustomTrackerPanel({
   onRerunSingleTracker,
   isTrackerRetryBusy,
 }: CustomTrackerPanelProps) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const addField = () => {
     onUpdate([...fields, { name: "New Field", value: "" }]);
   };
 
   const removeField = (idx: number) => {
+    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, customTrackerLockPrefix(), idx));
     onUpdate(fields.filter((_, i) => i !== idx));
   };
 
@@ -1739,6 +1794,7 @@ function QuestCardEditable({
   onUpdate: (q: QuestProgress) => void;
   onRemove: () => void;
 }) {
+  const { onUpdateFieldLocks } = useTrackerLockContext();
   const addObjective = () => {
     onUpdate({
       ...quest,
@@ -1753,6 +1809,9 @@ function QuestCardEditable({
   };
 
   const removeObjective = (idx: number) => {
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerArrayItemLocks(locks, questObjectivesTrackerLockPrefix(quest, questIndex), idx),
+    );
     onUpdate({ ...quest, objectives: quest.objectives.filter((_, objectiveIndex) => objectiveIndex !== idx) });
   };
 

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -6,6 +6,7 @@ import { useGameStatePatcher } from "../../../hooks/use-game-state-patcher";
 import { getCssBackgroundStyle, getCssColorFallback, isCssGradient } from "../../../lib/css-colors";
 import { cn } from "../../../lib/utils";
 import { useTrackerGameState } from "../hooks/use-tracker-game-state";
+import { useTrackerFieldLockUpdater } from "../hooks/use-tracker-field-lock-updater";
 import { useTrackerPanelModel } from "../hooks/use-tracker-panel-model";
 import { EmptySection } from "./controls/SectionControls";
 import { TrackerSectionList } from "./TrackerSectionList";
@@ -55,9 +56,10 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
   const [addMode, setAddMode] = useState(false);
   const [lockMode, setLockMode] = useState(false);
   const fieldLocks = currentGameState?.fieldLocks ?? null;
+  const updateFieldLocks = useTrackerFieldLockUpdater({ chatId: activeChatId, fieldLocks, patchField });
   const toggleFieldLock = useCallback((key: string) => {
-    patchField("fieldLocks", toggleTrackerFieldLock(fieldLocks, key));
-  }, [fieldLocks, patchField]);
+    updateFieldLocks((locks) => toggleTrackerFieldLock(locks, key));
+  }, [updateFieldLocks]);
   const hasFixedTrackerPanel = orderedTrackerSections.length > 0;
   const showTrackerSections = !!activeChatId && !isLoadingGameState && !!currentGameState && hasFixedTrackerPanel;
   const trackerPanelHasCustomBackground =
@@ -102,6 +104,7 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
         lockMode={lockMode}
         onSetLockMode={setLockMode}
         onToggleFieldLock={toggleFieldLock}
+        onUpdateFieldLocks={updateFieldLocks}
       >
         <TrackerSidebarHeader
           trackerPanelSide={trackerPanelSide}

--- a/packages/client/src/features/tracker-panel/components/TrackerLockContext.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerLockContext.tsx
@@ -1,11 +1,13 @@
 import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
 import { isTrackerFieldLocked, type TrackerFieldLocks } from "@marinara-engine/shared";
+import type { TrackerFieldLocksUpdater } from "../hooks/use-tracker-field-lock-updater";
 
 interface TrackerLockContextValue {
   fieldLocks?: TrackerFieldLocks | null;
   lockMode: boolean;
   onSetLockMode?: (enabled: boolean) => void;
   onToggleFieldLock?: (key: string) => void;
+  onUpdateFieldLocks?: (updater: TrackerFieldLocksUpdater) => void;
 }
 
 const TrackerLockContext = createContext<TrackerLockContextValue>({ lockMode: false });
@@ -16,10 +18,11 @@ export function TrackerLockProvider({
   lockMode,
   onSetLockMode,
   onToggleFieldLock,
+  onUpdateFieldLocks,
 }: TrackerLockContextValue & { children: ReactNode }) {
   const value = useMemo(
-    () => ({ fieldLocks, lockMode, onSetLockMode, onToggleFieldLock }),
-    [fieldLocks, lockMode, onSetLockMode, onToggleFieldLock],
+    () => ({ fieldLocks, lockMode, onSetLockMode, onToggleFieldLock, onUpdateFieldLocks }),
+    [fieldLocks, lockMode, onSetLockMode, onToggleFieldLock, onUpdateFieldLocks],
   );
   return <TrackerLockContext.Provider value={value}>{children}</TrackerLockContext.Provider>;
 }

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerAvatar.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerAvatar.tsx
@@ -2,6 +2,7 @@ import { ImagePlus } from "lucide-react";
 import type { PresentCharacter } from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
+import { InlineEdit } from "../controls/InlineControls";
 
 const AVATAR_BOTTOM_GLINT_CLASS =
   "pointer-events-none absolute -inset-[2px] z-[3] rounded-full bg-[conic-gradient(from_0deg_at_50%_50%,transparent_0deg,transparent_104deg,color-mix(in_srgb,var(--tracker-profile-dialogue-border)_58%,transparent)_148deg,color-mix(in_srgb,var(--tracker-profile-accent-solid)_46%,transparent)_192deg,transparent_226deg,transparent_360deg)] opacity-90 shadow-[0_1px_4px_color-mix(in_srgb,var(--tracker-profile-accent-solid)_28%,transparent)] [mask:radial-gradient(farthest-side,transparent_calc(100%-3px),black_calc(100%-2px),black_100%)] [transform:rotate(-8deg)]";
@@ -13,12 +14,21 @@ export function CharacterTrackerAvatar({
   avatarMedia,
   avatarSize,
   onUploadAvatar,
+  onSaveEmoji,
+  emojiLocked = false,
+  lockMode = false,
+  onToggleEmojiLock,
 }: {
   character: PresentCharacter;
   avatarMedia: string | null;
   avatarSize: string;
   onUploadAvatar?: () => void;
+  onSaveEmoji?: (emoji: string) => void;
+  emojiLocked?: boolean;
+  lockMode?: boolean;
+  onToggleEmojiLock?: () => void;
 }) {
+  const characterName = visibleText(character.name, "character");
   return (
     <div className={cn("relative shrink-0", avatarSize)}>
       <button
@@ -28,8 +38,8 @@ export function CharacterTrackerAvatar({
         title={avatarMedia ? "Change avatar" : "Upload avatar"}
         aria-label={
           avatarMedia
-            ? `Change ${visibleText(character.name, "character")} avatar`
-            : `Upload ${visibleText(character.name, "character")} avatar`
+            ? `Change ${characterName} avatar`
+            : `Upload ${characterName} avatar`
         }
         className={cn(
           "group/avatar relative z-[1] flex aspect-square w-full shrink-0 items-center justify-center overflow-hidden rounded-full border border-[color-mix(in_srgb,var(--tracker-profile-nameplate-rule)_34%,transparent)] bg-[var(--muted)] text-xs text-[var(--foreground)] shadow-[0_4px_10px_rgba(0,0,0,0.24)] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--border)]",
@@ -49,6 +59,23 @@ export function CharacterTrackerAvatar({
         )}
         <span aria-hidden="true" className={AVATAR_SOFT_INNER_GLOW_CLASS} />
       </button>
+      {onSaveEmoji && (
+        <span className="absolute -bottom-0.5 -right-0.5 z-[4]">
+          <InlineEdit
+            value={character.emoji || "?"}
+            onSave={(emoji) => onSaveEmoji(emoji || "?")}
+            placeholder="?"
+            title={`${characterName} emoji`}
+            className="h-4 w-4 justify-center rounded-full border border-[color-mix(in_srgb,var(--tracker-profile-nameplate-rule)_45%,transparent)] bg-[color-mix(in_srgb,var(--background)_82%,var(--tracker-profile-accent-solid)_18%)] px-0 py-0 text-center text-[0.5625rem] leading-none text-[color:var(--tracker-profile-text)] shadow-[0_1px_4px_rgba(0,0,0,0.28)] hover:bg-[color-mix(in_srgb,var(--background)_70%,var(--tracker-profile-accent-solid)_30%)]"
+            showEditHint={false}
+            fitPreview
+            fitAlign="center"
+            locked={emojiLocked}
+            lockMode={lockMode}
+            onToggleLock={onToggleEmojiLock}
+          />
+        </span>
+      )}
       <span aria-hidden="true" className={AVATAR_BOTTOM_GLINT_CLASS} />
     </div>
   );

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -201,6 +201,7 @@ export function CharacterTrackerCard({
   const hasDenseContent = characterStats.length > 0 || customFields.length > 0;
   const readableDetailRows = hasDenseContent;
   const readableCustomFields = trackerPanelSizeProfile === "expanded";
+  const emojiLockKey = characterTrackerLockKey(character, characterIndex, "emoji");
   const avatarSize = hasDenseContent
     ? "z-[5] mt-0 w-[clamp(2.25rem,28%,3rem)] -translate-y-0.5"
     : "z-[5] mt-0 w-[clamp(3rem,36%,3.75rem)] -translate-y-0.5";
@@ -295,6 +296,10 @@ export function CharacterTrackerCard({
           avatarMedia={avatarMedia}
           avatarSize={avatarSize}
           onUploadAvatar={compactAvatarUpload}
+          onSaveEmoji={onUpdate ? (emoji) => onUpdate({ ...character, emoji }) : undefined}
+          emojiLocked={isTrackerFieldLocked(fieldLocks, emojiLockKey)}
+          lockMode={lockMode}
+          onToggleEmojiLock={onToggleFieldLock ? () => onToggleFieldLock(emojiLockKey) : undefined}
         />
         <div className={CHARACTER_HEADER_COPY_CLASS}>
           {showThoughts && (

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterNameplate.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterNameplate.tsx
@@ -1,14 +1,16 @@
 import { type ReactNode, type RefObject } from "react";
 import { Brain, Minimize2 } from "lucide-react";
-import { characterTrackerLockKey, type PresentCharacter } from "@marinara-engine/shared";
+import { characterTrackerLockKey, isTrackerFieldLocked, type PresentCharacter } from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import type { TrackerProfileSide } from "../../lib/tracker-profile-layout";
+import { InlineEdit } from "../controls/InlineControls";
 import {
   TrackerProfileNameplate,
   TRACKER_PROFILE_NAMEPLATE_HEADER_BUTTON_CLASS,
   TRACKER_PROFILE_NAMEPLATE_ICON_BUTTON_ACTIVE_CLASS,
   TRACKER_PROFILE_NAMEPLATE_ICON_BUTTON_CLASS,
 } from "../controls/TrackerProfileNameplate";
+import { useTrackerLockContext } from "../TrackerLockContext";
 
 export function FeaturedCharacterNameplate({
   character,
@@ -33,8 +35,25 @@ export function FeaturedCharacterNameplate({
   action?: ReactNode;
   characterIndex: number;
 }) {
+  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const emojiLockKey = characterTrackerLockKey(character, characterIndex, "emoji");
   const nameLockKey = characterTrackerLockKey(character, characterIndex, "name");
   const thoughtButtonLabel = thoughtsOpen ? "Stop reading thoughts" : "Read thoughts";
+  const emojiControl = onUpdate ? (
+    <InlineEdit
+      value={character.emoji || "?"}
+      onSave={(emoji) => onUpdate({ ...character, emoji: emoji || "?" })}
+      placeholder="?"
+      title={`${character.name || "character"} emoji`}
+      className="h-4 w-4 justify-center rounded-sm px-0 py-0 text-center text-[0.625rem] leading-4"
+      showEditHint={false}
+      fitPreview
+      fitAlign="center"
+      locked={isTrackerFieldLocked(fieldLocks, emojiLockKey)}
+      lockMode={lockMode}
+      onToggleLock={onToggleFieldLock ? () => onToggleFieldLock(emojiLockKey) : undefined}
+    />
+  ) : null;
   const thoughtControl =
     hasThoughtsControl && onToggleThoughts ? (
       <button
@@ -56,8 +75,9 @@ export function FeaturedCharacterNameplate({
       </button>
     ) : null;
   const headerControls =
-    action || onToggleFeatured ? (
+    emojiControl || action || onToggleFeatured ? (
       <>
+        {emojiControl}
         {onToggleFeatured && (
           <button
             type="button"

--- a/packages/client/src/features/tracker-panel/components/controls/StatList.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/StatList.tsx
@@ -1,5 +1,5 @@
 import { X } from "lucide-react";
-import { isTrackerFieldLocked, type CharacterStat } from "@marinara-engine/shared";
+import { isTrackerFieldLocked, removeTrackerArrayItemLocks, type CharacterStat } from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import { TRACKER_BAR, TRACKER_TEXT_ROW } from "../../lib/tracker-panel.constants";
 import type { TrackerStatDensity, TrackerStatDisplayScale } from "../../tracker-panel.types";
@@ -326,7 +326,7 @@ export function StatList({
   visualTone?: StatListVisualTone;
   getLockKey?: (index: number, field: "name" | "value" | "max") => string;
 }) {
-  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
   if (stats.length === 0) {
     return onAdd && addMode ? (
       <InlineAddRow onClick={onAdd} title="Add stat" className="border-t-0" />
@@ -342,6 +342,12 @@ export function StatList({
   };
   const removeStat = (index: number) => {
     if (!onUpdate) return;
+    const nameLockKey = getLockKey?.(index, "name");
+    const nameSuffix = `.${index}.name`;
+    if (nameLockKey?.endsWith(nameSuffix)) {
+      const prefix = nameLockKey.slice(0, -nameSuffix.length);
+      onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, prefix, index));
+    }
     onUpdate(stats.filter((_, statIndex) => statIndex !== index));
   };
   const buildLockToggle = (index: number, field: "name" | "value" | "max") =>

--- a/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from "react";
 import { SlidersHorizontal, X } from "lucide-react";
-import { customTrackerLockKey, isTrackerFieldLocked, type CustomTrackerField } from "@marinara-engine/shared";
+import {
+  customTrackerLockKey,
+  customTrackerLockPrefix,
+  isTrackerFieldLocked,
+  removeTrackerArrayItemLocks,
+  type CustomTrackerField,
+} from "@marinara-engine/shared";
 import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
@@ -36,7 +42,7 @@ function CustomFieldList({
   deleteMode?: boolean;
   trackerPanelSizeProfile: TrackerPanelSizeProfile;
 }) {
-  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
   if (fields.length === 0 && !onUpdate) return <EmptySection>No custom stats tracked.</EmptySection>;
   const readableValues = trackerPanelSizeProfile !== "compact";
   const useFieldColumns = shouldUseCustomFieldColumns(fields, trackerPanelSizeProfile);
@@ -48,6 +54,7 @@ function CustomFieldList({
   };
   const removeField = (index: number) => {
     if (!onUpdate) return;
+    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, customTrackerLockPrefix(), index));
     onUpdate(fields.filter((_, fieldIndex) => fieldIndex !== index));
   };
   return (

--- a/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestRow.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestRow.tsx
@@ -1,8 +1,10 @@
 import { CheckCircle2, Lock, Plus, Target, Unlock, X } from "lucide-react";
 import {
   isTrackerFieldLocked,
+  questObjectivesTrackerLockPrefix,
   questObjectiveTrackerLockKey,
   questTrackerLockKey,
+  removeTrackerArrayItemLocks,
   type QuestProgress,
 } from "@marinara-engine/shared";
 import { cn } from "../../../../../lib/utils";
@@ -54,7 +56,7 @@ export function QuestRow({
   addMode?: boolean;
   textLineCount?: QuestTextLineCount;
 }) {
-  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
   const completed = quest.objectives.filter((objective) => objective.completed).length;
   const totalObjectives = quest.objectives.length;
   const completionPercent = quest.completed ? 100 : totalObjectives > 0 ? (completed / totalObjectives) * 100 : 0;
@@ -83,6 +85,9 @@ export function QuestRow({
   };
   const removeObjective = (index: number) => {
     if (!onUpdate) return;
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerArrayItemLocks(locks, questObjectivesTrackerLockPrefix(quest, questIndex), index),
+    );
     onUpdate({ ...quest, objectives: quest.objectives.filter((_, objectiveIndex) => objectiveIndex !== index) });
   };
   const addObjective = () => {

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-field-lock-updater.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-field-lock-updater.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { trackerFieldLocksAreEqual, type TrackerFieldLocks } from "@marinara-engine/shared";
+import type { GameStatePatchField } from "../../../hooks/use-game-state-patcher";
+import { useGameStateStore } from "../../../stores/game-state.store";
+
+export type TrackerFieldLocksUpdater = (locks: TrackerFieldLocks | null | undefined) => TrackerFieldLocks;
+
+export function useTrackerFieldLockUpdater({
+  chatId,
+  fieldLocks,
+  patchField,
+}: {
+  chatId: string | null;
+  fieldLocks?: TrackerFieldLocks | null;
+  patchField: (field: GameStatePatchField, value: unknown) => void;
+}) {
+  return useCallback(
+    (updater: TrackerFieldLocksUpdater) => {
+      if (!chatId) return;
+      const latestState = useGameStateStore.getState().current;
+      const currentLocks = latestState?.chatId === chatId ? latestState.fieldLocks : fieldLocks;
+      const nextLocks = updater(currentLocks);
+      if (trackerFieldLocksAreEqual(currentLocks, nextLocks)) return;
+      patchField("fieldLocks", nextLocks);
+    },
+    [chatId, fieldLocks, patchField],
+  );
+}

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
@@ -7,10 +7,17 @@ import type {
   PresentCharacter,
   QuestProgress,
 } from "@marinara-engine/shared";
+import {
+  inventoryTrackerLockPrefix,
+  removeTrackerArrayItemLocks,
+  removeTrackerCharacterLocks,
+  removeTrackerQuestLocks,
+} from "@marinara-engine/shared";
 import { api } from "../../../lib/api-client";
 import { useGameStateStore } from "../../../stores/game-state.store";
 import type { GameStatePatchField } from "../../../hooks/use-game-state-patcher";
 import { getCharacterFeatureKey } from "../lib/character-tracker-data";
+import { useTrackerFieldLockUpdater } from "./use-tracker-field-lock-updater";
 
 function makeManualTrackerId() {
   const id =
@@ -43,6 +50,7 @@ export function useTrackerMutations({
   const avatarFileInputRef = useRef<HTMLInputElement>(null);
   const avatarUploadSerialRef = useRef(0);
   const avatarUploadTokenByCharacterRef = useRef(new Map<string, number>());
+  const updateFieldLocks = useTrackerFieldLockUpdater({ chatId: activeChatId, patchField });
 
   const openAvatarUpload = useCallback((index: number) => {
     setAvatarUploadIndex(index);
@@ -131,13 +139,14 @@ export function useTrackerMutations({
       const removed = presentCharacters[index];
       if (removed) {
         removeFeaturedCharacterCard(getCharacterFeatureKey(removed, index));
+        updateFieldLocks((locks) => removeTrackerCharacterLocks(locks, removed, index));
       }
       patchField(
         "presentCharacters",
         presentCharacters.filter((_, characterIndex) => characterIndex !== index),
       );
     },
-    [patchField, presentCharacters, removeFeaturedCharacterCard],
+    [patchField, presentCharacters, removeFeaturedCharacterCard, updateFieldLocks],
   );
 
   const addCharacter = useCallback(() => {
@@ -174,8 +183,9 @@ export function useTrackerMutations({
   const removeInventoryItem = useCallback(
     (index: number) => {
       updateInventory(inventory.filter((_, itemIndex) => itemIndex !== index));
+      updateFieldLocks((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), index));
     },
-    [inventory, updateInventory],
+    [inventory, updateFieldLocks, updateInventory],
   );
 
   const addInventoryItem = useCallback(() => {
@@ -198,9 +208,11 @@ export function useTrackerMutations({
 
   const removeQuest = useCallback(
     (index: number) => {
+      const removed = quests[index];
+      if (removed) updateFieldLocks((locks) => removeTrackerQuestLocks(locks, removed, index));
       updateQuests(quests.filter((_, questIndex) => questIndex !== index));
     },
-    [quests, updateQuests],
+    [quests, updateFieldLocks, updateQuests],
   );
 
   const addQuest = useCallback(() => {

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -64,6 +64,17 @@ export function trackerFieldLocksAreEmpty(locks: TrackerFieldLocks | null | unde
   return !locks || !Object.values(locks).some(Boolean);
 }
 
+export function trackerFieldLocksAreEqual(
+  left: TrackerFieldLocks | null | undefined,
+  right: TrackerFieldLocks | null | undefined,
+) {
+  const leftLocks = normalizeTrackerFieldLocks(left);
+  const rightLocks = normalizeTrackerFieldLocks(right);
+  const leftKeys = Object.keys(leftLocks);
+  const rightKeys = Object.keys(rightLocks);
+  return leftKeys.length === rightKeys.length && leftKeys.every((key) => rightLocks[key] === true);
+}
+
 export function isTrackerFieldLocked(locks: TrackerFieldLocks | null | undefined, key: string) {
   return locks?.[key] === true;
 }
@@ -78,6 +89,83 @@ export function toggleTrackerFieldLock(locks: TrackerFieldLocks | null | undefin
   return next;
 }
 
+export function removeTrackerArrayItemLocks(
+  locks: TrackerFieldLocks | null | undefined,
+  prefix: string,
+  removedIndex: number,
+) {
+  return removeIndexedTrackerLocks(locks, prefix.trim() ? `${prefix.trim()}.` : "", removedIndex);
+}
+
+function removeIndexedTrackerLocks(
+  locks: TrackerFieldLocks | null | undefined,
+  indexedPrefix: string,
+  removedIndex: number,
+) {
+  const normalized = normalizeTrackerFieldLocks(locks);
+  if (!Number.isSafeInteger(removedIndex) || removedIndex < 0 || !indexedPrefix.trim()) return normalized;
+
+  const next: TrackerFieldLocks = {};
+
+  for (const [key, enabled] of Object.entries(normalized)) {
+    if (enabled !== true) continue;
+    if (!key.startsWith(indexedPrefix)) {
+      next[key] = true;
+      continue;
+    }
+
+    const suffix = key.slice(indexedPrefix.length);
+    const match = /^(\d+)(\.|$)/.exec(suffix);
+    if (!match) {
+      next[key] = true;
+      continue;
+    }
+
+    const indexText = match[1] ?? "";
+    const index = Number(indexText);
+    if (!Number.isSafeInteger(index)) {
+      next[key] = true;
+      continue;
+    }
+    if (index === removedIndex) continue;
+    if (index < removedIndex) {
+      next[key] = true;
+      continue;
+    }
+
+    next[`${indexedPrefix}${index - 1}${suffix.slice(indexText.length)}`] = true;
+  }
+
+  return next;
+}
+
+export function removeTrackerFieldLockPrefix(locks: TrackerFieldLocks | null | undefined, prefix: string) {
+  const normalized = normalizeTrackerFieldLocks(locks);
+  const lockPrefix = prefix.trim();
+  if (!lockPrefix) return normalized;
+
+  const childPrefix = `${lockPrefix}.`;
+  const next: TrackerFieldLocks = {};
+  for (const [key, enabled] of Object.entries(normalized)) {
+    if (enabled !== true) continue;
+    if (key === lockPrefix || key.startsWith(childPrefix)) continue;
+    next[key] = true;
+  }
+  return next;
+}
+
+function shiftIndexedReferenceLocks(
+  locks: TrackerFieldLocks | null | undefined,
+  collectionPrefix: string,
+  removedIndex: number,
+) {
+  return removeIndexedTrackerLocks(
+    locks,
+    collectionPrefix.trim() ? `${collectionPrefix.trim()}.index:` : "",
+    removedIndex,
+  );
+}
+
 export function worldTrackerLockKey(field: WorldTrackerField) {
   return `world.${field}`;
 }
@@ -90,8 +178,16 @@ export function personaStatTrackerLockKey(index: number, field: StatField) {
   return `persona.stats.${index}.${field}`;
 }
 
+export function personaStatsTrackerLockPrefix() {
+  return "persona.stats";
+}
+
 export function inventoryTrackerLockKey(index: number, field: InventoryField) {
   return `player.inventory.${index}.${field}`;
+}
+
+export function inventoryTrackerLockPrefix() {
+  return "player.inventory";
 }
 
 function characterLockRef(character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined, index: number) {
@@ -103,12 +199,19 @@ function characterLockRef(character: Pick<PresentCharacter, "characterId" | "nam
   return `index:${index}`;
 }
 
+export function characterTrackerLockPrefix(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  index: number,
+) {
+  return `characters.${characterLockRef(character, index)}`;
+}
+
 export function characterTrackerLockKey(
   character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
   index: number,
   field: TextCharacterField,
 ) {
-  return `characters.${characterLockRef(character, index)}.${field}`;
+  return `${characterTrackerLockPrefix(character, index)}.${field}`;
 }
 
 export function characterStatTrackerLockKey(
@@ -117,7 +220,26 @@ export function characterStatTrackerLockKey(
   statIndex: number,
   field: StatField,
 ) {
-  return `characters.${characterLockRef(character, characterIndex)}.stats.${statIndex}.${field}`;
+  return `${characterStatsTrackerLockPrefix(character, characterIndex)}.${statIndex}.${field}`;
+}
+
+export function characterStatsTrackerLockPrefix(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  index: number,
+) {
+  return `${characterTrackerLockPrefix(character, index)}.stats`;
+}
+
+export function removeTrackerCharacterLocks(
+  locks: TrackerFieldLocks | null | undefined,
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  removedIndex: number,
+) {
+  return shiftIndexedReferenceLocks(
+    removeTrackerFieldLockPrefix(locks, characterTrackerLockPrefix(character, removedIndex)),
+    "characters",
+    removedIndex,
+  );
 }
 
 export function characterCustomFieldTrackerLockKey(
@@ -126,7 +248,7 @@ export function characterCustomFieldTrackerLockKey(
   fieldName: string,
   field: CustomTrackerFieldKey,
 ) {
-  return `characters.${characterLockRef(character, characterIndex)}.custom.${encodeSegment(fieldName)}.${field}`;
+  return `${characterTrackerLockPrefix(character, characterIndex)}.custom.${encodeSegment(fieldName)}.${field}`;
 }
 
 function questLockRef(quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined, index: number) {
@@ -138,12 +260,19 @@ function questLockRef(quest: Pick<QuestProgress, "questEntryId" | "name"> | null
   return `index:${index}`;
 }
 
+export function questTrackerLockPrefix(
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  index: number,
+) {
+  return `quests.${questLockRef(quest, index)}`;
+}
+
 export function questTrackerLockKey(
   quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
   index: number,
   field: QuestField,
 ) {
-  return `quests.${questLockRef(quest, index)}.${field}`;
+  return `${questTrackerLockPrefix(quest, index)}.${field}`;
 }
 
 export function questObjectiveTrackerLockKey(
@@ -152,11 +281,34 @@ export function questObjectiveTrackerLockKey(
   objectiveIndex: number,
   field: QuestObjectiveField,
 ) {
-  return `quests.${questLockRef(quest, questIndex)}.objectives.${objectiveIndex}.${field}`;
+  return `${questObjectivesTrackerLockPrefix(quest, questIndex)}.${objectiveIndex}.${field}`;
+}
+
+export function questObjectivesTrackerLockPrefix(
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  index: number,
+) {
+  return `${questTrackerLockPrefix(quest, index)}.objectives`;
+}
+
+export function removeTrackerQuestLocks(
+  locks: TrackerFieldLocks | null | undefined,
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  removedIndex: number,
+) {
+  return shiftIndexedReferenceLocks(
+    removeTrackerFieldLockPrefix(locks, questTrackerLockPrefix(quest, removedIndex)),
+    "quests",
+    removedIndex,
+  );
 }
 
 export function customTrackerLockKey(index: number, field: CustomTrackerFieldKey) {
   return `player.custom.${index}.${field}`;
+}
+
+export function customTrackerLockPrefix() {
+  return "player.custom";
 }
 
 function normalizeEffectiveTrackerFieldLocks(


### PR DESCRIPTION
## Linked issue

No linked issue yet. Per `CONTRIBUTING.md`, one should be opened or linked before merge.

## Why this change

- Tracker field locks from #2568 need to cover editable character emoji fields in tracker card/nameplate/HUD surfaces, so generated tracker updates cannot overwrite a user-pinned emoji.
- Deleting tracker rows should not leave stale lock keys behind or cause locks to drift onto the wrong shifted row.

## What changed

- Added lock controls for character emoji fields in tracker cards, featured nameplates, and HUD panels.
- Added shared lock-prefix helpers for persona stats, inventory, characters, quests, and custom tracker fields.
- Pruned or shifted field locks when deleting stats, inventory rows, characters, quest objectives, quests, and custom tracker rows.
- Added a shared client hook for field-lock map updates with a no-op equality guard to avoid redundant `fieldLocks` patches.
- Deduplicated indexed lock removal/shifting logic in shared tracker lock utilities.
- Updated `CHANGELOG.md` to document the tracker field-lock feature added by #2568.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

Commands and proof run locally:

- `pnpm --filter @marinara-engine/shared lint`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm check`
- `git diff --check`
- `git diff --cached --check`
- Node runtime sanity check for tracker lock pruning/equality helpers
- `node scratch/browser-qa-2596/qa-pass.mjs`

### Manual verification notes

- Chromium QA used an isolated seeded server/client on `7869`/`5174`; the saved `Gemma 4` connection was present.
- Loaded the seeded roleplay chat and tracker panel.
- Verified tracker side panel character emoji locking persisted `characters.id:_Ik82GD2w4tCG-CGTg1Zg.emoji`.
- Deleted inventory, custom tracker, character, and quest objective rows through real tracker delete-mode UI.
- Verified stale locks were pruned and later indexed locks shifted for inventory, custom tracker fields, character locks, and quest objective locks.
- Opened HUD widgets for present characters, inventory, and world state.
- Reloaded at mobile viewport and verified the tracker panel still rendered.
- Browser signals from the Chromium pass: `0` console errors, `0` page errors, `0` failed requests, and `0` bad API/browser responses.
- Local screenshot/evidence artifacts: `scratch/browser-qa-2596/desktop-clean-before.png`, `scratch/browser-qa-2596/desktop-clean-after.png`, `scratch/browser-qa-2596/mobile-clean-after.png`, and `scratch/browser-qa-2596/qa-results.json`.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No install, update, release, launcher, Android, or version behavior changed.

## UI evidence (if applicable)

Local Chromium screenshots were captured under `scratch/browser-qa-2596/`; no PR image attachments were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline emoji editing for characters with lock state support.
  * Introduced a field lock updater hook for coordinated lock state management.

* **Bug Fixes**
  * Tracker lock state now automatically updates when removing inventory items, characters, quests, and custom trackers.

* **Refactor**
  * Expanded tracker lock context to support bulk lock updates via callbacks.
  * Added lock prefix and removal utilities for consistent lock key generation across tracker entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
