### PR TITLE
feat(lorebooks): nested folders

### DIFF
--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -801,6 +801,13 @@ export function LorebookEditor() {
     (folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries || draggingEntryIdx === null) return;
       e.preventDefault();
+      // Folder bodies nest — a sub-folder's body sits inside its parent's body —
+      // so stop here instead of bubbling: the INNERMOST body under the cursor
+      // claims the drop, rather than every ancestor firing and the outermost one
+      // winning. Because a sub-folder's left margin belongs to its parent, sliding
+      // the cursor left out of a nested body lands on the ancestor's body and
+      // targets that ancestor — so the indent rails let you aim at any level.
+      e.stopPropagation();
       e.dataTransfer.dropEffect = "move";
       setDropTargetContainer(folderId);
       // If hovering empty folder body, drop at end.
@@ -1139,6 +1146,9 @@ export function LorebookEditor() {
     const folderEntries = entriesByContainer.get(folder.id) ?? [];
     const isCollapsed = collapsedFolderIds.has(folder.id);
     const childFolders = folderForest.childrenByParent.get(folder.id) ?? [];
+    // Highlight this folder's body + indent rail while it's the live entry-drop
+    // target, so the user can see which nesting level they're aiming at.
+    const isEntryDropTarget = draggingEntryIdx !== null && dropTargetContainer === folder.id;
     const showFolderDropBefore =
       folderDropIdx === fIdx &&
       draggingFolderIdx !== null &&
@@ -1185,7 +1195,10 @@ export function LorebookEditor() {
         />
         {!isCollapsed && (
           <div
-            className="ml-2 space-y-1.5 border-l border-[var(--border)] pl-2 sm:ml-3 sm:pl-2.5"
+            className={cn(
+              "ml-2 space-y-1.5 border-l pl-2 transition-colors sm:ml-3 sm:pl-2.5",
+              isEntryDropTarget ? "border-amber-400 bg-amber-400/5" : "border-[var(--border)]",
+            )}
             onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
             onDrop={(e) => {
               e.stopPropagation();

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -2001,23 +2001,25 @@ export function LorebookEditor() {
                   <div className="space-y-3">
                     {/* Folder block — nested tree (folders may contain sub-folders) */}
                     {folders.length > 0 && (
-                      <div className="space-y-1.5">
-                        {/* Un-nest target: drop a nested folder here to lift it back to top level. */}
-                        {draggingFolderIdx !== null && folders[draggingFolderIdx]?.parentFolderId != null && (
-                          <div
-                            onDragOver={handleFolderRootDragOver}
-                            onDragLeave={() => setFolderRootDropActive(false)}
-                            onDrop={commitFolderRootDrop}
-                            className={cn(
-                              "rounded-lg border border-dashed px-2 py-1.5 text-center text-[0.625rem] italic transition-colors",
-                              folderRootDropActive
-                                ? "border-amber-400 bg-amber-400/10 text-amber-200"
-                                : "border-[var(--border)] text-[var(--muted-foreground)]",
-                            )}
-                          >
-                            Drop here to move to the top level
-                          </div>
+                      // The folder list is itself the "move to top level" drop zone for a
+                      // nested folder (its padding + the gaps between roots). It must NOT
+                      // appear/disappear on drag start: inserting a strip here shifted the
+                      // layout the instant a nested drag began, which cancels the drag in
+                      // Chrome and made sub-folders impossible to pick up. So the target is
+                      // always present and only its highlight changes.
+                      <div
+                        className={cn(
+                          "space-y-1.5 rounded-lg py-1 transition-colors",
+                          folderRootDropActive && "bg-amber-400/5 ring-1 ring-amber-400/40",
                         )}
+                        onDragOver={(e) => {
+                          if (draggingFolderIdx !== null) handleFolderRootDragOver(e);
+                        }}
+                        onDragLeave={() => setFolderRootDropActive(false)}
+                        onDrop={(e) => {
+                          if (draggingFolderIdx !== null) commitFolderRootDrop(e);
+                        }}
+                      >
                         {folderForest.roots.map((folder) => renderFolder(folder))}
                       </div>
                     )}

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -817,6 +817,25 @@ export function LorebookEditor() {
     [canReorderEntries, draggingEntryIdx, entriesByContainer],
   );
 
+  // Dragging a FOLDER over another folder's body nests it inside that folder, so
+  // the large body areas become valid drop targets (not just the thin headers).
+  const handleFolderBodyFolderDragOver = useCallback(
+    (folderId: string, e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderIdx === null) return;
+      const dragged = folders[draggingFolderIdx];
+      if (!dragged) return;
+      // Accept only a legal nest; otherwise let the event bubble so an ancestor
+      // body (or nothing) claims it, instead of showing a dead "no-drop" cursor.
+      if (dragged.parentFolderId === folderId || !canReparentFolder(folders, dragged.id, folderId).ok) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = "move";
+      setFolderNestTargetId(folderId);
+      setFolderDropIdx(null);
+    },
+    [canReorderFolders, draggingFolderIdx, folders],
+  );
+
   const handleRootListDragOver = useCallback(
     (e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderEntries || draggingEntryIdx === null) return;
@@ -1149,6 +1168,7 @@ export function LorebookEditor() {
     // Highlight this folder's body + indent rail while it's the live entry-drop
     // target, so the user can see which nesting level they're aiming at.
     const isEntryDropTarget = draggingEntryIdx !== null && dropTargetContainer === folder.id;
+    const isFolderNestTarget = draggingFolderIdx !== null && folderNestTargetId === folder.id;
     const showFolderDropBefore =
       folderDropIdx === fIdx &&
       draggingFolderIdx !== null &&
@@ -1197,12 +1217,16 @@ export function LorebookEditor() {
           <div
             className={cn(
               "ml-2 space-y-1.5 border-l pl-2 transition-colors sm:ml-3 sm:pl-2.5",
-              isEntryDropTarget ? "border-amber-400 bg-amber-400/5" : "border-[var(--border)]",
+              isEntryDropTarget || isFolderNestTarget ? "border-amber-400 bg-amber-400/5" : "border-[var(--border)]",
             )}
-            onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
+            onDragOver={(e) => {
+              if (draggingEntryIdx !== null) handleFolderBodyDragOver(folder.id, e);
+              else handleFolderBodyFolderDragOver(folder.id, e);
+            }}
             onDrop={(e) => {
               e.stopPropagation();
-              commitEntryDrop(e);
+              if (draggingEntryIdx !== null) commitEntryDrop(e);
+              else commitFolderDrop(e);
             }}
           >
             {folderEntries.length === 0 && childFolders.length === 0 && (

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -2048,15 +2048,22 @@ export function LorebookEditor() {
                       ref={entryListRef}
                       className={cn(
                         "space-y-1.5",
-                        // Highlight the zone when an entry from another
-                        // container is being dragged toward it.
-                        draggingEntryIdx !== null &&
-                          dragSourceContainer !== null &&
-                          dropTargetContainer === null &&
+                        // Highlight while an entry from another container, or a nested
+                        // folder being un-nested, is dragged toward this root zone.
+                        ((draggingEntryIdx !== null && dragSourceContainer !== null && dropTargetContainer === null) ||
+                          (draggingFolderIdx !== null && folderRootDropActive)) &&
                           "rounded-xl ring-1 ring-amber-400/40 bg-amber-400/5 transition-colors",
                       )}
-                      onDragOver={handleRootListDragOver}
-                      onDrop={commitEntryDrop}
+                      onDragOver={(e) => {
+                        // Dragging a folder down into the root-entries area un-nests it to
+                        // the top level (the root entries already live there).
+                        if (draggingFolderIdx !== null) handleFolderRootDragOver(e);
+                        else handleRootListDragOver(e);
+                      }}
+                      onDrop={(e) => {
+                        if (draggingFolderIdx !== null) commitFolderDrop(e);
+                        else commitEntryDrop(e);
+                      }}
                     >
                       {(entriesByContainer.get(null) ?? []).length === 0 && (
                         <p
@@ -2065,12 +2072,16 @@ export function LorebookEditor() {
                             // Only call out the empty-root zone while the user
                             // is actively dragging an entry from a folder; in
                             // the steady state it would just be visual noise.
-                            draggingEntryIdx !== null && dragSourceContainer !== null ? "opacity-100" : "opacity-50",
+                            draggingFolderIdx !== null || (draggingEntryIdx !== null && dragSourceContainer !== null)
+                              ? "opacity-100"
+                              : "opacity-50",
                           )}
                         >
-                          {draggingEntryIdx !== null && dragSourceContainer !== null
-                            ? "Drop here to move out of the folder"
-                            : "No entries at the root level"}
+                          {draggingFolderIdx !== null
+                            ? "Drop here to move the folder to the top level"
+                            : draggingEntryIdx !== null && dragSourceContainer !== null
+                              ? "Drop here to move out of the folder"
+                              : "No entries at the root level"}
                         </p>
                       )}
                       {(entriesByContainer.get(null) ?? []).map((entry, idx) => {
@@ -2116,10 +2127,13 @@ export function LorebookEditor() {
                               onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
                               onDragStart={(e) => handleEntryDragStart(null, idx, entry.id, e)}
                               onDragOver={(e) => {
+                                // Let folder drags fall through to the root list (un-nest).
+                                if (draggingFolderIdx !== null) return;
                                 e.stopPropagation();
                                 handleEntryDragOver(null, idx, e);
                               }}
                               onDrop={(e) => {
+                                if (draggingFolderIdx !== null) return;
                                 e.stopPropagation();
                                 commitEntryDrop(e);
                               }}

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -31,6 +31,7 @@ import {
   useCreateLorebookFolder,
   useUpdateLorebookEntry,
   useReorderLorebookFolders,
+  useUpdateLorebookFolder,
   useTransferLorebookEntries,
   lorebookKeys,
 } from "../../hooks/use-lorebooks";
@@ -78,6 +79,7 @@ import {
   testPrimaryKeys,
   testSecondaryKeys,
   buildFolderForest,
+  canReparentFolder,
   type Lorebook,
   type LorebookEntry,
   type LorebookFolder,
@@ -321,6 +323,7 @@ export function LorebookEditor() {
   const updateEntry = useUpdateLorebookEntry();
   const reorderEntries = useReorderLorebookEntries();
   const createFolder = useCreateLorebookFolder();
+  const updateFolder = useUpdateLorebookFolder();
   const reorderFolders = useReorderLorebookFolders();
   const transferEntries = useTransferLorebookEntries();
 
@@ -430,6 +433,12 @@ export function LorebookEditor() {
   const [draggingFolderIdx, setDraggingFolderIdx] = useState<number | null>(null);
   const [folderDragReadyIdx, setFolderDragReadyIdx] = useState<number | null>(null);
   const [folderDropIdx, setFolderDropIdx] = useState<number | null>(null);
+  // Drag-to-nest: the folder hovered as a nest target (the middle band of a
+  // folder header), plus whether a dragged folder is over the root strip (drop
+  // there un-nests to top level). Kept separate from folderDropIdx so the nest
+  // ring and the reorder line never appear at the same time.
+  const [folderNestTargetId, setFolderNestTargetId] = useState<string | null>(null);
+  const [folderRootDropActive, setFolderRootDropActive] = useState(false);
 
   // ── Form state for lorebook overview ──
   const [formName, setFormName] = useState("");
@@ -736,6 +745,8 @@ export function LorebookEditor() {
     setDraggingFolderIdx(null);
     setFolderDragReadyIdx(null);
     setFolderDropIdx(null);
+    setFolderNestTargetId(null);
+    setFolderRootDropActive(false);
   }, []);
 
   const calcEntryDropIdx = useCallback((cardIdx: number, e: ReactDragEvent<HTMLDivElement>) => {
@@ -910,20 +921,53 @@ export function LorebookEditor() {
       if (!canReorderFolders || draggingFolderIdx === null) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
+      const dragged = folders[draggingFolderIdx];
+      const target = folders[idx];
       const rect = e.currentTarget.getBoundingClientRect();
+      const offset = rect.height > 0 ? (e.clientY - rect.top) / rect.height : 0.5;
+      // The middle band nests the dragged folder inside this one; the top and
+      // bottom bands reorder it as a sibling. Only offer the nest band when the
+      // move is actually legal (canReparentFolder blocks self/descendant/cross-
+      // lorebook) and the folder isn't already inside this one — otherwise the
+      // whole header behaves as reorder.
+      const canNest =
+        !!dragged &&
+        !!target &&
+        dragged.parentFolderId !== target.id &&
+        canReparentFolder(folders, dragged.id, target.id).ok;
+      if (canNest && offset > 0.3 && offset < 0.7) {
+        setFolderNestTargetId(target.id);
+        setFolderDropIdx(null);
+        return;
+      }
+      setFolderNestTargetId(null);
       const midY = rect.top + rect.height / 2;
       setFolderDropIdx(e.clientY < midY ? idx : idx + 1);
     },
-    [canReorderFolders, draggingFolderIdx],
+    [canReorderFolders, draggingFolderIdx, folders],
   );
 
   const commitFolderDrop = useCallback(
     (e: ReactDragEvent<HTMLDivElement>) => {
       e.preventDefault();
       const sourceIdx = draggingFolderIdx;
+      const nestTargetId = folderNestTargetId;
       const targetIdx = folderDropIdx;
       resetFolderDragState();
-      if (!lorebookId || !canReorderFolders || sourceIdx === null || targetIdx === null) return;
+      if (!lorebookId || !canReorderFolders || sourceIdx === null) return;
+      const dragged = folders[sourceIdx];
+      if (!dragged) return;
+      // Nest band: reparent the dragged folder under the hovered one. Re-validate
+      // at drop time in case the tree shifted mid-drag.
+      if (nestTargetId) {
+        if (dragged.parentFolderId === nestTargetId) return;
+        if (!canReparentFolder(folders, dragged.id, nestTargetId).ok) return;
+        updateFolder.mutate({ lorebookId, folderId: dragged.id, parentFolderId: nestTargetId });
+        return;
+      }
+      // Reorder band: move within the flat order (the forest re-sorts each
+      // sibling group by it). Parent is unchanged.
+      if (targetIdx === null) return;
       let insertAt = targetIdx;
       if (sourceIdx < insertAt) insertAt--;
       if (sourceIdx === insertAt) return;
@@ -933,7 +977,46 @@ export function LorebookEditor() {
       ids.splice(insertAt, 0, moved);
       reorderFolders.mutate({ lorebookId, folderIds: ids });
     },
-    [canReorderFolders, draggingFolderIdx, folderDropIdx, folders, lorebookId, reorderFolders, resetFolderDragState],
+    [
+      canReorderFolders,
+      draggingFolderIdx,
+      folderNestTargetId,
+      folderDropIdx,
+      folders,
+      lorebookId,
+      reorderFolders,
+      updateFolder,
+      resetFolderDragState,
+    ],
+  );
+
+  // Root strip: dropping a nested folder here un-nests it back to the top level.
+  // Shown only while a folder that actually has a parent is being dragged.
+  const handleFolderRootDragOver = useCallback(
+    (e: ReactDragEvent<HTMLDivElement>) => {
+      if (!canReorderFolders || draggingFolderIdx === null) return;
+      const dragged = folders[draggingFolderIdx];
+      if (!dragged || dragged.parentFolderId == null) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setFolderNestTargetId(null);
+      setFolderDropIdx(null);
+      setFolderRootDropActive(true);
+    },
+    [canReorderFolders, draggingFolderIdx, folders],
+  );
+
+  const commitFolderRootDrop = useCallback(
+    (e: ReactDragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const sourceIdx = draggingFolderIdx;
+      resetFolderDragState();
+      if (!lorebookId || sourceIdx === null) return;
+      const dragged = folders[sourceIdx];
+      if (!dragged || dragged.parentFolderId == null) return;
+      updateFolder.mutate({ lorebookId, folderId: dragged.id, parentFolderId: null });
+    },
+    [draggingFolderIdx, folders, lorebookId, updateFolder, resetFolderDragState],
   );
 
   const handleAddFolder = useCallback(async () => {
@@ -1079,6 +1162,7 @@ export function LorebookEditor() {
           draggable={canReorderFolders}
           isDragging={draggingFolderIdx === fIdx}
           isDragReady={folderDragReadyIdx === fIdx}
+          isNestTarget={folderNestTargetId === folder.id}
           onDragHandleMouseDown={() => {
             if (canReorderFolders) setFolderDragReadyIdx(fIdx);
           }}
@@ -1880,7 +1964,25 @@ export function LorebookEditor() {
                   <div className="space-y-3">
                     {/* Folder block — nested tree (folders may contain sub-folders) */}
                     {folders.length > 0 && (
-                      <div className="space-y-1.5">{folderForest.roots.map((folder) => renderFolder(folder))}</div>
+                      <div className="space-y-1.5">
+                        {/* Un-nest target: drop a nested folder here to lift it back to top level. */}
+                        {draggingFolderIdx !== null && folders[draggingFolderIdx]?.parentFolderId != null && (
+                          <div
+                            onDragOver={handleFolderRootDragOver}
+                            onDragLeave={() => setFolderRootDropActive(false)}
+                            onDrop={commitFolderRootDrop}
+                            className={cn(
+                              "rounded-lg border border-dashed px-2 py-1.5 text-center text-[0.625rem] italic transition-colors",
+                              folderRootDropActive
+                                ? "border-amber-400 bg-amber-400/10 text-amber-200"
+                                : "border-[var(--border)] text-[var(--muted-foreground)]",
+                            )}
+                          >
+                            Drop here to move to the top level
+                          </div>
+                        )}
+                        {folderForest.roots.map((folder) => renderFolder(folder))}
+                      </div>
                     )}
 
                     {/* Root entries (entries with no folder).

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -77,6 +77,7 @@ import {
   LOCAL_SIDECAR_CONNECTION_ID,
   testPrimaryKeys,
   testSecondaryKeys,
+  buildFolderForest,
   type Lorebook,
   type LorebookEntry,
   type LorebookFolder,
@@ -607,6 +608,9 @@ export function LorebookEditor() {
     return map;
   }, [entries, folders]);
 
+  // Folder hierarchy: flat parentFolderId rows → sorted roots + child lists.
+  const folderForest = useMemo(() => buildFolderForest(folders), [folders]);
+
   const canReorderEntries = showFolderGrouping && entries.length > 1 && !reorderEntries.isPending;
   const canReorderFolders = showFolderGrouping && folders.length > 1 && !reorderFolders.isPending;
 
@@ -1040,6 +1044,137 @@ export function LorebookEditor() {
       </div>
     );
   }
+
+  // Recursive folder renderer: a folder header, then (when expanded) its entries
+  // followed by its child folders nested inside. `renderedFolderIds` guards a
+  // malformed cycle from rendering a folder twice.
+  const renderedFolderIds = new Set<string>();
+  const renderFolder = (folder: LorebookFolder): ReactNode => {
+    if (!lorebookId || renderedFolderIds.has(folder.id)) return null;
+    renderedFolderIds.add(folder.id);
+    const fIdx = folders.findIndex((f) => f.id === folder.id);
+    const folderEntries = entriesByContainer.get(folder.id) ?? [];
+    const isCollapsed = collapsedFolderIds.has(folder.id);
+    const childFolders = folderForest.childrenByParent.get(folder.id) ?? [];
+    const showFolderDropBefore =
+      folderDropIdx === fIdx &&
+      draggingFolderIdx !== null &&
+      draggingFolderIdx !== fIdx &&
+      draggingFolderIdx !== fIdx - 1;
+    const showFolderDropAfter =
+      fIdx === folders.length - 1 &&
+      folderDropIdx === folders.length &&
+      draggingFolderIdx !== null &&
+      draggingFolderIdx !== fIdx;
+    return (
+      <div key={folder.id} className="space-y-1">
+        {showFolderDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
+        <LorebookFolderRow
+          folder={folder}
+          lorebookId={lorebookId}
+          folders={folders}
+          entryCount={folderEntries.length}
+          isCollapsed={isCollapsed}
+          onToggleCollapse={() => toggleFolderCollapsed(folder.id)}
+          draggable={canReorderFolders}
+          isDragging={draggingFolderIdx === fIdx}
+          isDragReady={folderDragReadyIdx === fIdx}
+          onDragHandleMouseDown={() => {
+            if (canReorderFolders) setFolderDragReadyIdx(fIdx);
+          }}
+          onDragHandleMouseUp={() => setFolderDragReadyIdx(null)}
+          onDragStart={(e) => handleFolderDragStart(fIdx, folder.id, e)}
+          onDragOver={(e) => {
+            e.stopPropagation();
+            if (draggingEntryIdx !== null) handleFolderHeaderDragOver(folder.id, e);
+            else handleFolderDragOverHeader(fIdx, e);
+          }}
+          onDrop={(e) => {
+            e.stopPropagation();
+            if (draggingEntryIdx !== null) commitEntryDrop(e);
+            else commitFolderDrop(e);
+          }}
+          onDragEnd={() => {
+            resetFolderDragState();
+            resetEntryDragState();
+          }}
+        />
+        {!isCollapsed && (
+          <div
+            className="ml-2 space-y-1.5 border-l border-[var(--border)] pl-2 sm:ml-3 sm:pl-2.5"
+            onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
+            onDrop={(e) => {
+              e.stopPropagation();
+              commitEntryDrop(e);
+            }}
+          >
+            {folderEntries.length === 0 && childFolders.length === 0 && (
+              <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">
+                Empty — drag an entry here or pick this folder from an entry's folder selector.
+              </p>
+            )}
+            {folderEntries.map((entry, eIdx) => {
+              const isDropTarget = dropTargetContainer === folder.id && draggingEntryIdx !== null;
+              const sameContainer = dragSourceContainer === folder.id;
+              const showDropBefore =
+                isDropTarget &&
+                sameContainer &&
+                entryDropIdx === eIdx &&
+                draggingEntryIdx !== eIdx &&
+                draggingEntryIdx !== eIdx - 1;
+              const showDropAfter =
+                isDropTarget &&
+                sameContainer &&
+                eIdx === folderEntries.length - 1 &&
+                entryDropIdx === folderEntries.length &&
+                draggingEntryIdx !== eIdx;
+              return (
+                <div key={entry.id}>
+                  {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
+                  <LorebookEntryRow
+                    entry={entry}
+                    lorebookId={lorebookId}
+                    isExpanded={expandedEntryId === entry.id}
+                    onToggleExpand={() => toggleEntryExpanded(entry.id)}
+                    characters={characters}
+                    characterTags={characterTags}
+                    folders={folders}
+                    draggable={canReorderEntries}
+                    isDragging={sameContainer && draggingEntryIdx === eIdx}
+                    isDragReady={sameContainer && entryDragReadyIdx === eIdx}
+                    onDragHandleMouseDown={() => {
+                      if (canReorderEntries) {
+                        setEntryDragReadyIdx(eIdx);
+                        setDragSourceContainer(folder.id);
+                      }
+                    }}
+                    onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
+                    onDragStart={(e) => handleEntryDragStart(folder.id, eIdx, entry.id, e)}
+                    onDragOver={(e) => {
+                      e.stopPropagation();
+                      handleEntryDragOver(folder.id, eIdx, e);
+                    }}
+                    onDrop={(e) => {
+                      e.stopPropagation();
+                      commitEntryDrop(e);
+                    }}
+                    onDragEnd={resetEntryDragState}
+                    selectionMode={entrySelectionMode}
+                    isSelected={selectedEntryIds.has(entry.id)}
+                    onToggleSelected={() => toggleEntrySelection(entry.id)}
+                    previewMatch={previewMatches.get(entry.id)}
+                  />
+                  {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+                </div>
+              );
+            })}
+            {childFolders.map((child) => renderFolder(child))}
+          </div>
+        )}
+        {showFolderDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
+      </div>
+    );
+  };
 
   // ── Main editor ──
   return (
@@ -1743,150 +1878,9 @@ export function LorebookEditor() {
                 {/* Entries — folder-grouped view (default sort, no search) */}
                 {lorebookId && showFolderGrouping && (entries.length > 0 || folders.length > 0) && (
                   <div className="space-y-3">
-                    {/* Folder block */}
+                    {/* Folder block — nested tree (folders may contain sub-folders) */}
                     {folders.length > 0 && (
-                      <div className="space-y-1.5">
-                        {folders.map((folder, fIdx) => {
-                          const folderEntries = entriesByContainer.get(folder.id) ?? [];
-                          const isCollapsed = collapsedFolderIds.has(folder.id);
-                          const showFolderDropBefore =
-                            folderDropIdx === fIdx &&
-                            draggingFolderIdx !== null &&
-                            draggingFolderIdx !== fIdx &&
-                            draggingFolderIdx !== fIdx - 1;
-                          const showFolderDropAfter =
-                            fIdx === folders.length - 1 &&
-                            folderDropIdx === folders.length &&
-                            draggingFolderIdx !== null &&
-                            draggingFolderIdx !== fIdx;
-                          return (
-                            <div key={folder.id} className="space-y-1">
-                              {showFolderDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />}
-                              {/*
-                                When an entry from a different container is being
-                                dragged toward this folder, paint a faint amber ring
-                                around the header to mirror the root drop-zone hint.
-                                The ring goes ON the wrapper div above the folder row
-                                because LorebookFolderRow already manages its own ring
-                                state for collapse/dragging visuals.
-                              */}
-                              <LorebookFolderRow
-                                folder={folder}
-                                lorebookId={lorebookId}
-                                entryCount={folderEntries.length}
-                                isCollapsed={isCollapsed}
-                                onToggleCollapse={() => toggleFolderCollapsed(folder.id)}
-                                draggable={canReorderFolders}
-                                isDragging={draggingFolderIdx === fIdx}
-                                isDragReady={folderDragReadyIdx === fIdx}
-                                onDragHandleMouseDown={() => {
-                                  if (canReorderFolders) setFolderDragReadyIdx(fIdx);
-                                }}
-                                onDragHandleMouseUp={() => setFolderDragReadyIdx(null)}
-                                onDragStart={(e) => handleFolderDragStart(fIdx, folder.id, e)}
-                                onDragOver={(e) => {
-                                  e.stopPropagation();
-                                  // Two roles for the same dragOver: if the user is dragging
-                                  // an entry, this header is a cross-container drop target;
-                                  // otherwise it's a sibling for folder reorder.
-                                  if (draggingEntryIdx !== null) handleFolderHeaderDragOver(folder.id, e);
-                                  else handleFolderDragOverHeader(fIdx, e);
-                                }}
-                                onDrop={(e) => {
-                                  e.stopPropagation();
-                                  if (draggingEntryIdx !== null) commitEntryDrop(e);
-                                  else commitFolderDrop(e);
-                                }}
-                                onDragEnd={() => {
-                                  resetFolderDragState();
-                                  resetEntryDragState();
-                                }}
-                              />
-                              {!isCollapsed && (
-                                <div
-                                  className="ml-2 space-y-1.5 border-l border-[var(--border)] pl-2 sm:ml-3 sm:pl-2.5"
-                                  onDragOver={(e) => handleFolderBodyDragOver(folder.id, e)}
-                                  onDrop={(e) => {
-                                    e.stopPropagation();
-                                    commitEntryDrop(e);
-                                  }}
-                                >
-                                  {folderEntries.length === 0 && (
-                                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">
-                                      Empty — drag an entry here or pick this folder from an entry's folder selector.
-                                    </p>
-                                  )}
-                                  {folderEntries.map((entry, eIdx) => {
-                                    const isDropTarget = dropTargetContainer === folder.id && draggingEntryIdx !== null;
-                                    const sameContainer = dragSourceContainer === folder.id;
-                                    // Position bars only render for SAME-container drops because
-                                    // cross-container moves deliberately preserve the entry's
-                                    // existing Order (per the user's spec). Showing a bar
-                                    // between two entries during a cross-container drag would
-                                    // promise a position the move won't honor — the folder
-                                    // header's amber ring carries the "drop into this folder"
-                                    // affordance instead.
-                                    const showDropBefore =
-                                      isDropTarget &&
-                                      sameContainer &&
-                                      entryDropIdx === eIdx &&
-                                      draggingEntryIdx !== eIdx &&
-                                      draggingEntryIdx !== eIdx - 1;
-                                    const showDropAfter =
-                                      isDropTarget &&
-                                      sameContainer &&
-                                      eIdx === folderEntries.length - 1 &&
-                                      entryDropIdx === folderEntries.length &&
-                                      draggingEntryIdx !== eIdx;
-                                    return (
-                                      <div key={entry.id}>
-                                        {showDropBefore && (
-                                          <div className="mx-2 mb-1 h-0.5 rounded-full bg-amber-400" />
-                                        )}
-                                        <LorebookEntryRow
-                                          entry={entry}
-                                          lorebookId={lorebookId}
-                                          isExpanded={expandedEntryId === entry.id}
-                                          onToggleExpand={() => toggleEntryExpanded(entry.id)}
-                                          characters={characters}
-                                          characterTags={characterTags}
-                                          folders={folders}
-                                          draggable={canReorderEntries}
-                                          isDragging={sameContainer && draggingEntryIdx === eIdx}
-                                          isDragReady={sameContainer && entryDragReadyIdx === eIdx}
-                                          onDragHandleMouseDown={() => {
-                                            if (canReorderEntries) {
-                                              setEntryDragReadyIdx(eIdx);
-                                              setDragSourceContainer(folder.id);
-                                            }
-                                          }}
-                                          onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
-                                          onDragStart={(e) => handleEntryDragStart(folder.id, eIdx, entry.id, e)}
-                                          onDragOver={(e) => {
-                                            e.stopPropagation();
-                                            handleEntryDragOver(folder.id, eIdx, e);
-                                          }}
-                                          onDrop={(e) => {
-                                            e.stopPropagation();
-                                            commitEntryDrop(e);
-                                          }}
-                                          onDragEnd={resetEntryDragState}
-                                          selectionMode={entrySelectionMode}
-                                          isSelected={selectedEntryIds.has(entry.id)}
-                                          onToggleSelected={() => toggleEntrySelection(entry.id)}
-                                          previewMatch={previewMatches.get(entry.id)}
-                                        />
-                                        {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
-                                      </div>
-                                    );
-                                  })}
-                                </div>
-                              )}
-                              {showFolderDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-amber-400" />}
-                            </div>
-                          );
-                        })}
-                      </div>
+                      <div className="space-y-1.5">{folderForest.roots.map((folder) => renderFolder(folder))}</div>
                     )}
 
                     {/* Root entries (entries with no folder).

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -824,14 +824,26 @@ export function LorebookEditor() {
       if (!canReorderFolders || draggingFolderIdx === null) return;
       const dragged = folders[draggingFolderIdx];
       if (!dragged) return;
-      // Accept only a legal nest; otherwise let the event bubble so an ancestor
-      // body (or nothing) claims it, instead of showing a dead "no-drop" cursor.
-      if (dragged.parentFolderId === folderId || !canReparentFolder(folders, dragged.id, folderId).ok) return;
+      // Dragging a folder down into the body of its OWN parent lifts it out —
+      // "drag it past the parent, out the bottom" un-nests it to the top level.
+      if (dragged.parentFolderId === folderId) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.dataTransfer.dropEffect = "move";
+        setFolderRootDropActive(true);
+        setFolderNestTargetId(null);
+        setFolderDropIdx(null);
+        return;
+      }
+      // Otherwise nest inside this folder when legal; if not, let the event bubble
+      // so an ancestor body (or nothing) claims it instead of a dead "no-drop".
+      if (!canReparentFolder(folders, dragged.id, folderId).ok) return;
       e.preventDefault();
       e.stopPropagation();
       e.dataTransfer.dropEffect = "move";
       setFolderNestTargetId(folderId);
       setFolderDropIdx(null);
+      setFolderRootDropActive(false);
     },
     [canReorderFolders, draggingFolderIdx, folders],
   );
@@ -947,6 +959,7 @@ export function LorebookEditor() {
       if (!canReorderFolders || draggingFolderIdx === null) return;
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
+      setFolderRootDropActive(false);
       const dragged = folders[draggingFolderIdx];
       const target = folders[idx];
       const rect = e.currentTarget.getBoundingClientRect();
@@ -979,10 +992,17 @@ export function LorebookEditor() {
       const sourceIdx = draggingFolderIdx;
       const nestTargetId = folderNestTargetId;
       const targetIdx = folderDropIdx;
+      const unnest = folderRootDropActive;
       resetFolderDragState();
       if (!lorebookId || !canReorderFolders || sourceIdx === null) return;
       const dragged = folders[sourceIdx];
       if (!dragged) return;
+      // Un-nest: lift the folder back to the top level.
+      if (unnest) {
+        if (dragged.parentFolderId == null) return;
+        updateFolder.mutate({ lorebookId, folderId: dragged.id, parentFolderId: null });
+        return;
+      }
       // Nest band: reparent the dragged folder under the hovered one. Re-validate
       // at drop time in case the tree shifted mid-drag.
       if (nestTargetId) {
@@ -1008,6 +1028,7 @@ export function LorebookEditor() {
       draggingFolderIdx,
       folderNestTargetId,
       folderDropIdx,
+      folderRootDropActive,
       folders,
       lorebookId,
       reorderFolders,
@@ -1016,8 +1037,8 @@ export function LorebookEditor() {
     ],
   );
 
-  // Root strip: dropping a nested folder here un-nests it back to the top level.
-  // Shown only while a folder that actually has a parent is being dragged.
+  // The folder list's own padding/gaps are the un-nest drop zone: dropping a
+  // nested folder there lifts it back to the top level.
   const handleFolderRootDragOver = useCallback(
     (e: ReactDragEvent<HTMLDivElement>) => {
       if (!canReorderFolders || draggingFolderIdx === null) return;
@@ -1030,19 +1051,6 @@ export function LorebookEditor() {
       setFolderRootDropActive(true);
     },
     [canReorderFolders, draggingFolderIdx, folders],
-  );
-
-  const commitFolderRootDrop = useCallback(
-    (e: ReactDragEvent<HTMLDivElement>) => {
-      e.preventDefault();
-      const sourceIdx = draggingFolderIdx;
-      resetFolderDragState();
-      if (!lorebookId || sourceIdx === null) return;
-      const dragged = folders[sourceIdx];
-      if (!dragged || dragged.parentFolderId == null) return;
-      updateFolder.mutate({ lorebookId, folderId: dragged.id, parentFolderId: null });
-    },
-    [draggingFolderIdx, folders, lorebookId, updateFolder, resetFolderDragState],
   );
 
   const handleAddFolder = useCallback(async () => {
@@ -1272,12 +1280,19 @@ export function LorebookEditor() {
                     onDragHandleMouseUp={() => setEntryDragReadyIdx(null)}
                     onDragStart={(e) => handleEntryDragStart(folder.id, eIdx, entry.id, e)}
                     onDragOver={(e) => {
+                      // A folder dragged over an entry is really being dragged over the
+                      // enclosing folder's body — route it there (nest / un-nest).
+                      if (draggingFolderIdx !== null) {
+                        handleFolderBodyFolderDragOver(folder.id, e);
+                        return;
+                      }
                       e.stopPropagation();
                       handleEntryDragOver(folder.id, eIdx, e);
                     }}
                     onDrop={(e) => {
                       e.stopPropagation();
-                      commitEntryDrop(e);
+                      if (draggingFolderIdx !== null) commitFolderDrop(e);
+                      else commitEntryDrop(e);
                     }}
                     onDragEnd={resetEntryDragState}
                     selectionMode={entrySelectionMode}
@@ -2017,7 +2032,7 @@ export function LorebookEditor() {
                         }}
                         onDragLeave={() => setFolderRootDropActive(false)}
                         onDrop={(e) => {
-                          if (draggingFolderIdx !== null) commitFolderRootDrop(e);
+                          if (draggingFolderIdx !== null) commitFolderDrop(e);
                         }}
                       >
                         {folderForest.roots.map((folder) => renderFolder(folder))}

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -21,9 +21,9 @@ import {
 } from "react";
 import { ChevronDown, Copy, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
-import { showConfirmDialog } from "../../lib/app-dialogs";
+import { showConfirmDialog, showConfirmWithCheckbox } from "../../lib/app-dialogs";
 import { useUpdateLorebookFolder, useDeleteLorebookFolder, useCloneLorebookFolder } from "../../hooks/use-lorebooks";
-import { canReparentFolder, type LorebookFolder } from "@marinara-engine/shared";
+import { canReparentFolder, collectFolderSubtreeIds, type LorebookFolder } from "@marinara-engine/shared";
 
 interface Props {
   folder: LorebookFolder;
@@ -157,6 +157,21 @@ export function LorebookFolderRow({
   const handleDelete = useCallback(
     async (e: ReactMouseEvent) => {
       e.stopPropagation();
+      const descendantCount = collectFolderSubtreeIds(folders, folder.id).length - 1;
+      if (descendantCount > 0) {
+        // Nested subfolders present — offer to delete the whole subtree, or (the
+        // default) just remove this folder and lift its contents up a level.
+        const { confirmed, checked } = await showConfirmWithCheckbox({
+          title: "Delete Folder",
+          message: "Delete this folder? Its entries and subfolders move up to the top level.",
+          confirmLabel: "Delete",
+          tone: "destructive",
+          checkboxLabel: `Also delete the ${descendantCount} nested subfolder${descendantCount === 1 ? "" : "s"} and everything in them`,
+        });
+        if (!confirmed) return;
+        deleteFolder.mutate({ lorebookId, folderId: folder.id, cascade: checked });
+        return;
+      }
       const confirmed = await showConfirmDialog({
         title: "Delete Folder",
         message:
@@ -169,7 +184,7 @@ export function LorebookFolderRow({
       if (!confirmed) return;
       deleteFolder.mutate({ lorebookId, folderId: folder.id });
     },
-    [entryCount, lorebookId, folder.id, deleteFolder],
+    [entryCount, lorebookId, folder.id, folders, deleteFolder],
   );
 
   return (

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -158,26 +158,29 @@ export function LorebookFolderRow({
     async (e: ReactMouseEvent) => {
       e.stopPropagation();
       const descendantCount = collectFolderSubtreeIds(folders, folder.id).length - 1;
-      if (descendantCount > 0) {
-        // Nested subfolders present — offer to delete the whole subtree, or (the
-        // default) just remove this folder and lift its contents up a level.
+      const hasSubfolders = descendantCount > 0;
+      // Any folder with content (subfolders and/or entries) offers a checkbox to
+      // delete that content too, instead of lifting it up to the top level.
+      if (hasSubfolders || entryCount > 0) {
         const { confirmed, checked } = await showConfirmWithCheckbox({
           title: "Delete Folder",
-          message: "Delete this folder? Its entries and subfolders move up to the top level.",
+          message: hasSubfolders
+            ? "Delete this folder? Its contents move up to the top level."
+            : `Delete this folder? Its ${entryCount} entr${entryCount === 1 ? "y" : "ies"} move up to the top level.`,
           confirmLabel: "Delete",
           tone: "destructive",
-          checkboxLabel: `Also delete the ${descendantCount} nested subfolder${descendantCount === 1 ? "" : "s"} and everything in them`,
+          checkboxLabel: hasSubfolders
+            ? `Also delete the ${descendantCount} nested subfolder${descendantCount === 1 ? "" : "s"} and everything inside`
+            : "Also delete everything in it",
         });
         if (!confirmed) return;
         deleteFolder.mutate({ lorebookId, folderId: folder.id, cascade: checked });
         return;
       }
+      // Empty folder — nothing to cascade.
       const confirmed = await showConfirmDialog({
         title: "Delete Folder",
-        message:
-          entryCount > 0
-            ? `Delete this folder? The ${entryCount} entr${entryCount === 1 ? "y" : "ies"} inside will be moved back to the root level.`
-            : "Delete this folder?",
+        message: "Delete this folder?",
         confirmLabel: "Delete",
         tone: "destructive",
       });

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -40,6 +40,8 @@ interface Props {
   draggable: boolean;
   isDragging: boolean;
   isDragReady: boolean;
+  /** True while a dragged folder hovers this row's nest band — draws a nest ring. */
+  isNestTarget?: boolean;
   onDragHandleMouseDown: () => void;
   onDragHandleMouseUp: () => void;
   onDragStart: (e: ReactDragEvent<HTMLDivElement>) => void;
@@ -58,6 +60,7 @@ export function LorebookFolderRow({
   draggable,
   isDragging,
   isDragReady,
+  isNestTarget = false,
   onDragHandleMouseDown,
   onDragHandleMouseUp,
   onDragStart,
@@ -170,6 +173,7 @@ export function LorebookFolderRow({
         "rounded-xl bg-[var(--secondary)]/60 ring-1 ring-[var(--border)] transition-all",
         !isCollapsed && "ring-amber-400/30",
         isDragging && "opacity-40",
+        isNestTarget && "ring-2 ring-amber-400",
       )}
       draggable={draggable && isDragReady}
       onDragStart={onDragStart}

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -135,14 +135,23 @@ export function LorebookFolderRow({
     }
   }, [localName, folder.name, lorebookId, folder.id, updateFolder]);
 
+  // Guards the optimistic rollback below: if several parent changes fire in quick
+  // succession, only the latest may roll back — a stale out-of-order failure must
+  // not clobber a newer optimistic value.
+  const parentChangeSeqRef = useRef(0);
   const handleParentChange = useCallback(
     (parentFolderId: string | null) => {
       const previous = localParentId;
+      const seq = ++parentChangeSeqRef.current;
       // Optimistic flip; roll back if the move is rejected server-side.
       setLocalParentId(parentFolderId);
       updateFolder.mutate(
         { lorebookId, folderId: folder.id, parentFolderId },
-        { onError: () => setLocalParentId(previous) },
+        {
+          onError: () => {
+            if (parentChangeSeqRef.current === seq) setLocalParentId(previous);
+          },
+        },
       );
     },
     [localParentId, lorebookId, folder.id, updateFolder],

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -19,10 +19,10 @@ import {
   type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { ChevronDown, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } from "lucide-react";
+import { ChevronDown, Copy, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { useUpdateLorebookFolder, useDeleteLorebookFolder } from "../../hooks/use-lorebooks";
+import { useUpdateLorebookFolder, useDeleteLorebookFolder, useCloneLorebookFolder } from "../../hooks/use-lorebooks";
 import { canReparentFolder, type LorebookFolder } from "@marinara-engine/shared";
 
 interface Props {
@@ -70,6 +70,7 @@ export function LorebookFolderRow({
 }: Props) {
   const updateFolder = useUpdateLorebookFolder();
   const deleteFolder = useDeleteLorebookFolder();
+  const cloneFolder = useCloneLorebookFolder();
 
   // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
   const [localEnabled, setLocalEnabled] = useState(folder.enabled);
@@ -286,6 +287,21 @@ export function LorebookFolderRow({
         >
           {entryCount}
         </span>
+
+        {/* Clone — deep-copies the folder, its entries, and its sub-folders */}
+        <button
+          type="button"
+          aria-label="Clone folder"
+          title="Clone this folder, its entries, and its sub-folders"
+          disabled={cloneFolder.isPending}
+          onClick={(e) => {
+            e.stopPropagation();
+            cloneFolder.mutate({ lorebookId, folderId: folder.id });
+          }}
+          className="shrink-0 rounded p-1 opacity-0 transition-all hover:bg-[var(--accent)] group-hover:opacity-100 max-md:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <Copy size="0.75rem" className="text-[var(--muted-foreground)]" />
+        </button>
 
         {/* Delete (hover-revealed on desktop, always visible on mobile per the row-action convention) */}
         <button

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -23,11 +23,13 @@ import { ChevronDown, Folder, GripVertical, ToggleLeft, ToggleRight, Trash2 } fr
 import { cn } from "../../lib/utils";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { useUpdateLorebookFolder, useDeleteLorebookFolder } from "../../hooks/use-lorebooks";
-import type { LorebookFolder } from "@marinara-engine/shared";
+import { canReparentFolder, type LorebookFolder } from "@marinara-engine/shared";
 
 interface Props {
   folder: LorebookFolder;
   lorebookId: string;
+  /** All folders in this lorebook — builds the parent picker + validates moves. */
+  folders: LorebookFolder[];
   /** Number of entries currently inside this folder (for the count badge). */
   entryCount: number;
   /** UI-only collapse state — owned by the parent editor and persisted in localStorage. */
@@ -49,6 +51,7 @@ interface Props {
 export function LorebookFolderRow({
   folder,
   lorebookId,
+  folders,
   entryCount,
   isCollapsed,
   onToggleCollapse,
@@ -68,6 +71,7 @@ export function LorebookFolderRow({
   // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
   const [localEnabled, setLocalEnabled] = useState(folder.enabled);
   const [localName, setLocalName] = useState(folder.name);
+  const [localParentId, setLocalParentId] = useState(folder.parentFolderId);
 
   const lastSyncedRef = useRef(folder);
   useEffect(() => {
@@ -75,6 +79,7 @@ export function LorebookFolderRow({
     lastSyncedRef.current = folder;
     setLocalEnabled(folder.enabled);
     setLocalName(folder.name);
+    setLocalParentId(folder.parentFolderId);
   }, [folder]);
 
   const handleEnableToggle = useCallback(
@@ -121,6 +126,25 @@ export function LorebookFolderRow({
       );
     }
   }, [localName, folder.name, lorebookId, folder.id, updateFolder]);
+
+  const handleParentChange = useCallback(
+    (parentFolderId: string | null) => {
+      const previous = localParentId;
+      // Optimistic flip; roll back if the move is rejected server-side.
+      setLocalParentId(parentFolderId);
+      updateFolder.mutate(
+        { lorebookId, folderId: folder.id, parentFolderId },
+        { onError: () => setLocalParentId(previous) },
+      );
+    },
+    [localParentId, lorebookId, folder.id, updateFolder],
+  );
+
+  // Valid parents only: same lorebook, not this folder, not one of its own
+  // descendants — so the picker can never offer a move that would cycle.
+  const parentOptions = folders.filter(
+    (candidate) => candidate.id !== folder.id && canReparentFolder(folders, folder.id, candidate.id).ok,
+  );
 
   const handleDelete = useCallback(
     async (e: ReactMouseEvent) => {
@@ -231,6 +255,25 @@ export function LorebookFolderRow({
           placeholder="Untitled folder"
           className="min-w-0 flex-1 truncate bg-transparent px-1 text-sm font-semibold outline-none transition-colors hover:bg-[var(--accent)]/40 focus:bg-[var(--accent)]/40 focus:ring-1 focus:ring-[var(--ring)] rounded"
         />
+
+        {/* Parent folder picker — nest this folder under another (cycle-safe options) */}
+        {parentOptions.length > 0 && (
+          <select
+            value={localParentId ?? ""}
+            onChange={(e) => handleParentChange(e.target.value || null)}
+            onClick={(e) => e.stopPropagation()}
+            title="Nest this folder under another folder"
+            aria-label="Parent folder"
+            className="shrink-0 max-w-[7rem] truncate rounded bg-[var(--secondary)] px-1.5 py-0.5 text-[0.625rem] text-[var(--muted-foreground)] outline-none ring-1 ring-transparent transition-colors hover:ring-[var(--border)] focus:ring-[var(--ring)]"
+          >
+            <option value="">(top level)</option>
+            {parentOptions.map((candidate) => (
+              <option key={candidate.id} value={candidate.id}>
+                {candidate.name.trim() || "Untitled folder"}
+              </option>
+            ))}
+          </select>
+        )}
 
         {/* Entry count badge */}
         <span

--- a/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFolderRow.tsx
@@ -72,6 +72,10 @@ export function LorebookFolderRow({
   const deleteFolder = useDeleteLorebookFolder();
   const cloneFolder = useCloneLorebookFolder();
 
+  // The native drag is armed on this row imperatively (see the handle's onMouseDown)
+  // so a heavy re-render can't lose the race against the browser's drag threshold.
+  const rowRef = useRef<HTMLDivElement>(null);
+
   // Optimistic mirrors so toggle/rename feel snappy while the mutation flushes.
   const [localEnabled, setLocalEnabled] = useState(folder.enabled);
   const [localName, setLocalName] = useState(folder.name);
@@ -176,6 +180,7 @@ export function LorebookFolderRow({
         isDragging && "opacity-40",
         isNestTarget && "ring-2 ring-amber-400",
       )}
+      ref={rowRef}
       draggable={draggable && isDragReady}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
@@ -196,7 +201,14 @@ export function LorebookFolderRow({
           onClick={(e) => e.stopPropagation()}
           onMouseDown={(e) => {
             e.stopPropagation();
-            if (draggable) onDragHandleMouseDown();
+            if (draggable) {
+              // Arm the native drag synchronously so it can begin on THIS gesture.
+              // The React state flip alone (onDragHandleMouseDown) can lose the race
+              // with the browser's drag threshold on a heavy re-render (deep folder
+              // trees), leaving the folder unable to lift.
+              if (rowRef.current) rowRef.current.draggable = true;
+              onDragHandleMouseDown();
+            }
           }}
           onMouseUp={(e) => {
             e.stopPropagation();

--- a/packages/client/src/components/ui/AppDialogRenderer.tsx
+++ b/packages/client/src/components/ui/AppDialogRenderer.tsx
@@ -13,9 +13,11 @@ function getDialogTitle(kind: "alert" | "confirm" | "prompt", title?: string) {
 export function AppDialogRenderer() {
   const dialog = useDialogStore((state) => state.dialog);
   const [promptValue, setPromptValue] = useState("");
+  const [checked, setChecked] = useState(false);
   const promptInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    setChecked(false);
     if (dialog?.kind !== "prompt") {
       setPromptValue("");
       return;
@@ -81,21 +83,34 @@ export function AppDialogRenderer() {
         )}
 
         {dialog.kind === "confirm" && (
-          <div className="flex items-center justify-end gap-2">
-            <button
-              type="button"
-              onClick={dismissActiveDialog}
-              className="rounded-lg px-3 py-2 text-sm font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-            >
-              {dialog.cancelLabel ?? "Cancel"}
-            </button>
-            <button
-              type="button"
-              onClick={() => resolveActiveDialog(true)}
-              className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${confirmToneClass}`}
-            >
-              {dialog.confirmLabel ?? "Confirm"}
-            </button>
+          <div className="space-y-4">
+            {dialog.checkboxLabel && (
+              <label className="flex cursor-pointer items-center gap-2 text-sm text-[var(--foreground)]">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(event) => setChecked(event.target.checked)}
+                  className="h-4 w-4 shrink-0 accent-[var(--primary)]"
+                />
+                <span>{dialog.checkboxLabel}</span>
+              </label>
+            )}
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={dismissActiveDialog}
+                className="rounded-lg px-3 py-2 text-sm font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              >
+                {dialog.cancelLabel ?? "Cancel"}
+              </button>
+              <button
+                type="button"
+                onClick={() => resolveActiveDialog(dialog.checkboxLabel && checked ? "checked" : true)}
+                className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${confirmToneClass}`}
+              >
+                {dialog.confirmLabel ?? "Confirm"}
+              </button>
+            </div>
           </div>
         )}
 

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -339,8 +339,8 @@ export function useUpdateLorebookFolder() {
 export function useDeleteLorebookFolder() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ lorebookId, folderId }: { lorebookId: string; folderId: string }) =>
-      api.delete(`/lorebooks/${lorebookId}/folders/${folderId}`),
+    mutationFn: ({ lorebookId, folderId, cascade }: { lorebookId: string; folderId: string; cascade?: boolean }) =>
+      api.delete(`/lorebooks/${lorebookId}/folders/${folderId}${cascade ? "?cascade=true" : ""}`),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
       // Removing a folder reparents its entries to root, so the entry list shape changes.

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -362,6 +362,20 @@ export function useReorderLorebookFolders() {
   });
 }
 
+export function useCloneLorebookFolder() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ lorebookId, folderId }: { lorebookId: string; folderId: string }) =>
+      api.post<LorebookFolder>(`/lorebooks/${lorebookId}/folders/${folderId}/clone`),
+    onSuccess: (_data, variables) => {
+      // A clone adds folders AND entries, so refresh both lists + the active scan.
+      qc.invalidateQueries({ queryKey: lorebookKeys.folders(variables.lorebookId) });
+      qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+    },
+  });
+}
+
 export function useSearchLorebookEntries(query: string) {
   return useQuery({
     queryKey: lorebookKeys.search(query),

--- a/packages/client/src/lib/app-dialogs.ts
+++ b/packages/client/src/lib/app-dialogs.ts
@@ -65,6 +65,24 @@ export function showConfirmDialog(options: Omit<ConfirmDialogState, "kind">): Pr
   });
 }
 
+export type ConfirmWithCheckboxResult = { confirmed: boolean; checked: boolean };
+
+/**
+ * Confirm dialog with an extra opt-in checkbox (e.g. "also delete subfolders").
+ * Resolves both whether the user confirmed and whether the box was ticked.
+ */
+export function showConfirmWithCheckbox(options: Omit<ConfirmDialogState, "kind">): Promise<ConfirmWithCheckboxResult> {
+  return openDialog<boolean | string>({
+    kind: "confirm",
+    confirmLabel: "Confirm",
+    cancelLabel: "Cancel",
+    ...options,
+  }).then((result) => ({
+    confirmed: result === true || result === "checked",
+    checked: result === "checked",
+  }));
+}
+
 export function showPromptDialog(options: Omit<PromptDialogState, "kind">): Promise<string | null> {
   return openDialog<string | null>({
     kind: "prompt",

--- a/packages/client/src/lib/app-dialogs.ts
+++ b/packages/client/src/lib/app-dialogs.ts
@@ -56,7 +56,7 @@ export function showAlertDialog(options: Omit<AlertDialogState, "kind">): Promis
   });
 }
 
-export function showConfirmDialog(options: Omit<ConfirmDialogState, "kind">): Promise<boolean> {
+export function showConfirmDialog(options: Omit<ConfirmDialogState, "kind" | "checkboxLabel">): Promise<boolean> {
   return openDialog<boolean>({
     kind: "confirm",
     confirmLabel: "Confirm",
@@ -71,7 +71,9 @@ export type ConfirmWithCheckboxResult = { confirmed: boolean; checked: boolean }
  * Confirm dialog with an extra opt-in checkbox (e.g. "also delete subfolders").
  * Resolves both whether the user confirmed and whether the box was ticked.
  */
-export function showConfirmWithCheckbox(options: Omit<ConfirmDialogState, "kind">): Promise<ConfirmWithCheckboxResult> {
+export function showConfirmWithCheckbox(
+  options: Omit<ConfirmDialogState, "kind" | "checkboxLabel"> & { checkboxLabel: string },
+): Promise<ConfirmWithCheckboxResult> {
   return openDialog<boolean | string>({
     kind: "confirm",
     confirmLabel: "Confirm",

--- a/packages/client/src/stores/dialog.store.ts
+++ b/packages/client/src/stores/dialog.store.ts
@@ -16,6 +16,8 @@ export type AlertDialogState = AppDialogCommon & {
 
 export type ConfirmDialogState = AppDialogCommon & {
   kind: "confirm";
+  /** When set, the confirm dialog shows an opt-in checkbox whose state is returned. */
+  checkboxLabel?: string;
 };
 
 export type PromptDialogState = AppDialogCommon & {

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -580,12 +580,17 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     return updated;
   });
 
-  app.delete<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId", async (req, reply) => {
-    // Scope by lorebookId so a request to /lorebooks/A/folders/B cannot
-    // reach a folder belonging to lorebook X and reparent its entries.
-    await storage.removeFolder(req.params.folderId, req.params.id);
-    return reply.status(204).send();
-  });
+  app.delete<{ Params: { id: string; folderId: string }; Querystring: { cascade?: string } }>(
+    "/:id/folders/:folderId",
+    async (req, reply) => {
+      // Scope by lorebookId so a request to /lorebooks/A/folders/B cannot
+      // reach a folder belonging to lorebook X and reparent its entries.
+      // `?cascade=true` deletes the folder's whole subtree instead of promoting it.
+      const cascade = req.query.cascade === "true";
+      await storage.removeFolder(req.params.folderId, req.params.id, cascade);
+      return reply.status(204).send();
+    },
+  );
 
   app.post<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId/clone", async (req, reply) => {
     // Deep-clone the folder, its entries, and its whole sub-folder subtree into

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -14,9 +14,11 @@ import {
   updateLorebookFolderSchema,
   LOCAL_SIDECAR_CONNECTION_ID,
   stripMacroComments,
+  canReparentFolder,
   type CreateLorebookEntryInput,
   type LorebookEntryTimingState,
   type LorebookEntry,
+  type LorebookFolder,
 } from "@marinara-engine/shared";
 import type { ExportEnvelope } from "@marinara-engine/shared";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
@@ -549,17 +551,27 @@ export async function lorebooksRoutes(app: FastifyInstance) {
   app.post<{ Params: { id: string } }>("/:id/folders", async (req, reply) => {
     const input = createLorebookFolderSchema.parse(req.body);
     if (input.parentFolderId !== null) {
-      // v1 reserves nesting for a follow-up PR. Accept the field shape but
-      // refuse to persist non-null values rather than silently dropping them.
-      return reply.status(400).send({ error: "Nested folders are not supported in this version" });
+      // Nesting under a parent: the parent must exist in this lorebook. A brand-new
+      // folder has no descendants, so a missing/foreign parent is the only risk
+      // here — the full descendant-cycle check runs on move (PATCH) below.
+      const parent = await storage.getFolder(input.parentFolderId, req.params.id);
+      if (!parent) {
+        return reply.status(400).send({ error: "Parent folder not found in this lorebook" });
+      }
     }
     return storage.createFolder(req.params.id, input);
   });
 
   app.patch<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId", async (req, reply) => {
     const input = updateLorebookFolderSchema.parse(req.body);
-    if (input.parentFolderId !== undefined && input.parentFolderId !== null) {
-      return reply.status(400).send({ error: "Nested folders are not supported in this version" });
+    // Re-parenting: validate against the lorebook's folder set (no self-parent,
+    // same lorebook, no descendant cycle) before persisting.
+    if (input.parentFolderId !== undefined) {
+      const folders = (await storage.listFolders(req.params.id)) as LorebookFolder[];
+      const check = canReparentFolder(folders, req.params.folderId, input.parentFolderId);
+      if (!check.ok) {
+        return reply.status(400).send({ error: check.reason });
+      }
     }
     // Scope by lorebookId so /lorebooks/A/folders/B can't update folder B if
     // it actually belongs to lorebook X.

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -587,6 +587,16 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     return reply.status(204).send();
   });
 
+  app.post<{ Params: { id: string; folderId: string } }>("/:id/folders/:folderId/clone", async (req, reply) => {
+    // Deep-clone the folder, its entries, and its whole sub-folder subtree into
+    // the same lorebook. Scoped by lorebookId so /lorebooks/A/folders/B can't
+    // clone a folder that belongs to lorebook X.
+    const existing = await storage.getFolder(req.params.folderId, req.params.id);
+    if (!existing) return reply.status(404).send({ error: "Folder not found" });
+    const created = await storage.cloneFolder(req.params.folderId, req.params.id);
+    return reply.status(201).send(created);
+  });
+
   app.put<{ Params: { id: string } }>("/:id/folders/reorder", async (req, reply) => {
     const body = req.body as { folderIds?: unknown };
     const folderIds = Array.isArray(body.folderIds)

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -19,7 +19,7 @@ import type {
   CreateLorebookFolderInput,
   UpdateLorebookFolderInput,
 } from "@marinara-engine/shared";
-import { collectEffectivelyDisabledFolderIds } from "@marinara-engine/shared";
+import { collectEffectivelyDisabledFolderIds, collectFolderSubtreeIds } from "@marinara-engine/shared";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
 
 function resolveTimestamps(overrides?: TimestampOverrides | null) {
@@ -798,10 +798,24 @@ export function createLorebooksStorage(db: DB) {
      * `/lorebooks/A/folders/B` cannot reach a folder belonging to lorebook
      * `X` and accidentally reparent that other lorebook's entries.
      */
-    async removeFolder(folderId: string, lorebookId?: string) {
+    async removeFolder(folderId: string, lorebookId?: string, cascade = false) {
       const folder = (await this.getFolder(folderId, lorebookId)) as Record<string, unknown> | null;
       if (!folder) return;
       const ownerLorebookId = folder.lorebookId as string;
+      // Cascade: delete the folder, every descendant folder, and all their entries.
+      if (cascade) {
+        const subtreeIds = collectFolderSubtreeIds(
+          (await this.listFolders(ownerLorebookId)) as unknown as Array<{ id: string; parentFolderId: string | null }>,
+          folderId,
+        );
+        await db
+          .delete(lorebookEntries)
+          .where(and(eq(lorebookEntries.lorebookId, ownerLorebookId), inArray(lorebookEntries.folderId, subtreeIds)));
+        await db
+          .delete(lorebookFolders)
+          .where(and(eq(lorebookFolders.lorebookId, ownerLorebookId), inArray(lorebookFolders.id, subtreeIds)));
+        return;
+      }
       // Entries in this folder fall back to root...
       await db
         .update(lorebookEntries)

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -839,6 +839,89 @@ export function createLorebooksStorage(db: DB) {
       return this.listFolders(lorebookId);
     },
 
+    /**
+     * Deep-clone a folder into the same lorebook: the folder itself, its entries,
+     * and its entire subtree of sub-folders (with their entries). The clone is
+     * created as a sibling of the original (same parent); only the root copy is
+     * renamed "<name> (Copy)" — sub-folders keep their names. Folder and entry
+     * order is preserved within each group. Returns the new root folder.
+     *
+     * Folders are created top-down so each parent exists before its children, and
+     * entries are created afterwards so createEntry's "folder must belong to this
+     * lorebook" guard passes against the freshly-created folders.
+     */
+    async cloneFolder(folderId: string, lorebookId: string) {
+      const allFolders = (await this.listFolders(lorebookId)) as unknown as Array<{
+        id: string;
+        name: string;
+        enabled: boolean;
+        parentFolderId: string | null;
+        order: number;
+      }>;
+      const root = allFolders.find((f) => f.id === folderId);
+      if (!root) throw new Error("folder not found");
+      const allEntries = (await this.listEntries(lorebookId)) as unknown as Array<
+        Record<string, unknown> & { id: string; folderId: string | null; order: number }
+      >;
+
+      // Children indexed by parent, each group kept in display order.
+      const childrenByParent = new Map<string, typeof allFolders>();
+      for (const f of allFolders) {
+        if (f.parentFolderId == null) continue;
+        const group = childrenByParent.get(f.parentFolderId) ?? [];
+        group.push(f);
+        childrenByParent.set(f.parentFolderId, group);
+      }
+
+      // Depth-first list of the subtree (root first). A seen guard keeps a
+      // malformed cycle from looping forever.
+      const subtree: typeof allFolders = [];
+      const seen = new Set<string>();
+      const walk = (f: (typeof allFolders)[number]) => {
+        if (seen.has(f.id)) return;
+        seen.add(f.id);
+        subtree.push(f);
+        const kids = (childrenByParent.get(f.id) ?? []).slice().sort((a, b) => a.order - b.order);
+        for (const k of kids) walk(k);
+      };
+      walk(root);
+
+      // Recreate the folders. createFolder appends order, so creating in
+      // depth-first order preserves each group's relative ordering.
+      const idMap = new Map<string, string>();
+      for (const folder of subtree) {
+        const isRoot = folder.id === root.id;
+        const newParentId = isRoot ? root.parentFolderId : (idMap.get(folder.parentFolderId as string) ?? null);
+        const created = (await this.createFolder(lorebookId, {
+          name: isRoot ? `${folder.name} (Copy)` : folder.name,
+          enabled: folder.enabled,
+          parentFolderId: newParentId,
+        })) as { id: string } | null;
+        if (created) idMap.set(folder.id, created.id);
+      }
+
+      // Clone each entry into its matching new folder, preserving order. Drop the
+      // server-managed fields — createEntry re-derives id/timestamps and embedding
+      // is re-derived on demand, mirroring the single-entry duplicate path.
+      const subtreeFolderIds = new Set(subtree.map((f) => f.id));
+      const entriesToClone = allEntries
+        .filter((e) => e.folderId != null && subtreeFolderIds.has(e.folderId))
+        .sort((a, b) => a.order - b.order);
+      for (const entry of entriesToClone) {
+        const newFolderId = idMap.get(entry.folderId as string);
+        if (!newFolderId) continue;
+        const clone: Record<string, unknown> = { ...entry, lorebookId, folderId: newFolderId };
+        delete clone.id;
+        delete clone.createdAt;
+        delete clone.updatedAt;
+        delete clone.embedding;
+        await this.createEntry(clone as unknown as CreateLorebookEntryInput);
+      }
+
+      const newRootId = idMap.get(root.id);
+      return newRootId ? this.getFolder(newRootId, lorebookId) : null;
+    },
+
     // ── Search ──
 
     /** Search entries by keyword match in name/content/keys. */

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -794,10 +794,17 @@ export function createLorebooksStorage(db: DB) {
       const folder = (await this.getFolder(folderId, lorebookId)) as Record<string, unknown> | null;
       if (!folder) return;
       const ownerLorebookId = folder.lorebookId as string;
+      // Entries in this folder fall back to root...
       await db
         .update(lorebookEntries)
         .set({ folderId: null, updatedAt: now() })
         .where(and(eq(lorebookEntries.lorebookId, ownerLorebookId), eq(lorebookEntries.folderId, folderId)));
+      // ...and direct child folders are promoted to the top level (not cascade-
+      // deleted), so deleting a parent lifts its subtree up one level intact.
+      await db
+        .update(lorebookFolders)
+        .set({ parentFolderId: null, updatedAt: now() })
+        .where(and(eq(lorebookFolders.lorebookId, ownerLorebookId), eq(lorebookFolders.parentFolderId, folderId)));
       await db
         .delete(lorebookFolders)
         .where(and(eq(lorebookFolders.id, folderId), eq(lorebookFolders.lorebookId, ownerLorebookId)));

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -19,6 +19,7 @@ import type {
   CreateLorebookFolderInput,
   UpdateLorebookFolderInput,
 } from "@marinara-engine/shared";
+import { collectEffectivelyDisabledFolderIds } from "@marinara-engine/shared";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
 
 function resolveTimestamps(overrides?: TimestampOverrides | null) {
@@ -455,14 +456,21 @@ export function createLorebooksStorage(db: DB) {
         relevantBooks.filter((book) => book.excludeFromVectorization).map((book) => book.id),
       );
 
-      // Build the disabled-folder ID set for the relevant lorebooks. Done as
-      // an in-memory filter (rather than a SQL anti-join) because folder
-      // counts per book are small and this keeps the existing query shape.
-      const disabledFolderRows = await db
-        .select({ id: lorebookFolders.id })
+      // Build the *effectively* disabled-folder ID set: a folder is gated if it
+      // OR any ancestor is disabled (folders can nest). Fetch all folders for the
+      // relevant books and resolve ancestry in memory — per-book folder counts are
+      // small and this keeps the existing query shape.
+      const folderRows = await db
+        .select({
+          id: lorebookFolders.id,
+          parentFolderId: lorebookFolders.parentFolderId,
+          enabled: lorebookFolders.enabled,
+        })
         .from(lorebookFolders)
-        .where(and(inArray(lorebookFolders.lorebookId, bookIds), eq(lorebookFolders.enabled, "false")));
-      const disabledFolderIds = new Set(disabledFolderRows.map((r) => r.id));
+        .where(inArray(lorebookFolders.lorebookId, bookIds));
+      const disabledFolderIds = collectEffectivelyDisabledFolderIds(
+        folderRows.map((r) => ({ id: r.id, parentFolderId: r.parentFolderId, enabled: r.enabled === "true" })),
+      );
 
       const rows = await db
         .select()

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -83,3 +83,4 @@ export * from "./utils/quest-state.js";
 export * from "./utils/quote-format.js";
 export * from "./utils/image-prompt-compiler.js";
 export * from "./utils/thinking-tags.js";
+export * from "./utils/lorebook-folder-tree.js";

--- a/packages/shared/src/utils/lorebook-folder-tree.ts
+++ b/packages/shared/src/utils/lorebook-folder-tree.ts
@@ -77,6 +77,37 @@ export function collectHiddenFolderIds(
 }
 
 /**
+ * All folder ids in the subtree rooted at `rootId` — the root itself plus every
+ * descendant. Used to cascade-delete a folder together with its sub-folders, and
+ * to count how many would be removed. Cycle-safe via `seen`.
+ */
+export function collectFolderSubtreeIds(
+  folders: Pick<LorebookFolder, "id" | "parentFolderId">[],
+  rootId: string,
+): string[] {
+  const childrenByParent = new Map<string, string[]>();
+  for (const folder of folders) {
+    const parentId = folder.parentFolderId;
+    if (!parentId) continue;
+    const siblings = childrenByParent.get(parentId);
+    if (siblings) siblings.push(folder.id);
+    else childrenByParent.set(parentId, [folder.id]);
+  }
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const stack = [rootId];
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+    const children = childrenByParent.get(id);
+    if (children) stack.push(...children);
+  }
+  return ids;
+}
+
+/**
  * A folder is *effectively* disabled if it — or any ancestor — is disabled, so a
  * disabled parent gates the entries living in its enabled children too. Walks
  * each folder's parent chain upward with a per-walk `seen` cycle guard.

--- a/packages/shared/src/utils/lorebook-folder-tree.ts
+++ b/packages/shared/src/utils/lorebook-folder-tree.ts
@@ -1,0 +1,160 @@
+// ──────────────────────────────────────────────
+// Lorebook folder tree — nesting helpers shared by
+// the server (parent validation) and the client
+// (tree rendering, parent picker, disable gating).
+// ──────────────────────────────────────────────
+import type { LorebookFolder } from "../types/lorebook.js";
+
+type FolderTreeNode = Pick<LorebookFolder, "id" | "lorebookId" | "parentFolderId">;
+
+type ReparentResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Validate whether `folderId` may be re-parented under `newParentId`. Used by
+ * the server (reject invalid moves) and the client (filter the parent picker so
+ * invalid targets never appear). Walks the parent chain UPWARD from the target
+ * parent looking for the moving folder's own id; a `seen` set guards against any
+ * pre-existing malformed cycle. There is intentionally no max-depth limit.
+ */
+export function canReparentFolder(
+  folders: FolderTreeNode[],
+  folderId: string,
+  newParentId: string | null,
+): ReparentResult {
+  const byId = new Map(folders.map((folder) => [folder.id, folder]));
+  const folder = byId.get(folderId);
+  if (!folder) return { ok: false, reason: "Folder not found." };
+
+  if (newParentId === null) return { ok: true };
+  if (newParentId === folderId) {
+    return { ok: false, reason: "A folder cannot be its own parent." };
+  }
+
+  const newParent = byId.get(newParentId);
+  if (!newParent) return { ok: false, reason: "Target parent folder not found." };
+  if (newParent.lorebookId !== folder.lorebookId) {
+    return { ok: false, reason: "A folder can only nest under a folder in the same lorebook." };
+  }
+
+  // Reject descendant moves; seen prevents malformed existing cycles from looping.
+  const seen = new Set<string>();
+  let current: FolderTreeNode | undefined = newParent;
+  while (current && !seen.has(current.id)) {
+    if (current.id === folderId) {
+      return { ok: false, reason: "A folder cannot be nested inside one of its own subfolders." };
+    }
+    seen.add(current.id);
+    current = current.parentFolderId ? byId.get(current.parentFolderId) : undefined;
+  }
+
+  return { ok: true };
+}
+
+/** Collapsing a folder hides its whole subtree from "select visible". */
+export function collectHiddenFolderIds(
+  folders: Pick<LorebookFolder, "id" | "parentFolderId">[],
+  collapsedFolderIds: ReadonlySet<string>,
+): Set<string> {
+  if (collapsedFolderIds.size === 0) return new Set();
+  const childrenByParent = new Map<string, string[]>();
+  for (const folder of folders) {
+    const parentId = folder.parentFolderId;
+    if (!parentId) continue;
+    const siblings = childrenByParent.get(parentId);
+    if (siblings) siblings.push(folder.id);
+    else childrenByParent.set(parentId, [folder.id]);
+  }
+  const hidden = new Set<string>();
+  const stack = Array.from(collapsedFolderIds);
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (hidden.has(id)) continue;
+    hidden.add(id);
+    const children = childrenByParent.get(id);
+    if (children) stack.push(...children);
+  }
+  return hidden;
+}
+
+/**
+ * A folder is *effectively* disabled if it — or any ancestor — is disabled, so a
+ * disabled parent gates the entries living in its enabled children too. Walks
+ * each folder's parent chain upward with a per-walk `seen` cycle guard.
+ */
+export function collectEffectivelyDisabledFolderIds(
+  folders: Pick<LorebookFolder, "id" | "parentFolderId" | "enabled">[],
+): Set<string> {
+  const byId = new Map(folders.map((folder) => [folder.id, folder]));
+  const disabled = new Set<string>();
+  for (const folder of folders) {
+    const seen = new Set<string>();
+    let current: Pick<LorebookFolder, "id" | "parentFolderId" | "enabled"> | undefined = folder;
+    while (current && !seen.has(current.id)) {
+      if (current.enabled === false) {
+        disabled.add(folder.id);
+        break;
+      }
+      seen.add(current.id);
+      current = current.parentFolderId ? byId.get(current.parentFolderId) : undefined;
+    }
+  }
+  return disabled;
+}
+
+type ForestNode = { id: string; parentFolderId: string | null; order: number };
+
+/** Render shape: sorted roots plus sorted child lists. */
+export type FolderForest<T extends ForestNode> = {
+  roots: T[];
+  childrenByParent: Map<string, T[]>;
+};
+
+/**
+ * Assemble a flat folder list into a forest. A folder whose parent is missing
+ * from the set falls back to root (so an orphaned/just-deleted-parent folder
+ * stays editable), and folders trapped in a pure cycle are promoted to roots.
+ */
+export function buildFolderForest<T extends ForestNode>(folders: T[]): FolderForest<T> {
+  const ids = new Set(folders.map((folder) => folder.id));
+  const roots: T[] = [];
+  const childrenByParent = new Map<string, T[]>();
+  for (const folder of folders) {
+    const parentId = folder.parentFolderId;
+    // Dangling parents render at root so orphaned folders stay editable.
+    if (parentId !== null && ids.has(parentId)) {
+      const siblings = childrenByParent.get(parentId);
+      if (siblings) siblings.push(folder);
+      else childrenByParent.set(parentId, [folder]);
+    } else {
+      roots.push(folder);
+    }
+  }
+
+  // Promote unreachable cycle members to roots and remove their cyclic child edge.
+  const reachable = new Set<string>();
+  const stack = roots.map((folder) => folder.id);
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (reachable.has(id)) continue;
+    reachable.add(id);
+    for (const child of childrenByParent.get(id) ?? []) stack.push(child.id);
+  }
+  for (const folder of folders) {
+    if (reachable.has(folder.id)) continue;
+    roots.push(folder);
+    const parentId = folder.parentFolderId;
+    if (parentId !== null) {
+      const siblings = childrenByParent.get(parentId);
+      if (siblings) {
+        const remaining = siblings.filter((sibling) => sibling.id !== folder.id);
+        if (remaining.length > 0) childrenByParent.set(parentId, remaining);
+        else childrenByParent.delete(parentId);
+      }
+    }
+  }
+
+  const byOrder = (a: T, b: T) => a.order - b.order;
+  roots.sort(byOrder);
+  for (const siblings of childrenByParent.values()) siblings.sort(byOrder);
+  return { roots, childrenByParent };
+}


### PR DESCRIPTION
## Linked issue

Closes #2582

## Why this change

Lorebook folders are flat today. The data layer was already stubbed for nesting (the `parent_folder_id` column, `LorebookFolder.parentFolderId`, and the Zod schemas all exist) but the routes deliberately rejected any non-null parent with a 400. This finishes the feature so users can organize large lorebooks hierarchically (folders within folders).

## What changed

**Shared**

- `utils/lorebook-folder-tree.ts` (new) — one source of truth for server + client: `canReparentFolder` (no self-parent, same-lorebook, no descendant cycle via an upward parent-walk; no depth limit), `buildFolderForest` (flat rows → tree; a dangling/cyclic parent falls back to root), `collectHiddenFolderIds` (collapse hides the subtree), `collectEffectivelyDisabledFolderIds` (a disabled ancestor gates its descendants).

**Server**

- `lorebooks.routes.ts` — removed the two `400 "Nested folders not supported"` guards. Create now requires the parent to exist in the lorebook; move (PATCH) runs `canReparentFolder` and returns the specific reason on rejection.
- `lorebooks.storage.ts` `removeFolder` — deleting a folder promotes its direct child folders to root (`parentFolderId = null`), mirroring how entries already reparent. No cascade.
- `lorebooks.storage.ts` `cloneFolder` + `POST /:id/folders/:folderId/clone` — deep-clones a folder, its entries, and its whole sub-folder subtree into the same lorebook, as a sibling of the original. Folders are recreated top-down (each parent before its children); entries are then copied into the mapped new folders. Reuses `createFolder`/`createEntry`; a seen-guard makes a malformed cycle safe.

**Client**

- `LorebookEditor` renders the folder forest recursively (indent + collapse-hides-subtree + disabled-ancestor propagation; per-render cycle guard).
- `LorebookFolderRow` gained a parent-folder dropdown, filtered through `canReparentFolder` so invalid (self / descendant / cross-lorebook) targets never appear.
- The activation gate (`lorebooks.storage.ts`) uses `collectEffectivelyDisabledFolderIds`, so a disabled parent gates entries in its enabled children.
- **Drag-to-nest**: a folder header has three drop bands — the middle nests the dragged folder inside (reparent), top/bottom reorder it as a sibling. To un-nest by drag, drop the folder onto the folder-list area (the list itself is the drop zone) or drag it past its parent and out the bottom — the per-row parent dropdown also offers a "(top level)" option. The nest band only arms for a legal move (`canReparentFolder`) and is re-checked at drop; it draws an amber ring on the target. Reparenting reuses the existing folder PATCH (no new endpoint); entry-move drag is unchanged.
- **Clone** action on each folder row (`useCloneLorebookFolder`, Copy icon beside delete) — one click deep-copies the folder and its whole subtree; only the root copy is renamed "(Copy)".

**Re-parenting** is available two ways: the per-row parent dropdown, or drag-to-nest (above). Nesting depth is unlimited.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Shared build, server typecheck, and client typecheck + lint all pass.
- Created a folder, then create/move another folder under it (parent dropdown) → it nests and renders indented.
- Dragged a folder onto the **middle** of another folder's header → it nests inside (amber ring on the target). Drag onto the **top/bottom edge** → it reorders as a sibling.
- Dragged a nested folder out onto the folder-list area → it un-nests back to the top level (also via the row's **"(top level)"** dropdown option).
- Cloned a folder that has sub-folders and entries → a sibling **"(Copy)"** appears with the whole subtree duplicated; the originals stay untouched, and editing the clone doesn't change the original.
- Dragged an entry into a deeply-nested folder's empty area → it lands in **that** folder (not a top-level ancestor); while dragging, slide left onto an ancestor's indent rail (it highlights amber) → it targets that ancestor instead.
- Nested several levels deep (A › B › C › D) and confirm each indents; neither the dropdown nor drag ever offers a folder its own descendant as a parent.
- Confirmed the API rejects a cycle with a clear message (the same `canReparentFolder` guard runs server-side).
- Deleted a parent folder → its child folders rise to the top level (not deleted) and its entries fall back to root (unless selecting the option to delete all contents).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="783" height="556" alt="{1DCB24D5-FB5F-44FF-8F54-765121A4383D}" src="https://github.com/user-attachments/assets/5d89c4e4-85ec-4987-92b0-5a7518b76e47" />

<img width="647" height="256" alt="{AAF9E982-3B8F-4747-B760-D604152D2A31}" src="https://github.com/user-attachments/assets/c318c704-6009-43ce-a44c-d157fd6702a6" />

<img width="638" height="246" alt="{D79F8B5A-E1F4-4810-AF20-13CFBAA4B70A}" src="https://github.com/user-attachments/assets/8fb5f912-0af8-48c9-8381-7b4b73027118" />

<img width="780" height="552" alt="{E5B50388-61D0-4F8D-B03F-D8FCA186104A}" src="https://github.com/user-attachments/assets/a8db2f03-f4e3-4de0-ba0d-5ac74b396b8e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recursive folder nesting in lorebook entries via drag-and-drop
  * Added folder cloning functionality to duplicate folders with all content
  * Added cascade deletion option when removing folders with nested entries or subfolders
  * Enhanced folder organization with improved drop zones and root-level lifting support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
