### PR TITLE
Fix chat settings overlay and dropdown contrast

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2545,6 +2545,7 @@ export function ChatSettingsDrawer({
       <div
         className={cn(
           ROLEPLAY_POPOVER_SHELL,
+          "mari-chat-settings-drawer",
           "fixed bottom-3 z-[70] flex min-h-0 w-[min(34rem,calc(100vw-1.5rem))] flex-col overflow-hidden max-md:inset-x-2 max-md:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] max-md:top-[calc(3.5rem+env(safe-area-inset-top))] max-md:w-auto",
           anchor ? "" : "right-3 top-14",
         )}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -6767,7 +6767,7 @@ export function ChatSettingsDrawer({
       {/* First message confirmation dialog */}
       {firstMesConfirm && (
         <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 max-md:pt-[env(safe-area-inset-top)]"
+          className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 max-md:pt-[env(safe-area-inset-top)]"
           onClick={() => setFirstMesConfirm(null)}
         >
           <div

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -987,6 +987,20 @@
   color: var(--marinara-chat-chrome-button-text-active);
 }
 
+.mari-chat-settings-drawer select {
+  color: CanvasText;
+  color-scheme: light dark;
+}
+
+.mari-chat-settings-drawer select option {
+  background-color: Canvas;
+  color: CanvasText;
+}
+
+.mari-chat-settings-drawer select optgroup {
+  color: CanvasText;
+}
+
 .mari-chrome-sort-icon {
   color: var(--marinara-chat-chrome-button-text-active);
   opacity: 1;


### PR DESCRIPTION
## Linked issue

Closes #

No linked issue yet. One should be opened before this PR is submitted.

## Why this change

- Fix two chat-settings regressions: the first-message confirmation could render under the drawer backdrop, and native dropdown menus could become unreadable in Opera on Windows 11.

## What changed

- Raised the first-message confirmation overlay above the chat settings drawer layer.
- Scoped chat-settings native `select` styling to use system colors so browser-native dropdown popups keep readable text.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` is currently blocked in this environment because workspace dependencies are missing and `packages/shared` cannot find `tsc`.
- Manual browser verification still needs to be completed for the first-message confirmation flow, Chat Settings dropdown readability in Opera on Windows 11, and normal outside-click drawer closing.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- UI screenshots or recordings still need to be attached by the human contributor if required for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "First Message" confirmation overlay to reliably display above other UI elements in the chat interface

* **Style**
  * Enhanced select element styling within the chat settings drawer for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->