### PR TITLE
[codex] Fix connection model picker and generation responsiveness

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -2,7 +2,7 @@
 // Full-Page Connection Editor
 // Click a connection → opens this editor (like presets/characters)
 // ──────────────────────────────────────────────
-import { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useUIStore } from "../../stores/ui.store";
 import {
   useConnection,
@@ -199,48 +199,8 @@ export function ConnectionEditor() {
   // Model search
   const [modelSearch, setModelSearch] = useState("");
   const [showModelDropdown, setShowModelDropdown] = useState(false);
-  const modelTriggerRef = useRef<HTMLDivElement>(null);
   const modelSearchInputRef = useRef<HTMLInputElement>(null);
   const comfyWorkflowTextareaRef = useRef<HTMLTextAreaElement>(null);
-  const [dropdownRect, setDropdownRect] = useState<{ top: number; left: number; width: number; maxH: number } | null>(
-    null,
-  );
-
-  useLayoutEffect(() => {
-    if (!showModelDropdown || !modelTriggerRef.current) {
-      setDropdownRect(null);
-      return;
-    }
-
-    const update = () => {
-      if (!modelTriggerRef.current) return;
-      const rect = modelTriggerRef.current.getBoundingClientRect();
-      const spaceBelow = window.innerHeight - rect.bottom - 8;
-      const spaceAbove = rect.top - 8;
-      // Flip above trigger if there's more space above
-      const openAbove = spaceBelow < 120 && spaceAbove > spaceBelow;
-      const maxH = Math.min(320, openAbove ? spaceAbove : spaceBelow);
-      setDropdownRect({
-        top: openAbove ? rect.top - maxH - 4 : rect.bottom + 4,
-        left: rect.left,
-        width: rect.width,
-        maxH,
-      });
-    };
-
-    update();
-
-    // Recalculate on scroll/resize so the dropdown tracks the trigger
-    const scrollParent =
-      modelTriggerRef.current.closest(".overflow-y-auto, .overflow-auto, .overflow-y-scroll, .overflow-scroll") ??
-      window;
-    scrollParent.addEventListener("scroll", update, { passive: true });
-    window.addEventListener("resize", update, { passive: true });
-    return () => {
-      scrollParent.removeEventListener("scroll", update);
-      window.removeEventListener("resize", update);
-    };
-  }, [showModelDropdown]);
 
   // Remote models fetched from provider API
   const [remoteModels, setRemoteModels] = useState<RemoteConnectionModel[]>([]);
@@ -1237,7 +1197,7 @@ export function ConnectionEditor() {
             help="The specific AI model to use. You can pick from the list or type a custom model ID directly."
           >
             {/* Standard model dropdown + manual input (used for all providers including image_generation) */}
-            <div ref={modelTriggerRef} className="relative">
+            <div className={cn("relative", showModelDropdown && "z-50")}>
               <div
                 onClick={() => setShowModelDropdown(!showModelDropdown)}
                 className={cn(
@@ -1298,17 +1258,7 @@ export function ConnectionEditor() {
                     }}
                   />
                   <div
-                    className="fixed z-50 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
-                    style={
-                      dropdownRect
-                        ? {
-                            top: dropdownRect.top,
-                            left: dropdownRect.left,
-                            width: dropdownRect.width,
-                            maxHeight: dropdownRect.maxH,
-                          }
-                        : undefined
-                    }
+                    className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
                   >
                     {/* Fetch from API button */}
                     <div className="sticky top-0 z-10 border-b border-[var(--border)] bg-[var(--card)] p-2">

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -518,7 +518,11 @@ export async function connectionsRoutes(app: FastifyInstance) {
       const lowerBase = baseUrl.toLowerCase();
       const sanitizeProviderBody = (body: string): string => {
         if (body.includes("<html") || body.includes("<!DOCTYPE")) {
-          return "Provider returned an HTML page instead of JSON. Check the Base URL for this image service.";
+          const hint =
+            conn.provider === "image_generation"
+              ? "Check the Base URL for this image service."
+              : "Check the Base URL for this connection.";
+          return `Provider returned an HTML page instead of JSON. ${hint}`;
         }
         return body.slice(0, 300);
       };

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -88,7 +88,7 @@ import {
   type AssemblerInput,
 } from "../services/prompt/index.js";
 import { wrapContent } from "../services/prompt/format-engine.js";
-import { type ChatMessage, type LLMUsage } from "../services/llm/base-provider.js";
+import { yieldToEventLoop, type ChatMessage, type LLMUsage } from "../services/llm/base-provider.js";
 import { executeToolCalls } from "../services/tools/tool-executor.js";
 import { createAgentPipeline, type ResolvedAgent, type AgentInjection } from "../services/agents/agent-pipeline.js";
 import { DATA_DIR } from "../utils/data-dir.js";
@@ -5300,14 +5300,33 @@ export async function generateRoutes(app: FastifyInstance) {
         };
         const captureReasoning = chatMode === "roleplay" && showThoughts;
 
-        // Helper: write text content progressively as small SSE token chunks
-        const writeContentChunked = (text: string) => {
-          const CHUNK_SIZE = 6;
-          for (let i = 0; i < text.length; i += CHUNK_SIZE) {
-            const chunk = text.slice(i, i + CHUNK_SIZE);
+        // Helper: write text content progressively as small SSE token chunks.
+        // Some providers dump a full buffered response through the streaming
+        // path; yield periodically so health checks and chat navigation are not
+        // starved while we fan that response out to the client.
+        const TOKEN_CHUNK_SIZE = 6;
+        const TOKEN_CHUNK_YIELD_EVERY = 64;
+        let tokenChunksSinceYield = 0;
+        const sendTokenTextChunked = async (text: string) => {
+          for (let i = 0; i < text.length; i += TOKEN_CHUNK_SIZE) {
+            const chunk = text.slice(i, i + TOKEN_CHUNK_SIZE);
+            trySendSseEvent(reply, { type: "token", data: chunk });
+            tokenChunksSinceYield += 1;
+            if (tokenChunksSinceYield % TOKEN_CHUNK_YIELD_EVERY === 0) {
+              await yieldToEventLoop();
+            }
+          }
+        };
+        const writeContentChunked = async (text: string) => {
+          for (let i = 0; i < text.length; i += TOKEN_CHUNK_SIZE) {
+            const chunk = text.slice(i, i + TOKEN_CHUNK_SIZE);
             fullResponse += chunk;
             if (!holdForProseGuardianRewrite) {
               trySendSseEvent(reply, { type: "token", data: chunk });
+              tokenChunksSinceYield += 1;
+              if (tokenChunksSinceYield % TOKEN_CHUNK_YIELD_EVERY === 0) {
+                await yieldToEventLoop();
+              }
             }
           }
         };
@@ -5673,7 +5692,7 @@ export async function generateRoutes(app: FastifyInstance) {
           fullThinking = "";
           providerThinking = "";
           if (tailMessages.assistantPrefillInjected && assistantPrefill) {
-            writeContentChunked(assistantPrefill);
+            await writeContentChunked(assistantPrefill);
           }
           let geminiResponseParts: unknown[] | null = null;
           let chatCompletionsReasoning: Record<string, unknown> | null = null;
@@ -5774,8 +5793,7 @@ export async function generateRoutes(app: FastifyInstance) {
               // Some providers (e.g. Gemini with thinking) return the entire response
               // in one chunk. Break large chunks into small pieces so the client sees
               // progressive streaming instead of the whole message appearing at once.
-              const STREAM_CHUNK = 6;
-              const onToken = (chunk: string) => {
+              const onToken = async (chunk: string) => {
                 // If the request has been aborted, skip emitting any further tokens.
                 if (abortController.signal.aborted) {
                   return;
@@ -5784,15 +5802,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 if (holdForProseGuardianRewrite) {
                   return;
                 }
-                if (chunk.length <= STREAM_CHUNK) {
-                  reply.raw.write(`data: ${JSON.stringify({ type: "token", data: chunk })}\n\n`);
-                } else {
-                  for (let i = 0; i < chunk.length; i += STREAM_CHUNK) {
-                    reply.raw.write(
-                      `data: ${JSON.stringify({ type: "token", data: chunk.slice(i, i + STREAM_CHUNK) })}\n\n`,
-                    );
-                  }
-                }
+                await sendTokenTextChunked(chunk);
               };
 
               for (let round = 0; round < maxToolRounds; round++) {
@@ -5856,7 +5866,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 // If provider doesn't support onToken (fell back to non-streaming),
                 // write the content conventionally
                 if (result.content && !fullResponse.endsWith(result.content)) {
-                  writeContentChunked(result.content);
+                  await writeContentChunked(result.content);
                 }
 
                 // Accumulate usage across tool rounds
@@ -5995,7 +6005,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     onChatCompletionsReasoning: rememberChatCompletionsReasoning,
                   });
                   if (finalResult.content && fullResponse.length === prevLen) {
-                    writeContentChunked(finalResult.content);
+                    await writeContentChunked(finalResult.content);
                   }
                   if (finalResult.usage) {
                     if (!usage) {
@@ -6060,13 +6070,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   result = await gen.next();
                   continue;
                 }
-                if (val.length <= 6) {
-                  reply.raw.write(`data: ${JSON.stringify({ type: "token", data: val })}\n\n`);
-                } else {
-                  for (let i = 0; i < val.length; i += 6) {
-                    reply.raw.write(`data: ${JSON.stringify({ type: "token", data: val.slice(i, i + 6) })}\n\n`);
-                  }
-                }
+                await sendTokenTextChunked(val);
                 result = await gen.next();
               }
               // Generator return value contains usage

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5321,12 +5321,12 @@ export async function generateRoutes(app: FastifyInstance) {
           for (let i = 0; i < text.length; i += TOKEN_CHUNK_SIZE) {
             const chunk = text.slice(i, i + TOKEN_CHUNK_SIZE);
             fullResponse += chunk;
+            tokenChunksSinceYield += 1;
             if (!holdForProseGuardianRewrite) {
               trySendSseEvent(reply, { type: "token", data: chunk });
-              tokenChunksSinceYield += 1;
-              if (tokenChunksSinceYield % TOKEN_CHUNK_YIELD_EVERY === 0) {
-                await yieldToEventLoop();
-              }
+            }
+            if (tokenChunksSinceYield % TOKEN_CHUNK_YIELD_EVERY === 0) {
+              await yieldToEventLoop();
             }
           }
         };

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -32,7 +32,7 @@ import {
 } from "../../services/prompt/index.js";
 import { mergeAdjacentMessages } from "../../services/prompt/merger.js";
 import { wrapContent } from "../../services/prompt/format-engine.js";
-import { type BaseLLMProvider, type ChatMessage } from "../../services/llm/base-provider.js";
+import { yieldToEventLoop, type BaseLLMProvider, type ChatMessage } from "../../services/llm/base-provider.js";
 import {
   fitMessagesForModelAccess,
   mergeModelContextLimit,
@@ -1622,16 +1622,21 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       }, 15_000);
 
       const STREAM_CHUNK = 6;
+      const STREAM_CHUNK_YIELD_EVERY = 64;
+      let chunksSinceYield = 0;
       let full = "";
-      const onToken = (chunk: string) => {
-        full += chunk;
-        if (chunk.length <= STREAM_CHUNK) {
-          sendSseEvent(reply, { type: "token", data: chunk });
-        } else {
-          for (let i = 0; i < chunk.length; i += STREAM_CHUNK) {
-            sendSseEvent(reply, { type: "token", data: chunk.slice(i, i + STREAM_CHUNK) });
+      const sendTokenTextChunked = async (text: string) => {
+        for (let i = 0; i < text.length; i += STREAM_CHUNK) {
+          sendSseEvent(reply, { type: "token", data: text.slice(i, i + STREAM_CHUNK) });
+          chunksSinceYield += 1;
+          if (chunksSinceYield % STREAM_CHUNK_YIELD_EVERY === 0) {
+            await yieldToEventLoop();
           }
         }
+      };
+      const onToken = async (chunk: string) => {
+        full += chunk;
+        await sendTokenTextChunked(chunk);
       };
 
       try {
@@ -1655,7 +1660,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         });
 
         if (result.content && !full.endsWith(result.content)) {
-          onToken(result.content);
+          await onToken(result.content);
         }
 
         sendSseEvent(reply, { type: "result", data: { content: full || result.content || "" } });

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -39,6 +39,10 @@ export function llmFetch(
   });
 }
 
+export function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 export interface ChatMessage {
   role: "system" | "user" | "assistant" | "tool";
   content: string;
@@ -101,7 +105,7 @@ export interface ChatOptions {
   /** Prefer provider APIs that expose reasoning summaries when available */
   captureReasoning?: boolean;
   /** Callback for streaming text tokens as they arrive (used in tool path) */
-  onToken?: (chunk: string) => void;
+  onToken?: (chunk: string) => void | Promise<void>;
   /** Enable extended thinking (reasoning models) */
   enableThinking?: boolean;
   /** Reasoning effort level for models that support it */
@@ -606,7 +610,7 @@ export abstract class BaseLLMProvider {
     while (!result.done) {
       content += result.value;
       if (options.onToken) {
-        options.onToken(result.value);
+        await options.onToken(result.value);
       }
       result = await gen.next();
     }

--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -299,7 +299,7 @@ export class AnthropicProvider extends BaseLLMProvider {
     for (const block of blocks) {
       if (block.type === "thinking" && typeof block.thinking === "string") options.onThinking?.(block.thinking);
     }
-    if (text && options.onToken) options.onToken(text);
+    if (text && options.onToken) await options.onToken(text);
 
     const toolCalls = blocks
       .map((block) => anthropicToolCallFromBlock(block))

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -443,7 +443,7 @@ export class GoogleProvider extends BaseLLMProvider {
       const call = geminiToolCallFromPart(part, i);
       if (call) toolCalls.push(call);
     }
-    if (content && options.onToken) options.onToken(content);
+    if (content && options.onToken) await options.onToken(content);
 
     return {
       content: content || null,

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -1283,14 +1283,14 @@ export class OpenAIProvider extends BaseLLMProvider {
           if (!reasoning && blocks.thinking && options.onThinking) options.onThinking(blocks.thinking);
           if (blocks.text) {
             content += blocks.text;
-            options.onToken?.(blocks.text);
+            await options.onToken?.(blocks.text);
           }
         } else if (delta?.content) {
           content += delta.content as string;
-          options.onToken?.(delta.content as string);
+          await options.onToken?.(delta.content as string);
         } else if (typeof delta?.refusal === "string" && delta.refusal) {
           content += delta.refusal;
-          options.onToken?.(delta.refusal);
+          await options.onToken?.(delta.refusal);
         }
 
         // Accumulate tool call deltas. Some OpenAI-compatible backends (including llama.cpp)
@@ -1916,7 +1916,7 @@ export class OpenAIProvider extends BaseLLMProvider {
               const delta = parsed.delta as string | undefined;
               if (delta) {
                 content += delta;
-                options.onToken?.(delta);
+                await options.onToken?.(delta);
               }
               break;
             }
@@ -1925,7 +1925,7 @@ export class OpenAIProvider extends BaseLLMProvider {
               const delta = parsed.delta as string | undefined;
               if (delta) {
                 content += delta;
-                options.onToken?.(delta);
+                await options.onToken?.(delta);
               }
               break;
             }
@@ -2004,7 +2004,7 @@ export class OpenAIProvider extends BaseLLMProvider {
                   const fallback = this.extractResponsesText(resp);
                   if (fallback) {
                     content = fallback;
-                    options.onToken?.(fallback);
+                    await options.onToken?.(fallback);
                   }
                 }
               }


### PR DESCRIPTION
## Summary

- Anchor the connection editor model dropdown to the model search field so the Fetch Models panel moves with the field during editor scroll.
- Make fetched-model HTML error hints say "connection" for non-image providers while preserving "image service" for image-generation connections.
- Add cooperative event-loop yields during burst token fan-out in generation and dry-run streaming, and allow async LLM token callbacks across OpenAI, Anthropic, and Google provider paths.

## Why

Users reported that the connection model picker floated away from the model field while scrolling. Another report noted that large or buffered generations could monopolize server responsiveness, delaying chat navigation and health checks while Marinara fanned provider output into tiny SSE token chunks.

## Validation

- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/client build`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/server build`
- `git diff --check`

## Manual verification

- Manually verify the connection editor model dropdown stays attached to the model search field while scrolling.
- Manually verify `/api/health` remains responsive during a long generation on a Node 24 runtime.

## Issue

No linked issue yet; one should be opened before submission per `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection troubleshooting hints by showing provider-specific guidance when validating base URLs.

* **Performance Improvements**
  * Made token streaming more responsive and reliable during generation, reducing potential event-loop stalls.
  * Ensured token callbacks complete before continuing streaming flow across supported LLM providers.

* **UI/UX Improvements**
  * Simplified model dropdown placement and anchoring to be more consistent relative to the trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->