### PR TITLE
Fix assigned provider and connection issue sweep

### DIFF
--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -172,6 +172,7 @@ export function ConnectionEditor() {
   const [localImageEndpointId, setLocalImageEndpointId] = useState("");
   const [localMaxTokensOverride, setLocalMaxTokensOverride] = useState<number | null>(null);
   const [localClaudeFastMode, setLocalClaudeFastMode] = useState(false);
+  const [localTreatAsLocalEndpoint, setLocalTreatAsLocalEndpoint] = useState(false);
   const [localDefaultParametersEnabled, setLocalDefaultParametersEnabled] = useState(false);
   const [localDefaultParameters, setLocalDefaultParameters] =
     useState<EditableGenerationParameters>(ROLEPLAY_PARAMETER_DEFAULTS);
@@ -242,6 +243,7 @@ export function ConnectionEditor() {
     setLocalImageEndpointId((c.imageEndpointId as string) ?? "");
     setLocalMaxTokensOverride(typeof c.maxTokensOverride === "number" ? (c.maxTokensOverride as number) : null);
     setLocalClaudeFastMode(c.claudeFastMode === "true" || c.claudeFastMode === true);
+    setLocalTreatAsLocalEndpoint(c.treatAsLocalEndpoint === "true" || c.treatAsLocalEndpoint === true);
     setLocalDefaultParametersEnabled(!!parseEditableGenerationParameters(c.defaultParameters));
     setLocalDefaultParameters(getEditableGenerationParameters(ROLEPLAY_PARAMETER_DEFAULTS, c.defaultParameters));
     setLocalImageDefaults(
@@ -400,6 +402,7 @@ export function ConnectionEditor() {
           : null,
       maxTokensOverride: localMaxTokensOverride ?? null,
       claudeFastMode: localClaudeFastMode,
+      treatAsLocalEndpoint: localTreatAsLocalEndpoint,
     };
     // Only send API key if user typed a new one
     if (localApiKey.trim()) {
@@ -454,6 +457,7 @@ export function ConnectionEditor() {
     localImageEndpointId,
     localMaxTokensOverride,
     localClaudeFastMode,
+    localTreatAsLocalEndpoint,
     localDefaultParametersEnabled,
     localDefaultParameters,
     selectedImageService,
@@ -512,6 +516,7 @@ export function ConnectionEditor() {
       maxContext: localMaxContext,
       maxTokensOverride: localMaxTokensOverride ?? null,
       maxParallelJobs: localMaxParallelJobs,
+      treatAsLocalEndpoint: localTreatAsLocalEndpoint,
       promptPresetId: localProvider !== "image_generation" ? localPromptPresetId || null : null,
       defaultParameters,
       enableCaching: localEnableCaching,
@@ -545,6 +550,7 @@ export function ConnectionEditor() {
     localMaxContext,
     localMaxTokensOverride,
     localMaxParallelJobs,
+    localTreatAsLocalEndpoint,
     localPromptPresetId,
     localDefaultParametersEnabled,
     localDefaultParameters,
@@ -744,10 +750,7 @@ export function ConnectionEditor() {
     <div className="mari-editor-shell flex flex-1 flex-col overflow-hidden">
       {/* ── Header ── */}
       <div className="mari-editor-header">
-        <button
-          onClick={handleClose}
-          className="mari-editor-action inline-flex shrink-0"
-        >
+        <button onClick={handleClose} className="mari-editor-action inline-flex shrink-0">
           <ArrowLeft size="1.125rem" />
         </button>
         <div className="mari-editor-icon-tile">
@@ -773,9 +776,7 @@ export function ConnectionEditor() {
               <Check size="0.6875rem" /> <span className="max-md:hidden">Saved</span>
             </span>
           )}
-          {dirty && !saveError && (
-            <span className="mari-editor-status mr-2 text-amber-400 max-md:hidden">Unsaved</span>
-          )}
+          {dirty && !saveError && <span className="mari-editor-status mr-2 text-amber-400 max-md:hidden">Unsaved</span>}
           <button
             onClick={handleSave}
             disabled={updateConnection.isPending || saveConnectionDefaults.isPending}
@@ -881,6 +882,9 @@ export function ConnectionEditor() {
                     // Clear model when switching providers, except xAI where
                     // we can seed the newest supported Grok model.
                     setLocalModel(key === "xai" ? (defaultModel?.id ?? "grok-4.3") : "");
+                    setLocalMaxTokensOverride(null);
+                    setLocalDefaultParametersEnabled(false);
+                    setLocalDefaultParameters(ROLEPLAY_PARAMETER_DEFAULTS);
                     if (key === "xai" && defaultModel?.context) {
                       setLocalMaxContext(defaultModel.context);
                     }
@@ -1257,9 +1261,7 @@ export function ConnectionEditor() {
                       });
                     }}
                   />
-                  <div
-                    className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
-                  >
+                  <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-80 overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-2xl">
                     {/* Fetch from API button */}
                     <div className="sticky top-0 z-10 border-b border-[var(--border)] bg-[var(--card)] p-2">
                       <button
@@ -1595,7 +1597,9 @@ export function ConnectionEditor() {
           {localProvider !== "image_generation" && (
             <FieldGroup
               label="Max Parallel Agent Jobs"
-              icon={<SlidersHorizontal size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />}
+              icon={
+                <SlidersHorizontal size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />
+              }
               help="How many agent LLM requests Marinara may run at once for this connection. Higher values can speed up agent-heavy chats on providers that tolerate parallel calls."
             >
               <div className="flex items-center gap-3">
@@ -1617,6 +1621,27 @@ export function ConnectionEditor() {
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 Agent batches for the same connection can be split across this many parallel jobs. Set to 1 for the
                 safest provider behavior.
+              </p>
+            </FieldGroup>
+          )}
+
+          {localProvider !== "image_generation" && !isLocalAuthProvider && (
+            <FieldGroup
+              label="Local / Custom Endpoint"
+              icon={<Server size="0.875rem" className="text-emerald-400" />}
+              help="Use this for self-hosted or proxied OpenAI-compatible endpoints, especially custom domains that point at a LAN model server. Professor Mari will use a JSON tool protocol fallback for workspace tools instead of relying only on native tool calls."
+            >
+              <SettingsSwitch
+                label="Treat as local/custom endpoint"
+                checked={localTreatAsLocalEndpoint}
+                onChange={(checked) => {
+                  setLocalTreatAsLocalEndpoint(checked);
+                  markDirty();
+                }}
+              />
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Enable this if Professor Mari stops after tool use or your endpoint advertises OpenAI compatibility but
+                does not reliably support tool calls.
               </p>
             </FieldGroup>
           )}

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -109,6 +109,10 @@ const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
 
+function canProviderTreatAsLocalEndpoint(provider: APIProvider): boolean {
+  return provider !== "image_generation" && provider !== "claude_subscription" && provider !== "openai_chatgpt";
+}
+
 function normalizeCachingAtDepth(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return DEFAULT_CACHING_AT_DEPTH;
   return Math.min(MAX_CACHING_AT_DEPTH, Math.floor(value));
@@ -375,6 +379,7 @@ export function ConnectionEditor() {
   const handleSave = useCallback(async () => {
     if (!connectionDetailId) return;
     setSaveError(null);
+    const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
     const payload: Record<string, unknown> = {
       id: connectionDetailId,
       name: localName,
@@ -402,7 +407,7 @@ export function ConnectionEditor() {
           : null,
       maxTokensOverride: localMaxTokensOverride ?? null,
       claudeFastMode: localClaudeFastMode,
-      treatAsLocalEndpoint: localTreatAsLocalEndpoint,
+      treatAsLocalEndpoint: canTreatAsLocalEndpoint ? localTreatAsLocalEndpoint : false,
     };
     // Only send API key if user typed a new one
     if (localApiKey.trim()) {
@@ -507,6 +512,7 @@ export function ConnectionEditor() {
           : null;
     const imageService =
       localProvider === "image_generation" ? localImageGenerationSource || localImageService || null : null;
+    const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
     const exportRow: ConnectionTransferRow = {
       ...currentConnection,
       name: localName,
@@ -516,7 +522,7 @@ export function ConnectionEditor() {
       maxContext: localMaxContext,
       maxTokensOverride: localMaxTokensOverride ?? null,
       maxParallelJobs: localMaxParallelJobs,
-      treatAsLocalEndpoint: localTreatAsLocalEndpoint,
+      treatAsLocalEndpoint: canTreatAsLocalEndpoint ? localTreatAsLocalEndpoint : false,
       promptPresetId: localProvider !== "image_generation" ? localPromptPresetId || null : null,
       defaultParameters,
       enableCaching: localEnableCaching,
@@ -724,6 +730,7 @@ export function ConnectionEditor() {
   const isClaudeSubscriptionProvider = localProvider === "claude_subscription";
   const isOpenAIChatGPTProvider = localProvider === "openai_chatgpt";
   const isLocalAuthProvider = isClaudeSubscriptionProvider || isOpenAIChatGPTProvider;
+  const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
 
   if (!connectionDetailId) return null;
 
@@ -1625,7 +1632,7 @@ export function ConnectionEditor() {
             </FieldGroup>
           )}
 
-          {localProvider !== "image_generation" && !isLocalAuthProvider && (
+          {canTreatAsLocalEndpoint && (
             <FieldGroup
               label="Local / Custom Endpoint"
               icon={<Server size="0.875rem" className="text-emerald-400" />}

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -484,14 +484,14 @@ export function useUpdateChatMetadata() {
     mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
       api.patch<Chat>(`/chats/${id}/metadata`, metadata),
     onSuccess: (data, vars) => {
-      // Write the server response straight into the detail cache. Plain
-      // invalidation alone leaves stale data in place when no observer is
-      // mounted to trigger a refetch (e.g. user navigated away after firing
-      // the mutation), causing later renders to re-read the pre-mutation
-      // value — which is what made cleared chat backgrounds reappear after
-      // a chat switch round-trip.
+      // Metadata PATCH returns a full chat row, but concurrent updates to
+      // non-metadata fields (for example promptPresetId) may still be in
+      // flight. Merge only the metadata fields so a stale full-row response
+      // cannot clobber fresher chat detail state.
       if (data) {
-        qc.setQueryData(chatKeys.detail(vars.id), data);
+        qc.setQueryData<Chat>(chatKeys.detail(vars.id), (existing) =>
+          existing ? { ...existing, metadata: data.metadata, updatedAt: data.updatedAt } : data,
+        );
       } else {
         qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });
       }

--- a/packages/client/src/hooks/use-connections.ts
+++ b/packages/client/src/hooks/use-connections.ts
@@ -52,6 +52,7 @@ export type CreateConnectionPayload = {
   promptPresetId?: string | null;
   maxTokensOverride?: number | null;
   maxParallelJobs?: number;
+  treatAsLocalEndpoint?: boolean;
   claudeFastMode?: boolean;
 };
 

--- a/packages/client/src/lib/connection-transfer.ts
+++ b/packages/client/src/lib/connection-transfer.ts
@@ -25,6 +25,7 @@ export type ConnectionTransferRow = {
   service?: unknown;
   imageEndpointId?: unknown;
   comfyuiWorkflow?: unknown;
+  treatAsLocalEndpoint?: unknown;
   claudeFastMode?: unknown;
 };
 
@@ -51,6 +52,7 @@ export type SafeConnectionExport = {
   imageService: string | null;
   imageEndpointId: string | null;
   comfyuiWorkflow: string | null;
+  treatAsLocalEndpoint: boolean;
   claudeFastMode: boolean;
 };
 
@@ -117,6 +119,7 @@ export function normalizeImportedConnectionEntry(value: unknown): ConnectionImpo
       promptPresetId: asNullableString(value.promptPresetId),
       maxTokensOverride: asNullablePositiveInteger(value.maxTokensOverride),
       maxParallelJobs: asPositiveInteger(value.maxParallelJobs, 1),
+      treatAsLocalEndpoint: asBoolean(value.treatAsLocalEndpoint),
       claudeFastMode: asBoolean(value.claudeFastMode),
     },
     defaultParameters,
@@ -149,6 +152,7 @@ function serializeConnectionForExport(connection: ConnectionTransferRow): SafeCo
     imageService: asNullableString(connection.imageService ?? connection.service),
     imageEndpointId: asNullableString(connection.imageEndpointId),
     comfyuiWorkflow: asNullableString(connection.comfyuiWorkflow),
+    treatAsLocalEndpoint: asBoolean(connection.treatAsLocalEndpoint),
     claudeFastMode: asBoolean(connection.claudeFastMode),
   };
 }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -275,6 +275,7 @@ const CREATE_TABLES: string[] = [
     image_path TEXT,
     max_context INTEGER NOT NULL DEFAULT 128000,
     max_parallel_jobs INTEGER NOT NULL DEFAULT 1,
+    treat_as_local_endpoint TEXT NOT NULL DEFAULT 'false',
     is_default TEXT NOT NULL DEFAULT 'false',
     use_for_random TEXT NOT NULL DEFAULT 'false',
     enable_caching TEXT NOT NULL DEFAULT 'false',
@@ -769,6 +770,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
     definition: "INTEGER NOT NULL DEFAULT 1",
   },
   {
+    table: "api_connections",
+    column: "treat_as_local_endpoint",
+    definition: "TEXT NOT NULL DEFAULT 'false'",
+  },
+  {
     table: "lorebook_entries",
     column: "description",
     definition: "TEXT NOT NULL DEFAULT ''",
@@ -1019,7 +1025,9 @@ export async function runMigrations(db: DB) {
     ),
   );
   await db.run(
-    sql.raw(`CREATE INDEX IF NOT EXISTS idx_persona_card_versions ON persona_card_versions(persona_id, created_at DESC)`),
+    sql.raw(
+      `CREATE INDEX IF NOT EXISTS idx_persona_card_versions ON persona_card_versions(persona_id, created_at DESC)`,
+    ),
   );
   await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_custom_themes_active ON custom_themes(is_active)`));
   await db.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_chat_presets_mode_active ON chat_presets(mode, is_active)`));

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -62,6 +62,8 @@ export const apiConnections = sqliteTable("api_connections", {
   maxTokensOverride: integer("max_tokens_override"),
   /** Maximum number of agent LLM jobs Marinara may run at once for this connection. */
   maxParallelJobs: integer("max_parallel_jobs").notNull().default(1),
+  /** Treat as a local/custom endpoint for Professor Mari JSON tool fallback behavior. */
+  treatAsLocalEndpoint: text("treat_as_local_endpoint").notNull().default("false"),
   /**
    * Claude (Subscription) only. When "true", Marinara passes `settings.fastMode = true`
    * to the Claude Agent SDK, asking the SDK to use its faster, cheaper routing tier

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -5,7 +5,12 @@ import type { FastifyInstance } from "fastify";
 import { existsSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { extname, join } from "path";
-import { MODEL_LISTS, createConnectionSchema, inferImageSource } from "@marinara-engine/shared";
+import {
+  MODEL_LISTS,
+  createConnectionSchema,
+  generationParametersSchema,
+  inferImageSource,
+} from "@marinara-engine/shared";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { fetchOpenAIChatGPTModels, getOpenAIChatGPTAuth } from "../services/llm/openai-chatgpt-auth.js";
@@ -285,7 +290,20 @@ export async function connectionsRoutes(app: FastifyInstance) {
     if (raw !== null && (typeof raw !== "object" || Array.isArray(raw))) {
       return reply.status(400).send({ error: "Body must be a JSON object or null" });
     }
-    const params = raw as Record<string, unknown> | null;
+    let params: Record<string, unknown> | null = null;
+    if (raw !== null) {
+      const parsed = generationParametersSchema.partial().safeParse(raw);
+      if (!parsed.success) {
+        return reply.status(400).send({
+          error: "Invalid generation parameters",
+          issues: parsed.error.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        });
+      }
+      params = parsed.data;
+    }
     await storage.updateDefaultParameters(req.params.id, params);
     return { success: true };
   });

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -818,18 +818,37 @@ export function parseStoredGenerationParameters(raw: unknown): StoredGenerationP
   // dropping the whole advanced-parameter fallback.
   const source = parsed as Record<string, unknown>;
   const out: StoredGenerationParameters = {};
-  for (const key of [
-    "temperature",
-    "topP",
-    "topK",
-    "minP",
-    "maxTokens",
-    "maxContext",
-    "frequencyPenalty",
-    "presencePenalty",
-  ] as const) {
-    const value = source[key];
-    if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+  if (source.temperature !== undefined) {
+    const temperature = generationParametersSchema.shape.temperature.safeParse(source.temperature);
+    if (temperature.success) out.temperature = temperature.data;
+  }
+  if (source.topP !== undefined) {
+    const topP = generationParametersSchema.shape.topP.safeParse(source.topP);
+    if (topP.success) out.topP = topP.data;
+  }
+  if (source.topK !== undefined) {
+    const topK = generationParametersSchema.shape.topK.safeParse(source.topK);
+    if (topK.success) out.topK = topK.data;
+  }
+  if (source.minP !== undefined) {
+    const minP = generationParametersSchema.shape.minP.safeParse(source.minP);
+    if (minP.success) out.minP = minP.data;
+  }
+  if (source.maxTokens !== undefined) {
+    const maxTokens = generationParametersSchema.shape.maxTokens.safeParse(source.maxTokens);
+    if (maxTokens.success) out.maxTokens = maxTokens.data;
+  }
+  if (source.maxContext !== undefined) {
+    const maxContext = generationParametersSchema.shape.maxContext.safeParse(source.maxContext);
+    if (maxContext.success) out.maxContext = maxContext.data;
+  }
+  if (source.frequencyPenalty !== undefined) {
+    const frequencyPenalty = generationParametersSchema.shape.frequencyPenalty.safeParse(source.frequencyPenalty);
+    if (frequencyPenalty.success) out.frequencyPenalty = frequencyPenalty.data;
+  }
+  if (source.presencePenalty !== undefined) {
+    const presencePenalty = generationParametersSchema.shape.presencePenalty.safeParse(source.presencePenalty);
+    if (presencePenalty.success) out.presencePenalty = presencePenalty.data;
   }
   if (
     source.reasoningEffort === null ||

--- a/packages/server/src/services/generation/generation-parameters.ts
+++ b/packages/server/src/services/generation/generation-parameters.ts
@@ -1,7 +1,4 @@
-import {
-  DEFAULT_AGENT_MAX_TOKENS,
-  MIN_AGENT_MAX_TOKENS,
-} from "@marinara-engine/shared";
+import { DEFAULT_AGENT_MAX_TOKENS, MIN_AGENT_MAX_TOKENS } from "@marinara-engine/shared";
 import type { BaseLLMProvider } from "../llm/base-provider.js";
 
 export function normalizeMaxContext(value: unknown): number | undefined {
@@ -30,7 +27,7 @@ export function minContextLimit(...limits: Array<number | undefined>): number | 
 
 export function normalizeChatTopP(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-  if (value <= 0) return 1;
+  if (value < 0) return undefined;
   return Math.min(value, 1);
 }
 

--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -82,6 +82,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function formatAnthropicStreamError(error: unknown): string {
+  if (isRecord(error)) {
+    const type = typeof error.type === "string" && error.type.trim() ? error.type.trim() : null;
+    const message = typeof error.message === "string" && error.message.trim() ? error.message.trim() : null;
+    if (type && message) return `${type}: ${message}`;
+    if (message) return message;
+    if (type) return type;
+  }
+  return "Anthropic stream error";
+}
+
 function parseToolArguments(value: string): Record<string, unknown> {
   try {
     const parsed = JSON.parse(value) as unknown;
@@ -225,11 +236,11 @@ export class AnthropicProvider extends BaseLLMProvider {
     if (this.shouldSuppressModelParameters(options) || !options.tools?.length)
       return super.chatComplete(messages, options);
 
-    const configuredMaxTokens = options.maxTokens ?? 4096;
+    const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     messages = contextFit.messages;
     this.logContextTrim(contextFit, options.model);
-    const maxTokens = contextFit.maxTokens ?? configuredMaxTokens;
+    const maxTokens = this.applyMaxTokensCap(contextFit.maxTokens ?? configuredMaxTokens);
 
     const url = `${this.baseUrl}/messages`;
     const systemMessages = messages.filter((m) => m.role === "system" && m.content?.trim());
@@ -321,7 +332,7 @@ export class AnthropicProvider extends BaseLLMProvider {
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const suppressModelParameters = this.shouldSuppressModelParameters(options);
-    const configuredMaxTokens = suppressModelParameters ? undefined : (options.maxTokens ?? 4096);
+    const configuredMaxTokens = suppressModelParameters ? undefined : this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     messages = contextFit.messages;
     this.logContextTrim(contextFit, options.model);
@@ -331,7 +342,9 @@ export class AnthropicProvider extends BaseLLMProvider {
 
     // Claude requires system prompt separate from messages — filter out empty-content messages
     const systemMessages = messages.filter((m) => m.role === "system" && m.content?.trim());
-    const chatMessages = messages.filter((m) => m.role !== "system" && (m.content?.trim() || m.images?.length || m.files?.length));
+    const chatMessages = messages.filter(
+      (m) => m.role !== "system" && (m.content?.trim() || m.images?.length || m.files?.length),
+    );
 
     // Ensure alternating user/assistant pattern (Claude requirement)
     const mergedMessages = this.mergeConsecutiveMessages(chatMessages);
@@ -501,46 +514,53 @@ export class AnthropicProvider extends BaseLLMProvider {
           if (!trimmed.startsWith("data: ")) continue;
           const data = trimmed.slice(6);
 
+          let event: {
+            type: string;
+            error?: unknown;
+            message?: { usage?: { input_tokens: number; output_tokens: number } };
+            content_block?: { type: string };
+            delta?: { type: string; text?: string; thinking?: string };
+            usage?: { output_tokens: number };
+          };
           try {
-            const event = JSON.parse(data) as {
-              type: string;
-              message?: { usage?: { input_tokens: number; output_tokens: number } };
-              content_block?: { type: string };
-              delta?: { type: string; text?: string; thinking?: string };
-              usage?: { output_tokens: number };
-            };
-            // Capture input token count from message_start
-            if (event.type === "message_start" && event.message?.usage) {
-              inputTokens = event.message.usage.input_tokens;
-              outputTokens = event.message.usage.output_tokens;
-            }
-            // Capture final output token count from message_delta
-            if (event.type === "message_delta" && event.usage) {
-              outputTokens = event.usage.output_tokens;
-            }
-            // Track block type (thinking vs text)
-            if (event.type === "content_block_start" && event.content_block) {
-              currentBlockType = event.content_block.type;
-            }
-            if (event.type === "content_block_delta") {
-              if (currentBlockType === "thinking" && event.delta?.thinking && options.onThinking) {
-                options.onThinking(event.delta.thinking);
-              } else if (event.delta?.text) {
-                yield event.delta.text;
-              }
-            }
-            if (event.type === "message_stop") {
-              if (inputTokens || outputTokens) {
-                return {
-                  promptTokens: inputTokens,
-                  completionTokens: outputTokens,
-                  totalTokens: inputTokens + outputTokens,
-                };
-              }
-              return;
-            }
+            event = JSON.parse(data) as typeof event;
           } catch {
             // Skip malformed lines
+            continue;
+          }
+
+          if (event.type === "error") {
+            throw new Error(`Anthropic stream error: ${formatAnthropicStreamError(event.error)}`);
+          }
+          // Capture input token count from message_start
+          if (event.type === "message_start" && event.message?.usage) {
+            inputTokens = event.message.usage.input_tokens;
+            outputTokens = event.message.usage.output_tokens;
+          }
+          // Capture final output token count from message_delta
+          if (event.type === "message_delta" && event.usage) {
+            outputTokens = event.usage.output_tokens;
+          }
+          // Track block type (thinking vs text)
+          if (event.type === "content_block_start" && event.content_block) {
+            currentBlockType = event.content_block.type;
+          }
+          if (event.type === "content_block_delta") {
+            if (currentBlockType === "thinking" && event.delta?.thinking && options.onThinking) {
+              options.onThinking(event.delta.thinking);
+            } else if (event.delta?.text) {
+              yield event.delta.text;
+            }
+          }
+          if (event.type === "message_stop") {
+            if (inputTokens || outputTokens) {
+              return {
+                promptTokens: inputTokens,
+                completionTokens: outputTokens,
+                totalTokens: inputTokens + outputTokens,
+              };
+            }
+            return;
           }
         }
       }
@@ -550,6 +570,12 @@ export class AnthropicProvider extends BaseLLMProvider {
     if (inputTokens || outputTokens) {
       return { promptTokens: inputTokens, completionTokens: outputTokens, totalTokens: inputTokens + outputTokens };
     }
+  }
+
+  override async embed(_texts: string[], _model: string): Promise<number[][]> {
+    throw new Error(
+      "Anthropic connections do not support embeddings through Marinara's OpenAI-compatible /embeddings path. Configure a dedicated OpenAI-compatible or local embedding connection.",
+    );
   }
 
   /**

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -322,7 +322,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const suppressModelParameters = this.shouldSuppressModelParameters(options);
-    const configuredMaxTokens = suppressModelParameters ? undefined : (options.maxTokens ?? 4096);
+    const configuredMaxTokens = suppressModelParameters ? undefined : this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     this.logContextTrim(contextFit, options.model);
 

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -30,6 +30,37 @@ interface GeminiPart {
   functionCall?: GeminiFunctionCall;
 }
 
+interface GeminiCandidate {
+  content?: { parts?: GeminiPart[] };
+  finishReason?: string;
+  finishMessage?: string;
+}
+
+interface GeminiPromptFeedback {
+  blockReason?: string;
+  blockReasonMessage?: string;
+}
+
+interface GeminiApiError {
+  code?: number;
+  message?: string;
+  status?: string;
+}
+
+interface GeminiUsageMetadata {
+  promptTokenCount: number;
+  candidatesTokenCount: number;
+  totalTokenCount: number;
+  thoughtsTokenCount?: number;
+}
+
+interface GeminiResponsePayload {
+  candidates?: GeminiCandidate[];
+  promptFeedback?: GeminiPromptFeedback;
+  error?: GeminiApiError;
+  usageMetadata?: GeminiUsageMetadata;
+}
+
 type GoogleProviderKind = "google" | "google_vertex";
 
 interface GoogleServiceAccountKey {
@@ -163,6 +194,52 @@ function capGeminiThinkingBudget(requestedBudget: number, maxOutputTokens: numbe
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function formatGeminiApiError(error: GeminiApiError | undefined): string | null {
+  if (!error) return null;
+  const status = typeof error.status === "string" && error.status.trim() ? error.status.trim() : null;
+  const message = typeof error.message === "string" && error.message.trim() ? error.message.trim() : null;
+  const code = typeof error.code === "number" ? error.code : null;
+  if (status && message) return `${status}: ${sanitizeApiError(message)}`;
+  if (message) return sanitizeApiError(message);
+  if (status) return status;
+  if (code !== null) return `code ${code}`;
+  return "unknown Gemini API error";
+}
+
+function formatGeminiPromptBlock(feedback: GeminiPromptFeedback | undefined): string | null {
+  const reason = feedback?.blockReason?.trim();
+  if (!reason) return null;
+  const message = feedback?.blockReasonMessage?.trim();
+  return message ? `${reason}: ${message}` : reason;
+}
+
+function geminiFinishReasonError(finishReason: string | undefined, hasOutput: boolean): string | null {
+  const normalized = finishReason?.trim().toUpperCase();
+  if (!normalized || normalized === "STOP") return null;
+  if (hasOutput && normalized === "MAX_TOKENS") return null;
+  if (hasOutput) return null;
+  return `Gemini finished without content (${finishReason})`;
+}
+
+function assertGeminiUsableResponse(
+  payload: GeminiResponsePayload,
+  candidate: GeminiCandidate | undefined,
+  hasOutput: boolean,
+): void {
+  const apiError = formatGeminiApiError(payload.error);
+  if (apiError) throw new Error(`Gemini API error: ${apiError}`);
+
+  const blockReason = formatGeminiPromptBlock(payload.promptFeedback);
+  if (blockReason) throw new Error(`Gemini blocked the prompt (${blockReason})`);
+
+  if (!candidate) throw new Error("Gemini returned no candidates. The prompt may have been blocked or filtered.");
+
+  const finishError = geminiFinishReasonError(candidate.finishReason, hasOutput);
+  if (finishError) throw new Error(finishError);
+
+  if (!hasOutput) throw new Error("Gemini returned no content.");
 }
 
 function parseToolArguments(value: string): Record<string, unknown> {
@@ -302,12 +379,7 @@ function geminiToolCallFromPart(part: GeminiPart, index: number): LLMToolCall | 
   };
 }
 
-function geminiUsage(usage?: {
-  promptTokenCount: number;
-  candidatesTokenCount: number;
-  totalTokenCount: number;
-  thoughtsTokenCount?: number;
-}): LLMUsage | undefined {
+function geminiUsage(usage?: GeminiUsageMetadata): LLMUsage | undefined {
   if (!usage) return undefined;
   return {
     promptTokens: usage.promptTokenCount,
@@ -342,11 +414,11 @@ export class GoogleProvider extends BaseLLMProvider {
     if (this.shouldSuppressModelParameters(options) || !options.tools?.length)
       return super.chatComplete(messages, options);
 
-    const configuredMaxTokens = options.maxTokens ?? 4096;
+    const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     messages = contextFit.messages;
     this.logContextTrim(contextFit, options.model || "gemini-2.0-flash");
-    const maxTokens = contextFit.maxTokens ?? configuredMaxTokens;
+    const maxTokens = this.applyMaxTokensCap(contextFit.maxTokens ?? configuredMaxTokens);
     const model = options.model || "gemini-2.0-flash";
 
     const isGemini3 = /gemini-3/i.test(model);
@@ -421,18 +493,9 @@ export class GoogleProvider extends BaseLLMProvider {
       throw new Error(`${label} error ${response.status}: ${sanitizeApiError(errorText)}`);
     }
 
-    const json = JSON.parse(await readDecodedText()) as {
-      candidates?: Array<{ content?: { parts?: GeminiPart[] }; finishReason?: string }>;
-      usageMetadata?: {
-        promptTokenCount: number;
-        candidatesTokenCount: number;
-        totalTokenCount: number;
-        thoughtsTokenCount?: number;
-      };
-    };
+    const json = JSON.parse(await readDecodedText()) as GeminiResponsePayload;
     const candidate = json.candidates?.[0];
     const parts = candidate?.content?.parts ?? [];
-    options.onResponseParts?.(parts);
 
     let content = "";
     const toolCalls: LLMToolCall[] = [];
@@ -443,6 +506,8 @@ export class GoogleProvider extends BaseLLMProvider {
       const call = geminiToolCallFromPart(part, i);
       if (call) toolCalls.push(call);
     }
+    assertGeminiUsableResponse(json, candidate, content.length > 0 || toolCalls.length > 0);
+    options.onResponseParts?.(parts);
     if (content && options.onToken) await options.onToken(content);
 
     return {
@@ -455,7 +520,7 @@ export class GoogleProvider extends BaseLLMProvider {
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const suppressModelParameters = this.shouldSuppressModelParameters(options);
-    const configuredMaxTokens = suppressModelParameters ? undefined : (options.maxTokens ?? 4096);
+    const configuredMaxTokens = suppressModelParameters ? undefined : this.applyMaxTokensCap(options.maxTokens ?? 4096);
     const contextFit = this.fitMessagesToContext(messages, { ...options, maxTokens: configuredMaxTokens });
     messages = contextFit.messages;
     this.logContextTrim(contextFit, options.model || "gemini-2.0-flash");
@@ -588,18 +653,13 @@ export class GoogleProvider extends BaseLLMProvider {
 
     // ── Non-streaming path (also used when thinking is enabled) ──
     if (!useStreaming) {
-      const json = JSON.parse(await readDecodedText()) as {
-        candidates?: Array<{
-          content: { parts: GeminiPart[] };
-        }>;
-        usageMetadata?: {
-          promptTokenCount: number;
-          candidatesTokenCount: number;
-          totalTokenCount: number;
-          thoughtsTokenCount?: number;
-        };
-      };
-      const parts = json.candidates?.[0]?.content?.parts ?? [];
+      const json = JSON.parse(await readDecodedText()) as GeminiResponsePayload;
+      const candidate = json.candidates?.[0];
+      const parts = candidate?.content?.parts ?? [];
+      const hasVisibleText = parts.some(
+        (part) => !part.thought && typeof part.text === "string" && part.text.length > 0,
+      );
+      assertGeminiUsableResponse(json, candidate, hasVisibleText);
 
       // Report full parts (with thought signatures) for storage
       if (options.onResponseParts) options.onResponseParts(parts);
@@ -643,6 +703,8 @@ export class GoogleProvider extends BaseLLMProvider {
     let thoughtText = "";
     let responseText = "";
     let lastSignature: string | undefined;
+    let sawCandidate = false;
+    let lastFinishReason: string | undefined;
 
     try {
       while (true) {
@@ -661,38 +723,66 @@ export class GoogleProvider extends BaseLLMProvider {
           if (!trimmed.startsWith("data: ")) continue;
           const data = trimmed.slice(6);
 
+          let parsed: GeminiResponsePayload;
           try {
-            const parsed = JSON.parse(data);
-            if (parsed.usageMetadata) {
-              streamUsage = {
-                promptTokens: parsed.usageMetadata.promptTokenCount,
-                completionTokens: parsed.usageMetadata.candidatesTokenCount,
-                totalTokens: parsed.usageMetadata.totalTokenCount,
-                completionReasoningTokens: parsed.usageMetadata.thoughtsTokenCount,
-              };
-            }
-            const parts: GeminiPart[] = parsed.candidates?.[0]?.content?.parts ?? [];
-            for (const part of parts) {
-              // Capture thought signature from any part
-              if (part.thoughtSignature) lastSignature = part.thoughtSignature;
-
-              if (part.thought && part.text) {
-                // Thought summary part
-                thoughtText += part.text;
-                if (options.onThinking) options.onThinking(part.text);
-              } else if (part.text && !part.thought) {
-                // Regular text part
-                responseText += part.text;
-                yield part.text;
-              }
-            }
+            parsed = JSON.parse(data) as GeminiResponsePayload;
           } catch {
             // Skip malformed lines
+            continue;
+          }
+
+          const apiError = formatGeminiApiError(parsed.error);
+          if (apiError) throw new Error(`Gemini API streaming error: ${apiError}`);
+
+          const blockReason = formatGeminiPromptBlock(parsed.promptFeedback);
+          if (blockReason) throw new Error(`Gemini blocked the prompt (${blockReason})`);
+
+          if (parsed.usageMetadata) {
+            streamUsage = {
+              promptTokens: parsed.usageMetadata.promptTokenCount,
+              completionTokens: parsed.usageMetadata.candidatesTokenCount,
+              totalTokens: parsed.usageMetadata.totalTokenCount,
+              completionReasoningTokens: parsed.usageMetadata.thoughtsTokenCount,
+            };
+          }
+          const candidate = parsed.candidates?.[0];
+          const parts: GeminiPart[] = candidate?.content?.parts ?? [];
+          if (candidate) {
+            sawCandidate = true;
+            if (candidate.finishReason) lastFinishReason = candidate.finishReason;
+          }
+          const finishError = geminiFinishReasonError(
+            candidate?.finishReason,
+            responseText.length > 0 || parts.length > 0,
+          );
+          if (finishError) throw new Error(finishError);
+
+          for (const part of parts) {
+            // Capture thought signature from any part
+            if (part.thoughtSignature) lastSignature = part.thoughtSignature;
+
+            if (part.thought && part.text) {
+              // Thought summary part
+              thoughtText += part.text;
+              if (options.onThinking) options.onThinking(part.text);
+            } else if (part.text && !part.thought) {
+              // Regular text part
+              responseText += part.text;
+              yield part.text;
+            }
           }
         }
       }
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
+    }
+
+    if (!responseText) {
+      const finishError = geminiFinishReasonError(lastFinishReason, false);
+      if (finishError) throw new Error(finishError);
+      if (!sawCandidate)
+        throw new Error("Gemini stream returned no candidates. The prompt may have been blocked or filtered.");
+      throw new Error("Gemini stream returned no content.");
     }
 
     // Reconstruct the canonical parts array for storage (thought signatures + summaries)
@@ -706,5 +796,12 @@ export class GoogleProvider extends BaseLLMProvider {
     }
 
     if (streamUsage) return streamUsage;
+  }
+
+  override async embed(_texts: string[], _model: string): Promise<number[][]> {
+    const label = this.providerKind === "google_vertex" ? "Vertex AI Gemini" : "Google Gemini";
+    throw new Error(
+      `${label} connections do not support embeddings through Marinara's OpenAI-compatible /embeddings path. Configure a dedicated OpenAI-compatible or local embedding connection.`,
+    );
   }
 }

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -209,14 +209,14 @@ function formatGeminiApiError(error: GeminiApiError | undefined): string | null 
 }
 
 function formatGeminiPromptBlock(feedback: GeminiPromptFeedback | undefined): string | null {
-  const reason = feedback?.blockReason?.trim();
+  const reason = typeof feedback?.blockReason === "string" ? feedback.blockReason.trim() : "";
   if (!reason) return null;
-  const message = feedback?.blockReasonMessage?.trim();
+  const message = typeof feedback?.blockReasonMessage === "string" ? feedback.blockReasonMessage.trim() : "";
   return message ? `${reason}: ${message}` : reason;
 }
 
 function geminiFinishReasonError(finishReason: string | undefined, hasOutput: boolean): string | null {
-  const normalized = finishReason?.trim().toUpperCase();
+  const normalized = typeof finishReason === "string" ? finishReason.trim().toUpperCase() : "";
   if (!normalized || normalized === "STOP") return null;
   if (hasOutput && normalized === "MAX_TOKENS") return null;
   if (hasOutput) return null;

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -186,7 +186,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
   private static normalizeTopP(topP: number | null | undefined): number | undefined {
     if (topP == null || !Number.isFinite(topP)) return undefined;
-    if (topP <= 0) return 1;
+    if (topP < 0) return undefined;
     return Math.min(topP, 1);
   }
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -31,6 +31,7 @@ import {
 } from "@earendil-works/pi-ai";
 import type {
   BaseLLMProvider,
+  ChatCompletionResult,
   ChatMessage,
   ChatOptions,
   LLMToolCall,
@@ -81,6 +82,7 @@ type WorkspaceConnection = Pick<
   | "defaultParameters"
   | "openrouterProvider"
   | "claudeFastMode"
+  | "treatAsLocalEndpoint"
   | "enableCaching"
   | "cachingAtDepth"
 > & { provider: string; isLocalSidecar?: boolean };
@@ -407,6 +409,103 @@ function parseToolArgumentsValue(value: unknown): Record<string, unknown> {
   return {};
 }
 
+function shouldUseJsonToolProtocol(connection: WorkspaceConnection): boolean {
+  return isLocalSidecarConnection(connection) || bool(connection.treatAsLocalEndpoint);
+}
+
+function jsonToolProtocolInstruction(tools: LLMToolDefinition[]): string {
+  const toolList = tools
+    .map((tool) => {
+      const parameters = JSON.stringify(tool.function.parameters ?? {}, null, 2);
+      return `- ${tool.function.name}: ${tool.function.description || "Workspace tool"}\n  parameters: ${parameters}`;
+    })
+    .join("\n");
+
+  return `Professor Mari workspace tool protocol:
+If you need a workspace tool, respond with only JSON in this shape:
+{"tool_calls":[{"name":"tool_name","arguments":{}}]}
+You may include multiple tool_calls when they are independent. Do not wrap the JSON in markdown. Do not add prose around tool_calls.
+If no tool is needed, answer normally in plain text.
+
+Available tools:
+${toolList}`;
+}
+
+function extractJsonToolPayload(content: string): Record<string, unknown> | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
+  const objectStart = trimmed.indexOf("{");
+  const objectEnd = trimmed.lastIndexOf("}");
+  const candidates = [
+    trimmed,
+    fenced,
+    objectStart >= 0 && objectEnd > objectStart ? trimmed.slice(objectStart, objectEnd + 1) : null,
+  ].filter((candidate): candidate is string => !!candidate);
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+function rawJsonToolCalls(payload: Record<string, unknown>): unknown[] {
+  const plural = payload.tool_calls ?? payload.toolCalls ?? payload.calls;
+  if (Array.isArray(plural)) return plural;
+  const single = payload.tool_call ?? payload.toolCall;
+  if (single !== undefined) return [single];
+  if (typeof payload.name === "string") return [payload];
+  return [];
+}
+
+function parseJsonToolProtocolCalls(content: string, tools: LLMToolDefinition[]): LLMToolCall[] {
+  const payload = extractJsonToolPayload(content);
+  if (!payload) return [];
+  const knownTools = new Set(tools.map((tool) => tool.function.name));
+  const calls: LLMToolCall[] = [];
+  rawJsonToolCalls(payload).forEach((raw, index) => {
+    if (!isRecord(raw) || typeof raw.name !== "string" || !knownTools.has(raw.name)) return;
+    const args = parseToolArgumentsValue(raw.arguments ?? raw.args ?? raw.input ?? {});
+    const id =
+      typeof raw.id === "string" && raw.id.trim()
+        ? raw.id.trim()
+        : `mari_json_tool_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 8)}`;
+    calls.push({
+      id,
+      type: "function",
+      function: { name: raw.name, arguments: JSON.stringify(args) },
+    });
+  });
+  return calls;
+}
+
+async function runJsonToolProtocol(
+  provider: BaseLLMProvider,
+  messages: ChatMessage[],
+  baseOptions: ChatOptions,
+  tools: LLMToolDefinition[],
+): Promise<ChatCompletionResult> {
+  const protocolMessage: ChatMessage = {
+    role: "system",
+    content: jsonToolProtocolInstruction(tools),
+    contextKind: "prompt",
+  };
+  const firstNonSystemIndex = messages.findIndex((message) => message.role !== "system");
+  const fallbackMessages =
+    firstNonSystemIndex === -1
+      ? [protocolMessage, ...messages]
+      : [...messages.slice(0, firstNonSystemIndex), protocolMessage, ...messages.slice(firstNonSystemIndex)];
+  const result = await provider.chatComplete(fallbackMessages, { ...baseOptions, stream: false });
+  const toolCalls = parseJsonToolProtocolCalls(result.content ?? "", tools);
+  if (toolCalls.length === 0) return result;
+  return { ...result, content: null, toolCalls, finishReason: "tool_calls" };
+}
+
 function emptyUsage(): AssistantMessage["usage"] {
   return {
     input: 0,
@@ -523,10 +622,12 @@ export class ProfessorMariWorkspaceService {
       this.lastError = err instanceof Error ? err.message : String(err);
       return null;
     });
-    const skillsResponse = await getProfessorMariWorkspaceSkillsService().list().catch((err) => {
-      this.lastError = err instanceof Error ? err.message : String(err);
-      return { skills: [], diagnostics: [this.lastError ?? "Professor Mari skills unavailable"] };
-    });
+    const skillsResponse = await getProfessorMariWorkspaceSkillsService()
+      .list()
+      .catch((err) => {
+        this.lastError = err instanceof Error ? err.message : String(err);
+        return { skills: [], diagnostics: [this.lastError ?? "Professor Mari skills unavailable"] };
+      });
     return {
       enabled: this.enabled,
       piAvailable: true,
@@ -908,16 +1009,17 @@ export class ProfessorMariWorkspaceService {
           signal: options?.signal,
           onThinking: pushThinkingDelta,
         };
-        // Use provider-native tool calling only. OpenAI-compatible custom/local endpoints receive the
-        // standard OpenAI `tools` payload; no private JSON tool protocol fallback.
-        const result = tools?.length
-          ? await provider.chatComplete(messages, {
-              ...baseOptions,
-              stream: true,
-              tools,
-              onToken: pushTextDelta,
-            })
-          : await provider.chatComplete(messages, { ...baseOptions, stream: true, onToken: pushTextDelta });
+        const result =
+          tools?.length && shouldUseJsonToolProtocol(connection)
+            ? await runJsonToolProtocol(provider, messages, baseOptions, tools)
+            : tools?.length
+              ? await provider.chatComplete(messages, {
+                  ...baseOptions,
+                  stream: true,
+                  tools,
+                  onToken: pushTextDelta,
+                })
+              : await provider.chatComplete(messages, { ...baseOptions, stream: true, onToken: pushTextDelta });
 
         if (result.content && !sawTextDelta) pushTextDelta(result.content);
         if (isLengthFinishReason(result.finishReason)) output.stopReason = "length";
@@ -982,6 +1084,7 @@ export class ProfessorMariWorkspaceService {
       defaultParameters: null,
       openrouterProvider: null,
       claudeFastMode: "false",
+      treatAsLocalEndpoint: "true",
       enableCaching: "false",
       cachingAtDepth: 5,
       isLocalSidecar: true,

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -104,6 +104,7 @@ export function createConnectionsStorage(db: DB) {
         promptPresetId: input.promptPresetId ?? null,
         maxTokensOverride: input.maxTokensOverride ?? null,
         claudeFastMode: String(input.claudeFastMode ?? false),
+        treatAsLocalEndpoint: String(input.treatAsLocalEndpoint ?? false),
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -195,6 +196,9 @@ export function createConnectionsStorage(db: DB) {
       if (data.claudeFastMode !== undefined) {
         updateFields.claudeFastMode = String(data.claudeFastMode);
       }
+      if (data.treatAsLocalEndpoint !== undefined) {
+        updateFields.treatAsLocalEndpoint = String(data.treatAsLocalEndpoint);
+      }
       await db.update(apiConnections).set(updateFields).where(eq(apiConnections.id, id));
       return this.getById(id);
     },
@@ -232,6 +236,7 @@ export function createConnectionsStorage(db: DB) {
         maxTokensOverride: source.maxTokensOverride,
         maxParallelJobs: source.maxParallelJobs,
         claudeFastMode: source.claudeFastMode,
+        treatAsLocalEndpoint: source.treatAsLocalEndpoint,
         createdAt: timestamp,
         updatedAt: timestamp,
       });

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -43,6 +43,7 @@ export const createConnectionSchema = z.object({
   promptPresetId: z.string().nullable().default(null),
   maxTokensOverride: z.number().int().min(1).nullable().default(null),
   maxParallelJobs: z.number().int().min(1).max(16).default(1),
+  treatAsLocalEndpoint: z.boolean().default(false),
   claudeFastMode: z.boolean().default(false),
 });
 

--- a/packages/shared/src/schemas/prompt.schema.ts
+++ b/packages/shared/src/schemas/prompt.schema.ts
@@ -36,7 +36,7 @@ export const markerConfigSchema = z.object({
 
 export const generationParametersSchema = z.object({
   temperature: z.number().min(0).max(2).default(1),
-  topP: z.number().gt(0).max(1).default(1),
+  topP: z.number().min(0).max(1).default(1),
   topK: z.number().int().min(0).default(0),
   minP: z.number().min(0).max(1).default(0),
   maxTokens: z.number().int().min(1).default(4096),

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -65,6 +65,8 @@ export interface APIConnection {
   maxTokensOverride: number | null;
   /** Maximum number of agent LLM jobs Marinara may run at once for this connection. */
   maxParallelJobs: number;
+  /** Treat this endpoint as local/custom for Professor Mari tool-protocol fallbacks. */
+  treatAsLocalEndpoint: boolean;
   /** Folder this connection belongs to (null = root/unfiled). */
   folderId: string | null;
   /** Manual sort order within a folder (lower = higher). 0 = use default sort. */


### PR DESCRIPTION
## Why this change

This PR addresses the open issues assigned to SpicyMarinara around provider error handling, generation-parameter validation, preset/connection state races, and Professor Mari local/custom endpoint tool fallback.

Addresses closed issues: #2651, #2659, #2660, #2661, #2662, #2663, #2664, #2665, #2666, #2667.

## What changed

- Surface Anthropic and Gemini streamed provider errors instead of treating partial output as success.
- Surface Gemini blocked/empty responses instead of returning blank stop results.
- Apply connection max-output caps across Anthropic, Google/Gemini, and Claude subscription budget paths.
- Guard Anthropic/Gemini embedding calls from using inherited OpenAI-style /embeddings behavior.
- Preserve top_p=0 and validate/salvage stored generation parameters with schema bounds.
- Prevent metadata cache updates from overwriting newer chat fields such as promptPresetId.
- Reset stale model-specific connection state when switching providers.
- Add a Treat as local/custom endpoint connection toggle and Professor Mari JSON tool fallback path.

## Validation

- pnpm check
- pnpm db:push attempted, but this checkout has no db:push script/command.
- [ ] Manually verify Professor Mari workspace tool use against a custom-domain local endpoint.
- [ ] Manually verify connection editor provider switching clears stale output caps.
- [ ] Manually verify preset assignment no longer reverts under slow network conditions.

## Notes

The local shell is Node v20.11.1, while the repo declares Node >=24 <26. Vite also warned that it prefers Node >=20.19 or >=22.12, but the build completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Local / Custom Endpoint" toggle in connection settings for non-image-generation providers to support local endpoint configurations.

* **Improvements**
  * Enhanced parameter validation with clearer error messages.
  * Improved generation parameter handling and normalization across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->