### PR TITLE
Polish mobile UI and connection defaults

### DIFF
--- a/packages/client/src/components/chat/ChatCommonOverlays.tsx
+++ b/packages/client/src/components/chat/ChatCommonOverlays.tsx
@@ -63,7 +63,10 @@ function DeleteConfirmationDialog({
   if (!messageId) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] sm:p-4"
+      onClick={onClose}
+    >
       <div
         className="mx-4 w-full max-w-xs rounded-xl bg-[var(--card)] p-5 shadow-2xl ring-1 ring-[var(--border)]"
         onClick={(e) => e.stopPropagation()}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1557,7 +1557,7 @@ export function ChatRoleplaySurface({
               <div
                 className={cn(
                   "pointer-events-auto relative mx-auto w-full",
-                  centerCompact ? "px-3" : "max-w-[var(--mari-roleplay-message-column-width)] px-3 md:px-0",
+                  centerCompact ? "px-3" : "max-w-(--mari-roleplay-message-column-width) px-3 md:px-0",
                 )}
               >
                 {chatMeta.sceneStatus === "active" && (

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1554,7 +1554,12 @@ export function ChatRoleplaySurface({
               ref={inputChromeRef}
               className={cn("pointer-events-none absolute inset-x-0 bottom-0 z-30", TRACKER_FOREGROUND_AVOIDANCE_CLASS)}
             >
-              <div className={cn("pointer-events-auto relative", centerCompact ? "px-3" : "px-3 md:px-[12%]")}>
+              <div
+                className={cn(
+                  "pointer-events-auto relative mx-auto w-full",
+                  centerCompact ? "px-3" : "max-w-[var(--mari-roleplay-message-column-width)] px-3 md:px-0",
+                )}
+              >
                 {chatMeta.sceneStatus === "active" && (
                   <EndSceneBar
                     sceneChatId={activeChatId}

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -306,18 +306,19 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     const observedTargets = new Set<HTMLElement>();
     const observer = new ResizeObserver(() => scheduleUpdate());
     const observeTargets = () => {
-      const targets = [
-        ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_AREA_SELECTOR)),
-        ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR)),
-        ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR)),
-        ...Array.from(document.querySelectorAll<HTMLElement>(".rpg-hud")),
-      ];
+      const roleplayAreas = Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_AREA_SELECTOR));
+      const topAnchors = Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR));
+      const topRightControls = Array.from(
+        document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR),
+      );
+      const huds = Array.from(document.querySelectorAll<HTMLElement>(".rpg-hud"));
+      const targets = [...roleplayAreas, ...topAnchors, ...topRightControls, ...huds];
       targets.forEach((target) => {
         if (observedTargets.has(target)) return;
         observer.observe(target);
         observedTargets.add(target);
       });
-      return targets.length > 0;
+      return roleplayAreas.length > 0 && (isLeft ? huds.length > 0 : topRightControls.length > 0);
     };
     function scheduleUpdate() {
       if (frame) window.cancelAnimationFrame(frame);

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -40,12 +40,10 @@ const INPUT_BOX_H = 72; // bottom chat input area height
 const HUD_EDGE_GAP = 16; // Aligns with the roleplay HUD edge padding.
 const FLOATING_EDGE_GAP = 16;
 const TOP_BUTTON_GAP = 6; // Matches the tracker panel gap below the top controls.
+const DESKTOP_PANEL_WIDTH = 236;
+const ROLEPLAY_AREA_SELECTOR = ".rpg-chat-area";
 const ROLEPLAY_TOP_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
 const ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR = '[data-roleplay-top-controls="right"]';
-const TOP_BAR_SELECTOR = '[data-component="TopBar"]';
-const DESKTOP_PANEL_FALLBACK_W = 236;
-const DESKTOP_PANEL_MIN_W = 224;
-const DESKTOP_PANEL_MAX_W = 320;
 
 interface EchoChamberPanelProps {
   hiddenOnMobile?: boolean;
@@ -73,35 +71,51 @@ function findVisibleElement(selector: string): HTMLElement | null {
   return null;
 }
 
-function clampDesktopPanelWidth(width: number) {
-  return Math.max(DESKTOP_PANEL_MIN_W, Math.min(DESKTOP_PANEL_MAX_W, Math.ceil(width)));
+function getRoleplayAreaRect() {
+  return document.querySelector<HTMLElement>(ROLEPLAY_AREA_SELECTOR)?.getBoundingClientRect() ?? null;
 }
 
-function getAlignedDesktopPanelWidth(isLeft: boolean) {
-  const preferredElement = isLeft ? findVisibleHud() : findVisibleElement(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR);
-  const preferredRect = preferredElement ? readVisibleRect(preferredElement) : null;
-
-  return clampDesktopPanelWidth(preferredRect?.width ?? DESKTOP_PANEL_FALLBACK_W);
+function getDesktopAlignmentElement(isLeft: boolean) {
+  return isLeft
+    ? (findVisibleHud() ?? findVisibleElement(ROLEPLAY_TOP_ANCHOR_SELECTOR))
+    : findVisibleElement(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR);
 }
 
-function getRoleplayAreaTop() {
-  return document.querySelector<HTMLElement>(".rpg-chat-area")?.getBoundingClientRect().top ?? 0;
-}
-
-function getTopChromeBottomOffset() {
-  const containerTop = getRoleplayAreaTop();
+function getTopChromeBottomOffset(containerRect: DOMRect, alignmentRect: DOMRect | null) {
   const candidates: number[] = [];
-  const topBarRect = document.querySelector<HTMLElement>(TOP_BAR_SELECTOR);
-  const topBarBottom = topBarRect ? readVisibleRect(topBarRect)?.bottom : null;
-  if (topBarBottom != null) candidates.push(Math.ceil(topBarBottom - containerTop + TOP_BUTTON_GAP));
-
   const anchors = Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR));
   anchors.forEach((anchor) => {
     const rect = readVisibleRect(anchor);
-    if (rect) candidates.push(Math.ceil(rect.bottom - containerTop + TOP_BUTTON_GAP));
+    if (rect) candidates.push(Math.ceil(rect.bottom - containerRect.top + TOP_BUTTON_GAP));
   });
+  if (alignmentRect) candidates.push(Math.ceil(alignmentRect.bottom - containerRect.top + TOP_BUTTON_GAP));
 
   return candidates.length > 0 ? Math.max(TOP_BUTTON_GAP, ...candidates) : WIDGET_BAR_H + TOP_BUTTON_GAP;
+}
+
+function getDesktopPanelPosition(isTop: boolean, isLeft: boolean): CSSProperties {
+  const containerRect = getRoleplayAreaRect();
+  const alignmentElement = getDesktopAlignmentElement(isLeft);
+  const alignmentRect = alignmentElement ? readVisibleRect(alignmentElement) : null;
+  const edgeOffset = alignmentRect && containerRect ? Math.max(0, Math.round(alignmentRect.left - containerRect.left)) : null;
+  const rightEdgeOffset =
+    alignmentRect && containerRect ? Math.max(0, Math.round(containerRect.right - alignmentRect.right)) : null;
+  const topOffset = isTop && containerRect ? getTopChromeBottomOffset(containerRect, alignmentRect) : undefined;
+
+  return {
+    ...(topOffset !== undefined && { top: topOffset }),
+    ...(!isTop && { bottom: INPUT_BOX_H + FLOATING_EDGE_GAP }),
+    ...(isLeft && {
+      left: edgeOffset !== null ? `${edgeOffset}px` : `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-left, 0px))`,
+    }),
+    ...(!isLeft && {
+      right:
+        rightEdgeOffset !== null
+          ? `${rightEdgeOffset}px`
+          : `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-right, 0px))`,
+    }),
+    width: `${DESKTOP_PANEL_WIDTH}px`,
+  };
 }
 
 /** Tiny 4-square grid icon; the active corner is highlighted. */
@@ -263,7 +277,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
         // Position relative to container, so measure HUD bottom relative to rpg-chat-area
         const container = hudEl?.closest(".rpg-chat-area");
         const containerTop = container?.getBoundingClientRect().top ?? 0;
-        const hudBottom = hudEl ? hudEl.getBoundingClientRect().bottom - containerTop : 56;
+        const hudBottom = hudEl ? hudEl.getBoundingClientRect().bottom - containerTop : WIDGET_BAR_H;
         setPosStyle({ top: hudBottom + 8, left: 16, right: 16 });
       };
 
@@ -282,18 +296,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     const isTop = echoChamberSide.startsWith("top");
     const isLeft = echoChamberSide.endsWith("left");
     const update = () => {
-      const topOffset = isTop ? getTopChromeBottomOffset() : undefined;
-      const bottomOffset = !isTop ? INPUT_BOX_H + FLOATING_EDGE_GAP : undefined;
-      const leftOffset = isLeft ? `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-left, 0px))` : undefined;
-      const rightOffset = !isLeft ? `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-right, 0px))` : undefined;
-      const width = `${getAlignedDesktopPanelWidth(isLeft)}px`;
-      setPosStyle({
-        ...(topOffset !== undefined && { top: topOffset }),
-        ...(bottomOffset !== undefined && { bottom: bottomOffset }),
-        ...(leftOffset !== undefined && { left: leftOffset }),
-        ...(rightOffset !== undefined && { right: rightOffset }),
-        width,
-      });
+      setPosStyle(getDesktopPanelPosition(isTop, isLeft));
     };
 
     update();
@@ -304,7 +307,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     const observer = new ResizeObserver(() => scheduleUpdate());
     const observeTargets = () => {
       const targets = [
-        ...Array.from(document.querySelectorAll<HTMLElement>(TOP_BAR_SELECTOR)),
+        ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_AREA_SELECTOR)),
         ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR)),
         ...Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR)),
         ...Array.from(document.querySelectorAll<HTMLElement>(".rpg-hud")),
@@ -363,7 +366,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       className={cn(
         ROLEPLAY_POPOVER_SHELL,
         "absolute z-[60] flex flex-col",
-        "pointer-events-auto w-[14.75rem] max-md:w-auto md:max-h-[22rem] max-md:max-h-28",
+        "pointer-events-auto max-md:w-auto md:w-[14.75rem] md:max-h-[22rem] max-md:max-h-28",
       )}
       style={posStyle}
     >

--- a/packages/client/src/components/chat/HomeAchievements.tsx
+++ b/packages/client/src/components/chat/HomeAchievements.tsx
@@ -61,7 +61,7 @@ function AchievementBadge({ achievement, locked }: { achievement: AchievementDef
       )}
       aria-hidden="true"
     >
-      <div className="absolute inset-0 opacity-30 [background:radial-gradient(circle_at_30%_20%,currentColor,transparent_32%),linear-gradient(135deg,transparent_0_42%,currentColor_43%_45%,transparent_46%)]" />
+      <div className="absolute inset-0 opacity-25 [background:radial-gradient(circle_at_30%_20%,currentColor,transparent_34%)]" />
       <Icon className="relative z-10 h-5 w-5 sm:h-[1.65rem] sm:w-[1.65rem]" />
       {!locked && achievement.rankLabel && (
         <span className="absolute bottom-1.5 right-1.5 rounded bg-black/35 px-1 text-[0.55rem] font-bold text-white">
@@ -169,8 +169,11 @@ export function HomeAchievements({
         aria-label="Open achievements"
       >
         <span className="flex min-w-0 items-center gap-2.5 sm:gap-3">
-          <span className="mari-chrome-control flex h-9 w-9 shrink-0 p-0 sm:h-10 sm:w-10">
-            <Trophy size="1.15rem" />
+          <span
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--secondary)]/45 text-[var(--foreground)] shadow-sm sm:h-10 sm:w-10"
+            aria-hidden="true"
+          >
+            <Trophy size="1.15rem" strokeWidth={2.25} />
           </span>
           <span className="min-w-0">
             <span className="block text-sm font-semibold text-[var(--foreground)]">Achievements</span>

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -13,6 +13,7 @@ import {
   ImageIcon,
   Link,
   Loader2,
+  MessageCircle,
   Palette,
   Plus,
   RefreshCw,
@@ -59,6 +60,7 @@ import { HomeFaq } from "./HomeFaq";
 const MARI_AVATAR_URL = "/sprites/mari/Mari_profile.png";
 const MARI_CHIBI_URL = "/sprites/mari/chibi-professor-mari.png";
 const MARI_CONNECTION_STORAGE_KEY = "marinara:home-professor-mari-connection-id";
+const PROFESSOR_MARI_ERROR_TOAST_DURATION_MS = 120_000;
 const MARI_WELCOME =
   "Howdy, welcome to Marinara Engine!\n\nFeeling a little lost? It is not a skill issue yet, I am here to help! Ask me about the app, your setup, or what to do next.\n\nNeed something made or changed? I can create character cards, personas, lorebooks, chats, and presets, and I can make local workspace changes with your approval.";
 const NEW_SKILL_CONTENT = `# Custom Professor Mari Skill
@@ -125,6 +127,12 @@ function rememberConnectionId(id: string) {
   } catch {
     /* ignore */
   }
+}
+
+function describeProfessorMariError(error: unknown) {
+  const message = error instanceof Error ? error.message.trim() : "";
+  if (message) return `${message} This message will stay visible long enough to screenshot for troubleshooting.`;
+  return "The request failed before Professor Mari could answer. This message will stay visible long enough to screenshot for troubleshooting.";
 }
 
 function toMessageExtra(message: Message): Message["extra"] {
@@ -1493,7 +1501,6 @@ export function HomeProfessorMariChat({
   const [skillsSaving, setSkillsSaving] = useState(false);
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
   const [skillDraft, setSkillDraft] = useState<SkillDraftState>({ name: "", description: "", content: "" });
-  const [dottoreDismissed, setDottoreDismissed] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [sending, setSending] = useState(false);
   const [connectionMenuOpen, setConnectionMenuOpen] = useState(false);
@@ -1678,7 +1685,7 @@ export function HomeProfessorMariChat({
   const displayMessages = useMemo(() => [createWelcomeMessage(chatId), ...messages], [chatId, messages]);
   const workspaceTimelineActive = workspaceActive || hasActiveGeneration;
   const workspaceHasResponseText = workspaceTimeline.some((item) => item.type === "text" && item.content.trim());
-  const showDottoreSupport = workspaceTimelineActive && !workspaceHasResponseText && !dottoreDismissed;
+  const showDottoreSupport = workspaceTimelineActive && !workspaceHasResponseText;
 
   useEffect(() => {
     if (!mobileFocusMode) return;
@@ -1721,15 +1728,21 @@ export function HomeProfessorMariChat({
 
   const closeMobileFocusMode = useCallback(() => {
     setConnectionMenuOpen(false);
+    setSkillsMenuOpen(false);
     setMobileFocusMode(false);
     if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+  }, []);
+
+  const openMobileChat = useCallback(() => {
+    setSkillsMenuOpen(false);
+    setConnectionMenuOpen(false);
+    setMobileFocusMode(true);
   }, []);
 
   const toggleSkillsMenu = useCallback(() => {
     const next = !skillsMenuOpen;
     if (next) {
       setConnectionMenuOpen(false);
-      setMobileFocusMode(false);
       if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
     }
     setSkillsMenuOpen(next);
@@ -1924,7 +1937,6 @@ export function HomeProfessorMariChat({
       setWorkspaceActive(true);
       setWorkspaceActivity("Thinking...");
       setWorkspaceTimeline([]);
-      setDottoreDismissed(false);
       useChatStore.getState().setAbortController(chat.id, controller);
       useChatStore.getState().clearStreamBuffer(chat.id);
       useChatStore.getState().clearThinkingBuffer(chat.id);
@@ -2041,10 +2053,18 @@ export function HomeProfessorMariChat({
       setWorkspaceTimeline([]);
       await refreshWorkspaceStatus().catch(() => undefined);
       await invalidateWorkspaceData();
-      if (!received) toast.error("Professor Mari did not receive a reply from the model.");
+      if (!received) {
+        toast.error("Professor Mari did not receive a reply from the model.", {
+          description: "The model or server may still be busy. This message stays visible long enough to screenshot.",
+          duration: PROFESSOR_MARI_ERROR_TOAST_DURATION_MS,
+        });
+      }
     } catch (error) {
       console.error("[Professor Mari] Failed to send", error);
-      toast.error("Professor Mari could not answer right now.");
+      toast.error("Professor Mari could not answer right now.", {
+        description: describeProfessorMariError(error),
+        duration: PROFESSOR_MARI_ERROR_TOAST_DURATION_MS,
+      });
     } finally {
       setSending(false);
     }
@@ -2057,7 +2077,7 @@ export function HomeProfessorMariChat({
           "home-professor-mari-chat mt-10 w-full max-w-3xl border border-[var(--border)] bg-[var(--card)]/85 shadow-lg shadow-black/10 sm:mt-0",
           attachedFooter ? "rounded-t-xl rounded-b-none" : "rounded-xl",
           mobileFocusMode &&
-            "fixed inset-x-0 bottom-0 top-[calc(env(safe-area-inset-top)_+_3rem)] z-30 mt-0 max-w-none overflow-hidden rounded-t-2xl border-0 border-t border-[var(--border)]/70 bg-[var(--background)] sm:relative sm:inset-auto sm:z-auto sm:mt-0 sm:max-w-3xl sm:overflow-visible sm:rounded-xl sm:border sm:bg-[var(--card)]/85",
+            "fixed inset-0 z-[80] mt-0 h-screen max-h-screen max-w-none overflow-hidden rounded-none border-0 bg-[var(--background)] pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-[max(env(safe-area-inset-top),0.5rem)] sm:relative sm:inset-auto sm:z-auto sm:mt-0 sm:h-auto sm:max-h-none sm:max-w-3xl sm:overflow-visible sm:rounded-xl sm:border sm:bg-[var(--card)]/85 sm:pb-0 sm:pt-0 supports-[height:100dvh]:h-[100dvh] supports-[height:100dvh]:max-h-[100dvh]",
         )}
         data-paused={pageActive ? "false" : "true"}
       >
@@ -2065,44 +2085,33 @@ export function HomeProfessorMariChat({
           className={cn(
             "grid gap-2.5 p-2 sm:grid-cols-[minmax(0,0.72fr)_minmax(0,1.45fr)] sm:p-2.5",
             mobileFocusMode &&
-              "h-full grid-rows-[auto_minmax(0,1fr)] gap-0 p-0 sm:h-auto sm:grid-cols-[minmax(0,0.72fr)_minmax(0,1.45fr)] sm:gap-2.5 sm:p-2.5",
+              "h-full grid-cols-1 grid-rows-[minmax(0,1fr)] gap-0 p-0 sm:h-auto sm:grid-cols-[minmax(0,0.72fr)_minmax(0,1.45fr)] sm:gap-2.5 sm:p-2.5",
           )}
         >
           <div
             className={cn(
               "relative flex min-w-0 flex-col items-center justify-start gap-2 rounded-lg border border-[var(--border)]/70 bg-[var(--secondary)]/25 p-2.5",
-              mobileFocusMode &&
-                "z-10 overflow-visible rounded-none border-0 bg-[var(--secondary)]/22 px-3 pb-0 pt-2.5 sm:flex",
+              mobileFocusMode && "hidden sm:flex",
             )}
           >
-            {mobileFocusMode && (
-              <button
-                type="button"
-                onClick={closeMobileFocusMode}
-                className="absolute right-3 top-2.5 z-20 inline-flex h-8 w-8 items-center justify-center rounded-full border border-[var(--border)]/70 bg-[var(--card)] text-[var(--muted-foreground)] transition-colors active:bg-[var(--accent)] active:text-[var(--foreground)] sm:hidden"
-                aria-label="Back to home"
-                title="Back"
-              >
-                <X size="0.95rem" />
-              </button>
-            )}
-            <div
-              className={cn(
-                "w-full max-w-[14rem] [--mari-professor-sprite-bottom:5%]",
-                mobileFocusMode && "-mb-12 max-w-[10rem] self-start translate-x-2 translate-y-10",
-              )}
-            >
-              <div style={mobileFocusMode ? { transform: "scale(0.7)", transformOrigin: "bottom left" } : undefined}>
-                <ProfessorMariPixelScene active={isBusy || mariPhase !== null} />
-              </div>
+            <div className="w-full max-w-[14rem] [--mari-professor-sprite-bottom:5%]">
+              <ProfessorMariPixelScene active={isBusy || mariPhase !== null} />
             </div>
-            <div className={cn("w-full text-center sm:hidden", mobileFocusMode && "absolute left-0 top-2 z-10 px-14")}>
+            <div className="w-full text-center sm:hidden">
               <div className="min-w-0">
                 <div className="truncate text-sm font-semibold text-[var(--foreground)]">Professor Mari</div>
                 <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
                   {isBusy ? "Working on it..." : "Ready to help"}
                 </div>
               </div>
+              <button
+                type="button"
+                onClick={openMobileChat}
+                className="mari-chrome-control mari-chrome-control--primary mt-3 w-full gap-2 text-xs"
+              >
+                <MessageCircle size="0.9rem" />
+                Start Chatting
+              </button>
             </div>
             <div className="hidden sm:block w-full">
               <HomeFaq
@@ -2123,7 +2132,7 @@ export function HomeProfessorMariChat({
                 animate={{ opacity: 1, y: 0, rotateX: 0, transformOrigin: "top center" }}
                 exit={{ opacity: 0, y: 12, rotateX: 8, transformOrigin: "bottom center" }}
                 transition={PROFESSOR_MARI_PANE_TRANSITION}
-                className={cn("min-w-0", mobileFocusMode && "h-full")}
+                className={cn("min-w-0", !mobileFocusMode && "hidden sm:block", mobileFocusMode && "h-full")}
               >
                 <ProfessorMariSkillsMenu
                   skills={skills}
@@ -2156,34 +2165,29 @@ export function HomeProfessorMariChat({
                 animate={{ opacity: 1, y: 0, rotateX: 0, transformOrigin: "bottom center" }}
                 exit={{ opacity: 0, y: -12, rotateX: -10, transformOrigin: "top center" }}
                 transition={PROFESSOR_MARI_PANE_TRANSITION}
-                className={cn("min-w-0", mobileFocusMode && "h-full")}
+                className={cn("min-w-0", !mobileFocusMode && "hidden sm:block", mobileFocusMode && "h-full")}
               >
                 <div
                   className={cn(
                     "flex h-[clamp(24rem,70dvh,31rem)] min-w-0 flex-col rounded-lg border border-[var(--border)]/70 bg-[var(--background)]/70",
                     mobileFocusMode &&
-                      "h-full rounded-none border-0 bg-[var(--background)] sm:h-[clamp(24rem,70dvh,31rem)] sm:rounded-lg sm:border sm:bg-[var(--background)]/70",
+                      "h-full min-h-0 rounded-none border-0 bg-[var(--background)] sm:h-[clamp(24rem,70dvh,31rem)] sm:rounded-lg sm:border sm:bg-[var(--background)]/70",
                   )}
                 >
                   <div
                     className={cn(
                       "flex items-center justify-between gap-2 border-b border-[var(--border)]/60 px-3 py-2",
-                      mobileFocusMode && "relative min-h-12 bg-[var(--card)]/80 px-2 pt-2",
+                      mobileFocusMode && "min-h-12 bg-[var(--card)]/80 px-2 pt-2",
                     )}
                   >
-                    <div className={cn("flex min-w-0 flex-1 items-center gap-2", mobileFocusMode && "hidden sm:flex")}>
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
                       <span className="min-w-0 text-center">
                         <span className="block truncate text-xs font-semibold text-[var(--foreground)]">
                           Ask Professor Mari
                         </span>
                       </span>
                     </div>
-                    <div
-                      className={cn(
-                        "flex shrink-0 items-center gap-1",
-                        mobileFocusMode && "absolute right-2 top-1/2 -translate-y-1/2",
-                      )}
-                    >
+                    <div className="flex shrink-0 items-center gap-1">
                       <button
                         type="button"
                         onClick={toggleSkillsMenu}
@@ -2220,8 +2224,19 @@ export function HomeProfessorMariChat({
                         title="Restart Professor Mari chat"
                       >
                         <RefreshCw size="0.75rem" />
-                        /restart
+                        <span className="max-[380px]:hidden">Restart</span>
                       </button>
+                      {mobileFocusMode && (
+                        <button
+                          type="button"
+                          onClick={closeMobileFocusMode}
+                          className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--border)]/70 bg-[var(--card)] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] sm:hidden"
+                          aria-label="Close Professor Mari chat"
+                          title="Close"
+                        >
+                          <X size="0.9rem" />
+                        </button>
+                      )}
                     </div>
                   </div>
 
@@ -2243,8 +2258,13 @@ export function HomeProfessorMariChat({
                             thinking={message.role === "assistant" ? getMessageThinking(message) : null}
                           />
                         ))}
-                        {workspaceTimeline.length === 0 && workspaceTimelineActive && (
+                        {workspaceTimeline.length === 0 && workspaceTimelineActive && !showDottoreSupport && (
                           <WorkspaceStatusEvent content={workspaceActivity ?? "Thinking..."} />
+                        )}
+                        {showDottoreSupport && (
+                          <TranscriptRow marker={<MariAvatar active />}>
+                            <ProfessorMariWorkingWindow visible className="max-w-[18rem]" />
+                          </TranscriptRow>
                         )}
                         <WorkspaceTimelineList
                           items={workspaceTimeline}
@@ -2389,11 +2409,6 @@ export function HomeProfessorMariChat({
           />
         </div>
       </section>
-      <ProfessorMariWorkingWindow
-        visible={showDottoreSupport}
-        onDismiss={() => setDottoreDismissed(true)}
-        className="fixed bottom-4 right-4 z-50 w-[min(18rem,calc(100vw-2rem))] max-sm:bottom-3 max-sm:right-3"
-      />
     </>
   );
 }

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -1736,6 +1736,7 @@ export function HomeProfessorMariChat({
   const openMobileChat = useCallback(() => {
     setSkillsMenuOpen(false);
     setConnectionMenuOpen(false);
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
     setMobileFocusMode(true);
   }, []);
 

--- a/packages/client/src/components/game-assets/AudioPlayerModal.tsx
+++ b/packages/client/src/components/game-assets/AudioPlayerModal.tsx
@@ -34,7 +34,7 @@ export function AudioPlayerModal({ path, name, onClose }: { path: string; name: 
       role="dialog"
       aria-modal="true"
       aria-label={`Audio player: ${name}`}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
       <div

--- a/packages/client/src/components/game-assets/FileEditorModal.tsx
+++ b/packages/client/src/components/game-assets/FileEditorModal.tsx
@@ -115,11 +115,11 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={handleRequestClose}
     >
       <div
-        className="flex h-[85vh] w-full max-w-4xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+        className="flex h-[85vh] max-h-[calc(100vh-1.5rem)] w-full max-w-4xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl supports-[height:100dvh]:h-[85dvh] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/packages/client/src/components/game-assets/ImagePreviewModal.tsx
+++ b/packages/client/src/components/game-assets/ImagePreviewModal.tsx
@@ -33,16 +33,16 @@ export function ImagePreviewModal({ node, onClose }: { node: TreeNode; onClose: 
       role="dialog"
       aria-modal="true"
       aria-label={`Image preview: ${node.name}`}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
-      <div className="relative flex max-h-[90vh] max-w-[90vw]">
+      <div className="relative flex max-h-[90vh] max-w-[90vw] supports-[height:100dvh]:max-h-[90dvh]">
         <div className="relative">
           <img
             src={gameAssetFileUrl(node.path) ?? ""}
             alt={node.name}
             className={cn(
-              "max-h-[85vh] rounded-lg object-contain shadow-2xl",
+              "max-h-[85vh] rounded-lg object-contain shadow-2xl supports-[height:100dvh]:max-h-[85dvh]",
               showInfo ? "max-w-[60vw]" : "max-w-[80vw]",
             )}
             onClick={(e) => e.stopPropagation()}

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -386,13 +386,13 @@ export function GameCharacterSheet({
   return (
     <div
       data-game-skip-bg-nav="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
       <div
         className={cn(
           NEUTRAL_SURFACE_VARIABLES,
-          "marinara-chat-popover relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] shadow-2xl",
+          "marinara-chat-popover relative flex max-h-[85vh] w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] shadow-2xl supports-[height:100dvh]:max-h-[85dvh]",
         )}
         onClick={(e) => e.stopPropagation()}
       >

--- a/packages/client/src/components/game/GameInventory.tsx
+++ b/packages/client/src/components/game/GameInventory.tsx
@@ -197,8 +197,8 @@ export function GameInventory({
   }
 
   return (
-    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 backdrop-blur-sm">
-      <div className="relative mx-4 flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-lg border border-white/10 bg-black shadow-[0_0_40px_rgba(0,0,0,0.8)]">
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4">
+      <div className="relative flex max-h-[85vh] w-full max-w-md flex-col overflow-hidden rounded-lg border border-white/10 bg-black shadow-[0_0_40px_rgba(0,0,0,0.8)] supports-[height:100dvh]:max-h-[85dvh]">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-white/8 bg-white/[0.02] px-4 py-3">
           <div className="flex items-center gap-2">

--- a/packages/client/src/components/game/GameReadableDisplay.tsx
+++ b/packages/client/src/components/game/GameReadableDisplay.tsx
@@ -140,10 +140,10 @@ export function GameReadableDisplay({ type, content, onClose }: GameReadableDisp
   }, [content]);
 
   return (
-    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/70 backdrop-blur-md">
+    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-md sm:p-4">
       <div
         className={cn(
-          "relative mx-4 flex max-h-[75vh] w-full max-w-lg flex-col overflow-hidden rounded-xl p-0",
+          "relative flex max-h-[75vh] w-full max-w-lg flex-col overflow-hidden rounded-xl p-0 supports-[height:100dvh]:max-h-[75dvh]",
           style.wrapper,
           style.border,
         )}

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -736,7 +736,7 @@ export function AppShell() {
     <div
       data-component="AppShell"
       className={cn(
-        "mari-app fixed inset-0 flex overflow-hidden bg-[var(--background)] max-md:pt-[env(safe-area-inset-top)]",
+        "mari-app fixed inset-0 flex overflow-hidden bg-[var(--background)] max-md:h-screen max-md:max-h-screen max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-[env(safe-area-inset-top)] supports-[height:100dvh]:max-md:h-[100dvh] supports-[height:100dvh]:max-md:max-h-[100dvh]",
         showAmbientDecor && "retro-scanlines noise-bg geometric-grid",
       )}
     >
@@ -769,7 +769,7 @@ export function AppShell() {
           sidebarDragWidth == null && "transition-[width] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]",
           sidebarOpen && "mari-shell-panel-edge mari-shell-panel-edge--right md:relative",
           // Mobile: fixed overlay
-          "max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-50 max-md:shadow-2xl max-md:pt-[env(safe-area-inset-top)]",
+          "max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-50 max-md:h-screen max-md:max-h-screen max-md:pb-[max(env(safe-area-inset-bottom),0.5rem)] max-md:pt-[max(env(safe-area-inset-top),0.5rem)] max-md:shadow-2xl supports-[height:100dvh]:max-md:h-[100dvh] supports-[height:100dvh]:max-md:max-h-[100dvh]",
           !sidebarOpen && "max-md:!w-0",
         )}
         style={{ width: sidebarOpen ? (isMobile ? "100vw" : liveSidebarWidth) : 0 }}
@@ -859,7 +859,7 @@ export function AppShell() {
               data-component="TrackerDataSidebarMobile"
               aria-label="Tracker data panel"
               className={cn(
-                "mari-tracker-panel !fixed inset-y-0 z-50 h-[100dvh] w-screen max-w-none overflow-hidden bg-zinc-950/95 pt-[env(safe-area-inset-top)] shadow-2xl ring-1 ring-zinc-700/80 backdrop-blur-xl",
+                "mari-tracker-panel !fixed inset-y-0 z-50 h-screen max-h-screen w-screen max-w-none overflow-hidden bg-zinc-950/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-[max(env(safe-area-inset-top),0.5rem)] shadow-2xl ring-1 ring-zinc-700/80 backdrop-blur-xl supports-[height:100dvh]:h-[100dvh] supports-[height:100dvh]:max-h-[100dvh]",
                 trackerPanelSide === "left" ? "left-0" : "right-0",
               )}
               style={trackerPanelBackgroundStyle}
@@ -889,7 +889,7 @@ export function AppShell() {
               transition={{ type: "spring", damping: 28, stiffness: 350 }}
               data-component="RightPanelMobile"
               aria-label="Settings and tools panel"
-              className="mari-right-panel !fixed inset-y-0 right-0 z-50 !w-full shadow-2xl overflow-hidden bg-[var(--background)]/80 backdrop-blur-xl pt-[env(safe-area-inset-top)]"
+              className="mari-right-panel !fixed inset-y-0 right-0 z-50 h-screen max-h-screen !w-full overflow-hidden bg-[var(--background)]/80 pb-[max(env(safe-area-inset-bottom),0.5rem)] pt-[max(env(safe-area-inset-top),0.5rem)] shadow-2xl backdrop-blur-xl supports-[height:100dvh]:h-[100dvh] supports-[height:100dvh]:max-h-[100dvh]"
             >
               <Suspense fallback={<SidePanelFallback />}>
                 <RightPanel />

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -424,27 +424,59 @@ function connectionMatchesSearch(conn: ConnectionRowData, query: string) {
   return haystack.includes(query);
 }
 
+function formatDefaultConnectionOption(connection: ConnectionRowData, fallbackModelLabel: string): string {
+  const model = connection.model?.trim() || fallbackModelLabel;
+  return `${connection.name} - ${model}`;
+}
+
 function DefaultAgentConnectionCard({ connectionsList }: { connectionsList: ConnectionRowData[] }) {
   const openConnectionDetail = useUIStore((s) => s.openConnectionDetail);
+  const updateConnection = useUpdateConnection();
+  const agentConnections = useMemo(
+    () => connectionsList.filter((conn) => conn.provider !== "image_generation"),
+    [connectionsList],
+  );
   const defaultConnection =
-    connectionsList.find(
+    agentConnections.find(
       (conn) =>
         conn.provider !== "image_generation" && (conn.defaultForAgents === true || conn.defaultForAgents === "true"),
     ) ?? null;
+  const hasConnections = agentConnections.length > 0;
+
+  const handleDefaultChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextConnectionId = event.target.value;
+    if (nextConnectionId === defaultConnection?.id) return;
+    if (!nextConnectionId) {
+      if (defaultConnection) {
+        updateConnection.mutate({ id: defaultConnection.id, defaultForAgents: false });
+      }
+      return;
+    }
+    updateConnection.mutate({ id: nextConnectionId, defaultForAgents: true });
+  };
 
   return (
     <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
-      <div className="flex items-center gap-2.5">
+      <div className="flex items-center gap-2.5 max-sm:items-start">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
           <Sparkles size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium">Default for Agents</div>
-          <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
-            {defaultConnection
-              ? `${defaultConnection.name} • ${defaultConnection.model || "No model set"}`
-              : "No default agent connection set"}
-          </div>
+          <select
+            value={defaultConnection?.id ?? ""}
+            onChange={handleDefaultChange}
+            disabled={updateConnection.isPending || (!hasConnections && !defaultConnection)}
+            className="mt-1 w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-[0.75rem] text-[var(--foreground)] ring-1 ring-[var(--border)] transition focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Default agent connection"
+          >
+            <option value="">{hasConnections ? "No default agent connection" : "No text connections available"}</option>
+            {agentConnections.map((connection) => (
+              <option key={connection.id} value={connection.id}>
+                {formatDefaultConnectionOption(connection, "No model set")}
+              </option>
+            ))}
+          </select>
         </div>
         {defaultConnection && (
           <button
@@ -463,25 +495,54 @@ function DefaultAgentConnectionCard({ connectionsList }: { connectionsList: Conn
 
 function DefaultIllustratorConnectionCard({ connectionsList }: { connectionsList: ConnectionRowData[] }) {
   const openConnectionDetail = useUIStore((s) => s.openConnectionDetail);
+  const updateConnection = useUpdateConnection();
+  const illustratorConnections = useMemo(
+    () => connectionsList.filter((conn) => conn.provider === "image_generation"),
+    [connectionsList],
+  );
   const defaultConnection =
-    connectionsList.find(
+    illustratorConnections.find(
       (conn) =>
         conn.provider === "image_generation" && (conn.defaultForAgents === true || conn.defaultForAgents === "true"),
     ) ?? null;
+  const hasConnections = illustratorConnections.length > 0;
+
+  const handleDefaultChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextConnectionId = event.target.value;
+    if (nextConnectionId === defaultConnection?.id) return;
+    if (!nextConnectionId) {
+      if (defaultConnection) {
+        updateConnection.mutate({ id: defaultConnection.id, defaultForAgents: false });
+      }
+      return;
+    }
+    updateConnection.mutate({ id: nextConnectionId, defaultForAgents: true });
+  };
 
   return (
     <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
-      <div className="flex items-center gap-2.5">
+      <div className="flex items-center gap-2.5 max-sm:items-start">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
           <ImageIcon size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium">Default for Illustrator</div>
-          <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
-            {defaultConnection
-              ? `${defaultConnection.name} • ${defaultConnection.model || "Image generation"}`
-              : "No default Illustrator connection set"}
-          </div>
+          <select
+            value={defaultConnection?.id ?? ""}
+            onChange={handleDefaultChange}
+            disabled={updateConnection.isPending || (!hasConnections && !defaultConnection)}
+            className="mt-1 w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-[0.75rem] text-[var(--foreground)] ring-1 ring-[var(--border)] transition focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Default Illustrator connection"
+          >
+            <option value="">
+              {hasConnections ? "No default Illustrator connection" : "No image connections available"}
+            </option>
+            {illustratorConnections.map((connection) => (
+              <option key={connection.id} value={connection.id}>
+                {formatDefaultConnectionOption(connection, "Image generation")}
+              </option>
+            ))}
+          </select>
         </div>
         {defaultConnection && (
           <button

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -2300,9 +2300,9 @@ function ExpandedEditorModal({
 
   return (
     <PresetModalPortal>
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-6 max-md:pt-[max(1.5rem,env(safe-area-inset-top))]">
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-[max(0.75rem,env(safe-area-inset-top))] sm:p-6">
         <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-        <div className="mari-editor-shell relative flex h-[80vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--marinara-editor-border)] bg-[var(--marinara-editor-surface-bg)] shadow-2xl shadow-black/50">
+        <div className="mari-editor-shell relative flex h-[80vh] max-h-[calc(100vh-1.5rem)] w-full max-w-3xl flex-col rounded-2xl border border-[var(--marinara-editor-border)] bg-[var(--marinara-editor-surface-bg)] shadow-2xl shadow-black/50 supports-[height:100dvh]:h-[80dvh] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]">
           {/* Header */}
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <h3 className="text-sm font-semibold">{title}</h3>

--- a/packages/client/src/components/ui/ChibiProfessorMariEasterEgg.tsx
+++ b/packages/client/src/components/ui/ChibiProfessorMariEasterEgg.tsx
@@ -29,7 +29,7 @@ function showChibiProfessorMariToast() {
   rememberChibiProfessorMari();
   toast.custom(
     (toastId) => (
-      <div className="relative flex max-w-[360px] gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 pr-9 text-[var(--foreground)] shadow-lg">
+      <div className="relative flex max-w-[360px] gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 pr-9 text-[var(--foreground)] shadow-lg ring-1 ring-[var(--border)]/70">
         <button
           type="button"
           aria-label="Dismiss Professor Mari toast"
@@ -57,7 +57,14 @@ function showChibiProfessorMariToast() {
         </div>
       </div>
     ),
-    { duration: CHIBI_PROFESSOR_MARI_TOAST_DURATION_MS },
+    {
+      duration: CHIBI_PROFESSOR_MARI_TOAST_DURATION_MS,
+      style: {
+        background: "var(--card)",
+        border: "1px solid var(--border)",
+        color: "var(--foreground)",
+      },
+    },
   );
 }
 

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -117,8 +117,8 @@ function ExpandedMacroEditor({
 
   return (
     <MacroModalPortal>
-      <div className="fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-        <div className="flex h-[min(92vh,56rem)] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl">
+      <div className="fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4">
+        <div className="flex h-[min(92vh,56rem)] max-h-[calc(100vh-1.5rem)] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl supports-[height:100dvh]:h-[min(92dvh,56rem)] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]">
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <div>
               <h3 className="text-sm font-semibold text-[var(--foreground)]">{title}</h3>
@@ -179,8 +179,8 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
 
   return (
     <MacroModalPortal>
-      <div className="fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-        <div className="max-h-[88vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl">
+      <div className="fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4">
+        <div className="max-h-[88vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl supports-[height:100dvh]:max-h-[88dvh]">
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <div>
               <h3 className="text-sm font-semibold text-[var(--foreground)]">Macro reference</h3>
@@ -196,7 +196,7 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
               <X className="h-4 w-4" />
             </button>
           </div>
-          <div className="max-h-[calc(88vh-4rem)] space-y-4 overflow-y-auto p-4">
+          <div className="max-h-[calc(88vh-4rem)] space-y-4 overflow-y-auto p-4 supports-[height:100dvh]:max-h-[calc(88dvh-4rem)]">
             <section className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-xs text-[var(--muted-foreground)]">
               <p>
                 Use <code className="text-[var(--foreground)]">{"{{macro}}"}</code> anywhere in prompt fields. Conditional blocks let you include content only when a value exists.

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -4,6 +4,7 @@
 // avoid double-animation under React.StrictMode.
 // ──────────────────────────────────────────────
 import { useEffect, useRef, useState, type ReactNode, type Ref } from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import {
   NEUTRAL_PANEL_HEADER,
@@ -76,7 +77,7 @@ export function Modal({ open, onClose, title, children, width = "max-w-md", cont
 
   const isEntering = animating === "enter";
 
-  return (
+  return createPortal(
     <div
       ref={overlayRef}
       role="dialog"
@@ -131,6 +132,7 @@ export function Modal({ open, onClose, title, children, width = "max-w-md", cont
           {children}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/packages/client/src/components/ui/ProfessorMariWorkingWindow.tsx
+++ b/packages/client/src/components/ui/ProfessorMariWorkingWindow.tsx
@@ -24,39 +24,34 @@ export function ProfessorMariWorkingWindow({ visible, onDismiss, className }: Pr
   return (
     <aside
       className={cn(
-        "pointer-events-auto relative overflow-hidden rounded-xl border border-[var(--primary)]/25 bg-[var(--card)]/95 text-[var(--foreground)] shadow-xl shadow-black/25 ring-1 ring-[var(--border)]/60",
+        "pointer-events-auto relative inline-flex max-w-full items-center gap-2 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]/85 px-2.5 py-2 text-[var(--foreground)] shadow-sm ring-1 ring-[var(--border)]/50",
         className,
       )}
       role="status"
       aria-live="polite"
     >
-      <div className="flex items-start gap-2.5 px-3 py-2.5">
-        {!imageFailed && (
-          <img
-            src={DOTTOR_SUPPORT_GIF}
-            alt=""
-            className="mt-0.5 h-14 w-14 shrink-0 object-contain [image-rendering:pixelated]"
-            onError={() => setImageFailed(true)}
-          />
-        )}
-        <div className="min-w-0 flex-1 pr-5">
-          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--primary)]/85">Working</p>
-          <p className="mt-0.5 text-xs font-medium leading-relaxed text-[var(--foreground)]">
-            Professor Mari is working. Dottore is doing jumping jacks for moral support...
-          </p>
-        </div>
-        {onDismiss && (
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]/60"
-            aria-label="Hide Dottore support popup"
-            title="Hide"
-          >
-            <X size="0.78rem" />
-          </button>
-        )}
-      </div>
+      {!imageFailed && (
+        <img
+          src={DOTTOR_SUPPORT_GIF}
+          alt=""
+          className="h-10 w-10 shrink-0 object-contain [image-rendering:pixelated]"
+          onError={() => setImageFailed(true)}
+        />
+      )}
+      <p className={cn("min-w-0 text-xs font-medium leading-relaxed text-[var(--foreground)]", onDismiss && "pr-6")}>
+        Prof Mari is working...
+      </p>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="absolute right-1.5 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]/60"
+          aria-label="Hide Professor Mari working indicator"
+          title="Hide"
+        >
+          <X size="0.78rem" />
+        </button>
+      )}
     </aside>
   );
 }

--- a/packages/shared/src/constants/achievements.ts
+++ b/packages/shared/src/constants/achievements.ts
@@ -19,7 +19,7 @@ const RANKS = [
 function rankedAchievements(
   groupId: string,
   title: string,
-  descriptionSubject: string,
+  descriptionForTarget: (target: number) => string,
   icon: AchievementDefinition["icon"],
   metric: NonNullable<AchievementDefinition["metric"]>,
   category: AchievementDefinition["category"],
@@ -27,7 +27,7 @@ function rankedAchievements(
   return RANKS.map(({ rank, rankLabel, target }) => ({
     id: `${groupId}_${rank}`,
     title,
-    description: `${descriptionSubject} ${target} times.`,
+    description: descriptionForTarget(target),
     category,
     icon,
     rank,
@@ -77,7 +77,7 @@ export const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
   ...rankedAchievements(
     "who_needs_irl_friends",
     "Who Needs IRL Friends",
-    "Created Conversation chats",
+    (target) => `Created ${target} Conversation chats.`,
     "conversation",
     "conversationChats",
     "creation",
@@ -85,7 +85,7 @@ export const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
   ...rankedAchievements(
     "they_feel_real_to_me",
     "They Feel Real To Me",
-    "Created Roleplay chats",
+    (target) => `Created ${target} Roleplay chats.`,
     "roleplay",
     "roleplayChats",
     "creation",
@@ -93,21 +93,21 @@ export const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
   ...rankedAchievements(
     "i_have_no_other_hobbies",
     "I Have No Other Hobbies",
-    "Created Game mode chats",
+    (target) => `Created ${target} Game mode chats.`,
     "game",
     "gameChats",
     "creation",
   ),
-  ...rankedAchievements("hoarder", "Hoarder", "Collected characters", "character", "characters", "collection"),
+  ...rankedAchievements("hoarder", "Hoarder", (target) => `Collected ${target} Characters.`, "character", "characters", "collection"),
   ...rankedAchievements(
     "the_worlds_a_stage",
     "The World's A Stage",
-    "Collected lorebooks",
+    (target) => `Collected ${target} Lorebooks.`,
     "lorebook",
     "lorebooks",
     "collection",
   ),
-  ...rankedAchievements("i_am_a_gamer", "I Am A Gamer", "Collected personas", "persona", "personas", "collection"),
+  ...rankedAchievements("i_am_a_gamer", "I Am A Gamer", (target) => `Collected ${target} Personas.`, "persona", "personas", "collection"),
 ];
 
 export const ACHIEVEMENT_DEFINITION_BY_ID = new Map(ACHIEVEMENT_DEFINITIONS.map((item) => [item.id, item]));


### PR DESCRIPTION
## Summary

- polish Professor Mari mobile chat, achievements, and surprise visit feedback
- tighten mobile browser safe-area handling for shell panels and key overlays
- align roleplay Echo Chamber and input layout behavior
- add quick default selectors for Agents and Illustrator connections

## Linked Issue

No linked issue was provided for this polish batch.

## Validation

- pnpm check
- pnpm --filter @marinara-engine/client lint
- pnpm --filter @marinara-engine/client build

## Manual Verification Notes

- Review Professor Mari mobile chat in a phone browser viewport, especially the separate chat focus mode and close button placement.
- Confirm Connections tab default selectors switch agent and Illustrator defaults as expected.
- Confirm roleplay Echo Chamber and input alignment on desktop and mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection panel defaults now selectable via dropdown menu.

* **Bug Fixes**
  * Improved mobile safe-area spacing across modals and overlays.
  * Enhanced error handling for Professor Mari chat messaging.

* **UI/UX**
  * Restyled Professor Mari working indicator appearance.
  * Better viewport height handling for modals on mobile devices.
  * Refined responsive layouts and overlay positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->