### PR TITLE
feat(regex): scoped-regex management polish — global-only Presets, character-card manager, name fix

### DIFF
--- a/packages/client/src/components/agents/RegexScriptEditor.tsx
+++ b/packages/client/src/components/agents/RegexScriptEditor.tsx
@@ -107,6 +107,7 @@ function parseCharacterData(value: unknown): Record<string, unknown> {
 // ═══════════════════════════════════════════════
 export function RegexScriptEditor() {
   const regexDetailId = useUIStore((s) => s.regexDetailId);
+  const regexDetailDefaultCharacterIds = useUIStore((s) => s.regexDetailDefaultCharacterIds);
   const closeRegexDetail = useUIStore((s) => s.closeRegexDetail);
   const openRegexDetail = useUIStore((s) => s.openRegexDetail);
 
@@ -206,8 +207,10 @@ export function RegexScriptEditor() {
       setLocalPlacement(["ai_output"]);
       setLocalFlags("gi");
       setLocalPromptOnly(false);
-      setLocalTargetCharacterIds([]);
-      setLocalCharacterScopeEnabled(false);
+      // Pre-scope when opened from a character's scoped-regex manager.
+      const defaultScope = regexDetailDefaultCharacterIds ?? [];
+      setLocalTargetCharacterIds(defaultScope);
+      setLocalCharacterScopeEnabled(defaultScope.length > 0);
       setLocalOrder(0);
       setLocalMinDepth(null);
       setLocalMaxDepth(null);
@@ -215,7 +218,7 @@ export function RegexScriptEditor() {
     setDirty(false);
     setSaveError(null);
     setTestInput("");
-  }, [regexDetailId, dbRow]);
+  }, [regexDetailId, dbRow, regexDetailDefaultCharacterIds]);
 
   // Regex validity check
   const regexError = useMemo(() => {

--- a/packages/client/src/components/agents/RegexScriptEditor.tsx
+++ b/packages/client/src/components/agents/RegexScriptEditor.tsx
@@ -108,6 +108,7 @@ function parseCharacterData(value: unknown): Record<string, unknown> {
 export function RegexScriptEditor() {
   const regexDetailId = useUIStore((s) => s.regexDetailId);
   const regexDetailDefaultCharacterIds = useUIStore((s) => s.regexDetailDefaultCharacterIds);
+  const regexDetailReturn = useUIStore((s) => s.regexDetailReturn);
   const closeRegexDetail = useUIStore((s) => s.closeRegexDetail);
   const openRegexDetail = useUIStore((s) => s.openRegexDetail);
 
@@ -291,7 +292,8 @@ export function RegexScriptEditor() {
       } else {
         const created = (await createScript.mutateAsync(payload)) as RegexScriptRow | undefined;
         if (created?.id) {
-          openRegexDetail(created.id);
+          // Preserve the return target (e.g. back to the character card) across the post-save re-open.
+          openRegexDetail(created.id, regexDetailReturn ? { returnTo: regexDetailReturn } : undefined);
         }
       }
       setDirty(false);
@@ -319,6 +321,7 @@ export function RegexScriptEditor() {
     updateScript,
     createScript,
     openRegexDetail,
+    regexDetailReturn,
   ]);
 
   const markDirty = useCallback(() => setDirty(true), []);

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -42,6 +42,7 @@ import { AvatarGenerationModal } from "../ui/AvatarGenerationModal";
 import { AvatarCropWidget } from "../ui/AvatarCropWidget";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
+import { CharacterRegexSection } from "./CharacterRegexSection";
 import {
   ArrowLeft,
   Save,
@@ -951,7 +952,12 @@ export function CharacterEditor() {
               <CharacterCardTab formData={formData} updateField={updateField} updateExtension={updateExtension} />
             )}
             {activeTab === "advanced" && (
-              <AdvancedTab formData={formData} updateField={updateField} updateExtension={updateExtension} />
+              <AdvancedTab
+                formData={formData}
+                updateField={updateField}
+                updateExtension={updateExtension}
+                characterId={characterId}
+              />
             )}
             {activeTab === "sprites" && characterId && (
               <SpritesTab
@@ -1693,10 +1699,12 @@ function AdvancedTab({
   formData,
   updateField,
   updateExtension,
+  characterId,
 }: {
   formData: CharacterData;
   updateField: <K extends keyof CharacterData>(key: K, value: CharacterData[K]) => void;
   updateExtension: (key: string, value: unknown) => void;
+  characterId: string | null;
 }) {
   const depthPrompt = formData.extensions.depth_prompt ?? { prompt: "", depth: 4, role: "system" as const };
 
@@ -1780,6 +1788,8 @@ function AdvancedTab({
           </label>
         </div>
       </div>
+
+      <CharacterRegexSection characterId={characterId} characterName={formData.name} />
     </div>
   );
 }

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -226,7 +226,9 @@ export function CharacterEditor() {
   const uploadPersonaAvatar = useUploadPersonaAvatar();
   const { data: connectionsList } = useConnections();
 
-  const [activeTab, setActiveTab] = useState<TabId>("metadata");
+  const [activeTab, setActiveTab] = useState<TabId>(
+    () => (useUIStore.getState().characterDetailInitialTab as TabId | null) ?? "metadata",
+  );
   const [formData, setFormData] = useState<CharacterData | null>(null);
   const [characterComment, setCharacterComment] = useState("");
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);

--- a/packages/client/src/components/characters/CharacterRegexSection.tsx
+++ b/packages/client/src/components/characters/CharacterRegexSection.tsx
@@ -246,7 +246,7 @@ export function CharacterRegexSection({
               title="Import regexes from JSON"
             >
               <input type="file" accept="application/json" className="hidden" onChange={handleImport} />
-              <Download size="0.8125rem" />
+              <Upload size="0.8125rem" />
             </label>
             <button
               type="button"
@@ -255,7 +255,7 @@ export function CharacterRegexSection({
               className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400 disabled:cursor-not-allowed disabled:opacity-35"
               title="Export regexes to JSON"
             >
-              <Upload size="0.8125rem" />
+              <Download size="0.8125rem" />
             </button>
           </div>
         )}

--- a/packages/client/src/components/characters/CharacterRegexSection.tsx
+++ b/packages/client/src/components/characters/CharacterRegexSection.tsx
@@ -1,0 +1,347 @@
+// ──────────────────────────────────────────────
+// Character Regex Scripts — scoped-regex manager for the Advanced tab.
+// Lists, creates, edits, deletes, imports and exports the regex scripts that
+// target THIS character. These scripts are intentionally kept off the global
+// Presets → Regexes list; they apply only when a chat's "Scoped Regex Scripts"
+// mode includes this character.
+// ──────────────────────────────────────────────
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
+import { toast } from "sonner";
+import { Download, Pencil, Plus, Regex, ToggleLeft, ToggleRight, Trash2, Upload } from "lucide-react";
+import {
+  useRegexScripts,
+  useCreateRegexScript,
+  useDeleteRegexScript,
+  useUpdateRegexScript,
+  type RegexScriptRow,
+} from "../../hooks/use-regex-scripts";
+import { useUIStore } from "../../stores/ui.store";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import { downloadJsonFile } from "../../lib/download-json";
+import { getFolderImportEntries } from "@marinara-engine/shared";
+import { cn } from "../../lib/utils";
+
+// ── IO helpers (mirror the regex export/import format used by the Presets panel) ──
+function parseBooleanValue(value: unknown, fallback = true) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value === "true" || value === "1";
+  return fallback;
+}
+
+function parseStringArray(value: unknown): string[] {
+  const parsed = (() => {
+    if (Array.isArray(value)) return value;
+    if (typeof value !== "string") return [];
+    try {
+      const json = JSON.parse(value);
+      return Array.isArray(json) ? json : [];
+    } catch {
+      return [];
+    }
+  })();
+  return parsed.filter((item): item is string => typeof item === "string");
+}
+
+function parseNullableNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+// Scoped exports omit targetCharacterIds — the importer re-scopes to the target character.
+function serializeRegexScript(script: RegexScriptRow) {
+  return {
+    name: script.name,
+    enabled: parseBooleanValue(script.enabled),
+    findRegex: script.findRegex,
+    replaceString: script.replaceString,
+    trimStrings: parseStringArray(script.trimStrings),
+    placement: parseStringArray(script.placement),
+    flags: script.flags,
+    promptOnly: parseBooleanValue(script.promptOnly, false),
+    order: script.order,
+    minDepth: script.minDepth,
+    maxDepth: script.maxDepth,
+  };
+}
+
+function normalizeRegexImportEntry(entry: unknown) {
+  if (!isJsonRecord(entry)) return null;
+  const name =
+    typeof entry.name === "string" ? entry.name : typeof entry.scriptName === "string" ? entry.scriptName : "";
+  let findRegex = typeof entry.findRegex === "string" ? entry.findRegex : "";
+  let flags = typeof entry.flags === "string" ? entry.flags : "gi";
+  const delimited = findRegex.match(/^\/(.+)\/([gimsuy]*)$/s);
+  if (delimited) {
+    findRegex = delimited[1] ?? "";
+    flags = delimited[2] || "g";
+  }
+  if (!name || !findRegex) return null;
+
+  const stPlacementMap: Record<number, string> = { 1: "user_input", 2: "ai_output" };
+  const rawPlacement = Array.isArray(entry.placement) ? entry.placement : [];
+  const mappedPlacement = rawPlacement
+    .map((placementValue) => (typeof placementValue === "number" ? stPlacementMap[placementValue] : placementValue))
+    .filter(
+      (placementValue): placementValue is string => placementValue === "ai_output" || placementValue === "user_input",
+    );
+
+  return {
+    name,
+    enabled: parseBooleanValue(entry.enabled, entry.disabled === undefined ? true : !parseBooleanValue(entry.disabled)),
+    findRegex,
+    replaceString: typeof entry.replaceString === "string" ? entry.replaceString : "",
+    trimStrings: parseStringArray(entry.trimStrings),
+    placement: mappedPlacement.length > 0 ? mappedPlacement : ["ai_output"],
+    flags,
+    promptOnly: parseBooleanValue(entry.promptOnly, false),
+    order: typeof entry.order === "number" ? entry.order : 0,
+    minDepth: parseNullableNumber(entry.minDepth),
+    maxDepth: parseNullableNumber(entry.maxDepth),
+  };
+}
+
+export function CharacterRegexSection({
+  characterId,
+  characterName,
+}: {
+  characterId: string | null;
+  characterName?: string;
+}) {
+  const { data: regexScripts } = useRegexScripts();
+  const createRegex = useCreateRegexScript();
+  const updateRegex = useUpdateRegexScript();
+  const deleteRegex = useDeleteRegexScript();
+  const openRegexDetail = useUIStore((s) => s.openRegexDetail);
+  const editorDirty = useUIStore((s) => s.editorDirty);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importSuccess, setImportSuccess] = useState<string | null>(null);
+
+  const scopedScripts = useMemo(() => {
+    if (!characterId) return [];
+    return ((regexScripts ?? []) as RegexScriptRow[])
+      .filter((script) => parseStringArray(script.targetCharacterIds).includes(characterId))
+      .sort((a, b) => a.order - b.order);
+  }, [regexScripts, characterId]);
+
+  // Opening the full regex editor leaves (and unmounts) the character editor.
+  // Warn first if the character has unsaved changes so they aren't lost silently.
+  const openEditorGuarded = useCallback(
+    async (id: string, options?: { defaultCharacterIds?: string[] }) => {
+      if (editorDirty) {
+        const proceed = await showConfirmDialog({
+          title: "Unsaved Changes",
+          message:
+            "This character has unsaved changes. Opening the regex editor leaves the character editor and discards them. Save the character first, or discard and continue.",
+          confirmLabel: "Discard & Continue",
+          tone: "destructive",
+        });
+        if (!proceed) return;
+      }
+      openRegexDetail(id, options);
+    },
+    [editorDirty, openRegexDetail],
+  );
+
+  const handleCreate = useCallback(() => {
+    if (!characterId) return;
+    void openEditorGuarded("__new__", { defaultCharacterIds: [characterId] });
+  }, [characterId, openEditorGuarded]);
+
+  const handleExport = useCallback(() => {
+    if (scopedScripts.length === 0) {
+      toast.error("No regexes to export");
+      return;
+    }
+    const safeName = (characterName ?? "character").trim().replace(/[^a-z0-9_-]+/gi, "-").toLowerCase() || "character";
+    downloadJsonFile(
+      {
+        kind: "marinara.regex-scripts",
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        regexScripts: scopedScripts.map(serializeRegexScript),
+      },
+      `${safeName}-regexes.json`,
+    );
+    toast.success(`Exported ${scopedScripts.length} regex${scopedScripts.length === 1 ? "" : "es"}`);
+  }, [scopedScripts, characterName]);
+
+  const handleImport = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      setImportError(null);
+      setImportSuccess(null);
+      const file = event.target.files?.[0];
+      if (!file || !characterId) return;
+
+      try {
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+        const entries = getFolderImportEntries(parsed, ["regexScripts", "regexes", "scripts"]);
+        if (entries.length === 0) throw new Error("No regex scripts found in file");
+
+        let imported = 0;
+        for (const entry of entries) {
+          const normalized = normalizeRegexImportEntry(entry);
+          if (!normalized) continue;
+          // Force-scope every imported script to this character.
+          await createRegex.mutateAsync({ ...normalized, targetCharacterIds: [characterId] });
+          imported++;
+        }
+
+        setImportSuccess(`Imported ${imported} regex script${imported === 1 ? "" : "s"}.`);
+      } catch (error) {
+        setImportError(error instanceof Error ? error.message : "Failed to import regex scripts");
+      }
+
+      event.target.value = "";
+    },
+    [characterId, createRegex],
+  );
+
+  const handleDelete = useCallback(
+    async (script: RegexScriptRow) => {
+      if (
+        await showConfirmDialog({
+          title: "Delete Regex",
+          message: `Delete "${script.name}"?`,
+          confirmLabel: "Delete",
+          tone: "destructive",
+        })
+      ) {
+        deleteRegex.mutate(script.id);
+      }
+    },
+    [deleteRegex],
+  );
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <div className="flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1.5 text-xs font-semibold">
+          <Regex size="0.875rem" className="text-purple-400" />
+          Regex Scripts
+        </span>
+        {characterId && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleCreate}
+              className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400"
+              title="Create regex"
+            >
+              <Plus size="0.8125rem" />
+            </button>
+            <label
+              className="inline-flex cursor-pointer items-center justify-center rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400"
+              title="Import regexes from JSON"
+            >
+              <input type="file" accept="application/json" className="hidden" onChange={handleImport} />
+              <Download size="0.8125rem" />
+            </label>
+            <button
+              type="button"
+              onClick={handleExport}
+              disabled={scopedScripts.length === 0}
+              className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400 disabled:cursor-not-allowed disabled:opacity-35"
+              title="Export regexes to JSON"
+            >
+              <Upload size="0.8125rem" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+        Find/replace patterns scoped to this character. They stay off the global Presets → Regexes list and apply only
+        when a chat&rsquo;s Scoped Regex Scripts mode includes this character.
+      </p>
+
+      {!characterId ? (
+        <p className="py-1 text-[0.6875rem] text-[var(--muted-foreground)]">
+          Save this character first to add scoped regex scripts.
+        </p>
+      ) : (
+        <>
+          {importError && <div className="text-xs text-red-500">{importError}</div>}
+          {importSuccess && <div className="text-xs text-green-500">{importSuccess}</div>}
+          {scopedScripts.length === 0 ? (
+            <p className="py-1 text-[0.6875rem] text-[var(--muted-foreground)]">No regex scripts for this character yet.</p>
+          ) : (
+            <div className="space-y-1">
+              {scopedScripts.map((script) => {
+                const placements = parseStringArray(script.placement);
+                const enabled = script.enabled === "true";
+                return (
+                  <div
+                    key={script.id}
+                    className={cn(
+                      "flex items-start gap-2.5 rounded-xl p-2 transition-colors hover:bg-[var(--secondary)]",
+                      !enabled && "opacity-50",
+                    )}
+                  >
+                    <Regex size="0.875rem" className="mt-0.5 shrink-0 text-purple-400" />
+                    <button
+                      type="button"
+                      className="min-w-0 flex-1 text-left"
+                      onClick={() => void openEditorGuarded(script.id)}
+                    >
+                      <div className="text-xs font-medium">{script.name}</div>
+                      <div className="mt-0.5 flex items-center gap-1">
+                        {placements.map((placement) => (
+                          <span
+                            key={placement}
+                            className="rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]"
+                          >
+                            {placement === "ai_output" ? "AI" : "User"}
+                          </span>
+                        ))}
+                        <span className="max-w-[6.25rem] truncate font-mono text-[0.5625rem] text-[var(--muted-foreground)]">
+                          /{script.findRegex}/{script.flags}
+                        </span>
+                      </div>
+                    </button>
+                    <button
+                      type="button"
+                      className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-purple-400"
+                      title={enabled ? "Disable regex" : "Enable regex"}
+                      onClick={() => updateRegex.mutate({ id: script.id, enabled: !enabled })}
+                    >
+                      {enabled ? (
+                        <ToggleRight size="0.875rem" className="text-purple-400" />
+                      ) : (
+                        <ToggleLeft size="0.875rem" className="text-[var(--muted-foreground)]" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-purple-400"
+                      title="Edit regex"
+                      onClick={() => void openEditorGuarded(script.id)}
+                    >
+                      <Pencil size="0.8125rem" />
+                    </button>
+                    <button
+                      type="button"
+                      className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-[var(--destructive)]"
+                      title="Delete regex"
+                      onClick={() => handleDelete(script)}
+                    >
+                      <Trash2 size="0.8125rem" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/characters/CharacterRegexSection.tsx
+++ b/packages/client/src/components/characters/CharacterRegexSection.tsx
@@ -145,9 +145,12 @@ export function CharacterRegexSection({
         });
         if (!proceed) return;
       }
-      openRegexDetail(id, options);
+      openRegexDetail(id, {
+        ...options,
+        ...(characterId ? { returnTo: { characterId, tab: "advanced" } } : {}),
+      });
     },
-    [editorDirty, openRegexDetail],
+    [editorDirty, openRegexDetail, characterId],
   );
 
   const handleCreate = useCallback(() => {

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -678,21 +678,24 @@ export function ChatSettingsDrawer({
   // per-character list + the section badge, and whether the section shows at all.
   const chatScopedRegexGroups = useMemo(() => {
     if (!regexScripts) return [] as Array<{ characterId: string; name: string; scripts: RegexScriptRow[] }>;
-    const charById = new Map(((allCharacters as Array<{ id: string; name?: string }>) ?? []).map((c) => [c.id, c]));
+    const charById = new Map(((allCharacters as Array<{ id: string; data?: unknown }>) ?? []).map((c) => [c.id, c]));
     const scripts = regexScripts as RegexScriptRow[];
     return chatCharIds
-      .map((characterId) => ({
-        characterId,
-        name: charById.get(characterId)?.name ?? "Character",
-        scripts: scripts.filter((script) => {
-          try {
-            const ids = JSON.parse(script.targetCharacterIds ?? "[]");
-            return Array.isArray(ids) && ids.includes(characterId);
-          } catch {
-            return false;
-          }
-        }),
-      }))
+      .map((characterId) => {
+        const row = charById.get(characterId);
+        return {
+          characterId,
+          name: parseCharacterDisplayData({ data: row?.data }).name,
+          scripts: scripts.filter((script) => {
+            try {
+              const ids = JSON.parse(script.targetCharacterIds ?? "[]");
+              return Array.isArray(ids) && ids.includes(characterId);
+            } catch {
+              return false;
+            }
+          }),
+        };
+      })
       .filter((group) => group.scripts.length > 0);
   }, [regexScripts, allCharacters, chatCharIds]);
   const scopedRegexCount = useMemo(

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -313,8 +313,14 @@ export function PresetsPanel() {
     [filteredPresets, folderedPresetIds],
   );
 
+  // Presets shows GLOBAL regex scripts only. Character-scoped scripts (non-empty
+  // targetCharacterIds) live on the character (Advanced tab) and in a chat's
+  // Scoped Regex Scripts settings, so they are filtered out here.
   const sortedRegexScripts = useMemo(
-    () => [...((regexScripts ?? []) as RegexScriptRow[])].sort((a, b) => a.order - b.order),
+    () =>
+      ((regexScripts ?? []) as RegexScriptRow[])
+        .filter((script) => parseStringArray(script.targetCharacterIds).length === 0)
+        .sort((a, b) => a.order - b.order),
     [regexScripts],
   );
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -362,6 +362,8 @@ interface UIState {
   personaDetailId: string | null;
   /** When set, the main area shows the full-page regex script editor */
   regexDetailId: string | null;
+  /** Pre-selected target characters for a NEW regex script opened via openRegexDetail("__new__") */
+  regexDetailDefaultCharacterIds: string[] | null;
   /** When true, the main area shows the browser */
   botBrowserOpen: boolean;
   /** When true, the main area shows the game assets browser */
@@ -639,7 +641,7 @@ interface UIState {
   closeToolDetail: () => void;
   openPersonaDetail: (id: string) => void;
   closePersonaDetail: () => void;
-  openRegexDetail: (id: string) => void;
+  openRegexDetail: (id: string, options?: { defaultCharacterIds?: string[] }) => void;
   closeRegexDetail: () => void;
   openCharacterLibrary: () => void;
   closeCharacterLibrary: () => void;
@@ -978,6 +980,7 @@ export const useUIStore = create<UIState>()(
       toolDetailId: null,
       personaDetailId: null,
       regexDetailId: null,
+      regexDetailDefaultCharacterIds: null,
       botBrowserOpen: false,
       gameAssetsBrowserOpen: false,
       characterLibraryOpen: false,
@@ -1326,9 +1329,10 @@ export const useUIStore = create<UIState>()(
           editorDirty: false,
           ...restoreMobileDetailReturnPanel(s.detailReturnRightPanel),
         })),
-      openRegexDetail: (id) =>
+      openRegexDetail: (id, options) =>
         set((s) => ({
           regexDetailId: id,
+          regexDetailDefaultCharacterIds: options?.defaultCharacterIds ?? null,
           personaDetailId: null,
           characterLibraryOpen: false,
           botBrowserOpen: false,

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -364,6 +364,10 @@ interface UIState {
   regexDetailId: string | null;
   /** Pre-selected target characters for a NEW regex script opened via openRegexDetail("__new__") */
   regexDetailDefaultCharacterIds: string[] | null;
+  /** Where to return when the regex editor closes — e.g. back to a character's Advanced tab */
+  regexDetailReturn: { characterId: string; tab?: string } | null;
+  /** One-shot tab the character editor should open to (set by the regex-editor return path) */
+  characterDetailInitialTab: string | null;
   /** When true, the main area shows the browser */
   botBrowserOpen: boolean;
   /** When true, the main area shows the game assets browser */
@@ -641,7 +645,10 @@ interface UIState {
   closeToolDetail: () => void;
   openPersonaDetail: (id: string) => void;
   closePersonaDetail: () => void;
-  openRegexDetail: (id: string, options?: { defaultCharacterIds?: string[] }) => void;
+  openRegexDetail: (
+    id: string,
+    options?: { defaultCharacterIds?: string[]; returnTo?: { characterId: string; tab?: string } },
+  ) => void;
   closeRegexDetail: () => void;
   openCharacterLibrary: () => void;
   closeCharacterLibrary: () => void;
@@ -981,6 +988,8 @@ export const useUIStore = create<UIState>()(
       personaDetailId: null,
       regexDetailId: null,
       regexDetailDefaultCharacterIds: null,
+      regexDetailReturn: null,
+      characterDetailInitialTab: null,
       botBrowserOpen: false,
       gameAssetsBrowserOpen: false,
       characterLibraryOpen: false,
@@ -1183,6 +1192,7 @@ export const useUIStore = create<UIState>()(
           const preserveCharacterLibrary = options?.preserveCharacterLibrary ?? s.characterLibraryOpen;
           return {
             characterDetailId: id,
+            characterDetailInitialTab: null,
             lorebookDetailId: null,
             presetDetailId: null,
             connectionDetailId: null,
@@ -1333,6 +1343,7 @@ export const useUIStore = create<UIState>()(
         set((s) => ({
           regexDetailId: id,
           regexDetailDefaultCharacterIds: options?.defaultCharacterIds ?? null,
+          regexDetailReturn: options?.returnTo ?? null,
           personaDetailId: null,
           characterLibraryOpen: false,
           botBrowserOpen: false,
@@ -1346,11 +1357,26 @@ export const useUIStore = create<UIState>()(
           ...getMobileDetailReturnState(s),
         })),
       closeRegexDetail: () =>
-        set((s) => ({
-          regexDetailId: null,
-          editorDirty: false,
-          ...restoreMobileDetailReturnPanel(s.detailReturnRightPanel),
-        })),
+        set((s) => {
+          const ret = s.regexDetailReturn;
+          if (ret) {
+            // Opened from a character's scoped-regex manager — return to that character's tab.
+            return {
+              regexDetailId: null,
+              regexDetailReturn: null,
+              regexDetailDefaultCharacterIds: null,
+              characterDetailId: ret.characterId,
+              characterDetailInitialTab: ret.tab ?? null,
+              editorDirty: false,
+            };
+          }
+          return {
+            regexDetailId: null,
+            regexDetailReturn: null,
+            editorDirty: false,
+            ...restoreMobileDetailReturnPanel(s.detailReturnRightPanel),
+          };
+        }),
       openCharacterLibrary: () =>
         set({
           characterLibraryOpen: true,


### PR DESCRIPTION
## Linked issue

Closes #2624.

## Why this change

Follow-up polish to the character-scoped regex feature (#2603). Scoped scripts still polluted the global Presets → Regexes list, had no dedicated management home, and the per-character list in Chat Settings mislabeled its groups. This makes scoped regex behave as intended: **scoped scripts live with the character; global scripts live in Presets.**

## What changed

- **Presets → Regexes is global-only.** Character-scoped scripts (non-empty `targetCharacterIds`), including ST cards imported as "Character only," are filtered out of the global list.
- **Character editor → Advanced → "Regex Scripts".** A new section (`CharacterRegexSection`) to list / create / edit / delete / toggle / import / export that character's scoped scripts. "Create" opens the existing `RegexScriptEditor` pre-scoped to the character via a new `openRegexDetail(id, { defaultCharacterIds })` option.
- **Scoped Regex Scripts group labels.** Chat Settings → Scoped Regex Scripts now shows each character's name (via `parseCharacterDisplayData`) instead of the literal "Character".

These three are coupled: hiding scoped scripts from Presets removes their only create/edit/delete surface (Chat Settings only *toggles* them), so the character-card manager is the replacement home.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Confirmed that character-scoped regex scripts do not populate in the global Presets → Regexes list
- Confirmed that actual character names appear under the Chat Settings Scoped Regex Scripts, as opposed to literal "Character"
- Confirmed that a Regex Scripts section exists under the Advanced tab in character cards
- Confirmed that create, edit, delete, import, and export functionalities work as intended in character Regex Scripts section

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="690" height="590" alt="{38CB2853-4799-4915-B705-0D9013A0AFDD}" src="https://github.com/user-attachments/assets/3fd6dff4-4dde-4949-bfe0-d064b8cbaed4" />

<img width="793" height="558" alt="{FE955935-AE08-42AD-9CB4-6B72EE1F3552}" src="https://github.com/user-attachments/assets/ecfaadfb-a6bd-49c1-a2d1-dba0ea90726d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added character-scoped regex script management within the Character Editor's Advanced tab, allowing scripts to be created, edited, imported, exported, and deleted for individual characters.
  * Improved navigation context preservation when creating and saving regex scripts, automatically returning users to the previous character editor tab.
  * Enhanced Presets Panel to display only global regex scripts, with character-scoped scripts accessible via character settings.
  * Restored user preference for default Character Editor tab on reopening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->