### PR TITLE
Fix world-state phrase time layout

### DIFF
--- a/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
@@ -44,7 +44,7 @@ export function WorldDateTile({
               {display.main}
             </span>
             {display.detail && (
-              <span className="mt-0.5 line-clamp-1 max-w-full break-words text-[0.4375rem] font-semibold leading-[0.55rem] text-[var(--muted-foreground)]/78 [overflow-wrap:anywhere]">
+              <span className="mt-0.5 line-clamp-1 max-w-full break-words text-[0.5rem] font-semibold leading-[0.625rem] text-[var(--muted-foreground)]/82 [overflow-wrap:anywhere]">
                 {display.detail}
               </span>
             )}
@@ -106,6 +106,8 @@ export function WorldTimeTile({
 }) {
   const lock = useTrackerFieldLock(lockKey);
   const display = getWorldTimeDisplay(value);
+  const isPhraseTime = display.kind === "phrase";
+
   return (
     <WorldTileShell label="Time">
       <WorldRenderedEdit
@@ -113,24 +115,42 @@ export function WorldTimeTile({
         value={display.raw || value}
         onSave={onSave}
         placeholder="Set time"
-        className="grid grid-rows-[minmax(0,1fr)_0.625rem] px-1 pb-0.5 pt-0.5 text-center"
+        className={cn(
+          "overflow-hidden text-center",
+          isPhraseTime
+            ? "flex flex-col items-center justify-center px-0.5 py-1"
+            : "grid grid-rows-[minmax(0,1fr)_0.625rem] px-1 pb-0.5 pt-0.5",
+        )}
         inputClassName="text-center"
         showEditHint={false}
         {...lock}
       >
-        <div className="flex min-h-0 items-center justify-center overflow-visible">
-          <WorldClockFace hour={display.hour} minute={display.minute} />
-        </div>
-        <div className="flex min-w-0 max-w-full translate-y-px items-baseline justify-center gap-0.5">
-          <span className="truncate text-[0.5625rem] font-black leading-[0.625rem] text-[var(--foreground)]">
-            {display.main}
-          </span>
-          {display.suffix && (
-            <span className="shrink-0 text-[0.4375rem] font-bold leading-none text-[var(--muted-foreground)]">
-              {display.suffix}
+        {isPhraseTime ? (
+          <>
+            <span className="mb-0.5 max-w-full truncate text-[0.4375rem] font-bold uppercase leading-none text-[var(--muted-foreground)]/75">
+              Time
             </span>
-          )}
-        </div>
+            <span className="line-clamp-3 max-w-full whitespace-normal break-words text-center text-[0.625rem] font-black leading-[0.7rem] text-[var(--foreground)]">
+              {display.main}
+            </span>
+          </>
+        ) : (
+          <>
+            <div className="flex min-h-0 items-center justify-center overflow-visible">
+              <WorldClockFace hour={display.hour} minute={display.minute} />
+            </div>
+            <div className="flex min-w-0 max-w-full translate-y-px items-baseline justify-center gap-0.5">
+              <span className="truncate text-[0.5625rem] font-black leading-[0.625rem] text-[var(--foreground)]">
+                {display.main}
+              </span>
+              {display.suffix && (
+                <span className="shrink-0 text-[0.4375rem] font-bold leading-none text-[var(--muted-foreground)]">
+                  {display.suffix}
+                </span>
+              )}
+            </div>
+          </>
+        )}
       </WorldRenderedEdit>
     </WorldTileShell>
   );

--- a/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
@@ -6,10 +6,12 @@ import type { TrackerPanelSizeProfile, TrackerTemperatureUnit } from "../../../.
 import { cn } from "../../../../lib/utils";
 import {
   getWorldAmbienceStyle,
-  getWorldDashboardGridClass,
   getWorldDateDisplay,
+  getWorldTimeDisplay,
   WORLD_FREEFORM_DATE_GRID_BASE_CLASS,
+  WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS,
   WORLD_GRID_BASE_CLASS,
+  WORLD_GRID_PHRASE_TIME_CLASS,
 } from "../../lib/world-state-display";
 import { SectionHeader } from "../controls/SectionControls";
 import { WorldDateTile, WorldTimeTile } from "./WorldDateTimeTiles";
@@ -35,9 +37,14 @@ export function WorldStatePanel({
 }) {
   const dateDisplay = getWorldDateDisplay(state?.date);
   const hasFreeformDate = dateDisplay.kind === "freeform";
-  const dashboardGridClass = getWorldDashboardGridClass(state?.weather, state?.temperature, state?.location, {
-    hasFreeformDate,
-  });
+  const hasPhraseTime = getWorldTimeDisplay(state?.time).kind === "phrase";
+  const gridColumnsClass = hasFreeformDate
+    ? hasPhraseTime
+      ? WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS
+      : WORLD_FREEFORM_DATE_GRID_BASE_CLASS
+    : hasPhraseTime
+      ? WORLD_GRID_PHRASE_TIME_CLASS
+      : WORLD_GRID_BASE_CLASS;
 
   return (
     <div
@@ -56,11 +63,7 @@ export function WorldStatePanel({
 
       {!collapsed && (
         <div
-          className={cn(
-            "relative grid gap-px p-1 @min-[380px]:gap-1 @min-[380px]:p-1.5",
-            hasFreeformDate ? WORLD_FREEFORM_DATE_GRID_BASE_CLASS : WORLD_GRID_BASE_CLASS,
-            dashboardGridClass,
-          )}
+          className={cn("relative grid gap-px p-1 @min-[380px]:gap-1 @min-[380px]:p-1.5", gridColumnsClass)}
         >
           <WorldDateTile
             value={state?.date}
@@ -86,7 +89,7 @@ export function WorldStatePanel({
           <WorldLocationPlate
             value={state?.location}
             onSave={(value) => onSaveField("location", value || null)}
-            className="col-span-3 @min-[380px]:col-span-1"
+            className="col-span-full"
             lockKey={worldTrackerLockKey("location")}
           />
         </div>

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -3,53 +3,17 @@ import type { GameState } from "@marinara-engine/shared";
 import type { TrackerTemperatureUnit } from "../../../stores/ui.store";
 import { visibleText } from "./tracker-display";
 
+// Row 1 holds Date / Time / Forecast; the forecast column flexes to fill the
+// remaining width so weather is never squeezed. Location renders on its own
+// full-width row below (see WorldStatePanel), so no per-tile width balancing is
+// needed. Word-based times ("Afternoon") get a wider Time column so the word
+// stays readable and wraps on spaces instead of shrinking; clock times keep the
+// compact 2.5rem column.
 export const WORLD_GRID_BASE_CLASS = "grid-cols-[2.5rem_2.5rem_minmax(0,1fr)]";
+export const WORLD_GRID_PHRASE_TIME_CLASS = "grid-cols-[2.5rem_4.5rem_minmax(0,1fr)]";
 export const WORLD_FREEFORM_DATE_GRID_BASE_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_2.5rem_minmax(0,1fr)]";
-export const WORLD_GRID_BALANCED_CLASS =
-  "@min-[380px]:grid-cols-[2.5rem_2.5rem_minmax(6.25rem,1fr)_minmax(7.5rem,1.35fr)]";
-export const WORLD_GRID_FORECAST_HEAVY_CLASS =
-  "@min-[380px]:grid-cols-[2.5rem_2.5rem_minmax(7rem,1.05fr)_minmax(7.25rem,1.2fr)]";
-export const WORLD_GRID_LOCATION_HEAVY_CLASS =
-  "@min-[380px]:grid-cols-[2.5rem_2.5rem_minmax(7rem,0.95fr)_minmax(9rem,1.45fr)]";
-export const WORLD_FREEFORM_DATE_GRID_BALANCED_CLASS =
-  "@min-[380px]:grid-cols-[minmax(4.1rem,4.7rem)_2.5rem_minmax(5rem,0.86fr)_minmax(7.25rem,1.35fr)]";
-export const WORLD_FREEFORM_DATE_GRID_FORECAST_HEAVY_CLASS =
-  "@min-[380px]:grid-cols-[minmax(4.1rem,4.7rem)_2.5rem_minmax(5.75rem,1fr)_minmax(6.75rem,1.1fr)]";
-export const WORLD_FREEFORM_DATE_GRID_LOCATION_HEAVY_CLASS =
-  "@min-[380px]:grid-cols-[minmax(4.1rem,4.7rem)_2.5rem_minmax(5rem,0.75fr)_minmax(8.25rem,1.45fr)]";
-
-type WorldDashboardGridClassOptions = {
-  hasFreeformDate?: boolean;
-};
-
-export function getWorldTileTextNeed(value: string | null | undefined, fallback: string) {
-  const text = visibleText(value, fallback).replace(/\s+/g, " ");
-  const longestWord = text.split(" ").reduce((longest, word) => Math.max(longest, word.length), 0);
-  return text.length + longestWord * 0.7;
-}
-
-export function getWorldDashboardGridClass(
-  weather: string | null | undefined,
-  temperature: string | null | undefined,
-  location: string | null | undefined,
-  options: WorldDashboardGridClassOptions = {},
-) {
-  const { hasFreeformDate = false } = options;
-  const forecastNeed =
-    getWorldTileTextNeed(weather, "Set weather") + Math.min(8, getWorldTileTextNeed(temperature, "--") * 0.35);
-  const locationNeed = getWorldTileTextNeed(location, "Set location");
-  const hasLocation = visibleText(location, "").length > 0;
-  if (hasLocation && locationNeed >= forecastNeed + 2) {
-    return hasFreeformDate ? WORLD_FREEFORM_DATE_GRID_LOCATION_HEAVY_CLASS : WORLD_GRID_LOCATION_HEAVY_CLASS;
-  }
-  if (forecastNeed >= locationNeed + 4) {
-    return hasFreeformDate ? WORLD_FREEFORM_DATE_GRID_FORECAST_HEAVY_CLASS : WORLD_GRID_FORECAST_HEAVY_CLASS;
-  }
-  if (locationNeed >= forecastNeed + 6) {
-    return hasFreeformDate ? WORLD_FREEFORM_DATE_GRID_LOCATION_HEAVY_CLASS : WORLD_GRID_LOCATION_HEAVY_CLASS;
-  }
-  return hasFreeformDate ? WORLD_FREEFORM_DATE_GRID_BALANCED_CLASS : WORLD_GRID_BALANCED_CLASS;
-}
+export const WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS =
+  "grid-cols-[minmax(3.8rem,4.45rem)_4.5rem_minmax(0,1fr)]";
 
 export const WORLD_MONTH_LABELS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
 export const WORLD_MONTH_ALIASES: Record<string, number> = {
@@ -204,7 +168,7 @@ export type WorldDateDisplay = ReturnType<typeof getWorldDateDisplay>;
 
 export function getWorldTimeDisplay(time: string | null | undefined) {
   const text = (time ?? "").trim();
-  if (!text) return { main: "--:--", suffix: "", raw: "", hour: null, minute: null };
+  if (!text) return { kind: "empty" as const, main: "--:--", suffix: "", raw: "", hour: null, minute: null };
 
   const meridiem = text.match(/\b(1[0-2]|0?\d)(?::([0-5]\d))?\s*([ap])\.?m?\.?\b/i);
   if (meridiem) {
@@ -213,6 +177,7 @@ export function getWorldTimeDisplay(time: string | null | undefined) {
     const marker = meridiem[3]!.toLowerCase();
     const hour = marker === "p" ? (displayHour % 12) + 12 : displayHour % 12;
     return {
+      kind: "clock" as const,
       main: `${meridiem[1]!.padStart(2, "0")}:${meridiem[2] ?? "00"}`,
       suffix: `${meridiem[3]!.toUpperCase()}M`,
       hour,
@@ -226,6 +191,7 @@ export function getWorldTimeDisplay(time: string | null | undefined) {
     const hour = Number(twentyFourHour[1]);
     const minute = Number(twentyFourHour[2]);
     return {
+      kind: "clock" as const,
       main: `${twentyFourHour[1]!.padStart(2, "0")}:${twentyFourHour[2]}`,
       suffix: "",
       hour,
@@ -234,7 +200,9 @@ export function getWorldTimeDisplay(time: string | null | undefined) {
     };
   }
 
-  return { main: text, suffix: "", raw: text, hour: null, minute: null };
+  // Word-based time ("Late", "Midnight", "Just before dawn") — no clock face,
+  // shown as a wrapped phrase so it is never truncated to "Late...".
+  return { kind: "phrase" as const, main: text, suffix: "", raw: text, hour: null, minute: null };
 }
 
 export function getWeatherEmoji(weather: string | null | undefined) {


### PR DESCRIPTION
## Linked issue

- None provided. Follow-up: open or attach an issue before moving this PR out of draft.

## Why this change

- World-state time values like `Afternoon` or `Just before dawn` were handled by the compact clock tile layout, which could truncate readable phrase times and crowd neighboring forecast/location content.

## What changed

- Added a phrase display mode for non-clock world times and render those values as wrapped text instead of a clock face.
- Simplified world-state grid sizing so forecast content gets the flexible column and phrase-time values get a wider time column.
- Moved location onto its own full-width row so it no longer competes with forecast text.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Agent ran `pnpm install`; lockfile was already up to date.
- Agent ran `pnpm check` successfully.
- Agent reviewed the PR template, `CONTRIBUTING.md` branch/PR rules, `.github/agents/chai-workflow.md`, and `packages/client/.instructions.md`.
- Xel looked at the changes in the browser and thought "yup, that looks better"

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs, release metadata, database, server behavior, or version files changed.

## UI evidence (if applicable)

Not attached. This PR still needs manual UI screenshots or a browser click-through before it is marked ready for review.