### PR TITLE
[codex] Polish unified chat UI and library folders

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -11,7 +11,7 @@ import { AppDialogRenderer } from "./components/ui/AppDialogRenderer";
 import { ChibiProfessorMariEasterEgg } from "./components/ui/ChibiProfessorMariEasterEgg";
 import { CsrfOriginWarningBanner } from "./components/diagnostics/CsrfOriginWarningBanner";
 import { Toaster } from "sonner";
-import { useUIStore } from "./stores/ui.store";
+import { getDefaultChatChromeTextColor, useUIStore } from "./stores/ui.store";
 import { useSidecarStore } from "./stores/sidecar.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
@@ -93,6 +93,7 @@ export function App() {
   const visualTheme = useUIStore((s) => s.visualTheme);
   const fontFamily = useUIStore((s) => s.fontFamily);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
+  const chatChromeTextColor = useUIStore((s) => s.chatChromeTextColor);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
   useLegacyThemeMigration();
   useLegacyExtensionMigration();
@@ -171,6 +172,23 @@ export function App() {
       delete root.dataset.marinaraChatChromeAccentMode;
     }
   }, [appAccentColor]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const textColor = chatChromeTextColor.trim();
+    const variables = [
+      "--marinara-chat-chrome-text",
+      "--marinara-chat-chrome-button-text-base",
+      "--marinara-chat-chrome-highlight-text-base",
+    ];
+
+    if (textColor) {
+      const resolvedColor = getCssColorFallback(textColor, getDefaultChatChromeTextColor(theme));
+      variables.forEach((variable) => root.style.setProperty(variable, resolvedColor));
+    } else {
+      variables.forEach((variable) => root.style.removeProperty(variable));
+    }
+  }, [chatChromeTextColor, theme]);
 
   // Apply visual theme (default / sillytavern) to the document root
   useEffect(() => {

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -61,6 +61,7 @@ import {
   useDeleteKnowledgeSource,
 } from "../../hooks/use-knowledge-sources";
 import { cn } from "../../lib/utils";
+import { MacroTextarea } from "../ui/MacroTextarea";
 import {
   getAgentRunIntervalMeta,
   getCadenceInputValue,
@@ -1750,32 +1751,36 @@ export function AgentEditor() {
                 Illustrator image connection from Settings → Connections, if one is configured.
               </p>
               <div className="mt-3 grid gap-3 md:grid-cols-2">
-                <label className="flex flex-col gap-1.5">
+                <div className="flex flex-col gap-1.5">
                   <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
                     Positive prompt / tags
                   </span>
-                  <textarea
+                  <MacroTextarea
                     value={localImagePositivePrompt}
-                    onChange={(e) => {
-                      setLocalImagePositivePrompt(e.target.value);
+                    onChange={(value) => {
+                      setLocalImagePositivePrompt(value);
                       markDirty();
                     }}
                     placeholder="masterpiece, best quality, detailed lighting"
+                    rows={3}
+                    title="Positive prompt / tags"
                     className="min-h-[5rem] resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50"
                   />
-                </label>
-                <label className="flex flex-col gap-1.5">
+                </div>
+                <div className="flex flex-col gap-1.5">
                   <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Negative prompt</span>
-                  <textarea
+                  <MacroTextarea
                     value={localImageNegativePrompt}
-                    onChange={(e) => {
-                      setLocalImageNegativePrompt(e.target.value);
+                    onChange={(value) => {
+                      setLocalImageNegativePrompt(value);
                       markDirty();
                     }}
                     placeholder="lowres, bad anatomy, text artifacts"
+                    rows={3}
+                    title="Negative prompt"
                     className="min-h-[5rem] resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50"
                   />
-                </label>
+                </div>
               </div>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 Saved on the Illustrator agent. Positive tags are appended after the generated prompt; negative tags are
@@ -3191,13 +3196,14 @@ export function AgentEditor() {
                 </span>
               </div>
             ) : (
-              <textarea
+              <MacroTextarea
                 value={localPrompt}
-                onChange={(e) => {
-                  setLocalPrompt(e.target.value);
+                onChange={(value) => {
+                  setLocalPrompt(value);
                   markDirty();
                 }}
                 rows={16}
+                title="Prompt Template"
                 placeholder="Write the system prompt for this agent…"
                 className="w-full resize-y rounded-xl bg-[var(--secondary)] px-4 py-3 font-mono text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--ring)] max-h-[60vh] overflow-y-auto"
               />
@@ -3263,12 +3269,11 @@ export function AgentEditor() {
                         className="mb-2 w-full rounded-lg bg-[var(--background)] px-2.5 py-1.5 text-xs ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                         placeholder="Short description shown in Chat Settings"
                       />
-                      <textarea
+                      <MacroTextarea
                         value={option.promptTemplate}
-                        onChange={(e) =>
-                          handleUpdatePromptTemplate(option.id, { promptTemplate: e.target.value })
-                        }
+                        onChange={(value) => handleUpdatePromptTemplate(option.id, { promptTemplate: value })}
                         rows={7}
+                        title={option.name ? `${option.name} Prompt` : `Prompt Option ${index + 1}`}
                         className="w-full resize-y rounded-lg bg-[var(--background)] px-3 py-2 font-mono text-xs leading-relaxed ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)]/50 focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                         placeholder="Write the prompt template for this option…"
                       />

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -65,7 +65,6 @@ import {
   Loader2,
   Swords,
   Crop,
-  Maximize2,
   ImageDown,
   Download,
   Eraser,
@@ -79,7 +78,7 @@ import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
 import { ColorPicker } from "../ui/ColorPicker";
-import { ExpandedTextarea } from "../ui/ExpandedTextarea";
+import { MacroTextarea } from "../ui/MacroTextarea";
 import { Modal } from "../ui/Modal";
 import { SpriteFrameEditor } from "../ui/SpriteFrameEditor";
 import { SpriteWandCleanupEditor } from "../ui/SpriteWandCleanupEditor";
@@ -1091,46 +1090,26 @@ function CharacterDescriptionTab({
   formData: CharacterData;
   updateField: <K extends keyof CharacterData>(key: K, value: CharacterData[K]) => void;
 }) {
-  const [expandedField, setExpandedField] = useState(false);
-
   return (
     <div className="space-y-6">
       <div>
-        <div className="flex items-start justify-between gap-2 mb-4">
-          <SectionHeader
-            title="Description"
-            subtitle="The character's general description. This is sent in every prompt as part of the character's identity."
-            helpText={CHARACTER_DESCRIPTION_HELP}
-          />
-          <button
-            type="button"
-            onClick={() => setExpandedField(true)}
-            className="mt-0.5 shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
-        <textarea
+        <SectionHeader
+          title="Description"
+          subtitle="The character's general description. This is sent in every prompt as part of the character's identity."
+          helpText={CHARACTER_DESCRIPTION_HELP}
+        />
+        <MacroTextarea
           value={formData.description}
-          onChange={(event) => updateField("description", event.target.value)}
+          onChange={(value) => updateField("description", value)}
           placeholder="Describe who this character is, their role, and their key traits…"
           rows={12}
+          title="Description"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
         />
         <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
           {formData.description.length} characters
         </p>
       </div>
-
-      <ExpandedTextarea
-        open={expandedField}
-        onClose={() => setExpandedField(false)}
-        title="Description"
-        value={formData.description}
-        onChange={(value) => updateField("description", value)}
-        placeholder="Describe who this character is, their role, and their key traits…"
-      />
     </div>
   );
 }
@@ -1152,36 +1131,18 @@ function TextareaTab({
   placeholder: string;
   rows?: number;
 }) {
-  const [expanded, setExpanded] = useState(false);
   return (
     <div>
-      <div className="flex items-start justify-between gap-2 mb-4">
-        <SectionHeader title={title} subtitle={subtitle} helpText={helpText} />
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          className="mt-0.5 shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-          title="Expand editor"
-        >
-          <Maximize2 size="0.875rem" />
-        </button>
-      </div>
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        rows={rows}
-        className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
-      />
-      <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</p>
-      <ExpandedTextarea
-        open={expanded}
-        onClose={() => setExpanded(false)}
-        title={title}
+      <SectionHeader title={title} subtitle={subtitle} helpText={helpText} />
+      <MacroTextarea
         value={value}
         onChange={onChange}
         placeholder={placeholder}
+        rows={rows}
+        title={title}
+        className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
       />
+      <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</p>
     </div>
   );
 }
@@ -1359,19 +1320,20 @@ function MetadataTab({
       </div>
 
       {/* Creator Notes */}
-      <label className="block space-y-1.5">
+      <div className="block space-y-1.5">
         <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
           Creator Notes{" "}
           <HelpTooltip text="Private notes about this character — tips for use, known quirks, recommended settings. Not sent to the AI." />
         </span>
-        <textarea
+        <MacroTextarea
           value={formData.creator_notes}
-          onChange={(e) => updateField("creator_notes", e.target.value)}
+          onChange={(value) => updateField("creator_notes", value)}
           rows={4}
+          title="Creator Notes"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder="Notes about this character, intended use, tips for best results…"
         />
-      </label>
+      </div>
     </div>
   );
 }
@@ -1621,8 +1583,6 @@ function DialogueTab({
   formData: CharacterData;
   updateField: <K extends keyof CharacterData>(key: K, value: CharacterData[K]) => void;
 }) {
-  const [expandedField, setExpandedField] = useState<"first_mes" | "mes_example" | number | null>(null);
-
   const addGreeting = () => {
     updateField("alternate_greetings", [...formData.alternate_greetings, ""]);
   };
@@ -1649,29 +1609,20 @@ function DialogueTab({
       />
 
       {/* First Message */}
-      <label className="block space-y-1.5">
-        <div className="flex items-center justify-between">
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
-            First Message{" "}
-            <HelpTooltip text="The character's opening message when a new chat starts. Good first messages set the scene and establish the character's voice." />
-          </span>
-          <button
-            type="button"
-            onClick={() => setExpandedField("first_mes")}
-            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
-        <textarea
+      <div className="block space-y-1.5">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+          First Message{" "}
+          <HelpTooltip text="The character's opening message when a new chat starts. Good first messages set the scene and establish the character's voice." />
+        </span>
+        <MacroTextarea
           value={formData.first_mes}
-          onChange={(e) => updateField("first_mes", e.target.value)}
+          onChange={(value) => updateField("first_mes", value)}
           rows={6}
+          title="First Message"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder="What does the character say when they first meet someone? Use *asterisks* for actions…"
         />
-      </label>
+      </div>
 
       {/* Alternate Greetings */}
       <div className="space-y-3">
@@ -1689,90 +1640,48 @@ function DialogueTab({
           </button>
         </div>
         {formData.alternate_greetings.map((g, i) => (
-          <div key={i} className="relative">
-            <textarea
-              value={g}
-              onChange={(e) => updateGreeting(i, e.target.value)}
-              rows={3}
-              className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 pr-16 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40"
-              placeholder={`Greeting #${i + 1}…`}
-            />
-            <div className="absolute right-2 top-2 flex items-center gap-0.5">
-              <button
-                type="button"
-                onClick={() => setExpandedField(i)}
-                className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
-                title="Expand editor"
-              >
-                <Maximize2 size="0.75rem" />
-              </button>
+          <MacroTextarea
+            key={i}
+            value={g}
+            onChange={(value) => updateGreeting(i, value)}
+            rows={3}
+            title={`Alternate Greeting #${i + 1}`}
+            className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40"
+            placeholder={`Greeting #${i + 1}…`}
+            controlPaddingClassName="pr-14"
+            toolbarExtra={
               <button
                 type="button"
                 onClick={() => removeGreeting(i)}
-                className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)]"
+                className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+                aria-label={`Remove alternate greeting ${i + 1}`}
+                title="Remove greeting"
               >
                 <Trash2 size="0.75rem" />
               </button>
-            </div>
-          </div>
+            }
+          />
         ))}
       </div>
 
       {/* Example Messages */}
-      <label className="block space-y-1.5">
-        <div className="flex items-center justify-between">
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
-            Example Dialogue{" "}
-            <HelpTooltip text="Sample conversations showing how the character talks. Helps the AI learn the character's speaking style, vocabulary, and mannerisms." />
-          </span>
-          <button
-            type="button"
-            onClick={() => setExpandedField("mes_example")}
-            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
+      <div className="block space-y-1.5">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+          Example Dialogue{" "}
+          <HelpTooltip text="Sample conversations showing how the character talks. Helps the AI learn the character's speaking style, vocabulary, and mannerisms." />
+        </span>
         <p className="text-[0.625rem] text-[var(--muted-foreground)]/70">
           {"Use <START> to separate exchanges. Use {{user}} and {{char}} as placeholders."}
         </p>
-        <textarea
+        <MacroTextarea
           value={formData.mes_example}
-          onChange={(e) => updateField("mes_example", e.target.value)}
+          onChange={(value) => updateField("mes_example", value)}
           rows={10}
+          title="Example Dialogue"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 font-mono text-xs leading-relaxed outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder={"<START>\n{{user}}: Hello!\n{{char}}: *waves excitedly* Hey there!"}
         />
-      </label>
-
-      <ExpandedTextarea
-        open={expandedField === "first_mes"}
-        onClose={() => setExpandedField(null)}
-        title="First Message"
-        value={formData.first_mes}
-        onChange={(value) => updateField("first_mes", value)}
-        placeholder="What does the character say when they first meet someone? Use *asterisks* for actions…"
-      />
-      <ExpandedTextarea
-        open={expandedField === "mes_example"}
-        onClose={() => setExpandedField(null)}
-        title="Example Dialogue"
-        value={formData.mes_example}
-        onChange={(value) => updateField("mes_example", value)}
-        placeholder={"<START>\n{{user}}: Hello!\n{{char}}: *waves excitedly* Hey there!"}
-      />
-      {formData.alternate_greetings.map((g, i) => (
-        <ExpandedTextarea
-          key={i}
-          open={expandedField === i}
-          onClose={() => setExpandedField(null)}
-          title={`Alternate Greeting #${i + 1}`}
-          value={g}
-          onChange={(value) => updateGreeting(i, value)}
-          placeholder={`Greeting #${i + 1}…`}
-        />
-      ))}
+      </div>
     </div>
   );
 }
@@ -1787,7 +1696,6 @@ function AdvancedTab({
   updateExtension: (key: string, value: unknown) => void;
 }) {
   const depthPrompt = formData.extensions.depth_prompt ?? { prompt: "", depth: 4, role: "system" as const };
-  const [expandedField, setExpandedField] = useState<"system_prompt" | "post_history" | "depth_prompt" | null>(null);
 
   return (
     <div className="space-y-6">
@@ -1797,74 +1705,47 @@ function AdvancedTab({
         helpText={CHARACTER_ADVANCED_HELP}
       />
 
-      <label className="block space-y-1.5">
-        <div className="flex items-center justify-between">
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
-            System Prompt{" "}
-            <HelpTooltip text="Character-specific instructions inserted by the prompt preset's character block or wherever the preset uses {{charSysInfo}}. This does not replace the chat's main system prompt." />
-          </span>
-          <button
-            type="button"
-            onClick={() => setExpandedField("system_prompt")}
-            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
-        <textarea
+      <div className="block space-y-1.5">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+          System Prompt{" "}
+          <HelpTooltip text="Character-specific instructions inserted by the prompt preset's character block or wherever the preset uses {{charSysInfo}}. This does not replace the chat's main system prompt." />
+        </span>
+        <MacroTextarea
           value={formData.system_prompt}
-          onChange={(e) => updateField("system_prompt", e.target.value)}
+          onChange={(value) => updateField("system_prompt", value)}
           rows={6}
+          title="System Prompt"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder="Character-specific instructions inserted through {{charSysInfo}} or the character prompt block…"
         />
-      </label>
+      </div>
 
-      <label className="block space-y-1.5">
-        <div className="flex items-center justify-between">
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
-            Post-History Instructions{" "}
-            <HelpTooltip text="Text inserted after the chat history, right before the AI generates. Great for reminders like 'stay in character' or 'respond in 2 paragraphs'." />
-          </span>
-          <button
-            type="button"
-            onClick={() => setExpandedField("post_history")}
-            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
-        <textarea
+      <div className="block space-y-1.5">
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+          Post-History Instructions{" "}
+          <HelpTooltip text="Text inserted after the chat history, right before the AI generates. Great for reminders like 'stay in character' or 'respond in 2 paragraphs'." />
+        </span>
+        <MacroTextarea
           value={formData.post_history_instructions}
-          onChange={(e) => updateField("post_history_instructions", e.target.value)}
+          onChange={(value) => updateField("post_history_instructions", value)}
           rows={4}
+          title="Post-History Instructions"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder="Text inserted after the chat history but before generation…"
         />
-      </label>
+      </div>
 
       {/* Depth Prompt */}
       <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
-        <div className="flex items-center justify-between">
-          <span className="inline-flex items-center gap-1 text-xs font-semibold">
-            Depth Prompt{" "}
-            <HelpTooltip text="Injects text at a specific position in the chat history. Depth 0 = after the latest message, depth 4 = 4 messages back. Useful for persistent reminders." />
-          </span>
-          <button
-            type="button"
-            onClick={() => setExpandedField("depth_prompt")}
-            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
-        <textarea
+        <span className="inline-flex items-center gap-1 text-xs font-semibold">
+          Depth Prompt{" "}
+          <HelpTooltip text="Injects text at a specific position in the chat history. Depth 0 = after the latest message, depth 4 = 4 messages back. Useful for persistent reminders." />
+        </span>
+        <MacroTextarea
           value={depthPrompt.prompt}
-          onChange={(e) => updateExtension("depth_prompt", { ...depthPrompt, prompt: e.target.value })}
+          onChange={(value) => updateExtension("depth_prompt", { ...depthPrompt, prompt: value })}
           rows={4}
+          title="Depth Prompt"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm outline-none focus:border-[var(--primary)]/40"
           placeholder="Prompt injected at a specific depth in the chat history…"
         />
@@ -1896,31 +1777,6 @@ function AdvancedTab({
           </label>
         </div>
       </div>
-
-      <ExpandedTextarea
-        open={expandedField === "system_prompt"}
-        onClose={() => setExpandedField(null)}
-        title="System Prompt"
-        value={formData.system_prompt}
-        onChange={(value) => updateField("system_prompt", value)}
-        placeholder="Character-specific instructions inserted through {{charSysInfo}} or the character prompt block…"
-      />
-      <ExpandedTextarea
-        open={expandedField === "post_history"}
-        onClose={() => setExpandedField(null)}
-        title="Post-History Instructions"
-        value={formData.post_history_instructions}
-        onChange={(value) => updateField("post_history_instructions", value)}
-        placeholder="Text inserted after the chat history but before generation…"
-      />
-      <ExpandedTextarea
-        open={expandedField === "depth_prompt"}
-        onClose={() => setExpandedField(null)}
-        title="Depth Prompt"
-        value={depthPrompt.prompt}
-        onChange={(value) => updateExtension("depth_prompt", { ...depthPrompt, prompt: value })}
-        placeholder="Prompt injected at a specific depth in the chat history…"
-      />
     </div>
   );
 }

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1583,7 +1583,17 @@ function DialogueTab({
   formData: CharacterData;
   updateField: <K extends keyof CharacterData>(key: K, value: CharacterData[K]) => void;
 }) {
+  const greetingKeysRef = useRef<string[]>([]);
+
+  while (greetingKeysRef.current.length < formData.alternate_greetings.length) {
+    greetingKeysRef.current.push(generateClientId());
+  }
+  if (greetingKeysRef.current.length > formData.alternate_greetings.length) {
+    greetingKeysRef.current.length = formData.alternate_greetings.length;
+  }
+
   const addGreeting = () => {
+    greetingKeysRef.current.push(generateClientId());
     updateField("alternate_greetings", [...formData.alternate_greetings, ""]);
   };
 
@@ -1594,6 +1604,7 @@ function DialogueTab({
   };
 
   const removeGreeting = (i: number) => {
+    greetingKeysRef.current.splice(i, 1);
     updateField(
       "alternate_greetings",
       formData.alternate_greetings.filter((_, idx) => idx !== i),
@@ -1641,7 +1652,7 @@ function DialogueTab({
         </div>
         {formData.alternate_greetings.map((g, i) => (
           <MacroTextarea
-            key={i}
+            key={greetingKeysRef.current[i] ?? i}
             value={g}
             onChange={(value) => updateGreeting(i, value)}
             rows={3}
@@ -2830,7 +2841,6 @@ function StatsTab({
               ))}
             </div>
           </div>
-
         </>
       )}
     </div>
@@ -2960,7 +2970,6 @@ function ColorsTab({
         label="Message Box Color"
         helpText="Background color for this character's chat message bubbles. Use a semi-transparent color for best results (e.g. rgba)."
       />
-
     </div>
   );
 }

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -169,11 +169,14 @@ export function ChatBranchSelector({
   useLayoutEffect(() => {
     if (!open || !buttonRef.current) return;
     const rect = buttonRef.current.getBoundingClientRect();
-    const width = Math.max(rect.width, 360);
     const viewportPadding = 12;
+    const isMobile = window.innerWidth < 768;
+    const width = isMobile
+      ? Math.min(360, window.innerWidth - viewportPadding * 2)
+      : Math.max(rect.width, 360);
     const maxLeft = Math.max(viewportPadding, window.innerWidth - width - viewportPadding);
     setPosition({
-      top: rect.bottom + 8,
+      top: rect.bottom + (isMobile ? 0 : 8),
       left: Math.max(viewportPadding, Math.min(rect.right - width, maxLeft)),
       width,
     });

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -46,6 +46,7 @@ import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
 import { QuickReplyMenu, type QuickReplyAction } from "./QuickReplyMenu";
+import { getChatInputShellClass } from "./chat-input-styles";
 
 interface Attachment {
   type: string; // MIME type
@@ -1358,15 +1359,11 @@ export const ChatInput = memo(function ChatInput({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        className={cn(
-          "mari-chat-input-box relative flex items-center gap-1 rounded-2xl border px-2 py-1.5 shadow-sm transition-all duration-200 focus-within:border-foreground/35 focus-within:ring-1 focus-within:ring-foreground/10 sm:gap-2 sm:px-4 sm:py-2.5",
-          "border-foreground/20 bg-[var(--card)]",
-          isDragging
-            ? "border-foreground/40 bg-foreground/10 shadow-lg shadow-black/10"
-            : hasInput || attachments.length
-              ? "shadow-md shadow-black/5"
-              : "",
-        )}
+        className={getChatInputShellClass({
+          dragging: isDragging,
+          hasContent: hasInput || attachments.length > 0,
+          layout: "roleplay",
+        })}
       >
         {/* Attachment button */}
         <input

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1689,8 +1689,10 @@ export const ChatMessage = memo(function ChatMessage({
         <div
           ref={msgRef}
           className={cn(
-            "mari-message group mb-4 flex gap-3 px-2",
+            "mari-message mari-roleplay-message-row group mb-4 flex justify-center gap-3 px-2",
             isUser ? "mari-message-user flex-row-reverse" : "mari-message-assistant",
+            useCompactRectangleAvatar && "mari-roleplay-message-row--rect-avatar",
+            (hideRoleplayAvatars || showRoleplayAvatarPanel) && "mari-roleplay-message-row--wide",
             multiSelectMode && isSelected && "ring-2 ring-[var(--destructive)]/50 rounded-lg bg-[var(--destructive)]/5",
           )}
           data-message-id={message.id}
@@ -1702,7 +1704,7 @@ export const ChatMessage = memo(function ChatMessage({
         >
           {/* Multi-select checkbox */}
           {multiSelectMode && (
-            <div className="flex items-start pt-2 flex-shrink-0">
+            <div className="mari-roleplay-selection-toggle flex items-start pt-2 flex-shrink-0">
               <button
                 type="button"
                 role="checkbox"
@@ -1797,14 +1799,16 @@ export const ChatMessage = memo(function ChatMessage({
           )}
 
           {/* Spacer if grouped (no avatar) */}
-          {isGrouped && !hideRoleplayAvatars && <div className={cn("flex-shrink-0", compactAvatarSpacerClass)} />}
+          {isGrouped && !hideRoleplayAvatars && (
+            <div className={cn("mari-roleplay-avatar-spacer flex-shrink-0", compactAvatarSpacerClass)} />
+          )}
 
           {/* Content */}
           <div
             className={cn(
-              "mari-message-body flex min-w-0 max-w-[82%] flex-col gap-0.5",
+              "mari-message-body mari-roleplay-message-body flex min-w-0 flex-col gap-0.5",
               isUser && "items-end",
-              editing && "w-[82%]",
+              editing && "mari-roleplay-message-body--editing",
             )}
           >
             {/* Name + time (only if not grouped) */}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -44,7 +44,12 @@ import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { CyoaChoices } from "./CyoaChoices";
 import { ChatBranchSelector } from "./ChatBranchSelector";
-import { ChatToolbarButton, ChatToolbarMenu, getChatToolbarButtonClass } from "./ChatToolbarControls";
+import {
+  CHAT_TOOLBAR_ICON_GAP_CLASS,
+  ChatToolbarButton,
+  ChatToolbarMenu,
+  getChatToolbarButtonClass,
+} from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { EndSceneBar } from "./SceneBanner";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
@@ -100,16 +105,33 @@ const AuthorNotesPanel = lazy(async () => {
   return { default: module.AuthorNotesPanel };
 });
 
-const PANEL_BACKDROP =
-  "fixed inset-0 z-[9999] flex items-center justify-center p-4 max-md:pt-[max(1rem,env(safe-area-inset-top))]";
 const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
   "md:pl-[var(--tracker-chat-avoid-left)] md:pr-[var(--tracker-chat-avoid-right)] md:transition-[padding] md:duration-200 md:ease-[cubic-bezier(0.16,1,0.3,1)]";
-const PANEL_CONTAINER = cn(
-  ROLEPLAY_POPOVER_SHELL,
-  ROLEPLAY_POPOVER_SCROLL_AREA,
-  "relative max-h-[calc(100dvh-4rem)] w-full max-w-sm overflow-y-auto p-3",
-);
 const roleplayNotificationSeenKeys = new Set<string>();
+const MOBILE_FLOATING_PANEL_PADDING = 8;
+
+type MobileFloatingPanelFrame = {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+};
+
+function getMobileFloatingPanelFrame(
+  button: HTMLElement | null,
+  preferredWidth: number,
+): MobileFloatingPanelFrame | null {
+  if (!button || typeof window === "undefined") return null;
+  const rect = button.getBoundingClientRect();
+  const width = Math.min(preferredWidth, window.innerWidth - MOBILE_FLOATING_PANEL_PADDING * 2);
+  const left = Math.max(
+    MOBILE_FLOATING_PANEL_PADDING,
+    Math.min(rect.right - width, window.innerWidth - width - MOBILE_FLOATING_PANEL_PADDING),
+  );
+  const top = Math.max(MOBILE_FLOATING_PANEL_PADDING, rect.bottom);
+  const maxHeight = Math.max(160, window.innerHeight - top - MOBILE_FLOATING_PANEL_PADDING);
+  return { top, left, width, maxHeight };
+}
 
 function WeatherEffectsConnected() {
   const gs = useGameStateStore((s) => s.current);
@@ -306,6 +328,10 @@ function ActiveContextLinksButton({
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [mobileFrame, setMobileFrame] = useState<MobileFloatingPanelFrame | null>(null);
+  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const compact = useUIStore((s) => s.centerCompact);
   const { data: lorebooks } = useLorebooks();
   const { data: presets } = usePresets();
@@ -317,11 +343,25 @@ function ActiveContextLinksButton({
   useEffect(() => {
     if (!open) return;
     const handle = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
+      setOpen(false);
     };
     document.addEventListener("mousedown", handle);
     return () => document.removeEventListener("mousedown", handle);
   }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open || !isMobile) return;
+    const update = () => setMobileFrame(getMobileFloatingPanelFrame(buttonRef.current, 288));
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [isMobile, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -389,10 +429,88 @@ function ActiveContextLinksButton({
   const iconClassName = "shrink-0 text-[var(--marinara-chat-chrome-panel-muted)]";
   const entryClassName =
     "flex min-w-0 items-center gap-1.5 rounded-md bg-[var(--marinara-chat-chrome-highlight-bg)] px-2 py-1 text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)] ring-1 ring-[var(--marinara-chat-chrome-panel-divider)]";
+  const activeContextContent = (
+    <>
+      <div className={cn(ROLEPLAY_POPOVER_TITLE, "px-2 pb-1")}>
+        <BookOpen size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+        Active Context
+      </div>
+      <div className="space-y-1">
+        {characterIds.map((id, index) => (
+          <button
+            key={id}
+            type="button"
+            role="menuitem"
+            className={itemClassName}
+            onClick={() => openCharacter(id)}
+          >
+            <User size="0.8125rem" className={iconClassName} />
+            <span className="min-w-0 flex-1 truncate">
+              {characterMap.get(id)?.name ?? `Character ${index + 1}`}
+            </span>
+            <span className="shrink-0 text-[0.625rem] text-foreground/45">Card</span>
+          </button>
+        ))}
+        {visibleLorebookIds.map((id, index) => {
+          const entries = triggeredEntriesByLorebook.get(id) ?? [];
+          const skippedEntries = skippedEntriesByLorebook.get(id) ?? [];
+          return (
+            <div key={id} className="space-y-1">
+              <button type="button" role="menuitem" className={itemClassName} onClick={() => openLorebook(id)}>
+                <BookOpen size="0.8125rem" className={iconClassName} />
+                <span className="min-w-0 flex-1 truncate">
+                  {lorebookNameById.get(id) ?? `Lorebook ${index + 1}`}
+                </span>
+                <span className="shrink-0 text-[0.625rem] text-foreground/45">
+                  {entries.length > 0 ? `${entries.length} hit${entries.length === 1 ? "" : "s"}` : "Lorebook"}
+                </span>
+              </button>
+              {entries.length > 0 && (
+                <div className="ml-6 space-y-1 border-l border-foreground/10 pl-2">
+                  {entries.map((entry) => (
+                    <div key={entry.id} className={entryClassName} title={entry.content || entry.name}>
+                      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                      <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+                      {entry.constant && (
+                        <span className="shrink-0 rounded bg-amber-400/15 px-1 py-0.5 text-[0.5rem] font-semibold text-amber-300">
+                          CONST
+                        </span>
+                      )}
+                      <span className="shrink-0 text-foreground/40">#{entry.order}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {skippedEntries.length > 0 && (
+                <div className="ml-6 rounded-md bg-amber-500/10 px-2 py-1 text-[0.625rem] leading-relaxed text-amber-100/80 ring-1 ring-amber-500/20">
+                  {skippedEntries.length} matching {skippedEntries.length === 1 ? "entry was" : "entries were"} skipped
+                  by token budget.
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {activeLorebookScanLoading && visibleLorebookIds.length > 0 && (
+          <div className="flex items-center gap-2 px-2 py-1.5 text-[0.625rem] text-foreground/50">
+            <Loader2 size="0.6875rem" className="animate-spin" />
+            Scanning active lorebook entries...
+          </div>
+        )}
+        {promptPresetId && (
+          <button type="button" role="menuitem" className={itemClassName} onClick={() => openPreset(promptPresetId)}>
+            <FileText size="0.8125rem" className={iconClassName} />
+            <span className="min-w-0 flex-1 truncate">{presetName ?? "Prompt preset"}</span>
+            <span className="shrink-0 text-[0.625rem] text-foreground/45">Preset</span>
+          </button>
+        )}
+      </div>
+    </>
+  );
 
   return (
     <div className="relative" ref={ref} onClick={(event) => event.stopPropagation()}>
       <button
+        ref={buttonRef}
         onClick={() => setOpen((prev) => !prev)}
         className={getChatToolbarButtonClass({ compact, open })}
         title="Active Context"
@@ -402,95 +520,45 @@ function ActiveContextLinksButton({
       >
         <BookOpen size="0.875rem" />
       </button>
-      {open && (
-        <div
-          role="menu"
-          className={cn(
-            ROLEPLAY_POPOVER_SHELL,
-            ROLEPLAY_POPOVER_SCROLL_AREA,
-            "absolute right-0 top-full z-50 mt-2 max-h-[min(32rem,calc(100vh-6rem))] w-72 overflow-y-auto p-2",
-          )}
-        >
-          <div className={cn(ROLEPLAY_POPOVER_TITLE, "px-2 pb-1")}>
-            <BookOpen size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
-            Active Context
-          </div>
-          <div className="space-y-1">
-            {characterIds.map((id, index) => (
-              <button
-                key={id}
-                type="button"
-                role="menuitem"
-                className={itemClassName}
-                onClick={() => openCharacter(id)}
+      {open &&
+        (isMobile
+          ? createPortal(
+              <div
+                ref={panelRef}
+                role="menu"
+                className={cn(
+                  ROLEPLAY_POPOVER_SHELL,
+                  ROLEPLAY_POPOVER_SCROLL_AREA,
+                  "fixed z-[9999] overflow-y-auto p-2",
+                )}
+                style={
+                  mobileFrame
+                    ? {
+                        top: mobileFrame.top,
+                        left: mobileFrame.left,
+                        width: mobileFrame.width,
+                        maxHeight: mobileFrame.maxHeight,
+                      }
+                    : undefined
+                }
               >
-                <User size="0.8125rem" className={iconClassName} />
-                <span className="min-w-0 flex-1 truncate">
-                  {characterMap.get(id)?.name ?? `Character ${index + 1}`}
-                </span>
-                <span className="shrink-0 text-[0.625rem] text-foreground/45">Card</span>
-              </button>
-            ))}
-            {visibleLorebookIds.map((id, index) => {
-              const entries = triggeredEntriesByLorebook.get(id) ?? [];
-              const skippedEntries = skippedEntriesByLorebook.get(id) ?? [];
-              return (
-                <div key={id} className="space-y-1">
-                  <button type="button" role="menuitem" className={itemClassName} onClick={() => openLorebook(id)}>
-                    <BookOpen size="0.8125rem" className={iconClassName} />
-                    <span className="min-w-0 flex-1 truncate">
-                      {lorebookNameById.get(id) ?? `Lorebook ${index + 1}`}
-                    </span>
-                    <span className="shrink-0 text-[0.625rem] text-foreground/45">
-                      {entries.length > 0 ? `${entries.length} hit${entries.length === 1 ? "" : "s"}` : "Lorebook"}
-                    </span>
-                  </button>
-                  {entries.length > 0 && (
-                    <div className="ml-6 space-y-1 border-l border-foreground/10 pl-2">
-                      {entries.map((entry) => (
-                        <div key={entry.id} className={entryClassName} title={entry.content || entry.name}>
-                          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
-                          <span className="min-w-0 flex-1 truncate">{entry.name}</span>
-                          {entry.constant && (
-                            <span className="shrink-0 rounded bg-amber-400/15 px-1 py-0.5 text-[0.5rem] font-semibold text-amber-300">
-                              CONST
-                            </span>
-                          )}
-                          <span className="shrink-0 text-foreground/40">#{entry.order}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {skippedEntries.length > 0 && (
-                    <div className="ml-6 rounded-md bg-amber-500/10 px-2 py-1 text-[0.625rem] leading-relaxed text-amber-100/80 ring-1 ring-amber-500/20">
-                      {skippedEntries.length} matching {skippedEntries.length === 1 ? "entry was" : "entries were"}{" "}
-                      skipped by token budget.
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-            {activeLorebookScanLoading && visibleLorebookIds.length > 0 && (
-              <div className="flex items-center gap-2 px-2 py-1.5 text-[0.625rem] text-foreground/50">
-                <Loader2 size="0.6875rem" className="animate-spin" />
-                Scanning active lorebook entries...
+                {activeContextContent}
+              </div>,
+              document.body,
+            )
+          : (
+              <div
+                ref={panelRef}
+                role="menu"
+                className={cn(
+                  ROLEPLAY_POPOVER_SHELL,
+                  ROLEPLAY_POPOVER_SCROLL_AREA,
+                  "absolute right-0 top-full z-50 mt-2 max-h-[min(32rem,calc(100vh-6rem))] w-72 overflow-y-auto p-2",
+                )}
+              >
+                {activeContextContent}
               </div>
-            )}
-            {promptPresetId && (
-              <button
-                type="button"
-                role="menuitem"
-                className={itemClassName}
-                onClick={() => openPreset(promptPresetId)}
-              >
-                <FileText size="0.8125rem" className={iconClassName} />
-                <span className="min-w-0 flex-1 truncate">{presetName ?? "Prompt preset"}</span>
-                <span className="shrink-0 text-[0.625rem] text-foreground/45">Preset</span>
-              </button>
-            )}
-          </div>
-        </div>
-      )}
+          ))}
     </div>
   );
 }
@@ -521,14 +589,51 @@ function SummaryButton({
   totalMessageCount: number;
 }) {
   const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [anchor, setAnchor] = useState<ComponentProps<typeof SummaryPopover>["anchor"]>(null);
   const compact = useUIStore((s) => s.centerCompact);
+
+  useLayoutEffect(() => {
+    if (!open || !buttonRef.current) return;
+    const update = () => {
+      if (!buttonRef.current) return;
+      const rect = buttonRef.current.getBoundingClientRect();
+      setAnchor({
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+      });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [open]);
 
   if (!chatId) return null;
 
   return (
     <div className="relative" onClick={(e) => e.stopPropagation()}>
       <button
-        onClick={() => setOpen(!open)}
+        ref={buttonRef}
+        onClick={() => {
+          const rect = buttonRef.current?.getBoundingClientRect();
+          if (rect) {
+            setAnchor({
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+              left: rect.left,
+              width: rect.width,
+            });
+          }
+          setOpen(!open);
+        }}
         className={getChatToolbarButtonClass({ active: !!summary, compact, open })}
         title="Chat Summary"
       >
@@ -548,6 +653,7 @@ function SummaryButton({
             summaryRunInterval={summaryRunInterval}
             automaticSummariesAvailable={automaticSummariesAvailable}
             totalMessageCount={totalMessageCount}
+            anchor={anchor}
             onClose={() => setOpen(false)}
           />
         </Suspense>
@@ -559,17 +665,34 @@ function SummaryButton({
 function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMeta: Record<string, any> }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [mobileFrame, setMobileFrame] = useState<MobileFloatingPanelFrame | null>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const compact = useUIStore((s) => s.centerCompact);
 
   useEffect(() => {
-    if (!open || isMobile) return;
+    if (!open) return;
     const handle = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
+      setOpen(false);
     };
     document.addEventListener("mousedown", handle);
     return () => document.removeEventListener("mousedown", handle);
-  }, [open, isMobile]);
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open || !isMobile) return;
+    const update = () => setMobileFrame(getMobileFloatingPanelFrame(buttonRef.current, 288));
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [isMobile, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -587,6 +710,7 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
   return (
     <div className="relative" ref={ref} onClick={(e) => e.stopPropagation()}>
       <button
+        ref={buttonRef}
         onClick={() => setOpen(!open)}
         className={getChatToolbarButtonClass({ active: hasNotes, compact, open })}
         title="Author's Notes"
@@ -597,33 +721,45 @@ function AuthorNotesButton({ chatId, chatMeta }: { chatId: string | null; chatMe
         (isMobile ? (
           createPortal(
             <div
-              className={PANEL_BACKDROP}
+              ref={panelRef}
+              className={cn(
+                ROLEPLAY_POPOVER_SHELL,
+                ROLEPLAY_POPOVER_SCROLL_AREA,
+                "fixed z-[9999] overflow-y-auto p-3",
+              )}
+              style={
+                mobileFrame
+                  ? {
+                      top: mobileFrame.top,
+                      left: mobileFrame.left,
+                      width: mobileFrame.width,
+                      maxHeight: mobileFrame.maxHeight,
+                    }
+                  : undefined
+              }
               onMouseDown={(e) => e.stopPropagation()}
               onTouchStart={(e) => e.stopPropagation()}
             >
-              <div className="absolute inset-0 bg-black/30" onClick={() => setOpen(false)} />
-              <div className={PANEL_CONTAINER} onClick={(e) => e.stopPropagation()}>
-                <Suspense
-                  fallback={
-                    <div className="flex items-center gap-2 py-4 text-xs text-[var(--muted-foreground)]">
-                      <Loader2 size="0.75rem" className="animate-spin" />
-                      Loading author's notes...
-                    </div>
-                  }
-                >
-                  <AuthorNotesPanel
-                    chatId={chatId}
-                    chatMeta={chatMeta}
-                    isMobile={isMobile}
-                    onClose={() => setOpen(false)}
-                  />
-                </Suspense>
-              </div>
+              <Suspense
+                fallback={
+                  <div className="flex items-center gap-2 py-4 text-xs text-[var(--muted-foreground)]">
+                    <Loader2 size="0.75rem" className="animate-spin" />
+                    Loading author's notes...
+                  </div>
+                }
+              >
+                <AuthorNotesPanel
+                  chatId={chatId}
+                  chatMeta={chatMeta}
+                  isMobile={isMobile}
+                  onClose={() => setOpen(false)}
+                />
+              </Suspense>
             </div>,
             document.body,
           )
         ) : (
-          <div className={cn(ROLEPLAY_POPOVER_SHELL, "absolute right-0 top-full z-50 mt-2 w-72 p-3")}>
+          <div ref={panelRef} className={cn(ROLEPLAY_POPOVER_SHELL, "absolute right-0 top-full z-50 mt-2 w-72 p-3")}>
             <Suspense
               fallback={
                 <div className="flex items-center gap-2 py-4 text-xs text-[var(--muted-foreground)]">
@@ -1060,7 +1196,12 @@ export function ChatRoleplaySurface({
                     </Suspense>
                   </div>
                 )}
-                <div className="pointer-events-auto ml-auto flex shrink-0 items-center gap-1.5">
+                <div
+                  className={cn(
+                    "pointer-events-auto ml-auto flex shrink-0 items-center",
+                    CHAT_TOOLBAR_ICON_GAP_CLASS,
+                  )}
+                >
                   <ChatBranchSelector
                     activeChatId={activeChatId}
                     activeChatName={chat?.name}
@@ -1121,28 +1262,30 @@ export function ChatRoleplaySurface({
               >
                 {chat && chatMeta.enableAgents && (
                   <div
-                    className="flex min-w-0 w-full items-center gap-1.5 overflow-x-auto pb-1 pt-2"
+                    className="flex w-full min-w-0 items-start justify-between gap-1.5 pb-1 pt-2"
                     style={{
                       paddingLeft: "calc(0.5rem + var(--tracker-panel-hud-clear-left, 0px))",
                       paddingRight: "calc(0.5rem + var(--tracker-panel-hud-clear-right, 0px))",
                     }}
                   >
-                    <Suspense fallback={null}>
-                      <RoleplayHUD
-                        chatId={chat.id}
-                        characterCount={chatCharIds.length}
-                        layout="top"
-                        isStreaming={isStreaming}
-                        onRetriggerTrackers={onRerunTrackers}
-                        onRetryFailedAgents={onRetryFailedAgents}
-                        onRerunSingleTracker={onRerunSingleTracker}
-                        enabledAgentTypes={enabledAgentTypes}
-                        manualTrackers={!!chatMeta.manualTrackers}
-                        mobileCompact
-                        injectionSourceMessages={messages}
-                      />
-                    </Suspense>
-                    <div className="flex shrink-0 items-center gap-1.5">
+                    <div className="min-w-0 flex-1 overflow-x-auto">
+                      <Suspense fallback={null}>
+                        <RoleplayHUD
+                          chatId={chat.id}
+                          characterCount={chatCharIds.length}
+                          layout="top"
+                          isStreaming={isStreaming}
+                          onRetriggerTrackers={onRerunTrackers}
+                          onRetryFailedAgents={onRetryFailedAgents}
+                          onRerunSingleTracker={onRerunSingleTracker}
+                          enabledAgentTypes={enabledAgentTypes}
+                          manualTrackers={!!chatMeta.manualTrackers}
+                          mobileCompact
+                          injectionSourceMessages={messages}
+                        />
+                      </Suspense>
+                    </div>
+                    <div className={cn("ml-auto flex shrink-0 items-center", CHAT_TOOLBAR_ICON_GAP_CLASS)}>
                       <ChatToolbarMenu>
                         <ChatBranchSelector
                           activeChatId={activeChatId}
@@ -1199,7 +1342,12 @@ export function ChatRoleplaySurface({
                   </div>
                 )}
                 {chat && !chatMeta.enableAgents && (
-                  <div className="flex w-full items-center justify-end gap-1.5 px-2 pb-1 pt-2">
+                  <div
+                    className={cn(
+                      "flex w-full items-center justify-end px-2 pb-1 pt-2",
+                      CHAT_TOOLBAR_ICON_GAP_CLASS,
+                    )}
+                  >
                     <ChatToolbarMenu>
                       <ChatBranchSelector
                         activeChatId={activeChatId}
@@ -1267,7 +1415,7 @@ export function ChatRoleplaySurface({
                 data-chat-scroll
                 className={cn(
                   "rpg-chat-messages-mobile mari-messages-scroll relative h-full overflow-y-auto overflow-x-hidden",
-                  centerCompact ? "px-3" : "px-3 md:px-[15%]",
+                  centerCompact ? "px-3" : "px-3 md:px-8 lg:px-10 xl:px-12",
                 )}
                 style={{
                   paddingTop: Math.max(16, chromeHeights.top + 12),

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -9,7 +9,6 @@ import {
 } from "react";
 import { MoreHorizontal } from "lucide-react";
 import { cn } from "../../lib/utils";
-import { useUIStore } from "../../stores/ui.store";
 import { ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
 
 type ChatToolbarButtonClassInput = {
@@ -20,6 +19,17 @@ type ChatToolbarButtonClassInput = {
   sizeClassName?: string;
 };
 
+export const CHAT_TOOLBAR_ICON_GAP_CLASS = "gap-0.5";
+export const CHAT_TOOLBAR_DEFAULT_BUTTON_SIZE_CLASS = "h-8 w-8";
+export const CHAT_TOOLBAR_IDENTITY_PILL_SIZE_CLASS = "h-8 w-auto max-md:h-9";
+export const CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS = "max-md:h-9";
+export const CHAT_TOOLBAR_OVERFLOW_BUTTON_SIZE_CLASS = "h-9 w-10";
+export const CHAT_TOOLBAR_OVERFLOW_MENU_CLASS = cn(
+  ROLEPLAY_POPOVER_SHELL,
+  "marinara-chat-toolbar-overflow-menu flex w-10 flex-col items-center p-1",
+  CHAT_TOOLBAR_ICON_GAP_CLASS,
+);
+
 export function getChatToolbarButtonClass({
   active = false,
   className,
@@ -29,10 +39,13 @@ export function getChatToolbarButtonClass({
 }: ChatToolbarButtonClassInput = {}) {
   return cn(
     "marinara-chat-toolbar-button flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
-    sizeClassName ?? "h-8 w-8",
+    sizeClassName ?? CHAT_TOOLBAR_DEFAULT_BUTTON_SIZE_CLASS,
     compact ? "p-1" : "p-1.5",
-    (active || open) &&
+    active &&
       "marinara-chat-toolbar-button--active border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]",
+    !active &&
+      open &&
+      "marinara-chat-toolbar-button--open border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-hover)] text-[var(--marinara-chat-chrome-button-text-hover)]",
     className,
   );
 }
@@ -65,20 +78,66 @@ export function ChatToolbarButton({
 
 export function ChatToolbarMenu({
   children,
+  className,
   desktopChildren,
   mobileChildren,
 }: {
   children?: ReactNode;
+  className?: string;
   desktopChildren?: ReactNode;
   mobileChildren?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
-  const compact = useUIStore((s) => s.centerCompact);
+  const [overflowCollapsed, setOverflowCollapsed] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const desktopRef = useRef<HTMLDivElement>(null);
   const btnRef = useRef<HTMLDivElement>(null);
   const popRef = useRef<HTMLDivElement>(null);
+  const neededDesktopWidthRef = useRef(0);
   const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
   const resolvedDesktopChildren = desktopChildren ?? children;
   const resolvedMobileChildren = mobileChildren ?? children;
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root || typeof window === "undefined") return;
+
+    const mobileQuery = window.matchMedia("(max-width: 767px)");
+    const measure = () => {
+      if (mobileQuery.matches) {
+        setOverflowCollapsed(false);
+        return;
+      }
+
+      const desktop = desktopRef.current;
+      const availableWidth = root.clientWidth;
+      const measuredWidth = desktop?.scrollWidth ?? neededDesktopWidthRef.current;
+      if (desktop && measuredWidth > 0) {
+        neededDesktopWidthRef.current = measuredWidth;
+      }
+
+      if (desktop && measuredWidth > availableWidth + 2) {
+        setOverflowCollapsed(true);
+        return;
+      }
+
+      if (!desktop && neededDesktopWidthRef.current > 0 && availableWidth > neededDesktopWidthRef.current + 24) {
+        setOverflowCollapsed(false);
+      }
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    if (desktopRef.current) observer.observe(desktopRef.current);
+    mobileQuery.addEventListener("change", measure);
+    window.addEventListener("resize", measure);
+    return () => {
+      observer.disconnect();
+      mobileQuery.removeEventListener("change", measure);
+      window.removeEventListener("resize", measure);
+    };
+  }, [overflowCollapsed]);
 
   useLayoutEffect(() => {
     if (!open || !btnRef.current) return;
@@ -102,15 +161,17 @@ export function ChatToolbarMenu({
   }, [open]);
 
   return (
-    <>
-      <div className={cn("items-center gap-1.5 max-md:hidden", compact ? "hidden" : "flex")}>
-        {resolvedDesktopChildren}
-      </div>
-      <div className={cn("relative shrink-0", compact ? "block" : "block md:hidden")} ref={btnRef}>
+    <div ref={rootRef} className={cn("relative flex min-w-0 items-center justify-end", className)}>
+      {!overflowCollapsed && (
+        <div ref={desktopRef} className={cn("flex items-center max-md:hidden", CHAT_TOOLBAR_ICON_GAP_CLASS)}>
+          {resolvedDesktopChildren}
+        </div>
+      )}
+      <div className={cn("relative shrink-0", overflowCollapsed ? "block" : "block md:hidden")} ref={btnRef}>
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className={getChatToolbarButtonClass({ className: "h-9 w-9", open })}
+          className={getChatToolbarButtonClass({ className: CHAT_TOOLBAR_OVERFLOW_BUTTON_SIZE_CLASS, open })}
           title="More options"
           aria-label="More options"
           aria-haspopup="menu"
@@ -122,7 +183,7 @@ export function ChatToolbarMenu({
           createPortal(
             <div
               ref={popRef}
-              className={cn(ROLEPLAY_POPOVER_SHELL, "fixed z-[9999] flex w-9 flex-col items-center gap-0.5 p-1")}
+              className={cn(CHAT_TOOLBAR_OVERFLOW_MENU_CLASS, "fixed z-[9999]")}
               style={{ top: pos.top, right: pos.right }}
               onClick={() => setOpen(false)}
             >
@@ -131,6 +192,6 @@ export function ChatToolbarMenu({
             document.body,
           )}
       </div>
-    </>
+    </div>
   );
 }

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -106,6 +106,7 @@ export function ChatToolbarMenu({
     const measure = () => {
       if (mobileQuery.matches) {
         setOverflowCollapsed(false);
+        setOpen(false);
         return;
       }
 
@@ -123,6 +124,7 @@ export function ChatToolbarMenu({
 
       if (!desktop && neededDesktopWidthRef.current > 0 && availableWidth > neededDesktopWidthRef.current + 24) {
         setOverflowCollapsed(false);
+        setOpen(false);
       }
     };
 

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -15,10 +15,7 @@ import {
   Loader2,
   FileText,
   RefreshCw,
-  Bookmark,
-  Trash2,
   WandSparkles,
-  Dices,
 } from "lucide-react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
@@ -28,7 +25,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { useGenerate } from "../../hooks/use-generate";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, useChat, chatKeys } from "../../hooks/use-chats";
-import { characterKeys, usePersonas, useUpdatePersona } from "../../hooks/use-characters";
+import { characterKeys } from "../../hooks/use-characters";
 import {
   matchSlashCommand,
   getSlashCompletions,
@@ -49,6 +46,7 @@ import { GifPicker } from "../ui/GifPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
 import { QuickReplyMenu, type QuickReplyAction } from "./QuickReplyMenu";
+import { getChatInputShellClass } from "./chat-input-styles";
 import { buildGuidedGenerationInstructionMessage, formatTextQuotes, type Message } from "@marinara-engine/shared";
 
 interface Attachment {
@@ -70,19 +68,10 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yml",
 ]);
 
-const SAVED_STATUS_LIMIT = 12;
-const SAVED_STATUS_MAX_LENGTH = 120;
 const CONVERSATION_HIDDEN_SLASH_COMMANDS = new Set(["impersonate", "impersonate_prompt"]);
 
 function isConversationHiddenSlashCommand(command: SlashCommand): boolean {
   return CONVERSATION_HIDDEN_SLASH_COMMANDS.has(command.name);
-}
-
-interface PersonaStatusRow {
-  id: string;
-  name?: string;
-  isActive?: string | boolean;
-  savedStatusOptions?: string | string[] | null;
 }
 
 function getFileExtension(fileName: string): string {
@@ -115,43 +104,6 @@ function isSupportedChatAttachment(file: File): boolean {
     return true;
   }
   return TEXT_ATTACHMENT_EXTENSIONS.has(getFileExtension(file.name));
-}
-
-function normalizeSavedStatus(value: string): string {
-  return value.replace(/\s+/g, " ").trim().slice(0, SAVED_STATUS_MAX_LENGTH);
-}
-
-function parseSavedStatusOptions(value: PersonaStatusRow["savedStatusOptions"]): string[] {
-  const raw = (() => {
-    if (Array.isArray(value)) return value;
-    if (typeof value !== "string" || !value.trim()) return [];
-    try {
-      const parsed = JSON.parse(value) as unknown;
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  })();
-
-  const byKey = new Map<string, string>();
-  for (const item of raw) {
-    if (typeof item !== "string") continue;
-    const normalized = normalizeSavedStatus(item);
-    if (!normalized) continue;
-    byKey.set(normalized.toLowerCase(), normalized);
-  }
-  return [...byKey.values()].slice(0, SAVED_STATUS_LIMIT);
-}
-
-function resolveActivePersona(
-  personas: PersonaStatusRow[] | undefined,
-  chat: { personaId?: string | null; mode?: string } | undefined | null,
-) {
-  if (!personas) return undefined;
-  const chatPersonaId = chat?.personaId ?? null;
-  if (chatPersonaId) return personas.find((p) => p.id === chatPersonaId);
-  if (chat?.mode === "game") return undefined;
-  return personas.find((p) => p.isActive === "true" || p.isActive === true);
 }
 
 function readFileAsDataUrl(file: Blob): Promise<string> {
@@ -200,18 +152,11 @@ export function ConversationInput({
   const [mentionStartPos, setMentionStartPos] = useState(0);
   const [charPickerOpen, setCharPickerOpen] = useState(false);
   const [charPickerPos, setCharPickerPos] = useState<{ left: number; top: number } | null>(null);
-  const [statusMenuOpen, setStatusMenuOpen] = useState(false);
-  const [statusMenuPos, setStatusMenuPos] = useState<{ left: number; top: number } | null>(null);
-  const [diceMenuOpen, setDiceMenuOpen] = useState(false);
-  const [diceResult, setDiceResult] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const gifButtonRef = useRef<HTMLButtonElement>(null);
-  const statusButtonRef = useRef<HTMLButtonElement>(null);
-  const statusMenuRef = useRef<HTMLDivElement>(null);
-  const diceButtonRef = useRef<HTMLButtonElement>(null);
   const charPickerBtnRef = useRef<HTMLButtonElement>(null);
   const charPickerMenuRef = useRef<HTMLDivElement>(null);
   const inputBarRef = useRef<HTMLDivElement>(null);
@@ -238,13 +183,9 @@ export function ConversationInput({
   const showQuickReplyGuide = useUIStore((s) => s.showQuickReplyGuide);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
-  const userActivity = useUIStore((s) => s.userActivity);
-  const setUserActivity = useUIStore((s) => s.setUserActivity);
   const createMessage = useCreateMessage(activeChatId);
   const deleteMessage = useDeleteMessage(activeChatId);
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
-  const { data: allPersonas } = usePersonas();
-  const updatePersona = useUpdatePersona();
   const qc = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pendingAttachmentReads = activeChatId ? (pendingAttachmentReadsByChat[activeChatId] ?? 0) : 0;
@@ -542,38 +483,6 @@ export function ConversationInput({
       el.focus();
     },
     [activeChatId, mentionStartPos, setInputDraft, syncInputState],
-  );
-
-  const parseDiceNotation = useCallback((notation: string) => {
-    const match = notation.trim().match(/^(\d+)?d(\d+)([+-]\d+)?$/i);
-    if (!match) return null;
-    return {
-      count: Number.parseInt(match[1] ?? "1", 10),
-      sides: Number.parseInt(match[2]!, 10),
-      modifier: match[3] ? Number.parseInt(match[3], 10) : 0,
-    };
-  }, []);
-
-  const rollDice = useCallback((count: number, sides: number) => {
-    const rolls: number[] = [];
-    for (let i = 0; i < count; i += 1) rolls.push(Math.floor(Math.random() * sides) + 1);
-    return rolls;
-  }, []);
-
-  const handleDiceRoll = useCallback(
-    (notation: string) => {
-      const parsed = parseDiceNotation(notation);
-      if (!parsed) {
-        toast.error(`Invalid dice notation: ${notation}`);
-        return;
-      }
-      const rolls = rollDice(parsed.count, parsed.sides);
-      const sum = rolls.reduce((a, b) => a + b, 0) + parsed.modifier;
-      const modStr = parsed.modifier > 0 ? `+${parsed.modifier}` : parsed.modifier < 0 ? `${parsed.modifier}` : "";
-      const detail = parsed.count > 1 ? ` [${rolls.join(", ")}]${modStr}` : modStr ? ` (${rolls[0]}${modStr})` : "";
-      setDiceResult(`🎲 ${notation} → ${sum}${detail}`);
-    },
-    [parseDiceNotation, rollDice],
   );
 
   const handleSend = useCallback(async () => {
@@ -1321,23 +1230,6 @@ export function ConversationInput({
   }, [charPickerOpen]);
 
   useEffect(() => {
-    if (!statusMenuOpen) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (
-        statusMenuRef.current &&
-        !statusMenuRef.current.contains(target) &&
-        statusButtonRef.current &&
-        !statusButtonRef.current.contains(target)
-      ) {
-        setStatusMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [statusMenuOpen]);
-
-  useEffect(() => {
     if (!charPickerOpen || !charPickerBtnRef.current) return;
     const rect = charPickerBtnRef.current.getBoundingClientRect();
     const inputBox = charPickerBtnRef.current.closest(".rounded-2xl") as HTMLElement | null;
@@ -1353,32 +1245,7 @@ export function ConversationInput({
   }, [charPickerOpen]);
 
   const showCharPicker = groupResponseOrder === "manual" && !!activeChatCharacters && activeChatCharacters.length > 1;
-  const activePersona = resolveActivePersona(
-    allPersonas as PersonaStatusRow[] | undefined,
-    activeChat as { personaId?: string | null; mode?: string } | undefined,
-  );
-  const savedStatusOptions = parseSavedStatusOptions(activePersona?.savedStatusOptions);
-  const normalizedUserActivity = normalizeSavedStatus(userActivity);
-  const canSaveCurrentStatus =
-    !!activePersona &&
-    !!normalizedUserActivity &&
-    !savedStatusOptions.some((option) => option.toLowerCase() === normalizedUserActivity.toLowerCase());
   const showDraftTranslateButton = chatMetadata.showInputTranslateButton === true;
-
-  useEffect(() => {
-    if (!statusMenuOpen || !statusButtonRef.current) return;
-    const rect = statusButtonRef.current.getBoundingClientRect();
-    const inputBox = statusButtonRef.current.closest(".rounded-2xl") as HTMLElement | null;
-    const anchorTop = inputBox ? inputBox.getBoundingClientRect().top : rect.top;
-    requestAnimationFrame(() => {
-      const menuEl = statusMenuRef.current;
-      const menuHeight = menuEl?.offsetHeight || 260;
-      const menuWidth = menuEl?.offsetWidth || 260;
-      let left = rect.right - menuWidth;
-      if (left < 8) left = 8;
-      setStatusMenuPos({ left, top: Math.max(8, anchorTop - menuHeight - 4) });
-    });
-  }, [statusMenuOpen, savedStatusOptions.length, canSaveCurrentStatus]);
 
   const handleTranslateDraft = useCallback(async () => {
     if (!activeChatId || isTranslatingDraft) return;
@@ -1400,47 +1267,6 @@ export function ConversationInput({
       setIsTranslatingDraft(false);
     }
   }, [activeChatId, isTranslatingDraft, quoteFormat, setInputDraft, syncInputState]);
-
-  const persistSavedStatusOptions = useCallback(
-    async (nextOptions: string[]) => {
-      if (!activePersona) {
-        toast.info("Choose a persona before saving status options.");
-        return;
-      }
-      await updatePersona.mutateAsync({
-        id: activePersona.id,
-        savedStatusOptions: JSON.stringify(nextOptions.slice(0, SAVED_STATUS_LIMIT)),
-      });
-    },
-    [activePersona, updatePersona],
-  );
-
-  const handleSaveCurrentStatus = useCallback(async () => {
-    if (!normalizedUserActivity || !activePersona) return;
-    const nextOptions = [
-      normalizedUserActivity,
-      ...savedStatusOptions.filter((option) => option.toLowerCase() !== normalizedUserActivity.toLowerCase()),
-    ];
-    await persistSavedStatusOptions(nextOptions);
-    toast.success("Saved status for this persona");
-  }, [activePersona, normalizedUserActivity, persistSavedStatusOptions, savedStatusOptions]);
-
-  const handleApplySavedStatus = useCallback(
-    (status: string) => {
-      setUserActivity(status);
-      setStatusMenuOpen(false);
-    },
-    [setUserActivity],
-  );
-
-  const handleDeleteSavedStatus = useCallback(
-    async (status: string) => {
-      const nextOptions = savedStatusOptions.filter((option) => option.toLowerCase() !== status.toLowerCase());
-      await persistSavedStatusOptions(nextOptions);
-      toast.success("Removed saved status");
-    },
-    [persistSavedStatusOptions, savedStatusOptions],
-  );
 
   const handleSpeechTranscript = useCallback(
     (transcript: string) => {
@@ -1575,10 +1401,11 @@ export function ConversationInput({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        className={cn(
-          "relative flex flex-wrap items-end gap-1 rounded-2xl border border-foreground/20 bg-[var(--card)] px-2 py-1.5 shadow-sm transition-all duration-200 focus-within:border-foreground/35 focus-within:ring-1 focus-within:ring-foreground/10 sm:flex-nowrap sm:items-center sm:gap-2 sm:px-4 sm:py-2.5 dark:bg-black/40",
-          isDragging ? "border-foreground/40 bg-foreground/10 shadow-lg shadow-black/10" : "",
-        )}
+        className={getChatInputShellClass({
+          dragging: isDragging,
+          hasContent: hasInput || attachments.length > 0,
+          layout: "conversation",
+        })}
       >
         {/* Attach button */}
         <input
@@ -1595,7 +1422,7 @@ export function ConversationInput({
         <button
           onClick={() => fileInputRef.current?.click()}
           className={cn(
-            "order-2 flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 sm:order-none sm:h-8 sm:w-8",
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl transition-all active:scale-90 sm:h-8 sm:w-8",
             attachments.length
               ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -1608,7 +1435,7 @@ export function ConversationInput({
         {/* Quick Switchers — desktop: inline, mobile: chevron */}
         <QuickConnectionSwitcher className="hidden sm:flex" />
         <QuickPersonaSwitcher className="hidden sm:flex" />
-        <div className="order-2 sm:hidden">
+        <div className="flex shrink-0 sm:hidden">
           <QuickSwitcherMobile />
         </div>
 
@@ -1631,59 +1458,11 @@ export function ConversationInput({
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          className="order-1 max-h-[12.5rem] min-w-0 basis-full flex-1 resize-none bg-transparent py-0 text-[1rem] leading-normal text-foreground outline-none placeholder:text-foreground/30 sm:order-none sm:basis-auto"
+          className="max-h-[12.5rem] min-h-9 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-[1rem] leading-tight text-foreground outline-none placeholder:text-foreground/30 sm:min-h-0 sm:px-0 sm:py-0 sm:leading-normal"
         />
 
         {/* Right actions */}
-        <div className="order-2 ml-auto flex min-w-0 flex-1 flex-nowrap items-center justify-end gap-0.5 sm:order-none sm:flex-none sm:shrink-0">
-          <div className="relative">
-            <button
-              ref={diceButtonRef}
-              type="button"
-              onClick={() => {
-                setDiceMenuOpen((v) => !v);
-                setStatusMenuOpen(false);
-                setCharPickerOpen(false);
-              }}
-              className={cn(
-                "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
-                diceMenuOpen
-                  ? "bg-foreground/10 text-foreground/75"
-                  : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-              )}
-              title="Roll dice"
-            >
-              <Dices size="1rem" />
-            </button>
-            {diceMenuOpen && (
-              <div className="absolute bottom-full right-0 z-[9999] mb-2 w-48 rounded-xl border border-[var(--border)] bg-[var(--card)] p-2 shadow-2xl">
-                <div className="mb-2 text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
-                  Quick Roll
-                </div>
-                <div className="grid grid-cols-2 gap-1.5">
-                  {['1d4', '1d6', '1d8', '1d10', '1d20', '2d6', '3d6', '1d100'].map((notation) => (
-                    <button
-                      key={notation}
-                      type="button"
-                      onClick={() => {
-                        handleDiceRoll(notation);
-                        setDiceMenuOpen(false);
-                      }}
-                      className="rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs transition-colors hover:bg-[var(--accent)]"
-                    >
-                      {notation}
-                    </button>
-                  ))}
-                </div>
-                {diceResult && (
-                  <div className="mt-2 rounded-lg bg-[var(--secondary)]/60 px-2 py-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                    {diceResult}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
+        <div className="ml-0 flex shrink-0 flex-nowrap items-center justify-end gap-0 sm:ml-auto sm:gap-0.5">
           <div className="relative">
             <button
               ref={gifButtonRef}
@@ -1692,7 +1471,7 @@ export function ConversationInput({
                 setEmojiOpen(false);
               }}
               className={cn(
-                "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
+                "flex h-9 w-9 items-center justify-center rounded-xl transition-colors sm:h-8 sm:w-8 sm:rounded-full",
                 gifOpen
                   ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                   : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -1741,7 +1520,7 @@ export function ConversationInput({
               ref={charPickerBtnRef}
               onClick={() => setCharPickerOpen((v) => !v)}
               className={cn(
-                "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
+                "hidden h-11 w-11 items-center justify-center rounded-full transition-colors sm:flex sm:h-8 sm:w-8",
                 guideGenerations && hasInput
                   ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
                   : charPickerOpen
@@ -1762,7 +1541,7 @@ export function ConversationInput({
               onClick={() => void handleTranslateDraft()}
               disabled={!activeChatId || !hasInput || isTranslatingDraft}
               className={cn(
-                "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
+                "hidden h-11 w-11 items-center justify-center rounded-full transition-colors sm:flex sm:h-8 sm:w-8",
                 hasInput && !isTranslatingDraft
                   ? "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70"
                   : "text-foreground/25",
@@ -1777,34 +1556,18 @@ export function ConversationInput({
             <SpeechToTextButton
               disabled={!activeChatId}
               onTranscript={handleSpeechTranscript}
-              className="rounded-full"
+              className="hidden rounded-full sm:flex"
               iconSize={16}
             />
           )}
 
-          <button
-            ref={statusButtonRef}
-            type="button"
-            onClick={() => setStatusMenuOpen((v) => !v)}
-            disabled={!activePersona}
-            className={cn(
-              "flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-8 sm:w-8",
-              statusMenuOpen
-                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
-                : activePersona
-                  ? "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70"
-                  : "text-foreground/25",
-            )}
-            title={activePersona ? "Saved persona statuses" : "Choose a persona to save statuses"}
-          >
-            <Bookmark size="1rem" />
-          </button>
-
           {showQuickRepliesMenu && quickReplyActions.length > 0 && (
-            <QuickReplyMenu
-              actions={quickReplyActions}
-              disabled={!activeChatId || isReadingAttachments || (!hasInput && attachments.length === 0)}
-            />
+            <div className="hidden sm:block">
+              <QuickReplyMenu
+                actions={quickReplyActions}
+                disabled={!activeChatId || isReadingAttachments || (!hasInput && attachments.length === 0)}
+              />
+            </div>
           )}
 
           <button
@@ -1812,7 +1575,7 @@ export function ConversationInput({
             disabled={!isActuallyGenerating && (isReadingAttachments || !activeChatId || !canSubmit)}
             aria-label={sendButtonTitle}
             className={cn(
-              "flex h-11 w-11 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
+              "flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
               isActuallyGenerating
                 ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90"
                 : canSubmit && !isReadingAttachments
@@ -1831,70 +1594,6 @@ export function ConversationInput({
           </button>
         </div>
       </div>
-      {diceMenuOpen && (
-        <button
-          type="button"
-          aria-hidden="true"
-          tabIndex={-1}
-          className="fixed inset-0 z-[9998] cursor-default"
-          onClick={() => setDiceMenuOpen(false)}
-        />
-      )}
-      {statusMenuOpen &&
-        createPortal(
-          <div
-            ref={statusMenuRef}
-            className="fixed z-[9999] flex max-h-[320px] min-w-[240px] max-w-[300px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
-            style={
-              statusMenuPos ? { left: statusMenuPos.left, top: statusMenuPos.top } : { visibility: "hidden" as const }
-            }
-          >
-            <div className="border-b border-foreground/10 px-3 py-2">
-              <div className="truncate text-xs font-semibold">Saved Statuses</div>
-              <div className="truncate text-[0.625rem] text-foreground/45">
-                {activePersona?.name ?? "No persona selected"}
-              </div>
-            </div>
-            <div className="min-h-0 overflow-y-auto p-1">
-              {canSaveCurrentStatus && (
-                <button
-                  type="button"
-                  onClick={() => void handleSaveCurrentStatus()}
-                  disabled={updatePersona.isPending}
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs text-foreground/80 transition-colors hover:bg-foreground/10 disabled:opacity-50"
-                >
-                  <Plus size="0.875rem" className="shrink-0" />
-                  <span className="min-w-0 flex-1 truncate">Save &quot;{normalizedUserActivity}&quot;</span>
-                </button>
-              )}
-              {savedStatusOptions.length > 0 ? (
-                savedStatusOptions.map((status) => (
-                  <div key={status} className="group flex items-center gap-1 rounded-lg hover:bg-foreground/10">
-                    <button
-                      type="button"
-                      onClick={() => handleApplySavedStatus(status)}
-                      className="min-w-0 flex-1 px-3 py-2 text-left text-xs"
-                    >
-                      <span className="block truncate">{status}</span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void handleDeleteSavedStatus(status)}
-                      disabled={updatePersona.isPending}
-                      className="mr-1 rounded-md p-1.5 text-foreground/45 opacity-70 transition-colors hover:text-[var(--destructive)] disabled:opacity-40 sm:opacity-0 sm:group-hover:opacity-100"
-                      title="Remove saved status"
-                    >
-                      <Trash2 size="0.75rem" />
-                    </button>
-                  </div>
-                ))
-              ) : (
-                <div className="px-3 py-4 text-center text-[0.6875rem] text-foreground/45">No saved statuses yet</div>
-              )}
-            </div>
-          </div>,
-          document.body,
-        )}
       {showCharPicker &&
         charPickerOpen &&
         createPortal(

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -20,7 +20,12 @@ import { ConversationInput } from "./ConversationInput";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
 import { ChatBranchSelector } from "./ChatBranchSelector";
 import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
-import { ChatToolbarButton, ChatToolbarMenu, getChatToolbarButtonClass } from "./ChatToolbarControls";
+import {
+  CHAT_TOOLBAR_IDENTITY_PILL_SIZE_CLASS,
+  ChatToolbarButton,
+  ChatToolbarMenu,
+  getChatToolbarButtonClass,
+} from "./ChatToolbarControls";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -889,13 +894,14 @@ export function ConversationView({
             };
             const identityPillClass = getChatToolbarButtonClass({
               compact: true,
+              sizeClassName: CHAT_TOOLBAR_IDENTITY_PILL_SIZE_CLASS,
               className:
-                "w-auto min-w-0 max-w-[min(20rem,calc(100vw-8rem))] justify-start gap-2 px-2.5 text-[var(--foreground)]/80 hover:text-[var(--foreground)]/90",
+                "min-w-0 max-w-[min(20rem,calc(100vw-8rem))] justify-start gap-2 px-2.5 text-[var(--foreground)]/80 hover:text-[var(--foreground)]/90 max-md:max-w-[calc(100vw-5.75rem)]",
             });
             const avatarShellClass =
-              "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]/80";
+              "relative block h-5 w-5 overflow-hidden rounded-full ring-1 ring-[var(--border)]/80 max-md:h-6 max-md:w-6";
             const avatarFallbackClass =
-              "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--foreground)]/10 text-[0.5rem] font-bold text-[var(--foreground)]/70 ring-1 ring-[var(--border)]/80";
+              "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--foreground)]/10 text-[0.5rem] font-bold text-[var(--foreground)]/70 ring-1 ring-[var(--border)]/80 max-md:h-6 max-md:w-6 max-md:text-[0.5625rem]";
 
             if (chars.length === 1) {
               const c = chars[0]!;
@@ -974,7 +980,11 @@ export function ConversationView({
             );
           })()}
 
-          <ChatToolbarMenu desktopChildren={renderToolbarActions()} mobileChildren={renderToolbarActions(true)} />
+          <ChatToolbarMenu
+            className="flex-1"
+            desktopChildren={renderToolbarActions()}
+            mobileChildren={renderToolbarActions(true)}
+          />
         </div>
 
         {/* Load More */}

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -315,6 +315,20 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     };
   }, [echoChamberOpen, echoChamberSide]);
 
+  useEffect(() => {
+    if (!echoChamberOpen || !echoEnabled || (isMobile && hiddenOnMobile)) return;
+
+    let frame = window.requestAnimationFrame(() => {
+      frame = window.requestAnimationFrame(() => {
+        const scrollEl = scrollRef.current;
+        if (!scrollEl) return;
+        scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "auto" });
+      });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [echoChamberOpen, echoEnabled, hiddenOnMobile, isMobile]);
+
   if (!echoChamberOpen || !echoEnabled || (isMobile && hiddenOnMobile)) return null;
   const visibleMessages = echoMessages.slice(0, visibleCount);
 
@@ -323,7 +337,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       className={cn(
         ROLEPLAY_POPOVER_SHELL,
         "absolute z-[60] flex flex-col",
-        "pointer-events-auto w-60 max-md:w-auto md:max-h-[22rem] max-md:max-h-28",
+        "pointer-events-auto w-[14.75rem] max-md:w-auto md:max-h-[22rem] max-md:max-h-28",
       )}
       style={posStyle}
     >

--- a/packages/client/src/components/chat/QuickSwitcherMobile.tsx
+++ b/packages/client/src/components/chat/QuickSwitcherMobile.tsx
@@ -5,6 +5,7 @@
 // ──────────────────────────────────────────────
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { ChevronUp, ChevronDown, ChevronRight, Link, CircleUser, FolderOpen, Folder, Check } from "lucide-react";
+import { createPortal } from "react-dom";
 import { useConnections, useUpdateConnection } from "../../hooks/use-connections";
 import { usePersonas, usePersonaGroups } from "../../hooks/use-characters";
 import { useUpdateChat, useChat } from "../../hooks/use-chats";
@@ -190,7 +191,13 @@ export function QuickSwitcherMobile() {
     };
     requestAnimationFrame(update);
     const timer = setTimeout(update, 50);
-    return () => clearTimeout(timer);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
   }, [open, tab, expandedGroups]);
 
   if (!activeChatId) return null;
@@ -238,11 +245,12 @@ export function QuickSwitcherMobile() {
   return (
     <>
       <button
+        type="button"
         ref={btnRef}
         onClick={() => setOpen((v) => !v)}
         title="Quick Switcher"
         className={cn(
-          "flex h-11 w-11 items-center justify-center rounded-xl transition-all",
+          "flex h-9 w-9 items-center justify-center rounded-xl transition-all",
           open
             ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
             : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -251,188 +259,190 @@ export function QuickSwitcherMobile() {
         <ChevronUp size="1rem" className={cn("transition-transform", open && "rotate-180")} />
       </button>
 
-      {open && (
-        <div
-          ref={menuRef}
-          className="fixed z-[9999] flex max-h-[400px] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
-          style={pos ? { left: pos.left, top: pos.top, width: pos.width } : { visibility: "hidden" as const }}
-        >
-          <div className="flex border-b border-foreground/10">
-            <button
-              onClick={() => setTab("connections")}
-              className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
-                tab === "connections"
-                  ? "border-b-2 border-foreground/25 bg-foreground/10 text-foreground/85"
-                  : "text-foreground/50 hover:text-foreground/80",
-              )}
-            >
-              <Link size="0.75rem" />
-              Connections
-            </button>
-            <button
-              onClick={() => setTab("personas")}
-              className={cn(
-                "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
-                tab === "personas"
-                  ? "border-b-2 border-foreground/25 bg-foreground/10 text-foreground/85"
-                  : "text-foreground/50 hover:text-foreground/80",
-              )}
-            >
-              <CircleUser size="0.75rem" />
-              Personas
-            </button>
-          </div>
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className="fixed z-[9999] flex max-h-[min(400px,70dvh)] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-2xl"
+            style={pos ? { left: pos.left, top: pos.top, width: pos.width } : { visibility: "hidden" as const }}
+          >
+            <div className="flex border-b border-foreground/10">
+              <button
+                onClick={() => setTab("connections")}
+                className={cn(
+                  "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
+                  tab === "connections"
+                    ? "border-b-2 border-foreground/25 bg-foreground/10 text-foreground/85"
+                    : "text-foreground/50 hover:text-foreground/80",
+                )}
+              >
+                <Link size="0.75rem" />
+                Connections
+              </button>
+              <button
+                onClick={() => setTab("personas")}
+                className={cn(
+                  "flex flex-1 items-center justify-center gap-1.5 px-3 py-2.5 text-[0.6875rem] font-semibold transition-colors",
+                  tab === "personas"
+                    ? "border-b-2 border-foreground/25 bg-foreground/10 text-foreground/85"
+                    : "text-foreground/50 hover:text-foreground/80",
+                )}
+              >
+                <CircleUser size="0.75rem" />
+                Personas
+              </button>
+            </div>
 
-          <div className="overflow-y-auto p-1">
-            {tab === "connections" && (
-              <>
-                <button
-                  onClick={handleToggleRandom}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors",
-                    isRandom
-                      ? "bg-foreground/10 font-semibold text-foreground/85 ring-1 ring-foreground/15"
-                      : "hover:bg-foreground/10",
-                  )}
-                  title={isRandom ? "Random pool active — click to disable" : "Use random connection from pool"}
-                >
-                  <span>🎲 Random</span>
-                  {isRandom && <span className="ml-auto text-[0.6875rem]">active</span>}
-                </button>
-                <div className="mx-2 my-1 h-px bg-foreground/10" />
-                {sortedConnections.map((conn) => {
-                  const inPool = conn.useForRandom === "true";
-                  const isActive = activeConnectionId === conn.id;
-                  if (isRandom) {
+            <div className="overflow-y-auto p-1">
+              {tab === "connections" && (
+                <>
+                  <button
+                    onClick={handleToggleRandom}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors",
+                      isRandom
+                        ? "bg-foreground/10 font-semibold text-foreground/85 ring-1 ring-foreground/15"
+                        : "hover:bg-foreground/10",
+                    )}
+                    title={isRandom ? "Random pool active — click to disable" : "Use random connection from pool"}
+                  >
+                    <span>🎲 Random</span>
+                    {isRandom && <span className="ml-auto text-[0.6875rem]">active</span>}
+                  </button>
+                  <div className="mx-2 my-1 h-px bg-foreground/10" />
+                  {sortedConnections.map((conn) => {
+                    const inPool = conn.useForRandom === "true";
+                    const isActive = activeConnectionId === conn.id;
+                    if (isRandom) {
+                      return (
+                        <button
+                          key={conn.id}
+                          onClick={() => handleTogglePool(conn.id, inPool)}
+                          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10"
+                          title={inPool ? "In random pool — click to remove" : "Click to add to random pool"}
+                        >
+                          <span className="flex-1 truncate">{conn.name || conn.id}</span>
+                          <span
+                            className={cn(
+                              "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
+                              inPool
+                                ? "border-foreground/35 bg-foreground/10 text-foreground/75"
+                                : "border-foreground/20 bg-transparent",
+                            )}
+                          >
+                            {inPool && <Check size="0.625rem" strokeWidth={3} />}
+                          </span>
+                        </button>
+                      );
+                    }
                     return (
                       <button
                         key={conn.id}
-                        onClick={() => handleTogglePool(conn.id, inPool)}
-                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10"
-                        title={inPool ? "In random pool — click to remove" : "Click to add to random pool"}
+                        onClick={() => handleSwitchConnection(conn.id)}
+                        className={cn(
+                          "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10",
+                          isActive && "text-foreground font-semibold",
+                        )}
                       >
                         <span className="flex-1 truncate">{conn.name || conn.id}</span>
-                        <span
-                          className={cn(
-                            "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
-                            inPool
-                              ? "border-foreground/35 bg-foreground/10 text-foreground/75"
-                              : "border-foreground/20 bg-transparent",
-                          )}
-                        >
-                          {inPool && <Check size="0.625rem" strokeWidth={3} />}
-                        </span>
+                        {isActive && <span className="text-[0.6875rem]">✓</span>}
                       </button>
                     );
-                  }
-                  return (
-                    <button
-                      key={conn.id}
-                      onClick={() => handleSwitchConnection(conn.id)}
-                      className={cn(
-                        "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs transition-colors hover:bg-foreground/10",
-                        isActive && "text-foreground font-semibold",
-                      )}
-                    >
-                      <span className="flex-1 truncate">{conn.name || conn.id}</span>
-                      {isActive && <span className="text-[0.6875rem]">✓</span>}
-                    </button>
-                  );
-                })}
-                {sortedConnections.length === 0 && (
-                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
-                    No connections found.
-                  </div>
-                )}
-              </>
-            )}
-
-            {tab === "personas" && (
-              <>
-                <button
-                  onClick={() => handleSwitchPersona(null)}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
-                    !activePersonaId
-                      ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
-                      : "hover:bg-foreground/10",
-                  )}
-                >
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
-                    ?
-                  </div>
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className={cn("text-xs font-semibold", !activePersonaId && "text-foreground")}>None</span>
-                    <span className="text-[0.625rem] text-foreground/45">No persona selected</span>
-                  </div>
-                  {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
-                </button>
-                <div className="mx-2 my-1 h-px bg-foreground/10" />
-                {groups.map((group) => {
-                  const isExpanded = expandedGroups.has(group.id);
-                  const firstMember = group.members[0];
-                  const hasActiveInGroup = group.members.some((p) => p.id === activePersonaId);
-                  return (
-                    <div key={group.id}>
-                      <button
-                        onClick={() => toggleGroup(group.id)}
-                        className={cn(
-                          "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
-                          hasActiveInGroup
-                            ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
-                            : "hover:bg-foreground/10",
-                        )}
-                      >
-                        {firstMember?.avatarPath ? (
-                          <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-foreground/10">
-                            <img
-                              src={firstMember.avatarPath}
-                              alt={group.name}
-                              className="h-full w-full object-cover"
-                              style={getAvatarCropStyle(parseAvatarCropJson(firstMember.avatarCrop))}
-                            />
-                          </div>
-                        ) : (
-                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
-                            {group.name[0].toUpperCase()}
-                          </div>
-                        )}
-                        <div className="flex min-w-0 flex-1 flex-col">
-                          <span className="flex items-center gap-1 text-xs font-semibold">
-                            {isExpanded ? (
-                              <FolderOpen size="0.75rem" className="shrink-0 text-foreground/45" />
-                            ) : (
-                              <Folder size="0.75rem" className="shrink-0 text-foreground/45" />
-                            )}
-                            {group.name} ({group.members.length})
-                          </span>
-                          <span className="text-[0.625rem] text-foreground/45">
-                            {group.members.length} persona{group.members.length !== 1 ? "s" : ""}
-                          </span>
-                        </div>
-                        <span className="ml-auto shrink-0 text-foreground/45">
-                          {isExpanded ? <ChevronDown size="0.875rem" /> : <ChevronRight size="0.875rem" />}
-                        </span>
-                      </button>
-                      {isExpanded && (
-                        <div className="ml-2 border-l border-foreground/10 pl-1">
-                          {group.members.map((persona) => renderPersonaRow(persona, true))}
-                        </div>
-                      )}
+                  })}
+                  {sortedConnections.length === 0 && (
+                    <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
+                      No connections found.
                     </div>
-                  );
-                })}
-                {sortedPersonas.length === 0 && (
-                  <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
-                    No personas found.
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-      )}
+                  )}
+                </>
+              )}
+
+              {tab === "personas" && (
+                <>
+                  <button
+                    onClick={() => handleSwitchPersona(null)}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+                      !activePersonaId
+                        ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
+                        : "hover:bg-foreground/10",
+                    )}
+                  >
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
+                      ?
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <span className={cn("text-xs font-semibold", !activePersonaId && "text-foreground")}>None</span>
+                      <span className="text-[0.625rem] text-foreground/45">No persona selected</span>
+                    </div>
+                    {!activePersonaId && <span className="ml-auto text-[0.6875rem]">✓</span>}
+                  </button>
+                  <div className="mx-2 my-1 h-px bg-foreground/10" />
+                  {groups.map((group) => {
+                    const isExpanded = expandedGroups.has(group.id);
+                    const firstMember = group.members[0];
+                    const hasActiveInGroup = group.members.some((p) => p.id === activePersonaId);
+                    return (
+                      <div key={group.id}>
+                        <button
+                          onClick={() => toggleGroup(group.id)}
+                          className={cn(
+                            "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors",
+                            hasActiveInGroup
+                              ? "bg-foreground/10 text-foreground ring-1 ring-foreground/15"
+                              : "hover:bg-foreground/10",
+                          )}
+                        >
+                          {firstMember?.avatarPath ? (
+                            <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full border border-foreground/10">
+                              <img
+                                src={firstMember.avatarPath}
+                                alt={group.name}
+                                className="h-full w-full object-cover"
+                                style={getAvatarCropStyle(parseAvatarCropJson(firstMember.avatarCrop))}
+                              />
+                            </div>
+                          ) : (
+                            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-foreground/10 bg-foreground/10 text-xs font-semibold text-foreground/45">
+                              {group.name[0].toUpperCase()}
+                            </div>
+                          )}
+                          <div className="flex min-w-0 flex-1 flex-col">
+                            <span className="flex items-center gap-1 text-xs font-semibold">
+                              {isExpanded ? (
+                                <FolderOpen size="0.75rem" className="shrink-0 text-foreground/45" />
+                              ) : (
+                                <Folder size="0.75rem" className="shrink-0 text-foreground/45" />
+                              )}
+                              {group.name} ({group.members.length})
+                            </span>
+                            <span className="text-[0.625rem] text-foreground/45">
+                              {group.members.length} persona{group.members.length !== 1 ? "s" : ""}
+                            </span>
+                          </div>
+                          <span className="ml-auto shrink-0 text-foreground/45">
+                            {isExpanded ? <ChevronDown size="0.875rem" /> : <ChevronRight size="0.875rem" />}
+                          </span>
+                        </button>
+                        {isExpanded && (
+                          <div className="ml-2 border-l border-foreground/10 pl-1">
+                            {group.members.map((persona) => renderPersonaRow(persona, true))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {sortedPersonas.length === 0 && (
+                    <div className="px-3 py-4 text-center text-[0.6875rem] italic text-foreground/45">
+                      No personas found.
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
     </>
   );
 }

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -37,7 +37,11 @@ import {
 import { TrackerLockProvider } from "../../features/tracker-panel/components/TrackerLockContext";
 import { useTrackerFieldLockUpdater } from "../../features/tracker-panel/hooks/use-tracker-field-lock-updater";
 import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
-import { getChatToolbarButtonClass } from "./ChatToolbarControls";
+import {
+  CHAT_TOOLBAR_ICON_GAP_CLASS,
+  CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS,
+  getChatToolbarButtonClass,
+} from "./ChatToolbarControls";
 import type {
   GameState,
   PresentCharacter,
@@ -275,195 +279,199 @@ export function RoleplayHUD({
       <div
         className={cn(
           "rpg-hud",
-          isVertical ? "flex flex-col items-center gap-1.5" : "flex items-center gap-1.5",
-          mobileCompact && "flex-1 min-w-0",
+          isVertical ? "flex flex-col items-center" : "flex items-center",
+          CHAT_TOOLBAR_ICON_GAP_CLASS,
+          mobileCompact && "min-w-0",
         )}
       >
-      {trackerPanelEnabled && !trackerPanelOpen && <TrackerPanelToggleButton onToggle={toggleTrackerPanel} />}
+        {trackerPanelEnabled && !trackerPanelOpen && <TrackerPanelToggleButton onToggle={toggleTrackerPanel} />}
 
-      {/* Actions (Agents + Clear) */}
-      <ActionsGroup
-        chatId={chatId}
-        injectionSourceMessages={injectionSourceMessages}
-        agentConfigs={agentConfigs}
-        isVertical={isVertical}
-        agentsOpen={agentsOpen}
-        setAgentsOpen={setAgentsOpen}
-        isAgentProcessing={isAgentProcessing}
-        isGenerationBusy={isTrackerBusy}
-        thoughtBubbles={thoughtBubbles}
-        clearThoughtBubbles={clearThoughtBubbles}
-        dismissThoughtBubble={dismissThoughtBubble}
-        enabledAgentTypes={enabledAgentTypes}
-        clearGameState={clearGameState}
-        onRetriggerTrackers={onRetriggerTrackers}
-        onRetryFailedAgents={onRetryFailedAgents}
-        failedAgentTypes={failedAgentTypes}
-        failedAgentFailures={failedAgentFailures}
-        showInjectionsTab={showInjectionsTab}
-        showSecretPlotTab={showSecretPlotTab}
-      />
+        {/* Actions (Agents + Clear) */}
+        <ActionsGroup
+          chatId={chatId}
+          injectionSourceMessages={injectionSourceMessages}
+          agentConfigs={agentConfigs}
+          isVertical={isVertical}
+          agentsOpen={agentsOpen}
+          setAgentsOpen={setAgentsOpen}
+          isAgentProcessing={isAgentProcessing}
+          isGenerationBusy={isTrackerBusy}
+          thoughtBubbles={thoughtBubbles}
+          clearThoughtBubbles={clearThoughtBubbles}
+          dismissThoughtBubble={dismissThoughtBubble}
+          enabledAgentTypes={enabledAgentTypes}
+          clearGameState={clearGameState}
+          onRetriggerTrackers={onRetriggerTrackers}
+          onRetryFailedAgents={onRetryFailedAgents}
+          failedAgentTypes={failedAgentTypes}
+          failedAgentFailures={failedAgentFailures}
+          showInjectionsTab={showInjectionsTab}
+          showSecretPlotTab={showSecretPlotTab}
+        />
 
-      {/* ── Mobile: combined widgets, centered ── */}
-      {showHudTrackerWidgets && (
-        <div className={cn("flex items-center gap-0.5 md:hidden", mobileCompact && "flex-1 justify-center")}>
-          {enabledAgentTypes.has("world-state") && (
-            <CombinedWorldWidget
-              location={location ?? ""}
-              date={date ?? ""}
-              time={time ?? ""}
-              weather={weather ?? ""}
-              temperature={temperature ?? ""}
-              trackerTemperatureUnit={trackerTemperatureUnit}
-              onSaveLocation={(v) => patchField("location", v)}
-              onSaveDate={(v) => patchField("date", v)}
-              onSaveTime={(v) => patchField("time", v)}
-              onSaveWeather={(v) => patchField("weather", v)}
-              onSaveTemperature={(v) => patchField("temperature", v)}
-              layout={layout}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+        {/* ── Mobile: combined widgets, grouped with tracker and agent controls ── */}
+        {showHudTrackerWidgets && (
+          <div
+            className={cn(
+              "flex items-center md:hidden",
+              CHAT_TOOLBAR_ICON_GAP_CLASS,
+              mobileCompact && "min-w-0 justify-start",
+            )}
+          >
+            {enabledAgentTypes.has("world-state") && (
+              <CombinedWorldWidget
+                location={location ?? ""}
+                date={date ?? ""}
+                time={time ?? ""}
+                weather={weather ?? ""}
+                temperature={temperature ?? ""}
+                trackerTemperatureUnit={trackerTemperatureUnit}
+                onSaveLocation={(v) => patchField("location", v)}
+                onSaveDate={(v) => patchField("date", v)}
+                onSaveTime={(v) => patchField("time", v)}
+                onSaveWeather={(v) => patchField("weather", v)}
+                onSaveTemperature={(v) => patchField("temperature", v)}
+                layout={layout}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {hasPlayerTrackerSections && (
-            <CombinedPlayerWidget
-              layout={layout}
-              showPersona={hasPersonaStatsTracker}
-              showCharacters={enabledAgentTypes.has("character-tracker")}
-              showQuests={enabledAgentTypes.has("quest")}
-              showCustomTracker={enabledAgentTypes.has("custom-tracker")}
-              personaStats={personaStatBars}
-              onUpdatePersonaStats={(bars) => patchField("personaStats", bars)}
-              personaStatus={personaStatus}
-              onUpdatePersonaStatus={(status) => patchPlayerStats("status", status)}
-              characters={presentCharacters}
-              onUpdateCharacters={(chars) => patchField("presentCharacters", chars)}
-              inventory={inventory}
-              onUpdateInventory={updateInventoryItems}
-              onRemoveInventoryItem={removeInventoryItem}
-              quests={activeQuests}
-              onUpdateQuests={(q) => patchPlayerStats("activeQuests", q)}
-              customTrackerFields={customTrackerFields}
-              onUpdateCustomTracker={(fields) => patchPlayerStats("customTrackerFields", fields)}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+            {hasPlayerTrackerSections && (
+              <CombinedPlayerWidget
+                layout={layout}
+                showPersona={hasPersonaStatsTracker}
+                showCharacters={enabledAgentTypes.has("character-tracker")}
+                showQuests={enabledAgentTypes.has("quest")}
+                showCustomTracker={enabledAgentTypes.has("custom-tracker")}
+                personaStats={personaStatBars}
+                onUpdatePersonaStats={(bars) => patchField("personaStats", bars)}
+                personaStatus={personaStatus}
+                onUpdatePersonaStatus={(status) => patchPlayerStats("status", status)}
+                characters={presentCharacters}
+                onUpdateCharacters={(chars) => patchField("presentCharacters", chars)}
+                inventory={inventory}
+                onUpdateInventory={updateInventoryItems}
+                onRemoveInventoryItem={removeInventoryItem}
+                quests={activeQuests}
+                onUpdateQuests={(q) => patchPlayerStats("activeQuests", q)}
+                customTrackerFields={customTrackerFields}
+                onUpdateCustomTracker={(fields) => patchPlayerStats("customTrackerFields", fields)}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {/* Manual tracker trigger button (mobile) */}
-          {manualTrackers && onRetriggerTrackers && (
-            <button
-              onClick={(e) => {
-                e.preventDefault();
-                onRetriggerTrackers();
-              }}
-              disabled={isTrackerBusy}
-              className={cn(
-                MOBILE_HUD_BTN,
-                "justify-center text-[0.5625rem] font-medium",
-                isTrackerBusy ? "text-foreground/75" : "text-foreground/45 hover:text-foreground/70",
-              )}
-            >
-              <RefreshCw size="0.875rem" className={cn("shrink-0 h-4 w-4", isTrackerBusy && "animate-spin")} />
-            </button>
-          )}
-        </div>
-      )}
+            {/* Manual tracker trigger button (mobile) */}
+            {manualTrackers && onRetriggerTrackers && (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  onRetriggerTrackers();
+                }}
+                disabled={isTrackerBusy}
+                className={cn(
+                  MOBILE_HUD_BTN,
+                  "justify-center text-[0.5625rem] font-medium",
+                  isTrackerBusy && "text-[var(--marinara-chat-chrome-button-text-active)]",
+                )}
+              >
+                <RefreshCw size="0.875rem" className={cn("shrink-0 h-4 w-4", isTrackerBusy && "animate-spin")} />
+              </button>
+            )}
+          </div>
+        )}
 
-      {/* ── Desktop: separate individual widgets ── */}
-      {showHudTrackerWidgets && (
-        <div className="hidden md:flex items-center gap-1.5">
-          {enabledAgentTypes.has("world-state") && (
-            <CombinedWorldWidget
-              location={location ?? ""}
-              date={date ?? ""}
-              time={time ?? ""}
-              weather={weather ?? ""}
-              temperature={temperature ?? ""}
-              trackerTemperatureUnit={trackerTemperatureUnit}
-              onSaveLocation={(v) => patchField("location", v)}
-              onSaveDate={(v) => patchField("date", v)}
-              onSaveTime={(v) => patchField("time", v)}
-              onSaveWeather={(v) => patchField("weather", v)}
-              onSaveTemperature={(v) => patchField("temperature", v)}
-              layout={layout}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+        {/* ── Desktop: separate individual widgets ── */}
+        {showHudTrackerWidgets && (
+          <div className={cn("hidden items-center md:flex", CHAT_TOOLBAR_ICON_GAP_CLASS)}>
+            {enabledAgentTypes.has("world-state") && (
+              <CombinedWorldWidget
+                location={location ?? ""}
+                date={date ?? ""}
+                time={time ?? ""}
+                weather={weather ?? ""}
+                temperature={temperature ?? ""}
+                trackerTemperatureUnit={trackerTemperatureUnit}
+                onSaveLocation={(v) => patchField("location", v)}
+                onSaveDate={(v) => patchField("date", v)}
+                onSaveTime={(v) => patchField("time", v)}
+                onSaveWeather={(v) => patchField("weather", v)}
+                onSaveTemperature={(v) => patchField("temperature", v)}
+                layout={layout}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {hasPersonaStatsTracker && (
-            <PersonaStatsWidget
-              bars={personaStatBars}
-              onUpdate={(bars) => patchField("personaStats", bars)}
-              status={personaStatus}
-              onUpdateStatus={(status) => patchPlayerStats("status", status)}
-              layout={layout}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+            {hasPersonaStatsTracker && (
+              <PersonaStatsWidget
+                bars={personaStatBars}
+                onUpdate={(bars) => patchField("personaStats", bars)}
+                status={personaStatus}
+                onUpdateStatus={(status) => patchPlayerStats("status", status)}
+                layout={layout}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {enabledAgentTypes.has("character-tracker") && (
-            <CharactersWidget
-              characters={presentCharacters}
-              onUpdate={(chars) => patchField("presentCharacters", chars)}
-              chatId={chatId}
-              layout={layout}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+            {enabledAgentTypes.has("character-tracker") && (
+              <CharactersWidget
+                characters={presentCharacters}
+                onUpdate={(chars) => patchField("presentCharacters", chars)}
+                chatId={chatId}
+                layout={layout}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {hasPersonaStatsTracker && (
-            <InventoryWidget
-              items={inventory}
-              onUpdate={updateInventoryItems}
-              onRemoveItem={removeInventoryItem}
-              layout={layout}
-            />
-          )}
+            {hasPersonaStatsTracker && (
+              <InventoryWidget
+                items={inventory}
+                onUpdate={updateInventoryItems}
+                onRemoveItem={removeInventoryItem}
+                layout={layout}
+              />
+            )}
 
-          {enabledAgentTypes.has("quest") && (
-            <QuestsWidget
-              quests={activeQuests}
-              onUpdate={(q) => patchPlayerStats("activeQuests", q)}
-              layout={layout}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+            {enabledAgentTypes.has("quest") && (
+              <QuestsWidget
+                quests={activeQuests}
+                onUpdate={(q) => patchPlayerStats("activeQuests", q)}
+                layout={layout}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {enabledAgentTypes.has("custom-tracker") && (
-            <CustomTrackerWidget
-              fields={customTrackerFields}
-              onUpdate={(fields) => patchPlayerStats("customTrackerFields", fields)}
-              layout={layout}
-              onRerunSingleTracker={onRerunSingleTracker}
-              isTrackerRetryBusy={isTrackerBusy}
-            />
-          )}
+            {enabledAgentTypes.has("custom-tracker") && (
+              <CustomTrackerWidget
+                fields={customTrackerFields}
+                onUpdate={(fields) => patchPlayerStats("customTrackerFields", fields)}
+                layout={layout}
+                onRerunSingleTracker={onRerunSingleTracker}
+                isTrackerRetryBusy={isTrackerBusy}
+              />
+            )}
 
-          {/* Manual tracker trigger button (desktop) */}
-          {manualTrackers && onRetriggerTrackers && (
-            <button
-              onClick={(e) => {
-                e.preventDefault();
-                onRetriggerTrackers();
-              }}
-              disabled={isTrackerBusy}
-              className={cn(
-                WIDGET,
-                isTrackerBusy ? "text-foreground/75" : "text-foreground/45 hover:text-foreground/70",
-              )}
-              title={isTrackerBusy ? "Trackers running…" : "Run Trackers"}
-            >
-              <RefreshCw size="0.875rem" className={cn(isTrackerBusy && "animate-spin")} />
-            </button>
-          )}
-        </div>
-      )}
+            {/* Manual tracker trigger button (desktop) */}
+            {manualTrackers && onRetriggerTrackers && (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  onRetriggerTrackers();
+                }}
+                disabled={isTrackerBusy}
+                className={cn(WIDGET, isTrackerBusy && "text-[var(--marinara-chat-chrome-button-text-active)]")}
+                title={isTrackerBusy ? "Trackers running…" : "Run Trackers"}
+              >
+                <RefreshCw size="0.875rem" className={cn(isTrackerBusy && "animate-spin")} />
+              </button>
+            )}
+          </div>
+        )}
       </div>
     </TrackerLockProvider>
   );
@@ -475,7 +483,7 @@ export function RoleplayHUD({
 
 /** Common mobile HUD button sizing – used by all four strip buttons */
 const HUD_ICON_BUTTON = getChatToolbarButtonClass({ compact: true });
-const MOBILE_HUD_BTN = cn(HUD_ICON_BUTTON, "cursor-pointer select-none");
+const MOBILE_HUD_BTN = cn(HUD_ICON_BUTTON, CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS, "cursor-pointer select-none");
 
 function DeferredHUDPanelFallback({ label }: { label: string }) {
   return <div className="px-3 py-4 text-center text-[0.625rem] text-[var(--muted-foreground)]/60">{label}</div>;
@@ -498,7 +506,7 @@ function TrackerPanelToggleButton({ onToggle }: { onToggle: () => void }) {
     <button
       data-tracker-panel-toggle="roleplay-hud"
       onClick={onToggle}
-      className={cn(WIDGET, "text-foreground/50 hover:border-foreground/20 hover:text-foreground/75")}
+      className={WIDGET}
       title="Show Tracker Panel"
       aria-label="Show Tracker Panel"
     >
@@ -669,7 +677,7 @@ function ActionsGroup({
     );
 
   return (
-    <div className={cn("relative flex items-center gap-1", isVertical && "flex-col")}>
+    <div className={cn("relative flex items-center", CHAT_TOOLBAR_ICON_GAP_CLASS, isVertical && "flex-col")}>
       <button
         ref={btnRef}
         onClick={() => setAgentsOpen(!agentsOpen)}
@@ -677,7 +685,7 @@ function ActionsGroup({
           getChatToolbarButtonClass({
             compact: true,
             open: agentsOpen,
-            className: hasAgentCount ? "w-auto min-w-8 gap-1.5 px-2" : undefined,
+            className: cn(CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS, hasAgentCount && "w-auto min-w-8 gap-1.5 px-2"),
           }),
           "group cursor-pointer select-none",
         )}
@@ -685,26 +693,15 @@ function ActionsGroup({
         aria-label={agentsLabel}
       >
         {isAgentProcessing ? (
-          <Loader2
-            size="0.875rem"
-            strokeWidth={2.5}
-            className="shrink-0 animate-spin text-foreground/75 transition-colors group-hover:text-foreground/80"
-          />
+          <Loader2 size="0.875rem" strokeWidth={2.5} className="shrink-0 animate-spin transition-colors" />
         ) : (
-          <Sparkles
-            size="0.875rem"
-            strokeWidth={2.5}
-            className={cn(
-              "shrink-0 transition-colors group-hover:text-foreground/75",
-              agentsOpen ? "text-foreground/75" : "text-foreground/55",
-            )}
-          />
+          <Sparkles size="0.875rem" strokeWidth={2.5} className="shrink-0 transition-colors" />
         )}
         {generatedAgentCount > 0 && (
           <span
             className={cn(
-              "shrink-0 rounded-full bg-[var(--foreground)]/10 px-1.5 py-0.5 text-[0.625rem] font-medium tabular-nums text-[var(--foreground)]/65",
-              agentsOpen && "text-[var(--foreground)]/75",
+              "shrink-0 rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 py-0.5 text-[0.625rem] font-medium tabular-nums text-[var(--marinara-chat-chrome-button-text-hover)]",
+              agentsOpen && "bg-[var(--marinara-chat-chrome-highlight-bg-hover)]",
             )}
             aria-hidden="true"
           >
@@ -778,14 +775,9 @@ function CombinedPlayerWidget({
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
-        title="Player & Tracker"
-      >
+      <button ref={buttonRef} onClick={() => setOpen(!open)} className={WIDGET} title="Player & Tracker">
         <div className="flex h-4 items-center justify-center shrink-0">
-          <Swords size="0.875rem" className="text-orange-400/70 max-md:h-4 max-md:w-4" />
+          <Swords size="0.875rem" className="max-md:h-4 max-md:w-4" />
         </div>
         <span className="sr-only">Tracker</span>
       </button>
@@ -960,12 +952,7 @@ function CharactersWidget({
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
-        title="Present Characters"
-      >
+      <button ref={buttonRef} onClick={() => setOpen(!open)} className={WIDGET} title="Present Characters">
         {characters.length > 0 ? (
           <div className="flex items-center -space-x-0.5">
             {characters.slice(0, 3).map((c, i) => (
@@ -980,10 +967,7 @@ function CharactersWidget({
             )}
           </div>
         ) : (
-          <Users
-            size="0.875rem"
-            className="text-foreground/45 transition-colors group-hover:text-foreground/70 max-md:h-3.5 max-md:w-3.5"
-          />
+          <Users size="0.875rem" className="transition-colors max-md:h-3.5 max-md:w-3.5" />
         )}
       </button>
 
@@ -1032,12 +1016,7 @@ function PersonaStatsWidget({
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
-        title="Persona Stats"
-      >
+      <button ref={buttonRef} onClick={() => setOpen(!open)} className={WIDGET} title="Persona Stats">
         {bars.length > 0 ? (
           <div className="flex w-6 max-md:w-8 flex-col justify-center gap-0.5 max-md:gap-px shrink-0">
             {bars.map((bar) => {
@@ -1059,7 +1038,7 @@ function PersonaStatsWidget({
             })}
           </div>
         ) : (
-          <BarChart3 size="0.875rem" className="text-sky-400/45 max-md:h-3.5 max-md:w-3.5" />
+          <BarChart3 size="0.875rem" className="max-md:h-3.5 max-md:w-3.5" />
         )}
         <span className="sr-only">Persona</span>
       </button>
@@ -1131,12 +1110,7 @@ function CustomTrackerWidget({
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
-        title="Custom Tracker"
-      >
+      <button ref={buttonRef} onClick={() => setOpen(!open)} className={WIDGET} title="Custom Tracker">
         {fields.length > 0 && currentField ? (
           <span
             key={animKey}
@@ -1217,12 +1191,7 @@ function InventoryWidget({
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
-        title="Inventory"
-      >
+      <button ref={buttonRef} onClick={() => setOpen(!open)} className={WIDGET} title="Inventory">
         {items.length > 0 && currentItem ? (
           <span
             key={animKey}
@@ -1232,7 +1201,7 @@ function InventoryWidget({
             {itemLabel}
           </span>
         ) : (
-          <Package size="0.875rem" className="text-amber-400/60 max-md:h-3 max-md:w-3" />
+          <Package size="0.875rem" className="max-md:h-3 max-md:w-3" />
         )}
       </button>
 
@@ -1244,11 +1213,7 @@ function InventoryWidget({
         className="w-64 max-h-80 overflow-y-auto"
       >
         <Suspense fallback={<DeferredHUDPanelFallback label="Loading inventory…" />}>
-          <InventoryPanel
-            items={items}
-            onUpdate={onUpdate}
-            onRemoveItem={onRemoveItem}
-          />
+          <InventoryPanel items={items} onUpdate={onUpdate} onRemoveItem={onRemoveItem} />
         </Suspense>
       </WidgetPopover>
     </div>
@@ -1280,12 +1245,7 @@ function QuestsWidget({
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(WIDGET, "text-foreground/60 hover:text-foreground/75")}
-        title="Active Quests"
-      >
+      <button ref={buttonRef} onClick={() => setOpen(!open)} className={WIDGET} title="Active Quests">
         {currentObjective ? (
           <span className="widget-scroll-text w-full px-0.5 text-center text-[0.375rem] font-semibold leading-[1.15] max-md:text-[0.5rem]">
             <span className="inline-flex animate-[widget-scroll_8s_linear_infinite] whitespace-nowrap">
@@ -1296,7 +1256,7 @@ function QuestsWidget({
             </span>
           </span>
         ) : (
-          <Scroll size="0.875rem" className="text-emerald-400/60 max-md:h-3 max-md:w-3" />
+          <Scroll size="0.875rem" className="max-md:h-3 max-md:w-3" />
         )}
       </button>
 
@@ -1326,7 +1286,8 @@ function QuestsWidget({
 
 const WIDGET = cn(
   HUD_ICON_BUTTON,
-  "group flex-col gap-0 overflow-hidden cursor-pointer select-none dark:border-foreground/15",
+  CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS,
+  "group flex-col gap-0 overflow-hidden cursor-pointer select-none",
 );
 
 // ═══════════════════════════════════════════════
@@ -1367,7 +1328,6 @@ function CombinedWorldWidget({
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const weatherEmoji = weather ? getWeatherEmoji(weather) : "🌤️";
-  const pinColor = getLocationPinColor(location);
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
   const tempNumeric = temperature ? parseTemperatureValue(temperature) : null;
   const temp = tempNumeric ?? (temperature ? getTemperatureKeywordHint(temperature) : null);
@@ -1393,30 +1353,25 @@ function CombinedWorldWidget({
         ref={buttonRef}
         onClick={() => setOpen(!open)}
         className={cn(
-          getChatToolbarButtonClass({ compact: true, open }),
+          getChatToolbarButtonClass({
+            compact: true,
+            open,
+            className: CHAT_TOOLBAR_MOBILE_OVERFLOW_HEIGHT_CLASS,
+          }),
           "cursor-pointer select-none",
           !sideLayout && "w-auto min-w-8 gap-1 px-2",
         )}
         title="World State"
       >
         {/* Location pin */}
-        <MapPin size="0.9375rem" className={cn(pinColor, "drop-shadow-sm shrink-0")} />
+        <MapPin size="0.9375rem" className="shrink-0 drop-shadow-sm" />
 
         {/* Mini calendar with day number */}
         {!sideLayout && (
           <>
             <svg viewBox="0 0 20 20" fill="none" className="shrink-0 h-4 w-4">
-              <rect
-                x="2"
-                y="4"
-                width="16"
-                height="14"
-                rx="2"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                className="text-zinc-300/70"
-              />
-              <line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" strokeWidth="1.2" className="text-zinc-400/50" />
+              <rect x="2" y="4" width="16" height="14" rx="2" stroke="currentColor" strokeWidth="1.5" opacity="0.7" />
+              <line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" strokeWidth="1.2" opacity="0.5" />
               <line
                 x1="6"
                 y1="2"
@@ -1425,7 +1380,7 @@ function CombinedWorldWidget({
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
-                className="text-zinc-300/70"
+                opacity="0.7"
               />
               <line
                 x1="14"
@@ -1435,7 +1390,7 @@ function CombinedWorldWidget({
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
-                className="text-zinc-300/70"
+                opacity="0.7"
               />
               {dateParts.day && (
                 <text
@@ -1445,7 +1400,7 @@ function CombinedWorldWidget({
                   fill="currentColor"
                   fontSize="7"
                   fontWeight="700"
-                  className="text-zinc-100"
+                  opacity="0.95"
                 >
                   {dateParts.day}
                 </text>
@@ -1454,7 +1409,7 @@ function CombinedWorldWidget({
 
             {/* Mini clock with dynamic hands */}
             <svg viewBox="0 0 20 20" fill="none" className="shrink-0 h-4 w-4">
-              <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="1.5" className="text-amber-400/70" />
+              <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="1.5" opacity="0.7" />
               {hour >= 0 ? (
                 <>
                   <line
@@ -1465,7 +1420,7 @@ function CombinedWorldWidget({
                     stroke="currentColor"
                     strokeWidth="1.8"
                     strokeLinecap="round"
-                    className="text-amber-300"
+                    opacity="0.95"
                   />
                   <line
                     x1="10"
@@ -1475,7 +1430,7 @@ function CombinedWorldWidget({
                     stroke="currentColor"
                     strokeWidth="1.2"
                     strokeLinecap="round"
-                    className="text-amber-400/80"
+                    opacity="0.8"
                   />
                 </>
               ) : (
@@ -1488,7 +1443,7 @@ function CombinedWorldWidget({
                     stroke="currentColor"
                     strokeWidth="1.8"
                     strokeLinecap="round"
-                    className="text-amber-300"
+                    opacity="0.95"
                   />
                   <line
                     x1="10"
@@ -1498,11 +1453,11 @@ function CombinedWorldWidget({
                     stroke="currentColor"
                     strokeWidth="1.2"
                     strokeLinecap="round"
-                    className="text-amber-400/80"
+                    opacity="0.8"
                   />
                 </>
               )}
-              <circle cx="10" cy="10" r="1" fill="currentColor" className="text-amber-300" />
+              <circle cx="10" cy="10" r="1" fill="currentColor" opacity="0.95" />
             </svg>
 
             {/* Weather emoji */}
@@ -1561,7 +1516,7 @@ function CombinedWorldWidget({
             onSaveWeather={onSaveWeather}
             onSaveTemperature={onSaveTemperature}
             weatherEmoji={weatherEmoji}
-            pinColor={pinColor}
+            pinColor="text-[var(--marinara-chat-chrome-highlight-text)]"
             tempColor={tempColor}
             onClose={() => setOpen(false)}
             onRerunSingleTracker={onRerunSingleTracker}
@@ -1639,46 +1594,4 @@ function getWeatherEmoji(weather: string): string {
   if (w.includes("hot") || w.includes("swelter")) return "🥵";
   if (w.includes("cold") || w.includes("freez")) return "🥶";
   return "🌤️";
-}
-
-/** Categorise location text into a colour for the map-pin icon. */
-function getLocationPinColor(location: string): string {
-  const l = location.toLowerCase();
-  // Water
-  if (
-    /\b(sea|ocean|lake|river|pond|creek|bay|shore|beach|harbor|harbour|port|coast|marsh|swamp|waterfall|spring|well|dock|canal|dam|reef|lagoon|estuary|fjord|cove)\b/.test(
-      l,
-    )
-  )
-    return "text-blue-400";
-  // Mountains / rocky terrain
-  if (
-    /\b(mountain|hill|cliff|peak|ridge|canyon|gorge|cave|cavern|mine|quarry|summit|bluff|crag|volcano|crater|mesa|plateau|ravine|boulder)\b/.test(
-      l,
-    )
-  )
-    return "text-amber-700";
-  // Urban / city
-  if (
-    /\b(city|town|village|castle|palace|fortress|market|shop|inn|tavern|bar|pub|guild|district|quarter|bazaar|temple|church|cathedral|shrine|tower|gate|square|plaza|street|alley|arena|throne|court|capitol|capital|metro|subway)\b/.test(
-      l,
-    )
-  )
-    return "text-sky-400";
-  // Interior / indoors
-  if (
-    /\b(room|hall|chamber|dungeon|cellar|basement|attic|library|study|bedroom|kitchen|office|lab|laboratory|vault|corridor|passage|cabin|hut|tent|interior|house|home|building|apartment|manor|lodge|dormitor|warehouse|prison|cell|jail)\b/.test(
-      l,
-    )
-  )
-    return "text-amber-300";
-  // Nature / forest / fields (broadest — checked last)
-  if (
-    /\b(forest|wood|grove|jungle|garden|park|field|meadow|glade|clearing|plain|prairie|steppe|savanna|farm|ranch|orchard|vineyard|glen|vale|valley|thicket|copse|heath|moor|desert|tundra|waste|wild|trail|path|road)\b/.test(
-      l,
-    )
-  )
-    return "text-emerald-400";
-  // Default — the base emerald
-  return "text-emerald-400";
 }

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -51,7 +51,16 @@ interface SummaryPopoverProps {
   summaryRunInterval?: number;
   automaticSummariesAvailable?: boolean;
   totalMessageCount: number;
+  anchor?: SummaryPopoverAnchor | null;
   onClose: () => void;
+}
+
+interface SummaryPopoverAnchor {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
 }
 
 type SummarySourceMode = "last" | "range";
@@ -65,6 +74,20 @@ const MAX_AUTOMATIC_SUMMARY_INTERVAL = 200;
 const SUMMARY_TOKEN_WARNING_THRESHOLD = 1800;
 const SUMMARY_HEADING_PATTERN = /^(?:#{1,6}\s*)?(?:\*\*)?([^:\n]{3,80})(?:\*\*)?:\s*$/;
 const SUMMARY_BULLET_PATTERN = /^[-*•]\s+/;
+const MOBILE_SUMMARY_PADDING = 8;
+
+function getMobileSummaryFrame(anchor: SummaryPopoverAnchor | null | undefined) {
+  if (typeof window === "undefined") return null;
+  const width = Math.min(560, window.innerWidth - MOBILE_SUMMARY_PADDING * 2);
+  const fallbackLeft = (window.innerWidth - width) / 2;
+  const left = Math.max(
+    MOBILE_SUMMARY_PADDING,
+    Math.min((anchor?.right ?? fallbackLeft + width) - width, window.innerWidth - width - MOBILE_SUMMARY_PADDING),
+  );
+  const top = Math.max(MOBILE_SUMMARY_PADDING, anchor?.bottom ?? 56);
+  const maxHeight = Math.max(240, window.innerHeight - top - MOBILE_SUMMARY_PADDING);
+  return { top, left, width, maxHeight };
+}
 
 interface SummarySection {
   title: string | null;
@@ -178,6 +201,7 @@ export function SummaryPopover({
   summaryRunInterval,
   automaticSummariesAvailable = true,
   totalMessageCount,
+  anchor = null,
   onClose,
 }: SummaryPopoverProps) {
   const [expandedEntryIds, setExpandedEntryIds] = useState<Set<string>>(() => new Set());
@@ -659,6 +683,7 @@ export function SummaryPopover({
   const isGenerating = generateSummary.isPending;
 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const mobileFrame = isMobile ? getMobileSummaryFrame(anchor) : null;
 
   const handlePanelMouseDown = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -669,22 +694,26 @@ export function SummaryPopover({
       ref={panelRef}
       onMouseDown={handlePanelMouseDown}
       className={cn(
-        isMobile
-          ? "fixed inset-0 z-[9999] flex items-center justify-center p-4 max-md:pt-[max(1rem,env(safe-area-inset-top))]"
-          : "absolute right-0 top-full z-[100] mt-1",
+        isMobile ? "fixed z-[9999]" : "absolute right-0 top-full z-[100] mt-1",
       )}
+      style={
+        mobileFrame
+          ? {
+              top: mobileFrame.top,
+              left: mobileFrame.left,
+              width: mobileFrame.width,
+            }
+          : undefined
+      }
     >
-      {/* Mobile backdrop */}
-      {isMobile && <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />}
       <div
         className={cn(
           ROLEPLAY_POPOVER_SHELL,
           ROLEPLAY_POPOVER_SCROLL_AREA,
           "relative flex flex-col overflow-hidden p-3",
-          isMobile
-            ? "relative max-h-[calc(100dvh-2rem)] w-full max-w-lg"
-            : "max-h-[min(46rem,calc(100vh-5rem))] w-[36rem]",
+          isMobile ? "w-full" : "max-h-[min(46rem,calc(100vh-5rem))] w-[36rem]",
         )}
+        style={mobileFrame ? { maxHeight: mobileFrame.maxHeight } : undefined}
       >
         {/* Header */}
         <div className="mb-2 flex items-start justify-between gap-3">

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -35,7 +35,8 @@ interface SearchResult {
 let ytApiPromise: Promise<void> | null = null;
 
 const MUSIC_NEUTRAL_BORDER_CLASS = "border-[var(--marinara-chat-chrome-panel-border)]";
-const MUSIC_NEUTRAL_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-bg)]";
+const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
+const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
 const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-bg)]";
 const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[var(--marinara-chat-chrome-highlight-bg)]";
 const MUSIC_NEUTRAL_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-title)]";
@@ -93,17 +94,23 @@ function getMobileWidgetStyle(
 
 function getMobileExpandedPanelStyle(position: { x: number; y: number }): CSSProperties {
   if (typeof window === "undefined") return {};
+
   const width = Math.min(
     MOBILE_WIDGET_EXPANDED_MAX_WIDTH,
     window.innerWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER,
   );
+  const opensLeft =
+    position.x + width > window.innerWidth - MOBILE_WIDGET_VIEWPORT_PADDING ||
+    position.x + MOBILE_WIDGET_COLLAPSED_SIZE / 2 > window.innerWidth / 2;
+  const preferredLeft = opensLeft ? position.x + MOBILE_WIDGET_COLLAPSED_SIZE - width : position.x;
+  const clampedLeft = Math.max(
+    MOBILE_WIDGET_VIEWPORT_PADDING,
+    Math.min(window.innerWidth - width - MOBILE_WIDGET_VIEWPORT_PADDING, preferredLeft),
+  );
+
   return {
     width,
-    maxWidth: `calc(100vw - ${MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER}px)`,
-    transform:
-      position.x + width > window.innerWidth - MOBILE_WIDGET_VIEWPORT_PADDING
-        ? `translateX(-${Math.max(0, width - MOBILE_WIDGET_COLLAPSED_SIZE)}px)`
-        : undefined,
+    transform: `translateX(${Math.round(clampedLeft - position.x)}px)`,
   };
 }
 
@@ -479,8 +486,8 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
     <div
       className={cn(
         "fixed top-14 z-40 w-[calc(100vw-1rem)] max-w-80 overflow-hidden rounded-xl border shadow-[0_18px_50px_rgba(0,0,0,0.35)] transition-opacity",
-        MUSIC_NEUTRAL_BORDER_CLASS,
-        MUSIC_NEUTRAL_BG_CLASS,
+        MUSIC_NEUTRAL_SHELL_BORDER_CLASS,
+        MUSIC_NEUTRAL_SHELL_BG_CLASS,
         active && hasPlayerContent && showVideo ? "left-2 opacity-100" : "pointer-events-none -left-[9999px] opacity-0",
       )}
     >
@@ -521,8 +528,8 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
               <div
                 className={cn(
                   "flex h-12 w-12 items-center justify-center rounded-full border shadow-lg backdrop-blur-xl",
-                  MUSIC_NEUTRAL_BORDER_CLASS,
-                  MUSIC_NEUTRAL_BG_CLASS,
+                  MUSIC_NEUTRAL_SHELL_BORDER_CLASS,
+                  MUSIC_NEUTRAL_SHELL_BG_CLASS,
                 )}
               >
                 <MusicSourceGlyph source="youtube" className={cn("h-5 w-5", YOUTUBE_LOGO_CLASS)} />
@@ -531,8 +538,8 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
               <div
                 className={cn(
                   "rounded-xl border p-2 shadow-2xl backdrop-blur-xl",
-                  MUSIC_NEUTRAL_BORDER_CLASS,
-                  MUSIC_NEUTRAL_BG_CLASS,
+                  MUSIC_NEUTRAL_SHELL_BORDER_CLASS,
+                  MUSIC_NEUTRAL_SHELL_BG_CLASS,
                 )}
                 style={mobileExpandedPanelStyle}
               >
@@ -579,8 +586,8 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
         <div
           className={cn(
             "relative hidden h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border px-2.5 md:flex",
-            MUSIC_NEUTRAL_BORDER_CLASS,
-            MUSIC_NEUTRAL_BG_CLASS,
+            MUSIC_NEUTRAL_SHELL_BORDER_CLASS,
+            MUSIC_NEUTRAL_SHELL_BG_CLASS,
           )}
         >
           {compactBody}

--- a/packages/client/src/components/chat/chat-input-styles.ts
+++ b/packages/client/src/components/chat/chat-input-styles.ts
@@ -1,0 +1,49 @@
+import { cn } from "../../lib/utils";
+
+type ChatInputLayout = "conversation" | "game" | "roleplay";
+
+interface ChatInputShellClassOptions {
+  className?: string;
+  dragging?: boolean;
+  hasContent?: boolean;
+  inline?: boolean;
+  layout: ChatInputLayout;
+}
+
+const CHAT_INPUT_LAYOUT_CLASSES: Record<ChatInputLayout, string> = {
+  conversation: "items-center gap-0.5 px-1.5 py-1 sm:gap-2 sm:px-4 sm:py-2.5",
+  game: "items-center gap-1.5 px-2 py-2 sm:px-4 sm:py-3",
+  roleplay: "items-center gap-1 px-2 py-1.5 sm:gap-2 sm:px-4 sm:py-2.5",
+};
+
+const CHAT_INPUT_INLINE_LAYOUT_CLASSES: Partial<Record<ChatInputLayout, string>> = {
+  game: "items-center gap-1.5 px-2 py-2",
+};
+
+export const CHAT_INPUT_SHELL_BASE_CLASS =
+  "mari-chat-input-box marinara-chat-input-shell relative flex rounded-2xl border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-sm backdrop-blur-md transition-all duration-200 focus-within:border-[var(--marinara-chat-chrome-input-border-focus)] focus-within:ring-1 focus-within:ring-[var(--marinara-chat-chrome-focus-ring)]";
+
+export const CHAT_INPUT_DRAGGING_CLASS =
+  "border-[var(--marinara-chat-chrome-input-border-focus)] bg-[var(--marinara-chat-chrome-highlight-bg)] shadow-lg shadow-black/10";
+
+export const CHAT_INPUT_HAS_CONTENT_CLASS = "shadow-md shadow-black/5";
+
+export function getChatInputShellClass({
+  className,
+  dragging = false,
+  hasContent = false,
+  inline = false,
+  layout,
+}: ChatInputShellClassOptions) {
+  const layoutClass =
+    inline && CHAT_INPUT_INLINE_LAYOUT_CLASSES[layout]
+      ? CHAT_INPUT_INLINE_LAYOUT_CLASSES[layout]
+      : CHAT_INPUT_LAYOUT_CLASSES[layout];
+
+  return cn(
+    CHAT_INPUT_SHELL_BASE_CLASS,
+    layoutClass,
+    dragging ? CHAT_INPUT_DRAGGING_CLASS : hasContent ? CHAT_INPUT_HAS_CONTENT_CLASS : "",
+    className,
+  );
+}

--- a/packages/client/src/components/game/DirectionEngine.tsx
+++ b/packages/client/src/components/game/DirectionEngine.tsx
@@ -195,8 +195,9 @@ export function DirectionEngine({
       {/* Click to dismiss persistent effects — only visible while effects are actively playing */}
       {activeEffects.some((e) => !e.expiring) && (
         <button
+          type="button"
           onClick={clearAll}
-          className="absolute bottom-4 right-4 z-50 rounded-full bg-black/50 px-3 py-1 text-xs text-white/60 backdrop-blur-sm transition-opacity hover:text-white/80"
+          className="marinara-chat-toolbar-button absolute bottom-4 right-4 z-50 rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-3 py-1.5 text-xs font-medium text-[var(--marinara-chat-chrome-button-text)] backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]"
         >
           Skip effects
         </button>

--- a/packages/client/src/components/game/DraggablePanel.tsx
+++ b/packages/client/src/components/game/DraggablePanel.tsx
@@ -105,7 +105,7 @@ export function PanelLockButton({ locked, onToggle, size = 10, className }: Pane
       aria-label={locked ? "Unlock panel" : "Lock panel"}
       aria-pressed={!locked}
       className={cn(
-        "flex shrink-0 items-center justify-center text-white/30 transition-colors hover:text-white/70",
+        "flex shrink-0 items-center justify-center rounded-md text-[var(--marinara-chat-chrome-panel-muted)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]",
         className,
       )}
     >

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -88,9 +88,9 @@ function formatAttributeModifier(score: number): string {
 
 const FIELD_LABEL_CLASS = "text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]";
 const TEXT_INPUT_CLASS =
-  "w-full rounded-lg border border-zinc-700/80 bg-zinc-950/70 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40";
+  "w-full rounded-lg border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]";
 const NUMBER_INPUT_CLASS =
-  "w-full rounded-lg border border-zinc-700/80 bg-zinc-950/70 px-2.5 py-1.5 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--foreground)]/40";
+  "w-full rounded-lg border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] px-2.5 py-1.5 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]";
 
 function normalizeTextValue(value: unknown) {
   if (typeof value === "string") return value;
@@ -392,7 +392,7 @@ export function GameCharacterSheet({
       <div
         className={cn(
           NEUTRAL_SURFACE_VARIABLES,
-          "relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-zinc-700/80 bg-zinc-950/95 shadow-2xl",
+          "marinara-chat-popover relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] shadow-2xl",
         )}
         onClick={(e) => e.stopPropagation()}
       >
@@ -403,14 +403,14 @@ export function GameCharacterSheet({
                 <button
                   onClick={handleCancelEdit}
                   disabled={isSaving}
-                  className="inline-flex h-8 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/90 px-2.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:px-3 sm:py-1.5"
+                  className="inline-flex h-8 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-2.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:px-3 sm:py-1.5"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={() => void handleSave()}
                   disabled={isSaving}
-                  className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg bg-zinc-900 px-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
+                  className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg bg-[var(--marinara-chat-chrome-highlight-bg)] px-2 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--marinara-chat-chrome-panel-border)] transition-colors hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
                   title={isSaving ? "Saving..." : "Save Sheet"}
                   aria-label={isSaving ? "Saving sheet" : "Save sheet"}
                 >
@@ -424,7 +424,7 @@ export function GameCharacterSheet({
                   <button
                     onClick={() => void handleRegenerate()}
                     disabled={isRegenerating || isSaving}
-                    className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg border border-zinc-700/80 bg-zinc-950/90 px-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] disabled:cursor-wait disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
+                    className="inline-flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)] disabled:cursor-wait disabled:opacity-60 sm:h-auto sm:min-w-0 sm:px-3 sm:py-1.5"
                     title="Regenerate this sheet from character and current game context"
                     aria-label="Regenerate sheet"
                   >
@@ -436,7 +436,7 @@ export function GameCharacterSheet({
                   <button
                     onClick={() => setIsEditing(true)}
                     disabled={isRegenerating}
-                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/90 p-0 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:w-auto sm:min-w-0 sm:gap-1.5 sm:px-3 sm:py-1.5"
+                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-button-bg)] p-0 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)] disabled:opacity-60 sm:h-auto sm:w-auto sm:min-w-0 sm:gap-1.5 sm:px-3 sm:py-1.5"
                     title="Edit Sheet"
                     aria-label="Edit sheet"
                   >
@@ -451,17 +451,17 @@ export function GameCharacterSheet({
 
         <button
           onClick={onClose}
-          className="absolute right-3 top-3 z-10 flex h-7 w-7 items-center justify-center rounded-lg p-0 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)] sm:h-auto sm:w-auto sm:p-1.5"
+          className="absolute right-3 top-3 z-10 flex h-7 w-7 items-center justify-center rounded-lg p-0 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)] sm:h-auto sm:w-auto sm:p-1.5"
           aria-label="Close character sheet"
           title="Close character sheet"
         >
           <X className="h-4 w-4 sm:h-[18px] sm:w-[18px]" />
         </button>
 
-        <div className="relative border-b border-zinc-700/80 bg-zinc-900/70 px-4 py-4 sm:px-5">
+        <div className="relative border-b border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-4 py-4 sm:px-5">
           <div className="flex items-center gap-3 sm:gap-4">
             {card.avatarUrl ? (
-              <span className="relative block h-16 w-16 shrink-0 overflow-hidden rounded-xl border-2 border-zinc-700/80 shadow-xl sm:h-20 sm:w-20">
+              <span className="relative block h-16 w-16 shrink-0 overflow-hidden rounded-xl border-2 border-[var(--marinara-chat-chrome-panel-border)] shadow-xl sm:h-20 sm:w-20">
                 <img
                   src={card.avatarUrl}
                   alt={card.title}
@@ -470,7 +470,7 @@ export function GameCharacterSheet({
                 />
               </span>
             ) : (
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl border-2 border-zinc-700/80 bg-zinc-900 text-xl font-bold text-[var(--muted-foreground)] sm:h-20 sm:w-20 sm:text-2xl">
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl border-2 border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-xl font-bold text-[var(--muted-foreground)] sm:h-20 sm:w-20 sm:text-2xl">
                 {card.title[0]}
               </div>
             )}
@@ -501,7 +501,7 @@ export function GameCharacterSheet({
               )}
             </div>
             {card.level != null && (
-              <div className="mr-16 flex items-center gap-1 rounded border border-zinc-700/80 bg-zinc-950/70 px-1.5 py-0.5 sm:mr-0">
+              <div className="mr-16 flex items-center gap-1 rounded border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-input-bg)] px-1.5 py-0.5 sm:mr-0">
                 <span className="text-[0.4375rem] uppercase tracking-wider text-[var(--muted-foreground)]">LVL</span>
                 <span className="text-xs font-bold leading-none text-[var(--foreground)]">{card.level}</span>
               </div>
@@ -517,7 +517,7 @@ export function GameCharacterSheet({
         <div className="flex-1 overflow-y-auto">
           {isEditing && (
             <>
-              <div className="border-b border-zinc-700/80 px-5 py-4">
+              <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
                 <SectionHeader
                   icon={<Pencil size={12} />}
                   title="Sheet Details"
@@ -547,7 +547,7 @@ export function GameCharacterSheet({
                 </div>
               </div>
 
-              <div className="border-b border-zinc-700/80 px-5 py-4">
+              <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
                 <div className="mb-2.5 flex items-center justify-between gap-3">
                   <SectionHeader
                     icon={<Shield size={12} />}
@@ -609,7 +609,7 @@ export function GameCharacterSheet({
                           />
                           <button
                             onClick={() => removeAttribute(index)}
-                            className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
+                            className="inline-flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-red-400"
                             title="Remove attribute"
                           >
                             <Trash2 size={13} />
@@ -618,7 +618,7 @@ export function GameCharacterSheet({
                       ))}
                       <button
                         onClick={addAttribute}
-                        className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700/80 px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--marinara-chat-chrome-panel-border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)]"
                       >
                         <Plus size={13} />
                         Add Attribute
@@ -632,7 +632,7 @@ export function GameCharacterSheet({
                 )}
               </div>
 
-              <div className="border-b border-zinc-700/80 px-5 py-4">
+              <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
                 <div className="mb-2.5 flex items-center justify-between gap-3">
                   <SectionHeader
                     icon={<Zap size={12} />}
@@ -641,7 +641,7 @@ export function GameCharacterSheet({
                   />
                   <button
                     onClick={() => addListItem("abilities")}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700/80 px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--marinara-chat-chrome-panel-border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)]"
                   >
                     <Plus size={13} />
                     Add
@@ -659,7 +659,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => removeListItem("abilities", index)}
-                        className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
+                        className="inline-flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-red-400"
                         title="Remove ability"
                       >
                         <Trash2 size={13} />
@@ -669,7 +669,7 @@ export function GameCharacterSheet({
                 </div>
               </div>
 
-              <div className="border-b border-zinc-700/80 px-5 py-4">
+              <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
                 <div className="grid gap-4 md:grid-cols-2">
                   <div>
                     <div className="mb-2.5 flex items-center justify-between gap-3">
@@ -680,7 +680,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => addListItem("strengths")}
-                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-zinc-700/80 px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
+                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-[var(--marinara-chat-chrome-panel-border)] px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)]"
                       >
                         <Plus size={12} />
                         Add
@@ -698,7 +698,7 @@ export function GameCharacterSheet({
                           />
                           <button
                             onClick={() => removeListItem("strengths", index)}
-                            className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
+                            className="inline-flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-red-400"
                             title="Remove strength"
                           >
                             <Trash2 size={13} />
@@ -716,7 +716,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => addListItem("weaknesses")}
-                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-zinc-700/80 px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
+                        className="inline-flex items-center gap-1 rounded-lg border border-dashed border-[var(--marinara-chat-chrome-panel-border)] px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)]"
                       >
                         <Plus size={12} />
                         Add
@@ -734,7 +734,7 @@ export function GameCharacterSheet({
                           />
                           <button
                             onClick={() => removeListItem("weaknesses", index)}
-                            className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400"
+                            className="inline-flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-red-400"
                             title="Remove weakness"
                           >
                             <Trash2 size={13} />
@@ -746,7 +746,7 @@ export function GameCharacterSheet({
                 </div>
               </div>
 
-              <div className="border-b border-zinc-700/80 px-5 py-4">
+              <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
                 <div className="mb-2.5 flex items-center justify-between gap-3">
                   <SectionHeader
                     icon={<Info size={12} />}
@@ -755,7 +755,7 @@ export function GameCharacterSheet({
                   />
                   <button
                     onClick={addExtraEntry}
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-zinc-700/80 px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-[var(--foreground)]"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--marinara-chat-chrome-panel-border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)]"
                   >
                     <Plus size={13} />
                     Add Detail
@@ -786,7 +786,7 @@ export function GameCharacterSheet({
                       />
                       <button
                         onClick={() => removeExtraEntry(index)}
-                        className="inline-flex items-center justify-center rounded-lg border border-zinc-700/80 px-2 text-[var(--muted-foreground)] transition-colors hover:bg-zinc-900 hover:text-red-400 max-sm:h-10"
+                        className="inline-flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-red-400 max-sm:h-10"
                         title="Remove detail"
                       >
                         <Trash2 size={13} />
@@ -799,7 +799,7 @@ export function GameCharacterSheet({
           )}
 
           {!isEditing && hasRpgStats && previewGameCard?.rpgStats && (
-            <div className="border-b border-zinc-700/80 px-5 py-4">
+            <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
               <SectionHeader
                 icon={<Shield size={12} />}
                 title="Attributes"
@@ -810,7 +810,7 @@ export function GameCharacterSheet({
                   {previewGameCard.rpgStats.attributes.map((attr) => (
                     <div
                       key={attr.name}
-                      className="flex flex-col items-center rounded-lg border border-zinc-700/80 bg-zinc-900/70 px-2 py-1.5"
+                      className="flex flex-col items-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-2 py-1.5"
                     >
                       <span className="text-[0.5625rem] font-bold uppercase tracking-widest text-[var(--muted-foreground)]">
                         {attr.name}
@@ -835,7 +835,7 @@ export function GameCharacterSheet({
                           {hpValue}/{hpMax}
                         </span>
                       </div>
-                      <div className="h-2.5 overflow-hidden rounded-full bg-zinc-900 ring-1 ring-zinc-700/80">
+                      <div className="h-2.5 overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-panel-border)]">
                         <div
                           className="h-full rounded-full transition-all"
                           style={{
@@ -851,7 +851,7 @@ export function GameCharacterSheet({
           )}
 
           {card.stats && card.stats.length > 0 && (
-            <div className="border-b border-zinc-700/80 px-5 py-4">
+            <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
               <SectionHeader icon={<Shield size={12} />} title="Stats" className="text-[var(--muted-foreground)]" />
               <div className="space-y-2">
                 {card.stats.map((stat) => {
@@ -866,7 +866,7 @@ export function GameCharacterSheet({
                           {value}/{max}
                         </span>
                       </div>
-                      <div className="h-2 overflow-hidden rounded-full bg-zinc-900 ring-1 ring-zinc-700/80">
+                      <div className="h-2 overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-panel-border)]">
                         <div
                           className="h-full rounded-full transition-all"
                           style={{
@@ -883,13 +883,13 @@ export function GameCharacterSheet({
           )}
 
           {!isEditing && previewGameCard && previewGameCard.abilities.length > 0 && (
-            <div className="border-b border-zinc-700/80 px-5 py-4">
+            <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
               <SectionHeader icon={<Zap size={12} />} title="Abilities" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1">
                 {previewGameCard.abilities.map((ability, index) => (
                   <div
                     key={`${ability}-${index}`}
-                    className="rounded-lg bg-zinc-900 px-2.5 py-1.5 text-xs text-[var(--foreground)]/80"
+                    className="rounded-lg bg-[var(--marinara-chat-chrome-highlight-bg)] px-2.5 py-1.5 text-xs text-[var(--foreground)]/80"
                   >
                     {ability}
                   </div>
@@ -901,7 +901,7 @@ export function GameCharacterSheet({
           {!isEditing &&
             previewGameCard &&
             (previewGameCard.strengths.length > 0 || previewGameCard.weaknesses.length > 0) && (
-              <div className="border-b border-zinc-700/80 px-5 py-4">
+              <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
                 <div className="grid grid-cols-2 gap-3">
                   {previewGameCard.strengths.length > 0 && (
                     <div>
@@ -936,7 +936,7 @@ export function GameCharacterSheet({
             )}
 
           {!isEditing && previewGameCard && Object.keys(previewGameCard.extra).length > 0 && (
-            <div className="border-b border-zinc-700/80 px-5 py-4">
+            <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
               <SectionHeader icon={<Info size={12} />} title="Details" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1.5 text-xs">
                 {Object.entries(previewGameCard.extra).map(([key, value]) => (
@@ -952,13 +952,13 @@ export function GameCharacterSheet({
           )}
 
           {card.inventory && card.inventory.length > 0 && (
-            <div className="border-b border-zinc-700/80 px-5 py-4">
+            <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
               <SectionHeader icon={<Swords size={12} />} title="Inventory" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1">
                 {card.inventory.map((item) => (
                   <div
                     key={`${item.name}-${item.location ?? "bag"}`}
-                    className="flex items-center justify-between rounded-lg bg-zinc-900 px-2.5 py-1.5 text-xs"
+                    className="flex items-center justify-between rounded-lg bg-[var(--marinara-chat-chrome-highlight-bg)] px-2.5 py-1.5 text-xs"
                   >
                     <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                       <span className="min-w-0 whitespace-normal break-words text-[var(--foreground)]/80 [overflow-wrap:anywhere]">
@@ -980,7 +980,7 @@ export function GameCharacterSheet({
           )}
 
           {card.customFields && Object.keys(card.customFields).length > 0 && (
-            <div className="border-b border-zinc-700/80 px-5 py-4">
+            <div className="border-b border-[var(--marinara-chat-chrome-panel-border)] px-5 py-4">
               <SectionHeader icon={<Sparkles size={12} />} title="Traits" className="text-[var(--muted-foreground)]" />
               <div className="space-y-1.5 text-xs">
                 {Object.entries(card.customFields).map(([key, value]) => (

--- a/packages/client/src/components/game/GameGridMap.tsx
+++ b/packages/client/src/components/game/GameGridMap.tsx
@@ -28,6 +28,7 @@ interface GameGridMapProps {
   zoom?: number;
   topLeftAction?: ReactNode;
   topRightAction?: ReactNode;
+  compactFit?: boolean;
 }
 
 export function GameGridMap({
@@ -39,6 +40,7 @@ export function GameGridMap({
   zoom = 1,
   topLeftAction,
   topRightAction,
+  compactFit,
 }: GameGridMapProps) {
   const cells = map.cells || [];
   const width = map.width || 5;
@@ -81,72 +83,89 @@ export function GameGridMap({
     }
     rows.push(row);
   }
+  const compactFitWidth = `min(${zoom * 100}%, ${((15 * width) / height).toFixed(3)}rem, ${((42 * width) / height).toFixed(3)}dvh)`;
+  const mapWidth = compactFit && zoom <= 1 ? compactFitWidth : `${zoom * 100}%`;
+  const mapViewportMaxHeight = compactFit ? "min(42dvh, 15rem)" : "min(52vh, 340px)";
 
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="mb-1 flex items-center gap-2">
-        <span className="text-xs font-medium text-zinc-100">{map.name}</span>
-        <AnimatedText html={map.description || ""} className="text-xs text-zinc-400" />
-      </div>
+      {!compactFit && (
+        <div className="mb-1 flex items-center gap-2">
+          <span className="text-xs font-medium text-[var(--marinara-chat-chrome-panel-title)]">{map.name}</span>
+          <AnimatedText
+            html={map.description || ""}
+            className="text-xs text-[var(--marinara-chat-chrome-panel-muted)]"
+          />
+        </div>
+      )}
       <div className="relative">
-        {topLeftAction}
-        {topRightAction}
         <div
-          className="w-full overflow-auto rounded-lg"
+          className={cn(
+            "relative w-full rounded-lg",
+            compactFit && zoom <= 1 ? "flex justify-center overflow-hidden" : "overflow-auto",
+          )}
           style={{
             aspectRatio: `${width} / ${height}`,
-            maxHeight: "min(52vh, 340px)",
+            maxHeight: mapViewportMaxHeight,
           }}
         >
           <div
-            className="grid gap-0.5"
+            className="relative"
             style={{
-              gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))`,
-              width: `${zoom * 100}%`,
-              marginInline: zoom < 1 ? "auto" : undefined,
+              width: mapWidth,
+              marginInline: compactFit || zoom < 1 ? "auto" : undefined,
             }}
           >
-            {rows.map((row) =>
-              row.map((cell) => {
-                const isParty = partyPos && partyPos.x === cell.x && partyPos.y === cell.y;
-                const isSelected = selectedCell && selectedCell.x === cell.x && selectedCell.y === cell.y;
-                const isAdjacent = adjacentSet.has(`${cell.x},${cell.y}`);
-                const isMovable = !disabled && isAdjacent && cell.discovered;
-                const terrainBg = TERRAIN_COLORS[cell.terrain] || "bg-zinc-900/60";
+            {topLeftAction}
+            {topRightAction}
+            <div
+              className="grid gap-0.5"
+              style={{
+                gridTemplateColumns: `repeat(${width}, minmax(0, 1fr))`,
+              }}
+            >
+              {rows.map((row) =>
+                row.map((cell) => {
+                  const isParty = partyPos && partyPos.x === cell.x && partyPos.y === cell.y;
+                  const isSelected = selectedCell && selectedCell.x === cell.x && selectedCell.y === cell.y;
+                  const isAdjacent = adjacentSet.has(`${cell.x},${cell.y}`);
+                  const isMovable = !disabled && isAdjacent && cell.discovered;
+                  const terrainBg = TERRAIN_COLORS[cell.terrain] || "bg-zinc-900/60";
 
-                return (
-                  <button
-                    key={`${cell.x},${cell.y}`}
-                    onClick={() => isMovable && onCellClick(cell.x, cell.y)}
-                    disabled={!isMovable}
-                    title={
-                      cell.discovered
-                        ? `${cell.label}: ${cell.description || cell.terrain}${isMovable ? " (click to select)" : ""}`
-                        : "Undiscovered"
-                    }
-                    className={cn(
-                      "relative flex aspect-square items-center justify-center rounded text-base transition-all",
-                      cell.discovered ? terrainBg : "bg-zinc-950/75 game-map-fog",
-                      isParty && "ring-2 ring-amber-400 ring-offset-1 ring-offset-zinc-950",
-                      isSelected && !isParty && "ring-2 ring-sky-400/70 ring-offset-1 ring-offset-zinc-950",
-                      isMovable && "hover:brightness-125 cursor-pointer ring-1 ring-amber-400/30",
-                      !isMovable && "cursor-default opacity-80",
-                    )}
-                  >
-                    {cell.discovered ? (
-                      <>
-                        <span className="text-sm">{cell.emoji}</span>
-                        {isParty && (
-                          <span className="absolute -bottom-0.5 -right-0.5 text-[10px] game-party-marker">📍</span>
-                        )}
-                      </>
-                    ) : (
-                      <span className="text-sm opacity-50">❓</span>
-                    )}
-                  </button>
-                );
-              }),
-            )}
+                  return (
+                    <button
+                      key={`${cell.x},${cell.y}`}
+                      onClick={() => isMovable && onCellClick(cell.x, cell.y)}
+                      disabled={!isMovable}
+                      title={
+                        cell.discovered
+                          ? `${cell.label}: ${cell.description || cell.terrain}${isMovable ? " (click to select)" : ""}`
+                          : "Undiscovered"
+                      }
+                      className={cn(
+                        "relative flex aspect-square items-center justify-center rounded text-base transition-all",
+                        cell.discovered ? terrainBg : "bg-zinc-950/75 game-map-fog",
+                        isParty && "ring-2 ring-amber-400 ring-offset-1 ring-offset-zinc-950",
+                        isSelected && !isParty && "ring-2 ring-sky-400/70 ring-offset-1 ring-offset-zinc-950",
+                        isMovable && "hover:brightness-125 cursor-pointer ring-1 ring-amber-400/30",
+                        !isMovable && "cursor-default opacity-80",
+                      )}
+                    >
+                      {cell.discovered ? (
+                        <>
+                          <span className="text-sm">{cell.emoji}</span>
+                          {isParty && (
+                            <span className="absolute -bottom-0.5 -right-0.5 text-[10px] game-party-marker">📍</span>
+                          )}
+                        </>
+                      ) : (
+                        <span className="text-sm opacity-50">❓</span>
+                      )}
+                    </button>
+                  );
+                }),
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -10,6 +10,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { translateDraftText } from "../../lib/draft-translation";
 import { formatTextQuotes, type DiceRollResult } from "@marinara-engine/shared";
+import { getChatInputShellClass } from "../chat/chat-input-styles";
 
 interface Attachment {
   type: string;
@@ -333,27 +334,18 @@ export function GameInput({
 
   const riskyInterrupt = interruptMode === "risky";
   const forceInterrupt = interruptMode === "force";
+  const forceInterruptStyle = forceInterrupt
+    ? {
+        boxShadow: "0 0 18px -6px rgba(32, 194, 14, 0.6)",
+        backgroundColor: "rgba(32, 194, 14, 0.04)",
+        ["--tw-ring-color" as never]: "rgba(32, 194, 14, 0.45)",
+      }
+    : undefined;
 
   return (
     <div
-      className={cn(
-        inline ? "" : "border-t border-foreground/10 bg-[var(--card)]",
-        riskyInterrupt &&
-          "rounded-xl ring-1 ring-red-500/40 bg-red-500/5 shadow-[0_0_18px_-6px_rgba(248,113,113,0.55)]",
-        forceInterrupt && "rounded-xl ring-1",
-      )}
-      style={
-        forceInterrupt
-          ? {
-              ...(inline ? {} : { minHeight: 61 }),
-              boxShadow: "0 0 18px -6px rgba(32, 194, 14, 0.6)",
-              backgroundColor: "rgba(32, 194, 14, 0.04)",
-              ["--tw-ring-color" as never]: "rgba(32, 194, 14, 0.45)",
-            }
-          : inline
-            ? undefined
-            : { minHeight: 61 }
-      }
+      className={cn(inline ? "" : "px-3 pb-3 pt-2")}
+      style={inline ? undefined : { minHeight: 61 }}
     >
       {/* Dice picker */}
       {showDice && (
@@ -445,7 +437,20 @@ export function GameInput({
       )}
 
       {/* Main input */}
-      <div ref={inputBarRef} className={cn("relative flex items-center gap-1.5", inline ? "px-0 py-1" : "px-4 py-3")}>
+      <div
+        ref={inputBarRef}
+        className={getChatInputShellClass({
+          className: cn(
+            riskyInterrupt &&
+              "ring-1 ring-red-500/40 bg-red-500/5 shadow-[0_0_18px_-6px_rgba(248,113,113,0.55)]",
+            forceInterrupt && "ring-1",
+          ),
+          hasContent: text.trim().length > 0 || attachments.length > 0 || !!queuedDice || !!pendingMoveLabel,
+          inline,
+          layout: "game",
+        })}
+        style={forceInterruptStyle}
+      >
         {/* Left: Address selector + Attach files */}
         <div className="relative shrink-0">
           {addressMenuOpen && (

--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from "../../lib/utils";
 import { PanelLockButton, useDraggablePanel } from "./DraggablePanel";
 import { getChatToolbarButtonClass } from "../chat/ChatToolbarControls";
+import { NEUTRAL_SURFACE_VARIABLES } from "../ui/neutral-surface-styles";
 
 const STATE_CONFIG: Record<GameActiveState, { icon: typeof Compass; label: string; color: string }> = {
   exploration: { icon: Compass, label: "Exploration", color: "text-emerald-300" },
@@ -33,6 +34,15 @@ const STATE_CONFIG: Record<GameActiveState, { icon: typeof Compass; label: strin
 const MAP_ZOOM_MIN = 0.75;
 const MAP_ZOOM_MAX = 1.8;
 const MAP_ZOOM_STEP = 0.25;
+const GAME_MAP_PANEL_CLASS = cn(
+  NEUTRAL_SURFACE_VARIABLES,
+  "marinara-chat-popover rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-lg shadow-black/35 backdrop-blur-md",
+);
+const GAME_MAP_DIVIDER_CLASS = "border-[var(--marinara-chat-chrome-panel-divider)]";
+const GAME_MAP_FIELD_CLASS =
+  "rounded-md border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] text-[var(--marinara-chat-chrome-panel-text)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]";
+const GAME_MAP_ACTION_ITEM_CLASS =
+  "text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] disabled:cursor-not-allowed disabled:opacity-35";
 
 type TimePhase = "midnight" | "night" | "dawn" | "morning" | "noon" | "afternoon" | "evening";
 
@@ -227,7 +237,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
   const skipCommitRef = useRef(false);
   const timeLabel = getTimeOfDayStatusLabel(timeOfDay);
   const rootClassName = cn(
-    "inline-flex shrink-0 items-stretch overflow-hidden rounded-lg border border-zinc-700/80 bg-zinc-950/85 text-zinc-100/85 shadow-[0_2px_8px_rgba(0,0,0,0.2)]",
+    "inline-flex shrink-0 items-stretch overflow-hidden rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text-hover)] shadow-[0_2px_8px_rgba(0,0,0,0.2)]",
     size === "mobile" ? "h-7 text-[0.6875rem]" : "h-5 text-[0.625rem]",
     className,
   );
@@ -235,7 +245,10 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
     "flex items-center justify-center font-semibold leading-none",
     size === "mobile" ? "min-w-14 px-2.5" : "min-w-11 px-1.5",
   );
-  const dividerClassName = cn("my-auto w-px shrink-0 bg-zinc-600/70", size === "mobile" ? "h-5" : "h-3.5");
+  const dividerClassName = cn(
+    "my-auto w-px shrink-0 bg-[var(--marinara-chat-chrome-panel-divider)]",
+    size === "mobile" ? "h-5" : "h-3.5",
+  );
   const timeClassName = cn(
     "h-full rounded-l-none rounded-r-full border-0 shadow-none",
     size === "mobile" ? "w-8" : "w-7",
@@ -265,7 +278,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
   if (editing) {
     return (
       <div
-        className={cn(rootClassName, "focus-within:ring-2 focus-within:ring-zinc-500/35")}
+        className={cn(rootClassName, "focus-within:ring-2 focus-within:ring-[var(--marinara-chat-chrome-focus-ring)]")}
         onClick={(event) => event.stopPropagation()}
         onPointerDown={(event) => event.stopPropagation()}
         title={`Day ${safeDay}. ${timeLabel}.`}
@@ -291,7 +304,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
             }
           }}
           className={cn(
-            "h-full bg-transparent text-center font-semibold text-white outline-none",
+            "h-full bg-transparent text-center font-semibold text-[var(--marinara-chat-chrome-panel-title)] outline-none",
             size === "mobile" ? "w-14 px-2.5 text-[0.6875rem]" : "w-11 px-1.5 text-[0.625rem]",
           )}
           aria-label="Edit game day"
@@ -312,7 +325,7 @@ function DayTimeIndicator({ day, timeOfDay, onDayChange, size = "desktop", class
       onPointerDown={(event) => event.stopPropagation()}
       className={cn(
         rootClassName,
-        "transition-colors hover:bg-zinc-900 hover:text-zinc-50 focus:outline-none focus:ring-2 focus:ring-zinc-500/35",
+        "transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--marinara-chat-chrome-focus-ring)]",
       )}
       title={`Day ${safeDay}. ${timeLabel}. Tap to edit day.`}
       aria-label={`Day ${safeDay}. ${timeLabel}. Tap to edit day.`}
@@ -371,7 +384,7 @@ function MapZoomControls({ zoom, onZoomOut, onZoomIn }: MapZoomControlsProps) {
 
   return (
     <div
-      className="absolute right-1.5 top-1.5 z-20 flex h-6 overflow-hidden rounded-md border border-zinc-700/80 bg-zinc-950/90 shadow-lg shadow-black/35"
+      className="absolute right-1.5 top-1.5 z-20 flex h-6 overflow-hidden rounded-md border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] shadow-lg shadow-black/35 backdrop-blur-md"
       onPointerDown={stopPointer}
       title={`Map zoom: ${Math.round(zoom * 100)}%`}
     >
@@ -382,13 +395,13 @@ function MapZoomControls({ zoom, onZoomOut, onZoomIn }: MapZoomControlsProps) {
           onZoomOut();
         }}
         disabled={atMin}
-        className="flex h-full w-5 items-center justify-center text-zinc-200/80 transition-colors hover:bg-zinc-800 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-35"
+        className={cn("flex h-full w-5 items-center justify-center", GAME_MAP_ACTION_ITEM_CLASS)}
         title="Zoom out"
         aria-label="Zoom out map"
       >
         <Minus size={11} />
       </button>
-      <span className="w-px bg-zinc-700/80" />
+      <span className="w-px bg-[var(--marinara-chat-chrome-button-border)]" />
       <button
         type="button"
         onClick={(event) => {
@@ -396,7 +409,7 @@ function MapZoomControls({ zoom, onZoomOut, onZoomIn }: MapZoomControlsProps) {
           onZoomIn();
         }}
         disabled={atMax}
-        className="flex h-full w-5 items-center justify-center text-zinc-200/80 transition-colors hover:bg-zinc-800 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-35"
+        className={cn("flex h-full w-5 items-center justify-center", GAME_MAP_ACTION_ITEM_CLASS)}
         title="Zoom in"
         aria-label="Zoom in map"
       >
@@ -445,7 +458,12 @@ function MapGenerateButton({ onGenerateMap, disabled, onAfterGenerate }: MapGene
         onAfterGenerate?.();
       }}
       disabled={disabled}
-      className="absolute left-1.5 top-1.5 z-20 flex h-6 w-6 items-center justify-center rounded-md border border-zinc-700/80 bg-zinc-950/90 text-zinc-200/80 shadow-lg shadow-black/35 transition-colors hover:bg-zinc-900 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-45"
+      className={getChatToolbarButtonClass({
+        compact: true,
+        sizeClassName: "h-6 w-6",
+        className:
+          "absolute left-1.5 top-1.5 z-20 shadow-lg shadow-black/35 disabled:cursor-not-allowed disabled:opacity-45",
+      })}
       title="Generate another map"
       aria-label="Generate another map"
     >
@@ -500,14 +518,14 @@ export function GameMapPanel({
     return (
       <div
         data-tour="game-map"
-        className="flex w-52 flex-col items-center justify-center gap-2 rounded-lg border border-zinc-700/80 bg-zinc-950/90 p-3 text-zinc-400 shadow-lg backdrop-blur-sm"
+        className={cn(GAME_MAP_PANEL_CLASS, "flex w-52 flex-col items-center justify-center gap-2 p-3")}
       >
-        <span className="text-[0.625rem]">No map yet</span>
+        <span className="text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)]">No map yet</span>
         {onGenerateMap && (
           <button
             onClick={onGenerateMap}
             disabled={disabled}
-            className="flex items-center gap-1 rounded-md bg-zinc-900 px-2 py-1 text-[0.625rem] font-medium text-zinc-100 ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-zinc-900"
+            className="flex items-center gap-1 rounded-md border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-2 py-1 text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-button-text-hover)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Wand2 size={10} />
             Generate
@@ -534,8 +552,9 @@ export function GameMapPanel({
       onDragEnd={handleDragEnd}
       style={{ x, y }}
       className={cn(
-        "game-map-container flex w-52 flex-col gap-1 rounded-lg border border-zinc-700/80 bg-zinc-950/90 p-2 text-zinc-300 shadow-lg shadow-black/35 backdrop-blur-sm",
-        !locked && "cursor-grab ring-1 ring-zinc-500/30 active:cursor-grabbing",
+        GAME_MAP_PANEL_CLASS,
+        "game-map-container flex w-52 flex-col gap-1 p-2",
+        !locked && "cursor-grab ring-1 ring-[var(--marinara-chat-chrome-focus-ring)] active:cursor-grabbing",
       )}
     >
       <div
@@ -548,7 +567,7 @@ export function GameMapPanel({
             setCollapsed(!collapsed);
           }
         }}
-        className="relative flex cursor-pointer items-center gap-1.5 text-xs text-zinc-400 transition-colors hover:text-zinc-100"
+        className="relative flex cursor-pointer items-center gap-1.5 text-xs text-[var(--marinara-chat-chrome-panel-muted)] transition-colors hover:text-[var(--marinara-chat-chrome-panel-title)]"
       >
         {hasLeadingStatus && (
           <div className="flex shrink-0 items-center gap-1.5">
@@ -561,7 +580,7 @@ export function GameMapPanel({
               >
                 <StateIcon size={13} />
                 {stateHovered && (
-                  <span className="absolute -bottom-6 left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-950/95 px-1.5 py-0.5 text-[0.55rem] text-zinc-100 shadow">
+                  <span className="absolute -bottom-6 left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded bg-[var(--marinara-chat-chrome-panel-bg)] px-1.5 py-0.5 text-[0.55rem] text-[var(--marinara-chat-chrome-panel-title)] shadow">
                     {stateCfg!.label}
                   </span>
                 )}
@@ -570,7 +589,7 @@ export function GameMapPanel({
             <DayTimeIndicator day={day} timeOfDay={timeOfDay} onDayChange={onDayChange} />
           </div>
         )}
-        <span className="block min-w-0 flex-1 overflow-hidden text-center font-semibold text-zinc-100">
+        <span className="block min-w-0 flex-1 overflow-hidden text-center font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
           {shouldMarquee ? (
             <span className="game-map-marquee-track inline-flex whitespace-nowrap">
               <span className="pr-8">{mapName}</span>
@@ -581,7 +600,7 @@ export function GameMapPanel({
           )}
         </span>
         <PanelLockButton locked={locked} onToggle={toggleLocked} size={11} />
-        <span className="shrink-0 text-zinc-300/70">
+        <span className="shrink-0 text-[var(--marinara-chat-chrome-button-text)]">
           {collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}
         </span>
       </div>
@@ -590,7 +609,7 @@ export function GameMapPanel({
           <select
             value={selectedMapId ?? ""}
             onChange={(event) => onViewedMapChange?.(event.target.value)}
-            className="min-w-0 flex-1 rounded-md border border-zinc-700/80 bg-zinc-950/70 px-1.5 py-1 text-[0.625rem] text-zinc-100 outline-none focus:border-zinc-400/60"
+            className={cn(GAME_MAP_FIELD_CLASS, "min-w-0 flex-1 px-1.5 py-1 text-[0.625rem]")}
             title="View map"
           >
             {mapOptions.map((option, index) => {
@@ -637,7 +656,7 @@ export function GameMapPanel({
   );
 }
 
-// ── Mobile Map: Icon trigger + fullscreen modal ──
+// ── Mobile Map: icon trigger + anchored popover ──
 
 interface MobileMapButtonProps {
   map: GameMap | null;
@@ -656,7 +675,7 @@ interface MobileMapButtonProps {
   onDayChange?: (day: number) => void;
 }
 
-/** Mobile-only: map icon button in top-left that opens a centered modal. */
+/** Mobile-only: map icon button in top-left that opens a compact anchored popover. */
 export function MobileMapButton({
   map,
   maps,
@@ -676,6 +695,7 @@ export function MobileMapButton({
   const [open, setOpen] = useState(false);
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
   const [mapZoom, setMapZoom] = useState(1);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const mapOptions = buildMapOptions(map, maps);
   const selectedMapId = viewedMapId ?? getMapId(map);
   const activeMap = activeMapId == null || selectedMapId === activeMapId;
@@ -692,6 +712,31 @@ export function MobileMapButton({
     if (!open) return;
     setSelectedNode(typeof selectedPosition === "string" ? selectedPosition : null);
   }, [open, selectedPosition]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setOpen(false);
+      setSelectedNode(null);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      setSelectedNode(null);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
 
   const stateCfg = gameState ? STATE_CONFIG[gameState] : null;
   const StateIcon = stateCfg?.icon ?? Compass;
@@ -726,39 +771,39 @@ export function MobileMapButton({
     (selectedNodeData?.discovered || adjacentIds.has(selectedNode) || selectedNode === currentNode?.id);
 
   return (
-    <>
+    <div ref={popoverRef} className="relative flex items-center">
       {/* Floating map icon */}
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center">
         <button
-          onClick={() => setOpen(true)}
-          className={getChatToolbarButtonClass({ className: "shadow-lg shadow-black/25" })}
-          aria-label="Open map"
-          title="Open map"
+          onClick={() => setOpen((value) => !value)}
+          className={getChatToolbarButtonClass({ open, className: "shadow-lg shadow-black/25" })}
+          aria-expanded={open}
+          aria-label={open ? "Close map" : "Open map"}
+          title={open ? "Close map" : "Open map"}
         >
           <MapIcon size={14} />
         </button>
-        <DayTimeIndicator day={day} timeOfDay={timeOfDay} onDayChange={onDayChange} size="mobile" />
       </div>
 
-      {/* Modal overlay */}
+      {/* Anchored map popover */}
       {open && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
-          onClick={() => {
-            setOpen(false);
-            setSelectedNode(null);
-          }}
+          className={cn(
+            GAME_MAP_PANEL_CLASS,
+            "absolute left-0 top-[calc(100%+0.375rem)] z-50 w-[min(20rem,calc(100vw-1.5rem))] overflow-hidden shadow-2xl shadow-black/45",
+          )}
+          data-game-skip-bg-nav="true"
         >
           <div
-            className="relative flex max-h-[80vh] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-zinc-700/80 bg-zinc-950/95 shadow-2xl backdrop-blur-md"
+            className="relative flex max-h-[min(68dvh,26rem)] flex-col overflow-hidden"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
-            <div className="flex items-center gap-2 border-b border-zinc-700/80 px-4 py-3">
-              <StateIcon size={14} className={stateCfg?.color ?? "text-zinc-400"} />
+            <div className={cn("flex items-center gap-2 border-b px-2.5 py-2", GAME_MAP_DIVIDER_CLASS)}>
+              <StateIcon size={14} className={stateCfg?.color ?? "text-[var(--marinara-chat-chrome-panel-muted)]"} />
               <DayTimeIndicator day={day} timeOfDay={timeOfDay} onDayChange={onDayChange} size="mobile" />
               <div className="min-w-0 flex-1 overflow-hidden">
-                <p className="block overflow-hidden whitespace-nowrap text-sm font-bold text-[var(--foreground)]">
+                <p className="block overflow-hidden whitespace-nowrap text-xs font-bold text-[var(--marinara-chat-chrome-panel-title)]">
                   {(map?.name || "Map").length > 18 ? (
                     <span className="game-map-marquee-track inline-flex whitespace-nowrap">
                       <span className="pr-8">{map?.name || "Map"}</span>
@@ -769,7 +814,7 @@ export function MobileMapButton({
                   )}
                 </p>
                 {currentNode && (
-                  <p className="block overflow-hidden whitespace-nowrap text-[0.625rem] text-[var(--muted-foreground)]">
+                  <p className="block overflow-hidden whitespace-nowrap text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)]">
                     {currentNode.label.length > 22 ? (
                       <span className="game-map-marquee-track inline-flex whitespace-nowrap">
                         <span className="pr-8">📍 {currentNode.label}</span>
@@ -787,7 +832,7 @@ export function MobileMapButton({
                       onViewedMapChange?.(event.target.value);
                       setSelectedNode(null);
                     }}
-                    className="mt-1 w-full rounded-md border border-zinc-700/80 bg-zinc-950/70 px-1.5 py-1 text-[0.625rem] text-zinc-100 outline-none focus:border-zinc-400/60"
+                    className={cn(GAME_MAP_FIELD_CLASS, "mt-1 w-full px-1.5 py-1 text-[0.625rem]")}
                     title="View map"
                   >
                     {mapOptions.map((option, index) => {
@@ -807,14 +852,16 @@ export function MobileMapButton({
                   setOpen(false);
                   setSelectedNode(null);
                 }}
-                className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+                className={getChatToolbarButtonClass({ compact: true, sizeClassName: "h-7 w-7 shrink-0" })}
+                aria-label="Close map"
+                title="Close map"
               >
                 <X size={14} />
               </button>
             </div>
 
             {/* Map body */}
-            <div className="flex-1 overflow-auto p-3">
+            <div className="min-h-0 overflow-auto p-2 overscroll-contain">
               {!map ? (
                 <div className="flex flex-col items-center justify-center gap-3 py-8 text-[var(--muted-foreground)]">
                   <span className="text-xs">No map yet</span>
@@ -825,7 +872,7 @@ export function MobileMapButton({
                         setOpen(false);
                       }}
                       disabled={disabled}
-                      className="flex items-center gap-1 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-100 ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="flex items-center gap-1 rounded-md border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-3 py-1.5 text-xs font-medium text-[var(--marinara-chat-chrome-button-text-hover)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Wand2 size={12} />
                       Generate
@@ -839,6 +886,7 @@ export function MobileMapButton({
                   disabled={mapInteractionDisabled}
                   showPartyPosition={activeMap}
                   zoom={mapZoom}
+                  compactFit
                   topLeftAction={
                     onGenerateMap ? (
                       <MapGenerateButton
@@ -865,6 +913,7 @@ export function MobileMapButton({
                   disabled={mapInteractionDisabled}
                   showPartyPosition={activeMap}
                   zoom={mapZoom}
+                  compactFit
                   topLeftAction={
                     onGenerateMap ? (
                       <MapGenerateButton
@@ -884,7 +933,7 @@ export function MobileMapButton({
 
             {/* Selected node footer — shown when a node is tapped */}
             {selectedNodeData && (
-              <div className="flex items-center gap-2 border-t border-zinc-700/80 px-4 py-2.5">
+              <div className={cn("flex items-center gap-2 border-t px-2.5 py-2", GAME_MAP_DIVIDER_CLASS)}>
                 <span className="text-sm">{selectedNodeData.discovered ? selectedNodeData.emoji : "❓"}</span>
                 <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--foreground)]">
                   {selectedNodeData.discovered ? selectedNodeData.label : "Unknown location"}
@@ -892,7 +941,7 @@ export function MobileMapButton({
                 {canTravel && selectedNode !== currentNode?.id && (
                   <button
                     onClick={handleTravel}
-                    className="shrink-0 rounded-lg bg-zinc-900 px-3 py-1.5 text-[0.6875rem] font-semibold text-zinc-100 ring-1 ring-zinc-700/80 transition-colors hover:bg-zinc-800 active:opacity-80"
+                    className="shrink-0 rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-3 py-1.5 text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-button-text-hover)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] active:opacity-80"
                   >
                     Set destination
                   </button>
@@ -905,6 +954,6 @@ export function MobileMapButton({
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -523,6 +523,7 @@ export function GameMapPanel({
         <span className="text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)]">No map yet</span>
         {onGenerateMap && (
           <button
+            type="button"
             onClick={onGenerateMap}
             disabled={disabled}
             className="flex items-center gap-1 rounded-md border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-2 py-1 text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-button-text-hover)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
@@ -775,6 +776,7 @@ export function MobileMapButton({
       {/* Floating map icon */}
       <div className="flex items-center">
         <button
+          type="button"
           onClick={() => setOpen((value) => !value)}
           className={getChatToolbarButtonClass({ open, className: "shadow-lg shadow-black/25" })}
           aria-expanded={open}
@@ -848,6 +850,7 @@ export function MobileMapButton({
                 )}
               </div>
               <button
+                type="button"
                 onClick={() => {
                   setOpen(false);
                   setSelectedNode(null);
@@ -867,6 +870,7 @@ export function MobileMapButton({
                   <span className="text-xs">No map yet</span>
                   {onGenerateMap && (
                     <button
+                      type="button"
                       onClick={() => {
                         onGenerateMap();
                         setOpen(false);
@@ -940,6 +944,7 @@ export function MobileMapButton({
                 </span>
                 {canTravel && selectedNode !== currentNode?.id && (
                   <button
+                    type="button"
                     onClick={handleTravel}
                     className="shrink-0 rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-3 py-1.5 text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-button-text-hover)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] active:opacity-80"
                   >

--- a/packages/client/src/components/game/GameNodeMap.tsx
+++ b/packages/client/src/components/game/GameNodeMap.tsx
@@ -15,6 +15,7 @@ interface GameNodeMapProps {
   zoom?: number;
   topLeftAction?: ReactNode;
   topRightAction?: ReactNode;
+  compactFit?: boolean;
 }
 
 export function GameNodeMap({
@@ -26,6 +27,7 @@ export function GameNodeMap({
   zoom = 1,
   topLeftAction,
   topRightAction,
+  compactFit,
 }: GameNodeMapProps) {
   const nodes = map.nodes || [];
   const edges = map.edges || [];
@@ -47,7 +49,7 @@ export function GameNodeMap({
   // Guard against empty nodes — no SVG to render
   if (nodes.length === 0) {
     return (
-      <div className="flex items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/70 p-4 text-xs text-zinc-400">
+      <div className="flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] p-4 text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
         No map nodes available
       </div>
     );
@@ -71,6 +73,9 @@ export function GameNodeMap({
   const visibleMinX = centerX - visibleViewWidth / 2;
   const visibleMinY = centerY - visibleViewHeight / 2;
   const mapContentWidth = `${Math.max(zoom, 1) * 100}%`;
+  const compactFitWidth = `min(100%, ${((15 * viewWidth) / viewHeight).toFixed(3)}rem, ${((42 * viewWidth) / viewHeight).toFixed(3)}dvh)`;
+  const mapWidth = compactFit && zoom <= 1 ? compactFitWidth : mapContentWidth;
+  const mapViewportMaxHeight = compactFit ? "min(42dvh, 15rem)" : "min(52vh, 340px)";
 
   // Build adjacency for current node highlighting
   const adjacentIds = new Set<string>();
@@ -92,124 +97,134 @@ export function GameNodeMap({
 
   return (
     <div className="relative" onMouseLeave={() => setHoveredNodeId(null)}>
-      {topLeftAction}
-      {topRightAction}
       <div
-        className="w-full overflow-auto rounded-lg"
+        className={cn(
+          "relative w-full rounded-lg",
+          compactFit && zoom <= 1 ? "flex justify-center overflow-hidden" : "overflow-auto",
+        )}
         style={{
           aspectRatio: `${viewWidth} / ${viewHeight}`,
-          maxHeight: "min(52vh, 340px)",
+          maxHeight: mapViewportMaxHeight,
         }}
       >
-        <svg
-          viewBox={`${visibleMinX} ${visibleMinY} ${visibleViewWidth} ${visibleViewHeight}`}
-          className="block rounded-lg border border-zinc-700/80 bg-zinc-950/70"
-          style={{ width: mapContentWidth }}
+        <div
+          className="relative"
+          style={{
+            width: mapWidth,
+            marginInline: compactFit || zoom < 1 ? "auto" : undefined,
+          }}
         >
-          {/* Edges */}
-          {edges.map((edge) => {
-            const from = nodes.find((n) => n.id === edge.from);
-            const to = nodes.find((n) => n.id === edge.to);
-            if (!from || !to) return null;
-            const isTraversed = from.discovered && to.discovered;
-            return (
-              <line
-                key={`${edge.from}-${edge.to}`}
-                x1={from.x}
-                y1={from.y}
-                x2={to.x}
-                y2={to.y}
-                stroke={isTraversed ? "rgba(168, 162, 158, 0.5)" : "rgba(100, 100, 100, 0.2)"}
-                strokeWidth={edgeStrokeWidth}
-                strokeDasharray={isTraversed ? "none" : "4 4"}
-              />
-            );
-          })}
-
-          {/* Nodes */}
-          {nodes.map((node) => {
-            const isCurrent = node.id === currentNodeId;
-            const isSelected = node.id === selectedNodeId;
-            const isAdjacent = adjacentIds.has(node.id);
-            const isDiscovered = !!node.discovered;
-            const isClickable = !disabled && (isCurrent || isAdjacent || isDiscovered);
-            const isHovered = hoveredNodeId === node.id;
-
-            return (
-              <g
-                key={node.id}
-                onClick={() => handleTap(node.id, isClickable)}
-                onMouseEnter={() => setHoveredNodeId(node.id)}
-                className={cn(isClickable && "cursor-pointer")}
-              >
-                {/* Background circle */}
-                <circle
-                  cx={node.x}
-                  cy={node.y}
-                  r={nodeRadius}
-                  fill={
-                    isCurrent
-                      ? "rgba(255, 255, 255, 0.2)"
-                      : isSelected
-                        ? "rgba(56, 189, 248, 0.18)"
-                        : node.discovered
-                          ? "rgba(100, 100, 100, 0.3)"
-                          : "rgba(50, 50, 50, 0.4)"
-                  }
-                  stroke={
-                    isCurrent
-                      ? "#ffffff"
-                      : isSelected
-                        ? "#38bdf8"
-                        : isAdjacent && !disabled
-                          ? "#a8a29e"
-                          : isDiscovered && !disabled
-                            ? "rgba(148, 163, 184, 0.45)"
-                            : "transparent"
-                  }
-                  strokeWidth={(isCurrent || isSelected ? 2 : 1) * visualScale}
+          {topLeftAction}
+          {topRightAction}
+          <svg
+            viewBox={`${visibleMinX} ${visibleMinY} ${visibleViewWidth} ${visibleViewHeight}`}
+            className="block w-full rounded-lg border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)]"
+          >
+            {/* Edges */}
+            {edges.map((edge) => {
+              const from = nodes.find((n) => n.id === edge.from);
+              const to = nodes.find((n) => n.id === edge.to);
+              if (!from || !to) return null;
+              const isTraversed = from.discovered && to.discovered;
+              return (
+                <line
+                  key={`${edge.from}-${edge.to}`}
+                  x1={from.x}
+                  y1={from.y}
+                  x2={to.x}
+                  y2={to.y}
+                  stroke={isTraversed ? "rgba(168, 162, 158, 0.5)" : "rgba(100, 100, 100, 0.2)"}
+                  strokeWidth={edgeStrokeWidth}
+                  strokeDasharray={isTraversed ? "none" : "4 4"}
                 />
-                {/* Emoji */}
-                <text
-                  x={node.x}
-                  y={node.y}
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  fontSize={emojiFontSize}
-                  className="pointer-events-none"
+              );
+            })}
+
+            {/* Nodes */}
+            {nodes.map((node) => {
+              const isCurrent = node.id === currentNodeId;
+              const isSelected = node.id === selectedNodeId;
+              const isAdjacent = adjacentIds.has(node.id);
+              const isDiscovered = !!node.discovered;
+              const isClickable = !disabled && (isCurrent || isAdjacent || isDiscovered);
+              const isHovered = hoveredNodeId === node.id;
+
+              return (
+                <g
+                  key={node.id}
+                  onClick={() => handleTap(node.id, isClickable)}
+                  onMouseEnter={() => setHoveredNodeId(node.id)}
+                  className={cn(isClickable && "cursor-pointer")}
                 >
-                  {node.discovered ? node.emoji : "❓"}
-                </text>
-                {/* Tooltip label — shown on hover/tap only */}
-                {node.discovered && isHovered && (
-                  <>
-                    <rect
-                      x={node.x - tooltipWidth / 2}
-                      y={node.y - tooltipTopOffset}
-                      width={tooltipWidth}
-                      height={tooltipHeight}
-                      rx={tooltipRadius}
-                      fill="rgba(0, 0, 0, 0.85)"
-                      stroke="rgba(255, 255, 255, 0.15)"
-                      strokeWidth={0.5 * visualScale}
-                      className="pointer-events-none"
-                    />
-                    <text
-                      x={node.x}
-                      y={node.y - tooltipLabelOffset}
-                      textAnchor="middle"
-                      fontSize={tooltipFontSize}
-                      fill="rgba(255, 255, 255, 0.9)"
-                      className="pointer-events-none"
-                    >
-                      {node.label.length > 16 ? node.label.slice(0, 15) + "…" : node.label}
-                    </text>
-                  </>
-                )}
-              </g>
-            );
-          })}
-        </svg>
+                  {/* Background circle */}
+                  <circle
+                    cx={node.x}
+                    cy={node.y}
+                    r={nodeRadius}
+                    fill={
+                      isCurrent
+                        ? "rgba(255, 255, 255, 0.2)"
+                        : isSelected
+                          ? "rgba(56, 189, 248, 0.18)"
+                          : node.discovered
+                            ? "rgba(100, 100, 100, 0.3)"
+                            : "rgba(50, 50, 50, 0.4)"
+                    }
+                    stroke={
+                      isCurrent
+                        ? "#ffffff"
+                        : isSelected
+                          ? "#38bdf8"
+                          : isAdjacent && !disabled
+                            ? "#a8a29e"
+                            : isDiscovered && !disabled
+                              ? "rgba(148, 163, 184, 0.45)"
+                              : "transparent"
+                    }
+                    strokeWidth={(isCurrent || isSelected ? 2 : 1) * visualScale}
+                  />
+                  {/* Emoji */}
+                  <text
+                    x={node.x}
+                    y={node.y}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fontSize={emojiFontSize}
+                    className="pointer-events-none"
+                  >
+                    {node.discovered ? node.emoji : "❓"}
+                  </text>
+                  {/* Tooltip label — shown on hover/tap only */}
+                  {node.discovered && isHovered && (
+                    <>
+                      <rect
+                        x={node.x - tooltipWidth / 2}
+                        y={node.y - tooltipTopOffset}
+                        width={tooltipWidth}
+                        height={tooltipHeight}
+                        rx={tooltipRadius}
+                        fill="rgba(0, 0, 0, 0.85)"
+                        stroke="rgba(255, 255, 255, 0.15)"
+                        strokeWidth={0.5 * visualScale}
+                        className="pointer-events-none"
+                      />
+                      <text
+                        x={node.x}
+                        y={node.y - tooltipLabelOffset}
+                        textAnchor="middle"
+                        fontSize={tooltipFontSize}
+                        fill="rgba(255, 255, 255, 0.9)"
+                        className="pointer-events-none"
+                      >
+                        {node.label.length > 16 ? node.label.slice(0, 15) + "…" : node.label}
+                      </text>
+                    </>
+                  )}
+                </g>
+              );
+            })}
+          </svg>
+        </div>
       </div>
     </div>
   );

--- a/packages/client/src/components/game/GamePartyBar.tsx
+++ b/packages/client/src/components/game/GamePartyBar.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { X } from "lucide-react";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import { NEUTRAL_SURFACE_VARIABLES } from "../ui/neutral-surface-styles";
 
 interface PartyBarMember {
   id: string;
@@ -48,7 +49,7 @@ function PartyAvatar({ visual, className }: { visual: PartyMemberVisual; classNa
     return (
       <span
         className={cn(
-          "relative block h-8 w-8 overflow-hidden rounded-lg border border-zinc-700/80 shadow-lg shadow-black/25 transition-colors group-hover:border-zinc-500/80",
+          "relative block h-8 w-8 overflow-hidden rounded-lg border border-[var(--marinara-chat-chrome-button-border)] shadow-lg shadow-black/25 transition-colors group-hover:border-[var(--marinara-chat-chrome-button-border-hover)]",
           className,
         )}
       >
@@ -65,7 +66,7 @@ function PartyAvatar({ visual, className }: { visual: PartyMemberVisual; classNa
   return (
     <span
       className={cn(
-        "flex h-8 w-8 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/90 text-xs font-bold shadow-lg shadow-black/25 transition-colors group-hover:border-zinc-500/80",
+        "flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-xs font-bold text-[var(--marinara-chat-chrome-button-text-hover)] shadow-lg shadow-black/25 transition-colors group-hover:border-[var(--marinara-chat-chrome-button-border-hover)]",
         className,
       )}
       style={member.nameColor ? { color: member.nameColor } : undefined}
@@ -141,14 +142,14 @@ export function GamePartyBar({
               }
               setMobileMenuOpen((open) => !open);
             }}
-            className="group relative block rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
+            className="group relative block rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
             aria-expanded={mobileMenuOpen}
             aria-label={mobileMenuOpen ? "Close party members" : "Open party members"}
             title={memberVisuals.length === 1 ? "Open character sheet" : "Open party members"}
           >
             <PartyAvatar visual={memberVisuals[previewIndex]} />
             {memberVisuals.length > 1 && (
-              <span className="absolute -bottom-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/95 px-1 text-[0.55rem] font-bold leading-none text-zinc-100 shadow-md">
+              <span className="absolute -bottom-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] px-1 text-[0.55rem] font-bold leading-none text-[var(--marinara-chat-chrome-button-text-hover)] shadow-md">
                 {memberVisuals.length}
               </span>
             )}
@@ -156,7 +157,12 @@ export function GamePartyBar({
         )}
 
         {mobileMenuOpen && memberVisuals.length > 1 && (
-          <div className="absolute left-0 top-9 z-50 rounded-xl border border-zinc-700/80 bg-zinc-950/95 p-1.5 shadow-2xl backdrop-blur-md">
+          <div
+            className={cn(
+              NEUTRAL_SURFACE_VARIABLES,
+              "marinara-chat-popover absolute left-0 top-9 z-50 rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] p-1.5 shadow-2xl backdrop-blur-md",
+            )}
+          >
             <div className="flex max-h-[min(44svh,18rem)] flex-col items-center gap-1.5 overflow-y-auto overscroll-contain pr-0.5 [-webkit-overflow-scrolling:touch]">
               {memberVisuals.map((visual) => (
                 <div key={visual.member.id} className="group relative shrink-0">
@@ -166,7 +172,7 @@ export function GamePartyBar({
                       openCharacterSheet(visual.member.id);
                       setMobileMenuOpen(false);
                     }}
-                    className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
+                    className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                     title={`${visual.member.name} - Click to open character sheet`}
                   >
                     <PartyAvatar visual={visual} />
@@ -179,7 +185,7 @@ export function GamePartyBar({
                         onRemovePartyMember(visual.member);
                       }}
                       disabled={removingPartyMemberId === visual.member.id}
-                      className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 shadow-md transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text-hover)] shadow-md transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60"
                       aria-label={`Remove ${visual.member.name} from party`}
                       title={`Remove ${visual.member.name} from party`}
                     >
@@ -205,7 +211,7 @@ export function GamePartyBar({
               <button
                 type="button"
                 onClick={() => openCharacterSheet(member.id)}
-                className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
+                className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                 title={`${member.name} - Click to open character sheet`}
               >
                 <PartyAvatar visual={visual} />
@@ -218,7 +224,7 @@ export function GamePartyBar({
                     onRemovePartyMember(member);
                   }}
                   disabled={removingPartyMemberId === member.id}
-                  className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-lg border border-zinc-700/80 bg-zinc-950/95 text-zinc-100 opacity-80 shadow-md transition-opacity hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60 group-hover:opacity-100 focus:opacity-100 md:opacity-0"
+                  className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text-hover)] opacity-80 shadow-md transition-opacity hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-60 group-hover:opacity-100 focus:opacity-100 md:opacity-0"
                   aria-label={`Remove ${member.name} from party`}
                   title={`Remove ${member.name} from party`}
                 >

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -136,7 +136,11 @@ import {
 import { ChatGalleryDrawer } from "../chat/ChatGalleryDrawer";
 import { ChatBranchSelector } from "../chat/ChatBranchSelector";
 import { GameAssetsBrowserView } from "../game-assets/GameAssetsBrowserView";
-import { getChatToolbarButtonClass } from "../chat/ChatToolbarControls";
+import {
+  CHAT_TOOLBAR_ICON_GAP_CLASS,
+  CHAT_TOOLBAR_OVERFLOW_MENU_CLASS,
+  getChatToolbarButtonClass,
+} from "../chat/ChatToolbarControls";
 import {
   ROLEPLAY_POPOVER_HEADER,
   ROLEPLAY_POPOVER_SCROLL_AREA,
@@ -175,12 +179,12 @@ type GameAssetGenerationResult = {
 };
 
 const GAME_TOP_ICON_BUTTON = getChatToolbarButtonClass();
-const GAME_MOBILE_ROOT_BUTTON = getChatToolbarButtonClass();
+const GAME_MOBILE_ROOT_BUTTON = getChatToolbarButtonClass({ sizeClassName: "h-8 w-10" });
 const GAME_MOBILE_ICON_BUTTON = getChatToolbarButtonClass({ compact: true });
 const GAME_ACTION_MENU = cn(ROLEPLAY_POPOVER_SHELL, "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-1 p-1.5");
 const GAME_MOBILE_ACTIONS_MENU = cn(
-  ROLEPLAY_POPOVER_SHELL,
-  "absolute right-0 top-9 flex w-8 flex-col items-center gap-1 p-0.5",
+  CHAT_TOOLBAR_OVERFLOW_MENU_CLASS,
+  "absolute right-0 top-9",
 );
 const GAME_MOBILE_ACTION_MENU = cn(ROLEPLAY_POPOVER_SHELL, "flex w-72 max-w-[calc(100vw-4rem)] flex-col gap-1 p-1.5");
 const GAME_ACTION_MENU_ITEM =
@@ -8351,7 +8355,7 @@ export function GameSurface({
                 className={cn("pointer-events-none absolute right-3 z-30", topOverlayOffsetClass)}
               >
                 {/* Desktop controls */}
-                <div className="pointer-events-auto hidden items-center gap-1.5 md:flex">
+                <div className={cn("pointer-events-auto hidden items-center md:flex", CHAT_TOOLBAR_ICON_GAP_CLASS)}>
                   <ChatBranchSelector
                     activeChatId={activeChatId}
                     activeChatName={chat.name}

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -47,6 +47,20 @@ interface WidgetEditorDraft {
 /** Maximum number of custom HUD widgets displayed. */
 const MAX_WIDGETS = 4;
 
+const GAME_WIDGET_SHELL_CLASS =
+  "marinara-chat-popover overflow-hidden rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-[0_10px_28px_rgba(0,0,0,0.24)] backdrop-blur-md transition-colors";
+const GAME_WIDGET_HEADER_CLASS =
+  "flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)]";
+const GAME_WIDGET_TITLE_CLASS =
+  "flex-1 overflow-x-auto scrollbar-hide whitespace-nowrap text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-panel-title)]";
+const GAME_WIDGET_MUTED_CLASS = "text-[var(--marinara-chat-chrome-panel-muted)]";
+const GAME_WIDGET_BODY_DIVIDER_CLASS = "border-t border-[var(--marinara-chat-chrome-panel-divider)]";
+const GAME_WIDGET_ICON_BUTTON_CLASS =
+  "flex h-5 w-5 items-center justify-center rounded-md text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]";
+const GAME_WIDGET_TRACK_CLASS = "bg-[var(--marinara-chat-chrome-panel-divider)]";
+const GAME_WIDGET_TILE_CLASS =
+  "border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--marinara-chat-chrome-highlight-bg)]";
+
 const EMPTY_WIDGET_DRAFT: WidgetEditorDraft = {
   value: "",
   max: "",
@@ -314,16 +328,18 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
             return (
               <div
                 key={w.id}
-                className="w-40 overflow-hidden rounded-lg border border-white/15 bg-black/70 backdrop-blur-md transition-all"
+                className={cn(GAME_WIDGET_SHELL_CLASS, "w-40 transition-all")}
                 data-game-skip-bg-nav="true"
               >
                 <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-left">
                   {w.icon && <span className="text-xs">{w.icon}</span>}
-                  <span className="flex-1 truncate text-[0.6875rem] font-semibold text-white/90">{w.label}</span>
+                  <span className="flex-1 truncate text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                    {w.label}
+                  </span>
                   <button
                     type="button"
                     onClick={() => openEditor(w)}
-                    className="flex h-5 w-5 items-center justify-center rounded-full text-white/50 transition-colors hover:bg-white/10 hover:text-white"
+                    className={GAME_WIDGET_ICON_BUTTON_CLASS}
                     title={`Edit ${w.label}`}
                   >
                     <Pencil size={10} />
@@ -331,13 +347,13 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
                   <button
                     type="button"
                     onClick={() => setExpandedId(null)}
-                    className="flex h-5 w-5 items-center justify-center rounded-full text-xs font-medium text-white/40 transition-colors hover:bg-white/10 hover:text-white"
+                    className={cn(GAME_WIDGET_ICON_BUTTON_CLASS, "text-xs font-medium")}
                     title="Collapse widget"
                   >
                     ×
                   </button>
                 </div>
-                <div className="border-t border-white/10 px-2.5 py-2">
+                <div className={cn(GAME_WIDGET_BODY_DIVIDER_CLASS, "px-2.5 py-2")}>
                   <WidgetBody widget={w} />
                 </div>
               </div>
@@ -348,7 +364,7 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
             <button
               key={w.id}
               onClick={() => setExpandedId(w.id)}
-              className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/15 bg-black/60 text-base backdrop-blur-md transition-transform active:scale-95"
+              className="marinara-chat-toolbar-button flex h-9 w-9 items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-base text-[var(--marinara-chat-chrome-button-text)] backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] active:scale-95"
               title={w.label}
             >
               {w.icon || "📊"}
@@ -393,8 +409,9 @@ function WidgetCard({
       style={{ x, y }}
       data-game-skip-bg-nav="true"
       className={cn(
-        "w-full overflow-hidden rounded-lg border border-white/15 bg-black/60 backdrop-blur-md transition-colors",
-        !locked && "cursor-grab ring-1 ring-white/20 active:cursor-grabbing",
+        GAME_WIDGET_SHELL_CLASS,
+        "w-full",
+        !locked && "cursor-grab ring-1 ring-[var(--marinara-chat-chrome-focus-ring)] active:cursor-grabbing",
       )}
     >
       {/* Header */}
@@ -408,30 +425,28 @@ function WidgetCard({
             setCollapsed((c) => !c);
           }
         }}
-        className="flex w-full cursor-pointer items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-white/5"
+        className={GAME_WIDGET_HEADER_CLASS}
       >
         {widget.icon && <span className="text-xs">{widget.icon}</span>}
-        <span className="flex-1 overflow-x-auto scrollbar-hide whitespace-nowrap text-[0.6875rem] font-semibold text-white/90">
-          {widget.label}
-        </span>
+        <span className={GAME_WIDGET_TITLE_CLASS}>{widget.label}</span>
         <button
           type="button"
           onClick={(event) => {
             event.stopPropagation();
             onEdit(widget);
           }}
-          className="flex h-5 w-5 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white"
+          className={GAME_WIDGET_ICON_BUTTON_CLASS}
           title={`Edit ${widget.label}`}
         >
           <Pencil size={10} />
         </button>
         <PanelLockButton locked={locked} onToggle={toggleLocked} size={10} />
-        <span className="text-[0.5rem] text-white/30">{collapsed ? "+" : "-"}</span>
+        <span className={cn("text-[0.5rem]", GAME_WIDGET_MUTED_CLASS)}>{collapsed ? "+" : "-"}</span>
       </div>
 
       {/* Body */}
       {!collapsed && (
-        <div className="border-t border-white/10 px-2.5 py-2">
+        <div className={cn(GAME_WIDGET_BODY_DIVIDER_CLASS, "px-2.5 py-2")}>
           <WidgetBody widget={widget} />
         </div>
       )}
@@ -460,7 +475,7 @@ function WidgetBody({ widget }: { widget: HudWidget }) {
     case "timer":
       return <TimerWidget widget={widget} />;
     default:
-      return <p className="text-[0.625rem] text-white/40">Unknown widget type</p>;
+      return <p className={cn("text-[0.625rem]", GAME_WIDGET_MUTED_CLASS)}>Unknown widget type</p>;
   }
 }
 
@@ -936,10 +951,10 @@ function ProgressBarWidget({ widget }: { widget: HudWidget }) {
   return (
     <div>
       <div className="mb-1 flex items-center justify-between text-[0.5625rem]">
-        <span className="text-white/60">{value}</span>
-        <span className="text-white/30">/ {max}</span>
+        <span className="text-[var(--marinara-chat-chrome-panel-text)]">{value}</span>
+        <span className={GAME_WIDGET_MUTED_CLASS}>/ {max}</span>
       </div>
-      <div className="h-2 overflow-hidden rounded-full bg-white/10">
+      <div className={cn("h-2 overflow-hidden rounded-full", GAME_WIDGET_TRACK_CLASS)}>
         <div
           className={cn("h-full rounded-full transition-all duration-700", isDanger && "animate-pulse")}
           style={{
@@ -969,7 +984,7 @@ function GaugeWidget({ widget }: { widget: HudWidget }) {
       <div className="relative h-12 w-24 overflow-hidden">
         {/* Track */}
         <div
-          className="absolute inset-0 rounded-t-full border-4 border-b-0 border-white/10"
+          className="absolute inset-0 rounded-t-full border-4 border-b-0 border-[var(--marinara-chat-chrome-panel-divider)]"
           style={{ borderTopColor: `${accent}20` }}
         />
         {/* Fill */}
@@ -982,7 +997,14 @@ function GaugeWidget({ widget }: { widget: HudWidget }) {
           }}
         />
       </div>
-      <span className={cn("mt-0.5 text-sm font-bold", isDanger ? "text-red-400" : "text-white/80")}>{value}</span>
+      <span
+        className={cn(
+          "mt-0.5 text-sm font-bold",
+          isDanger ? "text-red-400" : "text-[var(--marinara-chat-chrome-panel-title)]",
+        )}
+      >
+        {value}
+      </span>
     </div>
   );
 }
@@ -1004,7 +1026,7 @@ function RelationshipMeterWidget({ widget }: { widget: HudWidget }) {
           {currentMilestone.label}
         </p>
       )}
-      <div className="relative h-2 overflow-hidden rounded-full bg-white/10">
+      <div className={cn("relative h-2 overflow-hidden rounded-full", GAME_WIDGET_TRACK_CLASS)}>
         <div
           className="h-full rounded-full transition-all duration-700"
           style={{
@@ -1016,13 +1038,13 @@ function RelationshipMeterWidget({ widget }: { widget: HudWidget }) {
         {milestones.map((m, i) => (
           <div
             key={`${m.at}-${i}`}
-            className="absolute top-0 h-full w-0.5 bg-white/20"
+            className="absolute top-0 h-full w-0.5 bg-[var(--marinara-chat-chrome-panel-divider)]"
             style={{ left: `${(m.at / Math.max(1, max)) * 100}%` }}
             title={m.label}
           />
         ))}
       </div>
-      <div className="mt-1 flex items-center justify-between text-[0.5rem] text-white/30">
+      <div className={cn("mt-1 flex items-center justify-between text-[0.5rem]", GAME_WIDGET_MUTED_CLASS)}>
         <span>0</span>
         <span>{max}</span>
       </div>
@@ -1052,7 +1074,7 @@ function StatBlockWidget({ widget }: { widget: HudWidget }) {
     <div className="grid grid-cols-2 gap-x-3 gap-y-1">
       {stats.map((s, i) => (
         <div key={s.name ?? i} className="flex items-center justify-between text-[0.5625rem]">
-          <span className="text-white/50">{s.name}</span>
+          <span className={GAME_WIDGET_MUTED_CLASS}>{s.name}</span>
           <span className="font-mono font-bold" style={{ color: accent }}>
             {s.value}
           </span>
@@ -1069,12 +1091,12 @@ function ListWidget({ widget }: { widget: HudWidget }) {
   return (
     <div className="space-y-0.5">
       {items.length === 0 ? (
-        <p className="text-[0.5625rem] italic text-white/30">Empty</p>
+        <p className={cn("text-[0.5625rem] italic", GAME_WIDGET_MUTED_CLASS)}>Empty</p>
       ) : (
         items.slice(0, 8).map((item, i) => (
           <div key={i} className="flex items-center gap-1.5 text-[0.5625rem]">
-            <span className="text-white/20">*</span>
-            <span className="text-white/70">{item}</span>
+            <span className="text-[var(--marinara-chat-chrome-panel-muted)]/55">*</span>
+            <span className="text-[var(--marinara-chat-chrome-panel-text)]">{item}</span>
           </div>
         ))
       )}
@@ -1100,7 +1122,9 @@ function InventoryGridWidget({ widget }: { widget: HudWidget }) {
             onClick={() => setActiveCategory(null)}
             className={cn(
               "shrink-0 rounded px-1.5 py-0.5 text-[0.5rem] transition-colors",
-              !activeCategory ? "bg-white/15 text-white/80" : "text-white/40 hover:text-white/60",
+              !activeCategory
+                ? "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-highlight-text)]"
+                : "text-[var(--marinara-chat-chrome-panel-muted)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]",
             )}
           >
             All
@@ -1111,7 +1135,9 @@ function InventoryGridWidget({ widget }: { widget: HudWidget }) {
               onClick={() => setActiveCategory(cat)}
               className={cn(
                 "shrink-0 rounded px-1.5 py-0.5 text-[0.5rem] capitalize transition-colors",
-                activeCategory === cat ? "bg-white/15 text-white/80" : "text-white/40 hover:text-white/60",
+                activeCategory === cat
+                  ? "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-highlight-text)]"
+                  : "text-[var(--marinara-chat-chrome-panel-muted)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]",
               )}
             >
               {cat}
@@ -1129,13 +1155,13 @@ function InventoryGridWidget({ widget }: { widget: HudWidget }) {
               key={i}
               className={cn(
                 "flex aspect-square items-center justify-center rounded border text-[0.5rem]",
-                item ? "border-white/15 bg-white/5" : "border-white/5 bg-white/[0.02]",
+                item ? GAME_WIDGET_TILE_CLASS : "border-[var(--marinara-chat-chrome-panel-divider)]/45 bg-transparent",
               )}
               title={item?.name}
             >
               {item ? (
                 <div className="flex w-full flex-col items-center overflow-hidden px-0.5 text-center">
-                  <span className="w-full whitespace-normal break-words text-white/70 [overflow-wrap:anywhere]">
+                  <span className="w-full whitespace-normal break-words text-[var(--marinara-chat-chrome-panel-text)] [overflow-wrap:anywhere]">
                     {item.name}
                   </span>
                   {item.quantity && item.quantity > 1 && (

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -826,7 +826,7 @@ export function AppShell() {
               data-component="TrackerDataSidebarMobile"
               aria-label="Tracker data panel"
               className={cn(
-                "mari-tracker-panel !fixed inset-y-0 z-50 w-[calc(100vw-0.5rem)] max-w-[24rem] overflow-hidden bg-zinc-950/95 pt-[env(safe-area-inset-top)] shadow-2xl ring-1 ring-zinc-700/80 backdrop-blur-xl",
+                "mari-tracker-panel !fixed inset-y-0 z-50 h-[100dvh] w-screen max-w-none overflow-hidden bg-zinc-950/95 pt-[env(safe-area-inset-top)] shadow-2xl ring-1 ring-zinc-700/80 backdrop-blur-xl",
                 trackerPanelSide === "left" ? "left-0" : "right-0",
               )}
               style={trackerPanelBackgroundStyle}

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -577,8 +577,7 @@ export function ChatSidebar() {
   );
 
   const getDragChatIds = useCallback(
-    (chatId: string) =>
-      multiSelectMode && selectedChatIds.has(chatId) ? Array.from(selectedChatIds) : [chatId],
+    (chatId: string) => (multiSelectMode && selectedChatIds.has(chatId) ? Array.from(selectedChatIds) : [chatId]),
     [multiSelectMode, selectedChatIds],
   );
 
@@ -594,25 +593,22 @@ export function ChatSidebar() {
     [moveChatMut],
   );
 
-  const startTouchDrag = useCallback(
-    (chatId: string, event: React.PointerEvent<HTMLDivElement>) => {
-      if (event.pointerType === "mouse") return;
-      const drag = {
-        chatId,
-        timer: null as number | null,
-        active: false,
-        lastX: event.clientX,
-        lastY: event.clientY,
-      };
-      drag.timer = window.setTimeout(() => {
-        drag.active = true;
-        setDraggedChatId(chatId);
-      }, 420);
-      touchDragRef.current = drag;
-      event.currentTarget.setPointerCapture(event.pointerId);
-    },
-    [],
-  );
+  const startTouchDrag = useCallback((chatId: string, event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "mouse") return;
+    const drag = {
+      chatId,
+      timer: null as number | null,
+      active: false,
+      lastX: event.clientX,
+      lastY: event.clientY,
+    };
+    drag.timer = window.setTimeout(() => {
+      drag.active = true;
+      setDraggedChatId(chatId);
+    }, 420);
+    touchDragRef.current = drag;
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
 
   const updateTouchDrag = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     const drag = touchDragRef.current;
@@ -1588,9 +1584,12 @@ const STATUS_OPTIONS: Array<{
 function UserStatusFooter() {
   const userStatus = useUIStore((s) => s.userStatus);
   const userActivity = useUIStore((s) => s.userActivity);
+  const recentUserActivities = useUIStore((s) => s.recentUserActivities);
   const setUserStatusManual = useUIStore((s) => s.setUserStatusManual);
   const setUserActivity = useUIStore((s) => s.setUserActivity);
+  const rememberUserActivity = useUIStore((s) => s.rememberUserActivity);
   const [open, setOpen] = useState(false);
+  const [activityFocused, setActivityFocused] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   // Close on click outside
@@ -1604,6 +1603,27 @@ function UserStatusFooter() {
   }, [open]);
 
   const current = STATUS_OPTIONS.find((s) => s.value === userStatus) ?? STATUS_OPTIONS[0]!;
+  const recentActivitySuggestions = useMemo(() => {
+    const currentActivity = userActivity.replace(/\s+/g, " ").trim().toLowerCase();
+    return recentUserActivities
+      .filter((activity) => activity.trim() && activity.trim().toLowerCase() !== currentActivity)
+      .slice(0, 3);
+  }, [recentUserActivities, userActivity]);
+
+  const commitCurrentActivity = useCallback(() => {
+    const normalized = userActivity.replace(/\s+/g, " ").trim().slice(0, 120);
+    if (normalized !== userActivity) setUserActivity(normalized);
+    if (normalized) rememberUserActivity(normalized);
+  }, [rememberUserActivity, setUserActivity, userActivity]);
+
+  const applyRecentActivity = useCallback(
+    (activity: string) => {
+      setUserActivity(activity);
+      rememberUserActivity(activity);
+      setActivityFocused(false);
+    },
+    [rememberUserActivity, setUserActivity],
+  );
 
   return (
     <div ref={ref} className="relative border-t border-[var(--border)]/30 px-3 py-2">
@@ -1631,6 +1651,24 @@ function UserStatusFooter() {
           ))}
         </div>
       )}
+      {activityFocused && !open && recentActivitySuggestions.length > 0 && (
+        <div className="absolute bottom-full left-2 right-2 mb-1 rounded-xl bg-[var(--popover)] p-1.5 shadow-xl ring-1 ring-[var(--border)]/40">
+          <div className="px-2 pb-1 pt-0.5 text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+            Recent status
+          </div>
+          {recentActivitySuggestions.map((activity) => (
+            <button
+              key={activity}
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => applyRecentActivity(activity)}
+              className="flex w-full min-w-0 items-center rounded-lg px-2 py-1.5 text-left text-xs text-[var(--sidebar-foreground)] transition-colors hover:bg-[var(--accent)]"
+            >
+              <span className="truncate">{activity}</span>
+            </button>
+          ))}
+        </div>
+      )}
 
       <div className="flex min-w-0 items-center gap-1.5">
         <button
@@ -1645,6 +1683,19 @@ function UserStatusFooter() {
         <input
           value={userActivity}
           onChange={(event) => setUserActivity(event.target.value)}
+          onFocus={() => setActivityFocused(true)}
+          onBlur={() => {
+            commitCurrentActivity();
+            setActivityFocused(false);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.currentTarget.blur();
+            } else if (event.key === "Escape") {
+              setActivityFocused(false);
+              event.currentTarget.blur();
+            }
+          }}
           maxLength={120}
           placeholder="What are you doing?"
           aria-label="Custom activity"

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -100,10 +100,10 @@ export function TopBar() {
     <header
       ref={headerRef}
       data-component="TopBar"
-      className="mari-topbar relative z-10 flex h-12 flex-shrink-0 items-center justify-between bg-[var(--card)]/80 px-3 backdrop-blur-sm"
+      className="mari-topbar relative z-10 flex h-12 flex-shrink-0 items-center justify-between bg-[var(--marinara-topbar-surface)] px-3 backdrop-blur-sm"
     >
       {/* Subtle bottom border only */}
-      <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--border)]/30" />
+      <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--marinara-topbar-border)]" />
 
       {/* Left section: window controls + chat info */}
       <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -38,6 +38,7 @@ import {
 import { cn } from "../../lib/utils";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { useUpdateLorebookEntry, useDeleteLorebookEntry, useDuplicateLorebookEntry } from "../../hooks/use-lorebooks";
+import { MacroTextarea } from "../ui/MacroTextarea";
 import type {
   LorebookEntry,
   LorebookFilterMode,
@@ -129,10 +130,10 @@ const STATUS_GUIDE: Array<{ status: EntryStatus; description: string }> = [
 ];
 
 const ENTRY_AUTOSAVE_DELAY_MS = 850;
-const ENTRY_STATUS_MENU_WIDTH = 272;
-const ENTRY_STATUS_MENU_ESTIMATED_HEIGHT = 168;
-const ENTRY_STATUS_MENU_MARGIN = 12;
-const ENTRY_STATUS_MENU_GAP = 8;
+const ENTRY_STATUS_MENU_WIDTH = 224;
+const ENTRY_STATUS_MENU_ESTIMATED_HEIGHT = 126;
+const ENTRY_STATUS_MENU_MARGIN = 10;
+const ENTRY_STATUS_MENU_GAP = 6;
 
 const FILTER_MODE_LABEL: Record<LorebookFilterMode, string> = {
   any: "Any",
@@ -570,7 +571,7 @@ export function LorebookEntryRow({
               ref={statusMenuRef}
               role="menu"
               aria-label="Choose entry type"
-              className="fixed z-[120] rounded-lg border border-[var(--border)] bg-[var(--popover)] p-1.5 text-[var(--popover-foreground)] shadow-xl ring-1 ring-[var(--border)]"
+              className="fixed z-[120] rounded-lg border border-[var(--border)] bg-[var(--popover)] p-1 text-[var(--popover-foreground)] shadow-xl ring-1 ring-[var(--border)]"
               style={{
                 left: statusMenuPosition.left,
                 top: statusMenuPosition.top,
@@ -592,16 +593,16 @@ export function LorebookEntryRow({
                       handleStatusChange(status);
                     }}
                     className={cn(
-                      "flex w-full items-start gap-2 rounded-md px-2 py-2 text-left transition-colors focus:outline-none focus:ring-1 focus:ring-[var(--ring)]",
+                      "flex w-full items-start gap-1.5 rounded-md px-1.5 py-1.5 text-left transition-colors focus:outline-none focus:ring-1 focus:ring-[var(--ring)]",
                       selected
                         ? "bg-[var(--accent)] text-[var(--foreground)]"
                         : "text-[var(--popover-foreground)] hover:bg-[var(--accent)]",
                     )}
                   >
-                    <span className={cn("mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full", STATUS_DOT_COLOR[status])} />
+                    <span className={cn("mt-1 h-2 w-2 shrink-0 rounded-full", STATUS_DOT_COLOR[status])} />
                     <span className="min-w-0">
-                      <span className="block text-[0.75rem] font-semibold leading-tight">{STATUS_LABEL[status]}</span>
-                      <span className="mt-0.5 block text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
+                      <span className="block text-[0.6875rem] font-semibold leading-tight">{STATUS_LABEL[status]}</span>
+                      <span className="mt-0.5 block text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
                         {description}
                       </span>
                     </span>
@@ -1344,13 +1345,14 @@ function ExpandedDrawer({
           icon={FileText}
           help="Brief summary of what this entry is about. Used by the Knowledge Router agent to decide whether to inject this entry — not sent to the main AI as content."
         >
-          <textarea
+          <MacroTextarea
             value={form.description ?? ""}
-            onChange={(e) => update({ description: e.target.value })}
+            onChange={(value) => update({ description: value })}
             onBlur={flushAutosave}
             rows={3}
             className="w-full resize-y rounded-lg bg-[var(--secondary)] px-2.5 py-2 text-xs leading-5 ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
             placeholder="Brief summary for routing."
+            title="Edit Description"
           />
         </FieldGroup>
 
@@ -1476,6 +1478,7 @@ function ExpandedDrawer({
           rows={5}
           placeholder="The content that will be injected into the prompt when this entry activates…"
           title="Edit Content"
+          showMacroReference
         />
         <p className="mt-1 flex items-center gap-1 text-[0.625rem] text-[var(--muted-foreground)]">
           <Hash size="0.5625rem" />~{estimateTokens(form.content ?? "").toLocaleString()} tokens

--- a/packages/client/src/components/lorebooks/LorebookFormFields.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFormFields.tsx
@@ -4,10 +4,11 @@
 // and LorebookEntryRow (the per-entry inline drawer).
 // Extracted from LorebookEditor.tsx so styling stays consistent.
 // ──────────────────────────────────────────────
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { FileText, Maximize2, ToggleLeft, ToggleRight, X } from "lucide-react";
+import { useState } from "react";
+import { FileText, ToggleLeft, ToggleRight } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
+import { MacroTextarea } from "../ui/MacroTextarea";
 
 export function FieldGroup({
   label,
@@ -136,31 +137,6 @@ export function NumberField({
   );
 }
 
-export function insertTabAtSelection(
-  element: HTMLTextAreaElement,
-  value: string,
-  applyValue: (nextValue: string) => void,
-) {
-  const start = element.selectionStart;
-  const end = element.selectionEnd;
-  const nextValue = `${value.slice(0, start)}\t${value.slice(end)}`;
-  applyValue(nextValue);
-
-  requestAnimationFrame(() => {
-    element.selectionStart = element.selectionEnd = start + 1;
-  });
-}
-
-export function handleTextareaTabKeyDown(
-  event: ReactKeyboardEvent<HTMLTextAreaElement>,
-  value: string,
-  applyValue: (nextValue: string) => void,
-) {
-  if (event.key !== "Tab" || event.shiftKey || event.altKey || event.metaKey || event.ctrlKey) return;
-  event.preventDefault();
-  insertTabAtSelection(event.currentTarget, value, applyValue);
-}
-
 /** Textarea with an expand button that opens a fullscreen modal editor. */
 export function ExpandableTextarea({
   value,
@@ -170,6 +146,7 @@ export function ExpandableTextarea({
   rows,
   placeholder,
   title,
+  showMacroReference = false,
 }: {
   value: string;
   onChange: (v: string) => void;
@@ -178,118 +155,20 @@ export function ExpandableTextarea({
   rows?: number;
   placeholder?: string;
   title?: string;
+  showMacroReference?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
-
   return (
-    <>
-      <div className="relative">
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onBlur={onBlur}
-          onKeyDown={(e) => handleTextareaTabKeyDown(e, value, onChange)}
-          rows={rows ?? 6}
-          className="w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 pr-9 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-          placeholder={placeholder}
-        />
-        <button
-          onClick={() => setExpanded(true)}
-          className="absolute right-2 top-2 rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-          title="Expand editor"
-        >
-          <Maximize2 size="0.8125rem" />
-        </button>
-      </div>
-
-      {expanded && (
-        <ExpandedContentModal
-          title={title ?? "Edit"}
-          value={value}
-          onChange={onChange}
-          onCommit={onCommit}
-          onClose={() => setExpanded(false)}
-          placeholder={placeholder}
-        />
-      )}
-    </>
-  );
-}
-
-/** Fullscreen modal editor for lorebook entry fields. */
-export function ExpandedContentModal({
-  title,
-  value,
-  onChange,
-  onCommit,
-  onClose,
-  placeholder,
-}: {
-  title: string;
-  value: string;
-  onChange: (v: string) => void;
-  onCommit?: () => void;
-  onClose: () => void;
-  placeholder?: string;
-}) {
-  const [local, setLocal] = useState(value);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    setTimeout(() => textareaRef.current?.focus(), 100);
-  }, []);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onChange(local);
-        onCommit?.();
-        onClose();
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose, onChange, onCommit, local]);
-
-  const handleClose = () => {
-    onChange(local);
-    onCommit?.();
-    onClose();
-  };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-6 max-md:pt-[max(1.5rem,env(safe-area-inset-top))]">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-      <div className="relative flex h-[80vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <h3 className="text-sm font-semibold">{title}</h3>
-          <button onClick={handleClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
-            <X size="1rem" />
-          </button>
-        </div>
-        <div className="flex-1 overflow-hidden p-4">
-          <textarea
-            ref={textareaRef}
-            value={local}
-            onChange={(e) => setLocal(e.target.value)}
-            onKeyDown={(e) => handleTextareaTabKeyDown(e, local, setLocal)}
-            className="h-full w-full resize-none rounded-lg bg-[var(--secondary)] p-4 text-sm text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-            placeholder={placeholder}
-          />
-        </div>
-        <div className="flex items-center justify-between border-t border-[var(--border)] px-4 py-2.5">
-          <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-            Changes auto-save on close. Press Escape to close.
-          </p>
-          <button
-            onClick={handleClose}
-            className="rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
-          >
-            Done
-          </button>
-        </div>
-      </div>
-    </div>
+    <MacroTextarea
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      onExpandedClose={onCommit}
+      rows={rows ?? 6}
+      placeholder={placeholder}
+      title={title ?? "Edit"}
+      showMacroReference={showMacroReference}
+      className="w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+    />
   );
 }
 

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -202,6 +202,11 @@ export function CharactersPanel() {
     return map;
   }, [parsedCharacters]);
 
+  const parsedCharacterMap = useMemo(
+    () => new Map(parsedCharacters.map((character) => [character.id, character])),
+    [parsedCharacters],
+  );
+
   const filteredCharacters = useMemo(() => {
     let list = parsedCharacters;
     const query = parseCharacterSearchQuery(search);
@@ -492,15 +497,6 @@ export function CharactersPanel() {
     [editGroupName, updateGroup],
   );
 
-  const toggleGroupMember = useCallback(
-    (groupId: string, charId: string, currentMembers: string[]) => {
-      const isMember = currentMembers.includes(charId);
-      const newMembers = isMember ? currentMembers.filter((id) => id !== charId) : [...currentMembers, charId];
-      updateGroup.mutate({ id: groupId, characterIds: newMembers });
-    },
-    [updateGroup],
-  );
-
   const getDraggedCharacterIds = useCallback(
     (charId: string) =>
       selectionMode && selectedCharacterIds.has(charId) ? Array.from(selectedCharacterIds) : [charId],
@@ -536,8 +532,9 @@ export function CharactersPanel() {
 
   const handleCharacterDrop = useCallback(
     (folderId: string | null, charIds?: string[]) => {
-      if (!draggedCharacterId) return;
-      void moveCharactersToFolder(charIds ?? [draggedCharacterId], folderId);
+      const ids = charIds ?? (draggedCharacterId ? [draggedCharacterId] : []);
+      if (ids.length === 0) return;
+      void moveCharactersToFolder(ids, folderId);
       setDraggedCharacterId(null);
     },
     [draggedCharacterId, moveCharactersToFolder],
@@ -1014,8 +1011,17 @@ export function CharactersPanel() {
                   {group.memberIds.map((memberId) => {
                     const member = charMap.get(memberId);
                     if (!member) return null;
+                    const fullMember = parsedCharacterMap.get(memberId);
                     const isBulkSelected = selectedCharacterIds.has(memberId);
-                    const memberTitle = getCharacterTitle(member);
+                    const memberName = fullMember?.parsed.name ?? member.name;
+                    const memberTitle = fullMember
+                      ? getCharacterTitle({ name: memberName, comment: fullMember.comment })
+                      : getCharacterTitle(member);
+                    const memberPreviewMetadata = fullMember ? getCharacterPreviewMetadata(fullMember) : null;
+                    const memberTags = fullMember ? getCharacterTags(fullMember) : [];
+                    const memberTokenEstimate = fullMember ? estimateCharacterCardTokens(fullMember.parsed) : null;
+                    const memberNameColor = (fullMember?.parsed.extensions?.nameColor as string) || undefined;
+                    const memberAvatarCrop = fullMember?.parsed.extensions?.avatarCrop as AvatarCropValue | undefined;
                     return (
                       <div
                         key={memberId}
@@ -1050,12 +1056,11 @@ export function CharactersPanel() {
                         onContextMenu={(e) => {
                           if (selectionMode) return;
                           e.preventDefault();
-                          const fullMember = parsedCharacters.find((c) => c.id === memberId);
                           setContextMenu({
                             x: e.clientX,
                             y: e.clientY,
                             charId: memberId,
-                            charName: member.name,
+                            charName: memberName,
                             firstMes: fullMember?.parsed?.first_mes as string | undefined,
                             altGreetings: (fullMember?.parsed?.alternate_greetings ?? []) as string[],
                           });
@@ -1091,9 +1096,10 @@ export function CharactersPanel() {
                             {member.avatarPath ? (
                               <img
                                 src={member.avatarPath}
-                                alt={member.name}
+                                alt={memberName}
                                 loading="lazy"
                                 className="h-full w-full object-cover"
+                                style={getAvatarCropStyle(memberAvatarCrop)}
                               />
                             ) : (
                               <div className="flex h-full w-full items-center justify-center">
@@ -1111,10 +1117,65 @@ export function CharactersPanel() {
                           )}
                         </div>
                         <div className="min-w-0 flex-1">
-                          <span className="block truncate text-[0.6875rem]">{member.name}</span>
+                          <span
+                            className="block truncate text-[0.75rem] font-medium"
+                            style={
+                              memberNameColor
+                                ? memberNameColor.startsWith("linear-gradient")
+                                  ? {
+                                      background: memberNameColor,
+                                      backgroundRepeat: "no-repeat",
+                                      backgroundSize: "100% 100%",
+                                      WebkitBackgroundClip: "text",
+                                      WebkitTextFillColor: "transparent",
+                                      backgroundClip: "text",
+                                      color: "transparent",
+                                      display: "inline-block",
+                                    }
+                                  : { color: memberNameColor }
+                                : undefined
+                            }
+                          >
+                            {memberName}
+                          </span>
                           {memberTitle && (
                             <span className="block truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
                               {memberTitle}
+                            </span>
+                          )}
+                          {memberPreviewMetadata && (
+                            <span className="block truncate text-[0.5625rem] text-[var(--muted-foreground)]">
+                              {memberPreviewMetadata}
+                            </span>
+                          )}
+                          {memberTokenEstimate !== null && (
+                            <span
+                              className="flex items-center gap-1 text-[0.5625rem] text-[var(--muted-foreground)]"
+                              title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                            >
+                              <Hash size="0.5rem" />
+                              {formatEstimatedTokens(memberTokenEstimate)}
+                            </span>
+                          )}
+                          {memberTags.length > 0 && (
+                            <span className="mt-0.5 flex flex-wrap gap-0.5">
+                              {memberTags.slice(0, 3).map((tag) => (
+                                <span
+                                  key={tag}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    toggleIncludedTag(tag);
+                                  }}
+                                  className="cursor-pointer rounded-full bg-[var(--primary)]/8 px-1.5 py-px text-[0.5rem] font-medium text-[var(--primary)]/70 transition-all hover:bg-[var(--primary)]/15 hover:text-[var(--primary)]"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                              {memberTags.length > 3 && (
+                                <span className="rounded-full bg-[var(--secondary)] px-1.5 py-px text-[0.5rem] text-[var(--muted-foreground)]">
+                                  +{memberTags.length - 3}
+                                </span>
+                              )}
                             </span>
                           )}
                         </div>
@@ -1124,10 +1185,9 @@ export function CharactersPanel() {
                               type="button"
                               onClick={(e) => {
                                 e.stopPropagation();
-                                const fullMember = parsedCharacters.find((c) => c.id === memberId);
                                 handleStartNewChat(
                                   memberId,
-                                  member.name,
+                                  memberName,
                                   fullMember?.parsed?.first_mes as string | undefined,
                                   (fullMember?.parsed?.alternate_greetings ?? []) as string[],
                                 );
@@ -1135,14 +1195,14 @@ export function CharactersPanel() {
                               disabled={isStartingChat}
                               className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--primary)]/10 hover:text-[var(--primary)] group-hover/member:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 max-md:opacity-100"
                               title="Start New Chat"
-                              aria-label={`Start New Chat with ${member.name}`}
+                              aria-label={`Start New Chat with ${memberName}`}
                             >
                               <MessageCircle size="0.6875rem" />
                             </button>
                             <button
                               onClick={(e) => {
                                 e.stopPropagation();
-                                toggleGroupMember(group.id, memberId, group.memberIds);
+                                void moveCharactersToFolder([memberId], null);
                               }}
                               className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
                               title="Remove from folder"
@@ -1206,6 +1266,11 @@ export function CharactersPanel() {
           draggedCharacterId && "ring-1 ring-[var(--primary)]/20",
         )}
       >
+        {draggedCharacterId && (
+          <div className="rounded-xl border border-dashed border-[var(--primary)]/35 bg-[var(--primary)]/5 px-3 py-2 text-[0.625rem] text-[var(--primary)]">
+            Drop here to move out of folder
+          </div>
+        )}
         {visibleRootCharacters.map((char) => {
           const charName = char.parsed.name ?? "Unnamed";
           const charTitle = getCharacterTitle({ name: charName, comment: char.comment });

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -72,6 +72,15 @@ function getNextUnnamedFolderName(folders: Array<{ name: string }>) {
   return `unnamed ${index}`;
 }
 
+function parseDroppedCharacterIds(payload: string): unknown {
+  if (!payload) return undefined;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+}
+
 function getCharacterTags(char: ParsedCharacterRow): string[] {
   return Array.isArray(char.parsed.tags) ? (char.parsed.tags as string[]).filter(Boolean) : [];
 }
@@ -531,8 +540,12 @@ export function CharactersPanel() {
   );
 
   const handleCharacterDrop = useCallback(
-    (folderId: string | null, charIds?: string[]) => {
-      const ids = charIds ?? (draggedCharacterId ? [draggedCharacterId] : []);
+    (folderId: string | null, charIds?: unknown) => {
+      const ids = Array.isArray(charIds)
+        ? charIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+        : draggedCharacterId
+          ? [draggedCharacterId]
+          : [];
       if (ids.length === 0) return;
       void moveCharactersToFolder(ids, folderId);
       setDraggedCharacterId(null);
@@ -923,7 +936,7 @@ export function CharactersPanel() {
                 event.preventDefault();
                 event.stopPropagation();
                 const payload = event.dataTransfer.getData("application/x-marinara-character-ids");
-                handleCharacterDrop(group.id, payload ? (JSON.parse(payload) as string[]) : undefined);
+                handleCharacterDrop(group.id, parseDroppedCharacterIds(payload));
               }}
               className="flex flex-col rounded-lg transition-colors"
             >
@@ -1259,7 +1272,7 @@ export function CharactersPanel() {
         onDrop={(event) => {
           event.preventDefault();
           const payload = event.dataTransfer.getData("application/x-marinara-character-ids");
-          handleCharacterDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
+          handleCharacterDrop(null, parseDroppedCharacterIds(payload));
         }}
         className={cn(
           "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -44,6 +44,9 @@ type PersonaRow = {
   id: string;
   name: string;
   comment?: string;
+  creator?: string;
+  personaVersion?: string;
+  creatorNotes?: string;
   description: string;
   personality: string;
   scenario: string;
@@ -73,6 +76,17 @@ function getNextUnnamedFolderName(folders: Array<{ name: string }>) {
 function estimateTokens(p: PersonaRow): number {
   const text = [p.description, p.personality, p.scenario, p.backstory, p.appearance].join("");
   return Math.ceil(text.length / 4);
+}
+
+function getPersonaPreviewMetadata(p: PersonaRow): string | null {
+  const parts: string[] = [];
+  const creator = p.creator?.trim() ?? "";
+  const version = p.personaVersion?.trim() ?? "";
+
+  if (creator) parts.push(`by ${creator}`);
+  if (version) parts.push(`v${version}`);
+
+  return parts.length > 0 ? parts.join(", ") : null;
 }
 
 export function PersonasPanel() {
@@ -229,15 +243,6 @@ export function PersonasPanel() {
     [editGroupName, updatePGroup],
   );
 
-  const toggleGroupMember = useCallback(
-    (groupId: string, personaId: string, currentMembers: string[]) => {
-      const isMember = currentMembers.includes(personaId);
-      const newMembers = isMember ? currentMembers.filter((id) => id !== personaId) : [...currentMembers, personaId];
-      updatePGroup.mutate({ id: groupId, personaIds: newMembers });
-    },
-    [updatePGroup],
-  );
-
   const getDraggedPersonaIds = useCallback(
     (personaId: string) =>
       selectionMode && selectedPersonaIds.has(personaId) ? Array.from(selectedPersonaIds) : [personaId],
@@ -273,8 +278,9 @@ export function PersonasPanel() {
 
   const handlePersonaDrop = useCallback(
     (folderId: string | null, personaIds?: string[]) => {
-      if (!draggedPersonaId) return;
-      void movePersonasToFolder(personaIds ?? [draggedPersonaId], folderId);
+      const ids = personaIds ?? (draggedPersonaId ? [draggedPersonaId] : []);
+      if (ids.length === 0) return;
+      void movePersonasToFolder(ids, folderId);
       setDraggedPersonaId(null);
     },
     [draggedPersonaId, movePersonasToFolder],
@@ -731,6 +737,7 @@ export function PersonasPanel() {
                         const p = personaMap.get(pid);
                         if (!p) return null;
                         const isBulkSelected = selectedPersonaIds.has(pid);
+                        const personaMetadata = getPersonaPreviewMetadata(p);
                         return (
                           <div
                             key={pid}
@@ -801,12 +808,27 @@ export function PersonasPanel() {
                                 <User size="0.625rem" />
                               )}
                             </div>
-                            <span className="min-w-0 flex-1 truncate">{p.name}</span>
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-[0.75rem] font-medium">{p.name}</div>
+                              {p.comment && (
+                                <div className="truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
+                                  {p.comment}
+                                </div>
+                              )}
+                              {personaMetadata && (
+                                <div className="truncate text-[0.5625rem] text-[var(--muted-foreground)]">
+                                  {personaMetadata}
+                                </div>
+                              )}
+                              <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
+                                {p.description || "No description"}
+                              </div>
+                            </div>
                             {!selectionMode && (
                               <button
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  toggleGroupMember(group.id, pid, group.memberIds);
+                                  void movePersonasToFolder([pid], null);
                                 }}
                                 className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)] group-hover/member:opacity-100 max-md:opacity-100"
                                 title="Remove from folder"
@@ -861,9 +883,15 @@ export function PersonasPanel() {
           draggedPersonaId && "ring-1 ring-emerald-400/20",
         )}
       >
+        {draggedPersonaId && (
+          <div className="rounded-xl border border-dashed border-emerald-400/35 bg-emerald-400/5 px-3 py-2 text-[0.625rem] text-emerald-300">
+            Drop here to move out of folder
+          </div>
+        )}
         {visibleRootPersonas.map((persona) => {
           const active = isActive(persona);
           const isBulkSelected = selectedPersonaIds.has(persona.id);
+          const personaMetadata = getPersonaPreviewMetadata(persona);
 
           return (
             <div
@@ -955,6 +983,9 @@ export function PersonasPanel() {
                   <div className="truncate text-[0.625rem] italic text-[var(--muted-foreground)]">
                     {persona.comment}
                   </div>
+                )}
+                {personaMetadata && (
+                  <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{personaMetadata}</div>
                 )}
                 <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
                   {persona.description || "No description"}

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -73,6 +73,15 @@ function getNextUnnamedFolderName(folders: Array<{ name: string }>) {
   return `unnamed ${index}`;
 }
 
+function parseDroppedPersonaIds(payload: string): unknown {
+  if (!payload) return undefined;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+}
+
 function estimateTokens(p: PersonaRow): number {
   const text = [p.description, p.personality, p.scenario, p.backstory, p.appearance].join("");
   return Math.ceil(text.length / 4);
@@ -277,8 +286,12 @@ export function PersonasPanel() {
   );
 
   const handlePersonaDrop = useCallback(
-    (folderId: string | null, personaIds?: string[]) => {
-      const ids = personaIds ?? (draggedPersonaId ? [draggedPersonaId] : []);
+    (folderId: string | null, personaIds?: unknown) => {
+      const ids = Array.isArray(personaIds)
+        ? personaIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+        : draggedPersonaId
+          ? [draggedPersonaId]
+          : [];
       if (ids.length === 0) return;
       void movePersonasToFolder(ids, folderId);
       setDraggedPersonaId(null);
@@ -645,7 +658,7 @@ export function PersonasPanel() {
                 event.preventDefault();
                 event.stopPropagation();
                 const payload = event.dataTransfer.getData("application/x-marinara-persona-ids");
-                handlePersonaDrop(group.id, payload ? (JSON.parse(payload) as string[]) : undefined);
+                handlePersonaDrop(group.id, parseDroppedPersonaIds(payload));
               }}
               className="flex flex-col rounded-lg transition-colors"
             >
@@ -876,7 +889,7 @@ export function PersonasPanel() {
         onDrop={(event) => {
           event.preventDefault();
           const payload = event.dataTransfer.getData("application/x-marinara-persona-ids");
-          handlePersonaDrop(null, payload ? (JSON.parse(payload) as string[]) : undefined);
+          handlePersonaDrop(null, parseDroppedPersonaIds(payload));
         }}
         className={cn(
           "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR,
   useUIStore,
   getDefaultAppAccentColor,
+  getDefaultChatChromeTextColor,
   getTrackerPanelWidthForProfile,
   type ConversationMessageStyle,
   type GameDialogueDisplayMode,
@@ -1714,6 +1715,9 @@ function AppearanceSettings() {
   const setTheme = useUIStore((s) => s.setTheme);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
   const setAppAccentColor = useUIStore((s) => s.setAppAccentColor);
+  const defaultAppAccentColor = getDefaultAppAccentColor(theme);
+  const displayedAppAccentColor =
+    appAccentColor.trim().toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : appAccentColor;
   const visualTheme = useUIStore((s) => s.visualTheme);
   const setVisualTheme = useUIStore((s) => s.setVisualTheme);
   const chatBackground = useUIStore((s) => s.chatBackground);
@@ -1722,6 +1726,13 @@ function AppearanceSettings() {
   const setChatBackgroundBlur = useUIStore((s) => s.setChatBackgroundBlur);
   const activeChatId = useChatStore((s) => s.activeChatId);
   const updateMeta = useUpdateChatMetadata();
+  const handleAppAccentColorChange = useCallback(
+    (color: string) => {
+      const normalized = color.trim();
+      setAppAccentColor(normalized.toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : normalized);
+    },
+    [defaultAppAccentColor, setAppAccentColor],
+  );
   // Persist background changes to the active chat's metadata immediately so
   // a clear (or pick) survives chat switches and page reloads. The effect-based
   // persist in ChatArea covers other sources (agents/scene/slash commands), but
@@ -1778,6 +1789,8 @@ function AppearanceSettings() {
   // Text appearance
   const chatFontColor = useUIStore((s) => s.chatFontColor);
   const setChatFontColor = useUIStore((s) => s.setChatFontColor);
+  const chatChromeTextColor = useUIStore((s) => s.chatChromeTextColor);
+  const setChatChromeTextColor = useUIStore((s) => s.setChatChromeTextColor);
   const chatFontOpacity = useUIStore((s) => s.chatFontOpacity);
   const setChatFontOpacity = useUIStore((s) => s.setChatFontOpacity);
   const roleplayAvatarStyle = useUIStore((s) => s.roleplayAvatarStyle);
@@ -1796,8 +1809,6 @@ function AppearanceSettings() {
   const setTextStrokeWidth = useUIStore((s) => s.setTextStrokeWidth);
   const textStrokeColor = useUIStore((s) => s.textStrokeColor);
   const setTextStrokeColor = useUIStore((s) => s.setTextStrokeColor);
-  const [draftChatFontColor, setDraftChatFontColor] = useState(chatFontColor || "#c3c2c2");
-  const [draftStrokeColor, setDraftStrokeColor] = useState(textStrokeColor);
 
   // Custom fonts — query is pre-warmed in App.tsx, no fetch here
   const { data: customFonts } = useQuery<CustomFontFace[]>({
@@ -1932,13 +1943,15 @@ function AppearanceSettings() {
           </label>
 
           <ColorPicker
-            value={appAccentColor || getDefaultAppAccentColor(theme)}
-            onChange={setAppAccentColor}
+            value={displayedAppAccentColor}
+            onChange={handleAppAccentColorChange}
             gradient
             compact
             label="Accent Color"
             helpText="Colors the shared chat, roleplay, and game chrome: toolbar icons, button borders, focus rings, highlights, and panel outlines. Gradients unlock rainbow accents."
-            clearLabel="Use scheme default"
+            emptyText={`Default ${defaultAppAccentColor}`}
+            emptyPreviewValue={defaultAppAccentColor}
+            clearLabel="Reset to default"
           />
 
           <label className="flex flex-col gap-1">
@@ -2134,30 +2147,28 @@ function AppearanceSettings() {
             </div>
 
             {/* Chat Text Color */}
-            <div className="flex flex-col gap-1">
-              <span className="text-[0.6875rem] font-medium">Chat Text Color</span>
-              <div className="flex items-center gap-2">
-                <input
-                  type="color"
-                  value={draftChatFontColor}
-                  onChange={(e) => {
-                    setDraftChatFontColor(e.target.value);
-                    setChatFontColor(e.target.value);
-                  }}
-                  className="h-8 w-8 flex-shrink-0 cursor-pointer rounded-md border border-[var(--border)] bg-transparent p-0.5"
-                />
-                <input
-                  type="text"
-                  value={draftChatFontColor}
-                  onChange={(e) => {
-                    setDraftChatFontColor(e.target.value);
-                    if (/^#[0-9a-fA-F]{6}$/.test(e.target.value)) setChatFontColor(e.target.value);
-                  }}
-                  onBlur={() => setDraftChatFontColor(chatFontColor || "#c3c2c2")}
-                  className="w-24 rounded-md bg-[var(--secondary)] px-2 py-1.5 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
-                />
-              </div>
-            </div>
+            <ColorPicker
+              value={chatFontColor}
+              onChange={setChatFontColor}
+              compact
+              label="Chat Text Color"
+              helpText="Controls the main chat message text color. Leave it on the scheme default to keep dark and light mode readable."
+              emptyText={`Scheme default ${getDefaultChatChromeTextColor(theme)}`}
+              emptyPreviewValue={getDefaultChatChromeTextColor(theme)}
+              clearLabel="Reset to default"
+            />
+
+            {/* Chat Chrome Text Color */}
+            <ColorPicker
+              value={chatChromeTextColor}
+              onChange={setChatChromeTextColor}
+              compact
+              label="Chat Chrome Text Color"
+              helpText="Controls text in tracker widgets, shared toolbar buttons, and windows opened from chat buttons. Leave it on the scheme default to swap automatically between dark and light mode."
+              emptyText={`Scheme default ${getDefaultChatChromeTextColor(theme)}`}
+              emptyPreviewValue={getDefaultChatChromeTextColor(theme)}
+              clearLabel="Reset to default"
+            />
 
             {/* Roleplay Messages Background Opacity */}
             <label className="flex flex-col gap-1">
@@ -2176,17 +2187,15 @@ function AppearanceSettings() {
                   {chatFontOpacity}%
                 </span>
               </div>
+              <button
+                type="button"
+                onClick={() => setChatFontOpacity(90)}
+                disabled={chatFontOpacity === 90}
+                className="self-start text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] disabled:pointer-events-none disabled:opacity-45"
+              >
+                Reset opacity to default
+              </button>
             </label>
-            <button
-              onClick={() => {
-                setChatFontColor("");
-                setDraftChatFontColor("#c3c2c2");
-                setChatFontOpacity(90);
-              }}
-              className="text-[0.625rem] text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors self-start"
-            >
-              Reset to default
-            </button>
 
             {/* Text Stroke */}
             <div className="flex flex-col gap-1.5">
@@ -2194,43 +2203,36 @@ function AppearanceSettings() {
                 Text Outline / Stroke
                 <HelpTooltip text="Adds an outline around chat text for better readability over backgrounds. Set width to 0 to disable." />
               </span>
-              <div className="flex items-center gap-3">
-                <label className="flex flex-col gap-1 flex-1">
-                  <span className="text-[0.625rem] text-[var(--muted-foreground)]">Width</span>
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="range"
-                      min={0}
-                      max={5}
-                      step={0.5}
-                      value={textStrokeWidth}
-                      onChange={(e) => setTextStrokeWidth(Number(e.target.value))}
-                      className="flex-1 accent-[var(--primary)]"
-                    />
-                    <span className="text-xs tabular-nums text-[var(--muted-foreground)] w-10 text-right">
-                      {textStrokeWidth}px
-                    </span>
-                  </div>
-                </label>
-                <div className="flex flex-col gap-1">
-                  <div className="flex items-center gap-1.5">
-                    <input
-                      type="color"
-                      value={draftStrokeColor}
-                      onChange={(e) => {
-                        setDraftStrokeColor(e.target.value);
-                        setTextStrokeColor(e.target.value);
-                      }}
-                      className="h-8 w-8 flex-shrink-0 cursor-pointer rounded-md border border-[var(--border)] bg-transparent p-0.5"
-                    />
-                  </div>
+              <ColorPicker
+                value={textStrokeColor || "#000000"}
+                onChange={(value) => setTextStrokeColor(value || "#000000")}
+                compact
+                label="Text Outline Color"
+                helpText="Controls the outline color used when text stroke width is above 0."
+                clearLabel="Reset to default"
+                clearValue="#000000"
+              />
+              <label className="flex flex-col gap-1">
+                <span className="text-[0.625rem] text-[var(--muted-foreground)]">Width</span>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="range"
+                    min={0}
+                    max={5}
+                    step={0.5}
+                    value={textStrokeWidth}
+                    onChange={(e) => setTextStrokeWidth(Number(e.target.value))}
+                    className="flex-1 accent-[var(--primary)]"
+                  />
+                  <span className="w-10 text-right text-xs tabular-nums text-[var(--muted-foreground)]">
+                    {textStrokeWidth}px
+                  </span>
                 </div>
-              </div>
+              </label>
               <button
                 onClick={() => {
                   setTextStrokeWidth(0.5);
                   setTextStrokeColor("#000000");
-                  setDraftStrokeColor("#000000");
                 }}
                 className="text-[0.625rem] text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors self-start"
               >
@@ -3419,7 +3421,7 @@ function ThemesSettings() {
             <code className="rounded bg-[var(--secondary)] px-1">--primary</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-accent</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-accent-gradient</code>,{" "}
-            <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-button-bg</code>) or add custom
+            <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-surface-bg</code>) or add custom
             styles. JSON themes should have{" "}
             <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "css": "..." }`}</code> format.
             Imported theme files sync to this Marinara server but do not auto-activate.
@@ -3460,22 +3462,31 @@ const CSS_TEMPLATE = `/* ══════════════════�
   /* ── Shared Chat / Roleplay / Game Chrome ── */
   /* --marinara-chat-chrome-accent: var(--foreground); */
   /* --marinara-chat-chrome-accent-gradient: linear-gradient(90deg, var(--marinara-chat-chrome-accent), var(--marinara-chat-chrome-accent)); */
-  /* --marinara-chat-chrome-button-bg: color-mix(in srgb, var(--card) 82%, transparent); */
-  /* --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--card) 94%, var(--foreground) 6%); */
-  /* --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--card) 92%, var(--foreground) 8%); */
+  /* --marinara-chat-chrome-text: var(--foreground); */
+  /* --marinara-chat-chrome-button-text-base: var(--marinara-chat-chrome-accent); */
+  /* --marinara-chat-chrome-highlight-text-base: var(--marinara-chat-chrome-accent); */
+  /* --marinara-chat-chrome-surface-bg: var(--card); */
+  /* --marinara-chat-chrome-surface-bg-hover: color-mix(in srgb, var(--marinara-chat-chrome-surface-bg) 92%, var(--foreground) 8%); */
+  /* --marinara-chat-chrome-surface-bg-active: color-mix(in srgb, var(--marinara-chat-chrome-surface-bg) 88%, var(--foreground) 12%); */
+  /* --marinara-chat-chrome-button-bg: var(--marinara-chat-chrome-surface-bg); */
+  /* --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--marinara-chat-chrome-surface-bg-hover) 90%, var(--marinara-chat-chrome-accent) 10%); */
+  /* --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--marinara-chat-chrome-surface-bg-active) 84%, var(--marinara-chat-chrome-accent) 16%); */
   /* --marinara-chat-chrome-button-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 12%, transparent); */
   /* --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 20%, transparent); */
   /* --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 24%, transparent); */
-  /* --marinara-chat-chrome-button-text: color-mix(in srgb, var(--marinara-chat-chrome-accent) 64%, transparent); */
-  /* --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 92%, transparent); */
-  /* --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 96%, transparent); */
-  /* --marinara-chat-chrome-panel-bg: color-mix(in srgb, var(--background) 88%, var(--card) 12%); */
+  /* --marinara-chat-chrome-button-text: color-mix(in srgb, var(--marinara-chat-chrome-button-text-base) 64%, transparent); */
+  /* --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--marinara-chat-chrome-button-text-base) 92%, transparent); */
+  /* --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--marinara-chat-chrome-button-text-base) 96%, transparent); */
+  /* --marinara-chat-chrome-panel-bg: var(--marinara-chat-chrome-button-bg); */
   /* --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 16%, transparent); */
   /* --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent); */
-  /* --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--foreground) 90%, transparent); */
-  /* --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--foreground) 58%, transparent); */
+  /* --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--marinara-chat-chrome-text) 90%, transparent); */
+  /* --marinara-chat-chrome-panel-title: color-mix(in srgb, var(--marinara-chat-chrome-text) 96%, transparent); */
+  /* --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--marinara-chat-chrome-text) 58%, transparent); */
   /* --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--marinara-chat-chrome-accent) 9%, transparent); */
   /* --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent); */
+  /* --marinara-chat-chrome-highlight-text: color-mix(in srgb, var(--marinara-chat-chrome-highlight-text-base) 94%, transparent); */
+  /* --marinara-chat-chrome-input-bg: var(--marinara-chat-chrome-surface-bg); */
 }
 
 /* Uncomment and edit the variables above.

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import {
   useUIStore,
   getDefaultAppAccentColor,
   getDefaultChatChromeTextColor,
+  getDefaultChatTextColor,
   getTrackerPanelWidthForProfile,
   type ConversationMessageStyle,
   type GameDialogueDisplayMode,
@@ -2153,8 +2154,8 @@ function AppearanceSettings() {
               compact
               label="Chat Text Color"
               helpText="Controls the main chat message text color. Leave it on the scheme default to keep dark and light mode readable."
-              emptyText={`Scheme default ${getDefaultChatChromeTextColor(theme)}`}
-              emptyPreviewValue={getDefaultChatChromeTextColor(theme)}
+              emptyText={`Scheme default ${getDefaultChatTextColor(theme)}`}
+              emptyPreviewValue={getDefaultChatTextColor(theme)}
               clearLabel="Reset to default"
             />
 

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -36,7 +36,6 @@ import {
   Activity,
   Plus,
   X,
-  Maximize2,
   Tag,
   Image,
   Upload,
@@ -58,7 +57,7 @@ import { showConfirmDialog } from "../../lib/app-dialogs";
 import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { ColorPicker } from "../ui/ColorPicker";
-import { ExpandedTextarea } from "../ui/ExpandedTextarea";
+import { MacroTextarea } from "../ui/MacroTextarea";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
 import { api } from "../../lib/api-client";
@@ -2326,19 +2325,20 @@ function PersonaMetadataTab({
         </div>
       </div>
 
-      <label className="block space-y-1.5">
+      <div className="block space-y-1.5">
         <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
           Creator Notes{" "}
           <HelpTooltip text="Private notes about this persona — tips for use, known quirks, recommended settings. Not sent to the AI." />
         </span>
-        <textarea
+        <MacroTextarea
           value={formData.creatorNotes}
-          onChange={(e) => updateField("creatorNotes", e.target.value)}
+          onChange={(value) => updateField("creatorNotes", value)}
           rows={4}
+          title="Creator Notes"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
           placeholder="Notes about this persona, intended use, tips for best results..."
         />
-      </label>
+      </div>
     </div>
   );
 }
@@ -2707,51 +2707,27 @@ function DescriptionTab({
   updateField: <K extends keyof PersonaFormData>(key: K, value: PersonaFormData[K]) => void;
   setDirty: (v: boolean) => void;
 }) {
-  const [expandedField, setExpandedField] = useState(false);
-
   return (
     <div className="space-y-6">
       {/* Main description */}
       <div>
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h3 className="inline-flex items-center gap-1.5 text-sm font-semibold">
-              Description
-              <HelpTooltip text={PERSONA_DESCRIPTION_HELP} side="bottom" wide size="0.8125rem" />
-            </h3>
-            <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
-              Your general description. This is sent in every prompt so the AI knows who you are.
-            </p>
-          </div>
-          <button
-            type="button"
-          onClick={() => setExpandedField(true)}
-            className="shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.875rem" />
-          </button>
-        </div>
-        <textarea
+        <SectionHeader
+          title="Description"
+          subtitle="Your general description. This is sent in every prompt so the AI knows who you are."
+          helpText={PERSONA_DESCRIPTION_HELP}
+        />
+        <MacroTextarea
           value={formData.description}
-          onChange={(e) => updateField("description", e.target.value)}
+          onChange={(value) => updateField("description", value)}
           placeholder="Describe who you are, your role in the story, and your key traits…"
           rows={12}
+          title="Description"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-emerald-400/40 focus:ring-1 focus:ring-emerald-400/20"
         />
         <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
           {formData.description.length} characters
         </p>
       </div>
-
-      <ExpandedTextarea
-        open={expandedField}
-        onClose={() => setExpandedField(false)}
-        title="Description"
-        value={formData.description}
-        onChange={(value) => updateField("description", value)}
-        placeholder="Describe who you are, your role in the story, and your key traits…"
-      />
     </div>
   );
 }
@@ -2795,36 +2771,18 @@ function TextareaTab({
   placeholder: string;
   rows?: number;
 }) {
-  const [expanded, setExpanded] = useState(false);
   return (
     <div>
-      <div className="flex items-start justify-between gap-2 mb-4">
-        <SectionHeader title={title} subtitle={subtitle} helpText={helpText} />
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          className="mt-0.5 shrink-0 rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-          title="Expand editor"
-        >
-          <Maximize2 size="0.875rem" />
-        </button>
-      </div>
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        rows={rows}
-        className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-emerald-400/40 focus:ring-1 focus:ring-emerald-400/20"
-      />
-      <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</p>
-      <ExpandedTextarea
-        open={expanded}
-        onClose={() => setExpanded(false)}
-        title={title}
+      <SectionHeader title={title} subtitle={subtitle} helpText={helpText} />
+      <MacroTextarea
         value={value}
         onChange={onChange}
         placeholder={placeholder}
+        rows={rows}
+        title={title}
+        className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-emerald-400/40 focus:ring-1 focus:ring-emerald-400/20"
       />
+      <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</p>
     </div>
   );
 }

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -51,7 +51,6 @@ import {
   X,
   AlertTriangle,
   Maximize2,
-  BookOpen,
   ListChecks,
   Shuffle,
   ToggleLeft,
@@ -60,9 +59,10 @@ import {
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
+import { MacroTextarea } from "../ui/MacroTextarea";
 import { api } from "../../lib/api-client";
 import { useAgentConfigs, type AgentConfigRow } from "../../hooks/use-agents";
-import { SUPPORTED_MACROS, type WrapFormat, type MarkerType } from "@marinara-engine/shared";
+import { type WrapFormat, type MarkerType } from "@marinara-engine/shared";
 import { useQuoteFormatter } from "../../hooks/use-quote-formatter";
 import { EditorTabRail } from "../ui/EditorTabRail";
 
@@ -1977,8 +1977,6 @@ function SectionContentTextarea({
   onCommit: (v: string) => void;
 }) {
   const [local, setLocal] = useState(value);
-  const [expanded, setExpanded] = useState(false);
-  const [showMacroRef, setShowMacroRef] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const focusedRef = useRef(false);
   const formatQuotes = useQuoteFormatter();
@@ -1993,8 +1991,8 @@ function SectionContentTextarea({
   }, [local, value, onCommit]);
 
   // Debounced auto-save while typing (800ms)
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const nextValue = formatQuotes(e.target.value);
+  const handleChange = (nextRawValue: string) => {
+    const nextValue = formatQuotes(nextRawValue);
     setLocal(nextValue);
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {
@@ -2025,71 +2023,15 @@ function SectionContentTextarea({
   );
 
   return (
-    <>
-      <div className="relative">
-        <textarea
-          value={local}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          onFocus={handleFocus}
-          onKeyDown={(e) =>
-            handleTextareaTab(
-              e,
-              local,
-              (v) => {
-                setLocal(v);
-                if (timeoutRef.current) clearTimeout(timeoutRef.current);
-                timeoutRef.current = setTimeout(() => {
-                  if (v !== value) onCommit(v);
-                }, 800);
-              },
-              formatQuotes,
-            )
-          }
-          className="min-h-[7.5rem] w-full rounded-lg bg-[var(--secondary)] p-2.5 pr-8 font-mono text-xs text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-          placeholder="Prompt content… (supports {{user}}, {{char}}, {{// comment}}, {{trim}} macros)"
-        />
-        <div className="absolute right-1.5 top-1.5 flex flex-col gap-0.5">
-          <button
-            onClick={() => setExpanded(true)}
-            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Expand editor"
-          >
-            <Maximize2 size="0.75rem" />
-          </button>
-          <button
-            onClick={() => setShowMacroRef(true)}
-            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            title="Macros reference"
-          >
-            <BookOpen size="0.75rem" />
-          </button>
-        </div>
-      </div>
-
-      {/* Macros reference modal */}
-      {showMacroRef && <MacrosReferenceModal onClose={() => setShowMacroRef(false)} />}
-
-      {/* Expanded editor modal */}
-      {expanded && (
-        <ExpandedEditorModal
-          title={sectionName ? `Edit: ${sectionName}` : "Edit Prompt"}
-          value={local}
-          onChange={(v) => {
-            const nextValue = formatQuotes(v);
-            setLocal(nextValue);
-            if (timeoutRef.current) clearTimeout(timeoutRef.current);
-            timeoutRef.current = setTimeout(() => {
-              if (nextValue !== value) onCommit(nextValue);
-            }, 800);
-          }}
-          onClose={() => {
-            setExpanded(false);
-            if (local !== value) onCommit(local);
-          }}
-        />
-      )}
-    </>
+    <MacroTextarea
+      value={local}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      title={sectionName ? `Edit: ${sectionName}` : "Edit Prompt"}
+      className="min-h-[7.5rem] w-full rounded-lg bg-[var(--secondary)] p-2.5 font-mono text-xs text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+      placeholder="Prompt content… (supports {{user}}, {{char}}, {{// comment}}, {{trim}} macros)"
+    />
   );
 }
 
@@ -2209,106 +2151,6 @@ function ExpandedEditorModal({
               className="rounded-xl bg-gradient-to-r from-purple-400 to-violet-500 px-4 py-1.5 text-xs font-medium text-white shadow-md hover:shadow-lg active:scale-[0.98]"
             >
               Done
-            </button>
-          </div>
-        </div>
-      </div>
-    </PresetModalPortal>
-  );
-}
-
-// ── Macros reference data ──
-const MACRO_REFERENCE = Array.from(
-  SUPPORTED_MACROS.reduce((categories, macro) => {
-    const macros = categories.get(macro.category) ?? [];
-    macros.push({ macro: macro.syntax, desc: macro.description });
-    categories.set(macro.category, macros);
-    return categories;
-  }, new Map<string, Array<{ macro: string; desc: string }>>()),
-  ([category, macros]) => ({ category, macros }),
-);
-
-// ── Macros Reference Modal ──
-function MacrosReferenceModal({ onClose }: { onClose: () => void }) {
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [onClose]);
-
-  return (
-    <PresetModalPortal>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-6 max-md:pt-[max(1.5rem,env(safe-area-inset-top))]">
-        <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
-        <div className="relative flex max-h-[80vh] w-full max-w-lg flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl shadow-black/50">
-          {/* Header */}
-          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-            <div className="flex items-center gap-2">
-              <BookOpen size="1rem" className="text-purple-400" />
-              <h3 className="text-sm font-semibold">Macros Reference</h3>
-            </div>
-            <button onClick={onClose} className="rounded-lg p-1.5 hover:bg-[var(--accent)]">
-              <X size="1rem" />
-            </button>
-          </div>
-          {/* Content */}
-          <div className="flex-1 space-y-4 overflow-y-auto p-4">
-            <p className="text-[0.6875rem] text-[var(--muted-foreground)]">
-              Use these macros in your prompt sections. They will be replaced with actual values at generation time.
-            </p>
-            <p className="text-[0.6875rem] text-[var(--muted-foreground)]">
-              In group chats, a bracketed block containing character macros like <code>{"{{char}}"}</code> and{" "}
-              <code>{"{{description}}"}</code> repeats once per character.
-            </p>
-            <div className="space-y-2 border-y border-[var(--border)] py-3">
-              <div>
-                <h4 className="text-[0.6875rem] font-semibold text-purple-400">Conditional blocks</h4>
-                <p className="mt-1 text-[0.6875rem] text-[var(--muted-foreground)]">
-                  Use <code>{"{{#if ...}}"}</code>, optional <code>{"{{else}}"}</code>, and <code>{"{{/if}}"}</code> to
-                  switch prompt text by the active speaker, user, or a preset variable.
-                </p>
-              </div>
-              <pre className="overflow-x-auto rounded-lg bg-[var(--secondary)] px-3 py-2 text-[0.625rem] leading-relaxed text-amber-300">
-                <code>{`{{#if character == "Dottore"}}
-Write this for Dottore.
-{{else}}
-Write this for anyone else.
-{{/if}}`}</code>
-              </pre>
-              <p className="text-[0.6875rem] text-[var(--muted-foreground)]">
-                Supported comparisons: <code>==</code>, <code>!=</code>, and <code>contains</code>. Character checks
-                also work with <code>char</code> or <code>speaker</code>, and group chats evaluate them for the speaking
-                character. Straight and typographic quotes both work.
-              </p>
-            </div>
-            {MACRO_REFERENCE.map((cat) => (
-              <div key={cat.category}>
-                <h4 className="mb-1.5 text-[0.6875rem] font-semibold text-purple-400">{cat.category}</h4>
-                <div className="space-y-1">
-                  {cat.macros.map((m) => (
-                    <div
-                      key={m.macro}
-                      className="flex items-start gap-2 rounded-lg px-2 py-1.5 hover:bg-[var(--accent)]"
-                    >
-                      <code className="shrink-0 rounded bg-[var(--secondary)] px-1.5 py-0.5 text-[0.625rem] font-medium text-amber-400">
-                        {m.macro}
-                      </code>
-                      <span className="text-[0.6875rem] text-[var(--muted-foreground)]">{m.desc}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-          {/* Footer */}
-          <div className="border-t border-[var(--border)] px-4 py-2.5 text-center">
-            <button
-              onClick={onClose}
-              className="rounded-xl px-4 py-1.5 text-xs font-medium text-[var(--muted-foreground)] hover:bg-[var(--accent)]"
-            >
-              Close
             </button>
           </div>
         </div>

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -1987,6 +1987,10 @@ function SectionContentTextarea({
   }, [value]);
 
   const commit = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     if (local !== value) onCommit(local);
   }, [local, value, onCommit]);
 
@@ -2003,10 +2007,6 @@ function SectionContentTextarea({
   // Commit on blur immediately
   const handleBlur = () => {
     focusedRef.current = false;
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
     commit();
   };
 
@@ -2028,6 +2028,7 @@ function SectionContentTextarea({
       onChange={handleChange}
       onBlur={handleBlur}
       onFocus={handleFocus}
+      onExpandedClose={commit}
       title={sectionName ? `Edit: ${sectionName}` : "Edit Prompt"}
       className="min-h-[7.5rem] w-full rounded-lg bg-[var(--secondary)] p-2.5 font-mono text-xs text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
       placeholder="Prompt content… (supports {{user}}, {{char}}, {{// comment}}, {{trim}} macros)"

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -136,8 +136,9 @@ const spotifyKeys = {
 
 const SPOTIFY_GREEN_CLASS = "text-[oklch(0.72_0.18_145)]";
 const SPOTIFY_GREEN_BG_CLASS = "bg-[oklch(0.72_0.18_145)]";
+const MUSIC_PLAYER_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
+const MUSIC_PLAYER_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
 const MUSIC_PLAYER_BORDER_CLASS = "border-[var(--marinara-chat-chrome-panel-border)]";
-const MUSIC_PLAYER_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-bg)]";
 const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-bg)]";
 const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[var(--marinara-chat-chrome-highlight-bg)]";
 const MUSIC_PLAYER_TILE_RING_CLASS = "ring-[var(--marinara-chat-chrome-panel-border)]";
@@ -1023,8 +1024,8 @@ export function SpotifyMiniPlayer({
           <div
             className={cn(
               "flex h-12 w-12 items-center justify-center rounded-full border shadow-lg backdrop-blur-xl",
-              MUSIC_PLAYER_BORDER_CLASS,
-              MUSIC_PLAYER_BG_CLASS,
+              MUSIC_PLAYER_SHELL_BORDER_CLASS,
+              MUSIC_PLAYER_SHELL_BG_CLASS,
               SPOTIFY_GREEN_CLASS,
             )}
           >
@@ -1034,8 +1035,8 @@ export function SpotifyMiniPlayer({
           <div
             className={cn(
               "rounded-xl border p-2 shadow-2xl backdrop-blur-xl",
-              MUSIC_PLAYER_BORDER_CLASS,
-              MUSIC_PLAYER_BG_CLASS,
+              MUSIC_PLAYER_SHELL_BORDER_CLASS,
+              MUSIC_PLAYER_SHELL_BG_CLASS,
             )}
             style={mobileExpandedPanelStyle}
           >
@@ -1072,8 +1073,8 @@ export function SpotifyMiniPlayer({
     <div
       className={cn(
         "relative hidden h-10 min-w-0 max-w-[31rem] flex-1 items-center gap-2 overflow-hidden rounded-full border px-2.5 md:flex",
-        MUSIC_PLAYER_BORDER_CLASS,
-        MUSIC_PLAYER_BG_CLASS,
+        MUSIC_PLAYER_SHELL_BORDER_CLASS,
+        MUSIC_PLAYER_SHELL_BG_CLASS,
       )}
     >
       {compactBody}

--- a/packages/client/src/components/ui/ColorPicker.tsx
+++ b/packages/client/src/components/ui/ColorPicker.tsx
@@ -19,8 +19,12 @@ interface ColorPickerProps {
   helpText?: string;
   /** Text shown when no color is set. */
   emptyText?: string;
+  /** Optional color/gradient shown in the preview when no explicit value is set. */
+  emptyPreviewValue?: string;
   /** Text shown for the clear/reset action. */
   clearLabel?: string;
+  /** Value restored by the clear/reset action. Defaults to empty string. */
+  clearValue?: string;
   /** Optional compact control shown beside the label. */
   headerAction?: ReactNode;
 }
@@ -89,7 +93,9 @@ export function ColorPicker({
   label,
   helpText,
   emptyText = "No color set — uses default",
+  emptyPreviewValue = "",
   clearLabel = "Clear",
+  clearValue = "",
   headerAction,
 }: ColorPickerProps) {
   const isGradient = isCssGradient(value);
@@ -162,14 +168,16 @@ export function ColorPicker({
   );
 
   const clearColor = useCallback(() => {
-    onChange("");
+    onChange(clearValue);
     setExpanded(false);
-  }, [onChange]);
+  }, [clearValue, onChange]);
 
-  const displayStyle = value
-    ? isCssGradient(value)
-      ? { background: value }
-      : { backgroundColor: value }
+  const previewValue = value || emptyPreviewValue;
+  const showClear = clearValue ? value !== clearValue : !!value;
+  const displayStyle = previewValue
+    ? isCssGradient(previewValue)
+      ? { background: previewValue }
+      : { backgroundColor: previewValue }
     : { backgroundColor: "transparent" };
 
   return (
@@ -181,7 +189,7 @@ export function ColorPicker({
           {headerAction}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          {value && (
+          {showClear && (
             <button
               type="button"
               onClick={clearColor}
@@ -209,7 +217,7 @@ export function ColorPicker({
           className={cn("shrink-0 rounded-lg ring-1 ring-[var(--border)]", compact ? "h-6 w-6" : "h-8 w-8")}
           style={{
             ...displayStyle,
-            ...(!value && {
+            ...(!previewValue && {
               backgroundImage: "repeating-conic-gradient(var(--border) 0% 25%, transparent 0% 50%)",
               backgroundSize: "0.5rem 0.5rem",
             }),
@@ -274,7 +282,7 @@ export function ColorPicker({
                   <span
                     className="h-6 w-6 shrink-0 rounded-md ring-1 ring-[var(--border)]"
                     style={{
-                      backgroundColor: value && !isCssGradient(value) ? value : "#6c5ce7",
+                      backgroundColor: previewValue && !isCssGradient(previewValue) ? previewValue : "#6c5ce7",
                     }}
                   />
                   <span className="min-w-0 text-xs font-medium text-[var(--foreground)]">Pick color</span>
@@ -283,7 +291,7 @@ export function ColorPicker({
                     ref={nativeRef}
                     type="color"
                     aria-label={`Pick ${label} color`}
-                    value={value && !isCssGradient(value) ? getNativeColorValue(value) : "#6c5ce7"}
+                    value={!isCssGradient(previewValue) ? getNativeColorValue(previewValue) : "#6c5ce7"}
                     onChange={(e) => handleSolidChange(e.target.value)}
                     className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                   />

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -1,0 +1,355 @@
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { BookOpen, Maximize2, X } from "lucide-react";
+import { SUPPORTED_MACROS } from "@marinara-engine/shared";
+
+import { cn } from "../../lib/utils";
+
+type MacroDefinition = (typeof SUPPORTED_MACROS)[number];
+
+const MACRO_REFERENCE = Array.from(
+  SUPPORTED_MACROS.reduce<Map<string, MacroDefinition[]>>((groups, macro) => {
+    const next = groups.get(macro.category) ?? [];
+    next.push(macro);
+    groups.set(macro.category, next);
+    return groups;
+  }, new Map()),
+);
+
+interface MacroModalPortalProps {
+  children: ReactNode;
+}
+
+function MacroModalPortal({ children }: MacroModalPortalProps) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(children, document.body);
+}
+
+interface ExpandedMacroEditorProps {
+  open: boolean;
+  title: string;
+  value: string;
+  onChange: (value: string) => void;
+  onClose: () => void;
+  placeholder?: string;
+}
+
+function insertTextAtSelection(target: HTMLTextAreaElement, insertText: string): { value: string; cursor: number } {
+  const { selectionStart, selectionEnd, value } = target;
+  return {
+    value: `${value.slice(0, selectionStart)}${insertText}${value.slice(selectionEnd)}`,
+    cursor: selectionStart + insertText.length,
+  };
+}
+
+function ExpandedMacroEditor({ open, title, value, onChange, onClose, placeholder }: ExpandedMacroEditorProps) {
+  const [localValue, setLocalValue] = useState(value);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setLocalValue(value);
+    window.setTimeout(() => textareaRef.current?.focus(), 20);
+  }, [open, value]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onChange(localValue);
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [localValue, onChange, onClose, open]);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      setLocalValue(event.target.value);
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      event.preventDefault();
+      const target = event.currentTarget;
+      const next = insertTextAtSelection(target, "  ");
+      setLocalValue(next.value);
+      onChange(next.value);
+      requestAnimationFrame(() => {
+        target.selectionStart = next.cursor;
+        target.selectionEnd = next.cursor;
+      });
+    },
+    [onChange],
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <MacroModalPortal>
+      <div className="fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+        <div className="flex h-[min(92vh,56rem)] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl">
+          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--foreground)]">{title}</h3>
+              <p className="text-xs text-[var(--muted-foreground)]">Expanded editor</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                onChange(localValue);
+                onClose();
+              }}
+              className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[var(--muted-foreground)] transition hover:border-[var(--foreground)] hover:text-[var(--foreground)]"
+              aria-label="Close expanded editor"
+              title="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <textarea
+            ref={textareaRef}
+            value={localValue}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            className="min-h-0 flex-1 resize-none bg-[var(--secondary)] p-4 font-mono text-sm leading-6 text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
+            spellCheck={false}
+          />
+        </div>
+      </div>
+    </MacroModalPortal>
+  );
+}
+
+interface MacrosReferenceModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <MacroModalPortal>
+      <div className="fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+        <div className="max-h-[88vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl">
+          <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--foreground)]">Macro reference</h3>
+              <p className="text-xs text-[var(--muted-foreground)]">Macros are replaced with live chat, character, and preset values during generation.</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[var(--muted-foreground)] transition hover:border-[var(--foreground)] hover:text-[var(--foreground)]"
+              aria-label="Close macro reference"
+              title="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="max-h-[calc(88vh-4rem)] space-y-4 overflow-y-auto p-4">
+            <section className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-xs text-[var(--muted-foreground)]">
+              <p>
+                Use <code className="text-[var(--foreground)]">{"{{macro}}"}</code> anywhere in prompt fields. Conditional blocks let you include content only when a value exists.
+              </p>
+              <div className="mt-3 grid gap-2 md:grid-cols-2">
+                <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-2">
+                  <p className="font-semibold text-[var(--foreground)]">Conditional block</p>
+                  <code className="mt-1 block whitespace-pre-wrap text-[var(--primary)]">{"{{#if character == \"Dottore\"}}\nWrite this for Dottore.\n{{else}}\nWrite this for anyone else.\n{{/if}}"}</code>
+                </div>
+                <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-2">
+                  <p className="font-semibold text-[var(--foreground)]">Supported comparisons</p>
+                  <code className="mt-1 block whitespace-pre-wrap text-[var(--primary)]">{"{{#if character != \"Dottore\"}}\n...\n{{/if}}\n{{#if user contains \"Mari\"}}\n...\n{{/if}}"}</code>
+                </div>
+              </div>
+            </section>
+            {MACRO_REFERENCE.map(([category, macros]) => (
+              <section key={category} className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3">
+                <h4 className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">{category}</h4>
+                <div className="grid gap-2 md:grid-cols-2">
+                  {macros.map((macro) => (
+                    <div key={macro.syntax} className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-2">
+                      <code className="text-xs font-semibold text-[var(--foreground)]">{macro.syntax}</code>
+                      <p className="mt-1 text-xs text-[var(--muted-foreground)]">{macro.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    </MacroModalPortal>
+  );
+}
+
+export interface MacroTextareaProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  onFocus?: () => void;
+  onExpandedClose?: () => void;
+  onKeyDown?: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
+  rows?: number;
+  title?: string;
+  placeholder?: string;
+  className?: string;
+  wrapperClassName?: string;
+  buttonClassName?: string;
+  toolbarClassName?: string;
+  controlPaddingClassName?: string;
+  toolbarExtra?: ReactNode;
+  showMacroReference?: boolean;
+  showExpand?: boolean;
+  spellCheck?: boolean;
+}
+
+export function MacroTextarea({
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  onExpandedClose,
+  onKeyDown,
+  rows = 6,
+  title = "Edit text",
+  placeholder,
+  className,
+  wrapperClassName,
+  buttonClassName,
+  toolbarClassName,
+  controlPaddingClassName,
+  toolbarExtra,
+  showMacroReference = true,
+  showExpand = true,
+  spellCheck = true,
+}: MacroTextareaProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [showMacroRef, setShowMacroRef] = useState(false);
+
+  const handleExpandedClose = useCallback(() => {
+    setExpanded(false);
+    onExpandedClose?.();
+  }, [onExpandedClose]);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(event.target.value);
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || event.key !== "Tab") {
+        return;
+      }
+
+      event.preventDefault();
+      const target = event.currentTarget;
+      const next = insertTextAtSelection(target, "  ");
+      onChange(next.value);
+      requestAnimationFrame(() => {
+        target.selectionStart = next.cursor;
+        target.selectionEnd = next.cursor;
+      });
+    },
+    [onChange, onKeyDown],
+  );
+
+  const affordanceButtonClassName = cn(
+    "rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]",
+    buttonClassName,
+  );
+
+  return (
+    <>
+      <div className={cn("relative", wrapperClassName)}>
+        <textarea
+          value={value}
+          onChange={handleChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          onKeyDown={handleKeyDown}
+          rows={rows}
+          placeholder={placeholder}
+          spellCheck={spellCheck}
+          className={cn(
+            "w-full resize-y rounded-lg bg-[var(--secondary)] p-2.5 text-sm leading-6 text-[var(--foreground)] ring-1 ring-[var(--border)] transition placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
+            className,
+            controlPaddingClassName ?? (toolbarExtra ? "pr-12" : "pr-8"),
+          )}
+        />
+        {(showExpand || showMacroReference || toolbarExtra) && (
+          <div className={cn("absolute right-1.5 top-1.5 flex flex-col gap-0.5", toolbarClassName)}>
+            {showExpand ? (
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                className={affordanceButtonClassName}
+                aria-label="Expand editor"
+                title="Expand editor"
+              >
+                <Maximize2 className="h-3 w-3" />
+              </button>
+            ) : null}
+            {showMacroReference ? (
+              <button
+                type="button"
+                onClick={() => setShowMacroRef(true)}
+                className={affordanceButtonClassName}
+                aria-label="Macro reference"
+                title="Macro reference"
+              >
+                <BookOpen className="h-3 w-3" />
+              </button>
+            ) : null}
+            {toolbarExtra}
+          </div>
+        )}
+      </div>
+      <ExpandedMacroEditor open={expanded} title={title} value={value} onChange={onChange} onClose={handleExpandedClose} placeholder={placeholder} />
+      <MacrosReferenceModal open={showMacroRef} onClose={() => setShowMacroRef(false)} />
+    </>
+  );
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -84,9 +84,13 @@ export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expande
 export const TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR = "#09090b";
 export const DEFAULT_APP_ACCENT_DARK = "#d4d4d4";
 export const DEFAULT_APP_ACCENT_LIGHT = "#1a1025";
+export const DEFAULT_CHAT_CHROME_TEXT_DARK = "#d4d4d4";
+export const DEFAULT_CHAT_CHROME_TEXT_LIGHT = "#1a1025";
 const IMAGE_DIMENSION_MIN = 64;
 const IMAGE_DIMENSION_MAX = 4096;
 const GAME_SETUP_LEARNED_LIMIT = 60;
+const USER_ACTIVITY_MAX_LENGTH = 120;
+const RECENT_USER_ACTIVITY_LIMIT = 8;
 export const TRACKER_DATA_PANEL_SECTIONS: TrackerDataPanelSection[] = [
   "world",
   "persona",
@@ -120,11 +124,23 @@ const DEFAULT_SUMMARY_POPOVER_SETTINGS: SummaryPopoverSettings = {
   collapseHiddenMessages: false,
 };
 
+function normalizeUserActivity(activity: string): string {
+  return activity.replace(/\s+/g, " ").trim().slice(0, USER_ACTIVITY_MAX_LENGTH);
+}
+
 export function getDefaultAppAccentColor(theme: "dark" | "light") {
   return theme === "light" ? DEFAULT_APP_ACCENT_LIGHT : DEFAULT_APP_ACCENT_DARK;
 }
 
+export function getDefaultChatChromeTextColor(theme: "dark" | "light") {
+  return theme === "light" ? DEFAULT_CHAT_CHROME_TEXT_LIGHT : DEFAULT_CHAT_CHROME_TEXT_DARK;
+}
+
 function normalizeAppAccentColor(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeChatChromeTextColor(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
 }
 
@@ -423,6 +439,8 @@ interface UIState {
   narrationOpacity: number;
   /** Color for chat message text (empty = theme default) */
   chatFontColor: string;
+  /** Color for shared chat chrome text/icons in tracker widgets, toolbar buttons, and popovers (empty = scheme default) */
+  chatChromeTextColor: string;
   /** Opacity for roleplay message backgrounds (0–100) */
   chatFontOpacity: number;
   /** Layout style for roleplay message avatars */
@@ -509,6 +527,8 @@ interface UIState {
   userStatus: UserStatus;
   /** Optional short activity shown with the user's status in Conversation mode. */
   userActivity: string;
+  /** Recent user activity strings shown under the chat sidebar status editor. */
+  recentUserActivities: string[];
 
   // ── Impersonate Settings ──
   /** Custom prompt template for /impersonate (empty = use server default). Persisted. */
@@ -642,6 +662,7 @@ interface UIState {
   setNarrationFontColor: (v: string) => void;
   setNarrationOpacity: (v: number) => void;
   setChatFontColor: (v: string) => void;
+  setChatChromeTextColor: (v: string) => void;
   setChatFontOpacity: (v: number) => void;
   setRoleplayAvatarStyle: (v: RoleplayAvatarStyle) => void;
   setRoleplayAvatarScale: (v: number) => void;
@@ -697,6 +718,7 @@ interface UIState {
   setUserStatus: (status: UserStatus) => void;
   setUserStatusManual: (status: UserStatus) => void;
   setUserActivity: (activity: string) => void;
+  rememberUserActivity: (activity: string) => void;
 }
 
 function getMobileDetailReturnState(state: UIState) {
@@ -793,6 +815,7 @@ export function pickSyncedSettings(state: UIState) {
     narrationFontColor: state.narrationFontColor,
     narrationOpacity: state.narrationOpacity,
     chatFontColor: state.chatFontColor,
+    chatChromeTextColor: state.chatChromeTextColor,
     chatFontOpacity: state.chatFontOpacity,
     roleplayAvatarStyle: state.roleplayAvatarStyle,
     roleplayAvatarScale: state.roleplayAvatarScale,
@@ -814,6 +837,7 @@ export function pickSyncedSettings(state: UIState) {
     echoChamberSide: state.echoChamberSide,
     userStatusManual: state.userStatusManual,
     userActivity: state.userActivity,
+    recentUserActivities: state.recentUserActivities,
     convoNotificationSound: state.convoNotificationSound,
     rpNotificationSound: state.rpNotificationSound,
     gameNotificationSound: state.gameNotificationSound,
@@ -931,6 +955,7 @@ export const useUIStore = create<UIState>()(
       narrationFontColor: "",
       narrationOpacity: 80,
       chatFontColor: "",
+      chatChromeTextColor: "",
       chatFontOpacity: 90,
       roleplayAvatarStyle: "circles" as RoleplayAvatarStyle,
       roleplayAvatarScale: 1,
@@ -970,6 +995,7 @@ export const useUIStore = create<UIState>()(
       userStatusManual: "active" as const,
       userStatus: "active" as UserStatus,
       userActivity: "",
+      recentUserActivities: [],
       centerCompact: false,
       chatModeShortcutRequest: null,
 
@@ -1423,6 +1449,7 @@ export const useUIStore = create<UIState>()(
       setNarrationFontColor: (v) => set({ narrationFontColor: v }),
       setNarrationOpacity: (v) => set({ narrationOpacity: Math.max(0, Math.min(100, v)) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),
+      setChatChromeTextColor: (v) => set({ chatChromeTextColor: normalizeChatChromeTextColor(v) }),
       setChatFontOpacity: (v) => set({ chatFontOpacity: Math.max(0, Math.min(100, v)) }),
       setRoleplayAvatarStyle: (v) => set({ roleplayAvatarStyle: v }),
       setRoleplayAvatarScale: (v) =>
@@ -1518,11 +1545,22 @@ export const useUIStore = create<UIState>()(
       setEchoChamberSide: (side) => set({ echoChamberSide: side }),
       setUserStatus: (status) => set({ userStatus: status }),
       setUserStatusManual: (status) => set({ userStatusManual: status, userStatus: status }),
-      setUserActivity: (activity) => set({ userActivity: activity.slice(0, 120) }),
+      setUserActivity: (activity) => set({ userActivity: activity.slice(0, USER_ACTIVITY_MAX_LENGTH) }),
+      rememberUserActivity: (activity) =>
+        set((state) => {
+          const normalized = normalizeUserActivity(activity);
+          if (!normalized) return { recentUserActivities: state.recentUserActivities };
+          return {
+            recentUserActivities: [
+              normalized,
+              ...state.recentUserActivities.filter((item) => item.toLowerCase() !== normalized.toLowerCase()),
+            ].slice(0, RECENT_USER_ACTIVITY_LIMIT),
+          };
+        }),
     }),
     {
       name: "marinara-engine-ui",
-      version: 47,
+      version: 49,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -1899,7 +1937,23 @@ export const useUIStore = create<UIState>()(
         if (version <= 46 && typeof persisted.youtubePlayerVolume !== "number") {
           persisted.youtubePlayerVolume = 70;
         }
+        if (version <= 47 && persisted.chatChromeTextColor === undefined) {
+          persisted.chatChromeTextColor = "";
+        }
+        if (version <= 48 && !Array.isArray(persisted.recentUserActivities)) {
+          persisted.recentUserActivities = [];
+        }
+        if (Array.isArray(persisted.recentUserActivities)) {
+          persisted.recentUserActivities = persisted.recentUserActivities
+            .filter((activity: unknown): activity is string => typeof activity === "string")
+            .map((activity: string) => normalizeUserActivity(activity))
+            .filter(Boolean)
+            .slice(0, RECENT_USER_ACTIVITY_LIMIT);
+        } else {
+          persisted.recentUserActivities = [];
+        }
         persisted.appAccentColor = normalizeAppAccentColor(persisted.appAccentColor);
+        persisted.chatChromeTextColor = normalizeChatChromeTextColor(persisted.chatChromeTextColor);
         delete persisted.trackerPanelWidth;
         return persisted;
       },
@@ -1979,6 +2033,7 @@ export const useUIStore = create<UIState>()(
         narrationFontColor: state.narrationFontColor,
         narrationOpacity: state.narrationOpacity,
         chatFontColor: state.chatFontColor,
+        chatChromeTextColor: state.chatChromeTextColor,
         chatFontOpacity: state.chatFontOpacity,
         roleplayAvatarStyle: state.roleplayAvatarStyle,
         roleplayAvatarScale: state.roleplayAvatarScale,
@@ -2006,6 +2061,7 @@ export const useUIStore = create<UIState>()(
         userStatusManual: state.userStatusManual,
         userStatus: state.userStatus,
         userActivity: state.userActivity,
+        recentUserActivities: state.recentUserActivities,
         convoNotificationSound: state.convoNotificationSound,
         rpNotificationSound: state.rpNotificationSound,
         gameNotificationSound: state.gameNotificationSound,

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -84,6 +84,8 @@ export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expande
 export const TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR = "#09090b";
 export const DEFAULT_APP_ACCENT_DARK = "#d4d4d4";
 export const DEFAULT_APP_ACCENT_LIGHT = "#1a1025";
+export const DEFAULT_CHAT_TEXT_DARK = "#d4d4d4";
+export const DEFAULT_CHAT_TEXT_LIGHT = "#1a1025";
 export const DEFAULT_CHAT_CHROME_TEXT_DARK = "#d4d4d4";
 export const DEFAULT_CHAT_CHROME_TEXT_LIGHT = "#1a1025";
 const IMAGE_DIMENSION_MIN = 64;
@@ -130,6 +132,10 @@ function normalizeUserActivity(activity: string): string {
 
 export function getDefaultAppAccentColor(theme: "dark" | "light") {
   return theme === "light" ? DEFAULT_APP_ACCENT_LIGHT : DEFAULT_APP_ACCENT_DARK;
+}
+
+export function getDefaultChatTextColor(theme: "dark" | "light") {
+  return theme === "light" ? DEFAULT_CHAT_TEXT_LIGHT : DEFAULT_CHAT_TEXT_DARK;
 }
 
 export function getDefaultChatChromeTextColor(theme: "dark" | "light") {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -56,6 +56,7 @@
    ─────────────────────────
    • Change the app's accent color → edit --primary in §2
    • Change chat toolbar/panel accents → edit --marinara-chat-chrome-accent in §2
+   • Change chat toolbar/panel text → edit --marinara-chat-chrome-text in §2
    • Change rainbow chrome accents → edit --marinara-chat-chrome-accent-gradient in §2
    • Change the background color   → edit --background in §2
    • Change the font               → edit --font-y2k in §2
@@ -82,6 +83,7 @@
      --glow-primary, --glow-accent      Glow effect bases
      --marinara-chat-chrome-*           Shared chat/game top buttons, panels, highlights
      --marinara-chat-chrome-accent      Shared chrome icon, border, ring, and highlight color
+     --marinara-chat-chrome-text        Shared chrome text color for tracker widgets, buttons, popovers
      --marinara-chat-chrome-accent-gradient  Optional gradient for rainbow chrome accents
 
    PALETTE (decorative flavor — components should NOT reference these
@@ -202,33 +204,71 @@
   --glow-accent: rgba(212, 173, 252, 0.12);
 
   /* Theme hooks for shared chat, roleplay, and game chrome. */
+  --marinara-topbar-surface: color-mix(in srgb, var(--card) 80%, transparent);
+  --marinara-topbar-border: color-mix(in srgb, var(--border) 30%, transparent);
+  --marinara-music-player-shell-bg: var(--marinara-topbar-surface);
+  --marinara-music-player-shell-border: var(--marinara-topbar-border);
   --marinara-chat-chrome-accent: var(--foreground);
   --marinara-chat-chrome-accent-gradient: linear-gradient(
     90deg,
     var(--marinara-chat-chrome-accent),
     var(--marinara-chat-chrome-accent)
   );
-  --marinara-chat-chrome-button-bg: color-mix(in srgb, var(--card) 82%, transparent);
-  --marinara-chat-chrome-button-bg-hover: color-mix(in srgb, var(--card) 94%, var(--foreground) 6%);
-  --marinara-chat-chrome-button-bg-active: color-mix(in srgb, var(--card) 92%, var(--foreground) 8%);
+  --marinara-chat-chrome-text: var(--foreground);
+  --marinara-chat-chrome-button-text-base: var(--marinara-chat-chrome-accent);
+  --marinara-chat-chrome-highlight-text-base: var(--marinara-chat-chrome-accent);
+  --marinara-chat-chrome-surface-bg: var(--card);
+  --marinara-chat-chrome-surface-bg-hover: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-surface-bg) 92%,
+    var(--foreground) 8%
+  );
+  --marinara-chat-chrome-surface-bg-active: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-surface-bg) 88%,
+    var(--foreground) 12%
+  );
+  --marinara-chat-chrome-button-bg: var(--marinara-chat-chrome-surface-bg);
+  --marinara-chat-chrome-button-bg-hover: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-surface-bg-hover) 90%,
+    var(--marinara-chat-chrome-accent) 10%
+  );
+  --marinara-chat-chrome-button-bg-active: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-surface-bg-active) 84%,
+    var(--marinara-chat-chrome-accent) 16%
+  );
   --marinara-chat-chrome-button-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 12%, transparent);
   --marinara-chat-chrome-button-border-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 20%, transparent);
   --marinara-chat-chrome-button-border-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 24%, transparent);
-  --marinara-chat-chrome-button-text: color-mix(in srgb, var(--marinara-chat-chrome-accent) 64%, transparent);
-  --marinara-chat-chrome-button-text-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 92%, transparent);
-  --marinara-chat-chrome-button-text-active: color-mix(in srgb, var(--marinara-chat-chrome-accent) 96%, transparent);
+  --marinara-chat-chrome-button-text: color-mix(in srgb, var(--marinara-chat-chrome-button-text-base) 64%, transparent);
+  --marinara-chat-chrome-button-text-hover: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-button-text-base) 92%,
+    transparent
+  );
+  --marinara-chat-chrome-button-text-active: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-button-text-base) 96%,
+    transparent
+  );
   --marinara-chat-chrome-focus-ring: color-mix(in srgb, var(--marinara-chat-chrome-accent) 22%, transparent);
-  --marinara-chat-chrome-panel-bg: color-mix(in srgb, var(--background) 88%, var(--card) 12%);
+  --marinara-chat-chrome-panel-bg: var(--marinara-chat-chrome-button-bg);
   --marinara-chat-chrome-panel-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 16%, transparent);
   --marinara-chat-chrome-panel-divider: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent);
-  --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--foreground) 90%, transparent);
-  --marinara-chat-chrome-panel-title: color-mix(in srgb, var(--foreground) 96%, transparent);
-  --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--foreground) 58%, transparent);
+  --marinara-chat-chrome-panel-text: color-mix(in srgb, var(--marinara-chat-chrome-text) 90%, transparent);
+  --marinara-chat-chrome-panel-title: color-mix(in srgb, var(--marinara-chat-chrome-text) 96%, transparent);
+  --marinara-chat-chrome-panel-muted: color-mix(in srgb, var(--marinara-chat-chrome-text) 58%, transparent);
   --marinara-chat-chrome-panel-scrollbar: color-mix(in srgb, var(--marinara-chat-chrome-accent) 22%, transparent);
   --marinara-chat-chrome-highlight-bg: color-mix(in srgb, var(--marinara-chat-chrome-accent) 9%, transparent);
   --marinara-chat-chrome-highlight-bg-hover: color-mix(in srgb, var(--marinara-chat-chrome-accent) 13%, transparent);
-  --marinara-chat-chrome-highlight-text: color-mix(in srgb, var(--marinara-chat-chrome-accent) 94%, transparent);
-  --marinara-chat-chrome-input-bg: color-mix(in srgb, var(--background) 78%, var(--card) 22%);
+  --marinara-chat-chrome-highlight-text: color-mix(
+    in srgb,
+    var(--marinara-chat-chrome-highlight-text-base) 94%,
+    transparent
+  );
+  --marinara-chat-chrome-input-bg: var(--marinara-chat-chrome-surface-bg);
   --marinara-chat-chrome-input-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 14%, transparent);
   --marinara-chat-chrome-input-border-focus: color-mix(in srgb, var(--marinara-chat-chrome-accent) 30%, transparent);
 
@@ -483,6 +523,14 @@
     var(--marinara-chat-chrome-accent-gradient) border-box;
 }
 
+[data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button--open {
+  border-color: transparent;
+  background:
+    linear-gradient(var(--marinara-chat-chrome-button-bg-hover), var(--marinara-chat-chrome-button-bg-hover))
+      padding-box,
+    var(--marinara-chat-chrome-accent-gradient) border-box;
+}
+
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button--active {
   border-color: transparent;
   background: var(--marinara-chat-chrome-accent-gradient);
@@ -494,6 +542,17 @@
   background:
     linear-gradient(var(--marinara-chat-chrome-panel-bg), var(--marinara-chat-chrome-panel-bg)) padding-box,
     var(--marinara-chat-chrome-accent-gradient) border-box;
+}
+
+[data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-input-shell {
+  border-color: transparent;
+  background:
+    linear-gradient(var(--marinara-chat-chrome-input-bg), var(--marinara-chat-chrome-input-bg)) padding-box,
+    var(--marinara-chat-chrome-accent-gradient) border-box;
+}
+
+.marinara-chat-popover.marinara-chat-toolbar-overflow-menu {
+  border-radius: 0.5rem;
 }
 
 /* ─────────────────────────────────────────────
@@ -980,6 +1039,10 @@ summary[class*="cursor-pointer"],
 /* Firefox on Windows can rasterize text inside large blurred/translucent layout layers,
    which shows up most clearly on high-DPI displays. Fall back to opaque shell chrome there. */
 @supports (-moz-appearance: none) {
+  :root {
+    --marinara-topbar-surface: var(--card);
+  }
+
   .mari-topbar,
   .mari-sidebar,
   .mari-sidebar-header,
@@ -1987,6 +2050,100 @@ summary[class*="cursor-pointer"],
   background: var(--background);
 }
 
+[data-chat-mode="roleplay"] {
+  --mari-roleplay-message-column-width: 58rem;
+}
+
+[data-chat-mode="roleplay"] .rpg-narrator-msg,
+[data-chat-mode="roleplay"] .mari-roleplay-message-row {
+  justify-content: center;
+  width: 100%;
+  padding-left: clamp(0.25rem, 1.5vw, 1.5rem);
+  padding-right: clamp(0.25rem, 1.5vw, 1.5rem);
+}
+
+[data-chat-mode="roleplay"] .rpg-narrator-msg {
+  display: flex;
+}
+
+[data-chat-mode="roleplay"] .rpg-narrator-msg > div {
+  width: min(100%, var(--mari-roleplay-message-column-width));
+}
+
+[data-chat-mode="roleplay"] .mari-roleplay-message-row {
+  --mari-roleplay-avatar-slot: calc(2.5rem * var(--roleplay-avatar-scale, 1));
+  --mari-roleplay-avatar-gap: 0.75rem;
+  --mari-roleplay-avatar-space: calc(var(--mari-roleplay-avatar-slot) + var(--mari-roleplay-avatar-gap));
+}
+
+[data-chat-mode="roleplay"] .mari-roleplay-message-row--rect-avatar {
+  --mari-roleplay-avatar-slot: calc(2.75rem * var(--roleplay-avatar-scale, 1));
+}
+
+[data-chat-mode="roleplay"] .mari-roleplay-message-row--wide {
+  --mari-roleplay-avatar-slot: 0rem;
+  --mari-roleplay-avatar-gap: 0rem;
+  --mari-roleplay-avatar-space: 0rem;
+}
+
+[data-chat-mode="roleplay"] .mari-roleplay-message-body {
+  width: min(100%, var(--mari-roleplay-message-column-width));
+  max-width: calc(100% - var(--mari-roleplay-avatar-space, 0rem));
+}
+
+[data-chat-mode="roleplay"] .mari-roleplay-message-body--editing {
+  width: min(100%, var(--mari-roleplay-message-column-width));
+}
+
+@media (min-width: 768px) {
+  [data-chat-mode="roleplay"] .mari-roleplay-message-row {
+    display: grid;
+    grid-template-columns:
+      minmax(0, 1fr)
+      var(--mari-roleplay-avatar-slot)
+      minmax(0, var(--mari-roleplay-message-column-width))
+      var(--mari-roleplay-avatar-slot)
+      minmax(0, 1fr);
+    column-gap: var(--mari-roleplay-avatar-gap);
+    row-gap: 0;
+    align-items: start;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-selection-toggle {
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: end;
+  }
+
+  [data-chat-mode="roleplay"] .mari-message-user .mari-roleplay-selection-toggle {
+    grid-column: 5;
+    justify-self: start;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-row > .mari-message-avatar,
+  [data-chat-mode="roleplay"] .mari-roleplay-message-row > .mari-roleplay-avatar-spacer {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: center;
+  }
+
+  [data-chat-mode="roleplay"] .mari-message-user > .mari-message-avatar,
+  [data-chat-mode="roleplay"] .mari-message-user > .mari-roleplay-avatar-spacer {
+    grid-column: 4;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-body {
+    grid-column: 3;
+    grid-row: 1;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-body--editing {
+    width: 100%;
+  }
+}
+
 .rpg-overlay {
   background: linear-gradient(
     180deg,
@@ -2357,8 +2514,36 @@ summary[class*="cursor-pointer"],
   }
 
   .rpg-chat-messages-mobile {
-    padding-left: 0.75rem !important;
-    padding-right: 0.75rem !important;
+    padding-left: max(0.5rem, env(safe-area-inset-left)) !important;
+    padding-right: max(0.5rem, env(safe-area-inset-right)) !important;
+  }
+
+  [data-chat-mode="roleplay"] .rpg-narrator-msg {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-row {
+    --mari-roleplay-mobile-avatar-space: calc((2.5rem * var(--roleplay-avatar-scale, 1)) + 0.5rem);
+    gap: 0.5rem;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-row--rect-avatar {
+    --mari-roleplay-mobile-avatar-space: calc((2.75rem * var(--roleplay-avatar-scale, 1)) + 0.5rem);
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-row--wide {
+    --mari-roleplay-mobile-avatar-space: 0rem;
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-body {
+    max-width: calc(100% - var(--mari-roleplay-mobile-avatar-space, 3rem));
+  }
+
+  [data-chat-mode="roleplay"] .mari-roleplay-message-body--editing {
+    width: calc(100% - var(--mari-roleplay-mobile-avatar-space, 3rem));
   }
 
   .rpg-hud {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2525,6 +2525,7 @@ summary[class*="cursor-pointer"],
 
   [data-chat-mode="roleplay"] .mari-roleplay-message-row {
     --mari-roleplay-mobile-avatar-space: calc((2.5rem * var(--roleplay-avatar-scale, 1)) + 0.5rem);
+
     gap: 0.5rem;
     padding-left: 0;
     padding-right: 0;


### PR DESCRIPTION
## Linked issue

No linked issue yet; maintainer-requested UI polish and folder bugfix.

## Why this change

- Unifies chat UI chrome across conversation, roleplay, and game surfaces so buttons, popovers, input chrome, panels, and mobile overflow controls share the same visual language.
- Keeps library/editor workflows compact and consistent while preserving metadata visibility.
- Fixes the persona folder workflow where personas could become awkward to move back out of folders, and prevents character/persona folder rows from hiding useful card metadata.

## What changed

- Shared and reused chat input/button styling across chat modes, including top-bar controls, expandable chat windows, mobile overflow buttons, tracker/agent controls, and light/accent color behavior.
- Polished game-mode widgets, map chrome, party cards, custom widgets, Spotify/YouTube player framing, Echo Chamber placement, and related chat-surface spacing.
- Added reusable macro/expand textarea affordances for editors and compacted character, persona, lorebook, preset, connection, and agent editor surfaces.
- Restored character/persona folder list metadata and made drag/drop removal to the root list more robust.
- Added shared helper components for chat input styling and macro-enabled textarea fields.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm check` locally after the persona/character folder fix; it completed successfully.
- Browser/manual viewport verification still needs a human pass before merge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are expected for this UI-only PR.

## UI evidence (if applicable)

No screenshots attached from this automation pass; manual UI evidence should be added during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Customizable “chat chrome” text color with persisted setting
  * Recent status suggestions in the user status editor
  * Macro-aware text editing (MacroTextarea) across multiple editors

* **Improvements**
  * Refined mobile popovers with anchored positioning (including portal rendering where needed)
  * Chat toolbar now auto-collapses into an overflow menu based on available space
  * Roleplay/chat UI layout and spacing improvements
  * Game map supports a new compact fitting mode

* **Style**
  * Expanded Marinara CSS-variable theming across chat, game, and UI elements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->