### PR TITLE
fix(agents): retry result-loop break, lorebook-write approval gate, tracker-tag sanitizer, PDF-cache poison, multi-pass double-inject

### DIFF
--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1103,8 +1103,10 @@ function resolveRetryAgentWritableLorebookId(settings: Record<string, unknown>):
 async function attachRetryLorebookWriterToolContexts(args: {
   lorebooksStore: ReturnType<typeof createLorebooksStorage>;
   resolvedAgents: ResolvedRetryAgent[];
+  requireApproval: boolean;
+  chatId: string;
 }) {
-  const { lorebooksStore, resolvedAgents } = args;
+  const { lorebooksStore, resolvedAgents, requireApproval, chatId } = args;
   const tool = toLLMToolDefinition(LOREBOOK_WRITE_TOOL_NAME);
   if (!tool) return;
 
@@ -1137,6 +1139,33 @@ async function attachRetryLorebookWriterToolContexts(args: {
           tag?: string;
           mode: "create" | "replace" | "append";
         }) => {
+          // When agent write-approval is required, never write inline — surface a
+          // proposal envelope (mirroring the structured lorebook_update gate) so the
+          // user approves the write before it touches the lorebook DB.
+          if (requireApproval) {
+            return {
+              requiresApproval: true,
+              approval: buildLorebookWriteApprovalProposal({
+                chatId,
+                agentType: entry.resolved.type,
+                agentName: entry.cfg?.name ?? entry.resolved.name ?? entry.resolved.type,
+                updates: [
+                  {
+                    action: loreEntry.mode === "create" ? "create" : "update",
+                    name: loreEntry.name,
+                    content: loreEntry.content,
+                    description: loreEntry.description ?? "",
+                    keys: loreEntry.keys,
+                    tag: loreEntry.tag ?? "",
+                    mode: loreEntry.mode,
+                  },
+                ],
+                preferredTargetLorebookId: writableLorebookId,
+                writableLorebookIds: [writableLorebookId],
+              }),
+            };
+          }
+
           const targetLorebook = await lorebooksStore.getById(writableLorebookId);
           if (!targetLorebook) {
             return { error: "Selected lorebook is no longer available.", lorebookId: writableLorebookId };
@@ -1944,6 +1973,9 @@ async function applyRetryResultEffects(args: {
   retrySwipeIndex: number;
   results: AgentResult[];
   agentContext: AgentContext;
+  /** Raw (unresolved) stored content of the message being retried, used as the
+   *  stale-edit baseline so macros in the message do not falsely trip the guard. */
+  mainResponseRaw: string;
   lorebooksStore: ReturnType<typeof createLorebooksStorage>;
   gameStateStore: ReturnType<typeof createGameStateStorage>;
   conns: ReturnType<typeof createConnectionsStorage>;
@@ -1960,6 +1992,7 @@ async function applyRetryResultEffects(args: {
     retrySwipeIndex,
     results,
     agentContext,
+    mainResponseRaw,
     lorebooksStore,
     gameStateStore,
     conns,
@@ -1975,6 +2008,11 @@ async function applyRetryResultEffects(args: {
   const chatMeta = parseExtra(chat.metadata) as Record<string, unknown>;
   let currentResponseForRewrite = agentContext.mainResponse;
   const originalResponseBeforeRewrite = agentContext.mainResponse;
+  // Stale-edit baseline tracked in the raw (unresolved) domain to match the
+  // stored message content. `currentResponseForRewrite` is macro-resolved, so
+  // comparing it against the raw stored content falsely trips on any message
+  // containing literal {{...}} macros.
+  let expectedStoredMessageContent = mainResponseRaw;
   let retryBaseGameStateSnapshotPromise: ReturnType<typeof gameStateStore.getForGeneration> | null = null;
   const loadRetryBaseGameStateSnapshot = () => {
     retryBaseGameStateSnapshotPromise ??= gameStateStore.getForGeneration(chatId, {
@@ -2008,14 +2046,18 @@ async function applyRetryResultEffects(args: {
           rewriteAllowed && editedText.trim().length > 0 && editedText !== currentResponseForRewrite;
         if (retryMessageId && changedMessage) {
           const currentMessage = await chats.getMessage(retryMessageId);
-          if ((currentMessage?.content ?? "") !== currentResponseForRewrite) {
+          if ((currentMessage?.content ?? "") !== expectedStoredMessageContent) {
             logger.info(
               "[retry-agents] Skipping rewrite for message %s because the message was edited during agent retry",
               retryMessageId,
             );
-            break;
+            // Skip only this stale rewrite — later results (tracker, quest, persona,
+            // cyoa, illustrator, sprite) must still be applied.
+            continue;
           }
           currentResponseForRewrite = editedText;
+          // We just wrote editedText, so that becomes the new expected stored content.
+          expectedStoredMessageContent = editedText;
           await chats.updateMessageContent(retryMessageId, editedText);
           const originalText = strictEditNeeded ? originalResponseBeforeRewrite : null;
           if (originalText) {
@@ -2765,7 +2807,12 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       }
       await attachRetrySpotifyToolContexts({ agentsStore, chats, chatId, chatMeta, resolvedAgents });
       await attachRetryChatMetadataToolContexts({ chats, chatId, chatMeta, resolvedAgents });
-      await attachRetryLorebookWriterToolContexts({ lorebooksStore, resolvedAgents });
+      await attachRetryLorebookWriterToolContexts({
+        lorebooksStore,
+        resolvedAgents,
+        requireApproval: requireAgentWriteApproval,
+        chatId,
+      });
       const cyoaAgentWillRun = resolvedAgents.some((e) => e.resolved.type === "cyoa");
       const agentContext = await buildRetryAgentContext({
         cyoaAgentWillRun,
@@ -3001,6 +3048,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         retrySwipeIndex,
         results,
         agentContext,
+        mainResponseRaw: (lastAssistant?.content as string) ?? "",
         lorebooksStore,
         gameStateStore,
         conns,

--- a/packages/server/src/routes/knowledge-sources.routes.ts
+++ b/packages/server/src/routes/knowledge-sources.routes.ts
@@ -153,6 +153,7 @@ export async function extractFileText(
 
   const ext = extname(filePath).toLowerCase();
   let text = "";
+  let extractionFailed = false;
 
   if (TEXT_EXTS.has(ext)) {
     text = await readFile(filePath, "utf-8");
@@ -166,6 +167,7 @@ export async function extractFileText(
       text = result.text;
     } catch {
       text = "[PDF text extraction failed]";
+      extractionFailed = true;
     } finally {
       // Always free the parser's workers/memory, even on a getText() failure,
       // and never let a destroy() error mask a successful extraction.
@@ -179,7 +181,9 @@ export async function extractFileText(
     }
   }
 
-  if (fileId && metadata) {
+  // Only cache a successful extraction. A transient parse failure must not poison
+  // the source for the process lifetime — skip the cache so the next turn re-attempts.
+  if (fileId && metadata && !extractionFailed) {
     setCachedText(fileId, { size: metadata.size, uploadedAt: metadata.uploadedAt, text });
   }
 

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1907,8 +1907,8 @@ const JSON_AGENTS = new Set([
  */
 function sanitizeTextAgentResponse(agentType: string, text: string): string {
   const cleaned = text
-    .replace(/<committed_tracker_state>[\s\S]*?<\/committed_tracker_state>/gi, "")
-    .replace(/<assistant_response>[\s\S]*?<\/assistant_response>/gi, "")
+    .replace(/<committed_tracker_state\b[^>]*>[\s\S]*?<\/committed_tracker_state\s*>/gi, "")
+    .replace(/<assistant_response\b[^>]*>[\s\S]*?<\/assistant_response\s*>/gi, "")
     .trim();
 
   return cleaned;

--- a/packages/server/src/services/agents/knowledge-retrieval.ts
+++ b/packages/server/src/services/agents/knowledge-retrieval.ts
@@ -80,18 +80,22 @@ export async function executeKnowledgeRetrieval(
   // ── Multi-pass: split into chunks ──
   const chunks = chunkText(sourceMaterial, contextBudget);
   const extractions: string[] = [];
+  let consolidatedText: string | null = null;
   let totalTokens = 0;
   let totalDuration = 0;
 
   for (let i = 0; i < chunks.length; i++) {
+    const isLastChunk = i === chunks.length - 1;
+    // The final chunk runs as a consolidation pass only when earlier chunks
+    // produced extractions to merge (so it receives `_previousExtractions`).
+    const isConsolidationPass = isLastChunk && extractions.length > 0;
     const chunkContext: AgentContext = {
       ...baseContext,
       memory: {
         ...baseContext.memory,
         _sourceMaterial: chunks[i]!,
         _chunkInfo: { current: i + 1, total: chunks.length },
-        // On the last chunk, include all previous extractions for consolidation
-        ...(i === chunks.length - 1 && extractions.length > 0 ? { _previousExtractions: extractions } : {}),
+        ...(isConsolidationPass ? { _previousExtractions: extractions } : {}),
       },
     };
 
@@ -102,66 +106,31 @@ export async function executeKnowledgeRetrieval(
     if (result.success && result.data) {
       const text = typeof result.data === "string" ? result.data : ((result.data as { text?: string })?.text ?? "");
       if (text && text !== "No relevant information found.") {
-        extractions.push(text);
+        if (isConsolidationPass) {
+          // The consolidation pass already merged every prior extraction with the
+          // final chunk; track its output explicitly so we return it alone instead
+          // of re-injecting the partials it absorbed.
+          consolidatedText = text;
+        } else {
+          extractions.push(text);
+        }
       }
     }
   }
 
-  // If we had multiple chunks but the last chunk did consolidation, use its result.
-  // If only one extraction or none, no extra consolidation needed.
-  if (extractions.length === 0) {
-    return {
-      agentId: config.id,
-      agentType: config.type,
-      type: "context_injection",
-      data: { text: "" },
-      tokensUsed: totalTokens,
-      durationMs: totalDuration,
-      success: true,
-      error: null,
-    };
-  }
-
-  // If we had extractions and multiple chunks, prefer the consolidated output
-  // when available. If the final chunk failed or produced no output, we may
-  // have fewer extractions than chunks; in that case, fall back to combining
-  // all partial extractions so we don't drop earlier results.
-  if (chunks.length > 1 && extractions.length > 0) {
-    if (extractions.length < chunks.length) {
-      // Best-effort consolidation: concatenate all partial extractions.
-      const combined = extractions.filter(Boolean).join("\n\n");
-      return {
-        agentId: config.id,
-        agentType: config.type,
-        type: "context_injection",
-        data: { text: combined },
-        tokensUsed: totalTokens,
-        durationMs: totalDuration,
-        success: true,
-        error: null,
-      };
-    }
-
-    // The last extraction is the consolidated result
-    const consolidated = extractions[extractions.length - 1]!;
-    return {
-      agentId: config.id,
-      agentType: config.type,
-      type: "context_injection",
-      data: { text: consolidated },
-      tokensUsed: totalTokens,
-      durationMs: totalDuration,
-      success: true,
-      error: null,
-    };
-  }
-
-  // Single extraction — return as-is
+  // Prefer the consolidated output when the final consolidation pass produced text.
+  // Only fall back to concatenating the raw partial extractions when the
+  // consolidation pass itself produced nothing (or never ran) — so we neither drop
+  // earlier results nor double-inject facts the consolidation already merged. This
+  // covers the case where a middle chunk returned "No relevant information found.":
+  // `extractions.length < chunks.length` no longer forces a partial concatenation
+  // that would duplicate the facts the final pass already consolidated.
+  const finalText = consolidatedText && consolidatedText.length > 0 ? consolidatedText : extractions.filter(Boolean).join("\n\n");
   return {
     agentId: config.id,
     agentType: config.type,
     type: "context_injection",
-    data: { text: extractions[0] ?? "" },
+    data: { text: finalText },
     tokensUsed: totalTokens,
     durationMs: totalDuration,
     success: true,

--- a/packages/server/src/services/generation/tool-resolution-runtime.ts
+++ b/packages/server/src/services/generation/tool-resolution-runtime.ts
@@ -13,6 +13,10 @@ import {
 import { resolveSpotifyCredentials, spotifyHasScope } from "../spotify/spotify.service.js";
 import { logger } from "../../lib/logger.js";
 import {
+  agentWriteApprovalRequired,
+  buildLorebookWriteApprovalProposal,
+} from "../../routes/generate/agent-write-approval.js";
+import {
   readSpotifyNumberField,
   readSpotifyPlaybackTrackUri,
   readSpotifyStringField,
@@ -367,6 +371,7 @@ function createLorebookEntryWriter(
   lorebooksStore: LorebooksStore,
   agent: ResolvedAgent,
   agentSettings: Record<string, unknown>,
+  options: { requireApproval: boolean; chatId: string },
 ) {
   const writableLorebookId = resolveAgentWritableLorebookId(agentSettings);
   if (!writableLorebookId) return undefined;
@@ -379,6 +384,33 @@ function createLorebookEntryWriter(
     tag?: string;
     mode: "create" | "replace" | "append";
   }) => {
+    // When agent write-approval is required, never write inline — surface a proposal
+    // envelope (mirroring the structured lorebook_update gate) so the user approves
+    // the write before it touches the lorebook DB.
+    if (options.requireApproval) {
+      return {
+        requiresApproval: true,
+        approval: buildLorebookWriteApprovalProposal({
+          chatId: options.chatId,
+          agentType: agent.type,
+          agentName: agent.name ?? agent.type,
+          updates: [
+            {
+              action: entry.mode === "create" ? "create" : "update",
+              name: entry.name,
+              content: entry.content,
+              description: entry.description ?? "",
+              keys: entry.keys,
+              tag: entry.tag ?? "",
+              mode: entry.mode,
+            },
+          ],
+          preferredTargetLorebookId: writableLorebookId,
+          writableLorebookIds: [writableLorebookId],
+        }),
+      };
+    }
+
     const targetLorebook = await lorebooksStore.getById(writableLorebookId);
     if (!targetLorebook) {
       return { error: "Selected lorebook is no longer available.", lorebookId: writableLorebookId };
@@ -664,7 +696,10 @@ export async function resolveGenerationTools({
     if (agentTools.length === 0) continue;
 
     const allowedToolNames = new Set(agentTools.map((toolDef) => toolDef.function.name));
-    const saveLorebookEntry = createLorebookEntryWriter(lorebooksStore, agent, agentSettings);
+    const saveLorebookEntry = createLorebookEntryWriter(lorebooksStore, agent, agentSettings, {
+      requireApproval: agentWriteApprovalRequired(chatMetadata),
+      chatId,
+    });
     const replaceChatMessageContentForAgent = customAgentHasCapability(agentSettings, "edit_messages")
       ? replaceChatMessageContent
       : undefined;


### PR DESCRIPTION
## Linked issue

Closes #2639
Closes #2640
Closes #2641
Closes #2642
Closes #2643

## Why this change

Five independent bugs in the agents subsystem, all in `packages/server`. They were filed separately but share a code area and are each small, so I'm batching them into one reviewable PR with a tight, per-issue diff.

- **#2639** — During an agent retry, `applyRetryResultEffects` runs every agent result through one `for (const result of sortedResults)` loop. The `text_rewrite` stale-edit guard ran `break`, which exits the *entire* loop the moment a rewrite is skipped, silently dropping every later result (tracker, quest, persona, cyoa, illustrator, sprite). On top of that, the guard compared the macro-*resolved* baseline (`currentResponseForRewrite`, seeded from `agentContext.mainResponse`) against the *raw* stored `currentMessage.content`, so any message containing literal `{{...}}` macros falsely tripped "edited during retry" — meaning a perfectly normal retry could drop tracker writes for no reason.
- **#2640** — The `save_lorebook_entry` tool writer wrote to the lorebook DB immediately, bypassing `agentWriteApprovalRequired`. Approval only gated the structured `lorebook_update` path, so an agent that wrote lore via the tool call skipped the user's approval gate entirely.
- **#2641** — `sanitizeTextAgentResponse` stripped only the bare `<committed_tracker_state>` tag, but `buildCommittedTrackerStateContext` now emits `<committed_tracker_state message_id="...">`. The attributed tag slipped through and a smaller model could leak tracker JSON into the injected directive.
- **#2642** — `extractFileText` cached the `"[PDF text extraction failed]"` sentinel unconditionally, so a single transient parse failure poisoned that knowledge source for the rest of the process lifetime — every later turn served the failure string instead of re-attempting.
- **#2643** — Multi-pass knowledge retrieval used `extractions.length < chunks.length` as the "consolidation missing" proxy, but a chunk is also absent from `extractions` when it returned `"No relevant information found."`. So when a middle chunk came back empty, it concatenated the raw partials with the final consolidation that had *already* merged them — double-injecting those facts into the prompt.

## What changed

- **#2639** (`routes/generate/retry-agents-route.ts`): changed the stale-rewrite guard's `break` to `continue` so only the stale rewrite is skipped and every later result still persists. Added an `expectedStoredMessageContent` baseline seeded from the raw last-assistant content (threaded in as `mainResponseRaw`) and advanced to `editedText` after each applied rewrite, so the guard now compares raw-vs-raw and no longer misfires on macro-bearing messages.
- **#2640** (`services/generation/tool-resolution-runtime.ts` + `routes/generate/retry-agents-route.ts`): both lorebook tool writers (`createLorebookEntryWriter` and the retry `attachRetryLorebookWriterToolContexts` writer) now check the approval flag and, when approval is required, return a proposal envelope built with `buildLorebookWriteApprovalProposal` instead of writing inline — mirroring the existing structured `lorebook_update` gate.
- **#2641** (`services/agents/agent-executor.ts`): made both strips attribute-tolerant — `/<committed_tracker_state\b[^>]*>[\s\S]*?<\/committed_tracker_state\s*>/gi` and the same for the adjacent `<assistant_response>` strip.
- **#2642** (`routes/knowledge-sources.routes.ts`): track an `extractionFailed` flag and skip `setCachedText` when extraction throws, so only successful extractions are cached and a transient failure is re-attempted next turn.
- **#2643** (`services/agents/knowledge-retrieval.ts`): track consolidation success with an explicit `consolidatedText` variable. Return only the consolidated text when the final pass produced output; fall back to concatenating raw partials only when the consolidation pass itself produced nothing.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- **#2639 (verified live):** Deployed this branch to my private EasyPanel instance and drove `/api/generate/retry-agents` on a roleplay chat whose assistant message contains a literal `{{user}}` macro (the false-trigger condition), with a batch of **prose-guardian (text_rewrite) + quest + world-state + character-tracker + persona-stats**. The stream ran `agent_start → 5 agent_results (incl. prose-guardian/text_rewrite, success) → 4 game_state_patch → done`: all four tracker writes persisted in the same batch as the rewrite result, no early break, no error. On that run prose-guardian returned no-edit-needed, so the stale-edit guard branch itself wasn't entered — the break-vs-continue decision is covered by the diff + `pnpm check` rather than a live trip.
- **#2640:** Manually verify that, with agent write-approval enabled, an agent using the `save_lorebook_entry` tool surfaces a proposal rather than a silent inline lorebook write (both the main generation path and the retry path).
- **#2641:** Manually verify a text-injection agent shown attributed `<committed_tracker_state message_id="...">` context no longer leaks the tracker block into its injected output.
- **#2642:** Manually verify that after a transient PDF parse failure the source recovers on a later turn rather than permanently returning the failure sentinel.
- **#2643:** Manually verify a long (multi-chunk) knowledge source with an empty middle chunk no longer double-injects the consolidated facts.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Knowledge base entries created or modified by agents can now require approval before being saved.

* **Bug Fixes**
  * PDF text extraction no longer caches failed extractions.
  * Agent message retries now handle stale content more gracefully without interrupting other agent effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->