### PR TITLE
[codex] Polish chat and settings UI controls

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -158,7 +158,7 @@ export function App() {
     const accent = appAccentColor.trim();
     if (accent) {
       if (isCssGradient(accent)) {
-        root.style.setProperty("--marinara-chat-chrome-accent", getCssColorFallback(accent, "#d4d4d4"));
+        root.style.setProperty("--marinara-chat-chrome-accent", getCssColorFallback(accent, "#d4acfb"));
         root.style.setProperty("--marinara-chat-chrome-accent-gradient", accent);
         root.dataset.marinaraChatChromeAccentMode = "gradient";
       } else {

--- a/packages/client/src/components/agents/RegexScriptEditor.tsx
+++ b/packages/client/src/components/agents/RegexScriptEditor.tsx
@@ -32,6 +32,7 @@ import {
 import { cn } from "../../lib/utils";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
 import { HelpTooltip } from "../ui/HelpTooltip";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { applyRegexReplacement, resolveMacros, type MacroContext, type RegexPlacement } from "@marinara-engine/shared";
 
 // ═══════════════════════════════════════════════
@@ -776,14 +777,14 @@ export function RegexScriptEditor() {
               {/* Order */}
               <div className="flex items-center gap-3">
                 <span className="text-xs font-medium w-24">Execution Order</span>
-                <input
-                  type="number"
+                <DraftNumberInput
                   value={localOrder}
-                  onChange={(e) => {
-                    setLocalOrder(parseInt(e.target.value) || 0);
+                  onCommit={(value) => {
+                    setLocalOrder(value);
                     markDirty();
                   }}
-                  className="w-20 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  selectOnFocus
+                  className="w-20 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                 />
                 <span className="text-[0.625rem] text-[var(--muted-foreground)]">Lower numbers run first</span>
               </div>
@@ -792,24 +793,30 @@ export function RegexScriptEditor() {
               <div className="flex items-center gap-3">
                 <span className="text-xs font-medium w-24">Depth Range</span>
                 <input
-                  type="number"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
                   value={localMinDepth ?? ""}
                   onChange={(e) => {
-                    setLocalMinDepth(e.target.value ? parseInt(e.target.value) : null);
+                    if (!/^\d*$/.test(e.target.value)) return;
+                    setLocalMinDepth(e.target.value ? parseInt(e.target.value, 10) : null);
                     markDirty();
                   }}
-                  className="w-16 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  className="w-16 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                   placeholder="Min"
                 />
                 <span className="text-[0.625rem] text-[var(--muted-foreground)]">to</span>
                 <input
-                  type="number"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
                   value={localMaxDepth ?? ""}
                   onChange={(e) => {
-                    setLocalMaxDepth(e.target.value ? parseInt(e.target.value) : null);
+                    if (!/^\d*$/.test(e.target.value)) return;
+                    setLocalMaxDepth(e.target.value ? parseInt(e.target.value, 10) : null);
                     markDirty();
                   }}
-                  className="w-16 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  className="w-16 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-xs ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                   placeholder="Max"
                 />
                 <span className="text-[0.625rem] text-[var(--muted-foreground)]">

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -2005,7 +2005,7 @@ export function BotBrowserView() {
                       setPage(1);
                     }}
                     placeholder="Search characters..."
-                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] py-2 pl-9 pr-8 text-sm text-[var(--foreground)] placeholder-[var(--muted-foreground)] outline-none transition-colors focus:border-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="h-10 w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] py-0 pl-9 pr-8 text-sm text-[var(--foreground)] placeholder-[var(--muted-foreground)] outline-none transition-colors focus:border-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60 md:h-9"
                   />
                   {query && (
                     <button
@@ -2023,7 +2023,7 @@ export function BotBrowserView() {
                     setSort(e.target.value);
                     setPage(1);
                   }}
-                  className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)] outline-none"
+                  className="h-10 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-0 text-xs text-[var(--foreground)] outline-none md:h-9"
                 >
                   {sortGroups.map((group) =>
                     group.label ? (
@@ -2047,7 +2047,7 @@ export function BotBrowserView() {
                 <button
                   onClick={() => setShowTagPanel((v) => !v)}
                   className={cn(
-                    "flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-colors",
+                    "flex h-10 items-center gap-1.5 rounded-lg border px-3 py-0 text-xs transition-colors md:h-9",
                     showTagPanel || includeTags.length > 0 || excludeTags.length > 0
                       ? "border-[var(--primary)]/40 bg-[var(--primary)]/10 text-[var(--primary)]"
                       : "border-[var(--border)] bg-[var(--secondary)] hover:bg-[var(--accent)]",
@@ -2068,7 +2068,7 @@ export function BotBrowserView() {
                   <button
                     onClick={() => setShowFiltersPanel((v) => !v)}
                     className={cn(
-                      "flex items-center gap-1.5 rounded-lg border px-3 py-2 text-xs transition-colors",
+                      "flex h-10 items-center gap-1.5 rounded-lg border px-3 py-0 text-xs transition-colors md:h-9",
                       showFiltersPanel || hasActiveFeatures
                         ? "border-[var(--primary)]/40 bg-[var(--primary)]/10 text-[var(--primary)]"
                         : "border-[var(--border)] bg-[var(--secondary)] hover:bg-[var(--accent)]",

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -4,7 +4,6 @@ import {
   ArrowUpDown,
   Download,
   Hash,
-  MessageCircle,
   Pencil,
   Plus,
   Search,
@@ -12,7 +11,6 @@ import {
   User,
 } from "lucide-react";
 import { useCharacters } from "../../hooks/use-characters";
-import { useStartChatFromCharacter } from "../../hooks/use-start-chat-from-character";
 import { getCharacterTitle } from "../../lib/character-display";
 import { estimateCharacterCardTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
@@ -20,9 +18,11 @@ import { useUIStore, type CharacterLibrarySort } from "../../stores/ui.store";
 import type { CharacterData } from "@marinara-engine/shared";
 
 const libraryToolbarButtonClass =
-  "mari-chrome-control mari-chrome-control--small h-7 min-w-0 px-2 text-[0.75rem]";
+  "mari-chrome-control h-10 min-w-0 px-3 text-[0.75rem] md:h-9";
 const libraryToolbarFieldClass =
-  "mari-chrome-field mari-chrome-field--compact h-7 w-full text-[0.75rem]";
+  "mari-chrome-field h-10 w-full text-[0.75rem] md:h-9";
+const libraryNewCharacterButtonClass =
+  "flex h-10 min-w-0 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-pink-400 to-rose-500 px-3 text-[0.75rem] font-semibold text-white shadow-md shadow-pink-500/15 transition-all hover:shadow-lg hover:shadow-pink-500/25 active:scale-[0.98] md:h-9";
 
 type CharacterRow = {
   id: string;
@@ -120,7 +120,6 @@ function CharacterLibraryDetailCard({
   character: ParsedCharacterRow;
   onEdit: (id: string) => void;
 }) {
-  const { startChatFromCharacter, isStartingChat } = useStartChatFromCharacter();
   const characterName = getText(character.parsed.name) || "Unnamed";
   const characterTitle = getCharacterTitle({ name: characterName, comment: character.comment });
   const characterMeta = getCharacterMeta(character);
@@ -184,27 +183,8 @@ function CharacterLibraryDetailCard({
 
             <div className="mt-4 flex flex-wrap gap-2">
               <button
-                type="button"
-                onClick={() =>
-                  startChatFromCharacter({
-                    characterId: character.id,
-                    characterName,
-                    mode: "roleplay",
-                    firstMessage: getText(character.parsed.first_mes),
-                    alternateGreetings: Array.isArray(character.parsed.alternate_greetings)
-                      ? character.parsed.alternate_greetings
-                      : [],
-                  })
-                }
-                disabled={isStartingChat}
-                className="inline-flex items-center gap-2 rounded-2xl bg-[var(--primary)] px-4 py-2.5 text-sm font-medium text-[var(--primary-foreground)] shadow-lg shadow-pink-500/15 transition-all hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <MessageCircle size="0.875rem" />
-                Start New Chat
-              </button>
-              <button
                 onClick={() => onEdit(character.id)}
-                className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-pink-400 to-rose-500 px-4 py-2.5 text-sm font-medium text-white shadow-lg shadow-pink-500/15 transition-all hover:shadow-pink-500/25"
+                className="mari-chrome-control mari-chrome-control--primary px-4 py-2.5 text-sm"
               >
                 <Pencil size="0.875rem" />
                 Edit Character
@@ -414,17 +394,19 @@ export function CharacterLibraryView() {
           <div className="grid w-full grid-cols-2 gap-1.5 sm:ml-auto sm:w-72 lg:w-80">
             <button
               onClick={() => openModal("create-character")}
-              className={libraryToolbarButtonClass}
+              className={libraryNewCharacterButtonClass}
+              title="New character"
+              aria-label="New character"
             >
               <Plus size="0.75rem" />
-              New
             </button>
             <button
               onClick={() => openModal("import-character")}
               className={libraryToolbarButtonClass}
+              title="Import character"
+              aria-label="Import character"
             >
               <Download size="0.75rem" />
-              Import
             </button>
 
             <div className="relative min-w-0">

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -59,11 +59,22 @@ import type { CharacterMap, ExpressionAvatarResolver, MessageSelectionToggle, Pe
 import { GenerationReplayDetailsModal, hasGenerationReplayDetails } from "./GenerationReplayDetailsModal";
 import { ImagePromptPanel } from "./ImagePromptPanel";
 import { SwipeJumpControl } from "./SwipeJumpControl";
+import {
+  NEUTRAL_PANEL_HEADER,
+  NEUTRAL_PANEL_SCROLL_AREA,
+  NEUTRAL_PANEL_SHELL,
+  NEUTRAL_PANEL_TITLE,
+} from "../ui/neutral-surface-styles";
 
 const MESSAGE_ACTION_ICON_SIZE = "1em";
 const MESSAGE_SWIPE_ICON_SIZE = "1.15em";
 const MESSAGE_DOUBLE_TAP_MS = 320;
 const MESSAGE_DOUBLE_TAP_DISTANCE_PX = 26;
+const MESSAGE_CHROME_ACTIVE_ICON_CLASS =
+  "text-[var(--marinara-chat-chrome-button-text-active)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
+const MESSAGE_CHROME_MARKER_LINE_CLASS = "bg-[var(--marinara-chat-chrome-button-border-active)]";
+const MESSAGE_CHROME_MARKER_TEXT_CLASS = "text-[var(--marinara-chat-chrome-highlight-text)]";
+const MESSAGE_CHROME_RING_CLASS = "ring-[var(--marinara-chat-chrome-focus-ring)]";
 
 function isMessageQuickEditIgnoredTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -86,8 +97,8 @@ function HiddenFromAIMessageButton({
   isHiddenExpanded: boolean;
 }) {
   const statusClassName = cn(
-    "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80",
-    roleplay && "text-amber-200/60",
+    "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-highlight-text)]",
+    roleplay && "opacity-80",
   );
 
   if (!canCollapse) {
@@ -104,9 +115,9 @@ function HiddenFromAIMessageButton({
         type="button"
         onClick={onExpand}
         className={cn(
-          "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80 transition-colors hover:bg-amber-500/10 hover:text-amber-400",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40",
-          roleplay && "text-amber-200/60 hover:bg-white/5 hover:text-amber-100/80",
+          "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-highlight-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
+          roleplay && "opacity-80 hover:opacity-100",
         )}
         aria-label={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
         title={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
@@ -127,8 +138,8 @@ function HiddenFromAIMessageSummary({ roleplay, onExpand }: { roleplay?: boolean
         onExpand();
       }}
       className={cn(
-        "flex w-full items-center gap-2 rounded-lg border border-amber-400/20 bg-amber-500/10 px-3 py-2 text-left text-[0.75rem] text-amber-600/90 transition-colors hover:bg-amber-500/15 dark:text-amber-200/75",
-        roleplay && "border-amber-200/15 bg-white/5 text-amber-100/70 hover:bg-white/10",
+        "flex w-full items-center gap-2 rounded-lg border border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-3 py-2 text-left text-[0.75rem] text-[var(--marinara-chat-chrome-highlight-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)]",
+        roleplay && "opacity-85 hover:opacity-100",
       )}
       title="Expand hidden from AI message"
       aria-label="Expand hidden from AI message"
@@ -1652,7 +1663,7 @@ export const ChatMessage = memo(function ChatMessage({
               }}
               aria-label="Delete message"
               className={cn(
-                "absolute -right-1 -top-1 rounded-md p-1 text-white/20 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100",
+                "absolute -right-1 -top-1 rounded-md p-1 text-white/20 opacity-0 transition-all hover:bg-foreground/10 hover:text-foreground/70 group-hover:opacity-100",
                 showActions && "opacity-100",
               )}
               title="Delete"
@@ -1712,7 +1723,7 @@ export const ChatMessage = memo(function ChatMessage({
                   onClick={() => onDelete(message.id)}
                   aria-label="Delete message"
                   className={cn(
-                    "absolute right-2 top-2 rounded-md p-1 text-white/20 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100",
+                    "absolute right-2 top-2 rounded-md p-1 text-white/20 opacity-0 transition-all hover:bg-foreground/10 hover:text-foreground/70 group-hover:opacity-100",
                     showActions && "opacity-100",
                   )}
                   title="Delete"
@@ -1908,11 +1919,11 @@ export const ChatMessage = memo(function ChatMessage({
             {/* Conversation start marker */}
             {isConversationStart && (
               <div className="flex items-center gap-1.5 px-1 mb-1">
-                <span className="h-px flex-1 bg-amber-400/30" />
-                <span className="text-[0.5625rem] font-semibold uppercase tracking-widest text-amber-400/70">
+                <span className={cn("h-px flex-1", MESSAGE_CHROME_MARKER_LINE_CLASS)} />
+                <span className={cn("text-[0.5625rem] font-semibold uppercase tracking-widest", MESSAGE_CHROME_MARKER_TEXT_CLASS)}>
                   New Start
                 </span>
-                <span className="h-px flex-1 bg-amber-400/30" />
+                <span className={cn("h-px flex-1", MESSAGE_CHROME_MARKER_LINE_CLASS)} />
               </div>
             )}
 
@@ -1926,8 +1937,8 @@ export const ChatMessage = memo(function ChatMessage({
                   : "rounded-tl-sm text-white/90 ring-1 ring-white/8",
                 isGrouped && (isUser ? "rounded-tr-2xl" : "rounded-tl-2xl"),
                 isStreaming && "rpg-streaming",
-                isConversationStart && "ring-amber-400/30",
-                isHiddenFromAI && "ring-amber-300/35 saturate-75",
+                isConversationStart && MESSAGE_CHROME_RING_CLASS,
+                isHiddenFromAI && cn(MESSAGE_CHROME_RING_CLASS, "saturate-75"),
                 editing && "w-full",
               )}
               style={
@@ -2120,7 +2131,7 @@ export const ChatMessage = memo(function ChatMessage({
               )}
             >
               <ActionBtn
-                icon={copied ? "\u2713" : <Copy size={MESSAGE_ACTION_ICON_SIZE} />}
+                icon={copied ? <Check size={MESSAGE_ACTION_ICON_SIZE} /> : <Copy size={MESSAGE_ACTION_ICON_SIZE} />}
                 onClick={handleCopy}
                 title="Copy"
                 dark
@@ -2129,7 +2140,6 @@ export const ChatMessage = memo(function ChatMessage({
                 icon={<Languages size={MESSAGE_ACTION_ICON_SIZE} />}
                 onClick={() => translate(message.id, message.content, message.chatId)}
                 title={translatedText ? "Hide translation" : "Translate"}
-                className={translatedText ? "text-blue-400/80 hover:text-blue-300" : undefined}
                 dark
               />
               <ActionBtn icon={<Pencil size={MESSAGE_ACTION_ICON_SIZE} />} onClick={startEditing} title="Edit" dark />
@@ -2159,7 +2169,7 @@ export const ChatMessage = memo(function ChatMessage({
                 icon={<Flag size={MESSAGE_ACTION_ICON_SIZE} />}
                 onClick={() => onToggleConversationStart?.(message.id, isConversationStart)}
                 title={isConversationStart ? "Remove conversation start" : "Mark as new start"}
-                className={isConversationStart ? "text-amber-400/80 hover:text-amber-300" : undefined}
+                className={isConversationStart ? MESSAGE_CHROME_ACTIVE_ICON_CLASS : undefined}
                 dark
               />
               {onToggleHiddenFromAI && (
@@ -2173,7 +2183,7 @@ export const ChatMessage = memo(function ChatMessage({
                   }
                   onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
                   title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
-                  className={isHiddenFromAI ? "text-amber-400/90 hover:text-amber-300" : undefined}
+                  className={isHiddenFromAI ? MESSAGE_CHROME_ACTIVE_ICON_CLASS : undefined}
                   dark
                 />
               )}
@@ -2222,7 +2232,6 @@ export const ChatMessage = memo(function ChatMessage({
                 icon={<Trash2 size={MESSAGE_ACTION_ICON_SIZE} />}
                 onClick={() => onDelete?.(message.id)}
                 title="Delete"
-                className="hover:text-red-400"
                 dark
               />
               {ttsEnabled && (
@@ -2239,14 +2248,12 @@ export const ChatMessage = memo(function ChatMessage({
                         }
                         onClick={handlePauseResumeTTS}
                         title={isPausedThis ? "Resume speaking" : "Pause speaking"}
-                        className="text-sky-400 hover:text-sky-300"
                         dark
                       />
                       <ActionBtn
                         icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}
                         onClick={handleRestartTTS}
                         title="Restart speaking"
-                        className="text-sky-400 hover:text-sky-300"
                         dark
                       />
                     </>
@@ -2271,7 +2278,6 @@ export const ChatMessage = memo(function ChatMessage({
                             ? "Stop speaking"
                             : "Speak"
                     }
-                    className={isSpeakingThis ? "text-sky-400 hover:text-sky-300" : undefined}
                     disabled={!hasTTSContent || (ttsBusy && !isSpeakingThis)}
                     dark
                   />
@@ -2434,11 +2440,11 @@ export const ChatMessage = memo(function ChatMessage({
           {/* Conversation start marker */}
           {isConversationStart && (
             <div className="flex items-center gap-1.5 px-2 mb-0.5">
-              <span className="h-px flex-1 bg-amber-500/30" />
-              <span className="text-[0.5625rem] font-semibold uppercase tracking-widest text-amber-500/70">
+              <span className={cn("h-px flex-1", MESSAGE_CHROME_MARKER_LINE_CLASS)} />
+              <span className={cn("text-[0.5625rem] font-semibold uppercase tracking-widest", MESSAGE_CHROME_MARKER_TEXT_CLASS)}>
                 New Start
               </span>
-              <span className="h-px flex-1 bg-amber-500/30" />
+              <span className={cn("h-px flex-1", MESSAGE_CHROME_MARKER_LINE_CLASS)} />
             </div>
           )}
 
@@ -2452,7 +2458,8 @@ export const ChatMessage = memo(function ChatMessage({
               isGrouped && isUser && "rounded-br-2xl rounded-tr-md",
               isGrouped && !isUser && "rounded-bl-2xl rounded-tl-md",
               isStreaming && "ring-2 ring-[var(--primary)]/20",
-              isConversationStart && "ring-1 ring-amber-500/30",
+              isConversationStart && cn("ring-1", MESSAGE_CHROME_RING_CLASS),
+              isHiddenFromAI && cn("ring-1 saturate-75", MESSAGE_CHROME_RING_CLASS),
               editing && "w-full",
             )}
             style={{ ...messageTextStyle, ...(boxBgColor ? { backgroundColor: boxBgColor } : {}) }}
@@ -2596,7 +2603,7 @@ export const ChatMessage = memo(function ChatMessage({
             )}
           >
             <ActionBtn
-              icon={copied ? "✓" : <Copy size={MESSAGE_ACTION_ICON_SIZE} />}
+              icon={copied ? <Check size={MESSAGE_ACTION_ICON_SIZE} /> : <Copy size={MESSAGE_ACTION_ICON_SIZE} />}
               onClick={handleCopy}
               title="Copy"
             />
@@ -2604,7 +2611,6 @@ export const ChatMessage = memo(function ChatMessage({
               icon={<Languages size={MESSAGE_ACTION_ICON_SIZE} />}
               onClick={() => translate(message.id, message.content, message.chatId)}
               title={translatedText ? "Hide translation" : "Translate"}
-              className={translatedText ? "text-blue-500" : undefined}
             />
             <ActionBtn icon={<Pencil size={MESSAGE_ACTION_ICON_SIZE} />} onClick={startEditing} title="Edit" />
             {proseGuardianOriginalText && (
@@ -2631,7 +2637,7 @@ export const ChatMessage = memo(function ChatMessage({
               icon={<Flag size={MESSAGE_ACTION_ICON_SIZE} />}
               onClick={() => onToggleConversationStart?.(message.id, isConversationStart)}
               title={isConversationStart ? "Remove conversation start" : "Mark as new start"}
-              className={isConversationStart ? "text-amber-500" : undefined}
+              className={isConversationStart ? MESSAGE_CHROME_ACTIVE_ICON_CLASS : undefined}
             />
             {isLastAssistantMessage && !isUser && (
               <ActionBtn
@@ -2676,7 +2682,7 @@ export const ChatMessage = memo(function ChatMessage({
                 }
                 onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
                 title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
-                className={isHiddenFromAI ? "text-amber-400/90 hover:text-amber-300" : undefined}
+                className={isHiddenFromAI ? MESSAGE_CHROME_ACTIVE_ICON_CLASS : undefined}
                 dark
               />
             )}
@@ -2684,7 +2690,6 @@ export const ChatMessage = memo(function ChatMessage({
               icon={<Trash2 size={MESSAGE_ACTION_ICON_SIZE} />}
               onClick={() => onDelete?.(message.id)}
               title="Delete"
-              className="hover:text-[var(--destructive)]"
             />
             {ttsEnabled && (
               <>
@@ -2700,13 +2705,11 @@ export const ChatMessage = memo(function ChatMessage({
                       }
                       onClick={handlePauseResumeTTS}
                       title={isPausedThis ? "Resume speaking" : "Pause speaking"}
-                      className="text-sky-500"
                     />
                     <ActionBtn
                       icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}
                       onClick={handleRestartTTS}
                       title="Restart speaking"
-                      className="text-sky-500"
                     />
                   </>
                 )}
@@ -2730,7 +2733,6 @@ export const ChatMessage = memo(function ChatMessage({
                           ? "Stop speaking"
                           : "Speak"
                   }
-                  className={isSpeakingThis ? "text-sky-500" : undefined}
                   disabled={!hasTTSContent || (ttsBusy && !isSpeakingThis)}
                 />
               </>
@@ -2793,25 +2795,25 @@ function ThinkingModal({ thinking, onClose }: { thinking: string; onClose: () =>
       onClick={onClose}
     >
       <div
-        className="relative mx-4 flex max-h-[70vh] w-full max-w-xl flex-col rounded-xl bg-[var(--card)] shadow-2xl ring-1 ring-[var(--border)]"
+        className={cn(NEUTRAL_PANEL_SHELL, "relative mx-4 flex max-h-[70vh] w-full max-w-xl flex-col overflow-hidden")}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-          <div className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
-            <Brain size="0.875rem" className="text-[var(--muted-foreground)]" />
+        <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between gap-3 px-4 py-3")}>
+          <div className={cn(NEUTRAL_PANEL_TITLE, "text-sm")}>
+            <Brain size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />
             Model Thoughts
           </div>
           <button
             type="button"
             onClick={onClose}
             aria-label="Close thoughts"
-            className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            className="mari-chrome-control mari-chrome-control--small p-1.5"
           >
             <X size="0.875rem" />
           </button>
         </div>
-        <div className="overflow-y-auto px-4 py-3">
-          <pre className="whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-[var(--muted-foreground)]">
+        <div className={cn(NEUTRAL_PANEL_SCROLL_AREA, "overflow-y-auto px-4 py-3")}>
+          <pre className="whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-[var(--marinara-chat-chrome-panel-text)]">
             {thinking}
           </pre>
         </div>
@@ -2845,7 +2847,7 @@ function ActionBtn({
       aria-label={title}
       disabled={disabled}
       className={cn(
-        "rounded-md p-[0.35em] text-[0.8125rem] transition-all active:scale-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
+        "inline-flex h-[1.7em] w-[1.7em] shrink-0 items-center justify-center rounded-md p-0 text-[0.8125rem] leading-none transition-all active:scale-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",
         dark
           ? "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70"
           : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1556,8 +1556,7 @@ export function ChatRoleplaySurface({
             >
               <div
                 className={cn(
-                  "pointer-events-auto relative mx-auto w-full",
-                  centerCompact ? "px-3" : "max-w-(--mari-roleplay-message-column-width) px-3 md:px-0",
+                  "mari-roleplay-input-column pointer-events-auto relative mx-auto px-3 md:px-0",
                 )}
               >
                 {chatMeta.sceneStatus === "active" && (

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2460,10 +2460,8 @@ export function ChatSettingsDrawer({
             updateMeta.mutate({ id: chat.id, enableMemoryRecall: !effectiveValue });
           }}
           className={cn(
-            "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-            effectiveValue
-              ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-              : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+            "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+            effectiveValue && "mari-chat-option-field--active",
           )}
         >
           <div className="flex-1 min-w-0">
@@ -2474,8 +2472,8 @@ export function ChatSettingsDrawer({
           </div>
           <div
             className={cn(
-              "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-              effectiveValue ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+              "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+              effectiveValue && "mari-chat-option-switch--active",
             )}
           >
             <div
@@ -3661,10 +3659,8 @@ export function ChatSettingsDrawer({
                   <button
                     onClick={() => updateMeta.mutate({ id: chat.id, groupSpeakerColors: !metadata.groupSpeakerColors })}
                     className={cn(
-                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.groupSpeakerColors
-                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                      "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                      metadata.groupSpeakerColors && "mari-chat-option-field--active",
                     )}
                   >
                     <div className="flex-1 min-w-0">
@@ -3676,8 +3672,8 @@ export function ChatSettingsDrawer({
                     </div>
                     <div
                       className={cn(
-                        "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.groupSpeakerColors ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                        "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                        metadata.groupSpeakerColors && "mari-chat-option-switch--active",
                       )}
                     >
                       <div
@@ -3745,10 +3741,8 @@ export function ChatSettingsDrawer({
                       })
                     }
                     className={cn(
-                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.groupTurnPromptEnabled !== false
-                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                      "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                      metadata.groupTurnPromptEnabled !== false && "mari-chat-option-field--active",
                     )}
                   >
                     <div className="min-w-0 flex-1">
@@ -3761,10 +3755,8 @@ export function ChatSettingsDrawer({
                     </div>
                     <div
                       className={cn(
-                        "ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.groupTurnPromptEnabled !== false
-                          ? "bg-[var(--primary)]"
-                          : "bg-[var(--muted-foreground)]/50",
+                        "mari-chat-option-switch ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                        metadata.groupTurnPromptEnabled !== false && "mari-chat-option-switch--active",
                       )}
                     >
                       <div
@@ -3783,10 +3775,8 @@ export function ChatSettingsDrawer({
                       })
                     }
                     className={cn(
-                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.groupSpeakerNamesInHistory === true
-                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                      "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                      metadata.groupSpeakerNamesInHistory === true && "mari-chat-option-field--active",
                     )}
                   >
                     <div className="min-w-0 flex-1">
@@ -3799,10 +3789,8 @@ export function ChatSettingsDrawer({
                     </div>
                     <div
                       className={cn(
-                        "ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.groupSpeakerNamesInHistory === true
-                          ? "bg-[var(--primary)]"
-                          : "bg-[var(--muted-foreground)]/50",
+                        "mari-chat-option-switch ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                        metadata.groupSpeakerNamesInHistory === true && "mari-chat-option-switch--active",
                       )}
                     >
                       <div
@@ -3875,10 +3863,8 @@ export function ChatSettingsDrawer({
                     updateMeta.mutate({ id: chat.id, autonomousMessages: !metadata.autonomousMessages });
                   }}
                   className={cn(
-                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    metadata.autonomousMessages
-                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                    "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                    metadata.autonomousMessages && "mari-chat-option-field--active",
                   )}
                 >
                   <div className="flex-1 min-w-0">
@@ -3889,8 +3875,8 @@ export function ChatSettingsDrawer({
                   </div>
                   <div
                     className={cn(
-                      "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      metadata.autonomousMessages ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                      "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                      metadata.autonomousMessages && "mari-chat-option-switch--active",
                     )}
                   >
                     <div
@@ -3911,10 +3897,8 @@ export function ChatSettingsDrawer({
                     });
                   }}
                   className={cn(
-                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    metadata.groupResponseOrder === "manual"
-                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                    "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                    metadata.groupResponseOrder === "manual" && "mari-chat-option-field--active",
                   )}
                 >
                   <div className="flex-1 min-w-0">
@@ -3925,10 +3909,8 @@ export function ChatSettingsDrawer({
                   </div>
                   <div
                     className={cn(
-                      "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      metadata.groupResponseOrder === "manual"
-                        ? "bg-[var(--primary)]"
-                        : "bg-[var(--muted-foreground)]/50",
+                      "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                      metadata.groupResponseOrder === "manual" && "mari-chat-option-switch--active",
                     )}
                   >
                     <div
@@ -3947,10 +3929,8 @@ export function ChatSettingsDrawer({
                       updateMeta.mutate({ id: chat.id, characterExchanges: !metadata.characterExchanges });
                     }}
                     className={cn(
-                      "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.characterExchanges
-                        ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                        : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                      "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                      metadata.characterExchanges && "mari-chat-option-field--active",
                     )}
                   >
                     <div className="flex-1 min-w-0">
@@ -3961,8 +3941,8 @@ export function ChatSettingsDrawer({
                     </div>
                     <div
                       className={cn(
-                        "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.characterExchanges ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                        "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                        metadata.characterExchanges && "mari-chat-option-switch--active",
                       )}
                     >
                       <div
@@ -3985,10 +3965,8 @@ export function ChatSettingsDrawer({
                     }
                   }}
                   className={cn(
-                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    conversationSchedulesEnabled
-                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                    "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                    conversationSchedulesEnabled && "mari-chat-option-field--active",
                   )}
                 >
                   <div className="flex-1 min-w-0">
@@ -3999,8 +3977,8 @@ export function ChatSettingsDrawer({
                   </div>
                   <div
                     className={cn(
-                      "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      conversationSchedulesEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                      "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                      conversationSchedulesEnabled && "mari-chat-option-switch--active",
                     )}
                   >
                     <div
@@ -4081,10 +4059,8 @@ export function ChatSettingsDrawer({
                     updateMeta.mutate({ id: chat.id, characterCommands: !conversationCommandsEnabled });
                   }}
                   className={cn(
-                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    conversationCommandsEnabled
-                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                    "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                    conversationCommandsEnabled && "mari-chat-option-field--active",
                   )}
                 >
                   <div className="min-w-0 flex-1">
@@ -4096,8 +4072,8 @@ export function ChatSettingsDrawer({
                   </div>
                   <div
                     className={cn(
-                      "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      conversationCommandsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                      "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                      conversationCommandsEnabled && "mari-chat-option-switch--active",
                     )}
                   >
                     <div
@@ -4127,10 +4103,8 @@ export function ChatSettingsDrawer({
                             })
                           }
                           className={cn(
-                            "flex min-h-[4.125rem] items-start justify-between gap-2 rounded-lg px-3 py-2 text-left transition-all",
-                            enabled
-                              ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                              : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                            "mari-chat-option-field flex min-h-[4.125rem] items-start justify-between gap-2 rounded-lg px-3 py-2 text-left transition-all",
+                            enabled && "mari-chat-option-field--active",
                           )}
                           aria-pressed={enabled}
                         >
@@ -4144,8 +4118,8 @@ export function ChatSettingsDrawer({
                           </div>
                           <div
                             className={cn(
-                              "mt-0.5 h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
-                              enabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                              "mari-chat-option-switch mt-0.5 h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
+                              enabled && "mari-chat-option-switch--active",
                             )}
                           >
                             <div

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -67,6 +67,7 @@ import {
   ROLEPLAY_PARAMETER_DEFAULTS,
   type EditableGenerationParameters,
 } from "../ui/GenerationParametersEditor";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 import {
   NEUTRAL_PANEL_HEADER,
   NEUTRAL_PANEL_SCROLL_AREA,
@@ -206,6 +207,8 @@ const WIZARD_PANEL_CLASS = cn(
 const WIZARD_FIELD_LABEL = "text-[0.6875rem] font-medium uppercase tracking-wider text-[var(--muted-foreground)]";
 const WIZARD_INPUT_CLASS =
   "w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow placeholder:text-[var(--muted-foreground)] focus:ring-[var(--primary)]/40";
+const WIZARD_NUMBER_INPUT_CLASS =
+  "w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)] outline-none ring-1 ring-transparent transition-shadow placeholder:text-[var(--muted-foreground)] focus:ring-[var(--primary)]/40";
 const WIZARD_GHOST_BUTTON_CLASS =
   "rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]";
 const WIZARD_PRIMARY_BUTTON_CLASS =
@@ -982,10 +985,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       <button
         onClick={() => setAutonomousEnabled((value) => !value)}
         className={cn(
-          "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-          autonomousEnabled
-            ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-            : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+          "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+          autonomousEnabled && "mari-chat-option-field--active",
         )}
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -1002,8 +1003,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
         </div>
         <div
           className={cn(
-            "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-            autonomousEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+            "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+            autonomousEnabled && "mari-chat-option-switch--active",
           )}
         >
           <div
@@ -1019,10 +1020,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
         <button
           onClick={() => setGenerateSchedule((value) => !value)}
           className={cn(
-            "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-            generateSchedule
-              ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-              : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+            "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+            generateSchedule && "mari-chat-option-field--active",
           )}
         >
           <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -1039,8 +1038,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
           </div>
           <div
             className={cn(
-              "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-              generateSchedule ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+              "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+              generateSchedule && "mari-chat-option-switch--active",
             )}
           >
             <div
@@ -1056,10 +1055,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       <button
         onClick={() => setCommandsEnabled((value) => !value)}
         className={cn(
-          "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-          commandsEnabled
-            ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-            : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+          "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+          commandsEnabled && "mari-chat-option-field--active",
         )}
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -1076,8 +1073,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
         </div>
         <div
           className={cn(
-            "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-            commandsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+            "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+            commandsEnabled && "mari-chat-option-switch--active",
           )}
         >
           <div
@@ -1105,10 +1102,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
                 }
                 aria-pressed={enabled}
                 className={cn(
-                  "flex min-h-[4rem] items-start justify-between gap-2 rounded-lg px-3 py-2 text-left transition-all",
-                  enabled
-                    ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                    : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                  "mari-chat-option-field flex min-h-[4rem] items-start justify-between gap-2 rounded-lg px-3 py-2 text-left transition-all",
+                  enabled && "mari-chat-option-field--active",
                 )}
               >
                 <div className="min-w-0 flex-1">
@@ -1119,8 +1114,8 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
                 </div>
                 <div
                   className={cn(
-                    "mt-0.5 h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
-                    enabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+                    "mari-chat-option-switch mt-0.5 h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
+                    enabled && "mari-chat-option-switch--active",
                   )}
                 >
                   <div
@@ -2030,10 +2025,8 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
             })
           }
           className={cn(
-            "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-            agentsEnabled
-              ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-              : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+            "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+            agentsEnabled && "mari-chat-option-field--active",
           )}
         >
           <div className="min-w-0 flex-1">
@@ -2044,8 +2037,8 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
           </div>
           <div
             className={cn(
-              "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-              agentsEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
+              "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+              agentsEnabled && "mari-chat-option-switch--active",
             )}
           >
             <div
@@ -2086,56 +2079,45 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                       <span className="block text-[0.625rem] font-medium text-[var(--muted-foreground)]">
                         Context Size
                       </span>
-                      <input
-                        type="number"
+                      <DraftNumberInput
                         min={1}
                         max={200}
                         value={agentAddPreview.contextSize}
-                        onChange={(event) => {
-                          const value = parseInt(event.target.value, 10);
+                        onCommit={(value) => {
                           setAgentAddPreview((current) =>
                             current
                               ? {
                                   ...current,
-                                  contextSize: Number.isFinite(value)
-                                    ? Math.max(1, Math.min(200, value))
-                                    : DEFAULT_AGENT_CONTEXT_SIZE,
+                                  contextSize: Math.max(1, Math.min(200, value)),
                                 }
                               : current,
                           );
                         }}
                         disabled={addingAgentToChat}
-                        className={WIZARD_INPUT_CLASS}
+                        selectOnFocus
+                        className={WIZARD_NUMBER_INPUT_CLASS}
                       />
                     </label>
                     <label className="space-y-1">
                       <span className="block text-[0.625rem] font-medium text-[var(--muted-foreground)]">
                         Max Output Tokens
                       </span>
-                      <input
-                        type="number"
+                      <DraftNumberInput
                         min={MIN_AGENT_MAX_TOKENS}
                         value={agentAddPreview.maxTokens}
-                        onChange={(event) => {
-                          const value = parseInt(event.target.value, 10);
+                        onCommit={(value) => {
                           setAgentAddPreview((current) =>
                             current
                               ? {
                                   ...current,
-                                  maxTokens: normalizeAgentMaxTokensInputValue(
-                                    Number.isFinite(value) ? value : undefined,
-                                  ),
+                                  maxTokens: normalizeAgentMaxTokensInputValue(value),
                                 }
                               : current,
                           );
                         }}
-                        onBlur={() =>
-                          setAgentAddPreview((current) =>
-                            current ? { ...current, maxTokens: normalizeAgentMaxTokens(current.maxTokens) } : current,
-                          )
-                        }
                         disabled={addingAgentToChat}
-                        className={WIZARD_INPUT_CLASS}
+                        selectOnFocus
+                        className={WIZARD_NUMBER_INPUT_CLASS}
                       />
                     </label>
                   </div>
@@ -2146,26 +2128,23 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
                     <span className="block text-[0.625rem] font-medium text-[var(--muted-foreground)]">
                       {agentAddIntervalMeta.label}
                     </span>
-                    <input
-                      type="number"
+                    <DraftNumberInput
                       min={1}
                       max={agentAddIntervalMeta.max}
                       value={agentAddPreview.runInterval}
-                      onChange={(event) => {
-                        const value = parseInt(event.target.value, 10);
+                      onCommit={(value) => {
                         setAgentAddPreview((current) =>
                           current
                             ? {
                                 ...current,
-                                runInterval: Number.isFinite(value)
-                                  ? Math.max(1, Math.min(agentAddIntervalMeta.max, value))
-                                  : agentAddIntervalMeta.defaultValue,
+                                runInterval: Math.max(1, Math.min(agentAddIntervalMeta.max, value)),
                               }
                             : current,
                         );
                       }}
                       disabled={addingAgentToChat}
-                      className={WIZARD_INPUT_CLASS}
+                      selectOnFocus
+                      className={WIZARD_NUMBER_INPUT_CLASS}
                     />
                     <span className="block text-[0.5625rem] text-[var(--muted-foreground)]">
                       {agentAddIntervalMeta.help}

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -32,9 +32,16 @@ import { ConversationMessageBubble } from "./ConversationMessageBubble";
 import { ConversationMessageLine } from "./ConversationMessageLine";
 import { MessageReactions } from "./MessageReactions";
 import { toggleReaction, USER_REACTOR } from "../../lib/reactions";
+import {
+  NEUTRAL_PANEL_HEADER,
+  NEUTRAL_PANEL_SCROLL_AREA,
+  NEUTRAL_PANEL_SHELL,
+  NEUTRAL_PANEL_TITLE,
+} from "../ui/neutral-surface-styles";
 
 const EMPTY_CUSTOM_EMOJI_MAP = new Map<string, string>();
 const EMPTY_CUSTOM_STICKER_MAP = new Map<string, string>();
+const CONVERSATION_MESSAGE_CHROME_RING_CLASS = "ring-[var(--marinara-chat-chrome-focus-ring)]";
 
 // ── Public props interface (unchanged external API) ──────────────
 
@@ -158,6 +165,7 @@ export const ConversationMessage = memo(function ConversationMessage({
     if (!message.extra) return {} as Record<string, any>;
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
+  const isConversationStart = extra.isConversationStart === true;
   const isHiddenFromAI = extra.hiddenFromAI === true;
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
   const canRegenerate = !isUser || generationReplay !== null;
@@ -670,23 +678,27 @@ export const ConversationMessage = memo(function ConversationMessage({
             onClick={() => setShowThinking(false)}
           >
             <div
-              className="relative mx-4 flex max-h-[70vh] w-full max-w-xl flex-col rounded-xl bg-[var(--card)] shadow-2xl ring-1 ring-[var(--border)]"
+              className={cn(
+                NEUTRAL_PANEL_SHELL,
+                "relative mx-4 flex max-h-[70vh] w-full max-w-xl flex-col overflow-hidden",
+              )}
               onClick={(e) => e.stopPropagation()}
             >
-              <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
-                <div className="flex items-center gap-2 text-sm font-semibold">
-                  <Brain size="0.875rem" className="text-[var(--muted-foreground)]" />
+              <div className={cn(NEUTRAL_PANEL_HEADER, "flex items-center justify-between gap-3 px-4 py-3")}>
+                <div className={cn(NEUTRAL_PANEL_TITLE, "text-sm")}>
+                  <Brain size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />
                   Model Thoughts
                 </div>
                 <button
                   onClick={() => setShowThinking(false)}
-                  className="rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+                  className="mari-chrome-control mari-chrome-control--small p-1.5"
+                  aria-label="Close thoughts"
                 >
                   <X size="0.875rem" />
                 </button>
               </div>
-              <div className="overflow-y-auto px-4 py-3">
-                <pre className="whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-[var(--muted-foreground)]">
+              <div className={cn(NEUTRAL_PANEL_SCROLL_AREA, "overflow-y-auto px-4 py-3")}>
+                <pre className="whitespace-pre-wrap break-words text-[0.8125rem] leading-relaxed text-[var(--marinara-chat-chrome-panel-text)]">
                   {thinking}
                 </pre>
               </div>
@@ -732,7 +744,7 @@ export const ConversationMessage = memo(function ConversationMessage({
                 onDelete(message.id);
               }}
               className={cn(
-                "absolute -right-1 -top-1 rounded-md p-1 text-[var(--muted-foreground)]/30 opacity-0 transition-all hover:bg-red-500/20 hover:text-red-400 group-hover:opacity-100",
+                "absolute -right-1 -top-1 rounded-md p-1 text-[var(--muted-foreground)]/30 opacity-0 transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] group-hover:opacity-100",
                 showActions && "opacity-100",
               )}
               title="Delete"
@@ -775,7 +787,9 @@ export const ConversationMessage = memo(function ConversationMessage({
                 isGrouped ? "mt-0" : "mt-4",
                 isStreaming && "bg-[var(--secondary)]/20",
               ),
-          multiSelectMode && isSelected && "bg-[var(--destructive)]/10",
+          isConversationStart && cn("rounded-lg ring-1", CONVERSATION_MESSAGE_CHROME_RING_CLASS),
+          isHiddenFromAI && cn("rounded-lg ring-1 saturate-75", CONVERSATION_MESSAGE_CHROME_RING_CLASS),
+          multiSelectMode && isSelected && "bg-[var(--destructive)]/10 ring-[var(--destructive)]/50",
         )}
         data-message-id={message.id}
         data-message-role={message.role}

--- a/packages/client/src/components/chat/ConversationMessageActions.tsx
+++ b/packages/client/src/components/chat/ConversationMessageActions.tsx
@@ -97,7 +97,6 @@ export function ConversationMessageActions({
         icon={<Languages size="0.75rem" />}
         onClick={onTranslate}
         title={translatedText ? "Hide translation" : "Translate"}
-        className={translatedText ? "text-blue-400" : undefined}
         tabIndex={tabIdx}
       />
       <MsgAction icon={<Pencil size="0.75rem" />} onClick={onEdit} title="Edit" tabIndex={tabIdx} />
@@ -115,7 +114,11 @@ export function ConversationMessageActions({
           icon={isHiddenFromAI ? <Eye size="0.75rem" /> : <EyeOff size="0.75rem" />}
           onClick={onToggleHiddenFromAI}
           title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
-          className={isHiddenFromAI ? "text-amber-400" : undefined}
+          className={
+            isHiddenFromAI
+              ? "text-[var(--marinara-chat-chrome-button-text-active)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
+              : undefined
+          }
           tabIndex={tabIdx}
         />
       )}
@@ -141,7 +144,6 @@ export function ConversationMessageActions({
           icon={<Trash2 size="0.75rem" />}
           onClick={onDelete}
           title="Delete"
-          className="hover:text-[var(--destructive)]"
           tabIndex={tabIdx}
         />
       )}

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -294,7 +294,10 @@ export function HiddenFromAIConversationButton({
 }) {
   if (!canCollapse) {
     return (
-      <span className="inline-flex items-center gap-1 align-middle text-[0.625rem] font-medium text-amber-500/80" title="Hidden from AI">
+      <span
+        className="inline-flex items-center gap-1 align-middle text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-highlight-text)]"
+        title="Hidden from AI"
+      >
         <EyeOff size="0.7rem" className="shrink-0" />
       </span>
     );
@@ -305,8 +308,8 @@ export function HiddenFromAIConversationButton({
         type="button"
         onClick={onExpand}
         className={cn(
-          "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-amber-500/80 transition-colors hover:bg-amber-500/10 hover:text-amber-400",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40",
+          "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-highlight-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
         )}
         aria-label={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
         title={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
@@ -323,7 +326,7 @@ export function HiddenFromAIConversationSummary({ onExpand }: { onExpand: () => 
     <button
       type="button"
       onClick={(event) => { event.stopPropagation(); onExpand(); }}
-      className="flex w-full items-center gap-2 rounded-md border border-amber-400/20 bg-amber-500/10 px-2.5 py-1.5 text-left text-[0.75rem] text-amber-600/90 transition-colors hover:bg-amber-500/15 dark:text-amber-200/75"
+      className="flex w-full items-center gap-2 rounded-md border border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-2.5 py-1.5 text-left text-[0.75rem] text-[var(--marinara-chat-chrome-highlight-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)]"
       title="Expand hidden from AI message"
       aria-label="Expand hidden from AI message"
     >
@@ -522,7 +525,7 @@ export function ConversationMessageTranslation({
   );
 }
 
-/** Swipe pill — consistent style for all message layouts. */
+/** Compact swipe control — consistent style for all Conversation layouts. */
 export function ConversationMessageSwipes({
   messageId,
   activeSwipeIndex,
@@ -543,10 +546,10 @@ export function ConversationMessageSwipes({
       swipeCount={swipeCount}
       onSetActiveSwipe={onSetActiveSwipe}
       className={cn(
-        "inline-flex items-center gap-0.5 rounded-full border border-[var(--border)] bg-[var(--secondary)] px-1.5 py-0.5 text-[0.625rem] text-[var(--muted-foreground)]",
+        "inline-flex items-center gap-0.5 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-1.5 py-0.5 text-[0.625rem] text-[var(--muted-foreground)]",
         className,
       )}
-      buttonClassName="rounded-full p-0.5 transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
+      buttonClassName="rounded-sm p-0.5 transition-colors hover:bg-[var(--accent)] disabled:opacity-30"
       inputClassName="h-[1.25rem] w-[2rem] border-none bg-transparent text-center text-[0.625rem] outline-none"
     />
   );

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -4,6 +4,17 @@
 import { useState, useMemo } from "react";
 import { X, ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "../../lib/utils";
+import {
+  NEUTRAL_PANEL_HEADER,
+  NEUTRAL_PANEL_SCROLL_AREA,
+  NEUTRAL_PANEL_SHELL,
+  NEUTRAL_PANEL_TITLE,
+} from "../ui/neutral-surface-styles";
+
+const PROMPT_TAG_CLASS =
+  "border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-highlight-text)]";
+const PROMPT_TAG_ACTIVE_CLASS =
+  "border border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]";
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
@@ -51,8 +62,8 @@ function sourceLabel(data: PeekPromptModalProps["data"]): string {
 }
 
 function sourceBadgeClass(data: PeekPromptModalProps["data"]): string {
-  if (data.exact) return "border-emerald-500/30 bg-emerald-500/10 text-emerald-400";
-  return "border-amber-500/30 bg-amber-500/10 text-amber-300";
+  if (data.exact) return PROMPT_TAG_ACTIVE_CLASS;
+  return PROMPT_TAG_CLASS;
 }
 
 function prettifyTag(tag: string): string {
@@ -300,9 +311,8 @@ function ChatHistorySection({ entries, rawContent }: { entries: ChatHistoryEntry
   const tokens = estimateTokens(rawContent);
 
   const msgRoleColor = (role: string) => {
-    if (role === "user") return "bg-blue-500/20 text-blue-400";
-    if (role === "assistant") return "bg-purple-500/20 text-purple-400";
-    return "bg-amber-500/20 text-amber-400";
+    if (role === "assistant") return PROMPT_TAG_ACTIVE_CLASS;
+    return PROMPT_TAG_CLASS;
   };
 
   return (
@@ -319,7 +329,7 @@ function ChatHistorySection({ entries, rawContent }: { entries: ChatHistoryEntry
         <span
           className={cn(
             "rounded-md px-2 py-0.5 text-[0.625rem] font-bold uppercase tracking-wider",
-            "bg-green-500/20 text-green-400",
+            PROMPT_TAG_ACTIVE_CLASS,
           )}
         >
           Chat History
@@ -420,10 +430,8 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
   }, [gen, params]);
 
   const sectionRoleColor = (role: string, label: string) => {
-    if (/last.?message/i.test(label)) return "bg-blue-500/20 text-blue-400";
-    if (role === "system") return "bg-amber-500/20 text-amber-400";
-    if (role === "user") return "bg-blue-500/20 text-blue-400";
-    return "bg-purple-500/20 text-purple-400";
+    if (/last.?message/i.test(label) || role === "assistant") return PROMPT_TAG_ACTIVE_CLASS;
+    return PROMPT_TAG_CLASS;
   };
 
   return (
@@ -432,12 +440,12 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
       onClick={onClose}
     >
       <div
-        className="mx-4 flex max-h-[85vh] w-full max-w-3xl flex-col rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl"
+        className={cn(NEUTRAL_PANEL_SHELL, "mx-4 flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden")}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="shrink-0 flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
+        <div className={cn(NEUTRAL_PANEL_HEADER, "shrink-0 flex items-center justify-between gap-3 px-5 py-3")}>
           <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <h3 className="shrink-0 text-sm font-bold">Assembled Prompt</h3>
+            <h3 className={cn(NEUTRAL_PANEL_TITLE, "shrink-0 text-sm")}>Assembled Prompt</h3>
             <span
               className={cn(
                 "shrink-0 rounded-md border px-2 py-0.5 text-[0.5625rem] font-bold uppercase tracking-wider",
@@ -452,12 +460,13 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
           </div>
           <button
             onClick={onClose}
-            className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+            className="mari-chrome-control mari-chrome-control--small p-1.5"
+            aria-label="Close assembled prompt"
           >
             <X size="1rem" />
           </button>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-2">
+        <div className={cn(NEUTRAL_PANEL_SCROLL_AREA, "min-h-0 flex-1 overflow-y-auto p-4 space-y-2")}>
           {/* Generation info panel */}
           {(gen || paramPills.length > 0) && (
             <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/30 px-4 py-3 space-y-2">
@@ -495,7 +504,7 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
             </div>
           )}
           {data.agentNote && (
-            <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[0.6875rem] text-amber-300/80">
+            <div className="rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-3 py-2 text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-text)]">
               Note: {data.agentNote}
             </div>
           )}

--- a/packages/client/src/components/chat/SwipeJumpControl.tsx
+++ b/packages/client/src/components/chat/SwipeJumpControl.tsx
@@ -75,7 +75,10 @@ export function SwipeJumpControl({
         pattern="[0-9]*"
         value={inputValue}
         onChange={(event) => handleInputChange(event.target.value)}
-        onBlur={() => setSwipeByDisplayIndex(Number.parseInt(inputValue, 10) || activeSwipeIndex + 1)}
+        onBlur={() => {
+          const parsed = Number.parseInt(inputValue, 10);
+          setSwipeByDisplayIndex(Number.isNaN(parsed) ? activeSwipeIndex + 1 : parsed);
+        }}
         onClick={(event) => event.stopPropagation()}
         onFocus={(event) => event.currentTarget.select()}
         onKeyDown={(event) => {

--- a/packages/client/src/components/chat/SwipeJumpControl.tsx
+++ b/packages/client/src/components/chat/SwipeJumpControl.tsx
@@ -42,7 +42,9 @@ export function SwipeJumpControl({
   };
 
   const handleInputChange = (value: string) => {
+    if (!/^\d*$/.test(value)) return;
     setInputValue(value);
+    if (value === "") return;
     const displayIndex = Number.parseInt(value, 10);
     if (Number.isNaN(displayIndex) || displayIndex < 1 || displayIndex > swipeCount) return;
     setSwipeByDisplayIndex(displayIndex);
@@ -68,18 +70,20 @@ export function SwipeJumpControl({
       </label>
       <input
         id={inputId}
-        type="number"
-        min={1}
-        max={swipeCount}
+        type="text"
         inputMode="numeric"
+        pattern="[0-9]*"
         value={inputValue}
         onChange={(event) => handleInputChange(event.target.value)}
         onBlur={() => setSwipeByDisplayIndex(Number.parseInt(inputValue, 10) || activeSwipeIndex + 1)}
         onClick={(event) => event.stopPropagation()}
         onFocus={(event) => event.currentTarget.select()}
-        onKeyDown={(event) => event.stopPropagation()}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.key === "Enter") event.currentTarget.blur();
+        }}
         className={cn(
-          "h-[1.625rem] w-[3.25rem] rounded border border-[var(--border)] bg-[var(--background)]/70 px-1 text-center tabular-nums text-[0.75rem] outline-none transition-colors focus:border-[var(--primary)] focus:ring-1 focus:ring-[var(--primary)]/40",
+          "h-[1.375rem] w-9 rounded-full border border-transparent bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 py-0.5 text-center tabular-nums text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-panel-muted)] outline-none transition-[background-color,border-color,box-shadow,color] focus:border-[var(--marinara-chat-chrome-button-border-active)] focus:bg-[var(--marinara-chat-chrome-button-bg-active)]",
           inputClassName,
         )}
         aria-label={`Jump to swipe, 1 through ${swipeCount}`}

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -34,18 +34,20 @@ interface SearchResult {
 
 let ytApiPromise: Promise<void> | null = null;
 
-const MUSIC_NEUTRAL_BORDER_CLASS = "border-[var(--marinara-chat-chrome-panel-border)]";
-const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
-const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
-const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-bg)]";
-const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[var(--marinara-chat-chrome-highlight-bg)]";
-const MUSIC_NEUTRAL_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-title)]";
-const MUSIC_NEUTRAL_MUTED_CLASS = "text-[var(--marinara-chat-chrome-panel-muted)]";
-const MUSIC_NEUTRAL_ICON_CLASS = "text-[var(--marinara-chat-chrome-button-text)]";
-const MUSIC_NEUTRAL_ICON_HOVER_CLASS = "hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
-const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-divider)]";
-const MUSIC_NEUTRAL_PROGRESS_FILL_CLASS = "bg-[var(--marinara-chat-chrome-accent)]";
-const YOUTUBE_LOGO_CLASS = "text-[oklch(0.62_0.16_25)]";
+const MUSIC_NEUTRAL_BORDER_CLASS = "border-[#f7f3ef]/15";
+const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[#f7f3ef]/10";
+const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[#0f0f0f]/95";
+const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
+const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[#f7f3ef]/5";
+const MUSIC_NEUTRAL_TEXT_CLASS = "text-[#f7f3ef]";
+const MUSIC_NEUTRAL_MUTED_CLASS = "text-[#aaa]";
+const MUSIC_NEUTRAL_ICON_CLASS = "text-[#aaa]";
+const MUSIC_NEUTRAL_ICON_HOVER_CLASS = "hover:bg-[#f7f3ef]/10 hover:text-[#f7f3ef]";
+const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[#f7f3ef]/15";
+const MUSIC_NEUTRAL_PROGRESS_FILL_CLASS = "bg-[#FF0000]";
+const MUSIC_NEUTRAL_ACTION_BG_CLASS = "bg-[#f7f3ef]";
+const MUSIC_NEUTRAL_ACTION_TEXT_CLASS = "text-[#0f0f0f]";
+const YOUTUBE_LOGO_CLASS = "text-[#FF0000]";
 const MOBILE_WIDGET_COLLAPSED_SIZE = 48;
 const MOBILE_WIDGET_EXPANDED_MAX_WIDTH = 320;
 const MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER = 24;
@@ -405,7 +407,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
         step={1}
         value={playerVolume}
         onChange={(event) => setPlayerVolume(Number(event.target.value))}
-        className="h-1.5 w-full cursor-pointer accent-[var(--marinara-chat-chrome-accent)]"
+        className="h-1.5 w-full cursor-pointer accent-[#FF0000]"
         title="Volume"
         aria-label="YouTube volume"
       />
@@ -420,7 +422,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
           className={cn(
             "flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1",
             MUSIC_NEUTRAL_TILE_BG_CLASS,
-            "ring-[var(--marinara-chat-chrome-panel-border)]",
+            "ring-[#f7f3ef]/10",
           )}
         >
           {loading ? (
@@ -445,7 +447,11 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
         <button
           type="button"
           onClick={togglePlay}
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--marinara-chat-chrome-button-text-active)] text-[var(--marinara-chat-chrome-panel-bg)] shadow-[0_1px_8px_rgba(255,255,255,0.10)] transition-transform hover:scale-105 active:scale-95"
+          className={cn(
+            "inline-flex h-7 w-7 items-center justify-center rounded-full shadow-[0_1px_8px_rgba(255,255,255,0.18)] transition-transform hover:scale-105 active:scale-95",
+            MUSIC_NEUTRAL_ACTION_BG_CLASS,
+            MUSIC_NEUTRAL_ACTION_TEXT_CLASS,
+          )}
           aria-label={paused ? "Play" : "Pause"}
         >
           {paused ? <Play size="0.8125rem" className="translate-x-px" /> : <Pause size="0.8125rem" />}

--- a/packages/client/src/components/game-assets/SearchInput.tsx
+++ b/packages/client/src/components/game-assets/SearchInput.tsx
@@ -29,7 +29,7 @@ export function SearchInput({ search, onSearch }: { search: string; onSearch: (v
       {!expanded && (
         <button
           onClick={() => setExpanded(true)}
-          className="rounded-lg border border-(--border) bg-(--background) p-1.5 text-(--muted-foreground) transition-colors hover:bg-(--accent) hover:text-(--foreground) sm:hidden"
+          className="flex h-10 w-10 items-center justify-center rounded-lg border border-(--border) bg-(--background) text-(--muted-foreground) transition-colors hover:bg-(--accent) hover:text-(--foreground) sm:hidden"
           title="Search in folder"
         >
           <Search size="0.875rem" />
@@ -54,7 +54,7 @@ export function SearchInput({ search, onSearch }: { search: string; onSearch: (v
             }
           }}
           placeholder="Search in folder..."
-          className="h-8 w-48 rounded-lg border border-(--border) bg-(--background) pl-7 pr-7 text-sm text-(--foreground) outline-none transition-colors focus:border-(--foreground)/40 focus:ring-1 focus:ring-(--foreground)/15 max-sm:absolute max-sm:right-0 max-sm:top-1/2 max-sm:w-48 max-sm:-translate-y-1/2"
+          className="h-10 w-48 rounded-lg border border-(--border) bg-(--background) pl-7 pr-7 text-sm text-(--foreground) outline-none transition-colors focus:border-(--foreground)/40 focus:ring-1 focus:ring-(--foreground)/15 max-sm:absolute max-sm:right-0 max-sm:top-1/2 max-sm:w-48 max-sm:-translate-y-1/2 sm:h-8"
         />
         {expanded && (
           <button

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -19,6 +19,7 @@ import {
   Zap,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { NEUTRAL_SURFACE_VARIABLES } from "../ui/neutral-surface-styles";
 
 export interface GameCharacterSheetGameCard {
@@ -90,7 +91,7 @@ const FIELD_LABEL_CLASS = "text-[0.6875rem] font-semibold uppercase tracking-wid
 const TEXT_INPUT_CLASS =
   "w-full rounded-lg border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]";
 const NUMBER_INPUT_CLASS =
-  "w-full rounded-lg border border-[var(--marinara-chat-chrome-input-border)] bg-[var(--marinara-chat-chrome-input-bg)] px-2.5 py-1.5 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]";
+  "w-full rounded-lg border border-transparent bg-[var(--marinara-chat-chrome-input-bg)] px-2.5 py-1.5 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]";
 
 function normalizeTextValue(value: unknown) {
   if (typeof value === "string") return value;
@@ -569,24 +570,20 @@ export function GameCharacterSheet({
                     <div className="grid grid-cols-2 gap-3">
                       <label className="block space-y-1.5">
                         <span className={FIELD_LABEL_CLASS}>Current HP</span>
-                        <input
-                          type="number"
+                        <DraftNumberInput
                           value={draft.hpValue}
-                          onChange={(e) =>
-                            setDraft((prev) => ({ ...prev, hpValue: parseInt(e.target.value, 10) || 0 }))
-                          }
+                          onCommit={(value) => setDraft((prev) => ({ ...prev, hpValue: value }))}
+                          selectOnFocus
                           className={NUMBER_INPUT_CLASS}
                         />
                       </label>
                       <label className="block space-y-1.5">
                         <span className={FIELD_LABEL_CLASS}>Max HP</span>
-                        <input
-                          type="number"
+                        <DraftNumberInput
                           value={draft.hpMax}
                           min={1}
-                          onChange={(e) =>
-                            setDraft((prev) => ({ ...prev, hpMax: Math.max(1, parseInt(e.target.value, 10) || 1) }))
-                          }
+                          onCommit={(value) => setDraft((prev) => ({ ...prev, hpMax: Math.max(1, value) }))}
+                          selectOnFocus
                           className={NUMBER_INPUT_CLASS}
                         />
                       </label>
@@ -601,10 +598,10 @@ export function GameCharacterSheet({
                             placeholder="STR"
                             className={TEXT_INPUT_CLASS}
                           />
-                          <input
-                            type="number"
+                          <DraftNumberInput
                             value={attr.value}
-                            onChange={(e) => updateAttribute(index, "value", parseInt(e.target.value, 10) || 0)}
+                            onCommit={(value) => updateAttribute(index, "value", value)}
+                            selectOnFocus
                             className={NUMBER_INPUT_CLASS}
                           />
                           <button

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -573,6 +573,7 @@ export function GameCharacterSheet({
                         <DraftNumberInput
                           value={draft.hpValue}
                           onCommit={(value) => setDraft((prev) => ({ ...prev, hpValue: value }))}
+                          min={0}
                           selectOnFocus
                           className={NUMBER_INPUT_CLASS}
                         />

--- a/packages/client/src/components/game/GameWidgetSetupEditor.tsx
+++ b/packages/client/src/components/game/GameWidgetSetupEditor.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import type { HudWidget, HudWidgetConfig, HudWidgetType } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 
 export const MAX_GAME_SETUP_WIDGETS = 4;
 
@@ -40,6 +41,9 @@ const DEFAULT_ICONS: Record<HudWidgetType, string> = {
   inventory_grid: "▣",
   timer: "◷",
 };
+
+const WIDGET_NUMBER_INPUT_CLASS =
+  "w-full rounded-lg border border-transparent bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/40";
 
 function isHudWidgetType(value: unknown): value is HudWidgetType {
   return (
@@ -391,27 +395,26 @@ function WidgetConfigFields({
       <div className="mt-2 grid gap-2 sm:grid-cols-2">
         <label className="space-y-1">
           <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Value</span>
-          <input
-            type="number"
+          <DraftNumberInput
             min={0}
             value={value}
             disabled={disabled}
-            onChange={(event) => {
-              const next = parseNumber(event.target.value, value, 0);
+            onCommit={(next) => {
               onConfigChange({ value: next, startingValue: next });
             }}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+            selectOnFocus
+            className={WIDGET_NUMBER_INPUT_CLASS}
           />
         </label>
         <label className="space-y-1">
           <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Max</span>
-          <input
-            type="number"
+          <DraftNumberInput
             min={1}
             value={max}
             disabled={disabled}
-            onChange={(event) => onConfigChange({ max: parseNumber(event.target.value, max, 1) })}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+            onCommit={(next) => onConfigChange({ max: next })}
+            selectOnFocus
+            className={WIDGET_NUMBER_INPUT_CLASS}
           />
         </label>
       </div>
@@ -422,12 +425,12 @@ function WidgetConfigFields({
     return (
       <label className="mt-2 block space-y-1">
         <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Count</span>
-        <input
-          type="number"
+        <DraftNumberInput
           value={parseNumber(widget.config.count, 0)}
           disabled={disabled}
-          onChange={(event) => onConfigChange({ count: Math.round(parseNumber(event.target.value, 0)) })}
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+          onCommit={(next) => onConfigChange({ count: Math.round(next) })}
+          selectOnFocus
+          className={WIDGET_NUMBER_INPUT_CLASS}
         />
       </label>
     );
@@ -517,13 +520,13 @@ function WidgetConfigFields({
       <div className="mt-2 grid gap-2 sm:grid-cols-[7rem_minmax(0,1fr)]">
         <label className="space-y-1">
           <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Slots</span>
-          <input
-            type="number"
+          <DraftNumberInput
             min={1}
             value={parseNumber(widget.config.slots, 8, 1)}
             disabled={disabled}
-            onChange={(event) => onConfigChange({ slots: Math.round(parseNumber(event.target.value, 8, 1)) })}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+            onCommit={(next) => onConfigChange({ slots: Math.round(next) })}
+            selectOnFocus
+            className={WIDGET_NUMBER_INPUT_CLASS}
           />
         </label>
         <label className="space-y-1">
@@ -552,13 +555,13 @@ function WidgetConfigFields({
     <div className="mt-2 grid gap-2 sm:grid-cols-2">
       <label className="space-y-1">
         <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Seconds</span>
-        <input
-          type="number"
+        <DraftNumberInput
           min={0}
           value={parseNumber(widget.config.seconds, 60, 0)}
           disabled={disabled}
-          onChange={(event) => onConfigChange({ seconds: Math.round(parseNumber(event.target.value, 60, 0)) })}
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+          onCommit={(next) => onConfigChange({ seconds: Math.round(next) })}
+          selectOnFocus
+          className={WIDGET_NUMBER_INPUT_CLASS}
         />
       </label>
       <label className="flex items-center gap-2 self-end rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs text-[var(--foreground)]">

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -39,7 +39,7 @@ import {
   useMoveChat,
 } from "../../hooks/use-chat-folders";
 import { useCharacters } from "../../hooks/use-characters";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useChatStore } from "../../stores/chat.store";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import { useUIStore, type UserStatus } from "../../stores/ui.store";
@@ -1484,7 +1484,8 @@ function FolderRow({
           role="button"
           tabIndex={0}
           aria-expanded={isExpanded}
-          aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}`}
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
+          title="Double-click or press F2 to rename."
           onClick={(e) =>
             handleFolderRenameGesture(folder.id, e, {
               onSingleClick: () => {
@@ -1494,12 +1495,13 @@ function FolderRow({
             })
           }
           onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              e.stopPropagation();
-              if (!canToggleCollapse) return;
-              onToggleCollapse(folder);
-            }
+            if (e.target !== e.currentTarget) return;
+            handleFolderRenameKeyDown(e, {
+              onSingleClick: () => {
+                if (canToggleCollapse) onToggleCollapse(folder);
+              },
+              onRename: beginRename,
+            });
           }}
           className="flex flex-1 items-center gap-1.5 min-w-0"
         >

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -26,7 +26,6 @@ import {
   Square as SquareIcon,
   ArrowUpDown,
   Tag,
-  Pencil,
 } from "lucide-react";
 import { useBulkExportChats, useChats, useCreateChat, useDeleteChat, useDeleteChatGroup } from "../../hooks/use-chats";
 import { useChatPresets, useApplyChatPreset } from "../../hooks/use-chat-presets";
@@ -40,6 +39,7 @@ import {
   useMoveChat,
 } from "../../hooks/use-chat-folders";
 import { useCharacters } from "../../hooks/use-characters";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useChatStore } from "../../stores/chat.store";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import { useUIStore, type UserStatus } from "../../stores/ui.store";
@@ -52,6 +52,7 @@ import { Reorder, useDragControls } from "framer-motion";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { getCurrentGameGroupRepresentative } from "../../lib/game-session-resolution";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type ChatSortOption = "newest" | "oldest" | "name-asc" | "name-desc";
 
@@ -1098,14 +1099,14 @@ export function ChatSidebar() {
               placeholder={`Search ${activeTab === "conversation" ? "conversations" : activeTab === "game" ? "games" : "roleplays"}...`}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+              className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
             />
           </div>
           <div className="relative">
             <select
               value={sort}
               onChange={(e) => setSort(e.target.value as ChatSortOption)}
-              className="mari-chrome-field h-full w-[6.5rem] appearance-none py-2 pl-2.5 pr-7 text-[0.6875rem]"
+              className="mari-chrome-field h-10 w-[6.5rem] appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
               title="Sort chats"
             >
               <option value="newest">Newest</option>
@@ -1268,12 +1269,12 @@ export function ChatSidebar() {
           </div>
         )}
 
-        <div className="stagger-children flex flex-col gap-0.5">
+        <div className="stagger-children flex flex-col gap-0.5 px-1">
           {activeModeHasChats && (
             <div className="flex items-center gap-1">
               <button
                 onClick={handleCreateFolder}
-                className="mari-chrome-control mari-chrome-control--small w-full justify-start text-[0.6875rem]"
+                className="mari-chrome-control mari-chrome-control--small flex-1 justify-center text-[0.6875rem]"
               >
                 <FolderPlus size="0.75rem" />
                 New Folder
@@ -1414,12 +1415,23 @@ function FolderRow({
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(folder.name);
   const [isDropTarget, setIsDropTarget] = useState(false);
+  const handleFolderRenameGesture = useFolderRenameGesture();
   const canToggleCollapse = !forceExpanded;
   const isExpanded = forceExpanded || !folder.collapsed;
+
+  useEffect(() => {
+    if (!renaming) setRenameValue(folder.name);
+  }, [folder.name, renaming]);
+
+  const beginRename = () => {
+    setRenameValue(folder.name);
+    setRenaming(true);
+  };
 
   return (
     <Reorder.Item
       value={folder.id}
+      layout="position"
       data-chat-folder-id={folder.id}
       dragListener={false}
       dragControls={dragControls}
@@ -1473,11 +1485,14 @@ function FolderRow({
           tabIndex={0}
           aria-expanded={isExpanded}
           aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (!canToggleCollapse) return;
-            onToggleCollapse(folder);
-          }}
+          onClick={(e) =>
+            handleFolderRenameGesture(folder.id, e, {
+              onSingleClick: () => {
+                if (canToggleCollapse) onToggleCollapse(folder);
+              },
+              onRename: beginRename,
+            })
+          }
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
@@ -1491,7 +1506,7 @@ function FolderRow({
           <ChevronRight
             size="0.75rem"
             className={cn(
-              "text-[var(--muted-foreground)] transition-transform shrink-0",
+              "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
               isExpanded && "rotate-90",
             )}
           />
@@ -1531,17 +1546,6 @@ function FolderRow({
         <button
           onClick={(e) => {
             e.stopPropagation();
-            setRenameValue(folder.name);
-            setRenaming(true);
-          }}
-          className="shrink-0 rounded-md p-1 opacity-0 transition-all hover:bg-[var(--accent)] group-hover:opacity-100 max-md:opacity-100"
-          title="Rename folder"
-        >
-          <Pencil size="0.75rem" className="text-[var(--muted-foreground)]" />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
             onDelete(folder, chatCount);
           }}
           className="shrink-0 rounded-md p-1 opacity-0 transition-all hover:bg-[var(--destructive)]/20 group-hover:opacity-100 max-md:opacity-100"
@@ -1550,11 +1554,13 @@ function FolderRow({
         </button>
       </div>
       {/* Folder contents */}
-      {isExpanded && entries.length > 0 && (
-        <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pl-1">
-          {entries.map(renderChatRow)}
-        </div>
-      )}
+      <SmoothFolderContent
+        open={isExpanded && entries.length > 0}
+        className="ml-4 border-l border-[var(--border)]/20 pl-1"
+        innerClassName="flex flex-col gap-0.5"
+      >
+        {entries.map(renderChatRow)}
+      </SmoothFolderContent>
     </Reorder.Item>
   );
 }

--- a/packages/client/src/components/lorebooks/LorebookFormFields.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFormFields.tsx
@@ -9,6 +9,7 @@ import { FileText, ToggleLeft, ToggleRight } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { MacroTextarea } from "../ui/MacroTextarea";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 
 export function FieldGroup({
   label,
@@ -125,13 +126,13 @@ export function NumberField({
   return (
     <div>
       <label className="mb-1 block text-[0.6875rem] text-[var(--muted-foreground)]">{label}</label>
-      <input
-        type="number"
+      <DraftNumberInput
         value={value}
-        onChange={(e) => onChange(parseInt(e.target.value) || 0)}
+        onCommit={(nextValue) => onChange(nextValue)}
         min={min}
         max={max}
-        className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+        selectOnFocus
+        className="w-full rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-xs ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
       />
     </div>
   );

--- a/packages/client/src/components/music/MusicSourceButton.tsx
+++ b/packages/client/src/components/music/MusicSourceButton.tsx
@@ -36,6 +36,10 @@ export function MusicSourceGlyph({ source, className }: { source: MusicPlayerSou
 export function MusicSourceButton({ source, className }: { source: MusicPlayerSource; className?: string }) {
   const setMusicPlayerSource = useUIStore((s) => s.setMusicPlayerSource);
   const nextSource: MusicPlayerSource = source === "spotify" ? "youtube" : "spotify";
+  const sourceClasses =
+    source === "spotify"
+      ? "border-[#f7f3ef]/15 bg-[#f7f3ef]/5 text-[#1DB954] hover:border-[#f7f3ef]/30 hover:bg-[#f7f3ef]/10"
+      : "border-[#f7f3ef]/15 bg-[#f7f3ef]/5 text-[#FF0000] hover:border-[#f7f3ef]/30 hover:bg-[#f7f3ef]/10";
 
   return (
     <button
@@ -45,9 +49,9 @@ export function MusicSourceButton({ source, className }: { source: MusicPlayerSo
         setMusicPlayerSource(nextSource);
       }}
       className={cn(
-        "marinara-chat-toolbar-button inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] active:scale-95",
+        "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border transition-colors active:scale-95",
+        sourceClasses,
         className,
-        source === "spotify" ? "text-[#1DB954]" : "text-[oklch(0.62_0.16_25)]",
       )}
       title={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}
       aria-label={`Switch to ${nextSource === "spotify" ? "Spotify" : "YouTube"} player`}

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -4,7 +4,7 @@
 import { useCallback, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from "react";
 import {
   Sparkles,
-  Pencil,
+  Copy,
   Plus,
   ChevronDown,
   ChevronRight,
@@ -55,6 +55,8 @@ import {
   useMoveLibraryItem,
   useUpdateLibraryFolder,
 } from "../../hooks/use-library-folders";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type JsonRecord = Record<string, unknown>;
 const BUILT_IN_AGENT_TYPE_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
@@ -148,6 +150,27 @@ function getAgentLibraryDisplayName(agent: AgentConfigRow) {
   return BUILT_IN_AGENTS.find((entry) => entry.id === agent.type)?.name ?? agent.name;
 }
 
+function createDuplicateAgentInput(agent: AgentConfigRow) {
+  const settings = sanitizeAgentSettingsForTransfer(parseAgentSettings(agent.settings));
+  if (typeof settings.author !== "string" || !settings.author.trim()) {
+    settings.author = "Unknown";
+  }
+  const resultType = typeof settings.resultType === "string" ? settings.resultType : undefined;
+
+  return {
+    type: `${agent.type}-copy`,
+    name: `${getAgentLibraryDisplayName(agent)} (Copy)`,
+    description: agent.description,
+    phase: normalizeAgentPhaseForType(agent.type, agent.phase),
+    enabled: parseBooleanValue(agent.enabled),
+    connectionId: agent.connectionId,
+    imagePath: agent.imagePath,
+    promptTemplate: agent.promptTemplate,
+    settings,
+    ...(resultType ? { resultType } : {}),
+  };
+}
+
 function normalizeAgentImportEntry(entry: unknown) {
   const source = getFolderManifestConfig(entry);
   if (!isJsonRecord(source)) return null;
@@ -208,6 +231,7 @@ export function AgentsPanel() {
   const [editingFolderId, setEditingFolderId] = useState<string | null>(null);
   const [editFolderName, setEditFolderName] = useState("");
   const [draggedAgentId, setDraggedAgentId] = useState<string | null>(null);
+  const handleFolderRenameGesture = useFolderRenameGesture();
 
   const agentConfigRows = useMemo(() => (agentConfigs ?? []) as AgentConfigRow[], [agentConfigs]);
   const visibleAgentConfigs = useMemo(
@@ -401,6 +425,20 @@ export function AgentsPanel() {
     }
   }, [selectedAgents]);
 
+  const handleDuplicateAgent = useCallback(
+    async (agent: AgentConfigRow) => {
+      try {
+        const created = await createAgent.mutateAsync(createDuplicateAgentInput(agent));
+        const createdId = typeof created === "object" && created && "id" in created ? String(created.id) : null;
+        toast.success(`Copied "${getAgentLibraryDisplayName(agent)}"`);
+        if (createdId) openAgentDetail(createdId);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to copy agent");
+      }
+    },
+    [createAgent, openAgentDetail],
+  );
+
   const handleDeleteSelectedAgents = useCallback(async () => {
     const ids = selectedAgents.map((agent) => agent.id);
     if (ids.length === 0) return;
@@ -501,6 +539,7 @@ export function AgentsPanel() {
         imagePath: agent.imagePath ?? null,
         custom,
         openAgentDetail,
+        onDuplicate: () => void handleDuplicateAgent(agent),
         onImagePick: () => handlePickAgentImage(custom ? agent.id : agent.type),
         selectionMode,
         selected: selectedAgentIds.has(agent.id),
@@ -536,6 +575,7 @@ export function AgentsPanel() {
       draggedAgentId,
       getDraggedAgentIds,
       handlePickAgentImage,
+      handleDuplicateAgent,
       openAgentDetail,
       selectedAgentIds,
       selectionMode,
@@ -623,14 +663,14 @@ export function AgentsPanel() {
           )}
           title="New"
         >
-          <Plus size="0.8125rem" /> <span className="md:hidden">New</span>
+          <Plus size="0.8125rem" />
         </button>
         <button
           onClick={() => agentImportInputRef.current?.click()}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
           title="Import agents"
         >
-          <Download size="0.8125rem" /> <span className="md:hidden">Import</span>
+          <Download size="0.8125rem" />
         </button>
         <button
           onClick={() => {
@@ -644,7 +684,7 @@ export function AgentsPanel() {
           )}
           title="Select agents"
         >
-          <Check size="0.8125rem" /> <span className="md:hidden">Select</span>
+          <Check size="0.8125rem" />
         </button>
       </div>
 
@@ -664,7 +704,7 @@ export function AgentsPanel() {
           value={agentSearch}
           onChange={(event) => setAgentSearch(event.target.value)}
           placeholder="Search agents"
-          className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+          className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
         />
       </div>
 
@@ -715,12 +755,20 @@ export function AgentsPanel() {
             >
               <div
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
-                onClick={() => setExpandedFolderId(isExpanded ? null : folder.id)}
+                onClick={(event) =>
+                  handleFolderRenameGesture(folder.id, event, {
+                    onSingleClick: () => setExpandedFolderId(isExpanded ? null : folder.id),
+                    onRename: () => {
+                      setEditingFolderId(folder.id);
+                      setEditFolderName(folder.name);
+                    },
+                  })
+                }
               >
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -754,17 +802,6 @@ export function AgentsPanel() {
                   <button
                     onClick={(event) => {
                       event.stopPropagation();
-                      setEditingFolderId(folder.id);
-                      setEditFolderName(folder.name);
-                    }}
-	                    className="mari-chrome-control mari-chrome-control--small p-1"
-	                    title="Rename folder"
-	                  >
-                    <Pencil size="0.6875rem" />
-                  </button>
-                  <button
-                    onClick={(event) => {
-                      event.stopPropagation();
                       void confirmNonEmptyFolderDelete(folder.itemIds.length, {
                         title: "Delete Folder",
                         message: `Delete "${folder.name}"? Its ${folder.itemIds.length} agent${
@@ -785,15 +822,17 @@ export function AgentsPanel() {
                   </button>
                 </div>
               </div>
-              {isExpanded && (
-                <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pb-1 pl-1">
-                  {folderAgents.length === 0 ? (
-                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop agents here.</p>
-                  ) : (
-                    folderAgents.map((agent) => renderFolderAgentCard(agent))
-                  )}
-                </div>
-              )}
+              <SmoothFolderContent
+                open={isExpanded}
+                className="ml-4 border-l border-[var(--border)]/20 pb-1 pl-1"
+                innerClassName="flex flex-col gap-0.5"
+              >
+                {folderAgents.length === 0 ? (
+                  <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop agents here.</p>
+                ) : (
+                  folderAgents.map((agent) => renderFolderAgentCard(agent))
+                )}
+              </SmoothFolderContent>
             </div>
           );
         })}
@@ -812,16 +851,18 @@ export function AgentsPanel() {
                 No {section.title.toLowerCase()} yet.
               </p>
             ) : (
-              visibleAgents.map((agent) =>
-                renderAgentCard({
+              visibleAgents.map((agent) => {
+                const sourceAgent = createBuiltInAgentConfigRow(agent, configByType.get(agent.id));
+                return renderAgentCard({
                   id: agent.id,
                   type: agent.id,
                   name: agent.name,
                   description: agent.description,
                   category: agent.category,
-                  imagePath: configByType.get(agent.id)?.imagePath ?? null,
+                  imagePath: sourceAgent.imagePath,
                   custom: false,
                   openAgentDetail,
+                  onDuplicate: () => void handleDuplicateAgent(sourceAgent),
                   onImagePick: () => handlePickAgentImage(agent.id),
                   selectionMode,
                   selected: selectedAgentIds.has(agent.id),
@@ -849,8 +890,8 @@ export function AgentsPanel() {
                       deleteAgent.mutate(agent.id);
                     }
                   },
-                }),
-              )
+                });
+              })
             )}
           </PanelSection>
         );
@@ -871,6 +912,7 @@ export function AgentsPanel() {
                 imagePath: agent.imagePath ?? null,
                 custom: true,
                 openAgentDetail,
+                onDuplicate: () => void handleDuplicateAgent(agent),
                 onImagePick: () => handlePickAgentImage(agent.id),
                 selectionMode,
                 selected: selectedAgentIds.has(agent.id),
@@ -923,6 +965,7 @@ function renderAgentCard({
   imagePath,
   custom,
   openAgentDetail,
+  onDuplicate,
   onImagePick,
   onDelete,
   selectionMode = false,
@@ -940,6 +983,7 @@ function renderAgentCard({
   imagePath?: string | null;
   custom: boolean;
   openAgentDetail: (id: string) => void;
+  onDuplicate: () => void;
   onImagePick: () => void;
   onDelete?: () => void;
   selectionMode?: boolean;
@@ -1035,13 +1079,13 @@ function renderAgentCard({
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
           <button
 	            className="mari-chrome-control mari-chrome-control--small p-1.5"
-	            title="Edit agent"
+	            title="Copy agent"
             onClick={(event) => {
               event.stopPropagation();
-              openAgentDetail(custom ? id : type);
+              onDuplicate();
             }}
           >
-            <Pencil size="0.75rem" />
+            <Copy size="0.75rem" />
           </button>
           {onDelete && (
             <button

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -55,7 +55,7 @@ import {
   useMoveLibraryItem,
   useUpdateLibraryFolder,
 } from "../../hooks/use-library-folders";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type JsonRecord = Record<string, unknown>;
@@ -754,6 +754,11 @@ export function AgentsPanel() {
               className="flex flex-col rounded-lg transition-colors"
             >
               <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
+                title="Double-click or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(folder.id, event, {
@@ -764,6 +769,16 @@ export function AgentsPanel() {
                     },
                   })
                 }
+                onKeyDown={(event) => {
+                  if (event.target !== event.currentTarget) return;
+                  handleFolderRenameKeyDown(event, {
+                    onSingleClick: () => setExpandedFolderId(isExpanded ? null : folder.id),
+                    onRename: () => {
+                      setEditingFolderId(folder.id);
+                      setEditFolderName(folder.name);
+                    },
+                  });
+                }}
               >
                 <ChevronRight
                   size="0.75rem"

--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -77,15 +77,15 @@ export function BotBrowserPanel() {
       {/* Search */}
       <div className="relative">
         <Search
-          size="0.75rem"
-          className="mari-chrome-field-icon pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2"
+          size="0.8125rem"
+          className="mari-chrome-field-icon pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
         />
         <input
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search imported..."
-          className="mari-chrome-field mari-chrome-field--compact w-full py-1.5 pl-7 pr-3 text-xs"
+          className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
         />
       </div>
 

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -36,7 +36,7 @@ import {
 } from "lucide-react";
 import { getCharacterTitle } from "../../lib/character-display";
 import { useUIStore, type CharacterLibrarySort } from "../../stores/ui.store";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { estimateCharacterCardTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
@@ -847,6 +847,11 @@ export function CharactersPanel() {
             >
               {/* Folder header */}
               <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${group.name}. Press F2 to rename.`}
+                title="Double-click or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(group.id, event, {
@@ -857,6 +862,16 @@ export function CharactersPanel() {
                     },
                   })
                 }
+                onKeyDown={(event) => {
+                  if (event.target !== event.currentTarget) return;
+                  handleFolderRenameKeyDown(event, {
+                    onSingleClick: () => setExpandedGroupId(isExpanded ? null : group.id),
+                    onRename: () => {
+                      setEditingGroupId(group.id);
+                      setEditGroupName(group.name);
+                    },
+                  });
+                }}
               >
                 <ChevronRight
                   size="0.75rem"

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -13,13 +13,8 @@ import {
   useUpdateCharacter,
   useDuplicateCharacter,
 } from "../../hooks/use-characters";
-import { useUpdateChat, useCreateMessage, chatKeys } from "../../hooks/use-chats";
-import { useStartChatFromCharacter } from "../../hooks/use-start-chat-from-character";
 import { api } from "../../lib/api-client";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
-import { useChatStore } from "../../stores/chat.store";
-import { ContextMenu, type ContextMenuItem } from "../ui/ContextMenu";
-import { useQueryClient } from "@tanstack/react-query";
 import {
   Plus,
   Trash2,
@@ -33,21 +28,19 @@ import {
   Copy,
   Users,
   X,
-  UserPlus,
   UserMinus,
   ArrowUpDown,
-  Pencil,
   Tag,
-  MessageCircle,
-  Wand2,
   Hash,
   Star,
 } from "lucide-react";
 import { getCharacterTitle } from "../../lib/character-display";
 import { useUIStore, type CharacterLibrarySort } from "../../stores/ui.store";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { estimateCharacterCardTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type CharacterRow = {
   id: string;
@@ -139,19 +132,6 @@ export function CharactersPanel() {
   const sort = useUIStore((s) => s.characterLibrarySort);
   const setCharacterLibrarySort = useUIStore((s) => s.setCharacterLibrarySort);
   const setCharacterPanelScrollTop = useUIStore((s) => s.setCharacterPanelScrollTop);
-  const activeChat = useChatStore((s) => s.activeChat);
-  const updateChat = useUpdateChat();
-  const createMessage = useCreateMessage(activeChat?.id ?? null);
-  const queryClient = useQueryClient();
-  const { startChatFromCharacter, isStartingChat } = useStartChatFromCharacter();
-  const [contextMenu, setContextMenu] = useState<{
-    x: number;
-    y: number;
-    charId: string;
-    charName: string;
-    firstMes?: string;
-    altGreetings?: string[];
-  } | null>(null);
 
   const [search, setSearch] = useState("");
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
@@ -163,12 +143,7 @@ export function CharactersPanel() {
   const panelScrollFrameRef = useRef<number | null>(null);
   const characterTouchDragRef = useRef<{ id: string; timer: number | null; active: boolean } | null>(null);
   const suppressCharacterClickRef = useRef(false);
-  const [firstMesConfirm, setFirstMesConfirm] = useState<{
-    charId: string;
-    charName: string;
-    message: string;
-    alternateGreetings: string[];
-  } | null>(null);
+  const handleFolderRenameGesture = useFolderRenameGesture();
   const [includedTags, setIncludedTags] = useState<Set<string>>(new Set());
   const [excludedTags, setExcludedTags] = useState<Set<string>>(new Set());
   const [tagsExpanded, setTagsExpanded] = useState(false);
@@ -176,13 +151,6 @@ export function CharactersPanel() {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedCharacterIds, setSelectedCharacterIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
-
-  const chatCharacterIds: string[] = activeChat
-    ? ((typeof activeChat.characterIds === "string" ? JSON.parse(activeChat.characterIds) : activeChat.characterIds) ??
-      [])
-    : [];
-
-  const isConversation = (activeChat as unknown as { mode?: string })?.mode === "conversation";
 
   // Parse character data and filter by search
   const parsedCharacters = useMemo(() => {
@@ -485,69 +453,6 @@ export function CharactersPanel() {
     [],
   );
 
-  const toggleCharacter = (charId: string) => {
-    if (!activeChat) return;
-    const isActive = chatCharacterIds.includes(charId);
-    const newIds = isActive ? chatCharacterIds.filter((id: string) => id !== charId) : [...chatCharacterIds, charId];
-    if (newIds.length === 0) return;
-    updateChat.mutate(
-      { id: activeChat.id, characterIds: newIds },
-      {
-        onSuccess: () => {
-          if (isActive) return; // removing, not adding
-          if (isConversation) return; // no greeting in conversation mode
-          const charList = (characters ?? []) as CharacterRow[];
-          const char = charList.find((c) => c.id === charId);
-          if (!char) return;
-          try {
-            const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-            const firstMes = (parsed as { first_mes?: string }).first_mes;
-            const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
-            const name = (parsed as { name?: string }).name ?? "Unknown";
-            if (firstMes) {
-              setFirstMesConfirm({ charId, charName: name, message: firstMes, alternateGreetings: altGreetings });
-            }
-          } catch {
-            /* ignore */
-          }
-        },
-      },
-    );
-  };
-
-  const addFolderToChat = (memberIds: string[]) => {
-    if (!activeChat || memberIds.length === 0) return;
-    const merged = [...new Set([...chatCharacterIds, ...memberIds])];
-    const newlyAdded = memberIds.filter((id) => !chatCharacterIds.includes(id));
-    updateChat.mutate(
-      { id: activeChat.id, characterIds: merged },
-      {
-        onSuccess: () => {
-          // Skip greeting for conversation mode
-          if (isConversation) return;
-          // Find the first newly-added character with a first_mes
-          const charList = (characters ?? []) as CharacterRow[];
-          for (const charId of newlyAdded) {
-            const char = charList.find((c) => c.id === charId);
-            if (!char) continue;
-            try {
-              const parsed = typeof char.data === "string" ? JSON.parse(char.data) : char.data;
-              const firstMes = (parsed as { first_mes?: string }).first_mes;
-              const altGreetings = (parsed as { alternate_greetings?: string[] }).alternate_greetings ?? [];
-              const name = (parsed as { name?: string }).name ?? "Unknown";
-              if (firstMes) {
-                setFirstMesConfirm({ charId, charName: name, message: firstMes, alternateGreetings: altGreetings });
-                break; // show one at a time
-              }
-            } catch {
-              /* ignore */
-            }
-          }
-        },
-      },
-    );
-  };
-
   const handleCreateFolder = useCallback(() => {
     createGroup.mutate({ name: getNextUnnamedFolderName(parsedGroups), characterIds: [] });
   }, [createGroup, parsedGroups]);
@@ -736,19 +641,6 @@ export function CharactersPanel() {
     exitSelectionMode();
   }, [selectedCharacterIds, deleteCharacter, exitSelectionMode]);
 
-  const handleStartNewChat = useCallback(
-    (characterId: string, characterName: string, firstMessage?: string, alternateGreetings?: string[]) => {
-      startChatFromCharacter({
-        characterId,
-        characterName,
-        mode: "roleplay",
-        firstMessage,
-        alternateGreetings,
-      });
-    },
-    [startChatFromCharacter],
-  );
-
   return (
     <div
       ref={panelScrollRef}
@@ -771,14 +663,14 @@ export function CharactersPanel() {
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-pink-400 to-rose-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-pink-500/15 transition-all hover:shadow-lg hover:shadow-pink-500/25 active:scale-[0.98]"
           title="New"
         >
-          <Plus size="0.8125rem" /> <span className="md:hidden">New</span>
+          <Plus size="0.8125rem" />
         </button>
         <button
           onClick={() => openModal("import-character")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
           title="Import"
         >
-          <Download size="0.8125rem" /> <span className="md:hidden">Import</span>
+          <Download size="0.8125rem" />
         </button>
         <button
           onClick={() => {
@@ -795,7 +687,6 @@ export function CharactersPanel() {
           title="Select"
         >
           <Check size="0.8125rem" />
-          <span className="md:hidden">Select</span>
         </button>
       </div>
 
@@ -810,14 +701,14 @@ export function CharactersPanel() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder='Search characters or -tag:"tag name"'
-            className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+            className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
           />
         </div>
         <div className="relative">
           <select
             value={sort}
             onChange={(e) => setCharacterLibrarySort(e.target.value as CharacterLibrarySort)}
-            className="mari-chrome-field h-full appearance-none py-2 pl-2.5 pr-7 text-[0.6875rem]"
+            className="mari-chrome-field h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
             <option value="name-asc">A-Z</option>
@@ -957,12 +848,20 @@ export function CharactersPanel() {
               {/* Folder header */}
               <div
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
-                onClick={() => setExpandedGroupId(isExpanded ? null : group.id)}
+                onClick={(event) =>
+                  handleFolderRenameGesture(group.id, event, {
+                    onSingleClick: () => setExpandedGroupId(isExpanded ? null : group.id),
+                    onRename: () => {
+                      setEditingGroupId(group.id);
+                      setEditGroupName(group.name);
+                    },
+                  })
+                }
               >
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -995,29 +894,6 @@ export function CharactersPanel() {
                   </span>
                 )}
                 <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
-                  {activeChat && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        addFolderToChat(group.memberIds);
-	                      }}
-	                      className="mari-chrome-control mari-chrome-control--small p-1"
-	                      title="Add all to chat"
-	                    >
-	                      <UserPlus size="0.6875rem" />
-                    </button>
-                  )}
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setEditingGroupId(group.id);
-                      setEditGroupName(group.name);
-                    }}
-	                    className="mari-chrome-control mari-chrome-control--small p-1"
-	                    title="Rename folder"
-	                  >
-                    <Pencil size="0.6875rem" />
-                  </button>
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
@@ -1032,70 +908,61 @@ export function CharactersPanel() {
               </div>
 
               {/* Expanded: show members */}
-              {isExpanded && (
-                <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pb-1 pl-1">
-                  {folderMemberIds.length === 0 && (
-                    <div className="py-2 text-[0.625rem] text-[var(--muted-foreground)] italic">
-                      Drop characters here.
-                    </div>
-                  )}
-                  {folderMemberIds.map((memberId) => {
-                    const member = charMap.get(memberId);
-                    if (!member) return null;
-                    const fullMember = parsedCharacterMap.get(memberId);
-                    const isBulkSelected = selectedCharacterIds.has(memberId);
-                    const memberName = fullMember?.parsed.name ?? member.name;
-                    const memberTitle = fullMember
-                      ? getCharacterTitle({ name: memberName, comment: fullMember.comment })
-                      : getCharacterTitle(member);
-                    const memberPreviewMetadata = fullMember ? getCharacterPreviewMetadata(fullMember) : null;
-                    const memberTags = fullMember ? getCharacterTags(fullMember) : [];
-                    const memberTokenEstimate = fullMember ? estimateCharacterCardTokens(fullMember.parsed) : null;
-                    const memberNameColor = (fullMember?.parsed.extensions?.nameColor as string) || undefined;
-                    const memberAvatarCrop = fullMember?.parsed.extensions?.avatarCrop as AvatarCropValue | undefined;
-                    return (
-                      <div
-                        key={memberId}
-                        onClick={() => {
-                          if (suppressCharacterClickRef.current) return;
-                          if (selectionMode) {
-                            toggleSelection(memberId);
-                            return;
-                          }
-                          openCharacterDetailFromPanel(memberId);
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key !== "Enter" && e.key !== " ") return;
-                          e.preventDefault();
-                          if (selectionMode) {
-                            toggleSelection(memberId);
-                            return;
-                          }
-                          openCharacterDetailFromPanel(memberId);
-                        }}
-                        draggable
-                        onDragStart={(event) => {
-                          const ids = getDraggedCharacterIds(memberId);
-                          setDraggedCharacterId(memberId);
-                          event.dataTransfer.effectAllowed = "move";
-                          event.dataTransfer.setData("application/x-marinara-character-ids", JSON.stringify(ids));
-                          event.dataTransfer.setData("text/plain", memberId);
-                        }}
+              <SmoothFolderContent
+                open={isExpanded}
+                className="ml-4 border-l border-[var(--border)]/20 pb-1 pl-1"
+                innerClassName="flex flex-col gap-0.5"
+              >
+                {folderMemberIds.length === 0 && (
+                  <div className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">
+                    Drop characters here.
+                  </div>
+                )}
+                {folderMemberIds.map((memberId) => {
+                  const member = charMap.get(memberId);
+                  if (!member) return null;
+                  const fullMember = parsedCharacterMap.get(memberId);
+                  const isBulkSelected = selectedCharacterIds.has(memberId);
+                  const memberName = fullMember?.parsed.name ?? member.name;
+                  const memberTitle = fullMember
+                    ? getCharacterTitle({ name: memberName, comment: fullMember.comment })
+                    : getCharacterTitle(member);
+                  const memberPreviewMetadata = fullMember ? getCharacterPreviewMetadata(fullMember) : null;
+                  const memberTags = fullMember ? getCharacterTags(fullMember) : [];
+                  const memberTokenEstimate = fullMember ? estimateCharacterCardTokens(fullMember.parsed) : null;
+                  const memberNameColor = (fullMember?.parsed.extensions?.nameColor as string) || undefined;
+                  const memberAvatarCrop = fullMember?.parsed.extensions?.avatarCrop as AvatarCropValue | undefined;
+                  return (
+                    <div
+                      key={memberId}
+                      onClick={() => {
+                        if (suppressCharacterClickRef.current) return;
+                        if (selectionMode) {
+                          toggleSelection(memberId);
+                          return;
+                        }
+                        openCharacterDetailFromPanel(memberId);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key !== "Enter" && e.key !== " ") return;
+                        e.preventDefault();
+                        if (selectionMode) {
+                          toggleSelection(memberId);
+                          return;
+                        }
+                        openCharacterDetailFromPanel(memberId);
+                      }}
+                      draggable
+                      onDragStart={(event) => {
+                        const ids = getDraggedCharacterIds(memberId);
+                        setDraggedCharacterId(memberId);
+                        event.dataTransfer.effectAllowed = "move";
+                        event.dataTransfer.setData("application/x-marinara-character-ids", JSON.stringify(ids));
+                        event.dataTransfer.setData("text/plain", memberId);
+                      }}
                         onDragEnd={() => setDraggedCharacterId(null)}
                         onTouchStart={(event) => startCharacterTouchDrag(event, memberId)}
                         onTouchEnd={finishCharacterTouchDrag}
-                        onContextMenu={(e) => {
-                          if (selectionMode) return;
-                          e.preventDefault();
-                          setContextMenu({
-                            x: e.clientX,
-                            y: e.clientY,
-                            charId: memberId,
-                            charName: memberName,
-                            firstMes: fullMember?.parsed?.first_mes as string | undefined,
-                            altGreetings: (fullMember?.parsed?.alternate_greetings ?? []) as string[],
-                          });
-                        }}
                         role="button"
                         tabIndex={0}
                         className={cn(
@@ -1211,42 +1078,21 @@ export function CharactersPanel() {
                           )}
                         </div>
                         {!selectionMode && (
-                          <>
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleStartNewChat(
-                                  memberId,
-                                  memberName,
-                                  fullMember?.parsed?.first_mes as string | undefined,
-                                  (fullMember?.parsed?.alternate_greetings ?? []) as string[],
-                                );
-                              }}
-                              disabled={isStartingChat}
-                              className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--primary)]/10 hover:text-[var(--primary)] group-hover/member:opacity-100 disabled:cursor-not-allowed disabled:opacity-50 max-md:opacity-100"
-                              title="Start New Chat"
-                              aria-label={`Start New Chat with ${memberName}`}
-                            >
-                              <MessageCircle size="0.6875rem" />
-                            </button>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                void moveCharactersToFolder([memberId], null);
-                              }}
-                              className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
-                              title="Remove from folder"
-                            >
-                              <UserMinus size="0.6875rem" className="text-[var(--destructive)]" />
-                            </button>
-                          </>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              void moveCharactersToFolder([memberId], null);
+                            }}
+                            className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
+                            title="Remove from folder"
+                          >
+                            <UserMinus size="0.6875rem" className="text-[var(--destructive)]" />
+                          </button>
                         )}
                       </div>
                     );
-                  })}
-                </div>
-              )}
+                })}
+              </SmoothFolderContent>
             </div>
           );
         })}
@@ -1307,7 +1153,6 @@ export function CharactersPanel() {
           const charTitle = getCharacterTitle({ name: charName, comment: char.comment });
           const charTags = getCharacterTags(char);
           const charNameColor = (char.parsed.extensions?.nameColor as string) || undefined;
-          const isSelected = chatCharacterIds.includes(char.id);
           const isBulkSelected = selectedCharacterIds.has(char.id);
           const isFavorite = !!char.parsed.extensions?.fav;
           const avatarUrl = char.avatarPath;
@@ -1336,22 +1181,9 @@ export function CharactersPanel() {
               onDragEnd={() => setDraggedCharacterId(null)}
               onTouchStart={(event) => startCharacterTouchDrag(event, char.id)}
               onTouchEnd={finishCharacterTouchDrag}
-              onContextMenu={(e) => {
-                if (selectionMode) return;
-                e.preventDefault();
-                setContextMenu({
-                  x: e.clientX,
-                  y: e.clientY,
-                  charId: char.id,
-                  charName,
-                  firstMes: char.parsed?.first_mes as string | undefined,
-                  altGreetings: (char.parsed?.alternate_greetings ?? []) as string[],
-                });
-              }}
               className={cn(
                 "group relative flex items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)] cursor-pointer",
                 selectionMode && isBulkSelected && "ring-1 ring-[var(--primary)]/40 bg-[var(--primary)]/8",
-                isSelected && "ring-1 ring-[var(--primary)]/40 bg-[var(--primary)]/5",
                 draggedCharacterId === char.id && "opacity-50",
               )}
             >
@@ -1393,11 +1225,6 @@ export function CharactersPanel() {
                     className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
                   >
                     <Star size="0.625rem" className="fill-current" />
-                  </div>
-                )}
-                {isSelected && (
-                  <div className="absolute -left-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--primary)] shadow-sm">
-                    <Check size="0.5625rem" className="text-white" />
                   </div>
                 )}
               </div>
@@ -1464,23 +1291,6 @@ export function CharactersPanel() {
               {/* Actions */}
               {!selectionMode && (
                 <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
-                  {activeChat && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleCharacter(char.id);
-                      }}
-                      className={cn(
-                        "rounded-lg p-1.5 transition-all active:scale-90",
-                        isSelected
-                          ? "text-[var(--destructive)] hover:bg-[var(--destructive)]/15"
-                          : "text-[var(--muted-foreground)] hover:bg-[var(--primary)]/10 hover:text-[var(--primary)]",
-                      )}
-                      title={isSelected ? "Remove from chat" : "Add to chat"}
-                    >
-                      {isSelected ? <X size="0.75rem" /> : <Check size="0.75rem" />}
-                    </button>
-                  )}
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
@@ -1522,12 +1332,6 @@ export function CharactersPanel() {
         })}
       </div>
 
-      {activeChat && !selectionMode && (
-        <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]/60">
-          Click to edit · Use ✓ to assign/remove from chat
-        </p>
-      )}
-
       {selectionMode && (
         <SelectionActionBar
           selectedCount={selectedCharacterIds.size}
@@ -1535,95 +1339,6 @@ export function CharactersPanel() {
           onDelete={handleDeleteSelected}
           exporting={exportingSelected}
         />
-      )}
-
-      {contextMenu &&
-        (() => {
-          const items: ContextMenuItem[] = [
-            {
-              label: "Quick Start Roleplay",
-              icon: <Wand2 size="0.75rem" />,
-              onSelect: () =>
-                handleStartNewChat(
-                  contextMenu.charId,
-                  contextMenu.charName,
-                  contextMenu.firstMes,
-                  contextMenu.altGreetings,
-                ),
-            },
-            {
-              label: "Quick Start Conversation",
-              icon: <MessageCircle size="0.75rem" />,
-              onSelect: () =>
-                startChatFromCharacter({
-                  characterId: contextMenu.charId,
-                  characterName: contextMenu.charName,
-                  mode: "conversation",
-                }),
-            },
-          ];
-          return <ContextMenu x={contextMenu.x} y={contextMenu.y} items={items} onClose={() => setContextMenu(null)} />;
-        })()}
-
-      {/* First message confirmation dialog */}
-      {firstMesConfirm && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 max-md:pt-[env(safe-area-inset-top)]"
-          onClick={() => setFirstMesConfirm(null)}
-        >
-          <div
-            className="relative mx-4 flex w-full max-w-sm flex-col rounded-xl bg-[var(--card)] shadow-2xl ring-1 ring-[var(--border)]"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center gap-2 border-b border-[var(--border)] px-4 py-3">
-              <MessageCircle size="0.875rem" className="text-[var(--muted-foreground)]" />
-              <span className="text-sm font-semibold text-[var(--foreground)]">First Message</span>
-            </div>
-            <div className="px-4 py-3">
-              <p className="text-sm text-[var(--foreground)]">
-                Add <strong>{firstMesConfirm.charName}</strong>'s first message to the chat?
-              </p>
-              <p className="mt-2 max-h-32 overflow-y-auto rounded-lg bg-[var(--accent)]/50 px-3 py-2 text-xs leading-relaxed text-[var(--muted-foreground)]">
-                {firstMesConfirm.message.length > 300
-                  ? firstMesConfirm.message.slice(0, 300) + "\u2026"
-                  : firstMesConfirm.message}
-              </p>
-            </div>
-            <div className="flex justify-end gap-2 border-t border-[var(--border)] px-4 py-3">
-	                <button
-	                  onClick={() => setFirstMesConfirm(null)}
-	                  className="mari-chrome-control mari-chrome-control--small text-xs"
-	                >
-                Skip
-              </button>
-              <button
-                onClick={async () => {
-                  const msg = await createMessage.mutateAsync({
-                    role: "assistant",
-                    content: firstMesConfirm.message,
-                    characterId: firstMesConfirm.charId,
-                  });
-                  // Add alternate greetings as swipes on the first message
-                  if (msg?.id && firstMesConfirm.alternateGreetings.length > 0) {
-                    for (const greeting of firstMesConfirm.alternateGreetings) {
-                      if (greeting.trim()) {
-                        await api.post(`/chats/${activeChat!.id}/messages/${msg.id}/swipes`, {
-                          content: greeting,
-                          silent: true,
-                        });
-                      }
-                    }
-                    queryClient.invalidateQueries({ queryKey: chatKeys.messages(activeChat!.id) });
-                  }
-                  setFirstMesConfirm(null);
-                }}
-                className="rounded-lg bg-[var(--primary)] px-3 py-1.5 text-xs font-medium text-[var(--primary-foreground)] transition-colors hover:opacity-90"
-              >
-                Add Message
-              </button>
-            </div>
-          </div>
-        </div>
       )}
     </div>
   );

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -18,6 +18,7 @@ import {
   useReorderConnectionFolders,
   useMoveConnection,
 } from "../../hooks/use-connection-folders";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent } from "../../hooks/use-agents";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -35,7 +36,6 @@ import {
   Link,
   Check,
   Download,
-  Upload,
   Search,
   Shuffle,
   ExternalLink,
@@ -48,7 +48,6 @@ import {
   ChevronRight,
   FolderPlus,
   GripVertical,
-  Pencil,
   Camera,
   Sparkles,
   ImageIcon,
@@ -63,7 +62,9 @@ import {
 } from "../../lib/connection-transfer";
 import { toast } from "sonner";
 import { TTSConfigCard } from "./settings/TTSConfigCard";
+import { SettingsSwitch } from "./settings/SettingControls";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 /** Provider color pair for connection icons. Kept as one blue family by design. */
 const CONNECTION_ICON_COLORS = {
@@ -287,48 +288,20 @@ function SidecarCard() {
                 {trackerLocalCount}/{trackerAgents.length} built-in tracker agents currently point at the local model.
                 This changes which model they use when enabled; it does not enable the agents by itself.
               </p>
-              <button
-                type="button"
-                onClick={() => updateConfig({ useForTrackers: !config.useForTrackers })}
-                className="flex items-center gap-2.5 cursor-pointer select-none text-left"
-              >
-                <div className="relative shrink-0">
-                  <div
-                    className={cn(
-                      "h-4 w-7 rounded-full transition-colors",
-                      config.useForTrackers ? "bg-sky-400/70" : "bg-[var(--border)]",
-                    )}
-                  />
-                  <div
-                    className={cn(
-                      "absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
-                      config.useForTrackers && "translate-x-3",
-                    )}
-                  />
-                </div>
-                <span className="text-xs text-[var(--muted-foreground)]">Use for tracker agents (roleplay)</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => updateConfig({ useForGameScene: !config.useForGameScene })}
-                className="flex items-center gap-2.5 cursor-pointer select-none text-left"
-              >
-                <div className="relative shrink-0">
-                  <div
-                    className={cn(
-                      "h-4 w-7 rounded-full transition-colors",
-                      config.useForGameScene ? "bg-sky-400/70" : "bg-[var(--border)]",
-                    )}
-                  />
-                  <div
-                    className={cn(
-                      "absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
-                      config.useForGameScene && "translate-x-3",
-                    )}
-                  />
-                </div>
-                <span className="text-xs text-[var(--muted-foreground)]">Use for game scene analysis</span>
-              </button>
+              <SettingsSwitch
+                label="Use for tracker agents (roleplay)"
+                checked={config.useForTrackers}
+                onChange={(checked) => updateConfig({ useForTrackers: checked })}
+                className="p-0 hover:bg-transparent"
+                labelClassName="text-xs text-[var(--muted-foreground)]"
+              />
+              <SettingsSwitch
+                label="Use for game scene analysis"
+                checked={config.useForGameScene}
+                onChange={(checked) => updateConfig({ useForGameScene: checked })}
+                className="p-0 hover:bg-transparent"
+                labelClassName="text-xs text-[var(--muted-foreground)]"
+              />
             </div>
           )}
           {!isDownloaded && (
@@ -569,7 +542,6 @@ function ConnectionRow({
   onDragStart,
   onDragEnd,
   onImagePick,
-  onExport,
 }: {
   conn: ConnectionRowData;
   isSelected: boolean;
@@ -580,7 +552,6 @@ function ConnectionRow({
   onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd: () => void;
   onImagePick: () => void;
-  onExport: () => void;
 }) {
   const duplicateConnection = useDuplicateConnection();
   const deleteConnection = useDeleteConnection();
@@ -679,16 +650,6 @@ function ConnectionRow({
           <Copy size="0.75rem" />
         </button>
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onExport();
-          }}
-          className="mari-chrome-control mari-chrome-control--small p-1.5"
-          title="Export"
-        >
-          <Upload size="0.75rem" />
-        </button>
-        <button
           onClick={async (e) => {
             e.stopPropagation();
             if (
@@ -738,11 +699,22 @@ function ConnectionFolderRow({
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(folder.name);
   const [isDropTarget, setIsDropTarget] = useState(false);
+  const handleFolderRenameGesture = useFolderRenameGesture();
   const isExpanded = forceExpanded || !folder.collapsed;
+
+  useEffect(() => {
+    if (!renaming) setRenameValue(folder.name);
+  }, [folder.name, renaming]);
+
+  const beginRename = () => {
+    setRenameValue(folder.name);
+    setRenaming(true);
+  };
 
   return (
     <Reorder.Item
       value={folder.id}
+      layout="position"
       dragListener={false}
       dragControls={dragControls}
       as="div"
@@ -780,7 +752,12 @@ function ConnectionFolderRow({
     >
       {/* Folder header */}
       <div
-        onClick={() => onToggleCollapse(folder)}
+        onClick={(event) =>
+          handleFolderRenameGesture(folder.id, event, {
+            onSingleClick: () => onToggleCollapse(folder),
+            onRename: beginRename,
+          })
+        }
         className="group relative flex items-center gap-1.5 rounded-lg px-2 py-1.5 hover:bg-[var(--sidebar-accent)]/40"
       >
         <div
@@ -791,7 +768,10 @@ function ConnectionFolderRow({
         </div>
         <ChevronRight
           size="0.75rem"
-          className={cn("text-[var(--muted-foreground)] transition-transform", isExpanded && "rotate-90")}
+          className={cn(
+            "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+            isExpanded && "rotate-90",
+          )}
         />
         {renaming ? (
           <input
@@ -816,7 +796,7 @@ function ConnectionFolderRow({
             className="flex-1 bg-transparent text-xs font-medium text-[var(--foreground)] outline-none"
           />
         ) : (
-          <span className="flex-1 cursor-pointer truncate text-xs font-medium text-[var(--muted-foreground)]">
+          <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--muted-foreground)]">
             {folder.name}
           </span>
         )}
@@ -826,33 +806,24 @@ function ConnectionFolderRow({
         <button
           onClick={(e) => {
             e.stopPropagation();
-            setRenameValue(folder.name);
-            setRenaming(true);
-          }}
-          className="shrink-0 rounded-md p-1 opacity-0 transition-all hover:bg-[var(--accent)] group-hover:opacity-100 max-md:opacity-100"
-          title="Rename folder"
-        >
-          <Pencil size="0.75rem" className="text-[var(--muted-foreground)]" />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
             onDelete(folder);
           }}
-          className="shrink-0 rounded-md p-1 opacity-0 transition-all hover:bg-[var(--destructive)]/20 group-hover:opacity-100 max-md:opacity-100"
+          className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger shrink-0 p-1 opacity-0 transition-opacity group-hover:opacity-100 max-md:opacity-100"
           title="Delete folder"
         >
-          <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+          <Trash2 size="0.75rem" />
         </button>
       </div>
       {/* Folder contents */}
-      {isExpanded && entries.length > 0 && (
-        <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pl-1">
-          {entries.map((c) => (
-            <div key={c.id}>{renderConnectionRow(c)}</div>
-          ))}
-        </div>
-      )}
+      <SmoothFolderContent
+        open={isExpanded && entries.length > 0}
+        className="ml-4 border-l border-[var(--border)]/20 pl-1"
+        innerClassName="flex flex-col gap-0.5"
+      >
+        {entries.map((c) => (
+          <div key={c.id}>{renderConnectionRow(c)}</div>
+        ))}
+      </SmoothFolderContent>
     </Reorder.Item>
   );
 }
@@ -1118,7 +1089,6 @@ export function ConnectionsPanel() {
         }}
         onDragEnd={() => setDraggedConnectionId(null)}
         onImagePick={() => handlePickConnectionImage(conn.id)}
-        onExport={() => void exportConnections([conn])}
       />
     );
   };
@@ -1140,14 +1110,14 @@ export function ConnectionsPanel() {
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-sky-400 to-blue-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-sky-400/15 transition-all hover:shadow-lg hover:shadow-sky-400/25 active:scale-[0.98]"
           title="New"
         >
-          <Plus size="0.8125rem" /> <span className="md:hidden">New</span>
+          <Plus size="0.8125rem" />
         </button>
         <button
           onClick={() => openModal("import-connection")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
           title="Import"
         >
-          <Download size="0.8125rem" /> <span className="md:hidden">Import</span>
+          <Download size="0.8125rem" />
         </button>
         <button
           onClick={() => (selectionMode ? exitSelectionMode() : setSelectionMode(true))}
@@ -1158,7 +1128,7 @@ export function ConnectionsPanel() {
           )}
           title="Select"
         >
-          <Check size="0.8125rem" /> <span className="md:hidden">Select</span>
+          <Check size="0.8125rem" />
         </button>
       </div>
 
@@ -1173,7 +1143,7 @@ export function ConnectionsPanel() {
           placeholder="Search connections..."
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+          className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
         />
       </div>
 

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -18,7 +18,7 @@ import {
   useReorderConnectionFolders,
   useMoveConnection,
 } from "../../hooks/use-connection-folders";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent } from "../../hooks/use-agents";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -752,12 +752,24 @@ function ConnectionFolderRow({
     >
       {/* Folder header */}
       <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
+        title="Double-click or press F2 to rename."
         onClick={(event) =>
           handleFolderRenameGesture(folder.id, event, {
             onSingleClick: () => onToggleCollapse(folder),
             onRename: beginRename,
           })
         }
+        onKeyDown={(event) => {
+          if (event.target !== event.currentTarget) return;
+          handleFolderRenameKeyDown(event, {
+            onSingleClick: () => onToggleCollapse(folder),
+            onRename: beginRename,
+          });
+        }}
         className="group relative flex items-center gap-1.5 rounded-lg px-2 py-1.5 hover:bg-[var(--sidebar-accent)]/40"
       >
         <div
@@ -1106,26 +1118,32 @@ export function ConnectionsPanel() {
       {/* Action buttons */}
       <div className="flex gap-2">
         <button
+          type="button"
           onClick={() => openModal("create-connection")}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-sky-400 to-blue-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-sky-400/15 transition-all hover:shadow-lg hover:shadow-sky-400/25 active:scale-[0.98]"
+          aria-label="Create connection"
           title="New"
         >
           <Plus size="0.8125rem" />
         </button>
         <button
+          type="button"
           onClick={() => openModal("import-connection")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
+          aria-label="Import connection"
           title="Import"
         >
           <Download size="0.8125rem" />
         </button>
         <button
+          type="button"
           onClick={() => (selectionMode ? exitSelectionMode() : setSelectionMode(true))}
           disabled={connectionsList.length === 0}
           className={cn(
             "mari-chrome-control mari-chrome-control--primary flex-1 text-xs",
             selectionMode && "mari-chrome-control--selected",
           )}
+          aria-label={selectionMode ? "Exit connection selection mode" : "Select connections"}
           title="Select"
         >
           <Check size="0.8125rem" />

--- a/packages/client/src/components/panels/GlobalGalleryPanel.tsx
+++ b/packages/client/src/components/panels/GlobalGalleryPanel.tsx
@@ -2,12 +2,13 @@
 // Panel: Global Gallery — profile-wide images + flat folders
 // ──────────────────────────────────────────────
 import { useCallback, useMemo, useState } from "react";
-import { Upload, Download, Trash2, X, FolderPlus, Pencil, Check, Folder } from "lucide-react";
+import { Upload, Download, Trash2, X, FolderPlus, Check, Folder } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "../../lib/utils";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import {
   useGlobalGalleryImages,
   useGalleryFolders,
@@ -44,6 +45,7 @@ export function GlobalGalleryPanel() {
   const [renameValue, setRenameValue] = useState("");
   const [dragImageId, setDragImageId] = useState<string | null>(null);
   const [dragOverFolder, setDragOverFolder] = useState<FolderFilter | null>(null);
+  const handleFolderRenameGesture = useFolderRenameGesture();
 
   const counts = useMemo(() => {
     const byFolder = new Map<string, number>();
@@ -168,11 +170,24 @@ export function GlobalGalleryPanel() {
     [dragImageId, handleMove],
   );
 
-  const chip = (key: FolderFilter, label: string, count: number, dropTarget: boolean) => (
+  const chip = (key: FolderFilter, label: string, count: number, dropTarget: boolean, renamable = false) => (
     <button
       key={key}
       type="button"
-      onClick={() => setActiveFolder(key)}
+      onClick={(event) => {
+        if (!renamable) {
+          setActiveFolder(key);
+          return;
+        }
+        handleFolderRenameGesture(key, event, {
+          onSingleClick: () => setActiveFolder(key),
+          onRename: () => {
+            setActiveFolder(key);
+            setRenameValue(label);
+            setRenaming(true);
+          },
+        });
+      }}
       onDragOver={dropTarget ? (e) => e.preventDefault() : undefined}
       onDragEnter={dropTarget ? () => setDragOverFolder(key) : undefined}
       onDragLeave={dropTarget ? () => setDragOverFolder((cur) => (cur === key ? null : cur)) : undefined}
@@ -211,7 +226,7 @@ export function GlobalGalleryPanel() {
       <div className="flex flex-wrap items-center gap-1.5">
         {chip("all", "All", counts.total, false)}
         {chip("unfiled", "Unfiled", counts.unfiled, true)}
-        {folders?.map((folder) => chip(folder.id, folder.name, counts.byFolder.get(folder.id) ?? 0, true))}
+        {folders?.map((folder) => chip(folder.id, folder.name, counts.byFolder.get(folder.id) ?? 0, true, true))}
         {creatingFolder ? (
           <span className="flex items-center gap-1">
             <input
@@ -293,27 +308,14 @@ export function GlobalGalleryPanel() {
               </button>
             </>
           ) : (
-            <>
-              <button
-                type="button"
-                onClick={() => {
-                  setRenameValue(activeFolderObj.name);
-                  setRenaming(true);
-                }}
-                className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-              >
-                <Pencil size="0.75rem" />
-                Rename
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleDeleteFolder()}
-                className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--destructive)] hover:bg-[var(--destructive)]/10"
-              >
-                <Trash2 size="0.75rem" />
-                Delete folder
-              </button>
-            </>
+            <button
+              type="button"
+              onClick={() => void handleDeleteFolder()}
+              className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-[var(--destructive)] hover:bg-[var(--destructive)]/10"
+            >
+              <Trash2 size="0.75rem" />
+              Delete folder
+            </button>
           )}
         </div>
       )}

--- a/packages/client/src/components/panels/GlobalGalleryPanel.tsx
+++ b/packages/client/src/components/panels/GlobalGalleryPanel.tsx
@@ -8,7 +8,7 @@ import { cn } from "../../lib/utils";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import {
   useGlobalGalleryImages,
   useGalleryFolders,
@@ -188,6 +188,21 @@ export function GlobalGalleryPanel() {
           },
         });
       }}
+      onKeyDown={
+        renamable
+          ? (event) =>
+              handleFolderRenameKeyDown(event, {
+                onSingleClick: () => setActiveFolder(key),
+                onRename: () => {
+                  setActiveFolder(key);
+                  setRenameValue(label);
+                  setRenaming(true);
+                },
+              })
+          : undefined
+      }
+      aria-label={renamable ? `${label}. Press F2 to rename.` : label}
+      title={renamable ? `${label}. Double-click or press F2 to rename.` : undefined}
       onDragOver={dropTarget ? (e) => e.preventDefault() : undefined}
       onDragEnter={dropTarget ? () => setDragOverFolder(key) : undefined}
       onDragLeave={dropTarget ? () => setDragOverFolder((cur) => (cur === key ? null : cur)) : undefined}

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -45,7 +45,7 @@ import {
   useMoveLibraryItem,
   useUpdateLibraryFolder,
 } from "../../hooks/use-library-folders";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
@@ -69,6 +69,21 @@ const CATEGORY_COLORS: Record<string, string> = {
   uncategorized: "from-amber-400 to-orange-500",
   all: "from-amber-400 to-orange-500",
 };
+
+function remapLorebookEntryRelationships(
+  relationships: Record<string, string> | null | undefined,
+  entryIdMap: Map<string, string>,
+) {
+  const remapped: Record<string, string> = {};
+  if (!relationships) return remapped;
+
+  for (const [sourceEntryId, relationshipType] of Object.entries(relationships)) {
+    const clonedEntryId = entryIdMap.get(sourceEntryId);
+    if (clonedEntryId) remapped[clonedEntryId] = relationshipType;
+  }
+
+  return remapped;
+}
 
 export function LorebooksPanel() {
   const [activeCategory, setActiveCategory] = useState<LorebookCategory | "all" | "active">("all");
@@ -437,18 +452,41 @@ export function LorebooksPanel() {
         }
 
         if (entries.length > 0) {
-          await api.post<LorebookEntry[]>(`/lorebooks/${createdId}/entries/bulk`, {
-            entries: entries.map((entry) => {
-              const clone: Partial<LorebookEntry> = { ...entry };
-              delete clone.id;
-              delete clone.lorebookId;
-              delete clone.createdAt;
-              delete clone.updatedAt;
-              delete clone.embedding;
-              clone.folderId = entry.folderId ? (folderIdMap.get(entry.folderId) ?? null) : null;
-              return clone;
-            }),
+          const clonedEntries = entries.map((entry) => {
+            const clone: Partial<LorebookEntry> = { ...entry };
+            delete clone.id;
+            delete clone.lorebookId;
+            delete clone.createdAt;
+            delete clone.updatedAt;
+            delete clone.embedding;
+            clone.folderId = entry.folderId ? (folderIdMap.get(entry.folderId) ?? null) : null;
+            clone.relationships = {};
+            return clone;
           });
+
+          const createdEntries = await api.post<LorebookEntry[]>(`/lorebooks/${createdId}/entries/bulk`, {
+            entries: clonedEntries,
+          });
+
+          const entryIdMap = new Map<string, string>();
+          entries.forEach((entry, index) => {
+            const createdEntry = createdEntries[index];
+            if (createdEntry) entryIdMap.set(entry.id, createdEntry.id);
+          });
+
+          const relationshipUpdates = entries
+            .map((entry, index) => {
+              const createdEntry = createdEntries[index];
+              if (!createdEntry) return null;
+
+              const relationships = remapLorebookEntryRelationships(entry.relationships, entryIdMap);
+              if (Object.keys(relationships).length === 0) return null;
+
+              return api.patch<LorebookEntry>(`/lorebooks/${createdId}/entries/${createdEntry.id}`, { relationships });
+            })
+            .filter((update): update is Promise<LorebookEntry> => Boolean(update));
+
+          await Promise.all(relationshipUpdates);
         }
 
         toast.success(`Copied "${lorebook.name}"`);
@@ -860,6 +898,11 @@ export function LorebooksPanel() {
               className="flex flex-col rounded-lg transition-colors"
             >
               <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
+                title="Double-click or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(folder.id, event, {
@@ -870,6 +913,16 @@ export function LorebooksPanel() {
                     },
                   })
                 }
+                onKeyDown={(event) => {
+                  if (event.target !== event.currentTarget) return;
+                  handleFolderRenameKeyDown(event, {
+                    onSingleClick: () => setExpandedFolderId(isExpanded ? null : folder.id),
+                    onRename: () => {
+                      setEditingFolderId(folder.id);
+                      setEditFolderName(folder.name);
+                    },
+                  });
+                }}
               >
                 <ChevronRight
                   size="0.75rem"

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -6,6 +6,7 @@ import { useState, useMemo, useCallback, useRef, type ChangeEvent, type DragEven
 import { toast } from "sonner";
 import {
   Plus,
+  Copy,
   Download,
   Check,
   BookOpen,
@@ -17,16 +18,21 @@ import {
   ChevronRight,
   ChevronUp,
   FolderPlus,
-  Pencil,
   X,
   Trash2,
   Camera,
 } from "lucide-react";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
-import { useLorebooks, useDeleteLorebook, useUpdateLorebook, useUploadLorebookImage } from "../../hooks/use-lorebooks";
+import {
+  useLorebooks,
+  useCreateLorebook,
+  useDeleteLorebook,
+  useUpdateLorebook,
+  useUploadLorebookImage,
+} from "../../hooks/use-lorebooks";
 import { useCharacters, usePersonas } from "../../hooks/use-characters";
-import type { Lorebook, LorebookCategory } from "@marinara-engine/shared";
+import type { Lorebook, LorebookCategory, LorebookEntry, LorebookFolder } from "@marinara-engine/shared";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
@@ -39,7 +45,9 @@ import {
   useMoveLibraryItem,
   useUpdateLibraryFolder,
 } from "../../hooks/use-library-folders";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 const CATEGORIES: Array<{ id: LorebookCategory | "all" | "active"; label: string }> = [
   { id: "all", label: "All" },
@@ -79,6 +87,7 @@ export function LorebooksPanel() {
   const imageTargetLorebookIdRef = useRef<string | null>(null);
   const lorebookTouchDragRef = useRef<{ id: string; timer: number | null; active: boolean } | null>(null);
   const suppressLorebookClickRef = useRef(false);
+  const handleFolderRenameGesture = useFolderRenameGesture();
 
   // Active chat context for the "Active" filter
   const activeChat = useChatStore((s) => s.activeChat);
@@ -102,6 +111,7 @@ export function LorebooksPanel() {
   );
   const { data: rawCharacters } = useCharacters();
   const { data: rawPersonas } = usePersonas();
+  const createLorebook = useCreateLorebook();
   const deleteLorebook = useDeleteLorebook();
   const updateLorebook = useUpdateLorebook();
   const uploadLorebookImage = useUploadLorebookImage();
@@ -371,6 +381,85 @@ export function LorebooksPanel() {
     }
   }, []);
 
+  const handleDuplicateLorebook = useCallback(
+    async (lorebook: Lorebook) => {
+      try {
+        const [folders, entries] = await Promise.all([
+          api.get<LorebookFolder[]>(`/lorebooks/${lorebook.id}/folders`),
+          api.get<LorebookEntry[]>(`/lorebooks/${lorebook.id}/entries`),
+        ]);
+        const created = await createLorebook.mutateAsync({
+          name: `${lorebook.name} (Copy)`,
+          description: lorebook.description,
+          category: lorebook.category,
+          imagePath: lorebook.imagePath,
+          scanDepth: lorebook.scanDepth,
+          tokenBudget: lorebook.tokenBudget,
+          entryLimit: lorebook.entryLimit,
+          recursiveScanning: lorebook.recursiveScanning,
+          maxRecursionDepth: lorebook.maxRecursionDepth,
+          excludeFromVectorization: lorebook.excludeFromVectorization,
+          characterId: lorebook.characterId,
+          characterIds: lorebook.characterIds,
+          personaId: lorebook.personaId,
+          personaIds: lorebook.personaIds,
+          chatId: lorebook.chatId,
+          isGlobal: lorebook.isGlobal,
+          enabled: lorebook.enabled,
+          scope: lorebook.scope,
+          tags: lorebook.tags,
+          generatedBy: lorebook.generatedBy,
+          sourceAgentId: lorebook.sourceAgentId,
+        });
+        const createdId = created.id;
+        const folderIdMap = new Map<string, string>();
+        const pendingFolders = [...folders].sort((a, b) => a.order - b.order);
+
+        while (pendingFolders.length > 0) {
+          let createdInPass = false;
+          for (let index = pendingFolders.length - 1; index >= 0; index--) {
+            const folder = pendingFolders[index];
+            const parentFolderId = folder.parentFolderId ? folderIdMap.get(folder.parentFolderId) : null;
+            if (folder.parentFolderId && !parentFolderId) continue;
+
+            const createdFolder = await api.post<LorebookFolder>(`/lorebooks/${createdId}/folders`, {
+              name: folder.name,
+              enabled: folder.enabled,
+              parentFolderId,
+              order: folder.order,
+            });
+            folderIdMap.set(folder.id, createdFolder.id);
+            pendingFolders.splice(index, 1);
+            createdInPass = true;
+          }
+
+          if (!createdInPass) throw new Error("Could not copy lorebook folders");
+        }
+
+        if (entries.length > 0) {
+          await api.post<LorebookEntry[]>(`/lorebooks/${createdId}/entries/bulk`, {
+            entries: entries.map((entry) => {
+              const clone: Partial<LorebookEntry> = { ...entry };
+              delete clone.id;
+              delete clone.lorebookId;
+              delete clone.createdAt;
+              delete clone.updatedAt;
+              delete clone.embedding;
+              clone.folderId = entry.folderId ? (folderIdMap.get(entry.folderId) ?? null) : null;
+              return clone;
+            }),
+          });
+        }
+
+        toast.success(`Copied "${lorebook.name}"`);
+        openLorebookDetail(createdId);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to copy lorebook");
+      }
+    },
+    [createLorebook, openLorebookDetail],
+  );
+
   const handleLorebookImageSelected = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
@@ -524,6 +613,7 @@ export function LorebooksPanel() {
               deleteLorebook.mutate(lb.id);
             }
           }}
+          onDuplicate={() => void handleDuplicateLorebook(lb)}
           onImagePick={() => handlePickLorebookImage(lb.id)}
           selectionMode={selectionMode}
           isSelected={selectedLorebookIds.has(lb.id)}
@@ -550,6 +640,7 @@ export function LorebooksPanel() {
       getCharacterNames,
       getDraggedLorebookIds,
       getPersonaNames,
+      handleDuplicateLorebook,
       handlePickLorebookImage,
       openLorebookDetail,
       selectedLorebookIds,
@@ -576,14 +667,14 @@ export function LorebooksPanel() {
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-amber-400/15 transition-all hover:shadow-lg hover:shadow-amber-400/25 active:scale-[0.98]"
           title="New"
         >
-          <Plus size="0.8125rem" /> <span className="md:hidden">New</span>
+          <Plus size="0.8125rem" />
         </button>
         <button
           onClick={() => openModal("import-lorebook")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
           title="Import"
         >
-          <Download size="0.8125rem" /> <span className="md:hidden">Import</span>
+          <Download size="0.8125rem" />
         </button>
         <button
           onClick={() => {
@@ -596,7 +687,7 @@ export function LorebooksPanel() {
           )}
           title="Select"
         >
-          <Check size="0.8125rem" /> <span className="md:hidden">Select</span>
+          <Check size="0.8125rem" />
         </button>
       </div>
 
@@ -612,14 +703,14 @@ export function LorebooksPanel() {
             placeholder="Search lorebooks"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+            className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
           />
         </div>
         <div className="relative">
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value as typeof sort)}
-            className="mari-chrome-field h-full appearance-none py-2 pl-2.5 pr-7 text-[0.6875rem]"
+            className="mari-chrome-field h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
             <option value="name-asc">A-Z</option>
@@ -770,12 +861,20 @@ export function LorebooksPanel() {
             >
               <div
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
-                onClick={() => setExpandedFolderId(isExpanded ? null : folder.id)}
+                onClick={(event) =>
+                  handleFolderRenameGesture(folder.id, event, {
+                    onSingleClick: () => setExpandedFolderId(isExpanded ? null : folder.id),
+                    onRename: () => {
+                      setEditingFolderId(folder.id);
+                      setEditFolderName(folder.name);
+                    },
+                  })
+                }
               >
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -811,17 +910,6 @@ export function LorebooksPanel() {
                   <button
                     onClick={(event) => {
                       event.stopPropagation();
-                      setEditingFolderId(folder.id);
-                      setEditFolderName(folder.name);
-                    }}
-	                    className="mari-chrome-control mari-chrome-control--small p-1"
-	                    title="Rename folder"
-	                  >
-                    <Pencil size="0.6875rem" />
-                  </button>
-                  <button
-                    onClick={(event) => {
-                      event.stopPropagation();
                       void confirmNonEmptyFolderDelete(folder.itemIds.length, {
                         title: "Delete Folder",
                         message: `Delete "${folder.name}"? Its ${folder.itemIds.length} lorebook${
@@ -842,15 +930,17 @@ export function LorebooksPanel() {
                   </button>
                 </div>
               </div>
-              {isExpanded && (
-                <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pb-1 pl-1">
-                  {folderItems.length === 0 ? (
-                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop lorebooks here.</p>
-                  ) : (
-                    folderItems.map((lb) => renderLorebookRow(lb))
-                  )}
-                </div>
-              )}
+              <SmoothFolderContent
+                open={isExpanded}
+                className="ml-4 border-l border-[var(--border)]/20 pb-1 pl-1"
+                innerClassName="flex flex-col gap-0.5"
+              >
+                {folderItems.length === 0 ? (
+                  <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop lorebooks here.</p>
+                ) : (
+                  folderItems.map((lb) => renderLorebookRow(lb))
+                )}
+              </SmoothFolderContent>
             </div>
           );
         })}
@@ -934,6 +1024,7 @@ function LorebookRow({
   personaName,
   onClick,
   onDelete,
+  onDuplicate,
   onImagePick,
   selectionMode,
   isSelected,
@@ -950,6 +1041,7 @@ function LorebookRow({
   personaName?: string;
   onClick: () => void;
   onDelete: () => void;
+  onDuplicate: () => void;
   onImagePick: () => void;
   selectionMode?: boolean;
   isSelected?: boolean;
@@ -1028,7 +1120,7 @@ function LorebookRow({
           </span>
         </button>
       )}
-      <div className="min-w-0 flex-1">
+      <div className={cn("min-w-0 flex-1", !selectionMode && "pr-16")}>
         <div className="flex items-center gap-1.5">
           <span className="truncate text-sm font-medium">{lorebook.name}</span>
           {!lorebook.enabled && (
@@ -1051,6 +1143,16 @@ function LorebookRow({
       </div>
       {!selectionMode && (
         <div className="absolute right-2 top-1/2 -translate-y-1/2 flex shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDuplicate();
+            }}
+            className="mari-chrome-control mari-chrome-control--small p-1.5"
+            title="Copy"
+          >
+            <Copy size="0.75rem" />
+          </button>
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -20,7 +20,6 @@ import {
   Plus,
   Trash2,
   User,
-  Pencil,
   Camera,
   ArrowUpDown,
   Download,
@@ -35,9 +34,11 @@ import {
   Tag,
 } from "lucide-react";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
 import { api } from "../../lib/api-client";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type PersonaRow = {
   id: string;
@@ -128,6 +129,7 @@ export function PersonasPanel() {
   const [draggedPersonaId, setDraggedPersonaId] = useState<string | null>(null);
   const personaTouchDragRef = useRef<{ id: string; timer: number | null; active: boolean } | null>(null);
   const suppressPersonaClickRef = useRef(false);
+  const handleFolderRenameGesture = useFolderRenameGesture();
 
   const isActive = (p: PersonaRow) => p.isActive === true || p.isActive === "true";
 
@@ -484,14 +486,13 @@ export function PersonasPanel() {
           title="New"
         >
           <Plus size="0.8125rem" />
-          <span className="md:hidden">New</span>
         </button>
         <button
           onClick={() => openModal("import-persona")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
           title="Import"
         >
-          <Download size="0.8125rem" /> <span className="md:hidden">Import</span>
+          <Download size="0.8125rem" />
         </button>
         <button
           onClick={() => {
@@ -505,7 +506,6 @@ export function PersonasPanel() {
           title="Select"
         >
           <Check size="0.8125rem" />
-          <span className="md:hidden">Select</span>
         </button>
       </div>
 
@@ -520,14 +520,14 @@ export function PersonasPanel() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search personas"
-            className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+            className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
           />
         </div>
         <div className="relative">
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value as SortOption)}
-            className="mari-chrome-field h-full appearance-none py-2 pl-2.5 pr-7 text-[0.6875rem]"
+            className="mari-chrome-field h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
             <option value="name-asc">A-Z</option>
@@ -662,12 +662,20 @@ export function PersonasPanel() {
               {/* Folder header */}
               <div
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
-                onClick={() => setExpandedGroupId(isExpanded ? null : group.id)}
+                onClick={(event) =>
+                  handleFolderRenameGesture(group.id, event, {
+                    onSingleClick: () => setExpandedGroupId(isExpanded ? null : group.id),
+                    onRename: () => {
+                      setEditingGroupId(group.id);
+                      setEditGroupName(group.name);
+                    },
+                  })
+                }
               >
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -704,17 +712,6 @@ export function PersonasPanel() {
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      setEditingGroupId(group.id);
-                      setEditGroupName(group.name);
-                    }}
-	                    className="mari-chrome-control mari-chrome-control--small p-1"
-	                    title="Rename folder"
-	                  >
-                    <Pencil size="0.6875rem" />
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
                       void handleDeleteGroup(group);
                     }}
 	                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1"
@@ -726,13 +723,16 @@ export function PersonasPanel() {
               </div>
 
               {/* Expanded member list */}
-              {isExpanded && (
-                <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pb-1 pl-1">
-                  {folderMemberIds.length === 0 ? (
-                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop personas here.</p>
-                  ) : (
-                    <div className="flex flex-col gap-0.5">
-                      {folderMemberIds.map((pid) => {
+              <SmoothFolderContent
+                open={isExpanded}
+                className="ml-4 border-l border-[var(--border)]/20 pb-1 pl-1"
+                innerClassName="flex flex-col gap-0.5"
+              >
+                {folderMemberIds.length === 0 ? (
+                  <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop personas here.</p>
+                ) : (
+                  <div className="flex flex-col gap-0.5">
+                    {folderMemberIds.map((pid) => {
                         const p = personaMap.get(pid);
                         if (!p) return null;
                         const isBulkSelected = selectedPersonaIds.has(pid);
@@ -839,11 +839,10 @@ export function PersonasPanel() {
                             )}
                           </div>
                         );
-                      })}
-                    </div>
-                  )}
-                </div>
-              )}
+                    })}
+                  </div>
+                )}
+              </SmoothFolderContent>
             </div>
           );
         })}

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -34,7 +34,7 @@ import {
   Tag,
 } from "lucide-react";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { cn, getAvatarCropStyle, parseAvatarCropJson } from "../../lib/utils";
 import { api } from "../../lib/api-client";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
@@ -661,6 +661,11 @@ export function PersonasPanel() {
             >
               {/* Folder header */}
               <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${group.name}. Press F2 to rename.`}
+                title="Double-click or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(group.id, event, {
@@ -671,6 +676,16 @@ export function PersonasPanel() {
                     },
                   })
                 }
+                onKeyDown={(event) => {
+                  if (event.target !== event.currentTarget) return;
+                  handleFolderRenameKeyDown(event, {
+                    onSingleClick: () => setExpandedGroupId(isExpanded ? null : group.id),
+                    onRename: () => {
+                      setEditingGroupId(group.id);
+                      setEditGroupName(group.name);
+                    },
+                  });
+                }}
               >
                 <ChevronRight
                   size="0.75rem"

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -71,7 +71,7 @@ import {
   useMoveLibraryItem,
   useUpdateLibraryFolder,
 } from "../../hooks/use-library-folders";
-import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type PresetRow = {
@@ -839,20 +839,25 @@ export function PresetsPanel() {
       {/* Action buttons */}
       <div className="flex gap-2">
         <button
+          type="button"
           onClick={() => openModal("create-preset")}
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-purple-400 to-violet-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-purple-400/15 transition-all hover:shadow-lg hover:shadow-purple-400/25 active:scale-[0.98]"
+          aria-label="Create preset"
           title="New"
         >
           <Plus size="0.8125rem" />
         </button>
         <button
+          type="button"
           onClick={() => openModal("import-preset")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
+          aria-label="Import preset"
           title="Import"
         >
           <Download size="0.8125rem" />
         </button>
         <button
+          type="button"
           onClick={() => {
             if (selectionMode) exitSelectionMode();
             else setSelectionMode(true);
@@ -861,6 +866,7 @@ export function PresetsPanel() {
             "mari-chrome-control mari-chrome-control--primary flex-1 text-xs",
             selectionMode && "mari-chrome-control--selected",
           )}
+          aria-label={selectionMode ? "Exit preset selection mode" : "Select presets"}
           title="Select"
         >
           <Check size="0.8125rem" />
@@ -925,6 +931,11 @@ export function PresetsPanel() {
                 className="flex flex-col rounded-lg transition-colors"
               >
                 <div
+                  role="button"
+                  tabIndex={0}
+                  aria-expanded={isExpanded}
+                  aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
+                  title="Double-click or press F2 to rename."
                   className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                   onClick={(event) =>
                     handleFolderRenameGesture(folder.id, event, {
@@ -935,6 +946,16 @@ export function PresetsPanel() {
                       },
                     })
                   }
+                  onKeyDown={(event) => {
+                    if (event.target !== event.currentTarget) return;
+                    handleFolderRenameKeyDown(event, {
+                      onSingleClick: () => setExpandedFolderId(isExpanded ? null : folder.id),
+                      onRename: () => {
+                        setEditingFolderId(folder.id);
+                        setEditFolderName(folder.name);
+                      },
+                    });
+                  }}
                 >
                   <ChevronRight
                     size="0.75rem"

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -71,6 +71,8 @@ import {
   useMoveLibraryItem,
   useUpdateLibraryFolder,
 } from "../../hooks/use-library-folders";
+import { useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
+import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
 type PresetRow = {
   id: string;
@@ -281,6 +283,7 @@ export function PresetsPanel() {
   const [draggedPresetId, setDraggedPresetId] = useState<string | null>(null);
   const presetTouchDragRef = useRef<{ id: string; timer: number | null; active: boolean } | null>(null);
   const suppressPresetClickRef = useRef(false);
+  const handleFolderRenameGesture = useFolderRenameGesture();
 
   const canAssignToActiveChat = !!activeChat && activeChat.mode !== "conversation";
   const activePresetId = canAssignToActiveChat ? (activeChat?.promptPresetId ?? null) : null;
@@ -840,14 +843,14 @@ export function PresetsPanel() {
           className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-purple-400 to-violet-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-purple-400/15 transition-all hover:shadow-lg hover:shadow-purple-400/25 active:scale-[0.98]"
           title="New"
         >
-          <Plus size="0.8125rem" /> <span className="md:hidden">New</span>
+          <Plus size="0.8125rem" />
         </button>
         <button
           onClick={() => openModal("import-preset")}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
           title="Import"
         >
-          <Download size="0.8125rem" /> <span className="md:hidden">Import</span>
+          <Download size="0.8125rem" />
         </button>
         <button
           onClick={() => {
@@ -860,7 +863,7 @@ export function PresetsPanel() {
           )}
           title="Select"
         >
-          <Check size="0.8125rem" /> <span className="md:hidden">Select</span>
+          <Check size="0.8125rem" />
         </button>
       </div>
 
@@ -875,7 +878,7 @@ export function PresetsPanel() {
           placeholder="Search presets…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="mari-chrome-field w-full py-2 pl-8 pr-3 text-xs"
+          className="mari-chrome-field h-10 w-full py-0 pl-8 pr-3 text-xs md:h-9"
         />
       </div>
 
@@ -923,12 +926,20 @@ export function PresetsPanel() {
               >
                 <div
                   className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
-                  onClick={() => setExpandedFolderId(isExpanded ? null : folder.id)}
+                  onClick={(event) =>
+                    handleFolderRenameGesture(folder.id, event, {
+                      onSingleClick: () => setExpandedFolderId(isExpanded ? null : folder.id),
+                      onRename: () => {
+                        setEditingFolderId(folder.id);
+                        setEditFolderName(folder.name);
+                      },
+                    })
+                  }
                 >
                   <ChevronRight
                     size="0.75rem"
                     className={cn(
-                      "shrink-0 text-[var(--muted-foreground)] transition-transform",
+                      "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
                       isExpanded && "rotate-90",
                     )}
                   />
@@ -965,19 +976,6 @@ export function PresetsPanel() {
                       type="button"
                       onClick={(event) => {
                         event.stopPropagation();
-                        setEditingFolderId(folder.id);
-                        setEditFolderName(folder.name);
-                      }}
-                      className="mari-chrome-control mari-chrome-control--small p-1"
-                      title="Rename folder"
-                      aria-label="Rename folder"
-                    >
-                      <Pencil size="0.6875rem" />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
                         void confirmNonEmptyFolderDelete(folder.itemIds.length, {
                           title: "Delete Folder",
                           message: `Delete "${folder.name}"? Its ${folder.itemIds.length} preset${
@@ -999,15 +997,17 @@ export function PresetsPanel() {
                     </button>
                   </div>
                 </div>
-                {isExpanded && (
-                  <div className="ml-4 flex flex-col gap-0.5 border-l border-[var(--border)]/20 pb-1 pl-1">
-                    {folderItems.length === 0 ? (
-                      <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop presets here.</p>
-                    ) : (
-                      folderItems.map((preset) => renderPresetRow(preset))
-                    )}
-                  </div>
-                )}
+                <SmoothFolderContent
+                  open={isExpanded}
+                  className="ml-4 border-l border-[var(--border)]/20 pb-1 pl-1"
+                  innerClassName="flex flex-col gap-0.5"
+                >
+                  {folderItems.length === 0 ? (
+                    <p className="py-2 text-[0.625rem] italic text-[var(--muted-foreground)]">Drop presets here.</p>
+                  ) : (
+                    folderItems.map((preset) => renderPresetRow(preset))
+                  )}
+                </SmoothFolderContent>
               </div>
             );
           })}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -94,6 +94,7 @@ import {
 import { useClearAllData, useExpungeData, useUpdateChatMetadata, type ExpungeScope } from "../../hooks/use-chats";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameAssetStore } from "../../stores/game-asset.store";
+import { useOpenGameAssetsFolder } from "../../hooks/use-game-assets";
 import { chatKeys } from "../../hooks/use-chats";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { ColorPicker } from "../ui/ColorPicker";
@@ -114,7 +115,7 @@ import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatD
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
-import { HOST_DEVICE_FILE_MANAGER_MESSAGE, isHostDeviceBrowser } from "../../lib/host-device";
+import { HOST_DEVICE_FILE_MANAGER_MESSAGE } from "../../lib/host-device";
 
 type CustomFontFace = {
   filename: string;
@@ -1557,6 +1558,7 @@ function ImageGenerationSettings() {
 
 function GameAssetsSettings() {
   const rescanGameAssets = useGameAssetStore((s) => s.rescanAssets);
+  const openGameAssetsFolder = useOpenGameAssetsFolder();
   const openGameAssetsBrowser = useUIStore((s) => s.openGameAssetsBrowser);
   const assetFileRef = useRef<HTMLInputElement>(null);
   const [assetCategory, setAssetCategory] = useState<GameAssetCategoryId>("backgrounds");
@@ -1575,11 +1577,12 @@ function GameAssetsSettings() {
   };
 
   const handleOpenGameAssetFolder = (subfolder: string) => {
-    if (!isHostDeviceBrowser()) {
-      toast.info(HOST_DEVICE_FILE_MANAGER_MESSAGE);
-      return;
-    }
-    api.post("/game-assets/open-folder", { subfolder }).catch(() => toast.error("Failed to open game assets folder."));
+    openGameAssetsFolder.mutate(subfolder, {
+      onError: (error) => {
+        if (error instanceof Error && error.message === HOST_DEVICE_FILE_MANAGER_MESSAGE) return;
+        toast.error("Failed to open game assets folder.");
+      },
+    });
   };
 
   const handleGameAssetUpload = async () => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -100,7 +100,13 @@ import { ColorPicker } from "../ui/ColorPicker";
 import { TrackerPanelIcon } from "../ui/TrackerPanelIcon";
 import { TrackerSizeTierIcon } from "../ui/TrackerSizeTierIcon";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
-import { ConversationSoundSetting, SettingsIntro, SettingsSection, ToggleSetting } from "./settings/SettingControls";
+import {
+  ConversationSoundSetting,
+  SettingsIntro,
+  SettingsSection,
+  SettingsSwitch,
+  ToggleSetting,
+} from "./settings/SettingControls";
 import { TrackerCardColorSettings } from "./settings/TrackerCardColorSettings";
 import { PromptOverridesEditor } from "./settings/PromptOverridesEditor";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
@@ -108,6 +114,7 @@ import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatD
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
+import { HOST_DEVICE_FILE_MANAGER_MESSAGE, isHostDeviceBrowser } from "../../lib/host-device";
 
 type CustomFontFace = {
   filename: string;
@@ -847,12 +854,6 @@ function TrackerPanelAppearanceDrawer({
   const [drawerOpen, setDrawerOpen] = useState(true);
   const drawerId = React.useId();
 
-  const toggleTrackerPanel = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    setTrackerPanelEnabled(!trackerPanelEnabled);
-    if (!trackerPanelEnabled) setDrawerOpen(true);
-  };
-
   return (
     <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--background)]/34 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_8%,transparent)]">
       <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-3 py-2.5">
@@ -871,26 +872,15 @@ function TrackerPanelAppearanceDrawer({
           </span>
         </div>
 
-        <button
-          type="button"
-          role="switch"
-          aria-checked={trackerPanelEnabled}
-          aria-label={trackerPanelEnabled ? "Disable Tracker Panel" : "Enable Tracker Panel"}
-          onClick={toggleTrackerPanel}
-          className={cn(
-            "inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 ring-1 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]",
-            trackerPanelEnabled
-              ? "bg-[var(--primary)]/80 ring-[var(--primary)]/45"
-              : "bg-[var(--secondary)] ring-[var(--border)]",
-          )}
-        >
-          <span
-            className={cn(
-              "h-5 w-5 rounded-full bg-[var(--background)] shadow-sm transition-transform",
-              trackerPanelEnabled ? "translate-x-5" : "translate-x-0",
-            )}
-          />
-        </button>
+        <SettingsSwitch
+          checked={trackerPanelEnabled}
+          onChange={(enabled) => {
+            setTrackerPanelEnabled(enabled);
+            if (enabled) setDrawerOpen(true);
+          }}
+          ariaLabel={trackerPanelEnabled ? "Disable Tracker Panel" : "Enable Tracker Panel"}
+          className="p-0 hover:bg-transparent"
+        />
 
         <button
           type="button"
@@ -1567,6 +1557,7 @@ function ImageGenerationSettings() {
 
 function GameAssetsSettings() {
   const rescanGameAssets = useGameAssetStore((s) => s.rescanAssets);
+  const openGameAssetsBrowser = useUIStore((s) => s.openGameAssetsBrowser);
   const assetFileRef = useRef<HTMLInputElement>(null);
   const [assetCategory, setAssetCategory] = useState<GameAssetCategoryId>("backgrounds");
   const [assetSubcategory, setAssetSubcategory] = useState<string>(
@@ -1581,6 +1572,14 @@ function GameAssetsSettings() {
     setAssetSubcategory(GAME_ASSET_CATEGORY_BY_ID.get(nextCategory)?.defaultFolder ?? "custom");
     setAssetFiles([]);
     if (assetFileRef.current) assetFileRef.current.value = "";
+  };
+
+  const handleOpenGameAssetFolder = (subfolder: string) => {
+    if (!isHostDeviceBrowser()) {
+      toast.info(HOST_DEVICE_FILE_MANAGER_MESSAGE);
+      return;
+    }
+    api.post("/game-assets/open-folder", { subfolder }).catch(() => toast.error("Failed to open game assets folder."));
   };
 
   const handleGameAssetUpload = async () => {
@@ -1642,6 +1641,14 @@ function GameAssetsSettings() {
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
           <button
+            onClick={openGameAssetsBrowser}
+            className="mari-chrome-control mari-chrome-control--primary text-[0.6875rem]"
+            title="Open Asset Browser"
+          >
+            <Image size="0.75rem" />
+            Asset Browser
+          </button>
+          <button
             onClick={() => {
               rescanGameAssets()
                 .then(() => toast.success("Game assets rescanned."))
@@ -1655,7 +1662,7 @@ function GameAssetsSettings() {
           {GAME_ASSET_CATEGORIES.map((folder) => (
             <button
               key={folder.id}
-              onClick={() => api.post("/game-assets/open-folder", { subfolder: folder.id }).catch(() => {})}
+              onClick={() => handleOpenGameAssetFolder(folder.id)}
               className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.6875rem] font-medium capitalize text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
             >
               <FolderOpen size="0.75rem" />
@@ -2913,7 +2920,7 @@ function BackgroundPicker({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search backgrounds..."
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] py-1.5 pl-7 pr-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/60 focus:border-[var(--primary)]/50"
+              className="h-10 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] py-0 pl-7 pr-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/60 focus:border-[var(--primary)]/50 md:h-9"
             />
           </div>
           {searchQuery.trim() && (
@@ -3622,7 +3629,7 @@ const CSS_TEMPLATE = `/* ══════════════════�
   /* --sidebar: #0c0c12; */
 
   /* ── Shared Chat / Roleplay / Game Chrome ── */
-  /* --marinara-chat-chrome-accent: var(--foreground); */
+  /* --marinara-chat-chrome-accent: #d4acfb; */
   /* --marinara-chat-chrome-accent-gradient: linear-gradient(90deg, var(--marinara-chat-chrome-accent), var(--marinara-chat-chrome-accent)); */
   /* --marinara-chat-chrome-text: var(--foreground); */
   /* --marinara-chat-chrome-button-text-base: var(--marinara-chat-chrome-accent); */
@@ -3850,6 +3857,9 @@ function ExtensionsSettings() {
             <strong>JSON format:</strong>{" "}
             <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "description": "...", "css": "..." }`}</code>
             . Extensions can inject custom CSS and/or JavaScript to modify the UI.
+          </div>
+          <div className="rounded-lg bg-[var(--secondary)]/35 p-2.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+            Extensions can be downloaded from the official Marinara Engine Discord server.
           </div>
         </div>
       </SettingsSection>

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -16,6 +16,7 @@ import { ApiError } from "../../../lib/api-client";
 import { showConfirmDialog } from "../../../lib/app-dialogs";
 import { cn } from "../../../lib/utils";
 import { HelpTooltip } from "../../ui/HelpTooltip";
+import { SettingsSwitch } from "./SettingControls";
 
 const PREFERRED_PROMPT_KEY = "conversation.selfie";
 
@@ -372,21 +373,16 @@ function PromptOverridesEditorBody({ keys, preferredKey }: { keys?: readonly str
         )}
       </div>
 
-      <label className="flex cursor-pointer items-start gap-2 rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]/70">
-        <input
-          type="checkbox"
-          checked={enabled}
-          disabled={loadingPrompt || !selectedKey}
-          onChange={(event) => setEnabled(event.target.checked)}
-          className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
-        />
-        <span className="min-w-0">
-          <span className="block text-xs font-medium text-[var(--foreground)]">Apply this override</span>
-          <span className="block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            Turn this off to keep the template saved without using it.
-          </span>
-        </span>
-      </label>
+      <SettingsSwitch
+        label="Apply this override"
+        description="Turn this off to keep the template saved without using it."
+        checked={enabled}
+        disabled={loadingPrompt || !selectedKey}
+        onChange={setEnabled}
+        labelPosition="start"
+        className="justify-between rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]/70"
+        labelClassName="text-xs font-medium text-[var(--foreground)]"
+      />
 
       {lastError && (
         <div className="flex items-start gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-2.5 py-2 text-[0.625rem] text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20">

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -266,6 +266,20 @@ export function SettingsCheckbox({
   );
 }
 
+type SettingsSwitchAccessibleLabel = { label: ReactNode; ariaLabel?: never } | { label?: undefined; ariaLabel: string };
+
+type SettingsSwitchProps = SettingsSwitchAccessibleLabel & {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  title?: string;
+  description?: ReactNode;
+  help?: string;
+  disabled?: boolean;
+  labelPosition?: "start" | "end";
+  className?: string;
+  labelClassName?: string;
+};
+
 export function SettingsSwitch({
   label,
   checked,
@@ -278,19 +292,7 @@ export function SettingsSwitch({
   labelPosition = "end",
   className,
   labelClassName,
-}: {
-  label?: ReactNode;
-  checked: boolean;
-  onChange: (v: boolean) => void;
-  ariaLabel?: string;
-  title?: string;
-  description?: ReactNode;
-  help?: string;
-  disabled?: boolean;
-  labelPosition?: "start" | "end";
-  className?: string;
-  labelClassName?: string;
-}) {
+}: SettingsSwitchProps) {
   const inputId = useId();
   const switchControl = (
     <span className="relative inline-flex h-5 w-9 shrink-0">

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import { Bell, Volume2 } from "lucide-react";
 import { toast } from "sonner";
 import { useUIStore } from "../../../stores/ui.store";
@@ -175,7 +175,17 @@ export function ToggleSetting({
   onChange: (v: boolean) => void;
   help?: string;
 }) {
-  return <SettingsCheckbox label={label} checked={checked} onChange={onChange} help={help} className="p-1" />;
+  return (
+    <SettingsSwitch
+      label={label}
+      checked={checked}
+      onChange={onChange}
+      help={help}
+      labelPosition="start"
+      className="justify-between gap-3 p-1.5"
+      labelClassName="text-xs"
+    />
+  );
 }
 
 export function SettingsCheckbox({
@@ -260,8 +270,10 @@ export function SettingsSwitch({
   label,
   checked,
   onChange,
+  ariaLabel,
   title,
   description,
+  help,
   disabled = false,
   labelPosition = "end",
   className,
@@ -270,46 +282,79 @@ export function SettingsSwitch({
   label?: ReactNode;
   checked: boolean;
   onChange: (v: boolean) => void;
+  ariaLabel?: string;
   title?: string;
   description?: ReactNode;
+  help?: string;
   disabled?: boolean;
   labelPosition?: "start" | "end";
   className?: string;
   labelClassName?: string;
 }) {
+  const inputId = useId();
+  const switchControl = (
+    <span className="relative inline-flex h-5 w-9 shrink-0">
+      <input
+        id={inputId}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        aria-label={!label ? ariaLabel : undefined}
+        onChange={(e) => onChange(e.target.checked)}
+        className="peer sr-only"
+      />
+      <label
+        htmlFor={inputId}
+        title={title}
+        className={cn(
+          "relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--ring)]",
+          checked ? "bg-[var(--primary)]/70" : "bg-[var(--border)]",
+          disabled ? "cursor-not-allowed" : "cursor-pointer",
+        )}
+      >
+        <span
+          className={cn(
+            "pointer-events-none absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-[var(--background)] shadow-sm ring-1 ring-[var(--border)] transition-transform",
+            checked && "translate-x-4",
+          )}
+        />
+      </label>
+    </span>
+  );
   const text = label ? (
     <span className={cn("min-w-0 text-sm", labelClassName)}>
-      <span className="block">{label}</span>
+      <span className="inline-flex min-w-0 items-center gap-1.5">
+        <label htmlFor={inputId} className={cn("min-w-0", disabled ? "cursor-not-allowed" : "cursor-pointer")}>
+          {label}
+        </label>
+        {help && <HelpTooltip text={help} />}
+      </span>
       {description && (
-        <span className="mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+        <label
+          htmlFor={inputId}
+          className={cn(
+            "mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]",
+            disabled ? "cursor-not-allowed" : "cursor-pointer",
+          )}
+        >
           {description}
-        </span>
+        </label>
       )}
     </span>
   ) : null;
 
   return (
-    <label
+    <div
       title={title}
       className={cn(
-        "flex cursor-pointer items-center gap-3 rounded-xl p-2 transition-colors hover:bg-[var(--secondary)]/50",
+        "flex items-center gap-3 rounded-xl p-2 transition-colors hover:bg-[var(--secondary)]/50",
         disabled && "cursor-not-allowed opacity-60 hover:bg-transparent",
         className,
       )}
     >
       {labelPosition === "start" && text}
-      <span className="relative inline-flex h-5 w-9 shrink-0">
-        <input
-          type="checkbox"
-          checked={checked}
-          disabled={disabled}
-          onChange={(e) => onChange(e.target.checked)}
-          className="peer sr-only"
-        />
-        <span className="h-5 w-9 rounded-full bg-[var(--border)] transition-colors peer-checked:bg-[var(--primary)]/70 peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--ring)]" />
-        <span className="absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-[var(--background)] shadow-sm ring-1 ring-[var(--border)] transition-transform peer-checked:translate-x-4" />
-      </span>
+      {switchControl}
       {labelPosition === "end" && text}
-    </label>
+    </div>
   );
 }

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -220,8 +220,20 @@ function sameStringSet(left: string[], right: string[]): boolean {
 }
 
 function ToggleRow({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return <SettingsCheckbox label={label} checked={checked} onChange={onChange} align="between" />;
+}
+
+function TtsDropdownIcon({ compact = false }: { compact?: boolean }) {
   return (
-    <SettingsCheckbox label={label} checked={checked} onChange={onChange} align="between" />
+    <span
+      className={cn(
+        "mari-chrome-control mari-chrome-control--small pointer-events-none absolute right-1.5 top-1/2 flex min-w-0 -translate-y-1/2 items-center justify-center p-0",
+        compact ? "h-6 w-6" : "h-7 w-7",
+      )}
+      aria-hidden="true"
+    >
+      <ChevronDown size={compact ? "0.6875rem" : "0.75rem"} />
+    </span>
   );
 }
 
@@ -680,21 +692,19 @@ export function TTSConfigCard() {
         <div className="flex items-center gap-1.5">
           {/* Enable toggle */}
           <SettingsSwitch
-            label={enabled ? "On" : "Off"}
             checked={enabled}
             onChange={(checked) => {
               setEnabled(checked);
               mark({ enabled: checked });
             }}
+            ariaLabel={enabled ? "Disable TTS" : "Enable TTS"}
             title={enabled ? "Disable TTS" : "Enable TTS"}
-            labelPosition="start"
-            className="gap-1.5 rounded-lg p-1 hover:bg-[var(--secondary)]"
-            labelClassName="text-[0.6875rem] text-[var(--muted-foreground)]"
+            className="rounded-lg p-1 hover:bg-[var(--secondary)]"
           />
 
           <button
             onClick={() => setExpanded((v) => !v)}
-            className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+            className="mari-chrome-control mari-chrome-control--small h-8 min-h-0 w-8 p-0"
             title={expanded ? "Collapse" : "Expand"}
           >
             {expanded ? <ChevronUp size="0.875rem" /> : <ChevronDown size="0.875rem" />}
@@ -779,16 +789,23 @@ export function TTSConfigCard() {
                   : "TTS model to use. e.g. tts-1, tts-1-hd, gpt-4o-mini-tts, or any model your provider supports."
             }
           >
-            <input
-              value={model}
-              list={source === "elevenlabs" ? "elevenlabs-tts-models" : undefined}
-              onChange={(e) => {
-                setModel(e.target.value);
-                mark({ model: e.target.value });
-              }}
-              className={INPUT_CLS}
-              placeholder={selectedSource.model}
-            />
+            <div className="relative">
+              <input
+                value={model}
+                list={source === "elevenlabs" ? "elevenlabs-tts-models" : undefined}
+                onChange={(e) => {
+                  setModel(e.target.value);
+                  mark({ model: e.target.value });
+                }}
+                className={cn(
+                  INPUT_CLS,
+                  source === "elevenlabs" &&
+                    "pr-10 [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-0",
+                )}
+                placeholder={selectedSource.model}
+              />
+              {source === "elevenlabs" && <TtsDropdownIcon />}
+            </div>
             {source === "elevenlabs" && (
               <>
                 <datalist id="elevenlabs-tts-models">

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -134,21 +134,21 @@ const spotifyKeys = {
   devices: ["spotify", "devices"] as const,
 };
 
-const SPOTIFY_GREEN_CLASS = "text-[oklch(0.72_0.18_145)]";
-const SPOTIFY_GREEN_BG_CLASS = "bg-[oklch(0.72_0.18_145)]";
-const MUSIC_PLAYER_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
-const MUSIC_PLAYER_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
-const MUSIC_PLAYER_BORDER_CLASS = "border-[var(--marinara-chat-chrome-panel-border)]";
-const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-bg)]";
-const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[var(--marinara-chat-chrome-highlight-bg)]";
-const MUSIC_PLAYER_TILE_RING_CLASS = "ring-[var(--marinara-chat-chrome-panel-border)]";
-const MUSIC_PLAYER_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-title)]";
-const MUSIC_PLAYER_MUTED_CLASS = "text-[var(--marinara-chat-chrome-panel-muted)]";
-const MUSIC_PLAYER_ICON_CLASS = "text-[var(--marinara-chat-chrome-button-text)]";
-const MUSIC_PLAYER_ICON_HOVER_CLASS = "hover:text-[var(--marinara-chat-chrome-button-text-hover)]";
-const MUSIC_PLAYER_ACTION_BG_CLASS = "bg-[var(--marinara-chat-chrome-button-text-active)]";
-const MUSIC_PLAYER_ACTION_TEXT_CLASS = "text-[var(--marinara-chat-chrome-panel-bg)]";
-const MUSIC_PLAYER_PROGRESS_BG_CLASS = "bg-[var(--marinara-chat-chrome-panel-divider)]";
+const SPOTIFY_GREEN_CLASS = "text-[#1DB954]";
+const SPOTIFY_GREEN_BG_CLASS = "bg-[#1DB954]";
+const MUSIC_PLAYER_SHELL_BORDER_CLASS = "border-[#f7f3ef]/10";
+const MUSIC_PLAYER_SHELL_BG_CLASS = "bg-[#191414]/95";
+const MUSIC_PLAYER_BORDER_CLASS = "border-[#f7f3ef]/15";
+const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
+const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[#f7f3ef]/5";
+const MUSIC_PLAYER_TILE_RING_CLASS = "ring-[#f7f3ef]/10";
+const MUSIC_PLAYER_TEXT_CLASS = "text-[#f7f3ef]";
+const MUSIC_PLAYER_MUTED_CLASS = "text-[#b3b3b3]";
+const MUSIC_PLAYER_ICON_CLASS = "text-[#b3b3b3]";
+const MUSIC_PLAYER_ICON_HOVER_CLASS = "hover:bg-[#f7f3ef]/10 hover:text-[#f7f3ef]";
+const MUSIC_PLAYER_ACTION_BG_CLASS = "bg-[#f7f3ef]";
+const MUSIC_PLAYER_ACTION_TEXT_CLASS = "text-[#191414]";
+const MUSIC_PLAYER_PROGRESS_BG_CLASS = "bg-[#f7f3ef]/15";
 const REPEAT_TRACK_END_GRACE_MS = 15_000;
 const REPEAT_TRACK_REPLAY_COOLDOWN_MS = 8_000;
 const MANUAL_CONTROL_REPEAT_SUPPRESS_MS = 15_000;
@@ -764,12 +764,12 @@ export function SpotifyMiniPlayer({
   const spotifyVolumeStyle: RangeCssProperties = useMemo(
     () => ({
       "--range-progress": `${volumeDraft}%`,
-      "--range-track-color": "var(--marinara-chat-chrome-panel-divider)",
-      "--range-fill-color": "var(--marinara-chat-chrome-button-text-active)",
-      "--range-thumb-color": "var(--marinara-chat-chrome-button-text-active)",
+      "--range-track-color": "color-mix(in srgb, #1DB954 26%, transparent)",
+      "--range-fill-color": "#1DB954",
+      "--range-thumb-color": "#1DB954",
       "--range-thumb-size": "0.6875rem",
       "--range-track-height": "0.25rem",
-      "--range-thumb-shadow": "0 0 0 0.125rem var(--marinara-chat-chrome-panel-bg)",
+      "--range-thumb-shadow": "0 0 0 0.125rem #191414",
     }),
     [volumeDraft],
   );
@@ -783,7 +783,7 @@ export function SpotifyMiniPlayer({
         <button
           type="button"
           className={cn(
-            "flex w-full shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)]",
+            "flex w-full shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-[#f7f3ef]/10",
             MUSIC_PLAYER_ICON_CLASS,
             MUSIC_PLAYER_ICON_HOVER_CLASS,
           )}
@@ -818,7 +818,6 @@ export function SpotifyMiniPlayer({
             "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors",
             MUSIC_PLAYER_ICON_CLASS,
             MUSIC_PLAYER_ICON_HOVER_CLASS,
-            volumeMuted && SPOTIFY_GREEN_CLASS,
           )}
           title={volumeMuted ? "Restore volume" : "Mute"}
         >
@@ -899,7 +898,7 @@ export function SpotifyMiniPlayer({
             type="button"
             onClick={() => void handlePlayPause()}
             className={cn(
-              "inline-flex h-7 w-7 items-center justify-center rounded-full shadow-[0_1px_8px_rgba(29,185,84,0.18)] transition-transform hover:scale-105 active:scale-95",
+              "inline-flex h-7 w-7 items-center justify-center rounded-full shadow-[0_1px_8px_rgba(255,255,255,0.18)] transition-transform hover:scale-105 active:scale-95",
               MUSIC_PLAYER_ACTION_BG_CLASS,
               MUSIC_PLAYER_ACTION_TEXT_CLASS,
             )}

--- a/packages/client/src/components/ui/ColorPicker.tsx
+++ b/packages/client/src/components/ui/ColorPicker.tsx
@@ -403,7 +403,7 @@ export function ColorPicker({
               {/* Gradient presets */}
               <div>
                 <p className="mb-1.5 text-[0.625rem] text-[var(--muted-foreground)]">Presets</p>
-                <div className="grid grid-cols-4 gap-1.5">
+                <div className="flex flex-wrap gap-1.5">
                   {GRADIENT_PRESETS.map((g) => (
                     <button
                       key={g}
@@ -415,8 +415,8 @@ export function ColorPicker({
                         onChange(g);
                       }}
                       className={cn(
-                        "h-6 rounded-md ring-1 ring-[var(--border)] transition-all hover:scale-105 hover:ring-2 hover:ring-[var(--primary)]/50",
-                        value === g && "ring-2 ring-[var(--primary)] scale-105",
+                        "h-6 w-6 rounded-md ring-1 ring-[var(--border)] transition-all hover:scale-110 hover:ring-2 hover:ring-[var(--primary)]/50",
+                        value === g && "ring-2 ring-[var(--primary)] scale-110",
                       )}
                       style={{ background: g }}
                       title={g === RAINBOW_GRADIENT_PRESET ? "Gay RGB rainbow" : g}

--- a/packages/client/src/components/ui/DraftNumberInput.tsx
+++ b/packages/client/src/components/ui/DraftNumberInput.tsx
@@ -41,6 +41,9 @@ export function DraftNumberInput({
     const trimmed = raw.trim();
     if (!trimmed) return null;
 
+    const numericPattern = integer ? /^-?\d+$/ : /^-?(?:\d+\.?\d*|\.\d+)$/;
+    if (!numericPattern.test(trimmed)) return null;
+
     const parsed = Number(trimmed);
     const validNumber = Number.isFinite(parsed) && (!integer || Number.isInteger(parsed));
 

--- a/packages/client/src/components/ui/DraftNumberInput.tsx
+++ b/packages/client/src/components/ui/DraftNumberInput.tsx
@@ -9,6 +9,11 @@ interface DraftNumberInputProps {
   integer?: boolean;
   selectOnFocus?: boolean;
   commitOnValidChange?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
+  placeholder?: string;
+  title?: string;
+  id?: string;
 }
 
 export function DraftNumberInput({
@@ -20,6 +25,11 @@ export function DraftNumberInput({
   integer = true,
   selectOnFocus = false,
   commitOnValidChange = false,
+  disabled = false,
+  ariaLabel,
+  placeholder,
+  title,
+  id,
 }: DraftNumberInputProps) {
   const [draft, setDraft] = useState(String(value));
 
@@ -33,17 +43,24 @@ export function DraftNumberInput({
 
     const parsed = Number(trimmed);
     const validNumber = Number.isFinite(parsed) && (!integer || Number.isInteger(parsed));
-    const inRange = validNumber && (min === undefined || parsed >= min) && (max === undefined || parsed <= max);
 
-    return inRange ? parsed : null;
+    return validNumber ? parsed : null;
+  };
+
+  const clampValue = (raw: number) => {
+    let next = raw;
+    if (min !== undefined && next < min) next = min;
+    if (max !== undefined && next > max) next = max;
+    return next;
   };
 
   const commit = () => {
     const parsed = parseDraft(draft);
 
     if (parsed !== null) {
-      onCommit(parsed);
-      setDraft(String(parsed));
+      const next = clampValue(parsed);
+      onCommit(next);
+      setDraft(String(next));
       return;
     }
 
@@ -53,8 +70,13 @@ export function DraftNumberInput({
   return (
     <input
       type="text"
-      inputMode={integer ? "numeric" : "decimal"}
+      inputMode={integer && (min === undefined || min < 0) ? "text" : integer ? "numeric" : "decimal"}
+      id={id}
       value={draft}
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      title={title}
+      disabled={disabled}
       onFocus={(e) => {
         if (selectOnFocus) e.target.select();
       }}
@@ -63,7 +85,7 @@ export function DraftNumberInput({
         setDraft(nextDraft);
         if (commitOnValidChange) {
           const parsed = parseDraft(nextDraft);
-          if (parsed !== null) onCommit(parsed);
+          if (parsed !== null) onCommit(clampValue(parsed));
         }
       }}
       onBlur={commit}

--- a/packages/client/src/components/ui/SmoothFolderContent.tsx
+++ b/packages/client/src/components/ui/SmoothFolderContent.tsx
@@ -1,0 +1,36 @@
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+interface SmoothFolderContentProps {
+  open: boolean;
+  children: ReactNode;
+  className?: string;
+  innerClassName?: string;
+}
+
+const folderContentTransition = {
+  height: { duration: 0.2, ease: [0.25, 0.8, 0.25, 1] },
+  opacity: { duration: 0.14, ease: "easeOut" },
+} as const;
+
+export function SmoothFolderContent({ open, children, className, innerClassName }: SmoothFolderContentProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <AnimatePresence initial={false}>
+      {open && (
+        <motion.div
+          key="folder-content"
+          initial={reduceMotion ? false : { height: 0, opacity: 0 }}
+          animate={reduceMotion ? { opacity: 1 } : { height: "auto", opacity: 1 }}
+          exit={reduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+          transition={reduceMotion ? { duration: 0.01 } : folderContentTransition}
+          className={cn("overflow-hidden will-change-[height,opacity]", className)}
+        >
+          <div className={innerClassName}>{children}</div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -8,6 +8,8 @@ import {
   type EditableGenerationParameters,
   ROLEPLAY_PARAMETER_DEFAULTS,
 } from "../../../components/ui/GenerationParametersEditor";
+import { DraftNumberInput } from "../../../components/ui/DraftNumberInput";
+import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { useSaveConnectionDefaults } from "../../../hooks/use-connections";
 import { cn } from "../../../lib/utils";
 
@@ -87,93 +89,48 @@ export function AdvancedParametersSection({
             onChange={setParameters}
           />
           <div className="space-y-2 pt-3">
-            <button
-              type="button"
-              aria-pressed={Boolean(contextMessageLimit)}
-              onClick={() => {
-                if (contextMessageLimit) {
-                  onContextMessageLimitChange(null);
-                } else {
-                  onContextMessageLimitChange(50);
-                }
-              }}
+            <SettingsSwitch
+              label="Limit Context Messages"
+              description="Only send the last N messages to the model."
+              checked={Boolean(contextMessageLimit)}
+              onChange={(checked) => onContextMessageLimitChange(checked ? 50 : null)}
+              labelPosition="start"
               className={cn(
-                "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                "justify-between rounded-lg px-3 py-2.5 text-left",
                 contextMessageLimit
                   ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                   : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
               )}
-            >
-              <div>
-                <span className="text-xs font-medium">Limit Context Messages</span>
-                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                  Only send the last N messages to the model.
-                </p>
-              </div>
-              <div
-                className={cn(
-                  "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors",
-                  contextMessageLimit ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-                )}
-              >
-                <div
-                  className={cn(
-                    "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                    contextMessageLimit && "translate-x-3.5",
-                  )}
-                />
-              </div>
-            </button>
+              labelClassName="text-xs font-medium"
+            />
             {contextMessageLimit && (
               <div className="flex items-center gap-2 px-1">
-                <input
-                  type="number"
+                <DraftNumberInput
                   aria-label="Context message limit"
                   min={1}
                   max={9999}
                   value={contextMessageLimit}
-                  onChange={(event) => {
-                    const value = parseInt(event.target.value, 10);
-                    if (value > 0) {
-                      onContextMessageLimitChange(value);
-                    }
-                  }}
+                  onCommit={(value) => onContextMessageLimitChange(Math.max(1, Math.min(9999, value)))}
+                  selectOnFocus
                   className="w-20 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                 />
                 <span className="text-[0.625rem] text-[var(--muted-foreground)]">messages</span>
               </div>
             )}
-            <button
-              type="button"
-              aria-pressed={excludeReasoningEnabled}
-              onClick={() => onExcludePastReasoningChange(!excludeReasoningEnabled)}
+            <SettingsSwitch
+              label="Exclude Past Reasoning"
+              description="Keep stored thinking/reasoning metadata out of future prompts."
+              checked={excludeReasoningEnabled}
+              onChange={onExcludePastReasoningChange}
+              labelPosition="start"
               className={cn(
-                "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                "justify-between rounded-lg px-3 py-2.5 text-left",
                 excludeReasoningEnabled
                   ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
                   : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
               )}
-            >
-              <div>
-                <span className="text-xs font-medium">Exclude Past Reasoning</span>
-                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                  Keep stored thinking/reasoning metadata out of future prompts.
-                </p>
-              </div>
-              <div
-                className={cn(
-                  "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors",
-                  excludeReasoningEnabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-                )}
-              >
-                <div
-                  className={cn(
-                    "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                    excludeReasoningEnabled && "translate-x-3.5",
-                  )}
-                />
-              </div>
-            </button>
+              labelClassName="text-xs font-medium"
+            />
           </div>
           {connectionId && connectionId !== "random" && (
             <button

--- a/packages/client/src/features/chat-settings/sections/FunctionCallingSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/FunctionCallingSection.tsx
@@ -1,5 +1,6 @@
 import { Check, FilePlus2, Plus, Trash2, Wrench } from "lucide-react";
 import { cn } from "../../../lib/utils";
+import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 import { PickerDropdown } from "../PickerDropdown";
 
@@ -51,35 +52,20 @@ export function FunctionCallingSection({
       help="When enabled, the AI can call built-in tools like dice rolls, game state updates, and lorebook searches during conversation."
     >
       <div className="space-y-2">
-        <button
-          onClick={() => onEnableToolsChange(!enableTools)}
+        <SettingsSwitch
+          label="Enable Tool Use"
+          description="Allow AI to call functions (dice rolls, game state, etc.)"
+          checked={!!enableTools}
+          onChange={onEnableToolsChange}
+          labelPosition="start"
           className={cn(
-            "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+            "justify-between rounded-lg px-3 py-2.5 text-left",
             enableTools
               ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
               : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
           )}
-        >
-          <div>
-            <span className="text-xs font-medium">Enable Tool Use</span>
-            <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-              Allow AI to call functions (dice rolls, game state, etc.)
-            </p>
-          </div>
-          <div
-            className={cn(
-              "h-5 w-9 overflow-hidden rounded-full p-0.5 transition-colors",
-              enableTools ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-            )}
-          >
-            <div
-              className={cn(
-                "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                enableTools && "translate-x-3.5",
-              )}
-            />
-          </div>
-        </button>
+          labelClassName="text-xs font-medium"
+        />
         <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1">
           {enableTools
             ? "If enabled, this chat can use globally enabled tools (or any tools you add below)."

--- a/packages/client/src/features/chat-settings/sections/ImpersonateSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ImpersonateSection.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Drama, RotateCcw } from "lucide-react";
 import { DEFAULT_IMPERSONATE_PROMPT } from "@marinara-engine/shared";
 import { useUIStore } from "../../../stores/ui.store";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
+import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 
 interface ImpersonateSectionProps {
@@ -118,45 +119,27 @@ export function ImpersonateSection({ presets, connections }: ImpersonateSectionP
           </div>
 
           <div className="grid gap-1 border-t border-[var(--border)]/60 pt-1.5">
-            <label className="flex min-w-0 items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--accent)]/35">
-              <span className="min-w-0">
-                <span className="flex items-center gap-1.5 text-xs font-semibold">
-                  Skip agents
-                  <span onClick={(event) => event.preventDefault()}>
-                    <HelpTooltip text="When enabled, the agent pipeline (trackers, lorebook routers, etc.) is suppressed during impersonate so generations stay fast and don't trigger world-state mutations." />
-                  </span>
-                </span>
-                <span className="mt-0.5 block text-[0.65rem] leading-tight text-[var(--muted-foreground)]">
-                  Suppress trackers, routers, and other agent work.
-                </span>
-              </span>
-              <input
-                type="checkbox"
-                checked={blockAgents}
-                onChange={(event) => setBlockAgents(event.target.checked)}
-                className="h-3.5 w-3.5 shrink-0 rounded border-[var(--border)] accent-[var(--primary)]"
-              />
-            </label>
+            <SettingsSwitch
+              label="Skip agents"
+              help="When enabled, the agent pipeline (trackers, lorebook routers, etc.) is suppressed during impersonate so generations stay fast and don't trigger world-state mutations."
+              description="Suppress trackers, routers, and other agent work."
+              checked={blockAgents}
+              onChange={setBlockAgents}
+              labelPosition="start"
+              className="justify-between rounded-md px-2 py-1.5 text-left"
+              labelClassName="text-xs font-semibold"
+            />
 
-            <label className="flex min-w-0 items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--accent)]/35">
-              <span className="min-w-0">
-                <span className="flex items-center gap-1.5 text-xs font-semibold">
-                  Use CYOA as direction
-                  <span onClick={(event) => event.preventDefault()}>
-                    <HelpTooltip text="When enabled, clicking a CYOA option uses it as the direction for an impersonate generation instead of sending the option as a normal user message." />
-                  </span>
-                </span>
-                <span className="mt-0.5 block text-[0.65rem] leading-tight text-[var(--muted-foreground)]">
-                  Treat choices as impersonate guidance.
-                </span>
-              </span>
-              <input
-                type="checkbox"
-                checked={cyoaChoices}
-                onChange={(event) => setCyoaChoices(event.target.checked)}
-                className="h-3.5 w-3.5 shrink-0 rounded border-[var(--border)] accent-[var(--primary)]"
-              />
-            </label>
+            <SettingsSwitch
+              label="Use CYOA as direction"
+              help="When enabled, clicking a CYOA option uses it as the direction for an impersonate generation instead of sending the option as a normal user message."
+              description="Treat choices as impersonate guidance."
+              checked={cyoaChoices}
+              onChange={setCyoaChoices}
+              labelPosition="start"
+              className="justify-between rounded-md px-2 py-1.5 text-left"
+              labelClassName="text-xs font-semibold"
+            />
           </div>
 
           <p className="border-t border-[var(--border)]/60 px-2 pt-1.5 text-[0.65rem] leading-snug text-[var(--muted-foreground)]">

--- a/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
@@ -77,7 +77,11 @@ export function LorebooksSection({
           inputMode="numeric"
           pattern="[0-9]*"
           value={tokenBudgetDraft}
-          onChange={(event) => setTokenBudgetDraft(event.target.value)}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            if (!/^\d*$/.test(nextValue)) return;
+            setTokenBudgetDraft(nextValue);
+          }}
           onBlur={commitTokenBudget}
           onKeyDown={(event) => {
             if (event.key === "Enter") {

--- a/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
@@ -73,8 +73,9 @@ export function LorebooksSection({
           />
         </label>
         <input
-          type="number"
-          min={0}
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
           value={tokenBudgetDraft}
           onChange={(event) => setTokenBudgetDraft(event.target.value)}
           onBlur={commitTokenBudget}
@@ -83,7 +84,7 @@ export function LorebooksSection({
               event.currentTarget.blur();
             }
           }}
-          className="w-full rounded-lg bg-[var(--background)] px-3 py-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+          className="w-full rounded-lg bg-[var(--background)] px-3 py-2 text-xs ring-1 ring-transparent focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
         />
       </div>
 

--- a/packages/client/src/features/chat-settings/sections/ManualRepliesSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ManualRepliesSection.tsx
@@ -1,5 +1,5 @@
 import { MessageCircle } from "lucide-react";
-import { cn } from "../../../lib/utils";
+import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 
 interface ManualRepliesSectionProps {
@@ -14,34 +14,24 @@ export function ManualRepliesSection({ enabled, onEnabledChange }: ManualReplies
       icon={<MessageCircle size="0.875rem" />}
       help="When enabled, conversation messages are saved without auto-generating a reply unless you @mention a character or trigger one from the input bar."
     >
-      <button
-        onClick={() => onEnabledChange(!enabled)}
-        className={cn(
-          "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+      <SettingsSwitch
+        label="Only Reply When Mentioned"
+        description={
+          enabled
+            ? "Characters will stay quiet until you type @Name or use the character picker."
+            : "Characters reply automatically; @mentions focus the response on the mentioned character."
+        }
+        checked={enabled}
+        onChange={onEnabledChange}
+        labelPosition="start"
+        className={[
+          "justify-between rounded-lg px-3 py-2.5 text-left",
           enabled
             ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
             : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
-        )}
-      >
-        <div className="min-w-0 flex-1">
-          <span className="text-[0.6875rem] font-medium">Only Reply When Mentioned</span>
-          <p className="mt-0.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            {enabled
-              ? "Characters will stay quiet until you type @Name or use the character picker."
-              : "Characters reply automatically; @mentions focus the response on the mentioned character."}
-          </p>
-        </div>
-        <div
-          className={cn(
-            "ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-            enabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-          )}
-        >
-          <div
-            className={cn("h-4 w-4 rounded-full bg-white shadow-sm transition-transform", enabled && "translate-x-3.5")}
-          />
-        </div>
-      </button>
+        ].join(" ")}
+        labelClassName="text-[0.6875rem] font-medium"
+      />
     </ChatSettingsSection>
   );
 }

--- a/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
@@ -1,6 +1,6 @@
 import { Languages } from "lucide-react";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
-import { cn } from "../../../lib/utils";
+import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 import type { ChatConnectionOption } from "./ConnectionSection";
 
@@ -143,31 +143,19 @@ function TranslationToggle({
   onToggle: () => void;
 }) {
   return (
-    <button
-      type="button"
-      aria-pressed={enabled}
-      onClick={onToggle}
-      className={cn(
-        "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+    <SettingsSwitch
+      label={title}
+      description={description}
+      checked={enabled}
+      onChange={onToggle}
+      labelPosition="start"
+      className={[
+        "justify-between rounded-lg px-3 py-2.5 text-left",
         enabled
           ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
           : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
-      )}
-    >
-      <div className="flex-1 min-w-0">
-        <span className="text-[0.6875rem] font-medium">{title}</span>
-        <p className="text-[0.625rem] text-[var(--muted-foreground)]">{description}</p>
-      </div>
-      <div
-        className={cn(
-          "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-          enabled ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-        )}
-      >
-        <div
-          className={cn("h-4 w-4 rounded-full bg-white shadow-sm transition-transform", enabled && "translate-x-3.5")}
-        />
-      </div>
-    </button>
+      ].join(" ")}
+      labelClassName="text-[0.6875rem] font-medium"
+    />
   );
 }

--- a/packages/client/src/hooks/use-folder-rename-gesture.ts
+++ b/packages/client/src/hooks/use-folder-rename-gesture.ts
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
 
-interface FolderRenameGestureOptions {
+export interface FolderRenameGestureOptions {
   onSingleClick: () => void;
   onRename: () => void;
   delayMs?: number;
@@ -53,4 +59,22 @@ export function useFolderRenameGesture() {
     },
     [],
   );
+}
+
+export function handleFolderRenameKeyDown(
+  event: ReactKeyboardEvent<HTMLElement>,
+  { onSingleClick, onRename }: Pick<FolderRenameGestureOptions, "onSingleClick" | "onRename">,
+) {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    event.stopPropagation();
+    onSingleClick();
+    return;
+  }
+
+  if (event.key === "F2") {
+    event.preventDefault();
+    event.stopPropagation();
+    onRename();
+  }
 }

--- a/packages/client/src/hooks/use-folder-rename-gesture.ts
+++ b/packages/client/src/hooks/use-folder-rename-gesture.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, type MouseEvent as ReactMouseEvent } from "react";
+
+interface FolderRenameGestureOptions {
+  onSingleClick: () => void;
+  onRename: () => void;
+  delayMs?: number;
+}
+
+interface PendingFolderRenameGesture {
+  lastClickAt: number;
+  timeout: ReturnType<typeof window.setTimeout>;
+}
+
+export function useFolderRenameGesture() {
+  const pendingGesturesRef = useRef(new Map<string, PendingFolderRenameGesture>());
+
+  useEffect(
+    () => () => {
+      for (const pending of pendingGesturesRef.current.values()) {
+        window.clearTimeout(pending.timeout);
+      }
+      pendingGesturesRef.current.clear();
+    },
+    [],
+  );
+
+  return useCallback(
+    (
+      key: string,
+      event: ReactMouseEvent<HTMLElement>,
+      { onSingleClick, onRename, delayMs = 360 }: FolderRenameGestureOptions,
+    ) => {
+      event.stopPropagation();
+
+      const now = Date.now();
+      const pending = pendingGesturesRef.current.get(key);
+
+      if (pending) {
+        window.clearTimeout(pending.timeout);
+        pendingGesturesRef.current.delete(key);
+      }
+
+      if (pending && now - pending.lastClickAt < delayMs) {
+        onRename();
+        return;
+      }
+
+      const timeout = window.setTimeout(() => {
+        pendingGesturesRef.current.delete(key);
+        onSingleClick();
+      }, delayMs);
+      pendingGesturesRef.current.set(key, { lastClickAt: now, timeout });
+    },
+    [],
+  );
+}

--- a/packages/client/src/hooks/use-game-assets.ts
+++ b/packages/client/src/hooks/use-game-assets.ts
@@ -4,6 +4,8 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import { encodeAssetPath } from "../components/game-assets/encode-asset-path";
+import { HOST_DEVICE_FILE_MANAGER_MESSAGE, isHostDeviceBrowser } from "../lib/host-device";
+import { toast } from "sonner";
 
 /**
  * Single node in the game-assets folder tree.
@@ -130,7 +132,13 @@ export function useDeleteGameAsset() {
  */
 export function useOpenGameAssetsFolder() {
   return useMutation({
-    mutationFn: (subfolder?: string) => api.post("/game-assets/open-folder", { subfolder }),
+    mutationFn: (subfolder?: string) => {
+      if (!isHostDeviceBrowser()) {
+        toast.info(HOST_DEVICE_FILE_MANAGER_MESSAGE);
+        return Promise.resolve({ ok: false });
+      }
+      return api.post("/game-assets/open-folder", { subfolder });
+    },
   });
 }
 

--- a/packages/client/src/hooks/use-game-assets.ts
+++ b/packages/client/src/hooks/use-game-assets.ts
@@ -135,7 +135,7 @@ export function useOpenGameAssetsFolder() {
     mutationFn: (subfolder?: string) => {
       if (!isHostDeviceBrowser()) {
         toast.info(HOST_DEVICE_FILE_MANAGER_MESSAGE);
-        return Promise.resolve({ ok: false });
+        throw new Error(HOST_DEVICE_FILE_MANAGER_MESSAGE);
       }
       return api.post("/game-assets/open-folder", { subfolder });
     },

--- a/packages/client/src/lib/host-device.ts
+++ b/packages/client/src/lib/host-device.ts
@@ -1,0 +1,17 @@
+export function isHostDeviceBrowser(): boolean {
+  if (typeof window === "undefined") return true;
+  if (window.location.protocol === "file:") return true;
+
+  const hostname = window.location.hostname.toLowerCase();
+  return (
+    hostname === "" ||
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+export const HOST_DEVICE_FILE_MANAGER_MESSAGE =
+  "System folders can only be opened from the device hosting Marinara Engine.";

--- a/packages/client/src/lib/host-device.ts
+++ b/packages/client/src/lib/host-device.ts
@@ -7,6 +7,7 @@ export function isHostDeviceBrowser(): boolean {
     hostname === "" ||
     hostname === "localhost" ||
     hostname.endsWith(".localhost") ||
+    hostname === "0.0.0.0" ||
     hostname === "127.0.0.1" ||
     hostname === "::1" ||
     hostname === "[::1]"

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -85,8 +85,9 @@ export const TRACKER_PANEL_WIDTH_DEFAULT = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.sta
 export const TRACKER_PANEL_WIDTH_MIN = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.compact;
 export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expanded;
 export const TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR = "#09090b";
-export const DEFAULT_APP_ACCENT_DARK = "#d4d4d4";
-export const DEFAULT_APP_ACCENT_LIGHT = "#1a1025";
+export const DEFAULT_APP_ACCENT_DARK = "#d4acfb";
+export const DEFAULT_APP_ACCENT_LIGHT = "#d4acfb";
+const LEGACY_DEFAULT_APP_ACCENTS = new Set(["#d4d4d4", "#1a1025"]);
 export const DEFAULT_CHAT_TEXT_DARK = "#d4d4d4";
 export const DEFAULT_CHAT_TEXT_LIGHT = "#1a1025";
 export const DEFAULT_CHAT_CHROME_TEXT_DARK = "#d4d4d4";
@@ -156,7 +157,8 @@ function normalizeScrollTop(value: unknown) {
 }
 
 function normalizeAppAccentColor(value: unknown) {
-  return typeof value === "string" ? value.trim() : "";
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return LEGACY_DEFAULT_APP_ACCENTS.has(normalized.toLowerCase()) ? "" : normalized;
 }
 
 function normalizeChatChromeTextColor(value: unknown) {
@@ -1690,7 +1692,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 56,
+      version: 57,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1297,6 +1297,7 @@ input[type="range"].mari-spotify-volume-slider {
   --range-thumb-size: 0.6875rem;
   --range-track-height: 0.25rem;
   --range-thumb-shadow: 0 0 0 0.125rem #191414;
+
   accent-color: #1db954;
 }
 

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -209,7 +209,7 @@
   --marinara-shell-edge-border: color-mix(in srgb, var(--foreground) 14%, var(--background) 86%);
   --marinara-music-player-shell-bg: var(--marinara-topbar-surface);
   --marinara-music-player-shell-border: var(--marinara-topbar-border);
-  --marinara-chat-chrome-accent: var(--foreground);
+  --marinara-chat-chrome-accent: #d4acfb;
   --marinara-chat-chrome-accent-gradient: linear-gradient(
     90deg,
     var(--marinara-chat-chrome-accent),
@@ -272,6 +272,13 @@
   --marinara-chat-chrome-input-bg: var(--marinara-chat-chrome-surface-bg);
   --marinara-chat-chrome-input-border: color-mix(in srgb, var(--marinara-chat-chrome-accent) 14%, transparent);
   --marinara-chat-chrome-input-border-focus: color-mix(in srgb, var(--marinara-chat-chrome-accent) 30%, transparent);
+  --marinara-chat-option-field-bg: var(--marinara-chat-chrome-button-bg);
+  --marinara-chat-option-field-bg-hover: var(--marinara-chat-chrome-button-bg-hover);
+  --marinara-chat-option-field-bg-active: var(--marinara-chat-chrome-button-bg-active);
+  --marinara-chat-option-field-border: var(--marinara-chat-chrome-button-border);
+  --marinara-chat-option-field-border-active: var(--marinara-chat-chrome-button-border-active);
+  --marinara-chat-option-field-ring: var(--marinara-chat-chrome-focus-ring);
+  --marinara-chat-option-switch-off: color-mix(in srgb, var(--muted-foreground) 48%, transparent);
   --marinara-editor-bg: var(--background);
   --marinara-editor-surface-bg: var(--marinara-chat-chrome-panel-bg);
   --marinara-editor-surface-bg-hover: var(--marinara-chat-chrome-surface-bg-hover);
@@ -570,6 +577,32 @@
     var(--marinara-chat-chrome-accent-gradient) border-box;
 }
 
+.marinara-chat-input-shell button:not(:disabled) {
+  color: color-mix(in srgb, var(--marinara-chat-chrome-accent) 58%, transparent);
+}
+
+.marinara-chat-input-shell button:disabled {
+  color: color-mix(in srgb, var(--marinara-chat-chrome-accent) 22%, transparent);
+}
+
+.marinara-chat-input-shell button:not(:disabled):hover,
+.marinara-chat-input-shell button:not(:disabled):focus-visible {
+  background-color: var(--marinara-chat-chrome-highlight-bg-hover);
+  color: var(--marinara-chat-chrome-button-text-hover);
+}
+
+.marinara-chat-input-shell button.bg-foreground\/10:not(:disabled),
+.marinara-chat-input-shell button:not(:disabled)[aria-expanded="true"],
+.marinara-chat-input-shell button:not(:disabled)[aria-pressed="true"] {
+  background-color: var(--marinara-chat-chrome-highlight-bg);
+  color: var(--marinara-chat-chrome-button-text-active);
+  box-shadow: 0 0 0 1px var(--marinara-chat-chrome-focus-ring);
+}
+
+.marinara-chat-input-shell .mari-chat-send-btn:not(:disabled) {
+  color: var(--marinara-chat-chrome-button-text-active);
+}
+
 .marinara-chat-popover.marinara-chat-toolbar-overflow-menu {
   border-radius: 0.5rem;
 }
@@ -780,6 +813,29 @@
   font-weight: 600;
 }
 
+.mari-chat-option-field {
+  border: 1px solid var(--marinara-chat-option-field-border);
+  background: var(--marinara-chat-option-field-bg);
+}
+
+.mari-chat-option-field:hover {
+  background: var(--marinara-chat-option-field-bg-hover);
+}
+
+.mari-chat-option-field--active {
+  border-color: var(--marinara-chat-option-field-border-active);
+  background: var(--marinara-chat-option-field-bg-active);
+  box-shadow: 0 0 0 1px var(--marinara-chat-option-field-ring);
+}
+
+.mari-chat-option-switch {
+  background: var(--marinara-chat-option-switch-off);
+}
+
+.mari-chat-option-switch--active {
+  background: var(--marinara-chat-chrome-accent);
+}
+
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control:not(.mari-chrome-control--danger) {
   border-color: transparent;
   background:
@@ -880,8 +936,8 @@
 .mari-editor-icon-tile,
 .mari-editor-avatar-tile {
   display: flex;
-  height: 2.5rem;
-  width: 2.5rem;
+  height: 2.25rem;
+  width: 2.25rem;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -907,6 +963,7 @@
 .mari-editor-action {
   display: inline-flex;
   min-height: 2.25rem;
+  min-width: 2.25rem;
   align-items: center;
   justify-content: center;
   gap: 0.375rem;
@@ -1083,8 +1140,8 @@
 
   .mari-editor-icon-tile,
   .mari-editor-avatar-tile {
-    height: 2.25rem;
-    width: 2.25rem;
+    height: 2rem;
+    width: 2rem;
     border-radius: 0.625rem;
   }
 
@@ -1097,8 +1154,9 @@
 
   .mari-editor-action {
     min-height: 2rem;
+    min-width: 2rem;
     border-radius: 0.625rem;
-    padding: 0.375rem 0.5rem;
+    padding: 0.375rem;
   }
 
   .mari-editor-action--primary {
@@ -1233,13 +1291,13 @@ input[type="range"]:disabled {
 }
 
 input[type="range"].mari-spotify-volume-slider {
-  --range-track-color: var(--marinara-chat-chrome-panel-divider);
-  --range-fill-color: var(--marinara-chat-chrome-button-text-active);
-  --range-thumb-color: var(--marinara-chat-chrome-button-text-active);
+  --range-track-color: color-mix(in srgb, #1db954 26%, transparent);
+  --range-fill-color: #1db954;
+  --range-thumb-color: #1db954;
   --range-thumb-size: 0.6875rem;
   --range-track-height: 0.25rem;
-  --range-thumb-shadow: 0 0 0 0.125rem var(--marinara-chat-chrome-panel-bg);
-  accent-color: var(--marinara-chat-chrome-button-text-active);
+  --range-thumb-shadow: 0 0 0 0.125rem #191414;
+  accent-color: #1db954;
 }
 
 input[type="range"].mari-spotify-volume-slider::-webkit-slider-runnable-track {
@@ -2663,6 +2721,10 @@ summary[class*="cursor-pointer"],
   width: min(100%, var(--mari-roleplay-message-column-width));
 }
 
+[data-chat-mode="roleplay"] .mari-roleplay-input-column {
+  width: min(100%, var(--mari-roleplay-message-column-width));
+}
+
 [data-chat-mode="roleplay"] .mari-roleplay-message-row {
   --mari-roleplay-avatar-slot: calc(2.5rem * var(--roleplay-avatar-scale, 1));
   --mari-roleplay-avatar-gap: 0.75rem;
@@ -2701,6 +2763,11 @@ summary[class*="cursor-pointer"],
 }
 
 @media (min-width: 768px) {
+  [data-chat-mode="roleplay"] .mari-roleplay-input-column > .mari-chat-input {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   [data-chat-mode="roleplay"] .mari-roleplay-message-row {
     display: grid;
     grid-template-columns:


### PR DESCRIPTION
## Summary

Polishes the current client UI batch across chat, settings, library panels, and compact controls.

- aligns chat and settings chrome with the shared appearance tokens while keeping branded music players isolated
- updates Settings toggles so help tooltips no longer intercept switch clicks
- smooths folder interactions with double-click/double-tap rename behavior and animated folder expansion
- tightens panel action buttons, search controls, copy/export actions, and related mobile-friendly affordances
- adds host-device detection before attempting to open local game asset folders from the browser

## Why

These changes collect the recent maintainer-requested UI/UX fixes into one staging PR so the updated controls, folder behavior, chat styling, and Settings interactions can be reviewed together. No linked issue was provided; this follows the current maintainer UI polish request thread.

## Validation

- `pnpm check`
- `git diff --check`
- focused ESLint while fixing Settings toggles

## Manual Verification Needed

- Manually verify Settings toggles with nearby help icons in browser.
- Manually verify folder rename and expand/collapse behavior on desktop and mobile widths.
- Manually verify Spotify and YouTube player colors remain brand-specific when Appearance accent colors change.
- Manually verify chat input/action chrome in conversation, roleplay, and game mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added duplicate functionality for agents and lorebooks with configuration cloning
  * Implemented gesture-based folder rename and smoother expandable folder content
  * Added a game asset folder browser with host-device detection messaging

* **Improvements**
  * Refreshed theme accent to vibrant purple and standardized chat chrome styling (including “hidden from AI” states and panels/modals)
  * Replaced many numeric fields with improved draft inputs (clamping, digit-only entry, commit-on-change)
  * Streamlined settings toggles using shared switch controls and restyled key toolbar/mobile search layouts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->