### PR TITLE
fix(ui): remove global gallery topbar panel

### DIFF
--- a/packages/client/src/components/layout/RightPanel.tsx
+++ b/packages/client/src/components/layout/RightPanel.tsx
@@ -2,7 +2,7 @@
 // Layout: Right Panel (polished with panel transitions)
 // ──────────────────────────────────────────────
 import { lazy, Suspense, type ComponentType, type LazyExoticComponent, type ReactNode } from "react";
-import { X, Users, BookOpen, FileText, Link, Sparkles, Settings, User, Bot, Images } from "lucide-react";
+import { X, Users, BookOpen, FileText, Link, Sparkles, Settings, User, Bot } from "lucide-react";
 import { useUIStore } from "../../stores/ui.store";
 
 const CharactersPanel = lazy(() =>
@@ -25,9 +25,6 @@ const SettingsPanel = lazy(() =>
 const BotBrowserPanel = lazy(() =>
   import("../panels/BotBrowserPanel").then((module) => ({ default: module.BotBrowserPanel })),
 );
-const GlobalGalleryPanel = lazy(() =>
-  import("../panels/GlobalGalleryPanel").then((module) => ({ default: module.GlobalGalleryPanel })),
-);
 
 const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient: string }> = {
   "bot-browser": { title: "Browser", icon: <Bot size="0.875rem" />, gradient: "from-cyan-400 to-blue-500" },
@@ -37,7 +34,6 @@ const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient: s
   connections: { title: "Connections", icon: <Link size="0.875rem" />, gradient: "from-sky-400 to-blue-500" },
   agents: { title: "Agents", icon: <Sparkles size="0.875rem" />, gradient: "from-violet-400 to-purple-500" },
   personas: { title: "Personas", icon: <User size="0.875rem" />, gradient: "from-emerald-400 to-teal-500" },
-  gallery: { title: "Gallery", icon: <Images size="0.875rem" />, gradient: "from-fuchsia-400 to-pink-500" },
   settings: { title: "Settings", icon: <Settings size="0.875rem" />, gradient: "from-gray-400 to-gray-500" },
 };
 
@@ -49,7 +45,6 @@ const PANELS: Record<string, LazyExoticComponent<ComponentType>> = {
   connections: ConnectionsPanel,
   agents: AgentsPanel,
   personas: PersonasPanel,
-  gallery: GlobalGalleryPanel,
   settings: SettingsPanel,
 };
 

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -12,7 +12,6 @@ import {
   FileText,
   User,
   Bot,
-  Images,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useUIStore } from "../../stores/ui.store";
@@ -28,7 +27,6 @@ const RIGHT_PANEL_BUTTONS = [
   { panel: "connections" as const, icon: Link, label: "Connections", color: "from-sky-400 to-blue-500" },
   { panel: "agents" as const, icon: Sparkles, label: "Agents", color: "from-violet-400 to-purple-500" },
   { panel: "personas" as const, icon: User, label: "Personas", color: "from-emerald-400 to-teal-500" },
-  { panel: "gallery" as const, icon: Images, label: "Gallery", color: "from-fuchsia-400 to-pink-500" },
 ] as const;
 
 const SPOTIFY_TOPBAR_MIN_WIDTH = 320;

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -19,7 +19,6 @@ type Panel =
   | "connections"
   | "agents"
   | "personas"
-  | "gallery"
   | "settings"
   | "bot-browser";
 export type ChatModeShortcut = "conversation" | "roleplay" | "game";


### PR DESCRIPTION
## Why this change

- The global Gallery was added as a top-right/right-panel tab by #2584, but Gallery should remain available only through the chat/editor gallery surfaces instead of as a separate app tab.

## What changed

- Removed the Gallery button from the top-right panel button list.
- Removed the global Gallery route from the right-panel registry.
- Removed `gallery` from the right-panel UI state type.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm --filter @marinara-engine/client lint`.
- Ran `pnpm --filter @marinara-engine/client build`.
- Confirmed chat-mode gallery drawer wiring was not removed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)
