### PR TITLE
[codex] Unify accent and RGB theming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ packages/server/data/
 
 # Temporary tests
 *.test.ts
+*.spec.ts
 
 # Custom agents (personal)
 .github/agents/qa.agent.md

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -11,11 +11,16 @@ import { AppDialogRenderer } from "./components/ui/AppDialogRenderer";
 import { ChibiProfessorMariEasterEgg } from "./components/ui/ChibiProfessorMariEasterEgg";
 import { CsrfOriginWarningBanner } from "./components/diagnostics/CsrfOriginWarningBanner";
 import { Toaster } from "sonner";
-import { getDefaultChatChromeTextColor, useUIStore } from "./stores/ui.store";
+import {
+  getDefaultAppAccentColor,
+  getDefaultAppBackgroundColor,
+  getDefaultChatChromeTextColor,
+  useUIStore,
+} from "./stores/ui.store";
 import { useSidecarStore } from "./stores/sidecar.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
-import { getCssColorFallback, isCssGradient } from "./lib/css-colors";
+import { getCssColorFallback, getCssGradientColorStops, isCssGradient } from "./lib/css-colors";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
 import { useLegacyExtensionMigration } from "./hooks/use-extensions";
 import { useSettingsSync } from "./hooks/use-settings-sync";
@@ -42,6 +47,21 @@ type CustomFontFace = {
 };
 
 const registeredCustomFontFaceKeys = new Set<string>();
+const APP_ACCENT_CUSTOM_VARIABLES = [
+  "--primary",
+  "--ring",
+  "--accent",
+  "--sidebar-accent",
+  "--sidebar-accent-foreground",
+  "--glow-primary",
+  "--marinara-app-accent-solid",
+  "--marinara-app-accent-gradient",
+  "--marinara-chat-chrome-accent",
+  "--marinara-chat-chrome-accent-gradient",
+] as const;
+const ACCENT_RGB_TICK_MS = 120;
+const ACCENT_RGB_SOLID_CYCLE_MS = 5_200;
+const ACCENT_RGB_GRADIENT_STOP_MS = 4_500;
 
 function stripFontFamilyQuotes(family: string): string {
   const trimmed = family.trim();
@@ -73,6 +93,79 @@ function syncRangeSliderProgress(input: HTMLInputElement) {
   input.style.setProperty("--range-progress", `${Math.max(0, Math.min(100, percent))}%`);
 }
 
+function getSolidAccentGradient(accent: string) {
+  return `linear-gradient(90deg, color-mix(in srgb, ${accent} 72%, var(--background) 28%), ${accent}, color-mix(in srgb, ${accent} 76%, var(--foreground) 24%), ${accent})`;
+}
+
+function getAccentSurface(accent: string, theme: "dark" | "light") {
+  return `color-mix(in srgb, var(--secondary) ${theme === "light" ? "84%" : "78%"}, ${accent} ${
+    theme === "light" ? "16%" : "22%"
+  })`;
+}
+
+function getAccentGlow(accent: string, theme: "dark" | "light") {
+  return `color-mix(in srgb, ${accent} ${theme === "light" ? "12%" : "18%"}, transparent)`;
+}
+
+function applyAppAccentVariables({
+  root,
+  accent,
+  gradient,
+  surfaceAccent,
+  theme,
+}: {
+  root: HTMLElement;
+  accent: string;
+  gradient: string;
+  surfaceAccent: string;
+  theme: "dark" | "light";
+}) {
+  root.style.setProperty("--primary", accent);
+  root.style.setProperty("--ring", accent);
+  root.style.setProperty("--accent", getAccentSurface(surfaceAccent, theme));
+  root.style.setProperty("--sidebar-accent", `color-mix(in srgb, ${surfaceAccent} 12%, transparent)`);
+  root.style.setProperty("--sidebar-accent-foreground", accent);
+  root.style.setProperty("--glow-primary", getAccentGlow(surfaceAccent, theme));
+  root.style.setProperty("--marinara-app-accent-solid", accent);
+  root.style.setProperty("--marinara-app-accent-gradient", gradient);
+  root.style.setProperty("--marinara-chat-chrome-accent", accent);
+  root.style.setProperty("--marinara-chat-chrome-accent-gradient", gradient);
+}
+
+function getSolidRgbAccent(accent: string) {
+  const wave = Math.sin((performance.now() / ACCENT_RGB_SOLID_CYCLE_MS) * Math.PI * 2);
+  const mixAmount = Math.abs(wave) * 36;
+  const target = wave >= 0 ? "var(--foreground)" : "var(--background)";
+  return `color-mix(in srgb, ${accent} ${(100 - mixAmount).toFixed(2)}%, ${target} ${mixAmount.toFixed(2)}%)`;
+}
+
+function getGradientRgbAccent(stops: string[]) {
+  if (stops.length <= 1) return stops[0] ?? "var(--primary)";
+
+  const cycleMs = Math.max(ACCENT_RGB_GRADIENT_STOP_MS * stops.length, 9_000);
+  const position = ((performance.now() % cycleMs) / cycleMs) * stops.length;
+  const fromIndex = Math.floor(position) % stops.length;
+  const toIndex = (fromIndex + 1) % stops.length;
+  const rawProgress = position - Math.floor(position);
+  const easedProgress = (1 - Math.cos(rawProgress * Math.PI)) / 2;
+  const fromPercent = (100 - easedProgress * 100).toFixed(2);
+  const toPercent = (easedProgress * 100).toFixed(2);
+
+  return `color-mix(in srgb, ${stops[fromIndex]} ${fromPercent}%, ${stops[toIndex]} ${toPercent}%)`;
+}
+
+function clearCustomAppAccentVariables(root: HTMLElement) {
+  APP_ACCENT_CUSTOM_VARIABLES.forEach((variable) => root.style.removeProperty(variable));
+}
+
+function canRunAccentAnimation() {
+  return (
+    document.visibilityState === "visible" &&
+    document.hasFocus() &&
+    !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
 async function recoverFromVersionSkew(serverVersion: string) {
   if (sessionStorage.getItem(VERSION_RECOVERY_KEY) === serverVersion) {
     return;
@@ -92,7 +185,9 @@ export function App() {
   const language = useUIStore((s) => s.language);
   const visualTheme = useUIStore((s) => s.visualTheme);
   const fontFamily = useUIStore((s) => s.fontFamily);
+  const appBackgroundColor = useUIStore((s) => s.appBackgroundColor);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
+  const appAccentRgbMode = useUIStore((s) => s.appAccentRgbMode);
   const chatChromeTextColor = useUIStore((s) => s.chatChromeTextColor);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
   useLegacyThemeMigration();
@@ -155,32 +250,123 @@ export function App() {
 
   useEffect(() => {
     const root = document.documentElement;
+    const background = appBackgroundColor.trim();
+    const defaultBackground = getDefaultAppBackgroundColor(theme);
+
+    if (background) {
+      root.style.setProperty("--background", getCssColorFallback(background, defaultBackground));
+      root.style.setProperty("--marinara-app-background-paint", background);
+    } else {
+      root.style.removeProperty("--background");
+      root.style.removeProperty("--marinara-app-background-paint");
+    }
+  }, [appBackgroundColor, theme]);
+
+  useEffect(() => {
+    const root = document.documentElement;
     const accent = appAccentColor.trim();
-    if (accent) {
-      if (isCssGradient(accent)) {
-        root.style.setProperty("--marinara-chat-chrome-accent", getCssColorFallback(accent, "#d4acfb"));
-        root.style.setProperty("--marinara-chat-chrome-accent-gradient", accent);
+    const defaultAccent = getDefaultAppAccentColor(theme);
+    const accentSource = accent || defaultAccent;
+    const solidAccent = getCssColorFallback(accentSource, defaultAccent);
+    const accentIsGradient = isCssGradient(accentSource);
+    const gradientStops = accentIsGradient ? getCssGradientColorStops(accentSource, solidAccent) : [solidAccent];
+
+    let accentAnimationTimer: ReturnType<typeof window.setInterval> | null = null;
+
+    const setAccentModeDataset = () => {
+      if (accentIsGradient) {
         root.dataset.marinaraChatChromeAccentMode = "gradient";
       } else {
-        root.style.setProperty("--marinara-chat-chrome-accent", accent);
-        root.style.removeProperty("--marinara-chat-chrome-accent-gradient");
         delete root.dataset.marinaraChatChromeAccentMode;
       }
-    } else {
-      root.style.removeProperty("--marinara-chat-chrome-accent");
-      root.style.removeProperty("--marinara-chat-chrome-accent-gradient");
-      delete root.dataset.marinaraChatChromeAccentMode;
+    };
+
+    const applyStaticAccent = () => {
+      if (!accent) {
+        clearCustomAppAccentVariables(root);
+        setAccentModeDataset();
+        return;
+      }
+
+      applyAppAccentVariables({
+        root,
+        accent: solidAccent,
+        gradient: accentIsGradient ? accentSource : getSolidAccentGradient(solidAccent),
+        surfaceAccent: solidAccent,
+        theme,
+      });
+      setAccentModeDataset();
+    };
+
+    const applyLiveAccent = () => {
+      const liveAccent =
+        accentIsGradient && gradientStops.length > 1 ? getGradientRgbAccent(gradientStops) : getSolidRgbAccent(solidAccent);
+
+      applyAppAccentVariables({
+        root,
+        accent: liveAccent,
+        gradient: getSolidAccentGradient(liveAccent),
+        surfaceAccent: accentIsGradient ? solidAccent : liveAccent,
+        theme,
+      });
+      setAccentModeDataset();
+    };
+
+    const stopAccentAnimation = () => {
+      if (accentAnimationTimer !== null) {
+        window.clearInterval(accentAnimationTimer);
+        accentAnimationTimer = null;
+      }
+      delete root.dataset.marinaraAccentAnimation;
+      applyStaticAccent();
+    };
+
+    const startAccentAnimation = () => {
+      root.dataset.marinaraAccentAnimation = accentIsGradient && gradientStops.length > 1 ? "gradient" : "solid";
+      applyLiveAccent();
+      if (accentAnimationTimer === null) {
+        accentAnimationTimer = window.setInterval(applyLiveAccent, ACCENT_RGB_TICK_MS);
+      }
+    };
+
+    const syncAccentAnimationState = () => {
+      if (appAccentRgbMode && canRunAccentAnimation()) {
+        startAccentAnimation();
+      } else {
+        stopAccentAnimation();
+      }
+    };
+
+    if (!appAccentRgbMode) {
+      applyStaticAccent();
     }
-  }, [appAccentColor]);
+    syncAccentAnimationState();
+    const reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    document.addEventListener("visibilitychange", syncAccentAnimationState);
+    window.addEventListener("focus", syncAccentAnimationState);
+    window.addEventListener("blur", syncAccentAnimationState);
+    window.addEventListener("pageshow", syncAccentAnimationState);
+    window.addEventListener("pagehide", syncAccentAnimationState);
+    reducedMotionQuery.addEventListener("change", syncAccentAnimationState);
+
+    return () => {
+      document.removeEventListener("visibilitychange", syncAccentAnimationState);
+      window.removeEventListener("focus", syncAccentAnimationState);
+      window.removeEventListener("blur", syncAccentAnimationState);
+      window.removeEventListener("pageshow", syncAccentAnimationState);
+      window.removeEventListener("pagehide", syncAccentAnimationState);
+      reducedMotionQuery.removeEventListener("change", syncAccentAnimationState);
+      if (accentAnimationTimer !== null) {
+        window.clearInterval(accentAnimationTimer);
+      }
+      delete root.dataset.marinaraAccentAnimation;
+    };
+  }, [appAccentColor, appAccentRgbMode, theme]);
 
   useEffect(() => {
     const root = document.documentElement;
     const textColor = chatChromeTextColor.trim();
-    const variables = [
-      "--marinara-chat-chrome-text",
-      "--marinara-chat-chrome-button-text-base",
-      "--marinara-chat-chrome-highlight-text-base",
-    ];
+    const variables = ["--marinara-chat-chrome-text"];
 
     if (textColor) {
       const resolvedColor = getCssColorFallback(textColor, getDefaultChatChromeTextColor(theme));

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -1785,28 +1785,28 @@ export function BotBrowserView() {
   };
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="mari-chrome-token-scope flex h-full flex-col overflow-hidden">
       {/* ═══ Header ═══ */}
-      <div className="relative flex h-12 flex-shrink-0 items-center gap-3 px-4">
+      <div className="relative flex h-12 flex-shrink-0 items-center gap-3 bg-[var(--card)]/80 px-4 backdrop-blur-sm">
         <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--border)]/30" />
         <button
           onClick={closeBotBrowser}
-          className="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          className="mari-chrome-control mari-chrome-control--small px-2 py-1.5 text-xs"
         >
           <ArrowLeft size="0.875rem" /> Back
         </button>
-        <h2 className="text-sm font-semibold text-[var(--foreground)]">Browser</h2>
+        <h2 className="mari-chrome-text-strong text-sm font-semibold">Browser</h2>
         <div className="relative ml-2">
           <button
             onClick={() => setSourceOpen((v) => !v)}
-            className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
+            className="mari-chrome-control mari-chrome-control--small px-3 py-1.5 text-xs"
           >
             <span>{provider.icon}</span>
             <span>{provider.name}</span>
             <ChevronDown size="0.625rem" className={cn("transition-transform", sourceOpen && "rotate-180")} />
           </button>
           {sourceOpen && (
-            <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)] shadow-xl">
+            <div className="mari-chrome-selection-bar absolute left-0 top-full z-50 mt-1 min-w-[180px] overflow-hidden shadow-xl">
               {ALL_PROVIDERS.map((p) => (
                 <button
                   key={p.id}
@@ -1814,7 +1814,7 @@ export function BotBrowserView() {
                   className={cn(
                     "flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-xs transition-colors",
                     p.id === sourceId
-                      ? "bg-[var(--primary)]/15 text-[var(--primary)] font-semibold"
+                      ? "mari-chrome-accent-surface mari-accent-animated font-semibold"
                       : "hover:bg-[var(--accent)]",
                   )}
                 >
@@ -1842,23 +1842,23 @@ export function BotBrowserView() {
       <div className="flex flex-1 overflow-hidden">
         {/* ═══ Tag Sidebar ═══ */}
         {showTagPanel && (
-          <div className="flex w-[260px] flex-shrink-0 flex-col border-r border-[var(--border)] bg-[var(--card)]/50">
-            <div className="flex items-center justify-between border-b border-[var(--border)] px-3 py-2">
-              <span className="flex items-center gap-1.5 text-xs font-semibold">
+          <div className="flex w-[260px] flex-shrink-0 flex-col border-r border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--marinara-chat-chrome-panel-bg)]/80">
+            <div className="flex items-center justify-between border-b border-[var(--marinara-chat-chrome-panel-divider)] px-3 py-2">
+              <span className="mari-chrome-text-strong flex items-center gap-1.5 text-xs font-semibold">
                 <Tag size="0.75rem" /> Tags
               </span>
               <div className="flex items-center gap-1">
                 {(includeTags.length > 0 || excludeTags.length > 0) && (
                   <button
                     onClick={clearAllTags}
-                    className="rounded px-1.5 py-0.5 text-[0.6rem] text-[var(--destructive)] hover:bg-[var(--destructive)]/10"
+                    className="mari-chrome-control mari-chrome-control--danger min-h-0 px-1.5 py-0.5 text-[0.6rem]"
                   >
                     Clear
                   </button>
                 )}
                 <button
                   onClick={() => setShowTagPanel(false)}
-                  className="rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--accent)]"
+                  className="mari-chrome-control mari-chrome-control--small min-h-0 p-0.5"
                 >
                   <X size="0.75rem" />
                 </button>
@@ -1876,11 +1876,11 @@ export function BotBrowserView() {
                   }
                 }}
                 placeholder="Search tags..."
-                className="w-full rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-1.5 text-xs outline-none transition-colors focus:border-[var(--primary)]"
+                className="mari-chrome-field mari-chrome-field--compact w-full px-2.5 py-1.5 text-xs"
               />
             </div>
             {(includeTags.length > 0 || excludeTags.length > 0) && (
-              <div className="flex flex-wrap gap-1 border-b border-[var(--border)] px-3 pb-2">
+              <div className="flex flex-wrap gap-1 border-b border-[var(--marinara-chat-chrome-panel-divider)] px-3 pb-2">
                 {includeTags.map((tag) => (
                   <span
                     key={`inc-${tag}`}
@@ -1937,7 +1937,7 @@ export function BotBrowserView() {
                   return (
                     <div
                       key={tag}
-                      className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-[var(--accent)]/50"
+                      className="mari-chrome-text flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-[var(--accent)]/50"
                     >
                       <button
                         onClick={() => toggleIncludeTag(tag)}
@@ -1995,7 +1995,7 @@ export function BotBrowserView() {
                 <div className="relative min-w-[200px] flex-1">
                   <Search
                     size="0.875rem"
-                    className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]"
+                    className="mari-chrome-field-icon pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
                   />
                   <input
                     type="text"
@@ -2005,12 +2005,12 @@ export function BotBrowserView() {
                       setPage(1);
                     }}
                     placeholder="Search characters..."
-                    className="h-10 w-full rounded-lg border border-[var(--border)] bg-[var(--secondary)] py-0 pl-9 pr-8 text-sm text-[var(--foreground)] placeholder-[var(--muted-foreground)] outline-none transition-colors focus:border-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60 md:h-9"
+                    className="mari-chrome-field h-10 w-full py-0 pl-9 pr-8 text-sm md:h-9"
                   />
                   {query && (
                     <button
                       onClick={() => setQuery("")}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                      className="mari-chrome-control mari-chrome-control--small absolute right-1.5 top-1/2 h-7 min-h-0 w-7 -translate-y-1/2 p-0"
                     >
                       <X size="0.75rem" />
                     </button>
@@ -2023,7 +2023,7 @@ export function BotBrowserView() {
                     setSort(e.target.value);
                     setPage(1);
                   }}
-                  className="h-10 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-0 text-xs text-[var(--foreground)] outline-none md:h-9"
+                  className="mari-chrome-field h-10 px-3 py-0 text-xs md:h-9"
                 >
                   {sortGroups.map((group) =>
                     group.label ? (
@@ -2047,15 +2047,15 @@ export function BotBrowserView() {
                 <button
                   onClick={() => setShowTagPanel((v) => !v)}
                   className={cn(
-                    "flex h-10 items-center gap-1.5 rounded-lg border px-3 py-0 text-xs transition-colors md:h-9",
+                    "mari-chrome-control h-10 px-3 py-0 text-xs md:h-9",
                     showTagPanel || includeTags.length > 0 || excludeTags.length > 0
-                      ? "border-[var(--primary)]/40 bg-[var(--primary)]/10 text-[var(--primary)]"
-                      : "border-[var(--border)] bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                      ? "mari-chrome-control--selected"
+                      : "",
                   )}
                 >
                   <Tag size="0.75rem" /> Tags
                   {(includeTags.length > 0 || excludeTags.length > 0) && (
-                    <span className="rounded-full bg-[var(--primary)]/20 px-1.5 text-[0.6rem] font-semibold">
+                    <span className="rounded-md bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 text-[0.6rem] font-semibold">
                       {includeTags.length + excludeTags.length}
                     </span>
                   )}
@@ -2068,15 +2068,13 @@ export function BotBrowserView() {
                   <button
                     onClick={() => setShowFiltersPanel((v) => !v)}
                     className={cn(
-                      "flex h-10 items-center gap-1.5 rounded-lg border px-3 py-0 text-xs transition-colors md:h-9",
-                      showFiltersPanel || hasActiveFeatures
-                        ? "border-[var(--primary)]/40 bg-[var(--primary)]/10 text-[var(--primary)]"
-                        : "border-[var(--border)] bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                      "mari-chrome-control h-10 px-3 py-0 text-xs md:h-9",
+                      (showFiltersPanel || hasActiveFeatures) && "mari-chrome-control--selected",
                     )}
                   >
                     <SlidersHorizontal size="0.75rem" /> Filters
                     {hasActiveFeatures && (
-                      <span className="rounded-full bg-[var(--primary)]/20 px-1.5 text-[0.6rem] font-semibold">
+                      <span className="rounded-md bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 text-[0.6rem] font-semibold">
                         {activeFeatureCount}
                       </span>
                     )}
@@ -2092,7 +2090,7 @@ export function BotBrowserView() {
                   return (
                     <label
                       className={cn(
-                        "flex select-none items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs",
+                        "mari-chrome-control h-10 select-none px-3 py-0 text-xs md:h-9",
                         nsfwGreyedOut
                           ? "cursor-not-allowed opacity-40"
                           : effectiveNsfwAvailable
@@ -2147,7 +2145,7 @@ export function BotBrowserView() {
                           if (sourceId === "pygmalion") handlePygmalionLogout();
                           else if (sourceId === "chartavern") handleCtLogout();
                         }}
-                        className="flex items-center gap-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-[0.65rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--destructive)]"
+                        className="mari-chrome-control mari-chrome-control--small px-2.5 py-2 text-[0.65rem] hover:text-[var(--destructive)]"
                         title="Log out"
                       >
                         <LogOut size="0.625rem" /> Logout
@@ -2156,7 +2154,7 @@ export function BotBrowserView() {
                   ) : (
                     <button
                       onClick={() => setShowLoginModal(true)}
-                      className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs transition-colors hover:bg-[var(--accent)]"
+                      className="mari-chrome-control h-10 px-3 py-0 text-xs md:h-9"
                     >
                       <LogIn size="0.75rem" /> Log In
                     </button>
@@ -2169,7 +2167,7 @@ export function BotBrowserView() {
 
                 <button
                   onClick={doSearch}
-                  className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-xs transition-colors hover:bg-[var(--accent)]"
+                  className="mari-chrome-control h-10 w-10 p-0 text-xs md:h-9 md:w-9"
                   title="Refresh"
                 >
                   <RefreshCw size="0.75rem" />
@@ -2178,10 +2176,10 @@ export function BotBrowserView() {
 
               {/* ═══ Filters panel ═══ */}
               {showFiltersPanel && (
-                <div className="flex flex-wrap gap-6 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/50 px-4 py-3">
+                <div className="mari-chrome-selection-bar flex flex-wrap gap-6 px-4 py-3">
                   {(provider.features.length > 0 || provider.extraToggles.length > 0) && (
                     <div className="flex flex-col gap-2">
-                      <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                      <span className="mari-chrome-text-muted text-[0.65rem] font-semibold uppercase tracking-wider">
                         Character Must Have
                       </span>
                       {provider.features.map((f) => (
@@ -2214,19 +2212,19 @@ export function BotBrowserView() {
                   )}
                   {(provider.hasSortDirection || provider.hasTokenFilters) && (
                     <div className="flex flex-col gap-2">
-                      <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+                      <span className="mari-chrome-text-muted text-[0.65rem] font-semibold uppercase tracking-wider">
                         Advanced Options
                       </span>
                       {provider.hasSortDirection && (
                         <div className="flex items-center gap-2">
-                          <label className="w-24 text-xs text-[var(--muted-foreground)]">Sort Direction</label>
+                          <label className="mari-chrome-text-muted w-24 text-xs">Sort Direction</label>
                           <select
                             value={sortAsc ? "asc" : "desc"}
                             onChange={(e) => {
                               setSortAsc(e.target.value === "asc");
                               setPage(1);
                             }}
-                            className="rounded border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs outline-none"
+                            className="mari-chrome-field mari-chrome-field--compact px-2 py-1 text-xs"
                           >
                             <option value="desc">Descending</option>
                             <option value="asc">Ascending</option>
@@ -2236,7 +2234,7 @@ export function BotBrowserView() {
                       {provider.hasTokenFilters && (
                         <>
                           <div className="flex items-center gap-2">
-                            <label className="w-24 text-xs text-[var(--muted-foreground)]">Min Tokens</label>
+                            <label className="mari-chrome-text-muted w-24 text-xs">Min Tokens</label>
                             <input
                               type="number"
                               value={minTokens}
@@ -2245,11 +2243,11 @@ export function BotBrowserView() {
                                 setPage(1);
                               }}
                               placeholder="50"
-                              className="w-20 rounded border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs outline-none focus:border-[var(--primary)]"
+                              className="mari-chrome-field mari-chrome-field--compact w-20 px-2 py-1 text-xs"
                             />
                           </div>
                           <div className="flex items-center gap-2">
-                            <label className="w-24 text-xs text-[var(--muted-foreground)]">Max Output Tokens</label>
+                            <label className="mari-chrome-text-muted w-24 text-xs">Max Output Tokens</label>
                             <input
                               type="number"
                               value={maxTokens}
@@ -2258,7 +2256,7 @@ export function BotBrowserView() {
                                 setPage(1);
                               }}
                               placeholder="100000"
-                              className="w-20 rounded border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs outline-none focus:border-[var(--primary)]"
+                              className="mari-chrome-field mari-chrome-field--compact w-20 px-2 py-1 text-xs"
                             />
                           </div>
                         </>
@@ -2278,7 +2276,7 @@ export function BotBrowserView() {
                   <span className="text-sm text-[var(--destructive)]">{error}</span>
                   <button
                     onClick={doSearch}
-                    className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)]/15 px-4 py-2 text-xs font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/25"
+                    className="mari-chrome-control mari-chrome-control--selected px-4 py-2 text-xs"
                   >
                     <RefreshCw size="0.75rem" /> Retry
                   </button>
@@ -2299,7 +2297,7 @@ export function BotBrowserView() {
                       <button
                         disabled={page <= 1}
                         onClick={() => setPage((p) => Math.max(1, p - 1))}
-                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+                        className="mari-chrome-control mari-chrome-control--small px-3 py-1.5 text-xs"
                       >
                         Previous
                       </button>
@@ -2310,7 +2308,7 @@ export function BotBrowserView() {
                       <button
                         disabled={page >= totalPages && totalPages > 1}
                         onClick={() => setPage((p) => p + 1)}
-                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-40"
+                        className="mari-chrome-control mari-chrome-control--small px-3 py-1.5 text-xs"
                       >
                         Next
                       </button>
@@ -2349,21 +2347,21 @@ export function BotBrowserView() {
         >
           <div className="absolute inset-0 bg-black/60" onClick={() => setPendingDatacatSwitch(false)} />
           <div
-            className="relative w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+            className="mari-chrome-selection-bar relative w-full max-w-md shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
-              <h3 className="flex items-center gap-2 text-sm font-bold text-[var(--foreground)]">
+            <div className="flex items-center justify-between border-b border-[var(--marinara-chat-chrome-panel-divider)] px-5 py-3">
+              <h3 className="mari-chrome-text-strong flex items-center gap-2 text-sm font-bold">
                 <span className="text-amber-400">⚠️</span> DataCat is NSFW only
               </h3>
               <button
                 onClick={() => setPendingDatacatSwitch(false)}
-                className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                className="mari-chrome-control mari-chrome-control--small p-1"
               >
                 <X size="1rem" />
               </button>
             </div>
-            <div className="flex flex-col gap-3 p-5 text-sm text-[var(--foreground)]">
+            <div className="mari-chrome-text flex flex-col gap-3 p-5 text-sm">
               <p>
                 Every character on DataCat is tagged NSFW upstream, so the NSFW filter is locked on for this provider.
               </p>
@@ -2374,13 +2372,13 @@ export function BotBrowserView() {
                     setPendingDatacatSwitch(false);
                     performSwitch("datacat");
                   }}
-                  className="flex-1 rounded-lg bg-pink-600 px-4 py-2 text-xs font-medium text-white transition-colors hover:bg-pink-500"
+                  className="mari-panel-gradient-button mari-panel-gradient--browser flex-1 px-4 py-2 text-xs"
                 >
                   Continue to DataCat
                 </button>
                 <button
                   onClick={() => setPendingDatacatSwitch(false)}
-                  className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
+                  className="mari-chrome-control flex-1 px-4 py-2 text-xs"
                 >
                   Don't continue to DataCat
                 </button>
@@ -2438,12 +2436,12 @@ function LoginModal({
     >
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
       <div
-        className="relative w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+        className="mari-chrome-selection-bar relative w-full max-w-md shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
-          <h3 className="flex items-center gap-2 text-sm font-bold text-[var(--foreground)]">
+        <div className="flex items-center justify-between border-b border-[var(--marinara-chat-chrome-panel-divider)] px-5 py-3">
+          <h3 className="mari-chrome-text-strong flex items-center gap-2 text-sm font-bold">
             {isPyg ? (
               <>
                 <KeyRound size="1rem" className="text-amber-400" /> Pygmalion Authentication
@@ -2454,10 +2452,7 @@ function LoginModal({
               </>
             )}
           </h3>
-          <button
-            onClick={onClose}
-            className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-          >
+          <button onClick={onClose} className="mari-chrome-control mari-chrome-control--small p-1">
             <X size="1rem" />
           </button>
         </div>
@@ -2487,7 +2482,7 @@ function LoginModal({
                   disabled={isLoggedIn || loginLoading}
                   placeholder="Paste your Pygmalion auth token here"
                   rows={3}
-                  className="w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 font-mono text-xs outline-none transition-colors focus:border-[var(--primary)] disabled:opacity-50"
+                  className="mari-chrome-field w-full resize-y px-3 py-2 font-mono text-xs disabled:opacity-50"
                 />
               </div>
               <details open={showPygHelp} onToggle={(e) => setShowPygHelp((e.target as HTMLDetailsElement).open)}>
@@ -2534,10 +2529,7 @@ function LoginModal({
                     Save & Connect
                   </button>
                 ) : (
-                  <button
-                    onClick={onPygLogout}
-                    className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
-                  >
+                  <button onClick={onPygLogout} className="mari-chrome-control px-4 py-2 text-xs">
                     <LogOut size="0.75rem" /> Log Out
                   </button>
                 )}
@@ -2545,7 +2537,7 @@ function LoginModal({
                   href="https://pygmalion.chat"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
+                  className="mari-chrome-control px-4 py-2 text-xs"
                 >
                   <ExternalLink size="0.75rem" /> Website
                 </a>
@@ -2561,7 +2553,7 @@ function LoginModal({
                   disabled={isLoggedIn || loginLoading}
                   placeholder="Paste your session cookie value here"
                   rows={3}
-                  className="w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-[var(--primary)] disabled:opacity-50"
+                  className="mari-chrome-field w-full resize-y px-3 py-2 text-sm disabled:opacity-50"
                 />
               </div>
               <details open={showHelp} onToggle={(e) => setShowHelp((e.target as HTMLDetailsElement).open)}>
@@ -2606,10 +2598,7 @@ function LoginModal({
                     Save & Connect
                   </button>
                 ) : (
-                  <button
-                    onClick={onCtLogout}
-                    className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
-                  >
+                  <button onClick={onCtLogout} className="mari-chrome-control px-4 py-2 text-xs">
                     <LogOut size="0.75rem" /> Log Out
                   </button>
                 )}
@@ -2617,7 +2606,7 @@ function LoginModal({
                   href="https://character-tavern.com"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium transition-colors hover:bg-[var(--accent)]"
+                  className="mari-chrome-control px-4 py-2 text-xs"
                 >
                   <ExternalLink size="0.75rem" /> CharacterTavern
                 </a>
@@ -2643,7 +2632,7 @@ function CardTile({ card, onClick }: { card: BrowseCard; onClick: () => void }) 
   return (
     <button
       onClick={onClick}
-      className="group flex flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] text-left transition-all hover:border-pink-500/40 hover:shadow-lg hover:shadow-pink-500/10 active:scale-[0.98]"
+      className="group flex flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] text-left transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:shadow-lg hover:shadow-[var(--glow-primary)] active:scale-[0.98]"
     >
       <div className="relative aspect-square w-full overflow-hidden bg-[var(--secondary)]">
         {imgError || !card.avatarUrl ? (
@@ -2671,7 +2660,7 @@ function CardTile({ card, onClick }: { card: BrowseCard; onClick: () => void }) 
         {card.tagline && (
           <p className="line-clamp-2 text-xs text-[var(--muted-foreground)] opacity-70">{card.tagline}</p>
         )}
-        <div className="mt-auto flex items-center gap-2 pt-1.5 text-[0.65rem] text-pink-400/80">
+        <div className="mari-chrome-text-muted mt-auto flex items-center gap-2 pt-1.5 text-[0.65rem]">
           {card.stat1 > 0 && card.stat1Label && (
             <span className="flex items-center gap-0.5" title={card.stat1Label}>
               <Stat1Icon size="0.625rem" /> {fmtNum(card.stat1)}
@@ -2772,10 +2761,7 @@ function DetailView({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-2">
-        <button
-          onClick={onBack}
-          className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-        >
+        <button onClick={onBack} className="mari-chrome-control mari-chrome-control--small px-2 py-1.5 text-xs">
           <ChevronLeft size="0.875rem" /> Back to results
         </button>
         <div className="flex-1" />
@@ -2783,7 +2769,7 @@ function DetailView({
           href={card.externalUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          className="mari-chrome-control mari-chrome-control--small px-2 py-1.5 text-xs"
         >
           <ExternalLink size="0.75rem" /> View on {provider.siteName}
         </a>
@@ -2841,7 +2827,7 @@ function DetailView({
               <button
                 onClick={() => onImport(card)}
                 disabled={importing}
-                className="flex items-center justify-center gap-2 rounded-lg bg-[var(--primary)] px-4 py-2.5 text-xs font-medium text-[var(--primary-foreground)] transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+                className="mari-panel-gradient-button mari-panel-gradient--browser px-4 py-2.5 text-xs"
               >
                 {importing ? <Loader2 size="0.875rem" className="animate-spin" /> : <Download size="0.875rem" />}
                 {importing ? "Importing..." : "Import"}
@@ -2849,12 +2835,12 @@ function DetailView({
               <button
                 onClick={handleDownloadPng}
                 disabled={downloading}
-                className="flex items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-4 py-2 text-xs font-medium text-[var(--foreground)] transition-all hover:bg-[var(--accent)] active:scale-95 disabled:opacity-50"
+                className="mari-chrome-control px-4 py-2 text-xs"
               >
                 {downloading ? <Loader2 size="0.75rem" className="animate-spin" /> : <Download size="0.75rem" />}
                 {downloading ? "Building PNG..." : "Download as PNG"}
               </button>
-              <div className="flex flex-col gap-1 rounded-lg bg-[var(--secondary)] p-2.5 text-xs text-pink-400/80">
+              <div className="mari-chrome-text-muted flex flex-col gap-1 rounded-lg bg-[var(--secondary)] p-2.5 text-xs">
                 {card.stat1 > 0 && card.stat1Label && (
                   <span className="flex items-center gap-1.5">
                     {(() => {

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -583,7 +583,7 @@ export function CharacterEditor() {
             { name: "Satiety", value: 100, max: 100, color: "#f59e0b" },
             { name: "Energy", value: 100, max: 100, color: "#22c55e" },
             { name: "Hygiene", value: 100, max: 100, color: "#3b82f6" },
-            { name: "Mood", value: 100, max: 100, color: "#ec4899" },
+            { name: "Mood", value: 100, max: 100, color: "#eab308" },
           ],
           rpgStats,
         })
@@ -2351,7 +2351,7 @@ function SpritesTab({
               type="button"
               onClick={() => setSpriteGenOpen(true)}
               disabled={spriteGenerationUnavailable}
-              className="flex min-w-0 items-center justify-center gap-1.5 rounded-lg bg-purple-500/10 px-3 py-1.5 text-center text-[0.6875rem] font-medium leading-tight text-purple-400 ring-1 ring-purple-500/20 transition-all hover:bg-purple-500/20 disabled:cursor-not-allowed disabled:opacity-40 max-md:flex-1 max-md:basis-[calc(50%-0.25rem)] max-md:px-2.5"
+              className="mari-chrome-accent-surface mari-accent-animated flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-center text-[0.6875rem] font-medium leading-tight transition-all disabled:cursor-not-allowed disabled:opacity-40 max-md:flex-1 max-md:basis-[calc(50%-0.25rem)] max-md:px-2.5"
               title={
                 spriteGenerationUnavailable ? spriteGenerationReason : "Generate sprites using AI image generation"
               }
@@ -2801,7 +2801,7 @@ function StatsTab({
               <button
                 type="button"
                 onClick={addAttribute}
-                className="flex items-center gap-1 rounded-lg bg-purple-500/15 px-2.5 py-1 text-[0.6875rem] font-medium text-purple-400 transition-colors hover:bg-purple-500/25"
+                className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1 rounded-lg px-2.5 py-1 text-[0.6875rem] font-medium transition-colors"
               >
                 <Plus size="0.75rem" />
                 Add
@@ -2890,7 +2890,7 @@ function ColorsTab({
         className={cn(
           "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-xs font-medium transition-all",
           avatarUrl
-            ? "bg-purple-500/15 text-purple-400 hover:bg-purple-500/25 active:scale-[0.98]"
+            ? "mari-chrome-accent-surface mari-accent-animated active:scale-[0.98]"
             : "cursor-not-allowed bg-white/5 text-[var(--muted-foreground)]/50",
         )}
       >
@@ -2902,7 +2902,7 @@ function ColorsTab({
       <div className="rounded-xl border border-[var(--border)] bg-black/30 p-4 space-y-3">
         <p className="text-[0.625rem] font-medium uppercase tracking-widest text-[var(--muted-foreground)]">Preview</p>
         <div className="flex gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-pink-600 ring-2 ring-purple-400/20">
+          <div className="mari-chrome-accent-tile mari-accent-animated flex h-10 w-10 shrink-0 items-center justify-center rounded-full ring-2 ring-[var(--marinara-chat-chrome-button-border-active)]">
             <User size="1rem" className="text-white" />
           </div>
           <div className="flex-1 space-y-1">

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -22,7 +22,7 @@ const libraryToolbarButtonClass =
 const libraryToolbarFieldClass =
   "mari-chrome-field h-10 w-full text-[0.75rem] md:h-9";
 const libraryNewCharacterButtonClass =
-  "flex h-10 min-w-0 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-pink-400 to-rose-500 px-3 text-[0.75rem] font-semibold text-white shadow-md shadow-pink-500/15 transition-all hover:shadow-lg hover:shadow-pink-500/25 active:scale-[0.98] md:h-9";
+  "mari-chrome-control mari-chrome-control--primary h-10 min-w-0 px-3 text-[0.75rem] md:h-9";
 
 type CharacterRow = {
   id: string;
@@ -130,7 +130,7 @@ function CharacterLibraryDetailCard({
   return (
     <div className="space-y-4">
       <div className="overflow-hidden rounded-[1.5rem] border border-[var(--border)]/50 bg-[var(--background)]/70 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.95)] sm:rounded-[2rem]">
-        <div className="relative aspect-square overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15">
+        <div className="mari-accent-soft-fill relative aspect-square overflow-hidden">
           {character.avatarPath ? (
             <img
               src={character.avatarPath}
@@ -365,7 +365,7 @@ export function CharacterLibraryView() {
     <div
       ref={libraryRootScrollRef}
       onScroll={handleLibraryScroll}
-      className="flex h-full min-h-0 flex-col overflow-y-auto overflow-x-hidden bg-[radial-gradient(circle_at_top_left,_rgba(244,114,182,0.14),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(56,189,248,0.14),_transparent_26%),var(--background)] lg:overflow-hidden"
+      className="flex h-full min-h-0 flex-col overflow-y-auto overflow-x-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_srgb,var(--primary)_14%,transparent),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(56,189,248,0.14),_transparent_26%),var(--background)] lg:overflow-hidden"
     >
       <div className="sticky top-0 z-10 border-b border-[var(--border)]/40 bg-[var(--card)]/85 backdrop-blur-xl">
         <div className="flex flex-col gap-2 px-3 py-2 md:px-6 md:py-3 lg:flex-row lg:items-start lg:justify-between">
@@ -426,7 +426,10 @@ export function CharacterLibraryView() {
               <select
                 value={sort}
                 onChange={(event) => handleSortChange(event.target.value)}
-                className={cn(libraryToolbarFieldClass, "appearance-none pl-2.5 pr-7")}
+                className={cn(
+                  libraryToolbarFieldClass,
+                  "mari-chrome-sort-field mari-accent-animated appearance-none pl-2.5 pr-7",
+                )}
               >
                 <option value="name-asc">Name A-Z</option>
                 <option value="name-desc">Name Z-A</option>
@@ -436,7 +439,7 @@ export function CharacterLibraryView() {
               </select>
               <ArrowUpDown
                 size="0.6875rem"
-                className="mari-chrome-field-icon pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2"
+                className="mari-chrome-field-icon mari-chrome-sort-icon mari-accent-animated pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2"
               />
             </div>
           </div>
@@ -459,7 +462,7 @@ export function CharacterLibraryView() {
 
           {!isLoading && sortedCharacters.length === 0 && (
             <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[2rem] border border-dashed border-[var(--border)]/60 bg-[var(--card)]/50 p-6 text-center">
-              <div className="flex h-14 w-14 items-center justify-center rounded-3xl bg-gradient-to-br from-pink-400/20 to-rose-500/20 text-[var(--primary)]">
+              <div className="mari-accent-soft-fill flex h-14 w-14 items-center justify-center rounded-3xl text-[var(--primary)]">
                 <User size="1.5rem" />
               </div>
               <div>
@@ -489,13 +492,13 @@ export function CharacterLibraryView() {
                       type="button"
                       onClick={() => setSelectedCharacterId(char.id)}
                       className={cn(
-                        "group flex h-full items-stretch overflow-hidden rounded-[1.25rem] border bg-[var(--card)]/70 text-left shadow-[0_20px_50px_-32px_rgba(15,23,42,0.75)] transition-all hover:border-[var(--primary)]/35 hover:shadow-[0_24px_60px_-32px_rgba(244,114,182,0.45)] sm:flex-col sm:rounded-[1.75rem] sm:hover:-translate-y-0.5",
+                        "group flex h-full items-stretch overflow-hidden rounded-[1.25rem] border bg-[var(--card)]/70 text-left shadow-[0_20px_50px_-32px_rgba(15,23,42,0.75)] transition-all hover:border-[var(--primary)]/35 hover:shadow-[0_24px_60px_-32px_color-mix(in_srgb,var(--primary)_45%,transparent)] sm:flex-col sm:rounded-[1.75rem] sm:hover:-translate-y-0.5",
                         isActive
                           ? "border-[var(--primary)]/45 ring-1 ring-[var(--primary)]/25"
                           : "border-[var(--border)]/50",
                       )}
                     >
-                      <div className="relative h-24 w-24 shrink-0 overflow-hidden bg-gradient-to-br from-pink-400/25 via-rose-500/15 to-sky-400/15 sm:h-auto sm:w-full sm:aspect-square">
+                      <div className="mari-accent-soft-fill relative h-24 w-24 shrink-0 overflow-hidden sm:h-auto sm:w-full sm:aspect-square">
                         {char.avatarPath ? (
                           <img
                             src={char.avatarPath}
@@ -583,7 +586,7 @@ export function CharacterLibraryView() {
               <CharacterLibraryDetailCard character={selectedCharacter} onEdit={openCharacterDetailFromLibrary} />
             ) : (
               <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[2rem] border border-dashed border-[var(--border)]/60 bg-[var(--background)]/65 p-6 text-center">
-                <div className="flex h-14 w-14 items-center justify-center rounded-3xl bg-gradient-to-br from-pink-400/20 to-rose-500/20 text-[var(--primary)]">
+                <div className="mari-accent-soft-fill flex h-14 w-14 items-center justify-center rounded-3xl text-[var(--primary)]">
                   <User size="1.5rem" />
                 </div>
                 <div>

--- a/packages/client/src/components/characters/CharacterRegexSection.tsx
+++ b/packages/client/src/components/characters/CharacterRegexSection.tsx
@@ -228,7 +228,7 @@ export function CharacterRegexSection({
     <div className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
       <div className="flex items-center justify-between gap-2">
         <span className="inline-flex items-center gap-1.5 text-xs font-semibold">
-          <Regex size="0.875rem" className="text-purple-400" />
+          <Regex size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />
           Regex Scripts
         </span>
         {characterId && (
@@ -236,13 +236,13 @@ export function CharacterRegexSection({
             <button
               type="button"
               onClick={handleCreate}
-              className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400"
+              className="mari-chrome-accent-text-muted mari-accent-animated rounded-lg p-1.5 transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
               title="Create regex"
             >
               <Plus size="0.8125rem" />
             </button>
             <label
-              className="inline-flex cursor-pointer items-center justify-center rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400"
+              className="mari-chrome-accent-text-muted mari-accent-animated inline-flex cursor-pointer items-center justify-center rounded-lg p-1.5 transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
               title="Import regexes from JSON"
             >
               <input type="file" accept="application/json" className="hidden" onChange={handleImport} />
@@ -252,7 +252,7 @@ export function CharacterRegexSection({
               type="button"
               onClick={handleExport}
               disabled={scopedScripts.length === 0}
-              className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-purple-400/10 hover:text-purple-400 disabled:cursor-not-allowed disabled:opacity-35"
+              className="mari-chrome-accent-text-muted mari-accent-animated rounded-lg p-1.5 transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] disabled:cursor-not-allowed disabled:opacity-35"
               title="Export regexes to JSON"
             >
               <Download size="0.8125rem" />
@@ -289,7 +289,7 @@ export function CharacterRegexSection({
                       !enabled && "opacity-50",
                     )}
                   >
-                    <Regex size="0.875rem" className="mt-0.5 shrink-0 text-purple-400" />
+                    <Regex size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated mt-0.5 shrink-0" />
                     <button
                       type="button"
                       className="min-w-0 flex-1 text-left"
@@ -312,19 +312,19 @@ export function CharacterRegexSection({
                     </button>
                     <button
                       type="button"
-                      className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-purple-400"
+                      className="mari-chrome-accent-text-muted mari-accent-animated mt-0.5 shrink-0 transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
                       title={enabled ? "Disable regex" : "Enable regex"}
                       onClick={() => updateRegex.mutate({ id: script.id, enabled: !enabled })}
                     >
                       {enabled ? (
-                        <ToggleRight size="0.875rem" className="text-purple-400" />
+                        <ToggleRight size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />
                       ) : (
                         <ToggleLeft size="0.875rem" className="text-[var(--muted-foreground)]" />
                       )}
                     </button>
                     <button
                       type="button"
-                      className="mt-0.5 shrink-0 text-[var(--muted-foreground)] transition-colors hover:text-purple-400"
+                      className="mari-chrome-accent-text-muted mari-accent-animated mt-0.5 shrink-0 transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
                       title="Edit regex"
                       onClick={() => void openEditorGuarded(script.id)}
                     >

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -10,6 +10,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
@@ -216,6 +217,72 @@ const GameSurface = lazy(async () => {
 });
 
 type FloatingPanelAnchor = { right: number; top: number } | null;
+
+type HomeGlistenStar = {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  duration: number;
+};
+
+function HomeStarfield() {
+  const [stars, setStars] = useState<HomeGlistenStar[]>([]);
+  const nextStarIdRef = useRef(0);
+
+  useEffect(() => {
+    let spawnTimer: number | null = null;
+    const removalTimers = new Set<number>();
+
+    const spawnStar = () => {
+      const duration = 4_200 + Math.random() * 2_400;
+      const star: HomeGlistenStar = {
+        id: nextStarIdRef.current,
+        x: 5 + Math.random() * 90,
+        y: 6 + Math.random() * 86,
+        size: 3 + Math.random() * 3.5,
+        duration,
+      };
+      nextStarIdRef.current += 1;
+
+      setStars((current) => [...current.slice(-9), star]);
+
+      const removalTimer = window.setTimeout(() => {
+        setStars((current) => current.filter((item) => item.id !== star.id));
+        removalTimers.delete(removalTimer);
+      }, duration + 250);
+      removalTimers.add(removalTimer);
+
+      spawnTimer = window.setTimeout(spawnStar, 700 + Math.random() * 1_600);
+    };
+
+    spawnTimer = window.setTimeout(spawnStar, 180);
+
+    return () => {
+      if (spawnTimer !== null) window.clearTimeout(spawnTimer);
+      removalTimers.forEach((timer) => window.clearTimeout(timer));
+    };
+  }, []);
+
+  return (
+    <div className="mari-home-starfield" aria-hidden="true">
+      {stars.map((star) => (
+        <span
+          key={star.id}
+          className="mari-home-starfield__star"
+          style={
+            {
+              "--mari-home-star-x": `${star.x}%`,
+              "--mari-home-star-y": `${star.y}%`,
+              "--mari-home-star-size": `${star.size}px`,
+              "--mari-home-star-duration": `${star.duration}ms`,
+            } as CSSProperties
+          }
+        />
+      ))}
+    </div>
+  );
+}
 
 export function ChatArea() {
   const activeChatId = useChatStore((s) => s.activeChatId);
@@ -1764,7 +1831,7 @@ export function ChatArea() {
     return (
       <div
         data-component="ChatArea.RestoringChat"
-        className="flex flex-1 items-center justify-center overflow-hidden p-6"
+        className="mari-app-background-paint flex flex-1 items-center justify-center overflow-hidden p-6"
       >
         <div className="flex flex-col items-center gap-3 text-center">
           {!hasOpenError && (
@@ -1801,9 +1868,10 @@ export function ChatArea() {
         <HomeCreditsModal open={creditsOpen} onClose={() => setCreditsOpen(false)} />
         <div
           data-component="ChatArea.EmptyState"
-          className="flex flex-1 flex-col items-center overflow-y-auto p-1.5 sm:p-3 lg:p-3"
+          className="mari-app-background-paint mari-chrome-token-scope relative isolate flex flex-1 flex-col items-center overflow-y-auto p-1.5 sm:p-3 lg:p-3"
         >
-          <div className="flex w-full max-w-3xl flex-col items-center gap-1.5 py-0 sm:gap-2 lg:pt-0 lg:pb-2">
+          {showEmptyStateEffects && <HomeStarfield />}
+          <div className="relative z-[1] flex w-full max-w-3xl flex-col items-center gap-1.5 py-0 sm:gap-2 lg:pt-0 lg:pb-2">
             {/* Central hero */}
             <div className="relative">
               <div
@@ -1827,8 +1895,17 @@ export function ChatArea() {
             </div>
 
             <div className="text-center">
-              <h3 className="retro-glow-text text-base sm:text-xl font-bold tracking-tight">Marinara Engine</h3>
-              <p className="mt-0.5 text-[0.625rem] tracking-wide text-[var(--muted-foreground)]/35">v{APP_VERSION}</p>
+              <h3
+                className={cn(
+                  "mari-logo-gradient-text text-base font-bold sm:text-xl",
+                  isPageActive && "mari-logo-gradient-text--active",
+                )}
+              >
+                Marinara Engine
+              </h3>
+              <p className="mari-chrome-text-muted mt-0.5 text-[0.625rem] tracking-wide opacity-65">
+                v{APP_VERSION}
+              </p>
             </div>
 
             {/* Recent Chats */}
@@ -1848,14 +1925,14 @@ export function ChatArea() {
 
             {/* Footer */}
             <div className="flex w-full max-w-2xl flex-col items-center gap-1">
-              <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 text-center text-[0.625rem] leading-tight text-[var(--muted-foreground)]/55 sm:text-xs">
+              <div className="mari-chrome-text-muted flex flex-wrap items-center justify-center gap-x-3 gap-y-0.5 text-center text-[0.625rem] leading-tight sm:text-xs">
                 <span>
                   Created by{" "}
                   <a
                     href="https://spicymarinara.github.io/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline decoration-[var(--muted-foreground)]/30 transition-colors hover:text-[var(--primary)] hover:decoration-[var(--primary)]/40"
+                    className="mari-chrome-text underline decoration-[var(--marinara-chat-chrome-panel-muted)]/30 transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)] hover:decoration-[var(--marinara-chat-chrome-button-border-hover)]"
                   >
                     Marinara
                   </a>
@@ -1866,7 +1943,7 @@ export function ChatArea() {
                     href="https://linkapi.ai/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline decoration-[var(--muted-foreground)]/30 transition-colors hover:text-[var(--primary)] hover:decoration-[var(--primary)]/40"
+                    className="mari-chrome-text underline decoration-[var(--marinara-chat-chrome-panel-muted)]/30 transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)] hover:decoration-[var(--marinara-chat-chrome-button-border-hover)]"
                   >
                     LinkAPI
                   </a>
@@ -1877,7 +1954,7 @@ export function ChatArea() {
                     href="https://huntercolliex.carrd.co/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline decoration-[var(--muted-foreground)]/30 transition-colors hover:text-[var(--primary)] hover:decoration-[var(--primary)]/40"
+                    className="mari-chrome-text underline decoration-[var(--marinara-chat-chrome-panel-muted)]/30 transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)] hover:decoration-[var(--marinara-chat-chrome-button-border-hover)]"
                   >
                     HunterCollieX
                   </a>

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -75,6 +75,14 @@ const MESSAGE_CHROME_ACTIVE_ICON_CLASS =
 const MESSAGE_CHROME_MARKER_LINE_CLASS = "bg-[var(--marinara-chat-chrome-button-border-active)]";
 const MESSAGE_CHROME_MARKER_TEXT_CLASS = "text-[var(--marinara-chat-chrome-highlight-text)]";
 const MESSAGE_CHROME_RING_CLASS = "ring-[var(--marinara-chat-chrome-focus-ring)]";
+const ROLEPLAY_USER_BUBBLE_PANEL_STRENGTH = 100;
+const ROLEPLAY_ASSISTANT_BUBBLE_PANEL_STRENGTH = 96;
+
+function getRoleplayPanelBubbleBackground(opacity: number, maxPanelStrength: number) {
+  const panelStrength = Math.max(0, Math.min(100, opacity * maxPanelStrength));
+  if (panelStrength <= 0) return "transparent";
+  return `color-mix(in srgb, var(--marinara-chat-chrome-panel-bg) ${panelStrength.toFixed(2)}%, transparent)`;
+}
 
 function isMessageQuickEditIgnoredTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -799,7 +807,6 @@ export const ChatMessage = memo(function ChatMessage({
     guideGenerations,
     boldDialogue,
     editMessageOnDoubleClick,
-    theme,
   } = useUIStore(
     useShallow((s) => ({
       chatFontSize: s.chatFontSize,
@@ -816,7 +823,6 @@ export const ChatMessage = memo(function ChatMessage({
       guideGenerations: s.guideGenerations,
       boldDialogue: s.boldDialogue ?? true,
       editMessageOnDoubleClick: s.editMessageOnDoubleClick,
-      theme: s.theme,
     })),
   );
   const isGuided = guideGenerations && hasDraftInput;
@@ -847,23 +853,15 @@ export const ChatMessage = memo(function ChatMessage({
     [roleplayAvatarScale],
   );
 
-  // Compute message bubble background with user-controlled opacity.
-  // Dark theme: neutral-900 (23,23,23) on dark bg → translucent dark bubble.
-  // Light theme: slightly grayer than --background (#faf8ff) so bubbles stay visible on light bg.
+  // Keep the top of the slider near the Chat Settings popover surface:
+  // solid enough to read, but still faintly translucent through the panel token.
   const { userBubbleBg, assistantBubbleBg } = useMemo(() => {
     const o = chatFontOpacity / 100;
-    if (theme === "light") {
-      // Higher base opacity in light mode so the bubble actually contrasts the page
-      return {
-        userBubbleBg: `rgba(225,220,235,${Math.min(1, 0.85 * o).toFixed(3)})`,
-        assistantBubbleBg: `rgba(238,234,245,${Math.min(1, 0.9 * o).toFixed(3)})`,
-      };
-    }
     return {
-      userBubbleBg: `rgba(23,23,23,${(0.7 * o).toFixed(3)})`,
-      assistantBubbleBg: `rgba(23,23,23,${(0.6 * o).toFixed(3)})`,
+      userBubbleBg: getRoleplayPanelBubbleBackground(o, ROLEPLAY_USER_BUBBLE_PANEL_STRENGTH),
+      assistantBubbleBg: getRoleplayPanelBubbleBackground(o, ROLEPLAY_ASSISTANT_BUBBLE_PANEL_STRENGTH),
     };
-  }, [chatFontOpacity, theme]);
+  }, [chatFontOpacity]);
 
   const [copied, setCopied] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -1418,7 +1416,14 @@ export const ChatMessage = memo(function ChatMessage({
   }, [isMergedGroup, characterMap, chatCharacterIds, expressionAvatarResolver, message]);
   const mergedNameColors = useMemo(() => {
     if (!isMergedGroup || !characterMap || !chatCharacterIds) return [];
-    const fallbackPalette = ["#c084fc", "#f472b6", "#fb923c", "#4ade80", "#60a5fa", "#facc15"];
+    const fallbackPalette = [
+      "var(--marinara-chat-chrome-text)",
+      "var(--marinara-chat-chrome-accent)",
+      "#fb923c",
+      "#4ade80",
+      "#60a5fa",
+      "#facc15",
+    ];
     return chatCharacterIds.map((id, i) => {
       const raw = characterMap.get(id)?.nameColor;
       return raw || fallbackPalette[i % fallbackPalette.length]!;
@@ -1854,13 +1859,13 @@ export const ChatMessage = memo(function ChatMessage({
                     compactAvatarFrameClass,
                     isUser
                       ? "bg-gradient-to-br from-neutral-500 to-neutral-600 ring-white/15"
-                      : "bg-gradient-to-br from-purple-500 to-pink-600 ring-purple-400/20",
+                      : "mari-chrome-accent-tile mari-accent-animated ring-[var(--marinara-chat-chrome-button-border-active)]",
                   )}
                 >
                   {isUser ? (
                     <User size={compactAvatarIconSize} className="text-white" />
                   ) : (
-                    <Bot size={compactAvatarIconSize} className="text-white" />
+                    <Bot size={compactAvatarIconSize} className="text-current" />
                   )}
                 </div>
               )}
@@ -1959,7 +1964,7 @@ export const ChatMessage = memo(function ChatMessage({
                       isUser ? "border-l border-white/8" : "border-r border-white/8",
                       isUser
                         ? "bg-gradient-to-b from-neutral-500/18 via-neutral-600/10 to-transparent"
-                        : "bg-gradient-to-b from-purple-500/18 via-pink-600/10 to-transparent",
+                        : "mari-chrome-accent-rail mari-accent-animated",
                     )}
                   >
                     <div
@@ -2018,13 +2023,13 @@ export const ChatMessage = memo(function ChatMessage({
                             "flex h-full w-full items-start justify-center pt-4",
                             isUser
                               ? "bg-gradient-to-b from-neutral-500/90 via-neutral-600/65 to-transparent"
-                              : "bg-gradient-to-b from-purple-500/90 via-pink-600/65 to-transparent",
+                              : "mari-chrome-accent-rail-strong mari-accent-animated",
                           )}
                         >
                           {isUser ? (
                             <User size="1.25rem" className="text-white" />
                           ) : (
-                            <Bot size="1.25rem" className="text-white" />
+                            <Bot size="1.25rem" className="text-[var(--primary-foreground)]" />
                           )}
                         </div>
                       )}

--- a/packages/client/src/components/chat/CyoaChoices.tsx
+++ b/packages/client/src/components/chat/CyoaChoices.tsx
@@ -223,7 +223,7 @@ export function CyoaChoices({ messages }: Props) {
           <span>What will you do?</span>
         </div>
         {impersonateCyoaChoices && (
-          <span className="rounded-full border border-purple-400/20 bg-purple-500/10 px-1.5 py-0.5 text-[0.5625rem] font-semibold text-purple-700 dark:text-purple-200">
+          <span className="mari-chrome-accent-surface mari-accent-animated rounded-full px-1.5 py-0.5 text-[0.5625rem] font-semibold">
             Impersonate
           </span>
         )}
@@ -262,14 +262,14 @@ export function CyoaChoices({ messages }: Props) {
                 value={choice.label}
                 onChange={(e) => updateDraftChoice(index, "label", e.target.value)}
                 placeholder={`Choice ${index + 1}`}
-                className="w-full rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 py-2 text-[0.6875rem] font-semibold text-purple-700 outline-none transition-colors focus:border-purple-400/40 dark:border-white/10 dark:bg-black/35 dark:text-purple-200"
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 py-2 text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-panel-title)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] dark:border-white/10 dark:bg-black/35"
               />
               <textarea
                 value={choice.text}
                 onChange={(e) => updateDraftChoice(index, "text", e.target.value)}
                 rows={Math.min(Math.max(choice.text.split("\n").length, 2), 6)}
                 placeholder="Describe the action or dialogue sent when this choice is clicked."
-                className="mt-2 w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 py-2 text-[0.6875rem] leading-relaxed text-[var(--foreground)]/80 outline-none transition-colors focus:border-purple-400/40 dark:border-white/10 dark:bg-black/35 dark:text-white/75"
+                className="mt-2 w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--muted)]/20 px-3 py-2 text-[0.6875rem] leading-relaxed text-[var(--foreground)]/80 outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] dark:border-white/10 dark:bg-black/35 dark:text-white/75"
               />
             </div>
           ))}
@@ -308,9 +308,9 @@ export function CyoaChoices({ messages }: Props) {
               type="button"
               onClick={() => handleChoice(choice.text)}
               disabled={isStreaming || isRerolling}
-              className="group relative rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-4 py-2.5 text-left backdrop-blur-md transition-all hover:border-purple-400/40 hover:bg-purple-500/10 hover:shadow-lg hover:shadow-purple-500/5 active:scale-[0.98] disabled:opacity-50 dark:border-white/10 dark:bg-black/50"
+              className="group relative rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-4 py-2.5 text-left backdrop-blur-md transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:shadow-lg active:scale-[0.98] disabled:opacity-50 dark:border-white/10 dark:bg-black/50"
             >
-              <span className="block text-[0.6875rem] font-semibold text-purple-700 group-hover:text-purple-600 dark:text-purple-300/90 dark:group-hover:text-purple-200">
+              <span className="mari-chrome-accent-text mari-accent-animated block text-[0.6875rem] font-semibold group-hover:text-[var(--marinara-chat-chrome-button-text-hover)]">
                 {choice.label}
               </span>
               <span className="mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--foreground)]/60 group-hover:text-[var(--foreground)]/80 dark:text-white/50 dark:group-hover:text-white/70">

--- a/packages/client/src/components/chat/HomeAchievements.tsx
+++ b/packages/client/src/components/chat/HomeAchievements.tsx
@@ -47,7 +47,7 @@ function rankClasses(achievement: AchievementDefinition, locked: boolean) {
   if (achievement.rank === "bronze") return "border-amber-700/50 bg-amber-900/35 text-amber-200";
   if (achievement.rank === "silver") return "border-slate-300/45 bg-slate-300/18 text-slate-100";
   if (achievement.rank === "gold") return "border-yellow-400/55 bg-yellow-500/20 text-yellow-100";
-  return "border-[var(--primary)]/35 bg-[var(--primary)]/12 text-[var(--primary)]";
+  return "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-title)]";
 }
 
 function AchievementBadge({ achievement, locked }: { achievement: AchievementDefinition; locked: boolean }) {
@@ -108,15 +108,15 @@ function AchievementCard({
             </p>
           </div>
           {progress?.unlockedAt && (
-            <span className="shrink-0 rounded-full border border-[var(--border)] bg-[var(--secondary)]/50 px-2 py-0.5 text-[0.6rem] text-[var(--muted-foreground)]">
+            <span className="mari-chrome-text-muted shrink-0 rounded-full border border-[var(--border)] bg-[var(--secondary)]/50 px-2 py-0.5 text-[0.6rem]">
               unlocked
             </span>
           )}
         </div>
-        <p className="mt-1.5 text-xs leading-relaxed text-[var(--muted-foreground)] sm:mt-2">{description}</p>
+        <p className="mari-chrome-text-muted mt-1.5 text-xs leading-relaxed sm:mt-2">{description}</p>
         {target !== null && (
           <div className="mt-3 space-y-1">
-            <div className="flex items-center justify-between text-[0.65rem] text-[var(--muted-foreground)]">
+            <div className="mari-chrome-text-muted flex items-center justify-between text-[0.65rem]">
               <span>Progress</span>
               <span>
                 {Math.min(progress?.progress ?? 0, target)} / {target}
@@ -124,7 +124,7 @@ function AchievementCard({
             </div>
             <div className="h-1.5 overflow-hidden rounded-full bg-[var(--secondary)]">
               <div
-                className="h-full rounded-full bg-[var(--primary)] transition-[width]"
+                className="mari-chrome-accent-progress mari-accent-animated h-full rounded-full transition-[width]"
                 style={{ width: `${progressPercent(progress ?? { id: achievement.id, unlocked: false, unlockedAt: null, progress: 0, target })}%` }}
               />
             </div>
@@ -170,14 +170,14 @@ export function HomeAchievements({
       >
         <span className="flex min-w-0 items-center gap-2.5 sm:gap-3">
           <span
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--secondary)]/45 text-[var(--foreground)] shadow-sm sm:h-10 sm:w-10"
+            className="mari-chrome-accent-surface mari-accent-animated flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border shadow-sm sm:h-10 sm:w-10"
             aria-hidden="true"
           >
             <Trophy size="1.15rem" strokeWidth={2.25} />
           </span>
           <span className="min-w-0">
             <span className="block text-sm font-semibold text-[var(--foreground)]">Achievements</span>
-            <span className="block truncate text-xs text-[var(--muted-foreground)]">
+            <span className="mari-chrome-text-muted block truncate text-xs">
               {achievements.isLoading ? "Checking the collection..." : `${unlockedCount} of ${totalCount} unlocked`}
             </span>
           </span>
@@ -186,7 +186,7 @@ export function HomeAchievements({
 
       <Modal open={open} onClose={() => setOpen(false)} title="Achievements" width="max-w-5xl">
         <div className="space-y-3 sm:space-y-4">
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--secondary)]/25 px-3 py-2 text-xs text-[var(--muted-foreground)]">
+          <div className="mari-chrome-text-muted rounded-xl border border-[var(--border)] bg-[var(--secondary)]/25 px-3 py-2 text-xs">
             {unlockedCount} of {totalCount} achievements unlocked in this profile.
           </div>
           {achievements.isError ? (

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -470,12 +470,14 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
 ];
 
 const CATEGORY_STYLES: Record<string, string> = {
-  "Top Issue": "border-rose-400/30 bg-rose-500/12 text-rose-700 dark:text-rose-200",
+  "Top Issue": "border-[var(--destructive)]/30 bg-[var(--destructive)]/12 text-[var(--destructive)]",
   Setup: "border-amber-400/30 bg-amber-500/12 text-amber-700 dark:text-amber-200",
   Connections: "border-cyan-400/30 bg-cyan-500/12 text-cyan-700 dark:text-cyan-200",
   Core: "border-emerald-400/30 bg-emerald-500/12 text-emerald-700 dark:text-emerald-200",
-  Agents: "border-violet-400/30 bg-violet-500/12 text-violet-700 dark:text-violet-200",
-  Images: "border-fuchsia-400/30 bg-fuchsia-500/12 text-fuchsia-700 dark:text-fuchsia-200",
+  Agents:
+    "border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-text)]",
+  Images:
+    "border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-text)]",
   "Game Mode": "border-orange-400/30 bg-orange-500/12 text-orange-700 dark:text-orange-200",
   Misc: "border-[var(--border)] bg-[var(--muted)]/30 text-[var(--muted-foreground)]",
 };

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -877,7 +877,7 @@ function toolToneClasses(tone: ToolTone) {
     case "skill":
       return "border-[var(--primary)]/20 bg-[var(--primary)]/10";
     case "theme":
-      return "border-fuchsia-400/20 bg-fuchsia-400/10";
+      return "border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-highlight-bg)]";
     case "image":
       return "border-sky-400/20 bg-sky-400/10";
     case "wiki":
@@ -1298,7 +1298,7 @@ function ProfessorMariSkillsMenu({
       <div className="flex items-center justify-between gap-2 border-b border-[var(--border)]/60 px-3 py-2">
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-2">
-            <ArrowDown size="0.9rem" className="shrink-0 text-[var(--primary)]" />
+            <ArrowDown size="0.9rem" className="shrink-0 text-[var(--marinara-chat-chrome-button-text-active)]" />
             <span className="truncate text-xs font-semibold text-[var(--foreground)]">Professor Mari Skills</span>
           </div>
           {hasSkills && (
@@ -1382,8 +1382,8 @@ function ProfessorMariSkillsMenu({
                       className={cn(
                         "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
                         skill.enabled
-                          ? "text-[var(--primary)] hover:bg-[var(--primary)]/10"
-                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                          ? "mari-chrome-accent-icon mari-accent-animated hover:bg-[var(--marinara-chat-chrome-highlight-bg)]"
+                          : "mari-chrome-text-muted hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
                         saving && "cursor-not-allowed opacity-55",
                       )}
                       aria-label={skill.enabled ? "Disable skill" : "Enable skill"}
@@ -2195,7 +2195,7 @@ export function HomeProfessorMariChat({
                         onClick={toggleSkillsMenu}
                         className={cn(
                           "inline-flex h-8 items-center gap-1 rounded-md px-2 text-[0.6875rem] font-semibold transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50",
-                          "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+                          "mari-chrome-accent-text-muted mari-accent-animated hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
                         )}
                         title="Open skills"
                         aria-expanded={skillsMenuOpen}
@@ -2203,7 +2203,7 @@ export function HomeProfessorMariChat({
                         <ArrowDown size="0.75rem" />
                         <span className="max-[360px]:hidden">Skills</span>
                         {skills.length > 0 && (
-                          <span className="rounded-full bg-[var(--primary)]/12 px-1.5 py-0.5 text-[0.56rem] text-[var(--primary)]">
+                          <span className="mari-chrome-muted-badge px-1.5 py-0.5 text-[0.56rem]">
                             {activeSkillCount}
                           </span>
                         )}
@@ -2222,7 +2222,7 @@ export function HomeProfessorMariChat({
                         type="button"
                         onClick={() => void runRestart()}
                         disabled={isBusy}
-                        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[0.6875rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                        className="mari-chrome-accent-text-muted mari-accent-animated inline-flex items-center gap-1 rounded-md px-2 py-1 text-[0.6875rem] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] disabled:cursor-not-allowed disabled:opacity-50"
                         title="Restart Professor Mari chat"
                       >
                         <RefreshCw size="0.75rem" />
@@ -2232,7 +2232,7 @@ export function HomeProfessorMariChat({
                         <button
                           type="button"
                           onClick={closeMobileFocusMode}
-                          className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[var(--border)]/70 bg-[var(--card)] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] sm:hidden"
+                          className="mari-chrome-control mari-chrome-control--small mari-accent-animated inline-flex h-8 w-8 items-center justify-center rounded-md p-0 sm:hidden"
                           aria-label="Close Professor Mari chat"
                           title="Close"
                         >

--- a/packages/client/src/components/chat/RecentChats.tsx
+++ b/packages/client/src/components/chat/RecentChats.tsx
@@ -3,30 +3,36 @@
 // interacted chats on the homepage (compact row)
 // ──────────────────────────────────────────────
 import { useMemo } from "react";
-import { MessageSquare, BookOpen } from "lucide-react";
+import { MessageSquare, BookOpen, Theater } from "lucide-react";
 import { useChats } from "../../hooks/use-chats";
 import { useCharacters } from "../../hooks/use-characters";
 import { useChatStore } from "../../stores/chat.store";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import type { Chat } from "@marinara-engine/shared";
 
-const MODE_BADGE: Record<string, { icon: React.ReactNode; bg: string; label: string }> = {
-  conversation: {
-    icon: <MessageSquare size="0.375rem" />,
-    bg: "linear-gradient(135deg, #4de5dd, #3ab8b1)",
-    label: "Conversation",
-  },
-  roleplay: {
-    icon: <BookOpen size="0.375rem" />,
-    bg: "linear-gradient(135deg, #eb8951, #d97530)",
-    label: "Roleplay",
-  },
-  visual_novel: {
-    icon: <BookOpen size="0.375rem" />,
-    bg: "linear-gradient(135deg, #e15c8c, #c94776)",
-    label: "Game",
-  },
-};
+const MODE_BADGE: Record<string, { icon: React.ReactNode; label: string; logoModeClass: string }> =
+  {
+    conversation: {
+      icon: <MessageSquare size="0.375rem" />,
+      label: "Conversation",
+      logoModeClass: "mari-chat-logo-mode--conversation",
+    },
+    roleplay: {
+      icon: <BookOpen size="0.375rem" />,
+      label: "Roleplay",
+      logoModeClass: "mari-chat-logo-mode--roleplay",
+    },
+    visual_novel: {
+      icon: <Theater size="0.375rem" />,
+      label: "Game",
+      logoModeClass: "mari-chat-logo-mode--game",
+    },
+    game: {
+      icon: <Theater size="0.375rem" />,
+      label: "Game",
+      logoModeClass: "mari-chat-logo-mode--game",
+    },
+  };
 
 export function RecentChats() {
   const { data: chats } = useChats();
@@ -57,9 +63,9 @@ export function RecentChats() {
   }, [chats]);
 
   return (
-    <div className="flex w-full max-w-md flex-col items-center gap-1.5">
+    <div className="mari-chrome-token-scope flex w-full max-w-md flex-col items-center gap-1.5">
       {recentChats.length === 0 ? (
-        <p className="rounded-lg border border-[var(--border)]/45 bg-[var(--card)]/45 px-3 py-1.5 text-xs text-[var(--muted-foreground)]/70">
+        <p className="rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] px-3 py-1.5 text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
           No chats yet
         </p>
       ) : (
@@ -129,8 +135,10 @@ function RecentChatChip({
           </div>
         ) : (
           <div
-            className="flex h-5 w-5 items-center justify-center rounded-md text-white"
-            style={{ background: mode.bg }}
+            className={cn(
+              "mari-chat-mode-avatar flex h-5 w-5 items-center justify-center rounded-md",
+              mode.logoModeClass,
+            )}
           >
             {mode.icon}
           </div>
@@ -138,8 +146,10 @@ function RecentChatChip({
 
         {/* Tiny mode dot */}
         <div
-          className="absolute -top-0.5 -left-0.5 flex h-3 w-3 items-center justify-center rounded-full text-white ring-1 ring-[var(--card)]"
-          style={{ background: mode.bg }}
+          className={cn(
+            "mari-chat-mode-badge absolute -top-0.5 -left-0.5 flex h-3 w-3 items-center justify-center rounded-full ring-1 ring-[var(--card)]",
+            mode.logoModeClass,
+          )}
           title={mode.label}
         >
           {mode.icon}
@@ -147,7 +157,7 @@ function RecentChatChip({
       </div>
 
       {/* Chat name only */}
-      <span className="truncate text-[0.625rem] font-medium text-[var(--foreground)]">{chat.name}</span>
+      <span className="mari-chrome-text truncate text-[0.625rem] font-medium">{chat.name}</span>
     </button>
   );
 }

--- a/packages/client/src/components/chat/SummariesEditorModal.tsx
+++ b/packages/client/src/components/chat/SummariesEditorModal.tsx
@@ -376,7 +376,9 @@ export function SummariesEditorModal({ chat, open, onClose }: SummariesEditorMod
                   <span
                     className={cn(
                       "shrink-0 rounded-full px-1.5 py-0.5 text-[0.5625rem] font-medium uppercase tracking-wider max-md:hidden",
-                      entry.kind === "week" ? "bg-purple-500/20 text-purple-400" : "bg-blue-500/20 text-blue-400",
+                      entry.kind === "week"
+                        ? "mari-chrome-accent-surface mari-accent-animated"
+                        : "bg-blue-500/20 text-blue-400",
                     )}
                   >
                     {entry.kind}

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -35,7 +35,7 @@ interface SearchResult {
 let ytApiPromise: Promise<void> | null = null;
 
 const MUSIC_NEUTRAL_BORDER_CLASS = "border-[#f7f3ef]/15";
-const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[#f7f3ef]/10";
+const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[#f7f3ef]/15";
 const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[#0f0f0f]/95";
 const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
 const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[#f7f3ef]/5";

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -1595,7 +1595,7 @@ export function ConnectionEditor() {
           {localProvider !== "image_generation" && (
             <FieldGroup
               label="Max Parallel Agent Jobs"
-              icon={<SlidersHorizontal size="0.875rem" className="text-fuchsia-400" />}
+              icon={<SlidersHorizontal size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />}
               help="How many agent LLM requests Marinara may run at once for this connection. Higher values can speed up agent-heavy chats on providers that tolerate parallel calls."
             >
               <div className="flex items-center gap-3">
@@ -1625,7 +1625,7 @@ export function ConnectionEditor() {
           {localProvider !== "image_generation" && (
             <FieldGroup
               label="Prompt Preset Override"
-              icon={<FileText size="0.875rem" className="text-violet-400" />}
+              icon={<FileText size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />}
               help="Optional. When roleplay or visual novel chats use this connection, Marinara assembles this prompt preset instead of the chat's selected prompt preset. Conversation and game mode keep their built-in prompt flows."
             >
               <select
@@ -1654,7 +1654,7 @@ export function ConnectionEditor() {
           {localProvider !== "image_generation" && (
             <FieldGroup
               label="Default Chat Parameters"
-              icon={<Zap size="0.875rem" className="text-purple-400" />}
+              icon={<Zap size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />}
               help="Default generation settings for chats that use this connection. Individual chats can still override these in Chat Settings."
             >
               <SettingsSwitch
@@ -1818,7 +1818,7 @@ export function ConnectionEditor() {
           {localProvider !== "image_generation" && localProvider !== "claude_subscription" && (
             <FieldGroup
               label="Embedding Model"
-              icon={<Server size="0.875rem" className="text-violet-400" />}
+              icon={<Server size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />}
               help="Optional. The model used for generating embeddings when vectorizing lorebook entries. Leave empty to skip semantic matching. Examples: text-embedding-3-small, text-embedding-ada-002."
             >
               <input
@@ -1925,7 +1925,7 @@ export function ConnectionEditor() {
                 <button
                   onClick={handleTestImage}
                   disabled={testImageGeneration.isPending}
-                  className="flex items-center gap-1.5 rounded-xl bg-violet-400/10 px-4 py-2.5 text-xs font-medium text-violet-400 ring-1 ring-violet-400/20 transition-all hover:bg-violet-400/20 active:scale-[0.98] disabled:opacity-50"
+                  className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1.5 rounded-xl px-4 py-2.5 text-xs font-medium transition-all active:scale-[0.98] disabled:opacity-50"
                   title={dirty ? "Save first to test image generation" : undefined}
                 >
                   {testImageGeneration.isPending ? (

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -493,8 +493,10 @@ export function GameCharacterSheet({
               )}
               {card.mood && (
                 <div className="mt-1.5 flex items-center gap-1.5">
-                  <Heart size={11} className="text-rose-400/70" />
-                  <span className="text-[0.6875rem] italic text-rose-400/70">{card.mood}</span>
+                  <Heart size={11} className="text-[var(--marinara-chat-chrome-panel-muted)]" />
+                  <span className="text-[0.6875rem] italic text-[var(--marinara-chat-chrome-panel-muted)]">
+                    {card.mood}
+                  </span>
                 </div>
               )}
               {card.status && (

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -3302,7 +3302,7 @@ export function GameNarration({
         NARRATION_META_BTN,
         "relative",
         combatGenerationFailed
-          ? "border-rose-300/30 bg-rose-500/15 text-rose-100 hover:bg-rose-500/25"
+          ? "border-[var(--destructive)]/30 bg-[var(--destructive)]/15 text-[var(--destructive)] hover:bg-[var(--destructive)]/25"
           : "border-amber-300/20 bg-amber-500/10 text-amber-100/90 hover:bg-amber-500/20",
         combatStarting && "cursor-wait opacity-80",
       )}
@@ -3318,7 +3318,7 @@ export function GameNarration({
         className={cn(
           "mt-2 flex items-center justify-between gap-2 rounded-lg border px-3 py-2 text-xs",
           combatGenerationFailed
-            ? "border-rose-300/25 bg-rose-500/10 text-rose-100"
+            ? "border-[var(--destructive)]/25 bg-[var(--destructive)]/10 text-[var(--destructive)]"
             : "border-amber-300/20 bg-amber-500/10 text-amber-100",
         )}
       >
@@ -3513,7 +3513,8 @@ export function GameNarration({
             seg.partyType === "side" && "bg-sky-500/15 text-sky-200/70",
             seg.partyType === "extra" && "bg-sky-500/15 text-sky-200/70",
             seg.partyType === "thought" && "bg-purple-500/15 text-purple-200/70",
-            seg.partyType === "whisper" && "bg-rose-500/15 text-rose-200/70",
+            seg.partyType === "whisper" &&
+              "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-text)]",
           )}
         >
           {PARTY_TYPE_ICONS[seg.partyType] ?? ""} {seg.partyType}
@@ -3988,7 +3989,8 @@ export function GameNarration({
                               className={cn(
                                 "rounded-full px-1.5 py-0.5 text-[0.5rem] font-semibold uppercase tracking-wide",
                                 active.partyType === "thought" && "bg-purple-500/15 text-purple-200/70",
-                                active.partyType === "whisper" && "bg-rose-500/15 text-rose-200/70",
+                                active.partyType === "whisper" &&
+                                  "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-text)]",
                               )}
                             >
                               {PARTY_TYPE_ICONS[active.partyType] ?? ""} {active.partyType}
@@ -4596,7 +4598,8 @@ export function GameNarration({
                               seg.partyType === "side" && "bg-sky-500/15 text-sky-200/70",
                               seg.partyType === "extra" && "bg-sky-500/15 text-sky-200/70",
                               seg.partyType === "thought" && "bg-purple-500/15 text-purple-200/70",
-                              seg.partyType === "whisper" && "bg-rose-500/15 text-rose-200/70",
+                              seg.partyType === "whisper" &&
+                                "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-text)]",
                             )}
                           >
                             {PARTY_TYPE_ICONS[seg.partyType] ?? ""} {seg.partyType}
@@ -5065,7 +5068,12 @@ function PartyOverlayBox({
     side: { border: "border-white/15", bg: "bg-black/75", icon: "💬", labelColor: "text-white/85" },
     extra: { border: "border-white/15", bg: "bg-black/75", icon: "💬", labelColor: "text-white/85" },
     thought: { border: "border-purple-400/20", bg: "bg-purple-950/70", icon: "💭", labelColor: "text-purple-200/80" },
-    whisper: { border: "border-rose-400/20", bg: "bg-rose-950/70", icon: "🤫", labelColor: "text-rose-200/80" },
+    whisper: {
+      border: "border-[var(--marinara-chat-chrome-button-border)]",
+      bg: "bg-[var(--marinara-chat-chrome-panel-bg)]",
+      icon: "🤫",
+      labelColor: "text-[var(--marinara-chat-chrome-panel-text)]",
+    },
   };
   const style = styleByType[line.type] ?? styleByType.side!;
 
@@ -5156,9 +5164,9 @@ const EXPRESSION_REACTIONS: Record<string, { symbol: string; color: string; effe
   mischievous: { symbol: "😈", color: "text-purple-300", effect: "pop" },
 
   // Affection
-  flirty: { symbol: "💗", color: "text-pink-400", effect: "heart" },
-  tender: { symbol: "💕", color: "text-pink-300", effect: "heart" },
-  loving: { symbol: "💕", color: "text-pink-300", effect: "heart" },
+  flirty: { symbol: "💗", color: "text-[var(--marinara-chat-chrome-panel-text)]", effect: "heart" },
+  tender: { symbol: "💕", color: "text-[var(--marinara-chat-chrome-panel-text)]", effect: "heart" },
+  loving: { symbol: "💕", color: "text-[var(--marinara-chat-chrome-panel-text)]", effect: "heart" },
 
   // Sadness
   sad: { symbol: "💧", color: "text-blue-300", effect: "tear" },
@@ -5761,7 +5769,7 @@ export function formatNarration(content: string, boldDialogue = true): string {
       const modifier = attrs.modifier ? `${attrs.stat || "modifier"} ${formatSignedNumber(attrs.modifier)}` : "";
       const turns = attrs.turns || attrs.duration ? `${attrs.turns || attrs.duration} turns` : "";
       return commandBadge(
-        "bg-rose-500/15 text-rose-200 ring-1 ring-rose-400/20",
+        "bg-[var(--destructive)]/15 text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20",
         "✦ Status",
         [attrs.effect || attrs.name || "Effect", attrs.target ? `on ${attrs.target}` : "", turns, modifier]
           .filter(Boolean)
@@ -5801,7 +5809,7 @@ export function formatNarration(content: string, boldDialogue = true): string {
     .replace(/\[reputation:\s*([^\]]+)\]/gi, (_match, rawAttrs: string) => {
       const attrs = parseCommandAttributes(rawAttrs);
       return commandBadge(
-        "bg-fuchsia-500/15 text-fuchsia-200 ring-1 ring-fuchsia-400/20",
+        "bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-panel-text)] ring-1 ring-[var(--marinara-chat-chrome-button-border)]",
         "◆ Reputation",
         [attrs.npc, attrs.action].filter(Boolean).join(": "),
       );

--- a/packages/client/src/components/game/GamePartySidebar.tsx
+++ b/packages/client/src/components/game/GamePartySidebar.tsx
@@ -206,8 +206,10 @@ export function GamePartySidebar({
                   </div>
                   {selectedCard.mood && (
                     <div className="mt-1.5 flex items-center gap-1">
-                      <Heart size={9} className="text-rose-400/60" />
-                      <span className="text-[0.5625rem] italic text-rose-300/50">{selectedCard.mood}</span>
+                      <Heart size={9} className="text-[var(--marinara-chat-chrome-panel-muted)]" />
+                      <span className="text-[0.5625rem] italic text-[var(--marinara-chat-chrome-panel-muted)]">
+                        {selectedCard.mood}
+                      </span>
                     </div>
                   )}
                 </div>

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -918,7 +918,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                   className={cn(
                     "rounded-full px-3 py-1 text-xs transition-colors",
                     rating === "nsfw"
-                      ? "bg-rose-500/20 text-rose-400 ring-1 ring-rose-500/40"
+                      ? "bg-[var(--destructive)]/20 text-[var(--destructive)] ring-1 ring-[var(--destructive)]/40"
                       : "bg-[var(--secondary)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
                   )}
                 >

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -148,7 +148,7 @@ function MountOnceWhenOpened({
         animate={open ? { opacity: 1, x: 0 } : { opacity: 0, x: 30 }}
         transition={{ duration: 0.2 }}
         className={cn(
-          "absolute inset-0 flex flex-col overflow-hidden bg-[var(--background)]",
+          "mari-app-background-paint absolute inset-0 flex flex-col overflow-hidden",
           open ? "z-20" : "z-10 pointer-events-none",
         )}
       >
@@ -736,7 +736,7 @@ export function AppShell() {
     <div
       data-component="AppShell"
       className={cn(
-        "mari-app fixed inset-0 flex overflow-hidden bg-[var(--background)] max-md:h-screen max-md:max-h-screen max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-[env(safe-area-inset-top)] supports-[height:100dvh]:max-md:h-[100dvh] supports-[height:100dvh]:max-md:max-h-[100dvh]",
+        "mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden max-md:h-screen max-md:max-h-screen max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-[env(safe-area-inset-top)] supports-[height:100dvh]:max-md:h-[100dvh] supports-[height:100dvh]:max-md:max-h-[100dvh]",
         showAmbientDecor && "retro-scanlines noise-bg geometric-grid",
       )}
     >
@@ -804,10 +804,10 @@ export function AppShell() {
         data-tour="chat-area"
         data-component="CenterContent"
         aria-label="Main content"
-        className="@container mari-main relative flex min-w-0 flex-1 flex-col overflow-hidden"
+        className="@container mari-main mari-app-background-paint relative flex min-w-0 flex-1 flex-col overflow-hidden"
       >
         <TopBar />
-        <div className="relative flex flex-1 flex-col overflow-hidden">
+        <div className="mari-app-background-paint relative flex flex-1 flex-col overflow-hidden">
           {/* Bot Browser — kept mounted once opened so state persists across close/reopen */}
           <MountOnceWhenOpened open={botBrowserOpen} overlay>
             <BotBrowserView />
@@ -817,7 +817,10 @@ export function AppShell() {
             <GameAssetsBrowserView />
           </MountOnceWhenOpened>
           <div
-            className={botBrowserOpen || gameAssetsBrowserOpen ? "hidden" : "flex flex-1 flex-col overflow-hidden"}
+            className={cn(
+              "mari-app-background-paint flex flex-1 flex-col overflow-hidden",
+              (botBrowserOpen || gameAssetsBrowserOpen) && "hidden",
+            )}
             style={
               {
                 "--tracker-chat-avoid-left": `${trackerPanelSide === "left" ? trackerPanelChatAvoidance : 0}px`,

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -91,42 +91,49 @@ function getNextUnnamedFolderName(existingFolders: Array<{ name: string }>): str
 
 const MODE_CONFIG: Record<
   string,
-  { icon: React.ReactNode; label: string; shortLabel: string; bg: string; description: string; comingSoon?: boolean }
+  {
+    icon: React.ReactNode;
+    label: string;
+    shortLabel: string;
+    description: string;
+    logoModeClass: string;
+    comingSoon?: boolean;
+  }
 > = {
   conversation: {
     icon: <MessageSquare size="0.875rem" />,
     label: "Conversation",
     shortLabel: "CONVO",
-    bg: "linear-gradient(135deg, #4de5dd, #3ab8b1)",
     description: "A straightforward AI conversation — no roleplay elements.",
+    logoModeClass: "mari-chat-logo-mode--conversation",
   },
   roleplay: {
     icon: <BookOpen size="0.875rem" />,
     label: "Roleplay",
     shortLabel: "RP",
-    bg: "linear-gradient(135deg, #eb8951, #d97530)",
     description: "Immersive roleplay with characters, game state tracking, and world simulation.",
+    logoModeClass: "mari-chat-logo-mode--roleplay",
   },
   visual_novel: {
     icon: <Theater size="0.875rem" />,
     label: "Visual Novel",
     shortLabel: "VN",
-    bg: "linear-gradient(135deg, #e15c8c, #c94776)",
     description: "A full game experience with backgrounds, sprites, text boxes, and choices.",
+    logoModeClass: "mari-chat-logo-mode--game",
     comingSoon: true,
   },
   game: {
     icon: <Theater size="0.875rem" />,
     label: "Game",
     shortLabel: "GM",
-    bg: "linear-gradient(135deg, #e15c8c, #c94776)",
     description: "AI-managed singleplayer RPG with a Game Master, party, dice, maps, and quests.",
+    logoModeClass: "mari-chat-logo-mode--game",
   },
 };
 
 function ChatSidebarTitleIcon() {
   return (
-    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-[linear-gradient(135deg,#4de5dd_0%,#eb8951_52%,#e15c8c_100%)] text-white shadow-sm">
+    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[linear-gradient(135deg,#4de5dd_0%,#eb8951_52%,#e15c8c_100%)] text-white shadow-sm">
       <MessageSquareText size="0.875rem" strokeWidth={2.35} />
     </div>
   );
@@ -796,16 +803,16 @@ export function ChatSidebar() {
         className={cn(
           "group relative flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition-all duration-150",
           multiSelectMode && isSelected
-            ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+            ? "mari-chrome-accent-surface mari-accent-animated"
             : isActive
-              ? "bg-[var(--sidebar-accent)] shadow-sm"
-              : "hover:bg-[var(--sidebar-accent)]/60",
+              ? "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)] shadow-sm"
+              : "hover:bg-[var(--marinara-chat-chrome-highlight-bg)]",
           draggedChatId === chat.id && "opacity-50",
         )}
       >
         {/* Multi-select checkbox */}
         {multiSelectMode && (
-          <div className="shrink-0 text-[var(--primary)]">
+          <div className="mari-chrome-accent-icon mari-accent-animated shrink-0">
             {isSelected ? (
               <CheckSquare size="0.875rem" />
             ) : (
@@ -816,10 +823,7 @@ export function ChatSidebar() {
 
         {/* Active indicator */}
         {isActive && (
-          <span
-            className="absolute -left-0.5 top-1/2 h-5 w-1 -translate-y-1/2 rounded-full"
-            style={{ background: cfg.bg }}
-          />
+          <span className="mari-chrome-accent-progress mari-accent-animated absolute -left-0.5 top-1/2 h-5 w-1 -translate-y-1/2 rounded-full" />
         )}
 
         {/* Chat avatar(s) or mode icon fallback — with unread badge overlay */}
@@ -850,7 +854,7 @@ export function ChatSidebar() {
                       : "bg-gray-400";
               return (
                 <span
-                  className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-[1.5px] ring-[var(--sidebar-background)] ${color}`}
+                  className={`absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-[0.1875rem] ring-[1.5px] ring-[var(--sidebar-background)] ${color}`}
                 />
               );
             };
@@ -860,9 +864,10 @@ export function ChatSidebar() {
                 <div
                   className={cn(
                     "flex h-7 w-7 items-center justify-center rounded-lg text-xs transition-transform group-active:scale-90",
-                    isActive ? "text-white shadow-sm" : "bg-[var(--secondary)] text-[var(--muted-foreground)]",
+                    isActive
+                      ? "mari-chrome-accent-tile mari-accent-animated shadow-sm"
+                      : "mari-chrome-accent-soft-tile mari-accent-animated",
                   )}
-                  style={isActive ? { background: cfg.bg } : undefined}
                 >
                   {cfg.icon}
                 </div>
@@ -873,7 +878,7 @@ export function ChatSidebar() {
               const a = avatars[0]!;
               return a.avatarUrl ? (
                 <div className="relative h-7 w-7 flex-shrink-0 transition-transform group-active:scale-90">
-                  <span className="relative block h-7 w-7 overflow-hidden rounded-full">
+                  <span className="relative block h-7 w-7 overflow-hidden rounded-lg">
                     <img
                       src={a.avatarUrl}
                       alt={a.name}
@@ -885,7 +890,7 @@ export function ChatSidebar() {
                 </div>
               ) : (
                 <div className="relative h-7 w-7 flex-shrink-0 transition-transform group-active:scale-90">
-                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--secondary)] text-[0.625rem] font-bold text-[var(--muted-foreground)]">
+                  <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--secondary)] text-[0.625rem] font-bold text-[var(--muted-foreground)]">
                     {a.name[0]}
                   </div>
                   {statusDot(a.conversationStatus)}
@@ -901,7 +906,7 @@ export function ChatSidebar() {
                     <span
                       key={i}
                       className={cn(
-                        "absolute h-5 w-5 overflow-hidden rounded-full ring-2 ring-[var(--sidebar-background)]",
+                        "absolute h-5 w-5 overflow-hidden rounded-md ring-2 ring-[var(--sidebar-background)]",
                         i === 0 ? "top-0 left-0 z-10" : "bottom-0 right-0",
                       )}
                     >
@@ -916,7 +921,7 @@ export function ChatSidebar() {
                     <div
                       key={i}
                       className={cn(
-                        "absolute flex h-5 w-5 items-center justify-center rounded-full bg-[var(--secondary)] text-[0.5rem] font-bold text-[var(--muted-foreground)] ring-2 ring-[var(--sidebar-background)]",
+                        "absolute flex h-5 w-5 items-center justify-center rounded-md bg-[var(--secondary)] text-[0.5rem] font-bold text-[var(--muted-foreground)] ring-2 ring-[var(--sidebar-background)]",
                         i === 0 ? "top-0 left-0 z-10" : "bottom-0 right-0",
                       )}
                     >
@@ -933,7 +938,7 @@ export function ChatSidebar() {
             const count = unreadCounts.get(chat.id) || 0;
             if (count === 0 || isActive) return null;
             return (
-              <span className="absolute -top-1 -right-1 z-20 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[0.5625rem] font-bold leading-none text-white shadow-sm ring-2 ring-[var(--sidebar-background)]">
+              <span className="absolute -top-1 -right-1 z-20 flex h-4 min-w-4 items-center justify-center rounded-md bg-red-500 px-1 text-[0.5625rem] font-bold leading-none text-white shadow-sm ring-2 ring-[var(--sidebar-background)]">
                 {count > 99 ? "99+" : count}
               </span>
             );
@@ -945,7 +950,7 @@ export function ChatSidebar() {
           <span
             className={cn(
               "block truncate text-sm",
-              isActive ? "font-medium text-[var(--sidebar-accent-foreground)]" : "text-[var(--sidebar-foreground)]",
+              isActive ? "mari-chrome-text-strong font-medium" : "mari-chrome-text",
             )}
           >
             {chat.name}
@@ -954,7 +959,7 @@ export function ChatSidebar() {
 
         {/* Branch count badge */}
         {branchCount > 1 && (
-          <span className="flex shrink-0 items-center gap-0.5 rounded-full bg-[var(--secondary)] px-1.5 py-0.5 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+          <span className="mari-chrome-muted-badge flex shrink-0 items-center gap-0.5 px-1.5 py-0.5 text-[0.625rem]">
             <GitBranch size="0.625rem" />
             {branchCount}
           </span>
@@ -991,18 +996,22 @@ export function ChatSidebar() {
   };
 
   return (
-    <nav data-component="ChatSidebar" aria-label="Chat navigation" className="mari-chat-sidebar flex h-full flex-col">
+    <nav
+      data-component="ChatSidebar"
+      aria-label="Chat navigation"
+      className="mari-chat-sidebar mari-chrome-token-scope flex h-full flex-col"
+    >
       {/* Header */}
       <div className="mari-sidebar-header relative flex h-12 items-center justify-between bg-[var(--card)]/80 px-4 backdrop-blur-sm">
         <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--border)]/30" />
         <div className="flex items-center gap-2.5">
           <ChatSidebarTitleIcon />
-          <h2 className="text-sm font-semibold text-[var(--foreground)]">Chats</h2>
+          <h2 className="mari-chrome-text-strong text-sm font-semibold">Chats</h2>
         </div>
         <div className="flex items-center gap-1">
           <button
             onClick={() => setSidebarOpen(false)}
-            className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--primary)] active:scale-90 md:hidden"
+            className="mari-chrome-control mari-chrome-control--small mari-accent-animated p-1.5 active:scale-90 md:hidden"
             title="Close"
             aria-label="Close chats"
           >
@@ -1027,7 +1036,7 @@ export function ChatSidebar() {
                 data-chat-mode-tab={tab}
                 data-tour={`chat-mode-${tab}`}
                 className={cn(
-                  "mari-chrome-segmented__button overflow-visible px-2 py-2 text-xs leading-normal",
+                  "mari-chrome-segmented__button gap-1 overflow-visible px-1.5 py-2 text-[0.625rem] leading-normal",
                   isActive && "mari-chrome-segmented__button--selected",
                 )}
               >
@@ -1036,7 +1045,7 @@ export function ChatSidebar() {
                   {cfg.shortLabel}
                 </span>
                 {tabUnread > 0 && !isActive && (
-                  <span className="absolute -top-1 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-red-500 px-0.5 text-[0.5rem] font-bold leading-none text-white">
+                  <span className="absolute -top-1 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-md bg-red-500 px-0.5 text-[0.5rem] font-bold leading-none text-white">
                     {tabUnread > 99 ? "99+" : tabUnread}
                   </span>
                 )}
@@ -1056,8 +1065,10 @@ export function ChatSidebar() {
         />
         <button
           onClick={handleNewChatFromTab}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-bold text-white shadow-md shadow-black/10 transition-all hover:brightness-110 active:scale-[0.98]"
-          style={{ background: activeModeConfig.bg }}
+          className={cn(
+            "mari-chrome-control mari-chrome-control--primary mari-chat-mode-action flex-1 text-xs",
+            activeModeConfig.logoModeClass,
+          )}
           title={`New ${activeModeConfig.label}`}
           aria-label={`New ${activeModeConfig.label}`}
         >
@@ -1106,7 +1117,7 @@ export function ChatSidebar() {
             <select
               value={sort}
               onChange={(e) => setSort(e.target.value as ChatSortOption)}
-              className="mari-chrome-field h-10 w-[6.5rem] appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
+              className="mari-chrome-field mari-chrome-sort-field mari-accent-animated h-10 w-[6.5rem] appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
               title="Sort chats"
             >
               <option value="newest">Newest</option>
@@ -1116,7 +1127,7 @@ export function ChatSidebar() {
             </select>
             <ArrowUpDown
               size="0.625rem"
-              className="mari-chrome-field-icon pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+              className="mari-chrome-field-icon mari-chrome-sort-icon mari-accent-animated pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
             />
           </div>
         </div>
@@ -1128,8 +1139,8 @@ export function ChatSidebar() {
               className={cn(
                 "flex max-w-full items-center gap-1 rounded-lg px-1.5 py-1 text-[0.625rem] transition-colors",
                 activeTag
-                  ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-                  : "text-[var(--muted-foreground)] hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]",
+                  ? "mari-chrome-accent-surface mari-accent-animated"
+                  : "mari-chrome-text-muted hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
               )}
               title={tagsExpanded ? "Collapse tags" : "Expand tags"}
             >
@@ -1158,8 +1169,8 @@ export function ChatSidebar() {
                 className={cn(
                   "max-w-full truncate rounded-lg px-2 py-1 text-[0.625rem] font-medium transition-all",
                   activeTag === tag
-                    ? "bg-[var(--primary)]/15 text-[var(--primary)] ring-1 ring-[var(--primary)]/30"
-                    : "bg-[var(--secondary)] text-[var(--muted-foreground)] hover:bg-[var(--sidebar-accent)]/40 hover:text-[var(--foreground)]",
+                    ? "mari-chrome-accent-surface mari-accent-animated"
+                    : "mari-chrome-muted-badge hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
                 )}
                 title={tag}
               >
@@ -1183,7 +1194,7 @@ export function ChatSidebar() {
         data-chat-root-drop-zone
         className={cn(
           "flex-1 overflow-y-auto px-2 pb-1 pt-0 transition-colors",
-          isRootDropTarget && "bg-[var(--primary)]/5",
+          isRootDropTarget && "bg-[var(--marinara-chat-chrome-highlight-bg)]",
         )}
         onDragEnter={(event) => {
           if (!draggedChatId) return;
@@ -1237,7 +1248,7 @@ export function ChatSidebar() {
             <button
               onClick={() => void refetchChats()}
               disabled={isFetching}
-              className="mt-1 rounded-lg bg-[var(--primary)]/15 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25 disabled:cursor-not-allowed disabled:opacity-60"
+              className="mari-chrome-control mari-chrome-control--compact mt-1 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isFetching ? "Checking..." : "Try Again"}
             </button>
@@ -1246,23 +1257,26 @@ export function ChatSidebar() {
 
         {displayChats.length === 0 && !isLoading && !chatsError && (
           <div className="flex flex-col items-center gap-2 px-3 py-12 text-center">
-            <div className="animate-float flex h-12 w-12 items-center justify-center rounded-2xl bg-[var(--secondary)]">
+            <div className="mari-chrome-accent-soft-tile mari-accent-animated animate-float flex h-12 w-12 items-center justify-center rounded-2xl">
               {activeTab === "conversation" ? (
-                <MessageSquare size="1.25rem" className="text-[var(--muted-foreground)]" />
+                <MessageSquare size="1.25rem" />
               ) : activeTab === "game" ? (
-                <Theater size="1.25rem" className="text-[var(--muted-foreground)]" />
+                <Theater size="1.25rem" />
               ) : (
-                <BookOpen size="1.25rem" className="text-[var(--muted-foreground)]" />
+                <BookOpen size="1.25rem" />
               )}
             </div>
-            <p className="text-xs text-[var(--muted-foreground)]">
+            <p className="mari-chrome-text-muted text-xs">
               {searchQuery.trim() || activeTag
                 ? `No ${activeTab === "conversation" ? "conversations" : activeTab === "game" ? "games" : "roleplays"} match the current filters`
                 : `No ${activeTab === "conversation" ? "conversations" : activeTab === "game" ? "games" : "roleplays"} yet`}
             </p>
             <button
               onClick={handleNewChatFromTab}
-              className="mt-1 rounded-lg bg-[var(--primary)]/15 px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25"
+              className={cn(
+                "mari-chrome-control mari-chrome-control--compact mari-chat-mode-action mt-1",
+                activeModeConfig.logoModeClass,
+              )}
             >
               + New {activeTab === "conversation" ? "Conversation" : activeTab === "game" ? "Game" : "Roleplay"}
             </button>
@@ -1466,7 +1480,7 @@ function FolderRow({
       }}
       className={cn(
         "flex flex-col rounded-lg transition-colors",
-        isDropTarget && "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30",
+        isDropTarget && "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
       )}
     >
       {/* Folder header */}
@@ -1478,7 +1492,7 @@ function FolderRow({
           }}
           className="cursor-grab touch-none opacity-0 transition-opacity active:cursor-grabbing group-hover:opacity-100 max-md:opacity-100"
         >
-          <GripVertical size="0.625rem" className="text-[var(--muted-foreground)]" />
+          <GripVertical size="0.625rem" className="mari-chrome-accent-icon mari-accent-animated" />
         </div>
         <div
           role="button"
@@ -1508,7 +1522,7 @@ function FolderRow({
           <ChevronRight
             size="0.75rem"
             className={cn(
-              "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+              "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
               isExpanded && "rotate-90",
             )}
           />
@@ -1537,13 +1551,13 @@ function FolderRow({
               className="flex-1 bg-transparent text-xs font-medium text-[var(--foreground)] outline-none min-w-0"
             />
           ) : (
-            <span className="flex-1 cursor-pointer truncate text-xs font-medium text-[var(--muted-foreground)] min-w-0">
+            <span className="mari-chrome-text flex-1 min-w-0 cursor-pointer truncate text-xs font-medium">
               {folder.name}
             </span>
           )}
         </div>
         {entries.length > 0 && (
-          <span className="text-[0.5625rem] text-[var(--muted-foreground)] shrink-0">{entries.length}</span>
+          <span className="mari-chrome-text-muted shrink-0 text-[0.5625rem]">{entries.length}</span>
         )}
         <button
           onClick={(e) => {
@@ -1702,7 +1716,7 @@ function UserStatusFooter() {
           aria-label="Change activity status"
         >
           <span className={`h-2 w-2 shrink-0 rounded-full ${current.color}`} />
-          <span className="max-w-20 truncate text-xs text-[var(--sidebar-foreground)]">{current.label}</span>
+          <span className="mari-chrome-text max-w-20 truncate text-xs">{current.label}</span>
         </button>
         <input
           value={userActivity}

--- a/packages/client/src/components/layout/RightPanel.tsx
+++ b/packages/client/src/components/layout/RightPanel.tsx
@@ -4,6 +4,7 @@
 import { lazy, Suspense, type ComponentType, type LazyExoticComponent, type ReactNode } from "react";
 import { X, Users, BookOpen, FileText, Link, Sparkles, Settings, User, Bot } from "lucide-react";
 import { useUIStore } from "../../stores/ui.store";
+import { cn } from "../../lib/utils";
 
 const CharactersPanel = lazy(() =>
   import("../panels/CharactersPanel").then((module) => ({ default: module.CharactersPanel })),
@@ -26,11 +27,19 @@ const BotBrowserPanel = lazy(() =>
   import("../panels/BotBrowserPanel").then((module) => ({ default: module.BotBrowserPanel })),
 );
 
-const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient: string }> = {
-  "bot-browser": { title: "Browser", icon: <Bot size="0.875rem" />, gradient: "from-cyan-400 to-blue-500" },
+const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient?: string; gradientClass?: string }> = {
+  "bot-browser": {
+    title: "Browser",
+    icon: <Bot size="0.875rem" />,
+    gradient: "from-lime-400 via-green-500 to-cyan-500",
+  },
   characters: { title: "Characters", icon: <Users size="0.875rem" />, gradient: "from-pink-400 to-rose-500" },
   lorebooks: { title: "Lorebooks", icon: <BookOpen size="0.875rem" />, gradient: "from-amber-400 to-orange-500" },
-  presets: { title: "Presets", icon: <FileText size="0.875rem" />, gradient: "from-purple-400 to-violet-500" },
+  presets: {
+    title: "Presets",
+    icon: <FileText size="0.875rem" />,
+    gradientClass: "mari-panel-gradient-surface mari-panel-gradient--presets",
+  },
   connections: { title: "Connections", icon: <Link size="0.875rem" />, gradient: "from-sky-400 to-blue-500" },
   agents: { title: "Agents", icon: <Sparkles size="0.875rem" />, gradient: "from-violet-400 to-purple-500" },
   personas: { title: "Personas", icon: <User size="0.875rem" />, gradient: "from-emerald-400 to-teal-500" },
@@ -52,9 +61,7 @@ const PANELS: Record<string, LazyExoticComponent<ComponentType>> = {
 const mountedPanels = new Set<string>();
 
 function PanelFallback() {
-  return (
-    <div className="flex h-full items-center justify-center text-sm text-[var(--muted-foreground)]">Loading...</div>
-  );
+  return <div className="mari-chrome-text-muted flex h-full items-center justify-center text-sm">Loading...</div>;
 }
 
 export function RightPanel() {
@@ -71,22 +78,25 @@ export function RightPanel() {
     <section
       data-component="RightPanel"
       aria-label={config.title}
-      className="mari-right-panel-content flex h-full flex-col"
+      className="mari-right-panel-content mari-chrome-token-scope flex h-full flex-col"
     >
       {/* Header - OS window style */}
       <div className="mari-right-panel-header relative flex h-12 flex-shrink-0 items-center justify-between bg-[var(--card)]/80 px-4 backdrop-blur-sm">
         <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--border)]/30" />
         <div className="flex items-center gap-2.5">
           <div
-            className={`flex h-6 w-6 items-center justify-center rounded-lg bg-gradient-to-br ${config.gradient} text-white shadow-sm`}
+            className={cn(
+              "flex h-6 w-6 items-center justify-center rounded-md shadow-sm",
+              config.gradientClass ?? `bg-gradient-to-br ${config.gradient ?? "from-slate-400 to-slate-500"} text-white`,
+            )}
           >
             {config.icon}
           </div>
-          <h2 className="text-sm font-semibold text-[var(--foreground)]">{config.title}</h2>
+          <h2 className="mari-chrome-text-strong text-sm font-semibold">{config.title}</h2>
         </div>
         <button
           onClick={close}
-          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--primary)] active:scale-90"
+          className="mari-chrome-control mari-chrome-control--small mari-accent-animated p-1.5 active:scale-90"
         >
           <X size="0.875rem" />
         </button>

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -2,6 +2,7 @@
 // Layout: Top Bar (polished, with hover glow)
 // ──────────────────────────────────────────────
 import { MessageSquareText, Home, Settings, Link, BookOpen, Users, Sparkles, FileText, User, Bot } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
@@ -10,25 +11,89 @@ import { cn } from "../../lib/utils";
 import { SpotifyMiniPlayer } from "../spotify/SpotifyMiniPlayer";
 import { YouTubePlayer } from "../chat/YouTubePlayer";
 
-const RIGHT_PANEL_BUTTONS = [
-  { panel: "lorebooks" as const, icon: BookOpen, label: "Lorebooks", color: "from-amber-400 to-orange-500" },
-  { panel: "presets" as const, icon: FileText, label: "Presets", color: "from-purple-400 to-violet-500" },
-  { panel: "connections" as const, icon: Link, label: "Connections", color: "from-sky-400 to-blue-500" },
-  { panel: "agents" as const, icon: Sparkles, label: "Agents", color: "from-violet-400 to-purple-500" },
-  { panel: "personas" as const, icon: User, label: "Personas", color: "from-emerald-400 to-teal-500" },
+type RightPanelButtonPanel = "lorebooks" | "presets" | "connections" | "agents" | "personas";
+
+type RightPanelButtonConfig = {
+  panel: RightPanelButtonPanel;
+  icon: LucideIcon;
+  label: string;
+  color: string;
+  iconColor: string;
+  hoverColor: string;
+  underlineClass?: string;
+};
+
+const RIGHT_PANEL_BUTTONS: readonly RightPanelButtonConfig[] = [
+  {
+    panel: "lorebooks" as const,
+    icon: BookOpen,
+    label: "Lorebooks",
+    color: "from-amber-400 to-orange-500",
+    iconColor: "text-amber-300",
+    hoverColor: "hover:text-amber-300",
+  },
+  {
+    panel: "presets" as const,
+    icon: FileText,
+    label: "Presets",
+    color: "",
+    iconColor: "mari-panel-gradient--presets text-[var(--mari-panel-gradient-start)]",
+    hoverColor: "mari-panel-gradient--presets hover:text-[var(--mari-panel-gradient-start)]",
+    underlineClass: "mari-panel-gradient-surface mari-panel-gradient--presets",
+  },
+  {
+    panel: "connections" as const,
+    icon: Link,
+    label: "Connections",
+    color: "from-sky-400 to-blue-500",
+    iconColor: "text-sky-300",
+    hoverColor: "hover:text-sky-300",
+  },
+  {
+    panel: "agents" as const,
+    icon: Sparkles,
+    label: "Agents",
+    color: "from-violet-400 to-purple-500",
+    iconColor: "text-violet-300",
+    hoverColor: "hover:text-violet-300",
+  },
+  {
+    panel: "personas" as const,
+    icon: User,
+    label: "Personas",
+    color: "from-emerald-400 to-teal-500",
+    iconColor: "text-emerald-300",
+    hoverColor: "hover:text-emerald-300",
+  },
 ] as const;
 
 const SPOTIFY_TOPBAR_MIN_WIDTH = 320;
 const SPOTIFY_TOPBAR_MIN_WIDTH_WITH_VOLUME = 416;
 const SPOTIFY_TOPBAR_LAYOUT_BUFFER = 32;
+const TOPBAR_BUTTON_CLASS = "relative rounded-lg p-2 transition-all hover:bg-[var(--accent)] active:scale-95";
+const TOPBAR_PANEL_BUTTON_CLASS = "relative rounded-lg p-2 transition-all duration-200 max-sm:p-1.5";
+const TOPBAR_ACTIVE_BUTTON_CLASS = "bg-[var(--accent)] shadow-sm";
 
 export function TopBar() {
+  const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
   const rightPanel = useUIStore((s) => s.rightPanel);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
+  const activeChatId = useChatStore((s) => s.activeChatId);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const closeAllDetails = useUIStore((s) => s.closeAllDetails);
+  const characterDetailId = useUIStore((s) => s.characterDetailId);
+  const lorebookDetailId = useUIStore((s) => s.lorebookDetailId);
+  const presetDetailId = useUIStore((s) => s.presetDetailId);
+  const connectionDetailId = useUIStore((s) => s.connectionDetailId);
+  const agentDetailId = useUIStore((s) => s.agentDetailId);
+  const toolDetailId = useUIStore((s) => s.toolDetailId);
+  const personaDetailId = useUIStore((s) => s.personaDetailId);
+  const regexDetailId = useUIStore((s) => s.regexDetailId);
+  const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
+  const gameAssetsBrowserOpen = useUIStore((s) => s.gameAssetsBrowserOpen);
+  const characterLibraryOpen = useUIStore((s) => s.characterLibraryOpen);
   const failedAgentCount = useAgentStore((s) => s.failedAgentTypes.length);
   const headerRef = useRef<HTMLElement | null>(null);
   const leftControlsRef = useRef<HTMLDivElement | null>(null);
@@ -36,8 +101,33 @@ export function TopBar() {
   const [spotifyDesktopViewport, setSpotifyDesktopViewport] = useState(false);
   const [spotifyUseFloatingFallback, setSpotifyUseFloatingFallback] = useState(false);
 
-  const isBotBrowserActive = rightPanelOpen && rightPanel === "bot-browser";
-  const isCharactersPanelActive = rightPanelOpen && rightPanel === "characters";
+  const isBotBrowserActive = (rightPanelOpen && rightPanel === "bot-browser") || botBrowserOpen;
+  const isCharactersPanelActive =
+    (rightPanelOpen && rightPanel === "characters") || Boolean(characterDetailId) || characterLibraryOpen;
+  const panelContextActive: Record<RightPanelButtonPanel, boolean> = {
+    lorebooks: (rightPanelOpen && rightPanel === "lorebooks") || Boolean(lorebookDetailId),
+    presets:
+      (rightPanelOpen && rightPanel === "presets") ||
+      Boolean(presetDetailId) ||
+      Boolean(regexDetailId) ||
+      Boolean(toolDetailId),
+    connections: (rightPanelOpen && rightPanel === "connections") || Boolean(connectionDetailId),
+    agents: (rightPanelOpen && rightPanel === "agents") || Boolean(agentDetailId),
+    personas: (rightPanelOpen && rightPanel === "personas") || Boolean(personaDetailId),
+  };
+  const isHomeActive =
+    !activeChatId &&
+    !characterDetailId &&
+    !lorebookDetailId &&
+    !presetDetailId &&
+    !connectionDetailId &&
+    !agentDetailId &&
+    !toolDetailId &&
+    !personaDetailId &&
+    !regexDetailId &&
+    !botBrowserOpen &&
+    !gameAssetsBrowserOpen &&
+    !characterLibraryOpen;
 
   useEffect(() => {
     const header = headerRef.current;
@@ -96,14 +186,22 @@ export function TopBar() {
 
       {/* Left section: window controls + chat info */}
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <div ref={leftControlsRef} className="flex shrink-0 items-center gap-2">
+        <div ref={leftControlsRef} className="mari-rgb-icon-scope flex shrink-0 items-center gap-2">
           <button
             onClick={toggleSidebar}
             data-tour="sidebar-toggle"
-            className="rounded-lg p-2 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--primary)] active:scale-95"
+            className={cn(
+              TOPBAR_BUTTON_CLASS,
+              sidebarOpen
+                ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "mari-topbar-chat-cycle")
+                : "text-[var(--muted-foreground)] hover:text-cyan-300",
+            )}
             title="Chats"
           >
             <MessageSquareText size="0.9375rem" />
+            {sidebarOpen && (
+              <span className="mari-topbar-chat-cycle-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
+            )}
           </button>
 
           <button
@@ -112,10 +210,18 @@ export function TopBar() {
               setActiveChatId(null);
               closeAllDetails();
             }}
-            className="rounded-lg p-2 text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] hover:text-[var(--primary)] active:scale-95"
+            className={cn(
+              TOPBAR_BUTTON_CLASS,
+              isHomeActive
+                ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "mari-chrome-accent-icon mari-accent-animated")
+                : "text-[var(--muted-foreground)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
+            )}
             title="Home"
           >
             <Home size="0.9375rem" />
+            {isHomeActive && (
+              <span className="mari-topbar-active-underline mari-accent-animated absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
+            )}
           </button>
         </div>
         {spotifyDesktopViewport && <SpotifyMiniPlayer forceFloating={spotifyUseFloatingFallback} />}
@@ -127,23 +233,23 @@ export function TopBar() {
         ref={rightNavRef}
         data-tour="panel-buttons"
         aria-label="Panel navigation"
-        className="flex shrink-0 items-center justify-end gap-0.5 rounded-xl p-1 max-sm:gap-0 max-sm:p-0.5"
+        className="mari-rgb-icon-scope flex shrink-0 items-center justify-end gap-0.5 rounded-xl p-1 max-sm:gap-0 max-sm:p-0.5"
       >
         {/* Browser */}
         <button
           onClick={() => toggleRightPanel("bot-browser")}
           data-tour="panel-bot-browser"
           className={cn(
-            "relative rounded-lg p-2 transition-all duration-200 max-sm:p-1.5",
+            TOPBAR_PANEL_BUTTON_CLASS,
             isBotBrowserActive
-              ? "bg-[var(--accent)] text-[var(--primary)] shadow-sm"
-              : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+              ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "text-lime-300")
+              : "text-[var(--muted-foreground)] hover:text-lime-300",
           )}
           title="Browser"
         >
           <Bot size="0.9375rem" />
           {isBotBrowserActive && (
-            <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-cyan-400 to-blue-500" />
+            <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-lime-400 via-green-500 to-cyan-500" />
           )}
         </button>
 
@@ -151,10 +257,10 @@ export function TopBar() {
           onClick={() => toggleRightPanel("characters")}
           data-tour="panel-characters"
           className={cn(
-            "relative rounded-lg p-2 transition-all duration-200 max-sm:p-1.5",
+            TOPBAR_PANEL_BUTTON_CLASS,
             isCharactersPanelActive
-              ? "bg-[var(--accent)] text-[var(--primary)] shadow-sm"
-              : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+              ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "text-rose-300")
+              : "text-[var(--muted-foreground)] hover:text-rose-300",
           )}
           title="Characters"
         >
@@ -164,18 +270,16 @@ export function TopBar() {
           )}
         </button>
 
-        {RIGHT_PANEL_BUTTONS.map(({ panel, icon: Icon, label, color }) => {
-          const isActive = rightPanelOpen && rightPanel === panel;
+        {RIGHT_PANEL_BUTTONS.map(({ panel, icon: Icon, label, color, iconColor, hoverColor, underlineClass }) => {
+          const isActive = panelContextActive[panel];
           return (
             <button
               key={panel}
               onClick={() => toggleRightPanel(panel)}
               data-tour={`panel-${panel}`}
               className={cn(
-                "relative rounded-lg p-2 transition-all duration-200 max-sm:p-1.5",
-                isActive
-                  ? "bg-[var(--accent)] text-[var(--primary)] shadow-sm"
-                  : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+                TOPBAR_PANEL_BUTTON_CLASS,
+                isActive ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, iconColor) : cn("text-[var(--muted-foreground)]", hoverColor),
               )}
               title={label}
             >
@@ -183,8 +287,8 @@ export function TopBar() {
               {isActive && (
                 <span
                   className={cn(
-                    "absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r",
-                    color,
+                    "absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full",
+                    underlineClass ?? cn("bg-gradient-to-r", color),
                   )}
                 />
               )}
@@ -200,10 +304,10 @@ export function TopBar() {
           onClick={() => toggleRightPanel("settings")}
           data-tour="panel-settings"
           className={cn(
-            "relative rounded-lg p-2 transition-all duration-200 max-sm:p-1.5",
+            TOPBAR_PANEL_BUTTON_CLASS,
             rightPanelOpen && rightPanel === "settings"
-              ? "bg-[var(--accent)] text-[var(--primary)] shadow-sm"
-              : "text-[var(--muted-foreground)] hover:text-[var(--primary)]",
+              ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "text-gray-300")
+              : "text-[var(--muted-foreground)] hover:text-gray-300",
           )}
           title="Settings"
         >

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -2316,7 +2316,7 @@ function VectorizeSection({
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--secondary)]/30 p-4 space-y-3">
       <div className="flex items-center gap-2">
-        <Sparkles size="0.875rem" className="text-violet-400" />
+        <Sparkles size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />
         <h4 className="text-xs font-semibold">Semantic Search (Embeddings)</h4>
         <HelpTooltip text="Vectorize entries to enable semantic matching. Entries will be found by meaning, not just keywords. Requires a connection with an Embedding Model configured." />
       </div>
@@ -2362,7 +2362,7 @@ function VectorizeSection({
             <button
               onClick={handleVectorize}
               disabled={vectorizing || vectorizableEntryCount === 0 || !selectedConnectionId}
-              className="flex items-center gap-1.5 rounded-xl bg-violet-500/15 px-3 py-1.5 text-xs font-medium text-violet-400 ring-1 ring-violet-500/30 transition-all hover:bg-violet-500/25 active:scale-[0.98] disabled:opacity-50"
+              className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium transition-all active:scale-[0.98] disabled:opacity-50"
             >
               {vectorizing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Sparkles size="0.75rem" />}
               {vectorizing

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -650,7 +650,7 @@ export function LorebookEntryRow({
           className={cn(
             "relative inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[0.625rem] ring-1 transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
             isVectorExcluded
-              ? "bg-rose-400/10 text-rose-400 ring-rose-400/20"
+              ? "bg-[var(--destructive)]/10 text-[var(--destructive)] ring-[var(--destructive)]/20"
               : isVectorized
                 ? "bg-emerald-400/10 text-emerald-400 ring-emerald-400/20"
                 : "bg-[var(--background)]/55 text-[var(--muted-foreground)] ring-[var(--border)] hover:text-[var(--foreground)]",

--- a/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
+++ b/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
@@ -194,8 +194,8 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
     <Modal open={open} onClose={closeAndAdvance} title="Review Character Card Updates" width="max-w-2xl">
       <div className="flex flex-col gap-3">
         <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-violet-400 to-fuchsia-500 shadow-lg shadow-violet-400/20">
-            <UserCog size="1.375rem" className="text-white" />
+          <div className="mari-chrome-accent-tile mari-accent-animated flex h-12 w-12 items-center justify-center rounded-xl">
+            <UserCog size="1.375rem" className="text-current" />
           </div>
           <div className="flex-1">
             <p className="text-sm font-medium">

--- a/packages/client/src/components/modals/CreateCharacterModal.tsx
+++ b/packages/client/src/components/modals/CreateCharacterModal.tsx
@@ -90,12 +90,12 @@ export function CreateCharacterModal({ open, onClose }: Props) {
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          className="group relative flex h-24 w-24 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-pink-400 to-rose-500 shadow-lg shadow-pink-400/20 transition-transform hover:scale-105"
+          className="mari-chrome-accent-tile mari-accent-animated group relative flex h-24 w-24 items-center justify-center overflow-hidden rounded-full transition-transform hover:scale-105"
         >
           {avatarDataUrl ? (
             <img src={avatarDataUrl} alt="Avatar" className="h-full w-full object-cover" />
           ) : (
-            <User size="2.25rem" className="text-white" />
+            <User size="2.25rem" className="text-current" />
           )}
           <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
             <Camera size="1.25rem" className="text-white" />

--- a/packages/client/src/components/modals/CreatePresetModal.tsx
+++ b/packages/client/src/components/modals/CreatePresetModal.tsx
@@ -61,8 +61,8 @@ export function CreatePresetModal({ open, onClose }: Props) {
     <Modal open={open} onClose={onClose} title="Create Preset" width="max-w-sm">
       <div className="flex flex-col gap-3">
         <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-purple-400 to-violet-500 shadow-lg shadow-purple-400/20">
-            <FileText size="1.375rem" className="text-white" />
+          <div className="mari-panel-gradient-surface mari-panel-gradient--presets flex h-12 w-12 items-center justify-center rounded-xl">
+            <FileText size="1.375rem" className="text-current" />
           </div>
           <div className="flex-1">
             <p className="text-xs text-[var(--muted-foreground)]">

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -437,8 +437,8 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     <Modal open={open} onClose={onClose} title="Local AI Model" width="max-w-2xl" contentRef={modalScrollRef}>
       <div className="flex flex-col gap-5">
         <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-purple-500/10">
-            <BrainCircuit size="1.25rem" className="text-purple-400" />
+          <div className="mari-chrome-accent-soft-tile mari-accent-animated flex h-10 w-10 shrink-0 items-center justify-center rounded-xl">
+            <BrainCircuit size="1.25rem" />
           </div>
           <div className="text-sm text-[var(--muted-foreground)]">
             <p>
@@ -477,7 +477,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           <div className="flex items-start justify-between gap-3 max-sm:flex-col">
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <Server size="0.95rem" className="text-purple-300" />
+                <Server size="0.95rem" className="mari-chrome-accent-icon mari-accent-animated" />
                 Runtime
               </div>
               <div className="mt-1 text-xs text-[var(--muted-foreground)]">
@@ -517,7 +517,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
               {!runtime.installed ? (
                 <button
                   onClick={() => void installRuntime()}
-                  className="flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+                  className="mari-chrome-accent-surface mari-accent-animated flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-colors"
                 >
                   <Download size="0.875rem" />
                   {activeBackend === "mlx" ? "Install MLX Runtime" : "Install Runtime"}
@@ -527,7 +527,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                   {hasModel && (
                     <button
                       onClick={() => void restartRuntime()}
-                      className="flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25"
+                      className="mari-chrome-accent-surface mari-accent-animated flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-colors"
                     >
                       <Loader2 size="0.875rem" />
                       {status === "server_error"
@@ -585,7 +585,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                           onChange={(event) =>
                             handleRuntimePreferenceChange(event.target.value as SidecarRuntimePreference)
                           }
-                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                         >
                           {runtimePreferenceOptions.map((option) => (
                             <option key={option} value={option}>
@@ -627,7 +627,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                           onChange={(event) =>
                             handleGpuLayersModeChange(event.target.value as "auto" | "cpu" | "custom")
                           }
-                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                         >
                           <option value="auto">Auto offload</option>
                           <option value="cpu">CPU only</option>
@@ -650,7 +650,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                             }}
                             placeholder="1-1024"
                             inputMode="numeric"
-                            className="w-24 shrink-0 rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-center text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                            className="w-24 shrink-0 rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-center text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                           />
                           <button
                             onClick={handleApplyCustomGpuLayers}
@@ -727,7 +727,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                       onChange={(event) => setContextSizeInput(event.target.value.replace(/[^\d]/g, ""))}
                       inputMode="numeric"
                       placeholder="8192"
-                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                     />
                   </label>
 
@@ -740,7 +740,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                       onChange={(event) => setMaxTokensInput(event.target.value.replace(/[^\d]/g, ""))}
                       inputMode="numeric"
                       placeholder="4096"
-                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                     />
                   </label>
 
@@ -753,7 +753,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                       onChange={(event) => setTemperatureInput(event.target.value.replace(/[^0-9.]/g, ""))}
                       inputMode="decimal"
                       placeholder="0.3"
-                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                     />
                   </label>
 
@@ -766,7 +766,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                       onChange={(event) => setTopPInput(event.target.value.replace(/[^0-9.]/g, ""))}
                       inputMode="decimal"
                       placeholder="0.95"
-                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                     />
                   </label>
 
@@ -779,7 +779,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                       onChange={(event) => setTopKInput(event.target.value.replace(/[^\d]/g, ""))}
                       inputMode="numeric"
                       placeholder="64"
-                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/20"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
                     />
                   </label>
                 </div>
@@ -951,13 +951,13 @@ export function ModelDownloadModal({ open, onClose }: Props) {
         </div>
 
         {showSetupProgress && (
-          <div className="rounded-xl border border-purple-400/25 bg-purple-500/5 p-4">
+          <div className="rounded-xl border border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] p-4">
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-purple-500/15">
-                <Loader2 size="1rem" className="animate-spin text-purple-300" />
+              <div className="mari-chrome-accent-soft-tile mari-accent-animated mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full">
+                <Loader2 size="1rem" className="animate-spin" />
               </div>
               <div className="flex-1">
-                <div className="text-sm font-medium text-purple-200">{setupLabel}</div>
+                <div className="mari-chrome-text-strong text-sm font-medium">{setupLabel}</div>
                 <div className="mt-1 text-xs text-[var(--muted-foreground)]/80">{setupDescription}</div>
               </div>
             </div>
@@ -973,7 +973,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                 </div>
                 <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--border)]">
                   <div
-                    className="h-full rounded-full bg-purple-400 transition-all duration-300"
+                    className="mari-chrome-accent-progress mari-accent-animated h-full rounded-full transition-all duration-300"
                     style={{ width: `${progressPercent}%` }}
                   />
                 </div>
@@ -984,7 +984,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
               </div>
             ) : (
               <div className="mt-4 h-2 w-full overflow-hidden rounded-full bg-[var(--border)]">
-                <div className="h-full w-1/3 animate-pulse rounded-full bg-purple-400/80" />
+                <div className="mari-chrome-accent-progress mari-accent-animated h-full w-1/3 animate-pulse rounded-full" />
               </div>
             )}
           </div>
@@ -1001,7 +1001,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                   key={`${model.backend}-${model.quantization}`}
                   className={`flex cursor-pointer items-center gap-3 rounded-xl border p-3 transition-colors ${
                     selectedQuant === model.quantization
-                      ? "border-purple-400/50 bg-purple-500/5"
+                      ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)]"
                       : "border-[var(--border)] hover:bg-[var(--secondary)]/50"
                   }`}
                 >
@@ -1016,7 +1016,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                   <div
                     className={`h-4 w-4 shrink-0 rounded-full border-2 transition-colors ${
                       selectedQuant === model.quantization
-                        ? "border-purple-400 bg-purple-400"
+                        ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-accent)]"
                         : "border-[var(--border)]"
                     }`}
                   >
@@ -1039,7 +1039,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                     </div>
                   </div>
                   {model.quantization === "q8_0" && (
-                    <span className="rounded-full bg-purple-500/15 px-2 py-0.5 text-[0.625rem] font-medium text-purple-300">
+                    <span className="mari-chrome-accent-surface mari-accent-animated rounded-full px-2 py-0.5 text-[0.625rem] font-medium">
                       Recommended
                     </span>
                   )}
@@ -1048,7 +1048,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
               <button
                 onClick={handleCuratedDownload}
                 disabled={!selectedPreset}
-                className="mt-1 flex items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25 disabled:opacity-50"
+                className="mari-chrome-accent-surface mari-accent-animated mt-1 flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors disabled:opacity-50"
               >
                 <Zap size="0.875rem" />
                 {hasModel ? "Switch to Curated Preset" : "Use Curated Preset"}
@@ -1076,7 +1076,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                       }
                     }}
                     placeholder="owner/repo"
-                    className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-purple-400/50"
+                    className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]"
                   />
                   <button
                     onClick={() => void handleListModels()}
@@ -1114,7 +1114,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                     <select
                       value={selectedCustomPath}
                       onChange={(event) => setSelectedCustomPath(event.target.value)}
-                      className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-purple-400/50"
+                      className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)]"
                     >
                       {customModels.map((entry) => (
                         <option key={entry.path} value={entry.path}>
@@ -1176,7 +1176,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
               <button
                 onClick={handleDone}
                 disabled={!canFinish}
-                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-purple-500/15 px-4 py-2.5 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/25 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-purple-500/15"
+                className="mari-chrome-accent-surface mari-accent-animated flex flex-1 items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Done
               </button>

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -61,9 +61,8 @@ import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 type JsonRecord = Record<string, unknown>;
 const BUILT_IN_AGENT_TYPE_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
 const AGENT_GRADIENT_SURFACE =
-  "bg-gradient-to-br from-violet-500 via-fuchsia-500 to-pink-500 text-white shadow-purple-500/25";
-const AGENT_GRADIENT_BUTTON =
-  "bg-gradient-to-r from-violet-500 via-fuchsia-500 to-pink-500 text-white shadow-md shadow-purple-500/20 hover:shadow-lg hover:shadow-purple-500/25";
+  "mari-panel-gradient-surface mari-panel-gradient--agents text-[var(--mari-panel-gradient-text)]";
+const AGENT_GRADIENT_BUTTON = "mari-panel-gradient-button mari-panel-gradient--agents";
 
 function isJsonRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -655,14 +654,7 @@ export function AgentsPanel() {
       />
 
       <div className="flex gap-2">
-        <button
-          onClick={handleCreateAgent}
-          className={cn(
-            "flex flex-1 items-center justify-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium transition-all hover:brightness-110 active:scale-[0.98]",
-            AGENT_GRADIENT_BUTTON,
-          )}
-          title="New"
-        >
+        <button onClick={handleCreateAgent} className={cn("flex-1 text-xs", AGENT_GRADIENT_BUTTON)} title="New">
           <Plus size="0.8125rem" />
         </button>
         <button
@@ -724,9 +716,7 @@ export function AgentsPanel() {
             New Folder
           </button>
         </div>
-        {agentFolders.length > 0 && (
-          <p className="mari-folder-helper">Drag and drop agents to folders</p>
-        )}
+        {agentFolders.length > 0 && <p className="mari-folder-helper">Drag and drop agents to folders</p>}
         {agentFolders.map((folder) => {
           const isEditing = editingFolderId === folder.id;
           const folderAgents = folder.itemIds
@@ -783,7 +773,7 @@ export function AgentsPanel() {
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+                    "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -830,9 +820,9 @@ export function AgentsPanel() {
                         if (expandedFolderId === folder.id) setExpandedFolderId(null);
                       });
                     }}
-	                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1"
-	                    title="Delete folder"
-	                  >
+                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1"
+                    title="Delete folder"
+                  >
                     <Trash2 size="0.6875rem" className="text-[var(--destructive)]" />
                   </button>
                 </div>
@@ -1031,7 +1021,9 @@ function renderAgentCard({
       }}
       className={cn(
         "group relative flex cursor-pointer items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)]",
-        selectionMode && selected && "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/40",
+        selectionMode &&
+          selected &&
+          "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
         isDragging && "opacity-50",
       )}
     >
@@ -1040,7 +1032,7 @@ function renderAgentCard({
           className={cn(
             "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
             selected
-              ? "border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]"
+              ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-button-text-active)]"
               : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
           )}
         >
@@ -1093,8 +1085,8 @@ function renderAgentCard({
       {!selectionMode && (
         <div className="absolute right-2 top-1/2 flex -translate-y-1/2 shrink-0 items-center gap-0.5 rounded-lg bg-[var(--sidebar)] px-1 py-0.5 opacity-0 shadow-sm ring-1 ring-[var(--border)] transition-opacity group-hover:opacity-100 max-md:opacity-100">
           <button
-	            className="mari-chrome-control mari-chrome-control--small p-1.5"
-	            title="Copy agent"
+            className="mari-chrome-control mari-chrome-control--small p-1.5"
+            title="Copy agent"
             onClick={(event) => {
               event.stopPropagation();
               onDuplicate();
@@ -1104,8 +1096,8 @@ function renderAgentCard({
           </button>
           {onDelete && (
             <button
-	              className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1.5"
-	              title="Delete agent"
+              className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1.5"
+              title="Delete agent"
               onClick={(event) => {
                 event.stopPropagation();
                 void onDelete();

--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -2,22 +2,28 @@
 // Panel: Browser (sidebar — shows imported characters)
 // ──────────────────────────────────────────────
 import { useState, useMemo, useCallback } from "react";
-import { useCharacters } from "../../hooks/use-characters";
+import { toast } from "sonner";
+import { useCharacters, useDeleteCharacter } from "../../hooks/use-characters";
 import { useStartChatFromCharacter } from "../../hooks/use-start-chat-from-character";
 import { useUIStore } from "../../stores/ui.store";
-import { Search, User, Globe, Wand2, MessageCircle } from "lucide-react";
+import { Search, User, Globe, Wand2, MessageCircle, Trash2 } from "lucide-react";
 import { cn, getAvatarCropStyle } from "../../lib/utils";
 import { ContextMenu, type ContextMenuItem } from "../ui/ContextMenu";
+import { showConfirmDialog } from "../../lib/app-dialogs";
 
 type CharacterRow = { id: string; data: string; avatarPath: string | null; createdAt: string; updatedAt: string };
 
 export function BotBrowserPanel() {
   const { data: characters, isLoading } = useCharacters();
+  const deleteCharacter = useDeleteCharacter();
   const openCharacterDetail = useUIStore((s) => s.openCharacterDetail);
+  const characterDetailId = useUIStore((s) => s.characterDetailId);
+  const closeCharacterDetail = useUIStore((s) => s.closeCharacterDetail);
   const openBotBrowser = useUIStore((s) => s.openBotBrowser);
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
   const { startChatFromCharacter } = useStartChatFromCharacter();
   const [search, setSearch] = useState("");
+  const [deletingCharacterId, setDeletingCharacterId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -60,6 +66,30 @@ export function BotBrowserPanel() {
     [characters],
   );
 
+  const handleDeleteCharacter = useCallback(
+    async (character: { id: string; name: string }) => {
+      const confirmed = await showConfirmDialog({
+        title: "Delete Imported Character",
+        message: `Delete "${character.name}" from your imported characters? This cannot be undone.`,
+        confirmLabel: "Delete",
+        tone: "destructive",
+      });
+      if (!confirmed) return;
+
+      setDeletingCharacterId(character.id);
+      try {
+        await deleteCharacter.mutateAsync(character.id);
+        if (characterDetailId === character.id) closeCharacterDetail();
+        toast.success(`Deleted "${character.name}".`);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Failed to delete character.");
+      } finally {
+        setDeletingCharacterId(null);
+      }
+    },
+    [characterDetailId, closeCharacterDetail, deleteCharacter],
+  );
+
   return (
     <div className="flex flex-col gap-2 p-3">
       {/* Browse online button */}
@@ -99,9 +129,8 @@ export function BotBrowserPanel() {
       ) : (
         <div className="flex flex-col gap-0.5">
           {filtered.map((char) => (
-            <button
+            <div
               key={char.id}
-              onClick={() => openCharacterDetail(char.id)}
               onContextMenu={(e) => {
                 e.preventDefault();
                 const greeting = getCharacterGreeting(char.id);
@@ -114,23 +143,47 @@ export function BotBrowserPanel() {
                   altGreetings: greeting.altGreetings,
                 });
               }}
-              className="group flex items-center gap-2.5 rounded-xl p-2 text-left transition-all hover:bg-[var(--sidebar-accent)]"
+              className="group flex items-center gap-1 rounded-xl transition-all hover:bg-[var(--sidebar-accent)]"
             >
-              <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-400 to-rose-500 text-white shadow-sm overflow-hidden">
-                {char.avatarPath ? (
-                  <img
-                    src={char.avatarPath}
-                    alt={char.name}
-                    loading="lazy"
-                    className="h-full w-full object-cover"
-                    style={getAvatarCropStyle()}
-                  />
-                ) : (
-                  <User size="0.875rem" />
-                )}
-              </div>
-              <span className="min-w-0 flex-1 truncate text-xs font-medium">{char.name}</span>
-            </button>
+              <button
+                type="button"
+                onClick={() => openCharacterDetail(char.id)}
+                className="flex min-w-0 flex-1 items-center gap-2.5 rounded-xl p-2 text-left"
+              >
+                <div className="mari-panel-gradient-surface mari-panel-gradient--browser relative flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-xl shadow-sm">
+                  {char.avatarPath ? (
+                    <img
+                      src={char.avatarPath}
+                      alt={char.name}
+                      loading="lazy"
+                      className="h-full w-full object-cover"
+                      style={getAvatarCropStyle()}
+                    />
+                  ) : (
+                    <User size="0.875rem" />
+                  )}
+                </div>
+                <span className="min-w-0 flex-1 truncate text-xs font-medium">{char.name}</span>
+              </button>
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void handleDeleteCharacter(char);
+                }}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                disabled={deletingCharacterId !== null}
+                className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger mr-1 h-8 w-8 shrink-0 p-0 text-[var(--destructive)] disabled:cursor-wait disabled:opacity-50"
+                title={`Delete ${char.name}`}
+                aria-label={`Delete ${char.name}`}
+              >
+                <Trash2 size="0.75rem" />
+              </button>
+            </div>
           ))}
         </div>
       )}

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -589,25 +589,22 @@ export function CharactersPanel() {
     });
   }, []);
 
-  const handleExportSelected = useCallback(
-    async () => {
-      if (selectedCharacterIds.size === 0) return;
-      setExportingSelected(true);
-      try {
-        await api.downloadPost(
-          "/characters/export-bulk",
-          { ids: [...selectedCharacterIds], format: "native" },
-          "marinara-characters.zip",
-        );
-        toast.success(`Exported ${selectedCharacterIds.size} character${selectedCharacterIds.size === 1 ? "" : "s"}`);
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to export characters");
-      } finally {
-        setExportingSelected(false);
-      }
-    },
-    [selectedCharacterIds],
-  );
+  const handleExportSelected = useCallback(async () => {
+    if (selectedCharacterIds.size === 0) return;
+    setExportingSelected(true);
+    try {
+      await api.downloadPost(
+        "/characters/export-bulk",
+        { ids: [...selectedCharacterIds], format: "native" },
+        "marinara-characters.zip",
+      );
+      toast.success(`Exported ${selectedCharacterIds.size} character${selectedCharacterIds.size === 1 ? "" : "s"}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export characters");
+    } finally {
+      setExportingSelected(false);
+    }
+  }, [selectedCharacterIds]);
 
   const handleDeleteSelected = useCallback(async () => {
     const ids = [...selectedCharacterIds];
@@ -660,7 +657,7 @@ export function CharactersPanel() {
       <div className="flex gap-2">
         <button
           onClick={() => openModal("create-character")}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-pink-400 to-rose-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-pink-500/15 transition-all hover:shadow-lg hover:shadow-pink-500/25 active:scale-[0.98]"
+          className="mari-panel-gradient-button mari-panel-gradient--characters flex-1 text-xs"
           title="New"
         >
           <Plus size="0.8125rem" />
@@ -693,10 +690,7 @@ export function CharactersPanel() {
       {/* Search + Sort */}
       <div className="flex gap-1.5">
         <div className="relative flex-1">
-          <Search
-            size="0.8125rem"
-            className="mari-chrome-field-icon absolute left-3 top-1/2 -translate-y-1/2"
-          />
+          <Search size="0.8125rem" className="mari-chrome-field-icon absolute left-3 top-1/2 -translate-y-1/2" />
           <input
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -708,7 +702,7 @@ export function CharactersPanel() {
           <select
             value={sort}
             onChange={(e) => setCharacterLibrarySort(e.target.value as CharacterLibrarySort)}
-            className="mari-chrome-field h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
+            className="mari-chrome-field mari-chrome-sort-field mari-accent-animated h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
             <option value="name-asc">A-Z</option>
@@ -719,7 +713,7 @@ export function CharactersPanel() {
           </select>
           <ArrowUpDown
             size="0.625rem"
-            className="mari-chrome-field-icon pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+            className="mari-chrome-field-icon mari-chrome-sort-icon mari-accent-animated pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
           />
         </div>
       </div>
@@ -793,11 +787,7 @@ export function CharactersPanel() {
                 }}
                 className={cn(
                   "mari-chrome-control mari-chrome-control--compact group/tag cursor-pointer",
-                  included
-                    ? "mari-chrome-control--selected"
-                    : excluded
-                      ? "mari-chrome-control--danger"
-                      : "",
+                  included ? "mari-chrome-control--selected" : excluded ? "mari-chrome-control--danger" : "",
                 )}
               >
                 {tag}
@@ -876,7 +866,7 @@ export function CharactersPanel() {
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+                    "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -895,7 +885,7 @@ export function CharactersPanel() {
                       }}
                       onClick={(e) => e.stopPropagation()}
                       onBlur={() => handleRenameGroup(group.id)}
-                      className="w-full bg-transparent text-xs font-medium outline-none ring-1 ring-[var(--primary)]/30 rounded px-1 py-0.5"
+                      className="w-full rounded bg-transparent px-1 py-0.5 text-xs font-medium outline-none ring-1 ring-[var(--marinara-chat-chrome-input-border-focus)]"
                     />
                   ) : (
                     <>
@@ -914,9 +904,9 @@ export function CharactersPanel() {
                       e.stopPropagation();
                       void handleDeleteGroup(group);
                     }}
-	                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1"
-	                    title="Delete folder"
-	                  >
+                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1"
+                    title="Delete folder"
+                  >
                     <Trash2 size="0.6875rem" className="text-[var(--destructive)]" />
                   </button>
                 </div>
@@ -975,137 +965,139 @@ export function CharactersPanel() {
                         event.dataTransfer.setData("application/x-marinara-character-ids", JSON.stringify(ids));
                         event.dataTransfer.setData("text/plain", memberId);
                       }}
-                        onDragEnd={() => setDraggedCharacterId(null)}
-                        onTouchStart={(event) => startCharacterTouchDrag(event, memberId)}
-                        onTouchEnd={finishCharacterTouchDrag}
-                        role="button"
-                        tabIndex={0}
-                        className={cn(
-                          "group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]",
-                          selectionMode && isBulkSelected && "bg-[var(--primary)]/8 ring-1 ring-[var(--primary)]/40",
-                          draggedCharacterId === memberId && "opacity-50",
-                        )}
-                      >
-                        {selectionMode && (
-                          <button
-                            type="button"
-                            aria-label={isBulkSelected ? "Deselect character" : "Select character"}
-                            className={cn(
-                              "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
-                              isBulkSelected
-                                ? "border-[var(--primary)] bg-[var(--primary)] text-white"
-                                : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
-                            )}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              toggleSelection(memberId);
-                            }}
-                          >
-                            <Check size="0.75rem" />
-                          </button>
-                        )}
-                        <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-pink-400 to-rose-500 text-white">
-                          <div className="absolute inset-0 overflow-hidden rounded-lg">
-                            {member.avatarPath ? (
-                              <img
-                                src={member.avatarPath}
-                                alt={memberName}
-                                loading="lazy"
-                                className="h-full w-full object-cover"
-                                style={getAvatarCropStyle(memberAvatarCrop)}
-                              />
-                            ) : (
-                              <div className="flex h-full w-full items-center justify-center">
-                                <User size="0.75rem" />
-                              </div>
-                            )}
-                          </div>
-                          {member.isFavorite && (
-                            <div
-                              aria-hidden="true"
-                              className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
-                            >
-                              <Star size="0.5625rem" className="fill-current" />
+                      onDragEnd={() => setDraggedCharacterId(null)}
+                      onTouchStart={(event) => startCharacterTouchDrag(event, memberId)}
+                      onTouchEnd={finishCharacterTouchDrag}
+                      role="button"
+                      tabIndex={0}
+                      className={cn(
+                        "group/member flex cursor-pointer items-center gap-2 rounded-lg p-1.5 transition-all hover:bg-[var(--sidebar-accent)]",
+                        selectionMode &&
+                          isBulkSelected &&
+                          "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
+                        draggedCharacterId === memberId && "opacity-50",
+                      )}
+                    >
+                      {selectionMode && (
+                        <button
+                          type="button"
+                          aria-label={isBulkSelected ? "Deselect character" : "Select character"}
+                          className={cn(
+                            "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                            isBulkSelected
+                              ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-button-text-active)]"
+                              : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleSelection(memberId);
+                          }}
+                        >
+                          <Check size="0.75rem" />
+                        </button>
+                      )}
+                      <div className="mari-accent-gradient-fill relative flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-[var(--primary-foreground)]">
+                        <div className="absolute inset-0 overflow-hidden rounded-lg">
+                          {member.avatarPath ? (
+                            <img
+                              src={member.avatarPath}
+                              alt={memberName}
+                              loading="lazy"
+                              className="h-full w-full object-cover"
+                              style={getAvatarCropStyle(memberAvatarCrop)}
+                            />
+                          ) : (
+                            <div className="flex h-full w-full items-center justify-center">
+                              <User size="0.75rem" />
                             </div>
                           )}
                         </div>
-                        <div className="min-w-0 flex-1">
-                          <span
-                            className="block truncate text-[0.75rem] font-medium"
-                            style={
-                              memberNameColor
-                                ? memberNameColor.startsWith("linear-gradient")
-                                  ? {
-                                      background: memberNameColor,
-                                      backgroundRepeat: "no-repeat",
-                                      backgroundSize: "100% 100%",
-                                      WebkitBackgroundClip: "text",
-                                      WebkitTextFillColor: "transparent",
-                                      backgroundClip: "text",
-                                      color: "transparent",
-                                      display: "inline-block",
-                                    }
-                                  : { color: memberNameColor }
-                                : undefined
-                            }
+                        {member.isFavorite && (
+                          <div
+                            aria-hidden="true"
+                            className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-md bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
                           >
-                            {memberName}
-                          </span>
-                          {memberTitle && (
-                            <span className="block truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
-                              {memberTitle}
-                            </span>
-                          )}
-                          {memberPreviewMetadata && (
-                            <span className="block truncate text-[0.5625rem] text-[var(--muted-foreground)]">
-                              {memberPreviewMetadata}
-                            </span>
-                          )}
-                          {memberTokenEstimate !== null && (
-                            <span
-                              className="flex items-center gap-1 text-[0.5625rem] text-[var(--muted-foreground)]"
-                              title="Estimated from character card text fields; actual tokenizer counts vary by model."
-                            >
-                              <Hash size="0.5rem" />
-                              {formatEstimatedTokens(memberTokenEstimate)}
-                            </span>
-                          )}
-                          {memberTags.length > 0 && (
-                            <span className="mt-0.5 flex flex-wrap gap-0.5">
-                              {memberTags.slice(0, 3).map((tag) => (
-                                <span
-                                  key={tag}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    toggleIncludedTag(tag);
-                                  }}
-                                  className="cursor-pointer rounded-full bg-[var(--primary)]/8 px-1.5 py-px text-[0.5rem] font-medium text-[var(--primary)]/70 transition-all hover:bg-[var(--primary)]/15 hover:text-[var(--primary)]"
-                                >
-                                  {tag}
-                                </span>
-                              ))}
-                              {memberTags.length > 3 && (
-                                <span className="rounded-full bg-[var(--secondary)] px-1.5 py-px text-[0.5rem] text-[var(--muted-foreground)]">
-                                  +{memberTags.length - 3}
-                                </span>
-                              )}
-                            </span>
-                          )}
-                        </div>
-                        {!selectionMode && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              void moveCharactersToFolder([memberId], null);
-                            }}
-                            className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
-                            title="Remove from folder"
-                          >
-                            <UserMinus size="0.6875rem" className="text-[var(--destructive)]" />
-                          </button>
+                            <Star size="0.5625rem" className="fill-current" />
+                          </div>
                         )}
                       </div>
-                    );
+                      <div className="min-w-0 flex-1">
+                        <span
+                          className="block truncate text-[0.75rem] font-medium"
+                          style={
+                            memberNameColor
+                              ? memberNameColor.startsWith("linear-gradient")
+                                ? {
+                                    background: memberNameColor,
+                                    backgroundRepeat: "no-repeat",
+                                    backgroundSize: "100% 100%",
+                                    WebkitBackgroundClip: "text",
+                                    WebkitTextFillColor: "transparent",
+                                    backgroundClip: "text",
+                                    color: "transparent",
+                                    display: "inline-block",
+                                  }
+                                : { color: memberNameColor }
+                              : undefined
+                          }
+                        >
+                          {memberName}
+                        </span>
+                        {memberTitle && (
+                          <span className="block truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
+                            {memberTitle}
+                          </span>
+                        )}
+                        {memberPreviewMetadata && (
+                          <span className="block truncate text-[0.5625rem] text-[var(--muted-foreground)]">
+                            {memberPreviewMetadata}
+                          </span>
+                        )}
+                        {memberTokenEstimate !== null && (
+                          <span
+                            className="mari-chrome-text-muted flex items-center gap-1 text-[0.5625rem]"
+                            title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                          >
+                            <Hash size="0.5rem" />
+                            {formatEstimatedTokens(memberTokenEstimate)}
+                          </span>
+                        )}
+                        {memberTags.length > 0 && (
+                          <span className="mt-0.5 flex flex-wrap gap-0.5">
+                            {memberTags.slice(0, 3).map((tag) => (
+                              <span
+                                key={tag}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleIncludedTag(tag);
+                                }}
+                                className="mari-chrome-muted-badge cursor-pointer px-1.5 py-px text-[0.5rem] transition-all hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                            {memberTags.length > 3 && (
+                              <span className="rounded-full bg-[var(--secondary)] px-1.5 py-px text-[0.5rem] text-[var(--muted-foreground)]">
+                                +{memberTags.length - 3}
+                              </span>
+                            )}
+                          </span>
+                        )}
+                      </div>
+                      {!selectionMode && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void moveCharactersToFolder([memberId], null);
+                          }}
+                          className="rounded p-0.5 opacity-0 transition-all hover:bg-[var(--destructive)]/15 group-hover/member:opacity-100"
+                          title="Remove from folder"
+                        >
+                          <UserMinus size="0.6875rem" className="text-[var(--destructive)]" />
+                        </button>
+                      )}
+                    </div>
+                  );
                 })}
               </SmoothFolderContent>
             </div>
@@ -1133,8 +1125,8 @@ export function CharactersPanel() {
 
       {!isLoading && filteredCharacters.length === 0 && (
         <div className="flex flex-col items-center gap-2 py-8 text-center">
-          <div className="animate-float flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-400/20 to-rose-500/20">
-            <User size="1.25rem" className="text-[var(--primary)]" />
+          <div className="mari-chrome-accent-soft-tile mari-accent-animated animate-float flex h-12 w-12 items-center justify-center rounded-2xl">
+            <User size="1.25rem" />
           </div>
           <p className="text-xs text-[var(--muted-foreground)]">{search ? "No matches found" : "No characters yet"}</p>
         </div>
@@ -1155,11 +1147,11 @@ export function CharactersPanel() {
         }}
         className={cn(
           "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
-          draggedCharacterId && "ring-1 ring-[var(--primary)]/20",
+          draggedCharacterId && "ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
         )}
       >
         {draggedCharacterId && (
-          <div className="rounded-xl border border-dashed border-[var(--primary)]/35 bg-[var(--primary)]/5 px-3 py-2 text-[0.625rem] text-[var(--primary)]">
+          <div className="rounded-xl border border-dashed border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-3 py-2 text-[0.625rem] text-[var(--marinara-chat-chrome-button-text-active)]">
             Drop here to move out of folder
           </div>
         )}
@@ -1198,7 +1190,9 @@ export function CharactersPanel() {
               onTouchEnd={finishCharacterTouchDrag}
               className={cn(
                 "group relative flex items-center gap-2.5 rounded-xl p-2 transition-all hover:bg-[var(--sidebar-accent)] cursor-pointer",
-                selectionMode && isBulkSelected && "ring-1 ring-[var(--primary)]/40 bg-[var(--primary)]/8",
+                selectionMode &&
+                  isBulkSelected &&
+                  "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
                 draggedCharacterId === char.id && "opacity-50",
               )}
             >
@@ -1209,7 +1203,7 @@ export function CharactersPanel() {
                   className={cn(
                     "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
                     isBulkSelected
-                      ? "border-[var(--primary)] bg-[var(--primary)] text-white"
+                      ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-button-text-active)]"
                       : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
                   )}
                   onClick={(e) => {
@@ -1221,7 +1215,7 @@ export function CharactersPanel() {
                 </button>
               )}
               {/* Avatar */}
-              <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-pink-400 to-rose-500 text-white shadow-sm">
+              <div className="mari-accent-gradient-fill relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-[var(--primary-foreground)] shadow-sm">
                 {avatarUrl ? (
                   <div className="absolute inset-0 overflow-hidden rounded-xl">
                     <img
@@ -1237,7 +1231,7 @@ export function CharactersPanel() {
                 {isFavorite && (
                   <div
                     aria-hidden="true"
-                    className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
+                    className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-md bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
                   >
                     <Star size="0.625rem" className="fill-current" />
                   </div>
@@ -1274,7 +1268,7 @@ export function CharactersPanel() {
                   <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">{previewMetadata}</div>
                 )}
                 <div
-                  className="flex items-center gap-1 text-[0.625rem] text-[var(--muted-foreground)]"
+                  className="mari-chrome-text-muted flex items-center gap-1 text-[0.625rem]"
                   title="Estimated from character card text fields; actual tokenizer counts vary by model."
                 >
                   <Hash size="0.5625rem" />
@@ -1289,7 +1283,7 @@ export function CharactersPanel() {
                           e.stopPropagation();
                           toggleIncludedTag(tag);
                         }}
-                        className="cursor-pointer rounded-full bg-[var(--primary)]/8 px-1.5 py-px text-[0.5rem] font-medium text-[var(--primary)]/70 transition-all hover:bg-[var(--primary)]/15 hover:text-[var(--primary)]"
+                        className="mari-chrome-muted-badge cursor-pointer px-1.5 py-px text-[0.5rem] transition-all hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
                       >
                         {tag}
                       </span>
@@ -1314,10 +1308,10 @@ export function CharactersPanel() {
                           toast.success(`Duplicated "${char.parsed?.name ?? "character"}"`);
                         },
                       });
-	                    }}
-	                    className="mari-chrome-control mari-chrome-control--small p-1.5"
-	                    title="Duplicate"
-	                  >
+                    }}
+                    className="mari-chrome-control mari-chrome-control--small p-1.5"
+                    title="Duplicate"
+                  >
                     <Copy size="0.75rem" />
                   </button>
                   <button
@@ -1335,9 +1329,9 @@ export function CharactersPanel() {
                       }
                       deleteCharacter.mutate(char.id);
                     }}
-	                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1.5"
-	                    title="Delete"
-	                  >
+                    className="mari-chrome-control mari-chrome-control--small mari-chrome-control--danger p-1.5"
+                    title="Delete"
+                  >
                     <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
                   </button>
                 </div>

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -605,7 +605,7 @@ function ConnectionRow({
         {(selectionMode ? isBulkSelected : isSelected) && (
           <div
             className={cn(
-              "absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full shadow-sm",
+              "absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-md shadow-sm",
               colors.badge,
             )}
           >
@@ -749,7 +749,8 @@ function ConnectionFolderRow({
       }}
       className={cn(
         "flex flex-col rounded-lg transition-colors",
-        isDropTarget && "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30",
+        isDropTarget &&
+          "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
       )}
     >
       {/* Folder header */}
@@ -778,12 +779,12 @@ function ConnectionFolderRow({
           onPointerDown={(e) => dragControls.start(e)}
           className="cursor-grab touch-none opacity-0 transition-opacity active:cursor-grabbing group-hover:opacity-100 max-md:opacity-100"
         >
-          <GripVertical size="0.625rem" className="text-[var(--muted-foreground)]" />
+          <GripVertical size="0.625rem" className="mari-chrome-accent-icon mari-accent-animated" />
         </div>
         <ChevronRight
           size="0.75rem"
           className={cn(
-            "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+            "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
             isExpanded && "rotate-90",
           )}
         />
@@ -1122,7 +1123,7 @@ export function ConnectionsPanel() {
         <button
           type="button"
           onClick={() => openModal("create-connection")}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-sky-400 to-blue-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-sky-400/15 transition-all hover:shadow-lg hover:shadow-sky-400/25 active:scale-[0.98]"
+          className="mari-panel-gradient-button mari-panel-gradient--connections flex-1 text-xs"
           aria-label="Create connection"
           title="New"
         >
@@ -1305,7 +1306,7 @@ export function ConnectionsPanel() {
         }}
         className={cn(
           "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
-          draggedConnectionId && "ring-1 ring-[var(--primary)]/20",
+          draggedConnectionId && "ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
         )}
       >
         {unfiledConnections.map(renderConnectionRow)}

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -702,7 +702,7 @@ export function LorebooksPanel() {
       <div className="flex gap-2">
         <button
           onClick={() => openModal("create-lorebook")}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-amber-400 to-orange-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-amber-400/15 transition-all hover:shadow-lg hover:shadow-amber-400/25 active:scale-[0.98]"
+          className="mari-panel-gradient-button mari-panel-gradient--lorebooks flex-1 text-xs"
           title="New"
         >
           <Plus size="0.8125rem" />
@@ -748,7 +748,7 @@ export function LorebooksPanel() {
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value as typeof sort)}
-            className="mari-chrome-field h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
+            className="mari-chrome-field mari-chrome-sort-field mari-accent-animated h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
             <option value="name-asc">A-Z</option>
@@ -759,7 +759,7 @@ export function LorebooksPanel() {
           </select>
           <ArrowUpDown
             size="0.625rem"
-            className="mari-chrome-field-icon pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+            className="mari-chrome-field-icon mari-chrome-sort-icon mari-accent-animated pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
           />
         </div>
       </div>
@@ -927,7 +927,7 @@ export function LorebooksPanel() {
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+                    "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -949,9 +949,7 @@ export function LorebooksPanel() {
                       className="w-full rounded bg-transparent px-1 py-0.5 text-xs font-medium outline-none ring-1 ring-amber-400/30"
                     />
                   ) : (
-                    <>
-                      <div className="truncate text-xs font-medium text-[var(--muted-foreground)]">{folder.name}</div>
-                    </>
+                    <div className="mari-chrome-text-muted truncate text-xs font-medium">{folder.name}</div>
                   )}
                 </div>
                 {(folderFilterActive ? folderItems.length : folder.itemIds.length) > 0 && (

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -482,7 +482,7 @@ export function PersonasPanel() {
       <div className="flex gap-2">
         <button
           onClick={handleCreate}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-emerald-400 to-teal-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-emerald-400/15 transition-all hover:shadow-lg hover:shadow-emerald-400/25 active:scale-[0.98]"
+          className="mari-panel-gradient-button mari-panel-gradient--personas flex-1 text-xs"
           title="New"
         >
           <Plus size="0.8125rem" />
@@ -527,7 +527,7 @@ export function PersonasPanel() {
           <select
             value={sort}
             onChange={(e) => setSort(e.target.value as SortOption)}
-            className="mari-chrome-field h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
+            className="mari-chrome-field mari-chrome-sort-field mari-accent-animated h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
             <option value="name-asc">A-Z</option>
@@ -538,7 +538,7 @@ export function PersonasPanel() {
           </select>
           <ArrowUpDown
             size="0.625rem"
-            className="mari-chrome-field-icon pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+            className="mari-chrome-field-icon mari-chrome-sort-icon mari-accent-animated pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
           />
         </div>
       </div>
@@ -690,7 +690,7 @@ export function PersonasPanel() {
                 <ChevronRight
                   size="0.75rem"
                   className={cn(
-                    "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+                    "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
                     isExpanded && "rotate-90",
                   )}
                 />
@@ -988,7 +988,7 @@ export function PersonasPanel() {
                   <Camera size="0.75rem" className="text-white" />
                 </div>
                 {active && (
-                  <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-400 shadow-sm">
+                  <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-md bg-emerald-400 shadow-sm">
                     <Check size="0.5rem" className="text-white" />
                   </div>
                 )}

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -295,8 +295,8 @@ export function PresetsPanel() {
     return (presets as unknown as PresetRow[]).filter(
       (p) =>
         p.name.toLowerCase().includes(q) ||
-      (p.description ?? "").toLowerCase().includes(q) ||
-      (p.author ?? "").toLowerCase().includes(q),
+        (p.description ?? "").toLowerCase().includes(q) ||
+        (p.author ?? "").toLowerCase().includes(q),
     );
   }, [presets, search]);
   const presetSearchActive = search.trim().length > 0;
@@ -615,27 +615,24 @@ export function PresetsPanel() {
     [draggedPresetId, movePresetsToFolder],
   );
 
-  const startPresetTouchDrag = useCallback(
-    (event: TouchEvent, presetId: string) => {
-      const timer = window.setTimeout(() => {
-        presetTouchDragRef.current = { id: presetId, timer: null, active: true };
-        suppressPresetClickRef.current = true;
-        setDraggedPresetId(presetId);
-      }, 450);
-      presetTouchDragRef.current = { id: presetId, timer, active: false };
-      event.currentTarget.addEventListener(
-        "touchcancel",
-        () => {
-          const current = presetTouchDragRef.current;
-          if (current?.timer) window.clearTimeout(current.timer);
-          presetTouchDragRef.current = null;
-          setDraggedPresetId(null);
-        },
-        { once: true },
-      );
-    },
-    [],
-  );
+  const startPresetTouchDrag = useCallback((event: TouchEvent, presetId: string) => {
+    const timer = window.setTimeout(() => {
+      presetTouchDragRef.current = { id: presetId, timer: null, active: true };
+      suppressPresetClickRef.current = true;
+      setDraggedPresetId(presetId);
+    }, 450);
+    presetTouchDragRef.current = { id: presetId, timer, active: false };
+    event.currentTarget.addEventListener(
+      "touchcancel",
+      () => {
+        const current = presetTouchDragRef.current;
+        if (current?.timer) window.clearTimeout(current.timer);
+        presetTouchDragRef.current = null;
+        setDraggedPresetId(null);
+      },
+      { once: true },
+    );
+  }, []);
 
   const finishPresetTouchDrag = useCallback(
     (event: TouchEvent) => {
@@ -672,15 +669,15 @@ export function PresetsPanel() {
       return (
         <div
           key={preset.id}
-	          className={cn(
-	            "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
-	            selectionMode &&
-	              isBulkSelected &&
-	              "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
-	            isSelected &&
-	              "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
-	            draggedPresetId === preset.id && "opacity-50",
-	          )}
+          className={cn(
+            "group relative flex cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
+            selectionMode &&
+              isBulkSelected &&
+              "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
+            isSelected &&
+              "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
+            draggedPresetId === preset.id && "opacity-50",
+          )}
           draggable
           onDragStart={(event) => {
             const ids = getDraggedPresetIds(preset.id);
@@ -704,31 +701,29 @@ export function PresetsPanel() {
             {selectionMode && (
               <div
                 className={cn(
-	                  "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
-	                  isBulkSelected
-	                    ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]"
-	                    : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
-	                )}
+                  "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                  isBulkSelected
+                    ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]"
+                    : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
+                )}
               >
                 <Check size="0.75rem" />
               </div>
             )}
-            <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-purple-400 to-violet-500 text-white shadow-sm">
+            <div className="mari-panel-gradient-surface mari-panel-gradient--presets relative flex h-10 w-10 shrink-0 items-center justify-center rounded-xl shadow-sm">
               <FileText size="1rem" />
               {isSelected && (
-                <div className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-purple-400 shadow-sm">
-                  <Check size="0.625rem" className="text-white" />
+                <div className="mari-panel-gradient-surface mari-panel-gradient--presets absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-md shadow-sm">
+                  <Check size="0.625rem" />
                 </div>
               )}
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
                 <span className="truncate text-sm font-medium">{preset.name}</span>
-	                {isDefault && (
-	                  <span className="mari-chrome-muted-badge shrink-0 rounded px-1 py-0.5 text-[0.5625rem]">
-	                    DEFAULT
-	                  </span>
-	                )}
+                {isDefault && (
+                  <span className="mari-chrome-muted-badge shrink-0 rounded px-1 py-0.5 text-[0.5625rem]">DEFAULT</span>
+                )}
               </div>
               <div className="flex items-center gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
                 <span className="flex items-center gap-0.5">
@@ -750,9 +745,9 @@ export function PresetsPanel() {
                     event.stopPropagation();
                     selectPreset(preset.id);
                   }}
-	                  className={cn(
-	                    "mari-chrome-control mari-chrome-control--small p-1.5",
-	                    isSelected && "mari-chrome-control--selected",
+                  className={cn(
+                    "mari-chrome-control mari-chrome-control--small p-1.5",
+                    isSelected && "mari-chrome-control--selected",
                   )}
                   title={isSelected ? "Unassign from chat" : "Assign to chat"}
                   aria-label={isSelected ? "Unassign preset from chat" : "Assign preset to chat"}
@@ -841,7 +836,7 @@ export function PresetsPanel() {
         <button
           type="button"
           onClick={() => openModal("create-preset")}
-          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gradient-to-r from-purple-400 to-violet-500 px-3 py-2.5 text-xs font-medium text-white shadow-md shadow-purple-400/15 transition-all hover:shadow-lg hover:shadow-purple-400/25 active:scale-[0.98]"
+          className="mari-panel-gradient-button mari-panel-gradient--presets flex-1 text-xs"
           aria-label="Create preset"
           title="New"
         >
@@ -898,9 +893,7 @@ export function PresetsPanel() {
             New Folder
           </button>
         </div>
-        {presetFolders.length > 0 && (
-          <p className="mari-folder-helper">Drag and drop presets to folders</p>
-        )}
+        {presetFolders.length > 0 && <p className="mari-folder-helper">Drag and drop presets to folders</p>}
       </div>
 
       <PanelSection title="Presets" icon={<FileText size="0.8125rem" />}>
@@ -960,7 +953,7 @@ export function PresetsPanel() {
                   <ChevronRight
                     size="0.75rem"
                     className={cn(
-                      "shrink-0 text-[var(--muted-foreground)] transition-transform duration-200 ease-out",
+                      "mari-chrome-accent-icon mari-accent-animated shrink-0 transition-transform duration-200 ease-out",
                       isExpanded && "rotate-90",
                     )}
                   />
@@ -979,11 +972,11 @@ export function PresetsPanel() {
                         }}
                         onClick={(event) => event.stopPropagation()}
                         onBlur={() => handleRenameFolder(folder.id)}
-                        className="w-full rounded bg-transparent px-1 py-0.5 text-xs font-medium outline-none ring-1 ring-purple-400/30"
+                        className="w-full rounded bg-transparent px-1 py-0.5 text-xs font-medium outline-none ring-1 ring-[var(--marinara-chat-chrome-input-border-focus)]"
                       />
                     ) : (
                       <>
-                        <div className="truncate text-xs font-medium text-[var(--muted-foreground)]">{folder.name}</div>
+                        <div className="mari-chrome-text truncate text-xs font-medium">{folder.name}</div>
                       </>
                     )}
                   </div>
@@ -1046,8 +1039,8 @@ export function PresetsPanel() {
         {/* Empty state */}
         {!isLoading && filteredPresets.length === 0 && (
           <div className="flex flex-col items-center gap-2 py-8 text-center">
-            <div className="animate-float flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-400/20 to-violet-500/20">
-              <FileText size="1.25rem" className="text-purple-400" />
+            <div className="mari-panel-gradient-surface mari-panel-gradient--presets animate-float flex h-12 w-12 items-center justify-center rounded-2xl">
+              <FileText size="1.25rem" />
             </div>
             <p className="text-xs text-[var(--muted-foreground)]">
               {search ? "No matching presets" : "No presets yet"}
@@ -1071,7 +1064,7 @@ export function PresetsPanel() {
           }}
           className={cn(
             "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
-            draggedPresetId && "ring-1 ring-purple-400/20",
+            draggedPresetId && "ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
           )}
         >
           {rootPresets.map((preset) => renderPresetRow(preset))}
@@ -1257,7 +1250,7 @@ function RegexSection({
               }}
             >
               <button
-                className="mt-0.5 shrink-0 cursor-grab rounded p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] active:cursor-grabbing"
+                className="mari-chrome-accent-text-muted mari-accent-animated mt-0.5 shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] active:cursor-grabbing"
                 title="Drag to reorder"
                 onClick={(event) => event.stopPropagation()}
                 onMouseDown={(event) => {
@@ -1298,12 +1291,8 @@ function RegexSection({
                   updateRegex.mutate({ id: script.id, enabled: !enabled });
                 }}
               >
-	                {enabled ? (
-	                  <ToggleRight size="0.875rem" />
-	                ) : (
-	                  <ToggleLeft size="0.875rem" />
-	                )}
-	              </button>
+                {enabled ? <ToggleRight size="0.875rem" /> : <ToggleLeft size="0.875rem" />}
+              </button>
               <button
                 type="button"
                 className="mari-chrome-control mari-chrome-control--small mt-0.5 shrink-0 p-1"
@@ -1452,12 +1441,8 @@ function FunctionsSection({
                   updateCustomTool.mutate({ id: tool.id, enabled: !enabled });
                 }}
               >
-	                {enabled ? (
-	                  <ToggleRight size="0.875rem" />
-	                ) : (
-	                  <ToggleLeft size="0.875rem" />
-	                )}
-	              </button>
+                {enabled ? <ToggleRight size="0.875rem" /> : <ToggleLeft size="0.875rem" />}
+              </button>
               <button
                 type="button"
                 className="mari-chrome-control mari-chrome-control--small mt-0.5 shrink-0 p-1"
@@ -1535,7 +1520,7 @@ function PanelSection({
         >
           <ChevronDown
             size="0.75rem"
-            className={cn("text-[var(--muted-foreground)] transition-transform", open && "rotate-180")}
+            className={cn("mari-chrome-accent-icon mari-accent-animated transition-transform", open && "rotate-180")}
           />
           <span className="text-[var(--marinara-chat-chrome-button-text)]">{icon}</span>
           {title}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_ROLEPLAY_BACKGROUND_URL,
   useUIStore,
   getDefaultAppAccentColor,
+  getDefaultAppBackgroundColor,
   getDefaultChatChromeTextColor,
   getDefaultChatTextColor,
   getTrackerPanelWidthForProfile,
@@ -134,6 +135,13 @@ const TABS = [
   { id: "import", label: "Import" },
   { id: "advanced", label: "Advanced" },
 ] as const;
+
+const SETTINGS_BUTTON_CLASS = "mari-chrome-control mari-chrome-control--small text-[0.6875rem]";
+const SETTINGS_PRIMARY_BUTTON_CLASS = "mari-chrome-control mari-chrome-control--primary text-xs";
+const SETTINGS_COMPACT_PRIMARY_BUTTON_CLASS =
+  "mari-chrome-control mari-chrome-control--compact mari-chrome-control--selected text-[0.625rem]";
+const SETTINGS_INLINE_ACCENT_BUTTON_CLASS =
+  "shrink-0 rounded-md border border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] px-1.5 py-0.5 text-[0.5625rem] font-semibold text-[var(--marinara-chat-chrome-button-text-active)] transition-colors hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] disabled:cursor-not-allowed disabled:opacity-45";
 
 const SETTINGS_COMPONENTS: Record<(typeof TABS)[number]["id"], React.FC> = {
   general: React.memo(GeneralSettings),
@@ -1060,7 +1068,7 @@ export function SettingsPanel() {
   mountedSettingsTabs.add(settingsTab);
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="mari-settings-panel-chrome flex h-full flex-col">
       <div role="tablist" className="grid flex-shrink-0 grid-cols-2 gap-2 p-3 pb-2 md:grid-cols-3">
         {TABS.map((tab) => (
           <button
@@ -1336,16 +1344,13 @@ function GeneralSettings() {
             onChange={setIntuitiveSwipeNavigation}
             help="In Conversation and Roleplay modes, use Left/Right Arrow on desktop or horizontal touch swipes on mobile to move between alternate generations on the latest assistant message."
           />
-          <div
-            className={cn("pl-5 transition-opacity", intuitiveSwipeNavigation ? "" : "pointer-events-none opacity-45")}
-          >
-            <ToggleSetting
-              label="Reroll past the newest swipe"
-              checked={intuitiveSwipeRerollLatest}
-              onChange={setIntuitiveSwipeRerollLatest}
-              help="When intuitive swipes are enabled, pressing Right Arrow or swiping left on the newest swipe of the latest assistant message creates a new reroll."
-            />
-          </div>
+          <ToggleSetting
+            label="Reroll past the newest swipe"
+            checked={intuitiveSwipeRerollLatest}
+            onChange={setIntuitiveSwipeRerollLatest}
+            disabled={!intuitiveSwipeNavigation}
+            help="When intuitive swipes are enabled, pressing Right Arrow or swiping left on the newest swipe of the latest assistant message creates a new reroll."
+          />
           <ToggleSetting
             label="Up Arrow edits last message"
             checked={editLastMessageOnArrowUp}
@@ -1657,7 +1662,7 @@ function GameAssetsSettings() {
                 .then(() => toast.success("Game assets rescanned."))
                 .catch(() => toast.error("Failed to rescan game assets."));
             }}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            className={SETTINGS_BUTTON_CLASS}
           >
             <RefreshCw size="0.75rem" />
             Rescan
@@ -1666,7 +1671,7 @@ function GameAssetsSettings() {
             <button
               key={folder.id}
               onClick={() => handleOpenGameAssetFolder(folder.id)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.6875rem] font-medium capitalize text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              className={cn(SETTINGS_BUTTON_CLASS, "capitalize")}
             >
               <FolderOpen size="0.75rem" />
               {folder.id}
@@ -1711,7 +1716,7 @@ function GameAssetsSettings() {
           />
           <button
             onClick={() => assetFileRef.current?.click()}
-            className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)]"
+            className={cn(SETTINGS_BUTTON_CLASS, "justify-center")}
           >
             <Upload size="0.875rem" />
             Choose Files
@@ -1720,10 +1725,9 @@ function GameAssetsSettings() {
             onClick={handleGameAssetUpload}
             disabled={assetUploading || assetFiles.length === 0}
             className={cn(
-              "inline-flex items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold ring-1 transition-all",
-              assetUploading || assetFiles.length === 0
-                ? "cursor-not-allowed bg-[var(--muted)] text-[var(--muted-foreground)] ring-[var(--border)]"
-                : "bg-[var(--primary)]/15 text-[var(--primary)] ring-[var(--primary)]/30 hover:bg-[var(--primary)]/20",
+              SETTINGS_BUTTON_CLASS,
+              "justify-center",
+              assetUploading || assetFiles.length === 0 ? "" : "mari-chrome-control--selected",
             )}
           >
             {assetUploading ? <Loader2 size="0.875rem" className="animate-spin" /> : <Upload size="0.875rem" />}
@@ -1748,8 +1752,15 @@ function GameAssetsSettings() {
 function AppearanceSettings() {
   const theme = useUIStore((s) => s.theme);
   const setTheme = useUIStore((s) => s.setTheme);
+  const appBackgroundColor = useUIStore((s) => s.appBackgroundColor);
+  const setAppBackgroundColor = useUIStore((s) => s.setAppBackgroundColor);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
   const setAppAccentColor = useUIStore((s) => s.setAppAccentColor);
+  const appAccentRgbMode = useUIStore((s) => s.appAccentRgbMode);
+  const setAppAccentRgbMode = useUIStore((s) => s.setAppAccentRgbMode);
+  const defaultAppBackgroundColor = getDefaultAppBackgroundColor(theme);
+  const displayedAppBackgroundColor =
+    appBackgroundColor.trim().toLowerCase() === defaultAppBackgroundColor.toLowerCase() ? "" : appBackgroundColor;
   const defaultAppAccentColor = getDefaultAppAccentColor(theme);
   const displayedAppAccentColor =
     appAccentColor.trim().toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : appAccentColor;
@@ -1763,6 +1774,13 @@ function AppearanceSettings() {
   const setChatBackgroundBlur = useUIStore((s) => s.setChatBackgroundBlur);
   const activeChatId = useChatStore((s) => s.activeChatId);
   const updateMeta = useUpdateChatMetadata();
+  const handleAppBackgroundColorChange = useCallback(
+    (color: string) => {
+      const normalized = color.trim();
+      setAppBackgroundColor(normalized.toLowerCase() === defaultAppBackgroundColor.toLowerCase() ? "" : normalized);
+    },
+    [defaultAppBackgroundColor, setAppBackgroundColor],
+  );
   const handleAppAccentColorChange = useCallback(
     (color: string) => {
       const normalized = color.trim();
@@ -1930,7 +1948,7 @@ function AppearanceSettings() {
           {/* ── Visual Style ── */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-1.5">
-              <Paintbrush size="0.75rem" className="text-[var(--muted-foreground)]" />
+              <Paintbrush size="0.75rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />
               <span className="text-xs font-medium">Visual Style</span>
               <HelpTooltip text="Choose how the entire app looks. 'Marinara' uses a retro Y2K aesthetic with glow effects. 'SillyTavern' uses a clean, minimal look inspired by the original SillyTavern." />
             </div>
@@ -1982,15 +2000,34 @@ function AppearanceSettings() {
           </label>
 
           <ColorPicker
+            value={displayedAppBackgroundColor}
+            onChange={handleAppBackgroundColorChange}
+            gradient
+            compact
+            label="Background Color"
+            helpText="Colors the main app shell background. Leave it on the scheme default to follow Dark and Light mode automatically. Gradients are supported for the shell paint."
+            emptyText={`Default ${defaultAppBackgroundColor}`}
+            emptyPreviewValue={defaultAppBackgroundColor}
+            clearLabel="Reset to default"
+          />
+
+          <ColorPicker
             value={displayedAppAccentColor}
             onChange={handleAppAccentColorChange}
             gradient
             compact
             label="Accent Color"
-            helpText="Colors the shared chat, roleplay, and game chrome: toolbar icons, button borders, focus rings, highlights, and panel outlines. Gradients unlock rainbow accents."
+            helpText="Colors the shared app accent layer: buttons, active icons, focus rings, highlights, panel outlines, and chat chrome."
             emptyText={`Default ${defaultAppAccentColor}`}
             emptyPreviewValue={defaultAppAccentColor}
             clearLabel="Reset to default"
+          />
+
+          <ToggleSetting
+            label="RGB Mode"
+            checked={appAccentRgbMode}
+            onChange={setAppAccentRgbMode}
+            help="Cycles the accent token itself. Solid accents gently brighten and darken; gradient accents slowly move color-to-color through the selected stops. Reduced-motion preferences are respected."
           />
 
           <label className="flex flex-col gap-1">
@@ -2018,7 +2055,7 @@ function AppearanceSettings() {
             )}
             <button
               onClick={() => api.post("/fonts/open-folder").catch(() => {})}
-              className="mt-1 inline-flex items-center gap-1.5 self-start rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+              className={cn(SETTINGS_BUTTON_CLASS, "mt-1 self-start")}
             >
               <FolderOpen size="0.75rem" />
               Open Fonts Folder
@@ -2047,7 +2084,7 @@ function AppearanceSettings() {
               <button
                 onClick={() => googleFontMutation.mutate(googleFontName.trim())}
                 disabled={!googleFontName.trim() || googleFontMutation.isPending}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-[0.6875rem] font-medium text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+                className={cn(SETTINGS_BUTTON_CLASS, "mari-chrome-control--selected")}
               >
                 {googleFontMutation.isPending ? (
                   <Loader2 size="0.75rem" className="animate-spin" />
@@ -2205,7 +2242,7 @@ function AppearanceSettings() {
               gradient
               compact
               label="Chat Chrome Text Color"
-              helpText="Controls text in tracker widgets, shared toolbar buttons, and windows opened from chat buttons. Leave it on the scheme default to swap automatically between dark and light mode. Gradients use a compatible fallback where plain CSS color is required."
+              helpText="Controls ordinary chrome copy in tracker widgets, folder labels, settings descriptors, and windows opened from chat buttons. Accent-colored button text and active icons follow Accent Color instead. Gradients use a compatible fallback where plain CSS color is required."
               emptyText={`Scheme default ${getDefaultChatChromeTextColor(theme)}`}
               emptyPreviewValue={getDefaultChatChromeTextColor(theme)}
               clearLabel="Reset to default"
@@ -2344,7 +2381,7 @@ function AppearanceSettings() {
                     ) : opt.id === "circles" ? (
                       <div className="flex h-14 items-center px-3">
                         <div className="relative flex-1 rounded-2xl rounded-tl-sm bg-black/25 px-3 py-2">
-                          <div className="absolute left-2 top-2 h-2.5 w-2.5 rounded-full bg-gradient-to-br from-rose-400 to-orange-300 shadow-[0_0_0_2px_rgba(255,255,255,0.16)]" />
+                          <div className="mari-settings-accent-dot absolute left-2 top-2 h-2.5 w-2.5 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.16)]" />
                           <div className="ml-4 h-1.5 w-14 rounded-full bg-white/20" />
                           <div className="mt-1.5 ml-4 h-1.5 w-20 rounded-full bg-white/12" />
                         </div>
@@ -2352,7 +2389,7 @@ function AppearanceSettings() {
                     ) : opt.id === "rectangles" ? (
                       <div className="flex h-14 items-center px-3">
                         <div className="relative flex-1 rounded-2xl rounded-tl-sm bg-black/25 py-2 pl-8 pr-3">
-                          <div className="absolute left-2 top-2 h-4 w-4 overflow-hidden rounded bg-gradient-to-b from-rose-400/75 via-orange-300/55 to-zinc-600/80 ring-1 ring-white/20">
+                          <div className="mari-settings-portrait-preview absolute left-2 top-2 h-4 w-4 overflow-hidden rounded ring-1 ring-white/20">
                             <div className="h-full w-full bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.24),transparent_58%)]" />
                           </div>
                           <div className="h-1.5 w-14 rounded-full bg-white/20" />
@@ -2361,7 +2398,7 @@ function AppearanceSettings() {
                       </div>
                     ) : (
                       <div className="flex h-14 items-stretch overflow-hidden bg-black/25">
-                        <div className="relative flex w-[42%] shrink-0 items-end justify-center overflow-hidden bg-[linear-gradient(155deg,rgba(251,146,60,0.96),rgba(244,114,182,0.78)_48%,rgba(39,39,42,0.96)_100%)]">
+                        <div className="mari-settings-scene-preview relative flex w-[42%] shrink-0 items-end justify-center overflow-hidden">
                           <div className="absolute left-1/2 top-2 h-4 w-4 -translate-x-1/2 rounded-full bg-orange-50/45 shadow-[0_0_12px_rgba(255,237,213,0.35)]" />
                           <div className="h-8 w-8 rounded-t-full bg-zinc-950/35" />
                           <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[32%] backdrop-blur-[4px] [mask-image:linear-gradient(to_bottom,transparent_0%,rgba(0,0,0,0.25)_28%,rgba(0,0,0,0.8)_100%)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0%,rgba(0,0,0,0.25)_28%,rgba(0,0,0,0.8)_100%)]" />
@@ -2395,7 +2432,7 @@ function AppearanceSettings() {
                   ) : (
                     <div
                       className={cn(
-                        "shrink-0 border border-white/20 bg-gradient-to-b from-rose-300/85 via-fuchsia-300/65 to-slate-900/90 shadow-lg transition-all",
+                        "mari-settings-portrait-preview shrink-0 border border-white/20 shadow-lg transition-all",
                         roleplayAvatarStyle === "circles"
                           ? "rounded-full"
                           : roleplayAvatarStyle === "rectangles"
@@ -2409,7 +2446,7 @@ function AppearanceSettings() {
                     />
                   )}
                   <div
-                    className="shrink-0 rounded-full border border-white/20 bg-gradient-to-b from-violet-200/85 via-purple-200/70 to-slate-900/95 shadow-lg transition-all"
+                    className="mari-settings-scene-preview shrink-0 rounded-full border border-white/20 shadow-lg transition-all"
                     style={{
                       width: toPreviewRem(roleplaySpritePreview.width),
                       height: toPreviewRem(roleplaySpritePreview.height),
@@ -2478,7 +2515,7 @@ function AppearanceSettings() {
                     }}
                   />
                   <div
-                    className="shrink-0 rounded-full border border-white/20 bg-gradient-to-b from-rose-200/85 via-fuchsia-200/70 to-slate-900/95 shadow-lg transition-all"
+                    className="mari-settings-portrait-preview shrink-0 rounded-full border border-white/20 shadow-lg transition-all"
                     style={{
                       width: toPreviewRem(gameFullBodyPreview.width),
                       height: toPreviewRem(gameFullBodyPreview.height),
@@ -2598,7 +2635,7 @@ function AppearanceSettings() {
                   className={cn(
                     "rounded-md px-2 py-1 transition-colors",
                     activeGradientScheme === "dark"
-                      ? "bg-[var(--primary)] text-[var(--primary-foreground)] shadow-sm"
+                      ? "mari-accent-animated bg-[var(--accent)] text-[var(--primary)] shadow-sm ring-1 ring-[var(--primary)]/25"
                       : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
                   )}
                 >
@@ -2610,7 +2647,7 @@ function AppearanceSettings() {
                   className={cn(
                     "rounded-md px-2 py-1 transition-colors",
                     activeGradientScheme === "light"
-                      ? "bg-[var(--primary)] text-[var(--primary-foreground)] shadow-sm"
+                      ? "mari-accent-animated bg-[var(--accent)] text-[var(--primary)] shadow-sm ring-1 ring-[var(--primary)]/25"
                       : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
                   )}
                 >
@@ -3013,7 +3050,7 @@ function BackgroundPicker({
                           <button
                             type="submit"
                             disabled={!renameInput.trim() || renameBg.isPending}
-                            className="shrink-0 rounded bg-[var(--primary)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--primary-foreground)] disabled:opacity-40"
+                            className={SETTINGS_INLINE_ACCENT_BUTTON_CLASS}
                           >
                             {renameBg.isPending ? "…" : "Save"}
                           </button>
@@ -3159,7 +3196,7 @@ function BackgroundPicker({
                         <button
                           onClick={() => addTag(bg.filename, bg.tags)}
                           disabled={!tagInput.trim()}
-                          className="shrink-0 rounded bg-[var(--primary)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--primary-foreground)] disabled:opacity-40"
+                          className={SETTINGS_INLINE_ACCENT_BUTTON_CLASS}
                         >
                           Add
                         </button>
@@ -3371,7 +3408,7 @@ function ThemesSettings() {
             <button
               onClick={handleSave}
               disabled={isSavingTheme}
-              className="flex items-center gap-1 rounded-md bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 active:scale-95 disabled:cursor-not-allowed disabled:opacity-60"
+              className={SETTINGS_COMPACT_PRIMARY_BUTTON_CLASS}
             >
               {isSavingTheme ? <Loader2 size="0.6875rem" className="animate-spin" /> : <Save size="0.6875rem" />}
               {isSavingTheme ? "Saving..." : "Save"}
@@ -3590,6 +3627,7 @@ function ThemesSettings() {
             <strong>Tip:</strong> CSS themes can override any CSS variable (e.g.{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--background</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--primary</code>,{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">--marinara-app-accent-solid</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-accent</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-accent-gradient</code>,{" "}
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-surface-bg</code>) or add custom
@@ -3613,6 +3651,8 @@ const CSS_TEMPLATE = `/* ══════════════════�
   /* --foreground: #e4e4e7; */
   /* --primary: #a78bfa; */
   /* --primary-foreground: #fff; */
+  /* --marinara-app-accent-solid: var(--primary); */
+  /* --marinara-app-accent-gradient: linear-gradient(90deg, var(--marinara-app-accent-solid), color-mix(in srgb, var(--marinara-app-accent-solid) 76%, var(--foreground) 24%), var(--marinara-app-accent-solid)); */
 
   /* ── Surface Colors ── */
   /* --card: #111118; */
@@ -3632,9 +3672,9 @@ const CSS_TEMPLATE = `/* ══════════════════�
   /* --sidebar: #0c0c12; */
 
   /* ── Shared Chat / Roleplay / Game Chrome ── */
-  /* --marinara-chat-chrome-accent: #d4acfb; */
-  /* --marinara-chat-chrome-accent-gradient: linear-gradient(90deg, var(--marinara-chat-chrome-accent), var(--marinara-chat-chrome-accent)); */
-  /* --marinara-chat-chrome-text: var(--foreground); */
+  /* --marinara-chat-chrome-accent: var(--marinara-app-accent-solid); */
+  /* --marinara-chat-chrome-accent-gradient: var(--marinara-app-accent-gradient); */
+  /* --marinara-chat-chrome-text: var(--foreground); Non-action chrome copy. */
   /* --marinara-chat-chrome-button-text-base: var(--marinara-chat-chrome-accent); */
   /* --marinara-chat-chrome-highlight-text-base: var(--marinara-chat-chrome-accent); */
   /* --marinara-chat-chrome-surface-bg: var(--card); */
@@ -4535,7 +4575,7 @@ function ImportSettings() {
         <div className="flex flex-col gap-2.5">
           <button
             onClick={() => openModal("st-bulk-import")}
-            className="flex items-center justify-center gap-2 rounded-lg bg-[var(--primary)]/12 px-3 py-3 text-xs font-semibold text-[var(--primary)] ring-1 ring-[var(--primary)]/30 transition-all hover:bg-[var(--primary)]/18 active:scale-[0.98]"
+            className={cn(SETTINGS_PRIMARY_BUTTON_CLASS, "w-full gap-2")}
           >
             <Download size="1rem" />
             Import from SillyTavern Folder
@@ -4646,7 +4686,7 @@ function ImportButton({
   };
 
   return (
-    <label className="flex cursor-pointer items-center justify-center rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-xs font-medium text-[var(--secondary-foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-[0.98]">
+    <label className={cn(SETTINGS_BUTTON_CLASS, "cursor-pointer py-2.5")}>
       {label}
       <input type="file" accept={accept} onChange={handleImport} className="hidden" />
     </label>
@@ -5017,7 +5057,7 @@ function AdvancedSettings() {
           <button
             type="button"
             onClick={saveAdminSecret}
-            className="max-w-full shrink-0 whitespace-nowrap rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95"
+            className={cn(SETTINGS_PRIMARY_BUTTON_CLASS, "max-w-full shrink-0 whitespace-nowrap")}
           >
             <span className="flex min-w-0 items-center justify-center gap-1.5">
               <Save size="0.75rem" className="shrink-0" />
@@ -5037,7 +5077,7 @@ function AdvancedSettings() {
             <button
               onClick={() => updateCheck.refetch()}
               disabled={updateCheck.isFetching}
-              className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+              className={SETTINGS_PRIMARY_BUTTON_CLASS}
             >
               {updateCheck.isFetching ? (
                 <>
@@ -5107,7 +5147,7 @@ function AdvancedSettings() {
                 <button
                   onClick={() => applyUpdate.mutate()}
                   disabled={applyUpdate.isPending}
-                  className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+                  className={SETTINGS_PRIMARY_BUTTON_CLASS}
                 >
                   {applyUpdate.isPending ? (
                     <>
@@ -5132,7 +5172,7 @@ function AdvancedSettings() {
                       href={updateCheck.data.releaseUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95"
+                      className={SETTINGS_PRIMARY_BUTTON_CLASS}
                     >
                       <Download size="0.8125rem" />
                       Download v{updateCheck.data.latestVersion}
@@ -5358,7 +5398,7 @@ function AdvancedSettings() {
                         className={cn(
                           "flex h-4 w-4 shrink-0 items-center justify-center rounded-full ring-1 transition-colors",
                           option.checked
-                            ? "bg-[var(--primary)] text-[var(--primary-foreground)] ring-[var(--primary)]"
+                            ? "mari-accent-animated bg-[var(--accent)] text-[var(--primary)] ring-[var(--primary)]/35"
                             : "bg-[var(--background)]/45 text-transparent ring-[var(--border)]/70 group-hover:text-[var(--muted-foreground)]",
                         )}
                         aria-hidden="true"
@@ -5426,7 +5466,7 @@ function AdvancedSettings() {
           <button
             onClick={handleCreateBackup}
             disabled={creatingBackup}
-            className="flex items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-medium text-white transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
+            className={SETTINGS_PRIMARY_BUTTON_CLASS}
           >
             {creatingBackup ? (
               <>

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -397,10 +397,8 @@ function PromptOverridesEditorBody({ keys, preferredKey }: { keys?: readonly str
           onClick={() => void handleSave()}
           disabled={!canSave}
           className={cn(
-            "inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50",
-            canSave
-              ? "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90"
-              : "bg-[var(--muted)] text-[var(--muted-foreground)]",
+            "mari-chrome-control flex-1 text-xs disabled:cursor-not-allowed",
+            canSave && "mari-chrome-control--selected",
           )}
         >
           {saveOverride.isPending ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Save size="0.8125rem" />}
@@ -410,7 +408,7 @@ function PromptOverridesEditorBody({ keys, preferredKey }: { keys?: readonly str
           type="button"
           onClick={() => void handleReset()}
           disabled={!canReset}
-          className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--background)] px-3 py-2 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--accent)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
+          className="mari-chrome-control flex-1 text-xs disabled:cursor-not-allowed"
         >
           {resetOverride.isPending ? (
             <Loader2 size="0.8125rem" className="animate-spin" />

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -12,7 +12,7 @@ import { cn } from "../../../lib/utils";
 import { HelpTooltip } from "../../ui/HelpTooltip";
 
 export function SettingsIntro({ children }: { children: ReactNode }) {
-  return <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">{children}</p>;
+  return <p className="text-xs leading-relaxed text-[var(--marinara-chat-chrome-panel-muted)]">{children}</p>;
 }
 
 export function SettingsSection({
@@ -49,7 +49,7 @@ export function SettingsSection({
               "mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md ring-1",
               tone === "danger"
                 ? "bg-[var(--destructive)]/10 text-[var(--destructive)] ring-[var(--destructive)]/25"
-                : "bg-[var(--secondary)]/70 text-[var(--primary)] ring-[var(--border)]",
+                : "bg-[var(--secondary)]/70 text-[var(--marinara-chat-chrome-button-text-active)] ring-[var(--border)]",
             )}
           >
             {icon}
@@ -66,7 +66,9 @@ export function SettingsSection({
             {help && <HelpTooltip text={help} />}
           </div>
           {description && (
-            <div className="mt-1 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">{description}</div>
+            <div className="mt-1 text-[0.625rem] leading-relaxed text-[var(--marinara-chat-chrome-panel-muted)]">
+              {description}
+            </div>
           )}
         </div>
       </div>
@@ -169,11 +171,13 @@ export function ToggleSetting({
   checked,
   onChange,
   help,
+  disabled = false,
 }: {
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
   help?: string;
+  disabled?: boolean;
 }) {
   return (
     <SettingsSwitch
@@ -181,6 +185,7 @@ export function ToggleSetting({
       checked={checked}
       onChange={onChange}
       help={help}
+      disabled={disabled}
       labelPosition="start"
       className="justify-between gap-3 p-1.5"
       labelClassName="text-xs"
@@ -235,7 +240,7 @@ export function SettingsCheckbox({
         )}
       </span>
       {description && (
-        <span className="mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+        <span className="mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--marinara-chat-chrome-panel-muted)]">
           {description}
         </span>
       )}
@@ -311,6 +316,7 @@ export function SettingsSwitch({
         className={cn(
           "relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--ring)]",
           checked ? "bg-[var(--primary)]/70" : "bg-[var(--border)]",
+          checked && "mari-accent-animated",
           disabled ? "cursor-not-allowed" : "cursor-pointer",
         )}
       >
@@ -335,7 +341,7 @@ export function SettingsSwitch({
         <label
           htmlFor={inputId}
           className={cn(
-            "mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]",
+            "mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--marinara-chat-chrome-panel-muted)]",
             disabled ? "cursor-not-allowed" : "cursor-pointer",
           )}
         >

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -901,7 +901,7 @@ export function TTSConfigCard() {
                 <button
                   onClick={() => void refetchVoices()}
                   disabled={fetchingVoices || !savedConfig?.enabled}
-                  className="flex shrink-0 items-center gap-1 rounded-xl bg-[var(--secondary)] px-3 py-2 text-xs ring-1 ring-[var(--border)] transition-colors hover:ring-rose-400/60 disabled:opacity-50"
+                  className="mari-chrome-control mari-chrome-control--small shrink-0 text-xs"
                   title="Refresh voices from provider"
                 >
                   <RefreshCw size="0.75rem" className={cn(fetchingVoices && "animate-spin")} />
@@ -975,7 +975,7 @@ export function TTSConfigCard() {
                     <button
                       type="button"
                       onClick={() => handleRemoveVoiceAssignment(index)}
-                      className="flex h-9 items-center justify-center rounded-lg border border-[var(--border)] px-2 text-[var(--muted-foreground)] transition-colors hover:border-rose-400/50 hover:text-rose-300 sm:w-9"
+                      className="mari-chrome-control mari-chrome-control--small h-9 min-h-0 px-2 sm:w-9"
                       title="Remove character voice"
                     >
                       <X size="0.75rem" />
@@ -986,7 +986,7 @@ export function TTSConfigCard() {
                   type="button"
                   onClick={handleAddVoiceAssignment}
                   disabled={voiceOptions.length === 0 || characterOptions.length === 0 || allCharactersAssigned}
-                  className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-[var(--border)] px-3 py-2 text-xs text-[var(--muted-foreground)] transition-colors hover:border-rose-400/50 hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+                  className="mari-chrome-control w-full text-xs"
                 >
                   <Plus size="0.75rem" />
                   Add character voice
@@ -1055,7 +1055,7 @@ export function TTSConfigCard() {
                     type="button"
                     onClick={() => void refetchVoices()}
                     disabled={fetchingVoices || !savedConfig?.enabled}
-                    className="flex shrink-0 items-center justify-center gap-1 rounded-xl bg-[var(--secondary)] px-3 py-2 text-xs ring-1 ring-[var(--border)] transition-colors hover:ring-rose-400/60 disabled:opacity-50"
+                    className="mari-chrome-control mari-chrome-control--small shrink-0 text-xs"
                     title="Refresh voices from provider"
                   >
                     <RefreshCw size="0.75rem" className={cn(fetchingVoices && "animate-spin")} />
@@ -1283,10 +1283,10 @@ export function TTSConfigCard() {
                 Saved
               </span>
             )}
-            {saveStatus === "error" && <span className="text-[0.6875rem] text-rose-400">Save failed</span>}
+            {saveStatus === "error" && <span className="text-[0.6875rem] text-[var(--destructive)]">Save failed</span>}
           </div>
           {previewError && (
-            <p className="rounded-lg border border-rose-400/20 bg-rose-500/10 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-rose-300">
+            <p className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 px-2.5 py-2 text-[0.6875rem] leading-relaxed text-[var(--destructive)]">
               {previewError}
             </p>
           )}

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -1381,7 +1381,7 @@ function PersonaSpritesTab({
               type="button"
               onClick={() => setSpriteGenOpen(true)}
               disabled={spriteGenerationUnavailable}
-              className="flex min-w-0 items-center justify-center gap-1.5 rounded-lg bg-purple-500/10 px-3 py-1.5 text-center text-[0.6875rem] font-medium leading-tight text-purple-400 ring-1 ring-purple-500/20 transition-all hover:bg-purple-500/20 disabled:cursor-not-allowed disabled:opacity-40 max-md:flex-1 max-md:basis-[calc(50%-0.25rem)] max-md:px-2.5"
+              className="mari-chrome-accent-surface mari-accent-animated flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-3 py-1.5 text-center text-[0.6875rem] font-medium leading-tight transition-all disabled:cursor-not-allowed disabled:opacity-40 max-md:flex-1 max-md:basis-[calc(50%-0.25rem)] max-md:px-2.5"
               title={
                 spriteGenerationUnavailable ? spriteGenerationReason : "Generate sprites using AI image generation"
               }
@@ -1779,7 +1779,7 @@ function PersonaColorsTab({
         className={cn(
           "flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-xs font-medium transition-all",
           avatarUrl
-            ? "bg-purple-500/15 text-purple-400 hover:bg-purple-500/25 active:scale-[0.98]"
+            ? "mari-chrome-accent-surface mari-accent-animated active:scale-[0.98]"
             : "cursor-not-allowed bg-white/5 text-[var(--muted-foreground)]/50",
         )}
       >
@@ -1910,7 +1910,7 @@ const DEFAULT_PERSONA_STATS: PersonaStatsData = {
     { name: "Satiety", value: 100, max: 100, color: "#f59e0b" },
     { name: "Energy", value: 100, max: 100, color: "#22c55e" },
     { name: "Hygiene", value: 100, max: 100, color: "#3b82f6" },
-    { name: "Mood", value: 100, max: 100, color: "#ec4899" },
+    { name: "Mood", value: 100, max: 100, color: "#eab308" },
   ],
   rpgStats: DEFAULT_RPG_STATS,
 };
@@ -1943,7 +1943,10 @@ function PersonaStatsTab({
   };
 
   const addBar = () => {
-    save({ ...parsed, bars: [...parsed.bars, { name: "New Stat", value: 100, max: 100, color: "#8b5cf6" }] });
+    save({
+      ...parsed,
+      bars: [...parsed.bars, { name: "New Stat", value: 100, max: 100, color: "#38bdf8" }],
+    });
   };
 
   const removeBar = (index: number) => {
@@ -2101,7 +2104,7 @@ function PersonaStatsTab({
                 <button
                   type="button"
                   onClick={addRpgAttribute}
-                  className="flex items-center gap-1 rounded-lg bg-purple-500/15 px-2.5 py-1 text-[0.6875rem] font-medium text-purple-400 transition-colors hover:bg-purple-500/25"
+                  className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1 rounded-lg px-2.5 py-1 text-[0.6875rem] font-medium transition-colors"
                 >
                   <Plus size="0.75rem" />
                   Add

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -98,7 +98,7 @@ type TabId = (typeof TABS)[number]["id"];
 const ROLE_COLORS: Record<string, string> = {
   system: "text-blue-400",
   user: "text-green-400",
-  assistant: "text-purple-400",
+  assistant: "mari-chrome-accent-text mari-accent-animated",
 };
 
 const ROLE_ICONS: Record<string, FC<{ size: string | number; className?: string }>> = {
@@ -357,7 +357,7 @@ export function PresetEditor() {
         >
           <ArrowLeft size="1.125rem" />
         </button>
-        <div className="mari-editor-icon-tile">
+        <div className="mari-editor-icon-tile mari-panel-gradient-surface mari-panel-gradient--presets">
           <FileText size="1.125rem" className="max-md:!h-[0.875rem] max-md:!w-[0.875rem]" />
         </div>
         <input
@@ -574,7 +574,7 @@ function OverviewTab({
               className={cn(
                 "flex items-center gap-2 rounded-xl px-4 py-2.5 text-xs font-medium transition-all",
                 wrapFormat === fmt
-                  ? "bg-purple-400/15 text-purple-400 ring-1 ring-purple-400/30"
+                  ? "mari-chrome-accent-surface mari-accent-animated"
                   : "bg-[var(--secondary)] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
               )}
             >
@@ -893,7 +893,8 @@ function SectionsTab({
                       onClick={() => handleAddSection({ isMarker: true, markerType: type })}
                       className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-xs text-[var(--foreground)] hover:bg-[var(--accent)]"
                     >
-                      <Layers size="0.8125rem" className="text-purple-400" /> {MARKER_LABELS[type]}
+                      <Layers size="0.8125rem" className="mari-chrome-accent-icon mari-accent-animated" />{" "}
+                      {MARKER_LABELS[type]}
                     </button>
                   ))}
                 {injectableAgents.length > 0 && (
@@ -1050,7 +1051,7 @@ function SectionsTab({
 
             return (
               <div key={section.id}>
-                {showDropBefore && <div className="mx-2 mb-1 h-0.5 rounded-full bg-purple-400" />}
+                {showDropBefore && <div className="mari-chrome-accent-progress mari-accent-animated mx-2 mb-1 h-0.5 rounded-full" />}
                 <div
                   draggable={dragReady === idx}
                   onDragStart={(e) => handleDragStart(idx, e)}
@@ -1123,7 +1124,7 @@ function SectionsTab({
                     </span>
 
                     {isMarker && (
-                      <span className="shrink-0 rounded bg-violet-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-violet-400">
+                      <span className="mari-chrome-accent-surface mari-accent-animated shrink-0 rounded px-1.5 py-0.5 text-[0.5625rem] font-medium">
                         MARKER
                       </span>
                     )}
@@ -1232,11 +1233,11 @@ function SectionsTab({
                           const isAgentMarker = mc.type === "agent_data";
                           return isAgentMarker ? (
                             <div className="space-y-2">
-                              <div className="rounded-lg bg-[var(--primary)]/5 p-3 text-xs text-[var(--primary)]">
+                              <div className="rounded-lg bg-[var(--primary)]/5 p-3 text-xs text-[var(--marinara-chat-chrome-panel-title)]">
                                 Agent section: <strong>{section.name}</strong>
                                 <p className="mt-1 text-[var(--muted-foreground)]">
                                   The{" "}
-                                  <code className="rounded bg-black/20 px-1 py-0.5 text-[0.625rem] font-mono text-pink-300">
+                                  <code className="rounded bg-black/20 px-1 py-0.5 text-[0.625rem] font-mono text-[var(--marinara-chat-chrome-panel-text)]">
                                     {"{{agent::" + (mc.agentType ?? "agent") + "}}"}
                                   </code>{" "}
                                   macro will be replaced with the latest output from the agent at assembly time. You can
@@ -1256,7 +1257,7 @@ function SectionsTab({
                               />
                             </div>
                           ) : (
-                            <div className="rounded-lg bg-violet-400/5 p-3 text-xs text-violet-300">
+                            <div className="mari-chrome-text rounded-lg bg-[var(--marinara-chat-chrome-highlight-bg)] p-3 text-xs">
                               Marker type: <strong>{MARKER_LABELS[mc.type as MarkerType] ?? "Unknown"}</strong>
                               <p className="mt-1 text-[var(--muted-foreground)]">
                                 Content is auto-generated at assembly time from your characters, lorebooks, etc.
@@ -1338,7 +1339,7 @@ function SectionsTab({
                     </div>
                   )}
                 </div>
-                {showDropAfter && <div className="mx-2 mt-1 h-0.5 rounded-full bg-purple-400" />}
+                {showDropAfter && <div className="mari-chrome-accent-progress mari-accent-animated mx-2 mt-1 h-0.5 rounded-full" />}
               </div>
             );
           })
@@ -1685,12 +1686,12 @@ function VariableCard({
           {opts.length} options
         </span>
         {opts.length === 1 && !isMultiSelect && (
-          <span className="shrink-0 rounded bg-purple-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-purple-400">
+          <span className="mari-chrome-accent-surface mari-accent-animated shrink-0 rounded px-1.5 py-0.5 text-[0.5625rem] font-medium">
             boolean
           </span>
         )}
         {isMultiSelect && (
-          <span className="shrink-0 rounded bg-purple-400/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-purple-400">
+          <span className="mari-chrome-accent-surface mari-accent-animated shrink-0 rounded px-1.5 py-0.5 text-[0.5625rem] font-medium">
             {isRandomPick ? "random" : "multi"}
           </span>
         )}
@@ -1740,8 +1741,8 @@ function VariableCard({
           {opts.length === 1 && !isMultiSelect ? (
             <div className="space-y-1.5 rounded-lg bg-[var(--secondary)] p-2.5 ring-1 ring-[var(--border)]">
               <div className="flex items-center gap-1.5">
-                <ToggleLeft size="0.75rem" className="text-purple-400" />
-                <span className="text-[0.625rem] font-medium text-purple-400">Boolean Toggle</span>
+                <ToggleLeft size="0.75rem" className="mari-chrome-accent-icon mari-accent-animated" />
+                <span className="mari-chrome-accent-text mari-accent-animated text-[0.625rem] font-medium">Boolean Toggle</span>
               </div>
               <p className="text-[0.5625rem] text-[var(--muted-foreground)]">
                 This variable has only one option, so it behaves as a Boolean toggle. Users can switch it on or off in
@@ -1752,14 +1753,14 @@ function VariableCard({
             <div className="space-y-2 rounded-lg bg-[var(--secondary)] p-2.5 ring-1 ring-[var(--border)]">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
-                  <ListChecks size="0.75rem" className="text-purple-400" />
+                  <ListChecks size="0.75rem" className="mari-chrome-accent-icon mari-accent-animated" />
                   <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Multi-Select</span>
                 </div>
                 <button
                   onClick={() => update({ multiSelect: !isMultiSelect })}
                   className={cn(
                     "relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full transition-colors",
-                    isMultiSelect ? "bg-purple-400" : "bg-[var(--border)]",
+                    isMultiSelect ? "mari-chrome-accent-progress mari-accent-animated" : "bg-[var(--border)]",
                   )}
                 >
                   <span
@@ -1813,7 +1814,7 @@ function VariableCard({
                         value={separatorValue}
                         onFocus={(e) => e.target.select()}
                         onChange={(e) => update({ separator: e.target.value })}
-                        className="w-20 rounded bg-[var(--background)] px-1.5 py-0.5 text-center font-mono text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-1 focus:ring-purple-400/50"
+                        className="w-20 rounded bg-[var(--background)] px-1.5 py-0.5 text-center font-mono text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-1 focus:ring-[var(--marinara-chat-chrome-input-border-focus)]"
                         placeholder=", "
                       />
                       <span className="text-[0.5625rem] text-[var(--muted-foreground)]">

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -136,8 +136,8 @@ const spotifyKeys = {
 
 const SPOTIFY_GREEN_CLASS = "text-[#1DB954]";
 const SPOTIFY_GREEN_BG_CLASS = "bg-[#1DB954]";
-const MUSIC_PLAYER_SHELL_BORDER_CLASS = "border-[#f7f3ef]/10";
-const MUSIC_PLAYER_SHELL_BG_CLASS = "bg-[#191414]/95";
+const MUSIC_PLAYER_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
+const MUSIC_PLAYER_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
 const MUSIC_PLAYER_BORDER_CLASS = "border-[#f7f3ef]/15";
 const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
 const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[#f7f3ef]/5";

--- a/packages/client/src/components/ui/HelpTooltip.tsx
+++ b/packages/client/src/components/ui/HelpTooltip.tsx
@@ -110,7 +110,7 @@ export function HelpTooltip({
         aria-label={label ? `Show help: ${label}` : "Show help"}
         aria-expanded={show}
         className={cn(
-          "inline-flex cursor-help items-center gap-1 rounded-full text-[var(--muted-foreground)] opacity-50 transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--primary)]/40",
+          "mari-chrome-accent-text-muted mari-accent-animated inline-flex cursor-help items-center gap-1 rounded-full opacity-70 transition-opacity hover:text-[var(--marinara-chat-chrome-button-text-hover)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
           buttonClassName,
         )}
         onMouseEnter={() => setShow(true)}

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -383,8 +383,10 @@ export function getWeatherIconColor(weather: string | null | undefined) {
   if (text.includes("ash") || text.includes("volcanic") || text.includes("smoke")) return "text-stone-300";
   if (text.includes("ember") || text.includes("fire") || text.includes("inferno")) return "text-red-400";
   if (text.includes("wind") || text.includes("breez") || text.includes("gust")) return "text-teal-300";
-  if (text.includes("cherry") || text.includes("blossom") || text.includes("petal")) return "text-pink-300";
-  if (text.includes("aurora") || text.includes("northern light")) return "text-fuchsia-300";
+  if (text.includes("cherry") || text.includes("blossom") || text.includes("petal"))
+    return "text-[var(--marinara-chat-chrome-panel-text)]";
+  if (text.includes("aurora") || text.includes("northern light"))
+    return "text-[var(--marinara-chat-chrome-panel-text)]";
   if (text.includes("cloud") || text.includes("overcast") || text.includes("grey") || text.includes("gray"))
     return "text-zinc-300";
   if (text.includes("clear") || text.includes("sunny") || text.includes("bright")) return "text-yellow-300";

--- a/packages/client/src/lib/css-colors.ts
+++ b/packages/client/src/lib/css-colors.ts
@@ -3,6 +3,9 @@ export const RAINBOW_GRADIENT_PRESET =
 
 const CSS_GRADIENT_RE = /\b(?:linear|radial|conic|repeating-linear|repeating-radial|repeating-conic)-gradient\(/i;
 const HEX_COLOR_RE = /#[0-9a-f]{3,8}\b/i;
+const COLOR_FUNCTION_RE = /^(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color|color-mix|var)\(/i;
+const CSS_DIRECTION_RE = /^(?:to\b|at\b|circle\b|ellipse\b|closest-side\b|closest-corner\b|farthest-side\b|farthest-corner\b)/i;
+const CSS_ANGLE_RE = /^[-+]?(?:\d+|\d*\.\d+)(?:deg|grad|rad|turn)\b/i;
 
 export function isCssGradient(value: string | null | undefined): value is string {
   return typeof value === "string" && CSS_GRADIENT_RE.test(value.trim());
@@ -12,9 +15,77 @@ export function getCssColorFallback(value: string | null | undefined, fallback: 
   const trimmed = typeof value === "string" ? value.trim() : "";
   if (!trimmed) return fallback;
   if (!isCssGradient(trimmed)) return trimmed;
-  return trimmed.match(HEX_COLOR_RE)?.[0] ?? fallback;
+  return getCssGradientColorStops(trimmed, fallback)[0] ?? fallback;
 }
 
 export function getCssBackgroundStyle(value: string) {
   return isCssGradient(value) ? { background: value } : { backgroundColor: value };
+}
+
+function splitTopLevelCommas(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth = Math.max(0, depth - 1);
+    } else if (char === "," && depth === 0) {
+      parts.push(value.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  parts.push(value.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+function readFunctionColor(value: string): string | null {
+  if (!COLOR_FUNCTION_RE.test(value)) return null;
+
+  let depth = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return value.slice(0, i + 1);
+    }
+  }
+
+  return null;
+}
+
+function extractColorStopColor(stop: string): string | null {
+  const trimmed = stop.trim();
+  if (!trimmed || CSS_DIRECTION_RE.test(trimmed) || CSS_ANGLE_RE.test(trimmed)) return null;
+
+  const hex = trimmed.match(HEX_COLOR_RE)?.[0];
+  if (hex) return hex;
+
+  const fn = readFunctionColor(trimmed);
+  if (fn) return fn;
+
+  const keyword = trimmed.match(/^[a-z][a-z-]*/i)?.[0];
+  return keyword ?? null;
+}
+
+export function getCssGradientColorStops(value: string | null | undefined, fallback: string): string[] {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) return [fallback];
+  if (!isCssGradient(trimmed)) return [trimmed];
+
+  const open = trimmed.indexOf("(");
+  const close = trimmed.lastIndexOf(")");
+  if (open < 0 || close <= open) return [fallback];
+
+  const colors = splitTopLevelCommas(trimmed.slice(open + 1, close))
+    .map(extractColorStopColor)
+    .filter((color): color is string => Boolean(color));
+
+  return colors.length > 0 ? colors : [fallback];
 }

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -85,6 +85,9 @@ export const TRACKER_PANEL_WIDTH_DEFAULT = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.sta
 export const TRACKER_PANEL_WIDTH_MIN = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.compact;
 export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expanded;
 export const TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR = "#09090b";
+export const DEFAULT_APP_BACKGROUND_DARK = "#050312";
+export const DEFAULT_APP_BACKGROUND_LIGHT = "#faf8ff";
+const DEFAULT_APP_BACKGROUNDS = new Set([DEFAULT_APP_BACKGROUND_DARK, DEFAULT_APP_BACKGROUND_LIGHT]);
 export const DEFAULT_APP_ACCENT_DARK = "#d4acfb";
 export const DEFAULT_APP_ACCENT_LIGHT = "#d4acfb";
 const LEGACY_DEFAULT_APP_ACCENTS = new Set(["#d4d4d4", "#1a1025"]);
@@ -138,6 +141,10 @@ export function getDefaultAppAccentColor(theme: "dark" | "light") {
   return theme === "light" ? DEFAULT_APP_ACCENT_LIGHT : DEFAULT_APP_ACCENT_DARK;
 }
 
+export function getDefaultAppBackgroundColor(theme: "dark" | "light") {
+  return theme === "light" ? DEFAULT_APP_BACKGROUND_LIGHT : DEFAULT_APP_BACKGROUND_DARK;
+}
+
 export function getDefaultChatTextColor(theme: "dark" | "light") {
   return theme === "light" ? DEFAULT_CHAT_TEXT_LIGHT : DEFAULT_CHAT_TEXT_DARK;
 }
@@ -159,6 +166,11 @@ function normalizeScrollTop(value: unknown) {
 function normalizeAppAccentColor(value: unknown) {
   const normalized = typeof value === "string" ? value.trim() : "";
   return LEGACY_DEFAULT_APP_ACCENTS.has(normalized.toLowerCase()) ? "" : normalized;
+}
+
+function normalizeAppBackgroundColor(value: unknown) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return DEFAULT_APP_BACKGROUNDS.has(normalized.toLowerCase()) ? "" : normalized;
 }
 
 function normalizeChatChromeTextColor(value: unknown) {
@@ -342,7 +354,9 @@ interface UIState {
   settingsTab: string;
   modal: { type: string; props?: Record<string, unknown> } | null;
   theme: "dark" | "light";
+  appBackgroundColor: string;
   appAccentColor: string;
+  appAccentRgbMode: boolean;
   chatBackground: string | null;
   /** Default background applied when a Roleplay chat has no saved background yet. */
   defaultRoleplayBackground: string;
@@ -487,7 +501,7 @@ interface UIState {
   narrationOpacity: number;
   /** Color for chat message text (empty = theme default) */
   chatFontColor: string;
-  /** Color for shared chat chrome text/icons in tracker widgets, toolbar buttons, and popovers (empty = scheme default) */
+  /** Color for non-action chrome copy in tracker widgets, folder labels, settings descriptors, and popovers (empty = scheme default) */
   chatChromeTextColor: string;
   /** Opacity for roleplay message backgrounds (0–100) */
   chatFontOpacity: number;
@@ -625,7 +639,9 @@ interface UIState {
   openModal: (type: string, props?: Record<string, unknown>) => void;
   closeModal: () => void;
   setTheme: (theme: "dark" | "light") => void;
+  setAppBackgroundColor: (color: string) => void;
   setAppAccentColor: (color: string) => void;
+  setAppAccentRgbMode: (enabled: boolean) => void;
   setChatBackground: (url: string | null) => void;
   setDefaultRoleplayBackground: (url: string) => void;
   setChatBackgroundBlur: (v: number) => void;
@@ -852,6 +868,7 @@ export function pickSyncedSettings(state: UIState) {
     trackerPanelCollapsedSections: state.trackerPanelCollapsedSections,
     trackerPanelSectionOrder: state.trackerPanelSectionOrder,
     theme: state.theme,
+    appBackgroundColor: state.appBackgroundColor,
     appAccentColor: state.appAccentColor,
     chatBackground: state.chatBackground,
     defaultRoleplayBackground: state.defaultRoleplayBackground,
@@ -977,7 +994,9 @@ export const useUIStore = create<UIState>()(
       settingsTab: "general",
       modal: null,
       theme: "dark" as const,
+      appBackgroundColor: "",
       appAccentColor: "",
+      appAccentRgbMode: true,
       chatBackground: null,
       defaultRoleplayBackground: DEFAULT_ROLEPLAY_BACKGROUND_URL,
       chatBackgroundBlur: 0,
@@ -1181,7 +1200,9 @@ export const useUIStore = create<UIState>()(
       openModal: (type, props) => set({ modal: { type, props } }),
       closeModal: () => set({ modal: null }),
       setTheme: (theme) => set({ theme }),
+      setAppBackgroundColor: (color) => set({ appBackgroundColor: normalizeAppBackgroundColor(color) }),
       setAppAccentColor: (color) => set({ appAccentColor: normalizeAppAccentColor(color) }),
+      setAppAccentRgbMode: (enabled) => set({ appAccentRgbMode: enabled }),
       setChatBackground: (url) => set({ chatBackground: url }),
       setDefaultRoleplayBackground: (url) => set({ defaultRoleplayBackground: normalizeDefaultRoleplayBackground(url) }),
       setChatBackgroundBlur: (v) => set({ chatBackgroundBlur: Math.max(0, Math.min(24, Math.round(v))) }),
@@ -1692,7 +1713,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 57,
+      version: 60,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2087,6 +2108,15 @@ export const useUIStore = create<UIState>()(
         if (version <= 52 && persisted.convertLatexSymbols === undefined) {
           persisted.convertLatexSymbols = true;
         }
+        if (version <= 57 && persisted.appAccentRgbMode === undefined) {
+          persisted.appAccentRgbMode = true;
+        }
+        if (version <= 58 && persisted.appBackgroundColor === undefined) {
+          persisted.appBackgroundColor = "";
+        }
+        if (version <= 59) {
+          persisted.appAccentRgbMode = true;
+        }
         persisted.characterLibrarySort = normalizeCharacterLibrarySort(persisted.characterLibrarySort);
         persisted.characterPanelScrollTop = normalizeScrollTop(persisted.characterPanelScrollTop);
         persisted.characterLibraryScrollTop = normalizeScrollTop(persisted.characterLibraryScrollTop);
@@ -2101,6 +2131,8 @@ export const useUIStore = create<UIState>()(
           persisted.recentUserActivities = [];
         }
         persisted.appAccentColor = normalizeAppAccentColor(persisted.appAccentColor);
+        persisted.appBackgroundColor = normalizeAppBackgroundColor(persisted.appBackgroundColor);
+        persisted.appAccentRgbMode = persisted.appAccentRgbMode === true;
         persisted.chatChromeTextColor = normalizeChatChromeTextColor(persisted.chatChromeTextColor);
         persisted.defaultRoleplayBackground = normalizeDefaultRoleplayBackground(persisted.defaultRoleplayBackground);
         delete persisted.trackerPanelWidth;
@@ -2141,7 +2173,9 @@ export const useUIStore = create<UIState>()(
         trackerPanelCollapsedSections: state.trackerPanelCollapsedSections,
         trackerPanelSectionOrder: state.trackerPanelSectionOrder,
         theme: state.theme,
+        appBackgroundColor: state.appBackgroundColor,
         appAccentColor: state.appAccentColor,
+        appAccentRgbMode: state.appAccentRgbMode,
         chatBackground: state.chatBackground,
         defaultRoleplayBackground: state.defaultRoleplayBackground,
         chatBackgroundBlur: state.chatBackgroundBlur,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -54,9 +54,9 @@
 
    QUICK CUSTOMIZATION GUIDE
    ─────────────────────────
-   • Change the app's accent color → edit --primary in §2
+   • Change the app's accent color → edit --primary / --marinara-app-accent-* in §2
    • Change chat toolbar/panel accents → edit --marinara-chat-chrome-accent in §2
-   • Change chat toolbar/panel text → edit --marinara-chat-chrome-text in §2
+   • Change ordinary chat chrome text → edit --marinara-chat-chrome-text in §2
    • Change rainbow chrome accents → edit --marinara-chat-chrome-accent-gradient in §2
    • Change the background color   → edit --background in §2
    • Change the font               → edit --font-y2k in §2
@@ -81,9 +81,10 @@
      --border, --input, --ring          Borders, inputs, focus rings
      --sidebar-*                        Left & right sidebar tones
      --glow-primary, --glow-accent      Glow effect bases
+     --marinara-app-accent-*            Shared app accent solid/gradient tokens
      --marinara-chat-chrome-*           Shared chat/game top buttons, panels, highlights
      --marinara-chat-chrome-accent      Shared chrome icon, border, ring, and highlight color
-     --marinara-chat-chrome-text        Shared chrome text color for tracker widgets, buttons, popovers
+     --marinara-chat-chrome-text        Shared non-action chrome text color for tracker widgets, panels, popovers
      --marinara-chat-chrome-accent-gradient  Optional gradient for rainbow chrome accents
 
    PALETTE (decorative flavor — components should NOT reference these
@@ -176,12 +177,13 @@
   color-scheme: dark;
 
   --background: #050312;
+  --marinara-app-background-paint: var(--background);
   --foreground: #d4d4d4;
   --card: #141414d9;
   --card-foreground: #d4d4d4;
   --popover: #141414d9;
   --popover-foreground: #d4d4d4;
-  --primary: #ffb3d9;
+  --primary: #d4acfb;
   --primary-foreground: #0a0a0a;
   --secondary: #1a1a2e;
   --secondary-foreground: #e8d4ff;
@@ -193,14 +195,14 @@
   --destructive-foreground: #0a0a0a;
   --border: #d4adfc33;
   --input: #d4adfc33;
-  --ring: #ffb3d9;
+  --ring: #d4acfb;
   --radius: 0.75rem;
   --sidebar: #08061a;
   --sidebar-foreground: #e8d4ff;
   --sidebar-border: #d4adfc22;
-  --sidebar-accent: #ffb3d91a;
-  --sidebar-accent-foreground: #ffb3d9;
-  --glow-primary: rgba(255, 179, 217, 0.15);
+  --sidebar-accent: #d4acfb1a;
+  --sidebar-accent-foreground: #d4acfb;
+  --glow-primary: color-mix(in srgb, var(--primary) 15%, transparent);
   --glow-accent: rgba(212, 173, 252, 0.12);
 
   /* Theme hooks for shared chat, roleplay, and game chrome. */
@@ -209,12 +211,24 @@
   --marinara-shell-edge-border: color-mix(in srgb, var(--foreground) 14%, var(--background) 86%);
   --marinara-music-player-shell-bg: var(--marinara-topbar-surface);
   --marinara-music-player-shell-border: var(--marinara-topbar-border);
-  --marinara-chat-chrome-accent: #d4acfb;
-  --marinara-chat-chrome-accent-gradient: linear-gradient(
+  --mari-logo-cyan: #4de5dd;
+  --mari-logo-cyan-deep: #3ab8b1;
+  --mari-logo-orange: #eb8951;
+  --mari-logo-orange-deep: #d97530;
+  --mari-logo-pink: #e15c8c;
+  --mari-logo-pink-deep: #c94776;
+  --mari-logo-title-cyan: #22d3ee;
+  --mari-logo-title-orange: #fb923c;
+  --mari-logo-title-pink: #ec4899;
+  --marinara-app-accent-solid: var(--primary);
+  --marinara-app-accent-gradient: linear-gradient(
     90deg,
-    var(--marinara-chat-chrome-accent),
-    var(--marinara-chat-chrome-accent)
+    var(--marinara-app-accent-solid),
+    color-mix(in srgb, var(--marinara-app-accent-solid) 76%, var(--foreground) 24%),
+    var(--marinara-app-accent-solid)
   );
+  --marinara-chat-chrome-accent: var(--marinara-app-accent-solid);
+  --marinara-chat-chrome-accent-gradient: var(--marinara-app-accent-gradient);
   --marinara-chat-chrome-text: var(--foreground);
   --marinara-chat-chrome-button-text-base: var(--marinara-chat-chrome-accent);
   --marinara-chat-chrome-highlight-text-base: var(--marinara-chat-chrome-accent);
@@ -343,32 +357,32 @@
 
   --glass-bg: linear-gradient(
     135deg,
-    rgba(255, 179, 217, 0.06) 0%,
+    color-mix(in srgb, var(--primary) 6%, transparent) 0%,
     rgba(212, 173, 252, 0.06) 50%,
     rgba(168, 216, 255, 0.06) 100%
   );
   --glass-border: rgba(255, 255, 255, 0.08);
   --glass-strong-bg: linear-gradient(
     135deg,
-    rgba(255, 179, 217, 0.1) 0%,
+    color-mix(in srgb, var(--primary) 10%, transparent) 0%,
     rgba(212, 173, 252, 0.1) 50%,
     rgba(168, 216, 255, 0.1) 100%
   );
   --glass-strong-border: rgba(255, 255, 255, 0.12);
   --glass-strong-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px rgba(255, 255, 255, 0.1);
 
-  --glow-color-1: rgba(255, 179, 217, 0.3);
+  --glow-color-1: color-mix(in srgb, var(--primary) 30%, transparent);
   --glow-color-2: rgba(212, 173, 252, 0.2);
   --glow-color-3: rgba(168, 216, 255, 0.1);
-  --glow-sm-1: rgba(255, 179, 217, 0.2);
+  --glow-sm-1: color-mix(in srgb, var(--primary) 20%, transparent);
   --glow-sm-2: rgba(212, 173, 252, 0.1);
 
   --scrollbar-track: #1a1a2e40;
   --scrollbar-border: #0a0a0a66;
 
-  --cursor-pink: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23FFB3D9' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E");
+  --cursor-pink: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23D4ACFB' stroke='%23000' stroke-width='1'/%3E%3C/svg%3E");
 
-  --y2k-pink: #ffb3d9;
+  --y2k-pink: var(--primary);
   --y2k-purple: #d4adfc;
   --y2k-blue: #a8d8ff;
   --y2k-mint: #b8f4d3;
@@ -406,13 +420,14 @@
   color-scheme: light;
 
   --background: #faf8ff;
+  --marinara-app-background-paint: var(--background);
   --foreground: #1a1025;
   --card: #ffffffee;
   --card-foreground: #1a1025;
   --popover: #ffffffee;
   --popover-foreground: #1a1025;
-  --primary: #e0709a;
-  --primary-foreground: #ffffff;
+  --primary: #d4acfb;
+  --primary-foreground: #0a0a0a;
   --secondary: #f0eaf7;
   --secondary-foreground: #3a2960;
   --muted: #f0eaf7;
@@ -423,13 +438,13 @@
   --destructive-foreground: #ffffff;
   --border: #d4adfc44;
   --input: #d4adfc44;
-  --ring: #e0709a;
+  --ring: #d4acfb;
   --sidebar: #f5f0fc;
   --sidebar-foreground: #3a2960;
   --sidebar-border: #d4adfc33;
-  --sidebar-accent: #e0709a18;
-  --sidebar-accent-foreground: #e0709a;
-  --glow-primary: rgba(224, 112, 154, 0.1);
+  --sidebar-accent: #d4acfb18;
+  --sidebar-accent-foreground: #d4acfb;
+  --glow-primary: color-mix(in srgb, var(--primary) 12%, transparent);
   --glow-accent: rgba(212, 173, 252, 0.08);
   --tracker-card-neutral-surface-top: color-mix(in srgb, var(--card) 84%, var(--accent) 16%);
   --tracker-card-neutral-surface-bottom: color-mix(in srgb, var(--secondary) 86%, var(--primary) 14%);
@@ -456,16 +471,16 @@
   --glass-strong-border: rgba(0, 0, 0, 0.08);
   --glass-strong-shadow: 0 4px 16px rgba(0, 0, 0, 0.06), inset 0 1px rgba(255, 255, 255, 0.5);
 
-  --glow-color-1: rgba(224, 112, 154, 0.2);
+  --glow-color-1: color-mix(in srgb, var(--primary) 20%, transparent);
   --glow-color-2: rgba(212, 173, 252, 0.15);
   --glow-color-3: rgba(168, 216, 255, 0.08);
-  --glow-sm-1: rgba(224, 112, 154, 0.15);
+  --glow-sm-1: color-mix(in srgb, var(--primary) 15%, transparent);
   --glow-sm-2: rgba(212, 173, 252, 0.08);
 
   --scrollbar-track: rgba(212, 173, 252, 0.1);
   --scrollbar-border: rgba(0, 0, 0, 0.1);
 
-  --y2k-pink: #e0709a;
+  --y2k-pink: var(--primary);
   --y2k-purple: #9b6ec6;
   --y2k-blue: #5ea0d4;
   --y2k-mint: #48c990;
@@ -504,8 +519,8 @@
 
 [data-theme="light"] .retro-glow-text {
   text-shadow:
-    0 0 5px rgba(224, 112, 154, 0.25),
-    0 0 10px rgba(155, 110, 198, 0.15);
+    0 0 5px color-mix(in srgb, var(--marinara-chat-chrome-text) 25%, transparent),
+    0 0 10px color-mix(in srgb, var(--marinara-chat-chrome-text) 12%, transparent);
 }
 
 [data-theme="light"] .os-window-btn {
@@ -536,45 +551,34 @@
    4a. SHARED CHROME GRADIENT ACCENTS
    ───────────────────────────────────────────── */
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg), var(--marinara-chat-chrome-button-bg)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border);
+  background: var(--marinara-chat-chrome-button-bg);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button:hover {
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg-hover), var(--marinara-chat-chrome-button-bg-hover))
-      padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border-hover);
+  background: var(--marinara-chat-chrome-surface-bg-hover);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button--open {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg-hover), var(--marinara-chat-chrome-button-bg-hover))
-      padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border-hover);
+  background: var(--marinara-chat-chrome-surface-bg-hover);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-toolbar-button--active {
-  border-color: transparent;
-  background: var(--marinara-chat-chrome-accent-gradient);
-  color: oklch(0.17 0.02 300);
+  border-color: var(--marinara-chat-chrome-button-border-active);
+  background: var(--marinara-chat-chrome-highlight-bg);
+  color: var(--marinara-chat-chrome-button-text-active);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-popover {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-panel-bg), var(--marinara-chat-chrome-panel-bg)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-panel-border);
+  background: var(--marinara-chat-chrome-panel-bg);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .marinara-chat-input-shell {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-input-bg), var(--marinara-chat-chrome-input-bg)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-input-border);
+  background: var(--marinara-chat-chrome-input-bg);
 }
 
 .marinara-chat-input-shell button:not(:disabled) {
@@ -687,6 +691,208 @@
   color: var(--destructive);
 }
 
+.mari-chat-logo-mode--conversation {
+  --mari-chat-logo-mode-color: var(--mari-logo-cyan);
+  --mari-chat-logo-mode-color-deep: var(--mari-logo-cyan-deep);
+  --mari-chat-logo-mode-text: #062426;
+}
+
+.mari-chat-logo-mode--roleplay {
+  --mari-chat-logo-mode-color: var(--mari-logo-orange);
+  --mari-chat-logo-mode-color-deep: var(--mari-logo-orange-deep);
+  --mari-chat-logo-mode-text: #261006;
+}
+
+.mari-chat-logo-mode--game {
+  --mari-chat-logo-mode-color: var(--mari-logo-pink);
+  --mari-chat-logo-mode-color-deep: var(--mari-logo-pink-deep);
+  --mari-chat-logo-mode-text: #fff7fb;
+}
+
+.mari-chat-mode-action {
+  border-color: color-mix(in srgb, var(--mari-chat-logo-mode-color) 42%, transparent);
+  background: linear-gradient(135deg, var(--mari-chat-logo-mode-color), var(--mari-chat-logo-mode-color-deep));
+  color: var(--mari-chat-logo-mode-text);
+  box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--mari-chat-logo-mode-color-deep) 20%, transparent);
+}
+
+.mari-chat-mode-action:hover,
+.mari-chat-mode-action:focus-visible {
+  border-color: color-mix(in srgb, var(--mari-chat-logo-mode-color) 62%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--mari-chat-logo-mode-color) 92%, var(--foreground) 8%),
+    color-mix(in srgb, var(--mari-chat-logo-mode-color-deep) 88%, var(--foreground) 12%)
+  );
+  color: var(--mari-chat-logo-mode-text);
+  box-shadow:
+    0 0.35rem 0.9rem color-mix(in srgb, var(--mari-chat-logo-mode-color-deep) 28%, transparent),
+    0 0 0 0.125rem color-mix(in srgb, var(--mari-chat-logo-mode-color) 18%, transparent);
+}
+
+.mari-chat-mode-avatar {
+  border: 1px solid color-mix(in srgb, var(--mari-chat-logo-mode-color) 34%, transparent);
+  background: color-mix(in srgb, var(--mari-chat-logo-mode-color) 16%, var(--marinara-chat-chrome-panel-bg) 84%);
+  color: var(--mari-chat-logo-mode-color);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--mari-chat-logo-mode-color) 18%, transparent);
+}
+
+.mari-chat-mode-badge {
+  background: color-mix(in srgb, var(--mari-chat-logo-mode-color) 18%, var(--card) 82%);
+  color: var(--mari-chat-logo-mode-color);
+  box-shadow: 0 0 0.45rem color-mix(in srgb, var(--mari-chat-logo-mode-color) 24%, transparent);
+}
+
+.mari-panel-gradient-button,
+.mari-panel-gradient-surface {
+  --mari-panel-gradient-start: var(--marinara-app-accent-solid);
+  --mari-panel-gradient-end: color-mix(in srgb, var(--marinara-app-accent-solid) 76%, var(--foreground) 24%);
+  --mari-panel-gradient-text: var(--primary-foreground);
+  background: linear-gradient(135deg, var(--mari-panel-gradient-start), var(--mari-panel-gradient-end));
+  color: var(--mari-panel-gradient-text);
+  box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--mari-panel-gradient-end) 18%, transparent);
+}
+
+.mari-panel-gradient-button {
+  display: inline-flex;
+  min-height: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  border: 1px solid color-mix(in srgb, var(--mari-panel-gradient-start) 34%, transparent);
+  border-radius: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  font-weight: 700;
+  transition:
+    filter 150ms ease,
+    transform 120ms ease,
+    box-shadow 150ms ease;
+}
+
+.mari-panel-gradient-button:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 0.35rem 0.9rem color-mix(in srgb, var(--mari-panel-gradient-end) 24%, transparent);
+}
+
+.mari-panel-gradient-button:active {
+  transform: scale(0.98);
+}
+
+.mari-panel-gradient-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  filter: none;
+}
+
+.mari-panel-gradient--characters {
+  --mari-panel-gradient-start: #f472b6;
+  --mari-panel-gradient-end: #f43f5e;
+  --mari-panel-gradient-text: #fff7fb;
+}
+
+.mari-panel-gradient--lorebooks {
+  --mari-panel-gradient-start: #f59e0b;
+  --mari-panel-gradient-end: #f97316;
+  --mari-panel-gradient-text: #fff7ed;
+}
+
+.mari-panel-gradient--presets {
+  --mari-panel-gradient-start: #c084fc;
+  --mari-panel-gradient-end: #8b5cf6;
+  --mari-panel-gradient-text: #fbf7ff;
+}
+
+.mari-panel-gradient--connections {
+  --mari-panel-gradient-start: #38bdf8;
+  --mari-panel-gradient-end: #3b82f6;
+  --mari-panel-gradient-text: #f0f9ff;
+}
+
+.mari-panel-gradient--agents {
+  --mari-panel-gradient-start: #a78bfa;
+  --mari-panel-gradient-end: #a855f7;
+  --mari-panel-gradient-text: #fbf7ff;
+}
+
+.mari-panel-gradient--personas {
+  --mari-panel-gradient-start: #34d399;
+  --mari-panel-gradient-end: #14b8a6;
+  --mari-panel-gradient-text: #ecfdf5;
+}
+
+.mari-panel-gradient--browser {
+  --mari-panel-gradient-start: #a3e635;
+  --mari-panel-gradient-end: #14b8a6;
+  --mari-panel-gradient-text: #07130f;
+}
+
+.mari-topbar-button {
+  color: var(--marinara-chat-chrome-button-text);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    opacity 150ms ease,
+    transform 120ms ease;
+}
+
+.mari-topbar-button:hover {
+  background: var(--accent);
+  color: var(--marinara-chat-chrome-button-text-hover);
+}
+
+.mari-topbar-button--active {
+  background: var(--accent);
+  color: var(--marinara-chat-chrome-button-text-active);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--primary) 16%, transparent);
+}
+
+.mari-topbar-chat-cycle {
+  color: var(--mari-logo-cyan);
+  animation: mari-topbar-logo-color-cycle 8.4s ease-in-out infinite;
+}
+
+.mari-topbar-chat-cycle-underline {
+  background: linear-gradient(
+    90deg,
+    var(--mari-logo-cyan) 0%,
+    var(--mari-logo-orange) 34%,
+    var(--mari-logo-pink) 68%,
+    var(--mari-logo-cyan) 100%
+  );
+  background-size: 220% 100%;
+  animation: mari-topbar-logo-underline-cycle 8.4s ease-in-out infinite;
+}
+
+@keyframes mari-topbar-logo-color-cycle {
+  0%,
+  100% {
+    color: var(--mari-logo-cyan);
+  }
+  34% {
+    color: var(--mari-logo-orange);
+  }
+  68% {
+    color: var(--mari-logo-pink);
+  }
+}
+
+@keyframes mari-topbar-logo-underline-cycle {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mari-topbar-chat-cycle,
+  .mari-topbar-chat-cycle-underline {
+    animation: none;
+  }
+}
+
 .mari-chrome-segmented {
   display: grid;
   min-height: 2.5rem;
@@ -767,6 +973,25 @@
   opacity: 0.68;
 }
 
+.mari-chrome-sort-field {
+  border-color: var(--marinara-chat-chrome-button-border);
+  color: var(--marinara-chat-chrome-button-text-active);
+}
+
+.mari-chrome-sort-field:hover {
+  border-color: var(--marinara-chat-chrome-button-border-hover);
+}
+
+.mari-chrome-sort-field option {
+  background: var(--marinara-chat-chrome-panel-bg);
+  color: var(--marinara-chat-chrome-button-text-active);
+}
+
+.mari-chrome-sort-icon {
+  color: var(--marinara-chat-chrome-button-text-active);
+  opacity: 1;
+}
+
 .mari-chrome-field:focus,
 .mari-chrome-field:focus-visible {
   border-color: var(--marinara-chat-chrome-input-border-focus);
@@ -797,9 +1022,88 @@
 .mari-folder-helper {
   margin-top: 0;
   padding: 0 0.625rem;
-  color: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+  color: var(--marinara-chat-chrome-panel-muted);
   font-size: 0.625rem;
   line-height: 1.25;
+}
+
+.mari-chrome-text {
+  color: var(--marinara-chat-chrome-panel-text);
+}
+
+.mari-chrome-text-strong {
+  color: var(--marinara-chat-chrome-panel-title);
+}
+
+.mari-chrome-text-muted {
+  color: var(--marinara-chat-chrome-panel-muted);
+}
+
+.mari-chrome-token-scope,
+.mari-settings-panel-chrome {
+  --accent: var(--marinara-chat-chrome-highlight-bg);
+  --accent-foreground: var(--marinara-chat-chrome-highlight-text);
+  --foreground: var(--marinara-chat-chrome-panel-title);
+  --muted-foreground: var(--marinara-chat-chrome-panel-muted);
+  --sidebar-accent: var(--marinara-chat-chrome-highlight-bg);
+  --sidebar-accent-foreground: var(--marinara-chat-chrome-panel-title);
+  --sidebar-foreground: var(--marinara-chat-chrome-panel-text);
+}
+
+.mari-chrome-accent-text,
+.mari-chrome-accent-icon {
+  color: var(--marinara-chat-chrome-button-text-active);
+}
+
+.mari-chrome-accent-text-muted {
+  color: var(--marinara-chat-chrome-button-text);
+}
+
+.mari-chrome-accent-surface {
+  border-color: var(--marinara-chat-chrome-button-border-active);
+  background: var(--marinara-chat-chrome-highlight-bg);
+  color: var(--marinara-chat-chrome-button-text-active);
+}
+
+.mari-chrome-accent-surface:hover {
+  border-color: var(--marinara-chat-chrome-button-border-hover);
+  background: var(--marinara-chat-chrome-highlight-bg-hover);
+  color: var(--marinara-chat-chrome-button-text-hover);
+}
+
+.mari-chrome-accent-tile {
+  background: var(--marinara-app-accent-gradient);
+  color: var(--primary-foreground);
+  box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--marinara-app-accent-solid) 18%, transparent);
+}
+
+.mari-chrome-accent-soft-tile {
+  background: color-mix(in srgb, var(--marinara-chat-chrome-accent) 14%, transparent);
+  color: var(--marinara-chat-chrome-button-text-active);
+  box-shadow: inset 0 0 0 1px var(--marinara-chat-chrome-button-border);
+}
+
+.mari-chrome-accent-dot,
+.mari-chrome-accent-progress {
+  background: var(--marinara-chat-chrome-accent);
+}
+
+.mari-chrome-accent-rail {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--marinara-chat-chrome-accent) 18%, transparent),
+    color-mix(in srgb, var(--marinara-chat-chrome-accent) 10%, transparent),
+    transparent
+  );
+}
+
+.mari-chrome-accent-rail-strong {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--marinara-chat-chrome-accent) 90%, transparent),
+    color-mix(in srgb, var(--marinara-chat-chrome-accent) 65%, transparent),
+    transparent
+  );
 }
 
 .mari-chrome-muted-badge {
@@ -837,41 +1141,105 @@
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control:not(.mari-chrome-control--danger) {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg), var(--marinara-chat-chrome-button-bg)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border);
+  background: var(--marinara-chat-chrome-button-bg);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control:not(.mari-chrome-control--danger):hover {
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg-hover), var(--marinara-chat-chrome-button-bg-hover))
-      padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border-hover);
+  background: var(--marinara-chat-chrome-surface-bg-hover);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control--selected,
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control[aria-pressed="true"] {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg-active), var(--marinara-chat-chrome-button-bg-active))
-      padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border-active);
+  background: var(--marinara-chat-chrome-surface-bg-active);
+  color: var(--marinara-chat-chrome-button-text-active);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-segmented {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-button-bg), var(--marinara-chat-chrome-button-bg)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-button-border);
+  background: var(--marinara-chat-chrome-button-bg);
 }
 
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-field:focus,
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-field:focus-visible {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-chat-chrome-input-bg), var(--marinara-chat-chrome-input-bg)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-chat-chrome-input-border-focus);
+  background: var(--marinara-chat-chrome-input-bg);
+}
+
+[data-marinara-accent-animation]
+  :where(.mari-chrome-token-scope, .mari-rgb-icon-scope, .mari-editor-shell, .mari-settings-panel-chrome)
+  svg:not(.mari-rgb-static-icon) {
+  color: var(--marinara-chat-chrome-button-text-active);
+  stroke: currentColor;
+  transition:
+    color 140ms linear,
+    stroke 140ms linear,
+    filter 140ms linear;
+}
+
+.mari-accent-gradient-fill,
+.mari-topbar-active-underline {
+  background: var(--marinara-app-accent-gradient);
+}
+
+.mari-accent-soft-fill {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--marinara-app-accent-solid) 24%, transparent),
+    color-mix(in srgb, var(--marinara-app-accent-solid) 12%, transparent)
+  );
+}
+
+.mari-settings-accent-dot {
+  background: linear-gradient(
+    135deg,
+    var(--marinara-app-accent-solid),
+    color-mix(in srgb, var(--marinara-app-accent-solid) 62%, var(--foreground) 38%)
+  );
+}
+
+.mari-settings-portrait-preview {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--marinara-app-accent-solid) 78%, var(--foreground) 22%),
+    color-mix(in srgb, var(--marinara-app-accent-solid) 48%, transparent),
+    color-mix(in srgb, var(--background) 88%, var(--marinara-app-accent-solid) 12%)
+  );
+}
+
+.mari-settings-scene-preview {
+  background: linear-gradient(
+    155deg,
+    color-mix(in srgb, var(--marinara-app-accent-solid) 76%, var(--foreground) 24%),
+    color-mix(in srgb, var(--marinara-app-accent-solid) 52%, transparent) 48%,
+    color-mix(in srgb, var(--background) 88%, var(--marinara-app-accent-solid) 12%) 100%
+  );
+}
+
+[data-marinara-accent-animation]
+  :where(
+    .mari-accent-animated,
+    .mari-accent-gradient-fill,
+    .mari-topbar-active-underline,
+    .mari-chrome-accent-text,
+    .mari-chrome-accent-icon,
+    .mari-chrome-accent-surface,
+    .mari-chrome-accent-tile,
+    .mari-chrome-accent-soft-tile,
+    .mari-chrome-accent-dot,
+    .mari-chrome-accent-progress,
+    .mari-chrome-accent-rail,
+    .mari-chrome-accent-rail-strong,
+    .mari-topbar-button
+  ) {
+  transition:
+    background 140ms linear,
+    background-color 140ms linear,
+    border-color 140ms linear,
+    color 140ms linear,
+    box-shadow 140ms linear;
 }
 
 /* ─────────────────────────────────────────────
@@ -951,6 +1319,13 @@
 
 .mari-editor-avatar-tile {
   cursor: var(--cursor-pink), pointer;
+}
+
+.mari-editor-icon-tile.mari-panel-gradient-surface {
+  border-color: color-mix(in srgb, var(--mari-panel-gradient-start) 34%, transparent);
+  background: linear-gradient(135deg, var(--mari-panel-gradient-start), var(--mari-panel-gradient-end));
+  color: var(--mari-panel-gradient-text);
+  box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--mari-panel-gradient-end) 18%, transparent);
 }
 
 .mari-editor-actions {
@@ -1122,10 +1497,9 @@
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-editor-action--primary,
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-editor-tab[data-active="true"],
 [data-marinara-chat-chrome-accent-mode="gradient"] .mari-editor-section-jump:hover {
-  border-color: transparent;
-  background:
-    linear-gradient(var(--marinara-editor-control-bg-hover), var(--marinara-editor-control-bg-hover)) padding-box,
-    var(--marinara-chat-chrome-accent-gradient) border-box;
+  border-color: var(--marinara-editor-border-strong);
+  background: var(--marinara-editor-control-bg-hover);
+  color: var(--marinara-editor-text);
 }
 
 @media (max-width: 767px) {
@@ -1335,12 +1709,102 @@ input[type="range"].mari-spotify-volume-slider::-moz-range-thumb {
 }
 
 body {
-  background: var(--background);
+  background: var(--marinara-app-background-paint);
   color: var(--foreground);
   overflow: hidden;
   font-family: var(--font-y2k);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.mari-app-background-paint {
+  background: var(--marinara-app-background-paint);
+}
+
+.mari-home-starfield {
+  --mari-home-star-core: color-mix(in srgb, var(--foreground) 70%, var(--marinara-app-accent-solid) 30%);
+  --mari-home-star-glow: color-mix(in srgb, var(--marinara-app-accent-solid) 48%, transparent);
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: none;
+  overflow: hidden;
+}
+
+:root:not([data-visual-theme]) .mari-home-starfield {
+  display: block;
+}
+
+.mari-home-starfield__star {
+  position: absolute;
+  left: var(--mari-home-star-x);
+  top: var(--mari-home-star-y);
+  width: var(--mari-home-star-size);
+  height: var(--mari-home-star-size);
+  opacity: 0;
+  color: var(--mari-home-star-core);
+  transform: translate(-50%, -50%) scale(0.42);
+  animation: mari-home-star-glisten var(--mari-home-star-duration) ease-in-out forwards;
+}
+
+.mari-home-starfield__star::before,
+.mari-home-starfield__star::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  border-radius: 999px;
+  background: currentColor;
+  transform: translate(-50%, -50%);
+}
+
+.mari-home-starfield__star::before {
+  width: 100%;
+  height: 1px;
+}
+
+.mari-home-starfield__star::after {
+  width: 1px;
+  height: 100%;
+}
+
+@keyframes mari-home-star-glisten {
+  0% {
+    opacity: 0;
+    filter: drop-shadow(0 0 0 transparent);
+    transform: translate(-50%, -50%) scale(0.42);
+  }
+  24% {
+    opacity: 0.34;
+    filter: drop-shadow(0 0 0.2rem var(--mari-home-star-glow));
+    transform: translate(-50%, -50%) scale(0.74);
+  }
+  54% {
+    opacity: 0.95;
+    filter:
+      drop-shadow(0 0 0.38rem var(--mari-home-star-glow))
+      drop-shadow(0 0 0.9rem var(--mari-home-star-glow));
+    transform: translate(-50%, -50%) scale(1.16);
+  }
+  72% {
+    opacity: 0.72;
+    filter:
+      drop-shadow(0 0 0.46rem var(--mari-home-star-glow))
+      drop-shadow(0 0 1.1rem var(--mari-home-star-glow));
+    transform: translate(-50%, -50%) scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    filter: drop-shadow(0 0 0.15rem var(--mari-home-star-glow));
+    transform: translate(-50%, -50%) scale(0.58);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mari-home-starfield {
+    display: none;
+  }
 }
 
 /* Tailwind v4 preflight does not restore italic/bold for semantic elements.
@@ -1795,8 +2259,8 @@ summary[class*="cursor-pointer"],
   height: 0.125rem;
   background: var(--y2k-pink);
   box-shadow:
-    0 0 8px 3px rgba(255, 179, 217, 0.5),
-    0 0 16px 6px rgba(255, 179, 217, 0.2);
+    0 0 8px 3px color-mix(in srgb, var(--primary) 50%, transparent),
+    0 0 16px 6px color-mix(in srgb, var(--primary) 20%, transparent);
 }
 
 .y2k-star-md {
@@ -1812,10 +2276,10 @@ summary[class*="cursor-pointer"],
 .y2k-star-lg {
   width: 0.25rem;
   height: 0.25rem;
-  background: #ffe4f5;
+  background: color-mix(in srgb, var(--primary) 34%, var(--foreground) 66%);
   box-shadow:
-    0 0 12px 5px rgba(255, 228, 245, 0.7),
-    0 0 24px 10px rgba(255, 228, 245, 0.4);
+    0 0 12px 5px color-mix(in srgb, var(--primary) 32%, transparent),
+    0 0 24px 10px color-mix(in srgb, var(--primary) 18%, transparent);
   animation-duration: 6s;
 }
 
@@ -1824,12 +2288,12 @@ summary[class*="cursor-pointer"],
   100% {
     box-shadow:
       0 0 8px rgba(212, 173, 252, 0.15),
-      0 0 16px rgba(255, 179, 217, 0.1);
+      0 0 16px color-mix(in srgb, var(--primary) 10%, transparent);
   }
   50% {
     box-shadow:
       0 0 12px rgba(212, 173, 252, 0.25),
-      0 0 24px rgba(255, 179, 217, 0.2);
+      0 0 24px color-mix(in srgb, var(--primary) 20%, transparent);
   }
 }
 
@@ -1838,8 +2302,48 @@ summary[class*="cursor-pointer"],
 }
 
 .retro-glow-text {
-  color: var(--primary);
-  text-shadow: 0 0 8px color-mix(in srgb, var(--primary) 20%, transparent);
+  color: var(--marinara-chat-chrome-text);
+  text-shadow: 0 0 8px color-mix(in srgb, var(--marinara-chat-chrome-text) 20%, transparent);
+}
+
+.mari-logo-gradient-text {
+  background: linear-gradient(
+    90deg,
+    var(--mari-logo-title-cyan) 0%,
+    var(--mari-logo-title-orange) 28%,
+    var(--mari-logo-title-pink) 55%,
+    var(--mari-logo-title-orange) 78%,
+    var(--mari-logo-title-cyan) 100%
+  );
+  background-clip: text;
+  background-position: 0% 50%;
+  background-size: 220% 100%;
+  color: transparent;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 0.45rem rgba(236, 72, 153, 0.16));
+}
+
+.mari-logo-gradient-text--active {
+  animation: mari-logo-title-shift 5.2s ease-in-out infinite;
+}
+
+@keyframes mari-logo-title-shift {
+  0%,
+  100% {
+    background-position: 0% 50%;
+    filter: drop-shadow(0 0 0.45rem color-mix(in srgb, var(--mari-logo-title-cyan) 16%, transparent));
+  }
+  50% {
+    background-position: 100% 50%;
+    filter: drop-shadow(0 0 0.5rem color-mix(in srgb, var(--mari-logo-title-pink) 22%, transparent));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mari-logo-gradient-text--active {
+    animation: none;
+  }
 }
 
 .os-button-pastel {
@@ -1950,7 +2454,7 @@ summary[class*="cursor-pointer"],
   opacity: 0;
   background: radial-gradient(
     circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
-    rgba(255, 179, 217, 0.2),
+    color-mix(in srgb, var(--primary) 20%, transparent),
     transparent 60%
   );
   transition: opacity 0.3s;
@@ -2463,13 +2967,13 @@ summary[class*="cursor-pointer"],
 
 @keyframes pulse-ring {
   0% {
-    box-shadow: 0 0 0 0 rgba(255, 179, 217, 0.4);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 40%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 8px rgba(255, 179, 217, 0);
+    box-shadow: 0 0 0 8px color-mix(in srgb, var(--primary) 0%, transparent);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(255, 179, 217, 0);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
   }
 }
 
@@ -2597,8 +3101,8 @@ summary[class*="cursor-pointer"],
 }
 
 .glimmer-name-gradient {
-  color: var(--y2k-pink, var(--primary));
-  text-shadow: 0 0 12px color-mix(in srgb, var(--y2k-pink, var(--primary)) 18%, transparent);
+  color: var(--marinara-chat-chrome-text);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--marinara-chat-chrome-text) 18%, transparent);
 }
 
 .glimmer-bubble {
@@ -2952,8 +3456,8 @@ summary[class*="cursor-pointer"],
 }
 
 .rpg-char-name {
-  color: color-mix(in srgb, var(--primary) 72%, var(--foreground));
-  text-shadow: 0 0 14px color-mix(in srgb, var(--primary) 20%, transparent);
+  color: var(--marinara-chat-chrome-text);
+  text-shadow: 0 0 14px color-mix(in srgb, var(--marinara-chat-chrome-text) 20%, transparent);
 }
 
 .rpg-streaming {
@@ -3075,7 +3579,7 @@ summary[class*="cursor-pointer"],
 
 .fn-call-card .fn-name {
   font-weight: 600;
-  color: var(--y2k-purple);
+  color: var(--marinara-chat-chrome-text);
   font-family: monospace;
 }
 
@@ -3711,20 +4215,20 @@ summary[class*="cursor-pointer"],
   0%,
   100% {
     text-shadow:
-      0 0 4px rgba(168, 85, 247, 0.4),
-      0 0 10px rgba(168, 85, 247, 0.15);
+      0 0 4px color-mix(in srgb, var(--marinara-chat-chrome-text) 40%, transparent),
+      0 0 10px color-mix(in srgb, var(--marinara-chat-chrome-text) 15%, transparent);
   }
   50% {
     text-shadow:
-      0 0 8px rgba(168, 85, 247, 0.7),
-      0 0 20px rgba(168, 85, 247, 0.3),
-      0 0 30px rgba(168, 85, 247, 0.1);
+      0 0 8px color-mix(in srgb, var(--marinara-chat-chrome-text) 70%, transparent),
+      0 0 20px color-mix(in srgb, var(--marinara-chat-chrome-text) 30%, transparent),
+      0 0 30px color-mix(in srgb, var(--marinara-chat-chrome-text) 10%, transparent);
   }
 }
 
 .anim-text-glow {
   display: inline;
-  color: #c084fc !important; /* purple-400 */
+  color: var(--marinara-chat-chrome-text) !important;
   animation: text-glow 2s ease-in-out infinite;
 }
 
@@ -3744,7 +4248,7 @@ summary[class*="cursor-pointer"],
 .anim-text-pulse {
   display: inline-block;
   animation: text-pulse 1.2s ease-in-out infinite;
-  color: #fb7185 !important; /* rose-400 */
+  color: var(--marinara-chat-chrome-text) !important;
 }
 
 /* Wave — singing, chanting (per-character) */
@@ -3917,7 +4421,7 @@ summary[class*="cursor-pointer"],
 .anim-text-glitch {
   display: inline-block;
   animation: text-glitch 2s steps(1) infinite;
-  color: #e879f9 !important; /* fuchsia-400 */
+  color: var(--marinara-chat-chrome-panel-text) !important;
   text-shadow:
     -1px 0 #f87171,
     1px 0 #60a5fa;


### PR DESCRIPTION
## Linked issue

No linked issue yet; requested directly by the maintainer during the 2.0 UI polish pass.

## Why this change

- Accent, chat chrome text, and background controls should apply consistently instead of leaving hard-coded pink/purple UI fragments behind.
- RGB mode should be visible enough, use color cycling semantics, and pause when the tab is hidden.
- Panel and navigation icon treatments should keep their intended mode/category identities while sharing the newer squared-off UI vocabulary.

## What changed

- Unified accent/chat chrome/background styling across topbar controls, panels, editors, chat surfaces, home/recent-chat UI, imports, tooltips, and resource lists.
- Added/extended background color and gradient handling, RGB defaults/animation behavior, and default Marinara home/title/star treatments.
- Restored category-specific chat/new-chat icon colors and panel gradients, including Presets using the shared Presets gradient token.
- Kept YouTube music player coloring independent from the user accent color and aligned topbar/player surfaces.
- Added imported-character delete affordance in the browser tab and ignored temporary `*.spec.ts` files.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` completed successfully in this checkout.
- Narrow Presets follow-up checks also passed: `pnpm --filter @marinara-engine/client exec eslint ...` and `pnpm --filter @marinara-engine/client exec tsc --noEmit --pretty false`.
- Local shell is on Node `v20.11.1`, so pnpm/Vite printed engine-version warnings while still exiting successfully.
- Browser click-through and screenshots still need human verification.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not attached in this agent pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added app background and accent color customization in Settings
  * Added starfield background animation to empty chat state
  * Enhanced character deletion with confirmation dialog in Bot Browser
  * Expanded preset search to include descriptions and authors

* **Style**
  * Complete UI theme redesign with new unified design tokens throughout the app
  * Updated color scheme consistency across all components using theme variables
  * Improved visual animations and accent effects

* **Refactor**
  * Consolidated CSS color parsing and gradient utilities
  * Improved button styling configuration and reusability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->