### PR TITLE
Fix assigned issue sweep across agents, trackers, imports, and game

### DIFF
--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -185,12 +185,14 @@ function attachEmbeddedLorebookToCharacterJson(raw: Record<string, unknown>, emb
 }
 
 function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function optionalStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const values = value.map(String).filter((item) => item.trim().length > 0);
+  const values = value.map((item) => String(item).trim()).filter((item) => item.length > 0);
   return values.length > 0 ? values : undefined;
 }
 

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -185,11 +185,13 @@ function attachEmbeddedLorebookToCharacterJson(raw: Record<string, unknown>, emb
 }
 
 function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
-function optionalStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.map(String) : [];
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.map(String).filter((item) => item.trim().length > 0);
+  return values.length > 0 ? values : undefined;
 }
 
 function optionalRecord(value: unknown): Record<string, unknown> | undefined {
@@ -696,11 +698,15 @@ const jannyProvider: ProviderConfig = {
         scenario: (char.scenario as string) || undefined,
         firstMessage: (char.firstMessage as string) || undefined,
         exampleDialogs: (char.exampleDialogs as string) || undefined,
+        alternateGreetings: optionalStringArray(char.alternateGreetings ?? char.alternate_greetings),
         creatorNotes: char.description
           ? typeof char.description === "string"
             ? char.description.replace(/<[^>]*>/g, "").trim()
             : undefined
           : undefined,
+        systemPrompt: optionalString(char.systemPrompt ?? char.system_prompt),
+        postHistoryInstructions: optionalString(char.postHistoryInstructions ?? char.post_history_instructions),
+        characterVersion: optionalString(char.characterVersion ?? char.character_version),
       };
     };
 
@@ -934,6 +940,16 @@ const pygmalionProvider: ProviderConfig = {
       firstMessage: p.greeting || undefined,
       exampleDialogs: p.mesExample || undefined,
       creatorNotes: p.characterNotes || undefined,
+      systemPrompt: optionalString(p.systemPrompt ?? p.system_prompt ?? char.systemPrompt ?? char.system_prompt),
+      postHistoryInstructions: optionalString(
+        p.postHistoryInstructions ??
+          p.post_history_instructions ??
+          char.postHistoryInstructions ??
+          char.post_history_instructions,
+      ),
+      characterVersion: optionalString(
+        p.characterVersion ?? p.character_version ?? char.characterVersion ?? char.character_version,
+      ),
       alternateGreetings: Array.isArray(p.alternateGreetings) ? p.alternateGreetings.filter(Boolean) : [],
     };
   },
@@ -1040,6 +1056,9 @@ const wyvernProvider: ProviderConfig = {
       firstMessage: c.first_mes || undefined,
       exampleDialogs: c.mes_example || undefined,
       creatorNotes: c.creator_notes || undefined,
+      systemPrompt: optionalString(c.systemPrompt ?? c.system_prompt),
+      postHistoryInstructions: optionalString(c.postHistoryInstructions ?? c.post_history_instructions),
+      characterVersion: optionalString(c.characterVersion ?? c.character_version),
       alternateGreetings: Array.isArray(c.alternate_greetings) ? c.alternate_greetings.filter(Boolean) : [],
       hasLorebook: !!(c.lorebooks?.length > 0),
     };
@@ -1248,6 +1267,9 @@ const datacatProvider: ProviderConfig = {
             firstMessage: d.first_mes || undefined,
             exampleDialogs: d.mes_example || undefined,
             creatorNotes: d.creator_notes || undefined,
+            systemPrompt: optionalString(d.systemPrompt ?? d.system_prompt),
+            postHistoryInstructions: optionalString(d.postHistoryInstructions ?? d.post_history_instructions),
+            characterVersion: optionalString(d.characterVersion ?? d.character_version),
             alternateGreetings: Array.isArray(d.alternate_greetings) ? d.alternate_greetings.filter(Boolean) : [],
           };
         }
@@ -1268,6 +1290,9 @@ const datacatProvider: ProviderConfig = {
         scenario: c.scenario || undefined,
         firstMessage: c.first_message || undefined,
         creatorNotes: plainDesc || undefined,
+        systemPrompt: optionalString(c.systemPrompt ?? c.system_prompt),
+        postHistoryInstructions: optionalString(c.postHistoryInstructions ?? c.post_history_instructions),
+        characterVersion: optionalString(c.characterVersion ?? c.character_version),
       };
     } catch {
       return null;
@@ -1589,6 +1614,9 @@ export function BotBrowserView() {
           first_mes: cardDetail?.firstMessage || "",
           mes_example: cardDetail?.exampleDialogs || "",
           creator_notes: cardDetail?.creatorNotes || "",
+          system_prompt: cardDetail?.systemPrompt || "",
+          post_history_instructions: cardDetail?.postHistoryInstructions || "",
+          character_version: cardDetail?.characterVersion || "",
           tags: card.tags,
           creator: card.creator,
           alternate_greetings: cardDetail?.alternateGreetings || [],
@@ -2730,6 +2758,9 @@ function DetailView({
         first_mes: d?.firstMessage || "",
         mes_example: d?.exampleDialogs || "",
         creator_notes: d?.creatorNotes || "",
+        system_prompt: d?.systemPrompt || "",
+        post_history_instructions: d?.postHistoryInstructions || "",
+        character_version: d?.characterVersion || "",
         tags: card.tags || [],
         creator: card.creator || "",
         alternate_greetings: d?.alternateGreetings || [],
@@ -2986,11 +3017,11 @@ async function buildCharacterCardPng(avatarUrl: string, charData: Record<string,
       first_mes: charData.first_mes || "",
       mes_example: charData.mes_example || "",
       creator_notes: charData.creator_notes || "",
-      system_prompt: "",
-      post_history_instructions: "",
+      system_prompt: charData.system_prompt || "",
+      post_history_instructions: charData.post_history_instructions || "",
       tags: charData.tags || [],
       creator: charData.creator || "",
-      character_version: "",
+      character_version: charData.character_version || "",
       alternate_greetings: charData.alternate_greetings || [],
       extensions: charData.extensions || {},
     },

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -25,6 +25,7 @@ import {
   useUpdateMessageExtra,
   usePeekPrompt,
   useSetActiveSwipe,
+  useTouchChat,
   useUpdateChatMetadata,
   useBranchChat,
   useChats,
@@ -429,6 +430,7 @@ export function ChatArea() {
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
   const peekPrompt = usePeekPrompt();
   const branchChat = useBranchChat();
+  const touchChat = useTouchChat();
   const { generate, retryAgents } = useGenerate();
   const setActiveSwipe = useSetActiveSwipe(activeChatId);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
@@ -446,6 +448,17 @@ export function ChatArea() {
     if (listedActiveChat) return;
     setActiveChatId(null);
   }, [activeChatId, allChats, listedActiveChat, setActiveChatId]);
+
+  const touchedActiveChatRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!chat?.id) {
+      touchedActiveChatRef.current = null;
+      return;
+    }
+    if (touchedActiveChatRef.current === chat.id) return;
+    touchedActiveChatRef.current = chat.id;
+    touchChat.mutate(chat.id);
+  }, [chat?.id, touchChat]);
 
   const currentGameSessionChatId = useMemo(() => resolveCurrentGameSessionChatId(chat, allChats), [allChats, chat]);
 

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -55,8 +55,9 @@ import type {
   Message,
 } from "@marinara-engine/shared";
 import {
-  inventoryTrackerLockPrefix,
-  removeTrackerArrayItemLocks,
+  inventoryItemTrackerLockPrefix,
+  normalizeTrackerFieldLocksForState,
+  removeTrackerFieldLockPrefix,
   toggleTrackerFieldLock,
 } from "@marinara-engine/shared";
 import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store";
@@ -224,7 +225,7 @@ export function RoleplayHUD({
   const inventory = playerStats?.inventory ?? EMPTY_INVENTORY;
   const activeQuests = playerStats?.activeQuests ?? [];
   const customTrackerFields = playerStats?.customTrackerFields ?? [];
-  const fieldLocks = gameState?.fieldLocks ?? null;
+  const fieldLocks = gameState ? normalizeTrackerFieldLocksForState(gameState.fieldLocks, gameState) : null;
   const updateFieldLocks = useTrackerFieldLockUpdater({ chatId, fieldLocks, patchField });
   const updateInventoryItems = useCallback(
     (items: InventoryItem[]) => patchPlayerStats("inventory", items),
@@ -233,7 +234,7 @@ export function RoleplayHUD({
   const removeInventoryItem = useCallback(
     (index: number) => {
       updateInventoryItems(inventory.filter((_, itemIndex) => itemIndex !== index));
-      updateFieldLocks((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), index));
+      updateFieldLocks((locks) => removeTrackerFieldLockPrefix(locks, inventoryItemTrackerLockPrefix(inventory[index]!, index)));
     },
     [inventory, updateFieldLocks, updateInventoryItems],
   );

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -1269,6 +1269,16 @@ export function CustomTrackerPanel({
   };
 
   const updateField = (idx: number, updated: CustomTrackerField) => {
+    const previous = fields[idx];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          customTrackerFieldLockPrefix(previous, idx),
+          customTrackerFieldLockPrefix(updated, idx),
+        ),
+      );
+    }
     const next = [...fields];
     next[idx] = updated;
     onUpdate(next);

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -37,6 +37,7 @@ import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
 import { useAgentConfigs, useUpdateAgent, type AgentConfigRow } from "../../hooks/use-agents";
 import { ROLEPLAY_POPOVER_HEADER, ROLEPLAY_POPOVER_TITLE } from "./roleplay-popover-styles";
+import { coerceStatNumber, getStatPercent } from "../../features/tracker-panel/lib/tracker-stat-layout";
 import type {
   CharacterStat,
   CustomTrackerField,
@@ -501,7 +502,7 @@ export function CombinedPlayerPanel({
                       onToggleLock={thoughtsLock.onToggle}
                     />
                   </div>
-                  {char.stats?.length > 0 && (
+                  {Array.isArray(char.stats) && char.stats.length > 0 && (
                     <div className="space-y-1 pt-1 border-t border-[var(--border)]">
                       {char.stats.map((stat, statIndex) => {
                         const valueLock = lockFor(characterStatTrackerLockKey(char, idx, stat, "value", statIndex));
@@ -511,12 +512,12 @@ export function CombinedPlayerPanel({
                             key={stat.name}
                             stat={stat}
                             onUpdateValue={(value) => {
-                              const next = [...(char.stats ?? [])];
+                              const next = Array.isArray(char.stats) ? [...char.stats] : [];
                               next[statIndex] = { ...next[statIndex]!, value };
                               updateCharacter(idx, { ...char, stats: next });
                             }}
                             onUpdateMax={(value) => {
-                              const next = [...(char.stats ?? [])];
+                              const next = Array.isArray(char.stats) ? [...char.stats] : [];
                               next[statIndex] = { ...next[statIndex]!, max: value };
                               updateCharacter(idx, { ...char, stats: next });
                             }}
@@ -1021,7 +1022,7 @@ export function CharactersPanel({
                 onToggleLock={thoughtsLock.onToggle}
               />
             </div>
-            {char.stats?.length > 0 && (
+            {Array.isArray(char.stats) && char.stats.length > 0 && (
               <div className="space-y-1 pt-1 border-t border-[var(--border)]">
                 {char.stats.map((stat, statIndex) => {
                   const valueLock = lockFor(characterStatTrackerLockKey(char, idx, stat, "value", statIndex));
@@ -1031,12 +1032,12 @@ export function CharactersPanel({
                       key={stat.name}
                       stat={stat}
                       onUpdateValue={(value) => {
-                        const next = [...(char.stats ?? [])];
+                        const next = Array.isArray(char.stats) ? [...char.stats] : [];
                         next[statIndex] = { ...next[statIndex]!, value };
                         updateCharacter(idx, { ...char, stats: next });
                       }}
                       onUpdateMax={(value) => {
-                        const next = [...(char.stats ?? [])];
+                        const next = Array.isArray(char.stats) ? [...char.stats] : [];
                         next[statIndex] = { ...next[statIndex]!, max: value };
                         updateCharacter(idx, { ...char, stats: next });
                       }}
@@ -1809,7 +1810,9 @@ function StatBarEditable({
   onToggleMaxLock?: () => void;
 }) {
   const { lockMode } = useTrackerLockContext();
-  const pct = stat.max > 0 ? Math.min(100, Math.max(0, (stat.value / stat.max) * 100)) : 0;
+  const pct = getStatPercent(stat);
+  const value = coerceStatNumber(stat.value);
+  const max = coerceStatNumber(stat.max);
   const removeButton = onRemove ? (
     <button
       type="button"
@@ -1845,7 +1848,7 @@ function StatBarEditable({
         <div className="group/field flex items-center gap-0.5 shrink-0 text-[0.5625rem] text-[var(--muted-foreground)]/60">
           <input
             type="number"
-            value={stat.value}
+            value={value}
             onChange={(e) => onUpdateValue(Number(e.target.value))}
             className={cn(
               "w-12 rounded bg-transparent text-right outline-none text-[var(--foreground)]/80 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
@@ -1856,7 +1859,7 @@ function StatBarEditable({
           <span>/</span>
           <input
             type="number"
-            value={stat.max}
+            value={max}
             onChange={(e) => onUpdateMax(Number(e.target.value))}
             className={cn(
               "w-12 rounded bg-transparent outline-none text-[var(--foreground)]/80 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -47,20 +47,22 @@ import type {
 import {
   characterStatTrackerLockKey,
   characterTrackerLockKey,
-  customTrackerLockPrefix,
+  characterTrackerLockPrefix,
+  customTrackerFieldLockPrefix,
   customTrackerLockKey,
-  inventoryTrackerLockPrefix,
+  inventoryItemTrackerLockPrefix,
   inventoryTrackerLockKey,
   isTrackerFieldLocked,
-  personaStatsTrackerLockPrefix,
+  personaStatTrackerLockPrefix,
   personaStatTrackerLockKey,
   personaStatusTrackerLockKey,
-  questObjectivesTrackerLockPrefix,
   questObjectiveTrackerLockKey,
+  questObjectiveTrackerLockPrefix,
   questTrackerLockKey,
-  removeTrackerArrayItemLocks,
   removeTrackerCharacterLocks,
+  removeTrackerFieldLockPrefix,
   removeTrackerQuestLocks,
+  renameTrackerFieldLockPrefix,
   worldTrackerLockKey,
 } from "@marinara-engine/shared";
 import { useTrackerLockContext } from "../../features/tracker-panel/components/TrackerLockContext";
@@ -220,8 +222,18 @@ export function CombinedPlayerPanel({
 }: CombinedPlayerPanelProps) {
   const { onUpdateFieldLocks } = useTrackerLockContext();
   const updateBar = (idx: number, field: "value" | "max" | "name", val: number | string) => {
+    const previous = personaStats[idx];
     const next = [...personaStats];
     next[idx] = { ...next[idx]!, [field]: val };
+    if (field === "name" && previous && previous.name !== next[idx]!.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          personaStatTrackerLockPrefix(previous, idx),
+          personaStatTrackerLockPrefix(next[idx]!, idx),
+        ),
+      );
+    }
     onUpdatePersonaStats(next);
   };
 
@@ -247,6 +259,16 @@ export function CombinedPlayerPanel({
     onUpdateCharacters(characters.filter((_, i) => i !== idx));
   };
   const updateCharacter = (idx: number, updated: PresentCharacter) => {
+    const previous = characters[idx];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          characterTrackerLockPrefix(previous, idx),
+          characterTrackerLockPrefix(updated, idx),
+        ),
+      );
+    }
     const next = [...characters];
     next[idx] = updated;
     onUpdateCharacters(next);
@@ -260,10 +282,22 @@ export function CombinedPlayerPanel({
       onRemoveInventoryItem(idx);
       return;
     }
-    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), idx));
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerFieldLockPrefix(locks, inventoryItemTrackerLockPrefix(inventory[idx]!, idx)),
+    );
     onUpdateInventory(inventory.filter((_, i) => i !== idx));
   };
   const updateItem = (idx: number, updated: InventoryItem) => {
+    const previous = inventory[idx];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          inventoryItemTrackerLockPrefix(previous, idx),
+          inventoryItemTrackerLockPrefix(updated, idx),
+        ),
+      );
+    }
     const next = [...inventory];
     next[idx] = updated;
     onUpdateInventory(next);
@@ -296,10 +330,22 @@ export function CombinedPlayerPanel({
     onUpdateCustomTracker([...customTrackerFields, { name: "New Field", value: "" }]);
   };
   const removeCustomField = (idx: number) => {
-    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, customTrackerLockPrefix(), idx));
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerFieldLockPrefix(locks, customTrackerFieldLockPrefix(customTrackerFields[idx]!, idx)),
+    );
     onUpdateCustomTracker(customTrackerFields.filter((_, i) => i !== idx));
   };
   const updateCustomField = (idx: number, updated: CustomTrackerField) => {
+    const previous = customTrackerFields[idx];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          customTrackerFieldLockPrefix(previous, idx),
+          customTrackerFieldLockPrefix(updated, idx),
+        ),
+      );
+    }
     const next = [...customTrackerFields];
     next[idx] = updated;
     onUpdateCustomTracker(next);
@@ -346,9 +392,9 @@ export function CombinedPlayerPanel({
             <div className="space-y-2">
               {personaStats.length === 0 && <div className={EMPTY_STATE}>No stats tracked</div>}
               {personaStats.map((bar, idx) => {
-                const nameLock = lockFor(personaStatTrackerLockKey(idx, "name"));
-                const valueLock = lockFor(personaStatTrackerLockKey(idx, "value"));
-                const maxLock = lockFor(personaStatTrackerLockKey(idx, "max"));
+                const nameLock = lockFor(personaStatTrackerLockKey(bar, "name", idx));
+                const valueLock = lockFor(personaStatTrackerLockKey(bar, "value", idx));
+                const maxLock = lockFor(personaStatTrackerLockKey(bar, "max", idx));
                 return (
                   <StatBarEditable
                     key={bar.name}
@@ -458,8 +504,8 @@ export function CombinedPlayerPanel({
                   {char.stats?.length > 0 && (
                     <div className="space-y-1 pt-1 border-t border-[var(--border)]">
                       {char.stats.map((stat, statIndex) => {
-                        const valueLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "value"));
-                        const maxLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "max"));
+                        const valueLock = lockFor(characterStatTrackerLockKey(char, idx, stat, "value", statIndex));
+                        const maxLock = lockFor(characterStatTrackerLockKey(char, idx, stat, "max", statIndex));
                         return (
                           <StatBarEditable
                             key={stat.name}
@@ -503,8 +549,8 @@ export function CombinedPlayerPanel({
             <div className="space-y-1">
               {inventory.length === 0 && <div className={EMPTY_STATE}>Inventory empty</div>}
               {inventory.map((item, idx) => {
-                const nameLock = lockFor(inventoryTrackerLockKey(idx, "name"));
-                const quantityLock = lockFor(inventoryTrackerLockKey(idx, "quantity"));
+                const nameLock = lockFor(inventoryTrackerLockKey(item, "name", idx));
+                const quantityLock = lockFor(inventoryTrackerLockKey(item, "quantity", idx));
                 return (
                   <div
                     key={idx}
@@ -599,8 +645,8 @@ export function CombinedPlayerPanel({
             <div className="space-y-1">
               {customTrackerFields.length === 0 && <div className={EMPTY_STATE}>No fields tracked</div>}
               {customTrackerFields.map((field, idx) => {
-                const nameLock = lockFor(customTrackerLockKey(idx, "name"));
-                const valueLock = lockFor(customTrackerLockKey(idx, "value"));
+                const nameLock = lockFor(customTrackerLockKey(field, "name", idx));
+                const valueLock = lockFor(customTrackerLockKey(field, "value", idx));
                 const toggleValueLock = () => {
                   if (field.locked) updateCustomField(idx, { ...field, locked: false });
                   if (valueLock.locked || !field.locked) valueLock.onToggle();
@@ -669,12 +715,24 @@ export function PersonaStatsPanel({
 }: PersonaStatsPanelProps) {
   const { onUpdateFieldLocks } = useTrackerLockContext();
   const updateBar = (idx: number, field: "value" | "max" | "name", val: number | string) => {
+    const previous = bars[idx];
     const next = [...bars];
     next[idx] = { ...next[idx]!, [field]: val };
+    if (field === "name" && previous && previous.name !== next[idx]!.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          personaStatTrackerLockPrefix(previous, idx),
+          personaStatTrackerLockPrefix(next[idx]!, idx),
+        ),
+      );
+    }
     onUpdate(next);
   };
   const removeBar = (idx: number) => {
-    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, personaStatsTrackerLockPrefix(), idx));
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerFieldLockPrefix(locks, personaStatTrackerLockPrefix(bars[idx]!, idx)),
+    );
     onUpdate(bars.filter((_, index) => index !== idx));
   };
   const lockFor = useHudFieldLockResolver();
@@ -704,9 +762,9 @@ export function PersonaStatsPanel({
       </div>
       <div className="p-2 space-y-2">
         {bars.map((bar, idx) => {
-          const nameLock = lockFor(personaStatTrackerLockKey(idx, "name"));
-          const valueLock = lockFor(personaStatTrackerLockKey(idx, "value"));
-          const maxLock = lockFor(personaStatTrackerLockKey(idx, "max"));
+          const nameLock = lockFor(personaStatTrackerLockKey(bar, "name", idx));
+          const valueLock = lockFor(personaStatTrackerLockKey(bar, "value", idx));
+          const maxLock = lockFor(personaStatTrackerLockKey(bar, "max", idx));
           return (
             <StatBarEditable
               key={bar.name}
@@ -820,6 +878,16 @@ export function CharactersPanel({
   };
 
   const updateCharacter = (idx: number, updated: PresentCharacter) => {
+    const previous = characters[idx];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          characterTrackerLockPrefix(previous, idx),
+          characterTrackerLockPrefix(updated, idx),
+        ),
+      );
+    }
     const next = [...characters];
     next[idx] = updated;
     onUpdate(next);
@@ -956,8 +1024,8 @@ export function CharactersPanel({
             {char.stats?.length > 0 && (
               <div className="space-y-1 pt-1 border-t border-[var(--border)]">
                 {char.stats.map((stat, statIndex) => {
-                  const valueLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "value"));
-                  const maxLock = lockFor(characterStatTrackerLockKey(char, idx, statIndex, "max"));
+                  const valueLock = lockFor(characterStatTrackerLockKey(char, idx, stat, "value", statIndex));
+                  const maxLock = lockFor(characterStatTrackerLockKey(char, idx, stat, "max", statIndex));
                   return (
                     <StatBarEditable
                       key={stat.name}
@@ -1022,11 +1090,23 @@ export function InventoryPanel({
       onRemoveItem(idx);
       return;
     }
-    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), idx));
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerFieldLockPrefix(locks, inventoryItemTrackerLockPrefix(items[idx]!, idx)),
+    );
     onUpdate(items.filter((_, i) => i !== idx));
   };
 
   const updateItem = (idx: number, updated: InventoryItem) => {
+    const previous = items[idx];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          inventoryItemTrackerLockPrefix(previous, idx),
+          inventoryItemTrackerLockPrefix(updated, idx),
+        ),
+      );
+    }
     const next = [...items];
     next[idx] = updated;
     onUpdate(next);
@@ -1049,8 +1129,8 @@ export function InventoryPanel({
       <div className="p-2 space-y-1">
         {items.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>Inventory empty</div>}
         {items.map((item, idx) => {
-          const nameLock = lockFor(inventoryTrackerLockKey(idx, "name"));
-          const quantityLock = lockFor(inventoryTrackerLockKey(idx, "quantity"));
+          const nameLock = lockFor(inventoryTrackerLockKey(item, "name", idx));
+          const quantityLock = lockFor(inventoryTrackerLockKey(item, "quantity", idx));
           return (
             <div key={idx} className="group/field flex items-center gap-1.5 rounded-lg bg-[var(--muted)]/20 px-2 py-1.5">
               <Package size="0.625rem" className="shrink-0 text-amber-400/60" />
@@ -1181,7 +1261,9 @@ export function CustomTrackerPanel({
   };
 
   const removeField = (idx: number) => {
-    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, customTrackerLockPrefix(), idx));
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerFieldLockPrefix(locks, customTrackerFieldLockPrefix(fields[idx]!, idx)),
+    );
     onUpdate(fields.filter((_, i) => i !== idx));
   };
 
@@ -1215,8 +1297,8 @@ export function CustomTrackerPanel({
       <div className="p-2 space-y-1">
         {fields.length === 0 && <div className={cn(EMPTY_STATE, "py-2")}>No fields tracked — add one above</div>}
         {fields.map((field, idx) => {
-          const nameLock = lockFor(customTrackerLockKey(idx, "name"));
-          const valueLock = lockFor(customTrackerLockKey(idx, "value"));
+          const nameLock = lockFor(customTrackerLockKey(field, "name", idx));
+          const valueLock = lockFor(customTrackerLockKey(field, "value", idx));
           const toggleValueLock = () => {
             if (field.locked) updateField(idx, { ...field, locked: false });
             if (valueLock.locked || !field.locked) valueLock.onToggle();
@@ -1823,14 +1905,24 @@ function QuestCardEditable({
 
   const removeObjective = (idx: number) => {
     onUpdateFieldLocks?.((locks) =>
-      removeTrackerArrayItemLocks(locks, questObjectivesTrackerLockPrefix(quest, questIndex), idx),
+      removeTrackerFieldLockPrefix(locks, questObjectiveTrackerLockPrefix(quest, questIndex, quest.objectives[idx]!, idx)),
     );
     onUpdate({ ...quest, objectives: quest.objectives.filter((_, objectiveIndex) => objectiveIndex !== idx) });
   };
 
   const updateObjectiveText = (idx: number, text: string) => {
+    const previous = quest.objectives[idx];
     const next = [...quest.objectives];
     next[idx] = { ...next[idx]!, text };
+    if (previous && previous.text !== text) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          questObjectiveTrackerLockPrefix(quest, questIndex, previous, idx),
+          questObjectiveTrackerLockPrefix(quest, questIndex, next[idx]!, idx),
+        ),
+      );
+    }
     onUpdate({ ...quest, objectives: next });
   };
 
@@ -1882,8 +1974,8 @@ function QuestCardEditable({
       {!quest.completed && (
         <div className="mt-1 space-y-0.5 pl-4">
           {quest.objectives.map((objective, idx) => {
-            const completedLock = lockFor(questObjectiveTrackerLockKey(quest, questIndex, idx, "completed"));
-            const textLock = lockFor(questObjectiveTrackerLockKey(quest, questIndex, idx, "text"));
+            const completedLock = lockFor(questObjectiveTrackerLockKey(quest, questIndex, objective, "completed", idx));
+            const textLock = lockFor(questObjectiveTrackerLockKey(quest, questIndex, objective, "text", idx));
             return (
               <div key={idx} className="group group/field flex items-center gap-1 text-[0.5625rem]">
                 <button

--- a/packages/client/src/components/game/DraggablePanel.tsx
+++ b/packages/client/src/components/game/DraggablePanel.tsx
@@ -132,8 +132,8 @@ interface PanelLockButtonProps {
 export function PanelLockButton({ locked, onToggle, onReset, size = 10, className }: PanelLockButtonProps) {
   const title = onReset
     ? locked
-      ? "Unlock to move. Double-click to reset position"
-      : "Lock in place. Double-click to reset position"
+      ? "Unlock to move. Double-click or press R to reset position"
+      : "Lock in place. Double-click or press R to reset position"
     : locked
       ? "Unlock to move"
       : "Lock in place";
@@ -147,6 +147,12 @@ export function PanelLockButton({ locked, onToggle, onReset, size = 10, classNam
       }}
       onDoubleClick={(event) => {
         if (!onReset) return;
+        event.stopPropagation();
+        onReset();
+      }}
+      onKeyDown={(event) => {
+        if (!onReset || event.key.toLowerCase() !== "r") return;
+        event.preventDefault();
         event.stopPropagation();
         onReset();
       }}

--- a/packages/client/src/components/game/DraggablePanel.tsx
+++ b/packages/client/src/components/game/DraggablePanel.tsx
@@ -6,12 +6,13 @@
 // by chatId so positions don't bleed across games.
 // `PanelLockButton` renders the lock toggle in headers.
 // ──────────────────────────────────────────────
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMotionValue } from "framer-motion";
 import { Lock, Unlock } from "lucide-react";
 import { cn } from "../../lib/utils";
 
 const STORAGE_PREFIX = "marinara-game-panel:";
+const MIN_VISIBLE_PANEL_PX = 96;
 
 interface PanelState {
   locked: boolean;
@@ -48,6 +49,21 @@ function writePanelState(key: string, state: PanelState) {
   }
 }
 
+function clampOffsetToViewport(value: number, axis: "x" | "y") {
+  if (typeof window === "undefined") return value;
+  const viewportSize = axis === "x" ? window.innerWidth : window.innerHeight;
+  const limit = Math.max(0, viewportSize - MIN_VISIBLE_PANEL_PX);
+  return Math.max(-limit, Math.min(limit, value));
+}
+
+function clampPanelState(state: PanelState): PanelState {
+  return {
+    ...state,
+    x: clampOffsetToViewport(state.x, "x"),
+    y: clampOffsetToViewport(state.y, "y"),
+  };
+}
+
 /**
  * Returns motion values + lock state for a draggable HUD panel, persisted per
  * chat so positions don't bleed across games. Reads from localStorage
@@ -62,37 +78,66 @@ export function useDraggablePanel(scopeId: string, panelId: string) {
   if (seedRef.current === null) {
     seedRef.current = readPanelState(key);
   }
-  const seed = seedRef.current;
+  const seed = clampPanelState(seedRef.current);
 
   const [locked, setLocked] = useState(seed.locked);
   const x = useMotionValue(seed.x);
   const y = useMotionValue(seed.y);
 
+  const clampAndPersist = useCallback(() => {
+    const next = clampPanelState({ locked, x: x.get(), y: y.get() });
+    if (next.x !== x.get()) x.set(next.x);
+    if (next.y !== y.get()) y.set(next.y);
+    writePanelState(key, next);
+  }, [key, locked, x, y]);
+
+  useEffect(() => {
+    clampAndPersist();
+    if (typeof window === "undefined") return;
+    window.addEventListener("resize", clampAndPersist);
+    return () => window.removeEventListener("resize", clampAndPersist);
+  }, [clampAndPersist]);
+
   const toggleLocked = useCallback(() => {
     setLocked((prev) => {
       const next = !prev;
-      writePanelState(key, { locked: next, x: x.get(), y: y.get() });
+      writePanelState(key, clampPanelState({ locked: next, x: x.get(), y: y.get() }));
       return next;
     });
   }, [key, x, y]);
 
   const handleDragEnd = useCallback(() => {
-    writePanelState(key, { locked, x: x.get(), y: y.get() });
+    clampAndPersist();
+  }, [clampAndPersist]);
+
+  const resetPosition = useCallback(() => {
+    x.set(0);
+    y.set(0);
+    writePanelState(key, { locked, x: 0, y: 0 });
   }, [key, locked, x, y]);
 
-  return { locked, toggleLocked, x, y, handleDragEnd };
+  return { locked, toggleLocked, resetPosition, x, y, handleDragEnd };
 }
 
 interface PanelLockButtonProps {
   locked: boolean;
   onToggle: () => void;
+  onReset?: () => void;
   /** Icon size in px. Matches the adjacent collapse indicator. */
   size?: number;
   className?: string;
 }
 
 /** Small lock toggle styled to match collapse/chevron buttons in HUD panels. */
-export function PanelLockButton({ locked, onToggle, size = 10, className }: PanelLockButtonProps) {
+export function PanelLockButton({ locked, onToggle, onReset, size = 10, className }: PanelLockButtonProps) {
+  const title = onReset
+    ? locked
+      ? "Unlock to move. Double-click to reset position"
+      : "Lock in place. Double-click to reset position"
+    : locked
+      ? "Unlock to move"
+      : "Lock in place";
+
   return (
     <button
       type="button"
@@ -100,12 +145,18 @@ export function PanelLockButton({ locked, onToggle, size = 10, className }: Pane
         event.stopPropagation();
         onToggle();
       }}
+      onDoubleClick={(event) => {
+        if (!onReset) return;
+        event.stopPropagation();
+        onReset();
+      }}
       onPointerDown={(event) => event.stopPropagation()}
-      title={locked ? "Unlock to move" : "Lock in place"}
+      title={title}
       aria-label={locked ? "Unlock panel" : "Lock panel"}
       aria-pressed={!locked}
       className={cn(
-        "flex shrink-0 items-center justify-center rounded-md text-[var(--marinara-chat-chrome-panel-muted)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]",
+        "flex shrink-0 items-center justify-center rounded-md text-[var(--marinara-chat-chrome-panel-muted)]",
+        "transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]",
         className,
       )}
     >

--- a/packages/client/src/components/game/GameMap.tsx
+++ b/packages/client/src/components/game/GameMap.tsx
@@ -501,7 +501,7 @@ export function GameMapPanel({
   const [collapsed, setCollapsed] = useState(false);
   const [stateHovered, setStateHovered] = useState(false);
   const [mapZoom, setMapZoom] = useState(1);
-  const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel(chatId, "map");
+  const { locked, toggleLocked, resetPosition, x, y, handleDragEnd } = useDraggablePanel(chatId, "map");
   const mapOptions = buildMapOptions(map, maps);
   const selectedMapId = viewedMapId ?? getMapId(map);
   const activeMap = activeMapId == null || selectedMapId === activeMapId;
@@ -600,7 +600,7 @@ export function GameMapPanel({
             <span className="block truncate">{mapName}</span>
           )}
         </span>
-        <PanelLockButton locked={locked} onToggle={toggleLocked} size={11} />
+        <PanelLockButton locked={locked} onToggle={toggleLocked} onReset={resetPosition} size={11} />
         <span className="shrink-0 text-[var(--marinara-chat-chrome-button-text)]">
           {collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}
         </span>

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -56,6 +56,7 @@ import { useConnections } from "../../hooks/use-connections";
 import { useGenerate } from "../../hooks/use-generate";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { spriteKeys, type SpriteInfo } from "../../hooks/use-characters";
+import { lorebookKeys } from "../../hooks/use-lorebooks";
 import { api, getJsonRepairRequest, type JsonRepairRequest } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn, type AvatarCrop, type LegacyAvatarCrop, type AvatarCropValue } from "../../lib/utils";
@@ -5027,6 +5028,10 @@ export function GameSurface({
       if (responseGameId) {
         queryClient.invalidateQueries({ queryKey: gameKeys.sessions(responseGameId) });
       }
+      if (typeof response.lorebookId === "string") {
+        queryClient.invalidateQueries({ queryKey: lorebookKeys.all });
+        queryClient.invalidateQueries({ queryKey: lorebookKeys.entries(response.lorebookId) });
+      }
 
       if (request.kind === "game_setup") {
         useGameModeStore.getState().setSetupActive(false);
@@ -7060,9 +7065,14 @@ export function GameSurface({
   const handleRegenerateSessionLorebook = useCallback(
     async (sessionNumber: number) => {
       if (!activeChatId) return;
-      await regenerateSessionLorebook.mutateAsync({ chatId: activeChatId, sessionNumber });
+      try {
+        await regenerateSessionLorebook.mutateAsync({ chatId: activeChatId, sessionNumber });
+      } catch (error) {
+        if (handleJsonRepairError(error)) return;
+        throw error;
+      }
     },
-    [activeChatId, regenerateSessionLorebook],
+    [activeChatId, handleJsonRepairError, regenerateSessionLorebook],
   );
 
   const handleUpdateCampaignProgression = useCallback(

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -3126,7 +3126,7 @@ export function GameSurface({
             context,
             limit: 50,
           },
-          { signal: AbortSignal.timeout(25_000) },
+          { signal: AbortSignal.timeout(8_000) },
         );
         return result.enabled ? (result.tracks ?? []) : [];
       } catch (error) {
@@ -4062,12 +4062,15 @@ export function GameSurface({
 
     if (useSpotifyGameMusic && (useSidecar || sceneConnId)) {
       void fetchSpotifySceneCandidates(tags.cleanContent, sceneContext).then((availableSpotifyTracks) => {
-        runSceneAnalysis({
-          ...sceneContext,
-          availableSpotifyTracks,
+        const fallback = availableSpotifyTracks[0];
+        if (!fallback) return;
+        void playSpotifySceneTrack({
+          uri: fallback.uri,
+          name: fallback.name,
+          artist: fallback.artist,
+          album: fallback.album ?? null,
         });
       });
-      return;
     }
 
     runSceneAnalysis(sceneContext);

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -82,7 +82,7 @@ function getNumericWidgetValue(widget: HudWidget) {
 }
 
 function getVisibleWidgets(widgets: HudWidget[], position: "hud_left" | "hud_right") {
-  return widgets.filter((w) => w.position === position && w.type !== "inventory_grid").slice(0, MAX_WIDGETS);
+  return widgets.filter((w) => w.position === position).slice(0, MAX_WIDGETS);
 }
 
 function formatWidgetTypeLabel(type: HudWidget["type"]) {
@@ -397,7 +397,7 @@ function WidgetCard({
   onEdit: (widget: HudWidget) => void;
 }) {
   const [collapsed, setCollapsed] = useState(false);
-  const { locked, toggleLocked, x, y, handleDragEnd } = useDraggablePanel(chatId, `widget:${widget.id}`);
+  const { locked, toggleLocked, resetPosition, x, y, handleDragEnd } = useDraggablePanel(chatId, `widget:${widget.id}`);
 
   return (
     <motion.div
@@ -440,7 +440,7 @@ function WidgetCard({
         >
           <Pencil size={10} />
         </button>
-        <PanelLockButton locked={locked} onToggle={toggleLocked} size={10} />
+        <PanelLockButton locked={locked} onToggle={toggleLocked} onReset={resetPosition} size={10} />
         <span className={cn("text-[0.5rem]", GAME_WIDGET_MUTED_CLASS)}>{collapsed ? "+" : "-"}</span>
       </div>
 
@@ -1184,6 +1184,8 @@ function TimerWidget({ widget }: { widget: HudWidget }) {
   const accent = widget.accent ?? "#ef4444";
   const [displaySeconds, setDisplaySeconds] = useState(seconds);
   const prevSecondsRef = useRef(seconds);
+  const completionPersistedRef = useRef(false);
+  const updateGameWidgets = useUpdateGameWidgets();
 
   // Reset display when the server-provided seconds value changes
   useEffect(() => {
@@ -1191,7 +1193,25 @@ function TimerWidget({ widget }: { widget: HudWidget }) {
       setDisplaySeconds(seconds);
       prevSecondsRef.current = seconds;
     }
-  }, [seconds]);
+    if (running && seconds > 0) {
+      completionPersistedRef.current = false;
+    }
+  }, [running, seconds]);
+
+  useEffect(() => {
+    if (!running || displaySeconds > 0 || completionPersistedRef.current) return;
+    completionPersistedRef.current = true;
+    const store = useGameModeStore.getState();
+    const chatId = store.activeSessionChatId;
+    if (!chatId) return;
+    const nextWidgets = store.hudWidgets.map((currentWidget) =>
+      currentWidget.id === widget.id
+        ? { ...currentWidget, config: { ...currentWidget.config, running: false, seconds: 0 } }
+        : currentWidget,
+    );
+    store.setHudWidgets(nextWidgets);
+    updateGameWidgets.mutate({ chatId, widgets: nextWidgets });
+  }, [displaySeconds, running, updateGameWidgets, widget.id]);
 
   // Count down when running
   useEffect(() => {

--- a/packages/client/src/components/game/GameWidgetSetupEditor.tsx
+++ b/packages/client/src/components/game/GameWidgetSetupEditor.tsx
@@ -93,6 +93,33 @@ function parseNumber(value: unknown, fallback: number, min?: number) {
   return typeof min === "number" ? Math.max(min, numeric) : numeric;
 }
 
+function buildInventoryGridContentsFromText(
+  value: string,
+  previousContents: NonNullable<HudWidgetConfig["contents"]>,
+): NonNullable<HudWidgetConfig["contents"]> {
+  const previousByName = new Map<string, NonNullable<HudWidgetConfig["contents"]>>();
+  for (const item of previousContents) {
+    const key = item.name.trim().toLowerCase();
+    if (!key) continue;
+    const bucket = previousByName.get(key) ?? [];
+    bucket.push(item);
+    previousByName.set(key, bucket);
+  }
+
+  return value
+    .split(/\r?\n/)
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .map((name) => {
+      const previous = previousByName.get(name.toLowerCase())?.shift();
+      return {
+        ...previous,
+        name,
+        quantity: previous?.quantity ?? 1,
+      };
+    });
+}
+
 function defaultWidgetConfig(type: HudWidgetType): HudWidgetConfig {
   switch (type) {
     case "progress_bar":
@@ -537,11 +564,7 @@ function WidgetConfigFields({
             rows={3}
             onChange={(event) =>
               onConfigChange({
-                contents: event.target.value
-                  .split(/\r?\n/)
-                  .map((name) => name.trim())
-                  .filter(Boolean)
-                  .map((name) => ({ name, quantity: 1 })),
+                contents: buildInventoryGridContentsFromText(event.target.value, contents),
               })
             }
             className="w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)]"

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -1117,6 +1117,8 @@ function buildEntrySavePayload(form: Partial<LorebookEntry>) {
     tag: form.tag,
     locked: form.locked,
     preventRecursion: form.preventRecursion,
+    excludeRecursion: form.excludeRecursion,
+    delayUntilRecursion: form.delayUntilRecursion,
     excludeFromVectorization: form.excludeFromVectorization,
   };
 }

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -44,6 +44,7 @@ import type {
   LorebookFilterMode,
   LorebookFolder,
   LorebookMatchingSource,
+  SelectiveLogic,
 } from "@marinara-engine/shared";
 import {
   ExpandableTextarea,
@@ -122,6 +123,13 @@ const STATUS_DOT_COLOR: Record<EntryStatus, string> = {
   selective: "bg-violet-400",
   normal: "bg-emerald-400",
 };
+
+const SELECTIVE_LOGIC_OPTIONS: Array<{ value: SelectiveLogic; label: string }> = [
+  { value: "and", label: "AND Any" },
+  { value: "and_all", label: "AND All" },
+  { value: "not", label: "NOT Any" },
+  { value: "not_all", label: "NOT All" },
+];
 
 const STATUS_GUIDE: Array<{ status: EntryStatus; description: string }> = [
   { status: "normal", description: "Triggers when primary keys match the scanned text." },
@@ -1371,23 +1379,23 @@ function ExpandedDrawer({
         <FieldGroup
           label="Secondary Keys"
           icon={Key}
-          help="Additional keywords used with AND/OR/NOT logic. 'AND' means both primary AND secondary must match. 'NOT' means primary must match but secondary must NOT."
+          help="Additional keywords used with SillyTavern-style selective logic. Any means at least one secondary key; All means every secondary key."
         >
           <KeysEditor keys={form.secondaryKeys ?? []} onChange={(keys) => update({ secondaryKeys: keys })} />
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
             <label className="text-[0.6875rem] text-[var(--muted-foreground)]">Logic:</label>
-            {(["and", "or", "not"] as const).map((logic) => (
+            {SELECTIVE_LOGIC_OPTIONS.map((option) => (
               <button
-                key={logic}
-                onClick={() => update({ selectiveLogic: logic })}
+                key={option.value}
+                onClick={() => update({ selectiveLogic: option.value })}
                 className={cn(
                   "rounded-md px-2 py-0.5 text-[0.6875rem] font-medium transition-colors",
-                  form.selectiveLogic === logic
+                  (form.selectiveLogic === "or" ? "and" : form.selectiveLogic) === option.value
                     ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
                     : "text-[var(--muted-foreground)] hover:bg-[var(--secondary)]",
                 )}
               >
-                {logic.toUpperCase()}
+                {option.label}
               </button>
             ))}
           </div>

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -181,7 +181,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const [topPInput, setTopPInput] = useState(String(config.topP));
   const [topKInput, setTopKInput] = useState(String(config.topK));
   const modalScrollRef = useRef<HTMLDivElement>(null);
-  const previousScrollLayoutRef = useRef({ isBlockingSetup: false, showRuntimeSettings: false });
+  const previousScrollLayoutRef = useRef({ showSetupProgress: false, showRuntimeSettings: false });
 
   const activeBackend = runtime.backend ?? config.backend;
   const isSystemRuntime = runtime.source === "system";
@@ -195,7 +195,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const hasModel = modelDownloaded;
   const activeModelName = hasModel ? modelDisplayName : null;
   const shouldAutoStart = config.useForTrackers || config.useForGameScene;
-  const isBlockingSetup = isDownloading || status === "downloading_runtime";
+  const isBlockingSetup = isDownloading || status === "downloading_runtime" || status === "downloading_model";
   const isPreparingServer =
     runtime.installed && hasModel && shouldAutoStart && !inferenceReady && status === "starting_server";
   const showSetupProgress = isBlockingSetup || isPreparingServer;
@@ -298,16 +298,16 @@ export function ModelDownloadModal({ open, onClose }: Props) {
 
   useEffect(() => {
     const previous = previousScrollLayoutRef.current;
-    previousScrollLayoutRef.current = { isBlockingSetup, showRuntimeSettings };
+    previousScrollLayoutRef.current = { showSetupProgress, showRuntimeSettings };
 
     if (!open) return;
 
     const runtimeSettingsOpened = showRuntimeSettings && !previous.showRuntimeSettings;
-    const setupVisibilityChanged = isBlockingSetup !== previous.isBlockingSetup;
+    const setupVisibilityChanged = showSetupProgress !== previous.showSetupProgress;
     if (!runtimeSettingsOpened && !setupVisibilityChanged) return;
 
     modalScrollRef.current?.scrollTo({ top: 0 });
-  }, [isBlockingSetup, open, showRuntimeSettings]);
+  }, [open, showRuntimeSettings, showSetupProgress]);
 
   const handleSkip = () => {
     markPrompted();
@@ -990,7 +990,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           </div>
         )}
 
-        {!isBlockingSetup && (
+        {!showSetupProgress && (
           <>
             <div className="flex flex-col gap-2">
               <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
@@ -1157,7 +1157,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
         )}
 
         <div className="flex items-center gap-2">
-          {isBlockingSetup ? (
+          {showSetupProgress ? (
             <button
               onClick={handleCancelSetup}
               className="flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--border)] px-4 py-2.5 text-sm text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)]"
@@ -1184,7 +1184,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           )}
         </div>
 
-        {!hasModel && !isBlockingSetup && (
+        {!hasModel && !showSetupProgress && (
           <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-3">
             <span className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
               What the local model handles

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, type CSSProperties } from "react";
-import { toggleTrackerFieldLock } from "@marinara-engine/shared";
+import { normalizeTrackerFieldLocksForState, toggleTrackerFieldLock } from "@marinara-engine/shared";
 import { TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR, useUIStore } from "../../../stores/ui.store";
 import { useChatStore } from "../../../stores/chat.store";
 import { useGameStatePatcher } from "../../../hooks/use-game-state-patcher";
@@ -55,7 +55,9 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
   const [deleteMode, setDeleteMode] = useState(false);
   const [addMode, setAddMode] = useState(false);
   const [lockMode, setLockMode] = useState(false);
-  const fieldLocks = currentGameState?.fieldLocks ?? null;
+  const fieldLocks = currentGameState
+    ? normalizeTrackerFieldLocksForState(currentGameState.fieldLocks, currentGameState)
+    : null;
   const updateFieldLocks = useTrackerFieldLockUpdater({ chatId: activeChatId, fieldLocks, patchField });
   const toggleFieldLock = useCallback((key: string) => {
     updateFieldLocks((locks) => toggleTrackerFieldLock(locks, key));

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type CSSProperties } from "react";
+import { Component, useCallback, useState, type CSSProperties, type ErrorInfo, type ReactNode } from "react";
 import { normalizeTrackerFieldLocksForState, toggleTrackerFieldLock } from "@marinara-engine/shared";
 import { TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR, useUIStore } from "../../../stores/ui.store";
 import { useChatStore } from "../../../stores/chat.store";
@@ -17,6 +17,34 @@ import { TrackerLockProvider } from "./TrackerLockContext";
 const TRACKER_PANEL_NEUTRAL_VARS =
   "[--accent:rgb(39_39_42)] [--accent-foreground:rgb(244_244_245)] [--background:rgb(18_18_21)] [--border:rgb(63_63_70)] [--card:rgb(24_24_27)] [--foreground:rgb(244_244_245)] [--input:rgb(63_63_70)] [--muted:rgb(39_39_42)] [--muted-foreground:rgb(161_161_170)] [--popover:rgb(24_24_27)] [--popover-foreground:rgb(244_244_245)] [--primary:rgb(212_212_216)] [--primary-foreground:rgb(18_18_21)] [--ring:rgb(161_161_170)] [--secondary:rgb(39_39_42)] [--tracker-panel-card-background:color-mix(in_srgb,var(--background)_22%,transparent)] [--tracker-panel-section-background:color-mix(in_srgb,var(--card)_6%,transparent)]";
 type TrackerPanelSurfaceStyle = CSSProperties & Record<`--${string}`, string>;
+
+class TrackerPanelErrorBoundary extends Component<
+  { children: ReactNode; resetKey: string },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    console.error("[TrackerPanel]", error, info);
+  }
+
+  componentDidUpdate(previousProps: Readonly<{ children: ReactNode; resetKey: string }>) {
+    if (this.state.hasError && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <EmptySection>Tracker data could not be rendered.</EmptySection>;
+    }
+    return this.props.children;
+  }
+}
 
 export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolean } = {}) {
   const activeChatId = useChatStore((s) => s.activeChatId);
@@ -122,34 +150,36 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
 
         <div className={cn("relative z-10", fillHeight && "min-h-0 flex-1 overflow-y-auto")}>
           {showTrackerSections ? (
-            <TrackerSectionList
-              activeChatId={activeChatId}
-              activePersona={activePersona}
-              autoGenerateCharacterAvatars={autoGenerateCharacterAvatars}
-              characterSpriteLookup={characterSpriteLookup}
-              characterTrackerConfig={characterTrackerConfig}
-              characterTrackerSettings={characterTrackerSettings}
-              currentGameState={currentGameState}
-              enabledAgentTypes={enabledAgentTypes}
-              expressionSpritesEnabled={expressionSpritesEnabled}
-              featuredCharacterCardKeys={featuredCharacterCardKeys}
-              flushPatch={flushPatch}
-              gameStateRefreshing={gameStateRefreshing}
-              orderedTrackerSections={orderedTrackerSections}
-              patchField={patchField}
-              patchPlayerStats={patchPlayerStats}
-              resolveSpriteCharacterId={resolveSpriteCharacterId}
-              spriteExpressions={spriteExpressions}
-              trackerPanelCollapsedSections={trackerPanelCollapsedSections}
-              trackerPanelSide={trackerPanelSide}
-              trackerPanelSizeProfile={trackerPanelSizeProfile}
-              trackerPanelThoughtBubbleDisplay={trackerPanelThoughtBubbleDisplay}
-              trackerPanelDockedThoughtsAlwaysVisible={trackerPanelDockedThoughtsAlwaysVisible}
-              trackerTemperatureUnit={trackerTemperatureUnit}
-              toggleTrackerPanelSectionCollapsed={toggleTrackerPanelSectionCollapsed}
-              deleteMode={deleteMode}
-              addMode={addMode}
-            />
+            <TrackerPanelErrorBoundary resetKey={`${activeChatId}:${currentGameState.id}:${currentGameState.createdAt}`}>
+              <TrackerSectionList
+                activeChatId={activeChatId}
+                activePersona={activePersona}
+                autoGenerateCharacterAvatars={autoGenerateCharacterAvatars}
+                characterSpriteLookup={characterSpriteLookup}
+                characterTrackerConfig={characterTrackerConfig}
+                characterTrackerSettings={characterTrackerSettings}
+                currentGameState={currentGameState}
+                enabledAgentTypes={enabledAgentTypes}
+                expressionSpritesEnabled={expressionSpritesEnabled}
+                featuredCharacterCardKeys={featuredCharacterCardKeys}
+                flushPatch={flushPatch}
+                gameStateRefreshing={gameStateRefreshing}
+                orderedTrackerSections={orderedTrackerSections}
+                patchField={patchField}
+                patchPlayerStats={patchPlayerStats}
+                resolveSpriteCharacterId={resolveSpriteCharacterId}
+                spriteExpressions={spriteExpressions}
+                trackerPanelCollapsedSections={trackerPanelCollapsedSections}
+                trackerPanelSide={trackerPanelSide}
+                trackerPanelSizeProfile={trackerPanelSizeProfile}
+                trackerPanelThoughtBubbleDisplay={trackerPanelThoughtBubbleDisplay}
+                trackerPanelDockedThoughtsAlwaysVisible={trackerPanelDockedThoughtsAlwaysVisible}
+                trackerTemperatureUnit={trackerTemperatureUnit}
+                toggleTrackerPanelSectionCollapsed={toggleTrackerPanelSectionCollapsed}
+                deleteMode={deleteMode}
+                addMode={addMode}
+              />
+            </TrackerPanelErrorBoundary>
           ) : null}
 
           {!activeChatId ? (

--- a/packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx
@@ -120,6 +120,7 @@ export function TrackerSectionList({
     updateQuest,
   } = useTrackerMutations({
     activeChatId,
+    customFields,
     inventory,
     personaStats,
     presentCharacters,

--- a/packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSectionList.tsx
@@ -90,12 +90,17 @@ export function TrackerSectionList({
     gameStateRefreshing,
   });
 
-  const playerStats = currentGameState.playerStats ?? null;
-  const personaStats = currentGameState.personaStats ?? [];
-  const presentCharacters = currentGameState.presentCharacters ?? [];
-  const inventory = playerStats?.inventory ?? [];
-  const quests = playerStats?.activeQuests ?? [];
-  const customFields = playerStats?.customTrackerFields ?? [];
+  const playerStats =
+    currentGameState.playerStats &&
+    typeof currentGameState.playerStats === "object" &&
+    !Array.isArray(currentGameState.playerStats)
+      ? currentGameState.playerStats
+      : null;
+  const personaStats = Array.isArray(currentGameState.personaStats) ? currentGameState.personaStats : [];
+  const presentCharacters = Array.isArray(currentGameState.presentCharacters) ? currentGameState.presentCharacters : [];
+  const inventory = Array.isArray(playerStats?.inventory) ? playerStats.inventory : [];
+  const quests = Array.isArray(playerStats?.activeQuests) ? playerStats.activeQuests : [];
+  const customFields = Array.isArray(playerStats?.customTrackerFields) ? playerStats.customTrackerFields : [];
   const {
     addCharacter,
     addInventoryItem,

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -5,6 +5,7 @@ import {
   characterStatTrackerLockKey,
   characterTrackerLockKey,
   isTrackerFieldLocked,
+  renameTrackerFieldLockPrefix,
   type PresentCharacter,
 } from "@marinara-engine/shared";
 import type {
@@ -162,7 +163,7 @@ export function CharacterTrackerCard({
   onToggleFeatured?: () => void;
   onUploadAvatar?: () => void;
 }) {
-  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
   if (featured) {
     return (
       <FeaturedCharacterTrackerCard
@@ -212,6 +213,15 @@ export function CharacterTrackerCard({
     const trimmedName = nextName.trim();
     if (trimmedName && trimmedName !== oldName && Object.prototype.hasOwnProperty.call(nextFields, trimmedName)) {
       return;
+    }
+    if (trimmedName && trimmedName !== oldName) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          characterCustomFieldTrackerLockKey(character, characterIndex, oldName, "name").replace(/\.name$/, ""),
+          characterCustomFieldTrackerLockKey(character, characterIndex, trimmedName, "name").replace(/\.name$/, ""),
+        ),
+      );
     }
     delete nextFields[oldName];
     if (trimmedName) nextFields[trimmedName] = nextValue;
@@ -364,7 +374,9 @@ export function CharacterTrackerCard({
             nameMode="truncate"
             deleteMode={deleteMode}
             addMode={addMode}
-            getLockKey={(statIndex, field) => characterStatTrackerLockKey(character, characterIndex, statIndex, field)}
+            getLockKey={(statIndex, field, stat) =>
+              characterStatTrackerLockKey(character, characterIndex, stat, field, statIndex)
+            }
           />
         </div>
       )}

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -190,7 +190,7 @@ export function CharacterTrackerCard({
   }
 
   const customFields = Object.entries(character.customFields ?? {});
-  const characterStats = character.stats ?? [];
+  const characterStats = Array.isArray(character.stats) ? character.stats : [];
   const hasDeleteAction = !!onRemove && deleteMode;
   const avatarMedia = characterPicture ?? character.avatarPath ?? null;
   const compactAvatarUpload = characterPicture ? undefined : onUploadAvatar;

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterFields.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterFields.tsx
@@ -204,7 +204,7 @@ export function FeaturedStatGrid({
   scrollable: boolean;
   wideColumns?: boolean;
   className?: string;
-  getLockKey?: (index: number, field: "name" | "value" | "max") => string;
+  getLockKey?: (index: number, field: "name" | "value" | "max", stat: CharacterStat) => string;
 }) {
   return (
     <div className={cn(FEATURED_STAT_SHELF_CLASS, scrollable ? "overflow-y-auto" : "overflow-y-hidden", className)}>

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
@@ -5,6 +5,7 @@ import {
   characterStatTrackerLockKey,
   characterTrackerLockKey,
   isTrackerFieldLocked,
+  renameTrackerFieldLockPrefix,
   type PresentCharacter,
 } from "@marinara-engine/shared";
 import type {
@@ -108,7 +109,7 @@ export function FeaturedCharacterTrackerCard({
   onToggleFeatured?: () => void;
   onUploadAvatar?: () => void;
 }) {
-  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
+  const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
   const thoughtAnchorRef = useRef<HTMLDivElement | null>(null);
   const thoughtBubbleRef = useRef<HTMLDivElement | null>(null);
   const thoughtControlRef = useRef<HTMLButtonElement | null>(null);
@@ -198,6 +199,15 @@ export function FeaturedCharacterTrackerCard({
     const trimmedName = nextName.trim();
     if (trimmedName && trimmedName !== oldName && Object.prototype.hasOwnProperty.call(nextFields, trimmedName)) {
       return;
+    }
+    if (trimmedName && trimmedName !== oldName) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          characterCustomFieldTrackerLockKey(character, characterIndex, oldName, "name").replace(/\.name$/, ""),
+          characterCustomFieldTrackerLockKey(character, characterIndex, trimmedName, "name").replace(/\.name$/, ""),
+        ),
+      );
     }
     delete nextFields[oldName];
     if (trimmedName) nextFields[trimmedName] = nextValue;
@@ -318,7 +328,9 @@ export function FeaturedCharacterTrackerCard({
             scrollable={characterStatsOverflowPortrait}
             wideColumns={useFeaturedStatColumns}
             className={FEATURED_STAT_BAND_CLASS}
-            getLockKey={(statIndex, field) => characterStatTrackerLockKey(character, characterIndex, statIndex, field)}
+            getLockKey={(statIndex, field, stat) =>
+              characterStatTrackerLockKey(character, characterIndex, stat, field, statIndex)
+            }
           />
         )}
       </div>

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
@@ -115,7 +115,7 @@ export function FeaturedCharacterTrackerCard({
   const thoughtControlRef = useRef<HTMLButtonElement | null>(null);
   const [thoughtsOpen, setThoughtsOpen] = useState(false);
   const customFields = Object.entries(character.customFields ?? {});
-  const characterStats = character.stats ?? [];
+  const characterStats = Array.isArray(character.stats) ? character.stats : [];
   const hasEditableStatAdd = !!onUpdate && addMode;
   const featuredStatColumnHeightRem =
     trackerPanelSizeProfile === "expanded"

--- a/packages/client/src/features/tracker-panel/components/controls/InlineControls.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/InlineControls.tsx
@@ -3,6 +3,7 @@ import { Pencil, Plus } from "lucide-react";
 import { cn } from "../../../../lib/utils";
 import { TRACKER_TEXT_MICRO } from "../../lib/tracker-panel.constants";
 import { getNumberValueWidth } from "../../lib/tracker-display";
+import { coerceStatNumber } from "../../lib/tracker-stat-layout";
 
 export function FittedText({
   children,
@@ -313,7 +314,8 @@ export function InlineNumber({
   lockMode?: boolean;
   onToggleLock?: () => void;
 }) {
-  const width = getNumberValueWidth(value);
+  const numericValue = coerceStatNumber(value);
+  const width = getNumberValueWidth(numericValue);
 
   if (lockMode && onToggleLock) {
     return (
@@ -333,7 +335,7 @@ export function InlineNumber({
           "[@media(pointer:coarse)]:min-h-[1.75rem]",
         )}
       >
-        <span>{Number.isFinite(value) ? value : 0}</span>
+        <span>{numericValue}</span>
       </button>
     );
   }
@@ -341,7 +343,7 @@ export function InlineNumber({
   return (
     <input
       type="number"
-      value={Number.isFinite(value) ? value : 0}
+      value={numericValue}
       onChange={(event) => {
         const numeric = Number(event.target.value);
         const next = Number.isFinite(numeric) ? numeric : 0;

--- a/packages/client/src/features/tracker-panel/components/controls/StatList.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/StatList.tsx
@@ -1,5 +1,10 @@
 import { X } from "lucide-react";
-import { isTrackerFieldLocked, removeTrackerArrayItemLocks, type CharacterStat } from "@marinara-engine/shared";
+import {
+  isTrackerFieldLocked,
+  removeTrackerFieldLockPrefix,
+  renameTrackerFieldLockPrefix,
+  type CharacterStat,
+} from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import { TRACKER_BAR, TRACKER_TEXT_ROW } from "../../lib/tracker-panel.constants";
 import type { TrackerStatDensity, TrackerStatDisplayScale } from "../../tracker-panel.types";
@@ -324,7 +329,7 @@ export function StatList({
   fillWideColumns?: boolean;
   showWideColumnGhost?: boolean;
   visualTone?: StatListVisualTone;
-  getLockKey?: (index: number, field: "name" | "value" | "max") => string;
+  getLockKey?: (index: number, field: "name" | "value" | "max", stat: CharacterStat) => string;
 }) {
   const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
   if (stats.length === 0) {
@@ -336,22 +341,28 @@ export function StatList({
   }
   const updateStat = (index: number, updated: CharacterStat) => {
     if (!onUpdate) return;
+    const previous = stats[index];
+    if (previous && previous.name !== updated.name) {
+      const fromKey = getLockKey?.(index, "name", previous);
+      const toKey = getLockKey?.(index, "name", updated);
+      if (fromKey && toKey) {
+        onUpdateFieldLocks?.((locks) =>
+          renameTrackerFieldLockPrefix(locks, fromKey.replace(/\.name$/, ""), toKey.replace(/\.name$/, "")),
+        );
+      }
+    }
     const next = [...stats];
     next[index] = updated;
     onUpdate(next);
   };
   const removeStat = (index: number) => {
     if (!onUpdate) return;
-    const nameLockKey = getLockKey?.(index, "name");
-    const nameSuffix = `.${index}.name`;
-    if (nameLockKey?.endsWith(nameSuffix)) {
-      const prefix = nameLockKey.slice(0, -nameSuffix.length);
-      onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, prefix, index));
-    }
+    const nameLockKey = getLockKey?.(index, "name", stats[index]!);
+    if (nameLockKey) onUpdateFieldLocks?.((locks) => removeTrackerFieldLockPrefix(locks, nameLockKey.replace(/\.name$/, "")));
     onUpdate(stats.filter((_, statIndex) => statIndex !== index));
   };
   const buildLockToggle = (index: number, field: "name" | "value" | "max") =>
-    getLockKey && onToggleFieldLock ? () => onToggleFieldLock(getLockKey(index, field)) : undefined;
+    getLockKey && onToggleFieldLock ? () => onToggleFieldLock(getLockKey(index, field, stats[index]!)) : undefined;
   const displayScale = getTrackerStatDisplayScale(
     stats.length,
     density,
@@ -403,9 +414,9 @@ export function StatList({
             compactNameRhythm={compactNameRhythm}
             wideColumnCell={wideColumnCell}
             visualTone={visualTone}
-            nameLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "name")) : false}
-            valueLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "value")) : false}
-            maxLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "max")) : false}
+            nameLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "name", stat)) : false}
+            valueLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "value", stat)) : false}
+            maxLocked={getLockKey ? isTrackerFieldLocked(fieldLocks, getLockKey(index, "max", stat)) : false}
             lockMode={lockMode}
             onToggleNameLock={buildLockToggle(index, "name")}
             onToggleValueLock={buildLockToggle(index, "value")}

--- a/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
@@ -2,9 +2,10 @@ import type { ReactNode } from "react";
 import { SlidersHorizontal, X } from "lucide-react";
 import {
   customTrackerLockKey,
-  customTrackerLockPrefix,
+  customTrackerFieldLockPrefix,
   isTrackerFieldLocked,
-  removeTrackerArrayItemLocks,
+  removeTrackerFieldLockPrefix,
+  renameTrackerFieldLockPrefix,
   type CustomTrackerField,
 } from "@marinara-engine/shared";
 import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
@@ -48,13 +49,25 @@ function CustomFieldList({
   const useFieldColumns = shouldUseCustomFieldColumns(fields, trackerPanelSizeProfile);
   const updateField = (index: number, updated: CustomTrackerField) => {
     if (!onUpdate) return;
+    const previous = fields[index];
+    if (previous && previous.name !== updated.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          customTrackerFieldLockPrefix(previous, index),
+          customTrackerFieldLockPrefix(updated, index),
+        ),
+      );
+    }
     const next = [...fields];
     next[index] = updated;
     onUpdate(next);
   };
   const removeField = (index: number) => {
     if (!onUpdate) return;
-    onUpdateFieldLocks?.((locks) => removeTrackerArrayItemLocks(locks, customTrackerLockPrefix(), index));
+    onUpdateFieldLocks?.((locks) =>
+      removeTrackerFieldLockPrefix(locks, customTrackerFieldLockPrefix(fields[index]!, index)),
+    );
     onUpdate(fields.filter((_, fieldIndex) => fieldIndex !== index));
   };
   return (
@@ -75,7 +88,7 @@ function CustomFieldList({
             const valueText = visibleText(field.value, "");
             const valueIsLong = valueText.length > 18 || valueText.includes(" ");
             const valueAlignment = allowWrap && valueIsLong ? "text-left" : "text-right tabular-nums";
-            const valueLockKey = customTrackerLockKey(index, "value");
+            const valueLockKey = customTrackerLockKey(field, "value", index);
             const valueLocked = isTrackerFieldLocked(fieldLocks, valueLockKey);
             const toggleValueLock = () => {
               // Migrate the deprecated per-field flag into the shared lock map on first toggle.
@@ -110,9 +123,9 @@ function CustomFieldList({
                     previewLineCount={allowWrap ? 2 : undefined}
                     scrollOnHover={!allowWrap}
                     showEditHint={false}
-                    locked={isTrackerFieldLocked(fieldLocks, customTrackerLockKey(index, "name"))}
+                    locked={isTrackerFieldLocked(fieldLocks, customTrackerLockKey(field, "name", index))}
                     lockMode={lockMode}
-                    onToggleLock={() => onToggleFieldLock?.(customTrackerLockKey(index, "name"))}
+                    onToggleLock={() => onToggleFieldLock?.(customTrackerLockKey(field, "name", index))}
                   />
                 ) : (
                   <span

--- a/packages/client/src/features/tracker-panel/components/sections/PersonaInventoryRow.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/PersonaInventoryRow.tsx
@@ -1,5 +1,11 @@
 import { X } from "lucide-react";
-import { inventoryTrackerLockKey, isTrackerFieldLocked, type InventoryItem } from "@marinara-engine/shared";
+import {
+  inventoryItemTrackerLockPrefix,
+  inventoryTrackerLockKey,
+  isTrackerFieldLocked,
+  renameTrackerFieldLockPrefix,
+  type InventoryItem,
+} from "@marinara-engine/shared";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 import { InlineEdit, InlineNumber } from "../controls/InlineControls";
@@ -20,9 +26,22 @@ export function PersonaInventoryRow({
   deleteMode: boolean;
   fullWidth?: boolean;
 }) {
-  const { fieldLocks, lockMode, onToggleFieldLock } = useTrackerLockContext();
-  const nameLockKey = inventoryTrackerLockKey(itemIndex, "name");
-  const quantityLockKey = inventoryTrackerLockKey(itemIndex, "quantity");
+  const { fieldLocks, lockMode, onToggleFieldLock, onUpdateFieldLocks } = useTrackerLockContext();
+  const nameLockKey = inventoryTrackerLockKey(item, "name", itemIndex);
+  const quantityLockKey = inventoryTrackerLockKey(item, "quantity", itemIndex);
+  const updateName = (name: string) => {
+    const nextItem = { ...item, name: name || "Item" };
+    if (nextItem.name !== item.name) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          inventoryItemTrackerLockPrefix(item, itemIndex),
+          inventoryItemTrackerLockPrefix(nextItem, itemIndex),
+        ),
+      );
+    }
+    onUpdate(nextItem);
+  };
   return (
     <div
       className={cn(
@@ -34,7 +53,7 @@ export function PersonaInventoryRow({
       <div className="grid min-h-4 grid-cols-[minmax(0,1fr)_max-content] items-center gap-0.5">
         <InlineEdit
           value={item.name}
-          onSave={(name) => onUpdate({ ...item, name: name || "Item" })}
+          onSave={updateName}
           className="h-4 w-full min-w-0 px-0.5 py-0 text-[0.625rem] font-medium leading-4 text-[color:var(--tracker-profile-text)] hover:bg-[var(--accent)]/25"
           placeholder="Item"
           title={visibleText(item.name, "Item")}

--- a/packages/client/src/features/tracker-panel/components/sections/PersonaTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/PersonaTrackerPanel.tsx
@@ -384,7 +384,7 @@ export function PersonaInventoryPanel({
                         wideColumns={useExpandedPersonaStatColumns}
                         fillWideColumns={useExpandedPersonaStatColumns}
                         visualTone="instrument"
-                        getLockKey={(index, field) => personaStatTrackerLockKey(index, field)}
+                        getLockKey={(index, field, stat) => personaStatTrackerLockKey(stat, field, index)}
                       />
                     )}
                   </div>

--- a/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestRow.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/quest-tracker/QuestRow.tsx
@@ -1,10 +1,11 @@
 import { CheckCircle2, Lock, Plus, Target, Unlock, X } from "lucide-react";
 import {
   isTrackerFieldLocked,
-  questObjectivesTrackerLockPrefix,
+  removeTrackerFieldLockPrefix,
   questObjectiveTrackerLockKey,
+  questObjectiveTrackerLockPrefix,
   questTrackerLockKey,
-  removeTrackerArrayItemLocks,
+  renameTrackerFieldLockPrefix,
   type QuestProgress,
 } from "@marinara-engine/shared";
 import { cn } from "../../../../../lib/utils";
@@ -73,8 +74,18 @@ export function QuestRow({
   const wrapClass = getQuestTextWrapClass(textLineCount);
   const updateObjective = (index: number, nextText: string) => {
     if (!onUpdate) return;
+    const previousObjective = quest.objectives[index];
     const nextObjectives = [...quest.objectives];
     nextObjectives[index] = { ...nextObjectives[index]!, text: nextText };
+    if (previousObjective && previousObjective.text !== nextText) {
+      onUpdateFieldLocks?.((locks) =>
+        renameTrackerFieldLockPrefix(
+          locks,
+          questObjectiveTrackerLockPrefix(quest, questIndex, previousObjective, index),
+          questObjectiveTrackerLockPrefix(quest, questIndex, nextObjectives[index]!, index),
+        ),
+      );
+    }
     onUpdate({ ...quest, objectives: nextObjectives });
   };
   const toggleObjective = (index: number) => {
@@ -86,7 +97,10 @@ export function QuestRow({
   const removeObjective = (index: number) => {
     if (!onUpdate) return;
     onUpdateFieldLocks?.((locks) =>
-      removeTrackerArrayItemLocks(locks, questObjectivesTrackerLockPrefix(quest, questIndex), index),
+      removeTrackerFieldLockPrefix(
+        locks,
+        questObjectiveTrackerLockPrefix(quest, questIndex, quest.objectives[index]!, index),
+      ),
     );
     onUpdate({ ...quest, objectives: quest.objectives.filter((_, objectiveIndex) => objectiveIndex !== index) });
   };
@@ -220,8 +234,8 @@ export function QuestRow({
               onToggle={onUpdate ? () => toggleObjective(index) : undefined}
               onUpdateText={onUpdate ? (text) => updateObjective(index, text) : undefined}
               onRemove={onUpdate && deleteMode ? () => removeObjective(index) : undefined}
-              textLockKey={questObjectiveTrackerLockKey(quest, questIndex, index, "text")}
-              completedLockKey={questObjectiveTrackerLockKey(quest, questIndex, index, "completed")}
+              textLockKey={questObjectiveTrackerLockKey(quest, questIndex, objective, "text", index)}
+              completedLockKey={questObjectiveTrackerLockKey(quest, questIndex, objective, "completed", index)}
             />
           ))}
           {onUpdate && addMode && (

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-field-lock-updater.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-field-lock-updater.ts
@@ -1,5 +1,9 @@
 import { useCallback } from "react";
-import { trackerFieldLocksAreEqual, type TrackerFieldLocks } from "@marinara-engine/shared";
+import {
+  normalizeTrackerFieldLocksForState,
+  trackerFieldLocksAreEqual,
+  type TrackerFieldLocks,
+} from "@marinara-engine/shared";
 import type { GameStatePatchField } from "../../../hooks/use-game-state-patcher";
 import { useGameStateStore } from "../../../stores/game-state.store";
 
@@ -18,7 +22,8 @@ export function useTrackerFieldLockUpdater({
     (updater: TrackerFieldLocksUpdater) => {
       if (!chatId) return;
       const latestState = useGameStateStore.getState().current;
-      const currentLocks = latestState?.chatId === chatId ? latestState.fieldLocks : fieldLocks;
+      const currentLocks =
+        latestState?.chatId === chatId ? normalizeTrackerFieldLocksForState(latestState.fieldLocks, latestState) : fieldLocks;
       const nextLocks = updater(currentLocks);
       if (trackerFieldLocksAreEqual(currentLocks, nextLocks)) return;
       patchField("fieldLocks", nextLocks);

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
@@ -43,13 +43,13 @@ function shallowRecordEqual(left: unknown, right: unknown) {
 
 function mergeChangedRecord<T extends Record<string, unknown>>(live: T, rendered: T | undefined, updated: T): T {
   if (!rendered) return updated;
-  const merged = { ...live };
+  const merged: Record<string, unknown> = { ...live };
   for (const key of Object.keys(updated)) {
     if (!Object.is(updated[key], rendered[key])) {
       merged[key] = updated[key];
     }
   }
-  return merged;
+  return merged as T;
 }
 
 function findUniqueNamedIndex<T extends { name?: string }>(items: T[], item: T | undefined) {
@@ -107,6 +107,7 @@ function reconcileListUpdate<T extends { name?: string }>(liveItems: T[], render
 
 export function useTrackerMutations({
   activeChatId,
+  customFields,
   inventory,
   personaStats,
   presentCharacters,
@@ -116,6 +117,7 @@ export function useTrackerMutations({
   removeFeaturedCharacterCard,
 }: {
   activeChatId: string | null;
+  customFields: CustomTrackerField[];
   inventory: InventoryItem[];
   personaStats: CharacterStat[];
   presentCharacters: PresentCharacter[];

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
@@ -29,6 +29,82 @@ function makeManualTrackerId() {
   return `manual-${id}`;
 }
 
+function shallowRecordEqual(left: unknown, right: unknown) {
+  if (Object.is(left, right)) return true;
+  if (!left || !right || typeof left !== "object" || typeof right !== "object") return false;
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const keys = new Set([...Object.keys(leftRecord), ...Object.keys(rightRecord)]);
+  for (const key of keys) {
+    if (!Object.is(leftRecord[key], rightRecord[key])) return false;
+  }
+  return true;
+}
+
+function mergeChangedRecord<T extends Record<string, unknown>>(live: T, rendered: T | undefined, updated: T): T {
+  if (!rendered) return updated;
+  const merged = { ...live };
+  for (const key of Object.keys(updated)) {
+    if (!Object.is(updated[key], rendered[key])) {
+      merged[key] = updated[key];
+    }
+  }
+  return merged;
+}
+
+function findUniqueNamedIndex<T extends { name?: string }>(items: T[], item: T | undefined) {
+  const name = item?.name?.trim().toLowerCase();
+  if (!name) return -1;
+  const matches = items
+    .map((candidate, index) => ({ index, name: candidate.name?.trim().toLowerCase() }))
+    .filter((candidate) => candidate.name === name);
+  return matches.length === 1 ? matches[0]!.index : -1;
+}
+
+function resolveIndexedMutationTarget<T extends { name?: string }>(
+  liveItems: T[],
+  renderedItems: T[],
+  index: number,
+) {
+  const renderedItem = renderedItems[index];
+  const namedIndex = findUniqueNamedIndex(liveItems, renderedItem);
+  const targetIndex = namedIndex >= 0 ? namedIndex : index;
+  return {
+    renderedItem,
+    targetIndex: targetIndex >= 0 && targetIndex < liveItems.length ? targetIndex : -1,
+  };
+}
+
+function reconcileListUpdate<T extends { name?: string }>(liveItems: T[], renderedItems: T[], updatedItems: T[]) {
+  if (updatedItems.length === renderedItems.length + 1) {
+    return [...liveItems, ...updatedItems.slice(renderedItems.length)];
+  }
+
+  if (updatedItems.length === renderedItems.length - 1) {
+    const removedIndex = renderedItems.findIndex((renderedItem, index) => !shallowRecordEqual(renderedItem, updatedItems[index]));
+    const fallbackIndex = removedIndex >= 0 ? removedIndex : renderedItems.length - 1;
+    const { targetIndex } = resolveIndexedMutationTarget(liveItems, renderedItems, fallbackIndex);
+    if (targetIndex < 0) return liveItems;
+    return liveItems.filter((_, index) => index !== targetIndex);
+  }
+
+  if (updatedItems.length === renderedItems.length) {
+    const changedIndex = updatedItems.findIndex((updatedItem, index) => !shallowRecordEqual(updatedItem, renderedItems[index]));
+    if (changedIndex < 0) return liveItems;
+    const { renderedItem, targetIndex } = resolveIndexedMutationTarget(liveItems, renderedItems, changedIndex);
+    if (targetIndex < 0) return updatedItems;
+    const next = [...liveItems];
+    next[targetIndex] = mergeChangedRecord(
+      liveItems[targetIndex]! as T & Record<string, unknown>,
+      renderedItem as (T & Record<string, unknown>) | undefined,
+      updatedItems[changedIndex]! as T & Record<string, unknown>,
+    ) as T;
+    return next;
+  }
+
+  return updatedItems;
+}
+
 export function useTrackerMutations({
   activeChatId,
   inventory,
@@ -48,51 +124,75 @@ export function useTrackerMutations({
   patchPlayerStats: (field: keyof PlayerStats, value: unknown) => void;
   removeFeaturedCharacterCard: (key: string) => void;
 }) {
-  const [avatarUploadIndex, setAvatarUploadIndex] = useState<number | null>(null);
+  const [avatarUploadCharacterId, setAvatarUploadCharacterId] = useState<string | null>(null);
   const avatarFileInputRef = useRef<HTMLInputElement>(null);
   const avatarUploadSerialRef = useRef(0);
   const avatarUploadTokenByCharacterRef = useRef(new Map<string, number>());
   const updateFieldLocks = useTrackerFieldLockUpdater({ chatId: activeChatId, patchField });
 
-  const openAvatarUpload = useCallback((index: number) => {
-    setAvatarUploadIndex(index);
-    avatarFileInputRef.current?.click();
-  }, []);
+  const readCurrentGameState = useCallback(() => {
+    if (!activeChatId) return null;
+    const current = useGameStateStore.getState().current;
+    return current?.chatId === activeChatId ? current : null;
+  }, [activeChatId]);
+
+  const readPresentCharacters = useCallback(
+    () => readCurrentGameState()?.presentCharacters ?? presentCharacters,
+    [presentCharacters, readCurrentGameState],
+  );
+  const readPlayerStats = useCallback(() => readCurrentGameState()?.playerStats ?? null, [readCurrentGameState]);
+  const readInventory = useCallback(() => readPlayerStats()?.inventory ?? inventory, [inventory, readPlayerStats]);
+  const readQuests = useCallback(() => readPlayerStats()?.activeQuests ?? quests, [quests, readPlayerStats]);
+  const readPersonaStats = useCallback(
+    () => readCurrentGameState()?.personaStats ?? personaStats,
+    [personaStats, readCurrentGameState],
+  );
+  const readCustomFields = useCallback(
+    () => readPlayerStats()?.customTrackerFields ?? [],
+    [readPlayerStats],
+  );
+
+  const openAvatarUpload = useCallback(
+    (index: number) => {
+      const characterId = presentCharacters[index]?.characterId ?? readPresentCharacters()[index]?.characterId ?? null;
+      if (!characterId) return;
+      setAvatarUploadCharacterId(characterId);
+      avatarFileInputRef.current?.click();
+    },
+    [presentCharacters, readPresentCharacters],
+  );
 
   const handleAvatarUpload = useCallback(
-    (index: number, file: File) => {
+    (characterId: string, file: File) => {
       if (!activeChatId) return;
-      const currentState = useGameStateStore.getState().current;
-      const currentCharacters = currentState?.chatId === activeChatId ? (currentState.presentCharacters ?? []) : [];
-      const character = currentCharacters[index];
+      const currentCharacters = readPresentCharacters();
+      const character = currentCharacters.find((candidate) => candidate.characterId === characterId);
       if (!character) return;
 
-      const targetCharacterId = character.characterId;
       const uploadToken = avatarUploadSerialRef.current + 1;
       avatarUploadSerialRef.current = uploadToken;
-      avatarUploadTokenByCharacterRef.current.set(targetCharacterId, uploadToken);
+      avatarUploadTokenByCharacterRef.current.set(characterId, uploadToken);
 
       const reader = new FileReader();
       reader.onload = async () => {
         const dataUrl = typeof reader.result === "string" ? reader.result : "";
         if (!dataUrl) {
-          if (avatarUploadTokenByCharacterRef.current.get(targetCharacterId) === uploadToken) {
-            avatarUploadTokenByCharacterRef.current.delete(targetCharacterId);
+          if (avatarUploadTokenByCharacterRef.current.get(characterId) === uploadToken) {
+            avatarUploadTokenByCharacterRef.current.delete(characterId);
           }
           return;
         }
-        if (avatarUploadTokenByCharacterRef.current.get(targetCharacterId) !== uploadToken) return;
+        if (avatarUploadTokenByCharacterRef.current.get(characterId) !== uploadToken) return;
 
         try {
           const response = await api.post<{ avatarPath: string }>(`/avatars/npc/${activeChatId}`, {
             name: character.name,
             avatar: dataUrl,
           });
-          if (avatarUploadTokenByCharacterRef.current.get(targetCharacterId) !== uploadToken) return;
+          if (avatarUploadTokenByCharacterRef.current.get(characterId) !== uploadToken) return;
 
-          const latestState = useGameStateStore.getState().current;
-          const latestCharacters = latestState?.chatId === activeChatId ? (latestState.presentCharacters ?? []) : [];
-          const targetIndex = latestCharacters.findIndex((candidate) => candidate.characterId === targetCharacterId);
+          const latestCharacters = readPresentCharacters();
+          const targetIndex = latestCharacters.findIndex((candidate) => candidate.characterId === characterId);
           if (targetIndex < 0) return;
 
           const nextCharacters = [...latestCharacters];
@@ -101,69 +201,90 @@ export function useTrackerMutations({
         } catch {
           // Match the original HUD widget behavior: failed avatar uploads leave tracker data unchanged.
         } finally {
-          if (avatarUploadTokenByCharacterRef.current.get(targetCharacterId) === uploadToken) {
-            avatarUploadTokenByCharacterRef.current.delete(targetCharacterId);
+          if (avatarUploadTokenByCharacterRef.current.get(characterId) === uploadToken) {
+            avatarUploadTokenByCharacterRef.current.delete(characterId);
           }
         }
       };
       reader.onerror = () => {
-        if (avatarUploadTokenByCharacterRef.current.get(targetCharacterId) === uploadToken) {
-          avatarUploadTokenByCharacterRef.current.delete(targetCharacterId);
+        if (avatarUploadTokenByCharacterRef.current.get(characterId) === uploadToken) {
+          avatarUploadTokenByCharacterRef.current.delete(characterId);
         }
       };
       reader.readAsDataURL(file);
     },
-    [activeChatId, patchField],
+    [activeChatId, patchField, readPresentCharacters],
   );
 
   const handleAvatarFileInputChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
-      const index = avatarUploadIndex;
-      setAvatarUploadIndex(null);
-      if (file && index !== null) handleAvatarUpload(index, file);
+      const characterId = avatarUploadCharacterId;
+      setAvatarUploadCharacterId(null);
+      if (file && characterId) handleAvatarUpload(characterId, file);
       event.target.value = "";
     },
-    [avatarUploadIndex, handleAvatarUpload],
+    [avatarUploadCharacterId, handleAvatarUpload],
   );
 
   const updateCharacter = useCallback(
     (index: number, character: PresentCharacter) => {
-      const previous = presentCharacters[index];
+      const liveCharacters = readPresentCharacters();
+      const renderedCharacter = presentCharacters[index];
+      const targetCharacterId = character.characterId || renderedCharacter?.characterId;
+      const targetIndex = targetCharacterId
+        ? liveCharacters.findIndex((candidate) => candidate.characterId === targetCharacterId)
+        : index;
+      if (targetIndex < 0 || targetIndex >= liveCharacters.length) return;
+
+      const previous = liveCharacters[targetIndex];
+      const nextCharacter = mergeChangedRecord(
+        previous as PresentCharacter & Record<string, unknown>,
+        renderedCharacter as (PresentCharacter & Record<string, unknown>) | undefined,
+        character as PresentCharacter & Record<string, unknown>,
+      ) as PresentCharacter;
       if (previous && previous.name !== character.name) {
         updateFieldLocks((locks) =>
           renameTrackerFieldLockPrefix(
             locks,
-            characterTrackerLockPrefix(previous, index),
-            characterTrackerLockPrefix(character, index),
+            characterTrackerLockPrefix(previous, targetIndex),
+            characterTrackerLockPrefix(nextCharacter, targetIndex),
           ),
         );
       }
-      const next = [...presentCharacters];
-      next[index] = character;
+      const next = [...liveCharacters];
+      next[targetIndex] = nextCharacter;
       patchField("presentCharacters", next);
     },
-    [patchField, presentCharacters, updateFieldLocks],
+    [patchField, presentCharacters, readPresentCharacters, updateFieldLocks],
   );
 
   const removeCharacter = useCallback(
     (index: number) => {
-      const removed = presentCharacters[index];
+      const liveCharacters = readPresentCharacters();
+      const renderedCharacter = presentCharacters[index];
+      const targetIndex = renderedCharacter?.characterId
+        ? liveCharacters.findIndex((candidate) => candidate.characterId === renderedCharacter.characterId)
+        : index;
+      if (targetIndex < 0 || targetIndex >= liveCharacters.length) return;
+
+      const removed = liveCharacters[targetIndex];
       if (removed) {
-        removeFeaturedCharacterCard(getCharacterFeatureKey(removed, index));
-        updateFieldLocks((locks) => removeTrackerCharacterLocks(locks, removed, index));
+        removeFeaturedCharacterCard(getCharacterFeatureKey(removed, targetIndex));
+        updateFieldLocks((locks) => removeTrackerCharacterLocks(locks, removed, targetIndex));
       }
       patchField(
         "presentCharacters",
-        presentCharacters.filter((_, characterIndex) => characterIndex !== index),
+        liveCharacters.filter((_, characterIndex) => characterIndex !== targetIndex),
       );
     },
-    [patchField, presentCharacters, removeFeaturedCharacterCard, updateFieldLocks],
+    [patchField, presentCharacters, readPresentCharacters, removeFeaturedCharacterCard, updateFieldLocks],
   );
 
   const addCharacter = useCallback(() => {
+    const liveCharacters = readPresentCharacters();
     patchField("presentCharacters", [
-      ...presentCharacters,
+      ...liveCharacters,
       {
         characterId: makeManualTrackerId(),
         name: "New Character",
@@ -176,7 +297,7 @@ export function useTrackerMutations({
         thoughts: null,
       },
     ]);
-  }, [patchField, presentCharacters]);
+  }, [patchField, readPresentCharacters]);
 
   const updateInventory = useCallback(
     (items: InventoryItem[]) => patchPlayerStats("inventory", items),
@@ -185,24 +306,36 @@ export function useTrackerMutations({
 
   const updateInventoryItem = useCallback(
     (index: number, item: InventoryItem) => {
-      const next = [...inventory];
-      next[index] = item;
+      const liveInventory = readInventory();
+      const { renderedItem, targetIndex } = resolveIndexedMutationTarget(liveInventory, inventory, index);
+      if (targetIndex < 0) return;
+      const next = [...liveInventory];
+      next[targetIndex] = mergeChangedRecord(
+        liveInventory[targetIndex]! as InventoryItem & Record<string, unknown>,
+        renderedItem as (InventoryItem & Record<string, unknown>) | undefined,
+        item as InventoryItem & Record<string, unknown>,
+      ) as InventoryItem;
       updateInventory(next);
     },
-    [inventory, updateInventory],
+    [inventory, readInventory, updateInventory],
   );
 
   const removeInventoryItem = useCallback(
     (index: number) => {
-      updateInventory(inventory.filter((_, itemIndex) => itemIndex !== index));
-      updateFieldLocks((locks) => removeTrackerFieldLockPrefix(locks, inventoryItemTrackerLockPrefix(inventory[index]!, index)));
+      const liveInventory = readInventory();
+      const { targetIndex } = resolveIndexedMutationTarget(liveInventory, inventory, index);
+      if (targetIndex < 0) return;
+      updateInventory(liveInventory.filter((_, itemIndex) => itemIndex !== targetIndex));
+      updateFieldLocks((locks) =>
+        removeTrackerFieldLockPrefix(locks, inventoryItemTrackerLockPrefix(liveInventory[targetIndex]!, targetIndex)),
+      );
     },
-    [inventory, updateFieldLocks, updateInventory],
+    [inventory, readInventory, updateFieldLocks, updateInventory],
   );
 
   const addInventoryItem = useCallback(() => {
-    updateInventory([...inventory, { name: "New Item", description: "", quantity: 1, location: "on_person" }]);
-  }, [inventory, updateInventory]);
+    updateInventory([...readInventory(), { name: "New Item", description: "", quantity: 1, location: "on_person" }]);
+  }, [readInventory, updateInventory]);
 
   const updateQuests = useCallback(
     (nextQuests: QuestProgress[]) => patchPlayerStats("activeQuests", nextQuests),
@@ -211,25 +344,43 @@ export function useTrackerMutations({
 
   const updateQuest = useCallback(
     (index: number, quest: QuestProgress) => {
-      const next = [...quests];
-      next[index] = quest;
+      const liveQuests = readQuests();
+      const renderedQuest = quests[index];
+      const targetQuestId = quest.questEntryId || renderedQuest?.questEntryId;
+      const targetIndex = targetQuestId
+        ? liveQuests.findIndex((candidate) => candidate.questEntryId === targetQuestId)
+        : index;
+      if (targetIndex < 0 || targetIndex >= liveQuests.length) return;
+      const next = [...liveQuests];
+      next[targetIndex] = mergeChangedRecord(
+        liveQuests[targetIndex]! as QuestProgress & Record<string, unknown>,
+        renderedQuest as (QuestProgress & Record<string, unknown>) | undefined,
+        quest as QuestProgress & Record<string, unknown>,
+      ) as QuestProgress;
       updateQuests(next);
     },
-    [quests, updateQuests],
+    [quests, readQuests, updateQuests],
   );
 
   const removeQuest = useCallback(
     (index: number) => {
-      const removed = quests[index];
-      if (removed) updateFieldLocks((locks) => removeTrackerQuestLocks(locks, removed, index));
-      updateQuests(quests.filter((_, questIndex) => questIndex !== index));
+      const liveQuests = readQuests();
+      const renderedQuest = quests[index];
+      const targetIndex = renderedQuest?.questEntryId
+        ? liveQuests.findIndex((candidate) => candidate.questEntryId === renderedQuest.questEntryId)
+        : index;
+      if (targetIndex < 0 || targetIndex >= liveQuests.length) return;
+      const removed = liveQuests[targetIndex];
+      if (removed) updateFieldLocks((locks) => removeTrackerQuestLocks(locks, removed, targetIndex));
+      updateQuests(liveQuests.filter((_, questIndex) => questIndex !== targetIndex));
     },
-    [quests, updateFieldLocks, updateQuests],
+    [quests, readQuests, updateFieldLocks, updateQuests],
   );
 
   const addQuest = useCallback(() => {
+    const liveQuests = readQuests();
     updateQuests([
-      ...quests,
+      ...liveQuests,
       {
         questEntryId: makeManualTrackerId(),
         name: "New Quest",
@@ -238,19 +389,26 @@ export function useTrackerMutations({
         completed: false,
       },
     ]);
-  }, [quests, updateQuests]);
+  }, [readQuests, updateQuests]);
 
   const savePersonaStatus = useCallback((status: string) => patchPlayerStats("status", status), [patchPlayerStats]);
 
-  const updatePersonaStats = useCallback((stats: CharacterStat[]) => patchField("personaStats", stats), [patchField]);
+  const updatePersonaStats = useCallback(
+    (stats: CharacterStat[]) => patchField("personaStats", reconcileListUpdate(readPersonaStats(), personaStats, stats)),
+    [patchField, personaStats, readPersonaStats],
+  );
 
   const addPersonaStat = useCallback(() => {
-    patchField("personaStats", [...personaStats, { name: "New Stat", value: 0, max: 100, color: "var(--primary)" }]);
-  }, [patchField, personaStats]);
+    patchField("personaStats", [
+      ...readPersonaStats(),
+      { name: "New Stat", value: 0, max: 100, color: "var(--primary)" },
+    ]);
+  }, [patchField, readPersonaStats]);
 
   const updateCustomFields = useCallback(
-    (fields: CustomTrackerField[]) => patchPlayerStats("customTrackerFields", fields),
-    [patchPlayerStats],
+    (fields: CustomTrackerField[]) =>
+      patchPlayerStats("customTrackerFields", reconcileListUpdate(readCustomFields(), customFields, fields)),
+    [customFields, patchPlayerStats, readCustomFields],
   );
 
   return {

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
@@ -8,10 +8,12 @@ import type {
   QuestProgress,
 } from "@marinara-engine/shared";
 import {
-  inventoryTrackerLockPrefix,
-  removeTrackerArrayItemLocks,
+  characterTrackerLockPrefix,
+  inventoryItemTrackerLockPrefix,
   removeTrackerCharacterLocks,
+  removeTrackerFieldLockPrefix,
   removeTrackerQuestLocks,
+  renameTrackerFieldLockPrefix,
 } from "@marinara-engine/shared";
 import { api } from "../../../lib/api-client";
 import { useGameStateStore } from "../../../stores/game-state.store";
@@ -127,11 +129,21 @@ export function useTrackerMutations({
 
   const updateCharacter = useCallback(
     (index: number, character: PresentCharacter) => {
+      const previous = presentCharacters[index];
+      if (previous && previous.name !== character.name) {
+        updateFieldLocks((locks) =>
+          renameTrackerFieldLockPrefix(
+            locks,
+            characterTrackerLockPrefix(previous, index),
+            characterTrackerLockPrefix(character, index),
+          ),
+        );
+      }
       const next = [...presentCharacters];
       next[index] = character;
       patchField("presentCharacters", next);
     },
-    [patchField, presentCharacters],
+    [patchField, presentCharacters, updateFieldLocks],
   );
 
   const removeCharacter = useCallback(
@@ -183,7 +195,7 @@ export function useTrackerMutations({
   const removeInventoryItem = useCallback(
     (index: number) => {
       updateInventory(inventory.filter((_, itemIndex) => itemIndex !== index));
-      updateFieldLocks((locks) => removeTrackerArrayItemLocks(locks, inventoryTrackerLockPrefix(), index));
+      updateFieldLocks((locks) => removeTrackerFieldLockPrefix(locks, inventoryItemTrackerLockPrefix(inventory[index]!, index)));
     },
     [inventory, updateFieldLocks, updateInventory],
   );

--- a/packages/client/src/features/tracker-panel/lib/tracker-profile-style.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-profile-style.ts
@@ -325,9 +325,10 @@ export function getCharacterAmbienceStyle(
   character: PresentCharacter,
   profileColors?: TrackerProfileColors | null,
 ): CSSProperties {
+  const stats = Array.isArray(character.stats) ? character.stats : [];
   const palette = getTrackerProfilePalette(
     profileColors,
-    getSolidCssColor(character.stats?.find((stat) => stat.color)?.color) ?? DEFAULT_TRACKER_CARD_ACCENT,
+    getSolidCssColor(stats.find((stat) => stat.color)?.color) ?? DEFAULT_TRACKER_CARD_ACCENT,
   );
   const finish = getTrackerCardSkinFinish(palette.finish);
   const surfaceOpacity = palette.hasSurfacePaint ? palette.opacity.boxColorOpacity : 0;

--- a/packages/client/src/features/tracker-panel/lib/tracker-stat-layout.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-stat-layout.ts
@@ -48,7 +48,14 @@ export function getTrackerStatDisplayScale(
   return statCount + (includeAdd ? 1 : 0) <= 4 ? "spacious" : "roomy";
 }
 
+export function coerceStatNumber(value: unknown, fallback = 0) {
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
 export function getStatPercent(stat: CharacterStat) {
-  if (!Number.isFinite(stat.max) || stat.max <= 0) return 0;
-  return Math.max(0, Math.min(100, (stat.value / stat.max) * 100));
+  const max = coerceStatNumber(stat.max);
+  if (max <= 0) return 0;
+  const value = coerceStatNumber(stat.value);
+  return Math.max(0, Math.min(100, (value / max) * 100));
 }

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -229,10 +229,11 @@ export function getWeatherEmoji(weather: string | null | undefined) {
 }
 
 export function parseTemperatureValue(temperature: string | null | undefined) {
-  const match = (temperature ?? "").match(/-?\d+(\.\d+)?/);
+  const match = (temperature ?? "").match(/(-?\d+(?:\.\d+)?)(?:\s*°?\s*(f(?:ahrenheit)?|c(?:elsius)?)\b)?/i);
   if (!match) return null;
-  const numeric = parseFloat(match[0]!);
-  if (/-?\d+(?:\.\d+)?\s*°?\s*f(?:ahrenheit)?\b/i.test(temperature ?? "")) return (numeric - 32) * (5 / 9);
+  const numeric = parseFloat(match[1]!);
+  const unit = match[2]?.toLowerCase();
+  if (unit?.startsWith("f")) return (numeric - 32) * (5 / 9);
   return numeric;
 }
 

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -232,7 +232,7 @@ export function parseTemperatureValue(temperature: string | null | undefined) {
   const match = (temperature ?? "").match(/-?\d+(\.\d+)?/);
   if (!match) return null;
   const numeric = parseFloat(match[0]!);
-  if (/°?\s*f/i.test(temperature ?? "")) return (numeric - 32) * (5 / 9);
+  if (/-?\d+(?:\.\d+)?\s*°?\s*f(?:ahrenheit)?\b/i.test(temperature ?? "")) return (numeric - 32) * (5 / 9);
   return numeric;
 }
 

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -478,6 +478,26 @@ export function useUpdateChat() {
   });
 }
 
+export function useTouchChat() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.post<Chat>(`/chats/${id}/touch`, {}),
+    onMutate: async (id) => {
+      const updatedAt = new Date().toISOString();
+      qc.setQueryData<Chat[]>(chatKeys.list(), (existing) =>
+        existing
+          ?.map((chat) => (chat.id === id ? { ...chat, updatedAt } : chat))
+          .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+      );
+      qc.setQueryData<Chat>(chatKeys.detail(id), (existing) => (existing ? { ...existing, updatedAt } : existing));
+    },
+    onSuccess: (chat, id) => {
+      if (chat) qc.setQueryData<Chat>(chatKeys.detail(id), chat);
+      qc.invalidateQueries({ queryKey: chatKeys.list() });
+    },
+  });
+}
+
 export function useUpdateChatMetadata() {
   const qc = useQueryClient();
   return useMutation({

--- a/packages/client/src/hooks/use-game-state-patcher.ts
+++ b/packages/client/src/hooks/use-game-state-patcher.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 import type { GameState, PlayerStats } from "@marinara-engine/shared";
-import { api } from "../lib/api-client";
+import { ApiError, api } from "../lib/api-client";
 import { useGameStateStore } from "../stores/game-state.store";
 
 export type GameStatePatchField =
@@ -288,8 +288,18 @@ export async function flushGameStatePatch(chatId?: string) {
       .patch(`/chats/${queuedSnapshot.chatId}/game-state`, { ...payload, manual: true }, { signal: controller.signal })
       .then(() => undefined)
       .catch((error) => {
-        if (!inFlightEntry.canceled) {
+        const staleExplicitTarget =
+          error instanceof ApiError &&
+          error.status === 404 &&
+          queuedSnapshot.target.messageId &&
+          queuedSnapshot.target.swipeIndex !== undefined;
+        if (!inFlightEntry.canceled && !staleExplicitTarget) {
           requeuePatch(key, queuedSnapshot);
+        }
+        if (staleExplicitTarget) {
+          durablePatches.delete(key);
+          pendingPatches.delete(key);
+          persistPendingPatches();
         }
         throw error;
       })

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -8,8 +8,10 @@ import { api, isJsonRepairApiError } from "../lib/api-client";
 import { chatKeys } from "./use-chats";
 import { lorebookKeys } from "./use-lorebooks";
 import {
+  clearPendingHudWidgetPersist,
   getHudWidgetStateSignature,
   getPendingHudWidgetPersistenceSignature,
+  registerPendingHudWidgetPersistence,
   useGameModeStore,
 } from "../stores/game-mode.store";
 import { useGameAssetStore } from "../stores/game-asset.store";
@@ -590,6 +592,10 @@ export function useUpdateGameWidgets() {
   return useMutation({
     mutationFn: ({ chatId, widgets }: { chatId: string; widgets: HudWidget[] }) =>
       api.put<UpdateGameWidgetsResponse>(`/game/${chatId}/widgets`, { widgets }),
+    onMutate: (variables) => {
+      clearPendingHudWidgetPersist(variables.chatId);
+      registerPendingHudWidgetPersistence(variables.chatId, variables.widgets);
+    },
     onSuccess: (_, variables) => {
       useGameModeStore.getState().setHudWidgets(variables.widgets);
       const queryKey = chatKeys.detail(variables.chatId);
@@ -604,6 +610,9 @@ export function useUpdateGameWidgets() {
     },
     onError: (err) => {
       console.error("[updateGameWidgets] Error:", err);
+    },
+    onSettled: (_, __, variables) => {
+      clearPendingHudWidgetPersist(variables.chatId, getHudWidgetStateSignature(variables.widgets));
     },
   });
 }

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -184,6 +184,9 @@ export function useCreateGame() {
     },
     onError: (err) => {
       console.error("[createGame] Error:", err);
+      toast.error(err.message || "Failed to create game. Check the selected connection and try again.", {
+        duration: 10000,
+      });
     },
   });
 }

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -382,6 +382,12 @@ export function useRegenerateSessionLorebook() {
     },
     onError: (err, variables) => {
       console.error("[game/session/regenerate-lorebook] Error:", err);
+      if (isJsonRepairApiError(err)) {
+        toast.info("Review the generated lorebook JSON before applying it.", {
+          id: `game-session-lorebook:${variables.chatId}:${variables.sessionNumber}`,
+        });
+        return;
+      }
       toast.error(err.message || "Failed to regenerate session lorebook.", {
         id: `game-session-lorebook:${variables.chatId}:${variables.sessionNumber}`,
       });

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -10,6 +10,7 @@ import { formatAgentFailuresToast, toAgentFailure, type AgentFailure } from "../
 import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { requestChatScrollToBottom } from "../lib/chat-scroll-events";
 import { agentKeys } from "./use-agents";
+import { discardPendingGameStatePatch } from "./use-game-state-patcher";
 import type { PendingAgentWriteApproval, PendingCardUpdate } from "../stores/agent.store";
 import type { DelayedCharacterInfo } from "../stores/chat.store";
 import {
@@ -1681,6 +1682,7 @@ export function useGenerate() {
               const patch = event.data as Record<string, unknown>;
               console.warn(`[Generate] ${event.type} received:`, patch);
               if (!isActiveChat()) break;
+              discardPendingGameStatePatch(params.chatId);
               applyGameStatePatchToStore(params.chatId, patch, gameStatePatchAnchor);
               break;
             }
@@ -2440,7 +2442,11 @@ export function useGenerate() {
     async (chatId: string, agentTypes: string[], options?: RetryAgentsOptions): Promise<boolean> => {
       const isActiveChat = () => useChatStore.getState().activeChatId === chatId;
       const abortController = new AbortController();
+      const isTrackerRetry = agentTypes.some(
+        (agentType) => BUILT_IN_TRACKER_AGENT_TYPE_SET.has(agentType) || !BUILT_IN_AGENT_TYPE_SET.has(agentType),
+      );
       setProcessing(true);
+      if (isTrackerRetry) useGameStateStore.getState().setRefreshingChat(chatId);
       clearFailedAgentTypes();
       clearThoughtBubbles();
       let hasError = false;
@@ -2459,9 +2465,6 @@ export function useGenerate() {
         let agentResultCount = 0;
         let trackerPatchCount = 0;
         let spriteChangeReceived = false;
-        const isTrackerRetry = agentTypes.some(
-          (agentType) => BUILT_IN_TRACKER_AGENT_TYPE_SET.has(agentType) || !BUILT_IN_AGENT_TYPE_SET.has(agentType),
-        );
         const failedRetryFailures: Array<ReturnType<typeof toAgentFailure>> = [];
         for await (const event of api.streamEvents(
           "/generate/retry-agents",
@@ -2652,6 +2655,7 @@ export function useGenerate() {
               console.warn(`[Retry] ${event.type} received:`, patch);
               if (patch && Object.keys(patch).length > 0) trackerPatchCount += 1;
               if (!isActiveChat()) break;
+              discardPendingGameStatePatch(chatId);
               applyGameStatePatchToStore(chatId, patch);
               break;
             }
@@ -2729,6 +2733,7 @@ export function useGenerate() {
         showError(msg);
       } finally {
         setProcessing(false);
+        if (isTrackerRetry) useGameStateStore.getState().clearRefreshingChat(chatId);
         if (hasError && isActiveChat()) {
           void refreshMessagesAuthoritatively(qc, chatId);
         }

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -25,7 +25,7 @@ export class ApiError extends Error {
   }
 }
 
-export type JsonRepairKind = "game_setup" | "session_conclusion" | "campaign_progression";
+export type JsonRepairKind = "game_setup" | "session_conclusion" | "campaign_progression" | "lorebook_keeper";
 
 export type JsonRepairRequest = {
   kind: JsonRepairKind;
@@ -49,7 +49,10 @@ export function getJsonRepairRequest(error: unknown): JsonRepairRequest | null {
   const rawJson = repair.rawJson;
   const applyEndpoint = repair.applyEndpoint;
   if (
-    (kind !== "game_setup" && kind !== "session_conclusion" && kind !== "campaign_progression") ||
+    (kind !== "game_setup" &&
+      kind !== "session_conclusion" &&
+      kind !== "campaign_progression" &&
+      kind !== "lorebook_keeper") ||
     typeof title !== "string" ||
     typeof rawJson !== "string" ||
     typeof applyEndpoint !== "string"

--- a/packages/client/src/lib/chub-character-card.ts
+++ b/packages/client/src/lib/chub-character-card.ts
@@ -40,6 +40,11 @@ function hasStringArrayField(target: Record<string, unknown>, field: string) {
   return Array.isArray(value) && value.some((item) => typeof item === "string" && item.trim().length > 0);
 }
 
+function nonEmptyStringArray(value: string[] | undefined) {
+  const filtered = value?.map((item) => item.trim()).filter((item) => item.length > 0) ?? [];
+  return filtered.length > 0 ? filtered : null;
+}
+
 function getCharacterDataTarget(raw: Record<string, unknown>) {
   const cloned: Record<string, unknown> = { ...raw };
   const target =
@@ -74,9 +79,11 @@ export function mergeChubDetailIntoCharacterJson(
 
   if (!hasStringField(target, "name") && summary.name?.trim()) target.name = summary.name;
   if (!hasStringField(target, "creator") && summary.creator?.trim()) target.creator = summary.creator;
-  if (!hasStringArrayField(target, "tags") && summary.tags && summary.tags.length > 0) target.tags = summary.tags;
-  if (detail.alternateGreetings && detail.alternateGreetings.length > 0) {
-    target.alternate_greetings = detail.alternateGreetings;
+  const summaryTags = nonEmptyStringArray(summary.tags);
+  if (!hasStringArrayField(target, "tags") && summaryTags) target.tags = summaryTags;
+  const alternateGreetings = nonEmptyStringArray(detail.alternateGreetings);
+  if (alternateGreetings) {
+    target.alternate_greetings = alternateGreetings;
   }
 
   if (detail.extensions) {

--- a/packages/client/src/lib/chub-character-card.ts
+++ b/packages/client/src/lib/chub-character-card.ts
@@ -27,7 +27,17 @@ function hasCharacterBookEntries(value: unknown): boolean {
 }
 
 function setStringField(target: Record<string, unknown>, field: string, value: string | undefined) {
-  if (value !== undefined) target[field] = value;
+  if (value !== undefined && value.trim()) target[field] = value;
+}
+
+function hasStringField(target: Record<string, unknown>, field: string) {
+  const value = target[field];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasStringArrayField(target: Record<string, unknown>, field: string) {
+  const value = target[field];
+  return Array.isArray(value) && value.some((item) => typeof item === "string" && item.trim().length > 0);
 }
 
 function getCharacterDataTarget(raw: Record<string, unknown>) {
@@ -62,10 +72,12 @@ export function mergeChubDetailIntoCharacterJson(
   setStringField(target, "post_history_instructions", detail.postHistoryInstructions);
   setStringField(target, "character_version", detail.characterVersion);
 
-  if (summary.name) target.name = summary.name;
-  if (summary.creator !== undefined) target.creator = summary.creator;
-  if (summary.tags) target.tags = summary.tags;
-  if (detail.alternateGreetings) target.alternate_greetings = detail.alternateGreetings;
+  if (!hasStringField(target, "name") && summary.name?.trim()) target.name = summary.name;
+  if (!hasStringField(target, "creator") && summary.creator?.trim()) target.creator = summary.creator;
+  if (!hasStringArrayField(target, "tags") && summary.tags && summary.tags.length > 0) target.tags = summary.tags;
+  if (detail.alternateGreetings && detail.alternateGreetings.length > 0) {
+    target.alternate_greetings = detail.alternateGreetings;
+  }
 
   if (detail.extensions) {
     const currentExtensions =

--- a/packages/client/src/stores/game-mode.store.ts
+++ b/packages/client/src/stores/game-mode.store.ts
@@ -84,11 +84,28 @@ export function getPendingHudWidgetPersistenceSignature(chatId: string): string 
   return pendingWidgetPersistence?.chatId === chatId ? pendingWidgetPersistence.signature : null;
 }
 
+export function registerPendingHudWidgetPersistence(chatId: string, widgets: readonly HudWidget[]) {
+  pendingWidgetPersistence = { chatId, signature: getHudWidgetStateSignature(widgets) };
+}
+
+export function clearPendingHudWidgetPersist(chatId?: string, signature?: string) {
+  const matchesChat = !chatId || pendingWidgetPersistence?.chatId === chatId;
+  const matchesSignature = !signature || pendingWidgetPersistence?.signature === signature;
+  if (matchesChat && widgetPersistTimer) {
+    clearTimeout(widgetPersistTimer);
+    widgetPersistTimer = null;
+  }
+  if (matchesChat && matchesSignature) {
+    pendingWidgetPersistence = null;
+  }
+}
+
 function debouncedPersistWidgets(chatId: string, widgets: HudWidget[]) {
   const signature = getHudWidgetStateSignature(widgets);
   pendingWidgetPersistence = { chatId, signature };
   if (widgetPersistTimer) clearTimeout(widgetPersistTimer);
   widgetPersistTimer = setTimeout(() => {
+    widgetPersistTimer = null;
     api
       .put(`/game/${chatId}/widgets`, { widgets })
       .catch(() => {
@@ -333,13 +350,27 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
         const changes = update.changes;
         const newConfig = { ...w.config };
 
-        // Handle stat_block: update a specific stat by name
-        if (changes.statName && w.type === "stat_block" && newConfig.stats) {
-          const targetName = changes.statName;
-          const newValue = changes.value;
-          newConfig.stats = newConfig.stats.map((stat) =>
-            stat.name === targetName && newValue !== undefined ? { ...stat, value: newValue } : stat,
-          );
+        // Handle stat_block: update a specific stat by name, creating it when needed.
+        if (changes.statName && w.type === "stat_block") {
+          const targetName = changes.statName.trim();
+          const rawValue = changes.value;
+          const newValue =
+            typeof rawValue === "number"
+              ? rawValue
+              : typeof rawValue === "string" && rawValue.trim()
+                ? rawValue.trim()
+                : undefined;
+          if (targetName && newValue !== undefined) {
+            const stats = Array.isArray(newConfig.stats) ? [...newConfig.stats] : [];
+            const targetKey = targetName.toLowerCase();
+            const statIndex = stats.findIndex((stat) => stat.name.trim().toLowerCase() === targetKey);
+            if (statIndex >= 0) {
+              stats[statIndex] = { ...stats[statIndex]!, value: newValue };
+            } else {
+              stats.push({ name: targetName, value: newValue });
+            }
+            newConfig.stats = stats;
+          }
         } else {
           // Merge simple numeric/config fields
           if (changes.value !== undefined)

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -101,6 +101,8 @@ interface SidecarState {
 const PROMPTED_KEY = "marinara_sidecar_prompted";
 const TRANSITIONAL_STATUSES = new Set<SidecarStatus>(["downloading_runtime", "downloading_model", "starting_server"]);
 let statusPollTimer: number | null = null;
+let activeDownloadController: AbortController | null = null;
+let downloadCancelRequested = false;
 
 function clearStatusPollTimer() {
   if (statusPollTimer !== null) {
@@ -132,93 +134,118 @@ async function consumeDownloadStream(
   set: (partial: Partial<SidecarState>) => void,
   get: () => SidecarState,
 ): Promise<void> {
+  activeDownloadController?.abort();
+  const controller = new AbortController();
+  activeDownloadController = controller;
+  downloadCancelRequested = false;
+
   const apiPath = path.startsWith("/api/") ? path.slice(4) : path;
-  const response = await api.raw(apiPath, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  try {
+    const response = await api.raw(apiPath, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    let detail = text.slice(0, 300) || response.statusText || "unknown error";
-    try {
-      const parsed = JSON.parse(text) as { error?: string; message?: string };
-      detail = parsed.error ?? parsed.message ?? detail;
-    } catch {
-      // Keep the plain-text detail.
-    }
-    throw new Error(`Download request failed (${response.status}): ${detail}`);
-  }
-
-  if (!response.body) {
-    throw new Error(`Download request failed (${response.status}): missing response body`);
-  }
-
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue;
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      let detail = text.slice(0, 300) || response.statusText || "unknown error";
       try {
-        const data = JSON.parse(line.slice(6)) as Partial<SidecarDownloadProgress> & {
-          done?: boolean;
-          status?: string;
-          error?: string;
-        };
-
-        if (data.done) {
-          set({ downloadProgress: null });
-          await get().fetchStatus();
-          return;
-        }
-
-        if (data.status === "error") {
-          set({
-            downloadProgress: {
-              phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
-              status: "error",
-              downloaded: 0,
-              total: 0,
-              speed: 0,
-              error: data.error ?? "Download failed",
-              label: data.label,
-            },
-          });
-          await get().fetchStatus();
-          return;
-        }
-
-        if (data.status === "downloading") {
-          set({
-            downloadProgress: {
-              phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
-              status: "downloading",
-              downloaded: Number(data.downloaded ?? 0),
-              total: Number(data.total ?? 0),
-              speed: Number(data.speed ?? 0),
-              label: data.label,
-            },
-            status: (data.phase === "runtime" ? "downloading_runtime" : "downloading_model") as SidecarStatus,
-          });
-        }
+        const parsed = JSON.parse(text) as { error?: string; message?: string };
+        detail = parsed.error ?? parsed.message ?? detail;
       } catch {
-        // Ignore malformed SSE chunks.
+        // Keep the plain-text detail.
+      }
+      throw new Error(`Download request failed (${response.status}): ${detail}`);
+    }
+
+    if (!response.body) {
+      throw new Error(`Download request failed (${response.status}): missing response body`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        try {
+          const data = JSON.parse(line.slice(6)) as Partial<SidecarDownloadProgress> & {
+            done?: boolean;
+            status?: string;
+            error?: string;
+          };
+
+          if (data.done) {
+            set({ downloadProgress: null });
+            await get().fetchStatus();
+            return;
+          }
+
+          if (data.status === "error") {
+            if (downloadCancelRequested || controller.signal.aborted) {
+              set({ downloadProgress: null });
+              await get().fetchStatus();
+              return;
+            }
+            set({
+              downloadProgress: {
+                phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
+                status: "error",
+                downloaded: 0,
+                total: 0,
+                speed: 0,
+                error: data.error ?? "Download failed",
+                label: data.label,
+              },
+            });
+            await get().fetchStatus();
+            return;
+          }
+
+          if (data.status === "downloading") {
+            set({
+              downloadProgress: {
+                phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
+                status: "downloading",
+                downloaded: Number(data.downloaded ?? 0),
+                total: Number(data.total ?? 0),
+                speed: Number(data.speed ?? 0),
+                label: data.label,
+              },
+              status: (data.phase === "runtime" ? "downloading_runtime" : "downloading_model") as SidecarStatus,
+            });
+          }
+        } catch {
+          // Ignore malformed SSE chunks.
+        }
       }
     }
-  }
 
-  set({ downloadProgress: null });
-  await get().fetchStatus();
+    set({ downloadProgress: null });
+    await get().fetchStatus();
+  } catch (error) {
+    if (controller.signal.aborted || downloadCancelRequested) {
+      set({ downloadProgress: null });
+      await get().fetchStatus();
+      return;
+    }
+    throw error;
+  } finally {
+    if (activeDownloadController === controller) {
+      activeDownloadController = null;
+      downloadCancelRequested = false;
+    }
+  }
 }
 
 export const useSidecarStore = create<SidecarState>((set, get) => ({
@@ -295,6 +322,7 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
     try {
       await consumeDownloadStream("/api/sidecar/download", { quantization }, set, get);
     } catch (error) {
+      await get().fetchStatus();
       set({
         downloadProgress: {
           phase: "model",
@@ -326,6 +354,7 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
     try {
       await consumeDownloadStream("/api/sidecar/download/custom", modelPath ? { repo, modelPath } : { repo }, set, get);
     } catch (error) {
+      await get().fetchStatus();
       set({
         downloadProgress: {
           phase: "model",
@@ -359,6 +388,8 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
   },
 
   cancelDownload: async () => {
+    downloadCancelRequested = true;
+    activeDownloadController?.abort();
     try {
       await api.post("/sidecar/download/cancel");
     } catch {
@@ -436,6 +467,7 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
     try {
       await consumeDownloadStream("/api/sidecar/runtime/install", reinstall ? { reinstall: true } : {}, set, get);
     } catch (error) {
+      await get().fetchStatus();
       set({
         downloadProgress: {
           phase: "runtime",
@@ -496,7 +528,26 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
     }
   },
 
-  setShowDownloadModal: (open) => set({ showDownloadModal: open }),
+  setShowDownloadModal: (open) => {
+    if (!open) {
+      const { downloadProgress, status } = get();
+      const shouldCancelSetup =
+        activeDownloadController !== null || downloadProgress !== null || TRANSITIONAL_STATUSES.has(status);
+      downloadCancelRequested = true;
+      activeDownloadController?.abort();
+      if (shouldCancelSetup) {
+        void api
+          .post("/sidecar/download/cancel")
+          .catch(() => {
+            // Best-effort cancel.
+          })
+          .finally(() => {
+            void get().fetchStatus();
+          });
+      }
+    }
+    set({ showDownloadModal: open });
+  },
 
   markPrompted: () => {
     localStorage.setItem(PROMPTED_KEY, "true");

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -203,6 +203,8 @@ const CREATE_TABLES: string[] = [
     activation_conditions TEXT NOT NULL DEFAULT '[]',
     schedule TEXT,
     prevent_recursion TEXT NOT NULL DEFAULT 'false',
+    exclude_recursion TEXT NOT NULL DEFAULT 'false',
+    delay_until_recursion TEXT NOT NULL DEFAULT 'false',
     exclude_from_vectorization TEXT NOT NULL DEFAULT 'false',
     embedding TEXT,
     created_at TEXT NOT NULL,
@@ -628,6 +630,16 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   {
     table: "lorebook_entries",
     column: "prevent_recursion",
+    definition: "TEXT NOT NULL DEFAULT 'false'",
+  },
+  {
+    table: "lorebook_entries",
+    column: "exclude_recursion",
+    definition: "TEXT NOT NULL DEFAULT 'false'",
+  },
+  {
+    table: "lorebook_entries",
+    column: "delay_until_recursion",
     definition: "TEXT NOT NULL DEFAULT 'false'",
   },
   {

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -108,7 +108,7 @@ export const lorebookEntries = sqliteTable("lorebook_entries", {
   enabled: text("enabled").notNull().default("true"),
   constant: text("constant").notNull().default("false"),
   selective: text("selective").notNull().default("false"),
-  selectiveLogic: text("selective_logic", { enum: ["and", "or", "not"] })
+  selectiveLogic: text("selective_logic", { enum: ["and", "and_all", "or", "not", "not_all"] })
     .notNull()
     .default("and"),
   probability: integer("probability"),

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -164,6 +164,12 @@ export const lorebookEntries = sqliteTable("lorebook_entries", {
   /** When true, this entry's content won't trigger further entries during recursive scanning */
   preventRecursion: text("prevent_recursion").notNull().default("false"),
 
+  /** When true, recursive scanning cannot activate this entry */
+  excludeRecursion: text("exclude_recursion").notNull().default("false"),
+
+  /** When true, only recursive scanning can activate this entry */
+  delayUntilRecursion: text("delay_until_recursion").notNull().default("false"),
+
   /** When true, bulk vectorization skips this entry and semantic matching ignores stored vectors */
   excludeFromVectorization: text("exclude_from_vectorization").notNull().default("false"),
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@ import { getHost, getPort, getServerProtocol, loadTlsOptions, logStorageDiagnost
 import { logCsrfTrustSummary } from "./middleware/csrf-protection.js";
 import { startEnvWatcher } from "./config/env-watcher.js";
 import { migrateTaskbarShortcuts } from "./services/setup/taskbar-shortcut-migration.js";
+import { sidecarProcessService } from "./services/sidecar/sidecar-process.service.js";
 
 function isAddressInUseError(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err && err.code === "EADDRINUSE";
@@ -24,6 +25,15 @@ function scheduleTaskbarShortcutMigration() {
   timeout.unref?.();
 }
 
+function logFatalProcessError(reason: unknown, message: string): void {
+  if (reason instanceof Error) {
+    logger.error(reason, message);
+    return;
+  }
+
+  logger.error({ reason }, message);
+}
+
 async function main() {
   const tls = loadTlsOptions();
   logStorageDiagnostics();
@@ -33,6 +43,22 @@ async function main() {
   const port = getPort();
   const host = getHost();
   let isShuttingDown = false;
+
+  const reapSidecar = () => {
+    sidecarProcessService.killCurrentChildForProcessExit();
+  };
+
+  process.once("exit", reapSidecar);
+  process.on("uncaughtException", (err) => {
+    logFatalProcessError(err, "[process] Uncaught exception; reaping sidecar before exit");
+    reapSidecar();
+    process.exit(1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    logFatalProcessError(reason, "[process] Unhandled rejection; reaping sidecar before exit");
+    reapSidecar();
+    process.exit(1);
+  });
 
   const shutdown = async (signal: NodeJS.Signals) => {
     if (isShuttingDown) {

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -40,10 +40,13 @@ const BACKUP_DIRS = [
   "fonts",
   "knowledge-sources",
   "game-assets",
+  "custom-emojis",
+  "custom-stickers",
   "lorebooks/images",
   "agents/images",
   "connections/images",
 ];
+const ENCRYPTION_KEY_FILENAME = ".encryption-key";
 const PROFILE_ASSET_DIRS = BACKUP_DIRS.filter((dirName) => dirName !== "storage");
 const PROFILE_IMPORT_BODY_LIMIT_BYTES = 256 * 1024 * 1024;
 const PROFILE_IMPORT_ARCHIVE_LIMIT_BYTES = 1024 * 1024 * 1024;
@@ -170,6 +173,10 @@ function sendProfileImportRequestError(reply: FastifyReply, err: ProfileImportRe
 
 function resolveBackupDir(dataDir: string, dirName: string) {
   return dirName === "storage" ? getFileStorageDir() : join(dataDir, dirName);
+}
+
+function resolvePersistedEncryptionKeyPath(dataDir: string) {
+  return assertInsideDir(dataDir, join(dataDir, ENCRYPTION_KEY_FILENAME));
 }
 
 function toSafeExportName(name: string, fallback: string) {
@@ -1604,6 +1611,9 @@ function buildBackupRestoreNotes() {
     "Marinara Engine backup",
     "",
     "This archive contains a raw filesystem backup for manual recovery.",
+    "Treat it as sensitive: full backups include local secret material such as .encryption-key when that file exists.",
+    "Restore .encryption-key together with the database/storage files to keep saved API keys decryptable.",
+    "If this install used an ENCRYPTION_KEY environment variable instead of a persisted key file, restore that environment variable separately.",
     "",
     "For one-click import inside Marinara:",
     "1. Open Settings -> Import.",
@@ -1612,6 +1622,18 @@ function buildBackupRestoreNotes() {
     "",
     "The .marinara.json importer is for individual characters, personas, lorebooks, and presets.",
   ].join("\n");
+}
+
+async function copyPersistedEncryptionKey(dataDir: string, backupDir: string) {
+  const keyPath = resolvePersistedEncryptionKeyPath(dataDir);
+  if (!existsSync(keyPath)) return;
+  await copyFile(keyPath, join(backupDir, ENCRYPTION_KEY_FILENAME));
+}
+
+async function addPersistedEncryptionKeyToZip(dataDir: string, zip: AdmZip, backupName: string) {
+  const keyPath = resolvePersistedEncryptionKeyPath(dataDir);
+  if (!existsSync(keyPath)) return;
+  zip.addFile(`${backupName}/${ENCRYPTION_KEY_FILENAME}`, await readFile(keyPath));
 }
 
 function getBackupErrorMessage(err: unknown, fallback: string) {
@@ -1663,6 +1685,7 @@ export async function backupRoutes(app: FastifyInstance) {
           }
         }
       }
+      await copyPersistedEncryptionKey(dataDir, backupDir);
 
       // 2. Copy data directories
       for (const dirName of BACKUP_DIRS) {
@@ -1732,6 +1755,7 @@ export async function backupRoutes(app: FastifyInstance) {
           }
         }
       }
+      await addPersistedEncryptionKeyToZip(dataDir, zip, backupName);
 
       const buf = zip.toBuffer();
       return reply

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -2028,6 +2028,12 @@ export async function backupRoutes(app: FastifyInstance) {
                       ? p.trackerCardColors
                       : JSON.stringify(p.trackerCardColors ?? { mode: "chat" }),
                   personaStats: p.personaStats,
+                  tags: typeof p.tags === "string" ? p.tags : JSON.stringify(p.tags ?? []),
+                  savedStatusOptions:
+                    typeof p.savedStatusOptions === "string"
+                      ? p.savedStatusOptions
+                      : JSON.stringify(p.savedStatusOptions ?? []),
+                  avatarCrop: typeof p.avatarCrop === "string" ? p.avatarCrop : JSON.stringify(p.avatarCrop ?? null),
                 },
                 normalizeTimestampOverrides({ createdAt: p.createdAt, updatedAt: p.updatedAt }),
               );

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -197,9 +197,11 @@ function asStringArray(value: unknown): string[] {
 }
 
 function stSelectiveLogic(value: unknown): number {
-  if (value === "or") return 0;
+  if (value === "and" || value === "or") return 0;
+  if (value === "not_all") return 1;
   if (value === "not") return 2;
-  return 3;
+  if (value === "and_all") return 3;
+  return 0;
 }
 
 function stPosition(value: unknown): number {

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -197,7 +197,16 @@ function asStringArray(value: unknown): string[] {
 }
 
 function stSelectiveLogic(value: unknown): number {
-  return value === "or" ? 1 : value === "not" ? 2 : 0;
+  if (value === "or") return 0;
+  if (value === "not") return 2;
+  return 3;
+}
+
+function stPosition(value: unknown): number {
+  const position = Number(value ?? 0);
+  if (position === 2) return 4;
+  if (position === 1) return 1;
+  return 0;
 }
 
 function stRole(value: unknown): number {
@@ -218,7 +227,7 @@ function buildCompatibleLorebookExport(lb: Record<string, any>) {
       selective: entry.selective === true,
       selectiveLogic: stSelectiveLogic(entry.selectiveLogic),
       order: Number(entry.order ?? 100),
-      position: Number(entry.position ?? 0),
+      position: stPosition(entry.position),
       depth: Number(entry.depth ?? 4),
       probability: entry.probability ?? null,
       scanDepth: entry.scanDepth ?? null,
@@ -230,6 +239,10 @@ function buildCompatibleLorebookExport(lb: Record<string, any>) {
       sticky: entry.sticky ?? null,
       cooldown: entry.cooldown ?? null,
       delay: entry.delay ?? null,
+      useRegex: entry.useRegex === true,
+      preventRecursion: entry.preventRecursion === true,
+      excludeRecursion: entry.excludeRecursion === true,
+      delayUntilRecursion: entry.delayUntilRecursion === true,
     };
   });
 

--- a/packages/server/src/routes/bot-browser-chartavern.routes.ts
+++ b/packages/server/src/routes/bot-browser-chartavern.routes.ts
@@ -3,9 +3,11 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
+import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
 
 const CT_API_BASE = "https://character-tavern.com/api";
 const CT_CARDS_CDN = "https://cards.character-tavern.com";
+const AVATAR_PROXY_MAX_BYTES = 10 * 1024 * 1024;
 
 // In-memory session cookie store (persists until server restart)
 let ctSessionCookie: string = "";
@@ -23,6 +25,22 @@ async function proxyFetch(url: string, init?: RequestInit): Promise<unknown> {
   } finally {
     clearTimeout(timeout);
   }
+}
+
+async function fetchAvatarImage(url: string, signal: AbortSignal) {
+  const res = await safeFetch(url, {
+    signal,
+    policy: { allowedProtocols: ["https:"] },
+    maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+  });
+  if (!res.ok) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
+  const imageInfo = isAllowedImageBuffer(buf);
+  if (!contentType.startsWith("image/") || !imageInfo) {
+    throw new Error("Unsupported avatar image content");
+  }
+  return { buf, mimeType: imageInfo.mimeType };
 }
 
 /** Build headers for CT API — includes session cookie if stored */
@@ -261,20 +279,18 @@ export async function botBrowserChartavernRoutes(app: FastifyInstance) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
-      const res = await fetch(`${CT_CARDS_CDN}/cdn-cgi/image/format=auto,width=320,quality=85/${encodeURI(path)}.png`, {
-        signal: controller.signal,
-      });
-      if (!res.ok) {
-        const res2 = await fetch(`${CT_CARDS_CDN}/${encodeURI(path)}.png`, {
-          signal: controller.signal,
-        });
-        if (!res2.ok) return reply.status(404).send({ error: "Avatar not found" });
-        const buf = Buffer.from(await res2.arrayBuffer());
-        return reply.header("Content-Type", "image/png").header("Cache-Control", "public, max-age=86400").send(buf);
+      const primary = await fetchAvatarImage(
+        `${CT_CARDS_CDN}/cdn-cgi/image/format=auto,width=320,quality=85/${encodeURI(path)}.png`,
+        controller.signal,
+      );
+      const image = primary ?? (await fetchAvatarImage(`${CT_CARDS_CDN}/${encodeURI(path)}.png`, controller.signal));
+      if (!image) return reply.status(404).send({ error: "Avatar not found" });
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(image.buf);
+    } catch (err) {
+      if ((err as Error).message.includes("Unsupported avatar image content")) {
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
       }
-      const buf = Buffer.from(await res.arrayBuffer());
-      const ct = res.headers.get("content-type") || "image/png";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      throw err;
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -6,10 +6,12 @@
 import { randomUUID } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
+import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
 
 const DATACAT_API_BASE = "https://datacat.run";
 const DATACAT_IMAGE_BASE = "https://ella.janitorai.com/bot-avatars/";
 const DEFAULT_MIN_TOTAL_TOKENS = 889;
+const AVATAR_PROXY_MAX_BYTES = 10 * 1024 * 1024;
 const DC_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
@@ -71,6 +73,22 @@ function dcHeaders(token: string): Record<string, string> {
     Referer: `${DATACAT_API_BASE}/`,
     "X-Session-Token": token,
   };
+}
+
+async function fetchAvatarImage(url: string, signal: AbortSignal) {
+  const res = await safeFetch(url, {
+    signal,
+    policy: { allowedProtocols: ["https:"] },
+    maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+  });
+  if (!res.ok) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
+  const imageInfo = isAllowedImageBuffer(buf);
+  if (!contentType.startsWith("image/") || !imageInfo) {
+    throw new Error("Unsupported avatar image content");
+  }
+  return { buf, mimeType: imageInfo.mimeType };
 }
 
 async function dcFetch(path: string): Promise<unknown> {
@@ -227,11 +245,14 @@ export async function botBrowserDatacatRoutes(app: FastifyInstance) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
-      const res = await fetch(url, { signal: controller.signal });
-      if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
-      const buf = Buffer.from(await res.arrayBuffer());
-      const ct = res.headers.get("content-type") || "image/jpeg";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      const image = await fetchAvatarImage(url, controller.signal);
+      if (!image) return reply.status(404).send({ error: "Avatar not found" });
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(image.buf);
+    } catch (err) {
+      if ((err as Error).message.includes("Unsupported avatar image content")) {
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      throw err;
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -2,6 +2,7 @@
 // Routes: Browser — JannyAI provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
+import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
 
 const JANNY_SEARCH_URL = "https://search.jannyai.com/multi-search";
 const JANNY_IMAGE_BASE = "https://image.jannyai.com/bot-avatars/";
@@ -11,6 +12,23 @@ const JANNY_FALLBACK_TOKEN = "88a6463b66e04fb07ba87ee3db06af337f492ce511d93df6e2
 
 const BROWSER_UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+const AVATAR_PROXY_MAX_BYTES = 10 * 1024 * 1024;
+
+async function fetchAvatarImage(url: string, signal: AbortSignal) {
+  const res = await safeFetch(url, {
+    signal,
+    policy: { allowedProtocols: ["https:"] },
+    maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+  });
+  if (!res.ok) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
+  const imageInfo = isAllowedImageBuffer(buf);
+  if (!contentType.startsWith("image/") || !imageInfo) {
+    throw new Error("Unsupported avatar image content");
+  }
+  return { buf, mimeType: imageInfo.mimeType };
+}
 
 function jannySearchHeaders(token: string): Record<string, string> {
   return {
@@ -445,13 +463,14 @@ export async function botBrowserJannyRoutes(app: FastifyInstance) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
-      const res = await fetch(`${JANNY_IMAGE_BASE}${avatarPath}`, {
-        signal: controller.signal,
-      });
-      if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
-      const buf = Buffer.from(await res.arrayBuffer());
-      const ct = res.headers.get("content-type") || "image/jpeg";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      const image = await fetchAvatarImage(`${JANNY_IMAGE_BASE}${avatarPath}`, controller.signal);
+      if (!image) return reply.status(404).send({ error: "Avatar not found" });
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(image.buf);
+    } catch (err) {
+      if ((err as Error).message.includes("Unsupported avatar image content")) {
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      throw err;
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser.routes.ts
+++ b/packages/server/src/routes/bot-browser.routes.ts
@@ -2,9 +2,27 @@
 // Routes: Browser (proxy to character sources)
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
+import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
 
 const CHUB_API_BASE = "https://api.chub.ai";
 const CHUB_AVATARS = "https://avatars.charhub.io";
+const AVATAR_PROXY_MAX_BYTES = 10 * 1024 * 1024;
+
+async function fetchAvatarImage(url: string, signal: AbortSignal) {
+  const res = await safeFetch(url, {
+    signal,
+    policy: { allowedProtocols: ["https:"] },
+    maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+  });
+  if (!res.ok) return null;
+  const buf = Buffer.from(await res.arrayBuffer());
+  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
+  const imageInfo = isAllowedImageBuffer(buf);
+  if (!contentType.startsWith("image/") || !imageInfo) {
+    throw new Error("Unsupported avatar image content");
+  }
+  return { buf, mimeType: imageInfo.mimeType };
+}
 
 /** Safely proxy-fetch an external URL, returning sanitised JSON. */
 async function proxyFetch(url: string, init?: RequestInit): Promise<unknown> {
@@ -163,20 +181,17 @@ export async function botBrowserRoutes(app: FastifyInstance) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
-      const res = await fetch(`${CHUB_AVATARS}/avatars/${encodeURI(fullPath)}/avatar.webp`, {
-        signal: controller.signal,
-      });
-      if (!res.ok) {
-        // Fallback to chara_card_v2.png thumbnail
-        const res2 = await fetch(`${CHUB_AVATARS}/avatars/${encodeURI(fullPath)}/chara_card_v2.png`, {
-          signal: controller.signal,
-        });
-        if (!res2.ok) return reply.status(404).send({ error: "Avatar not found" });
-        const buf = Buffer.from(await res2.arrayBuffer());
-        return reply.header("Content-Type", "image/png").header("Cache-Control", "public, max-age=86400").send(buf);
+      const primary = await fetchAvatarImage(`${CHUB_AVATARS}/avatars/${encodeURI(fullPath)}/avatar.webp`, controller.signal);
+      const image =
+        primary ??
+        (await fetchAvatarImage(`${CHUB_AVATARS}/avatars/${encodeURI(fullPath)}/chara_card_v2.png`, controller.signal));
+      if (!image) return reply.status(404).send({ error: "Avatar not found" });
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(image.buf);
+    } catch (err) {
+      if ((err as Error).message.includes("Unsupported avatar image content")) {
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
       }
-      const buf = Buffer.from(await res.arrayBuffer());
-      return reply.header("Content-Type", "image/webp").header("Cache-Control", "public, max-age=86400").send(buf);
+      throw err;
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -753,8 +753,16 @@ export async function charactersRoutes(app: FastifyInstance) {
         try {
           const avatarBuffer = await readFile(avatarFile);
           const imageInfo = isAllowedImageBuffer(avatarBuffer, extname(filename));
-          pngBuffer = imageInfo?.mimeType === "image/png" ? avatarBuffer : createMinimalPng();
-        } catch {
+          if (imageInfo?.mimeType === "image/png") {
+            pngBuffer = avatarBuffer;
+          } else if (imageInfo) {
+            const sharp = (await import("sharp")).default;
+            pngBuffer = await sharp(avatarBuffer).png().toBuffer();
+          } else {
+            pngBuffer = createMinimalPng();
+          }
+        } catch (err) {
+          logger.warn(err, "Failed to prepare avatar PNG for character card export");
           pngBuffer = createMinimalPng();
         }
       } else {

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -571,6 +571,14 @@ export async function chatsRoutes(app: FastifyInstance) {
     return storage.update(req.params.id, data);
   });
 
+  app.post<{ Params: { id: string } }>("/:id/touch", async (req, reply) => {
+    const chat = await storage.getById(req.params.id);
+    if (!chat || (hasProfessorMariCharacter(chat) && !isHomeProfessorMariChat(chat))) {
+      return reply.status(404).send({ error: "Chat not found" });
+    }
+    return storage.touch(req.params.id);
+  });
+
   // Update chat metadata (partial merge)
   app.patch<{ Params: { id: string } }>("/:id/metadata", async (req, reply) => {
     const chat = await storage.getById(req.params.id);

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -20,7 +20,6 @@ import {
   stripMacroComments,
   summariesPatchSchema,
   coerceGameStateTextValue,
-  formatCustomTrackerFieldForPrompt,
   normalizeTrackerFieldLocks,
   parseTrackerFieldLocks,
 } from "@marinara-engine/shared";
@@ -76,6 +75,7 @@ import {
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import { applyImmersiveHtmlPromptInjection } from "../services/generation/immersive-html-injection.js";
+import { buildCommittedTrackerContextBlock } from "../services/generation/committed-tracker-context.js";
 import { parseLorebookWriteApprovalText } from "./generate/agent-write-approval.js";
 import { persistLorebookKeeperUpdates } from "./generate/lorebook-keeper-utils.js";
 
@@ -227,123 +227,16 @@ function formatPeekTrackerContextBlock(args: {
   wrapFormat: TrackerWrapFormat;
   snap: typeof gameStateSnapshots.$inferSelect;
   chatMeta: Record<string, unknown>;
+  chatEnableAgents: boolean;
   activeAgentIds: string[];
 }): string | null {
-  const { wrapFormat, snap, chatMeta, activeAgentIds } = args;
-  const active = new Set(activeAgentIds);
-  const hasWorldState = active.has("world-state");
-  const hasCharTracker = active.has("character-tracker");
-  const hasPersonaStats = active.has("persona-stats");
-  const hasQuest = active.has("quest");
-  const hasCustomTracker = active.has("custom-tracker");
-
-  if (!hasWorldState && !hasCharTracker && !hasPersonaStats && !hasQuest && !hasCustomTracker) return null;
-
-  const trackerParts: string[] = [];
-
-  if (hasWorldState) {
-    const wsParts: string[] = [];
-    if (snap.date) wsParts.push(`Date: ${snap.date}`);
-    if (snap.time) wsParts.push(`Time: ${snap.time}`);
-    if (snap.location) wsParts.push(`Location: ${snap.location}`);
-    if (snap.weather) wsParts.push(`Weather: ${snap.weather}`);
-    if (snap.temperature) wsParts.push(`Temperature: ${snap.temperature}`);
-    if (wsParts.length > 0) trackerParts.push(wrapContent(wsParts.join("\n"), "World", wrapFormat));
-  }
-
-  if (hasCharTracker) {
-    try {
-      const presentChars = JSON.parse(snap.presentCharacters);
-      if (Array.isArray(presentChars) && presentChars.length > 0) {
-        const charLines = presentChars.map((c: any) => {
-          if (typeof c === "string") return `- ${c}`;
-          const details: string[] = [];
-          if (c.mood) details.push(`mood: ${c.mood}`);
-          if (c.appearance) details.push(`appearance: ${c.appearance}`);
-          if (c.outfit) details.push(`outfit: ${c.outfit}`);
-          if (c.thoughts) details.push(`thoughts: ${c.thoughts}`);
-          if (Array.isArray(c.stats) && c.stats.length > 0) {
-            const statStr = c.stats.map((s: any) => `${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`).join(", ");
-            details.push(`stats: ${statStr}`);
-          }
-          const detailStr = details.length > 0 ? ` (${details.join("; ")})` : "";
-          return `- ${c.emoji ?? ""} ${c.name ?? c}${detailStr}`;
-        });
-        trackerParts.push(wrapContent(charLines.join("\n"), "Present Characters", wrapFormat));
-      }
-    } catch {
-      /* ignore malformed tracker data */
-    }
-  }
-
-  if (hasPersonaStats && snap.personaStats) {
-    try {
-      const psBars = typeof snap.personaStats === "string" ? JSON.parse(snap.personaStats) : snap.personaStats;
-      if (Array.isArray(psBars) && psBars.length > 0) {
-        const barLines = psBars.map((b: any) => `- ${b.name}: ${b.value}/${b.max}`);
-        trackerParts.push(wrapContent(barLines.join("\n"), "Persona Stats", wrapFormat));
-      }
-    } catch {
-      /* ignore malformed tracker data */
-    }
-  }
-
-  if (snap.playerStats) {
-    try {
-      const stats = typeof snap.playerStats === "string" ? JSON.parse(snap.playerStats) : snap.playerStats;
-
-      if (hasPersonaStats && stats?.status)
-        trackerParts.push(wrapContent(`Status: ${stats.status}`, "Status", wrapFormat));
-
-      if (hasQuest && Array.isArray(stats?.activeQuests) && stats.activeQuests.length > 0) {
-        const questLines = stats.activeQuests.map((q: any) => {
-          const objectives = Array.isArray(q.objectives)
-            ? q.objectives.map((o: any) => `  ${o.completed ? "[x]" : "[ ]"} ${o.text}`).join("\n")
-            : "";
-          return `- ${q.name}${q.completed ? " (completed)" : ""}${objectives ? "\n" + objectives : ""}`;
-        });
-        trackerParts.push(wrapContent(questLines.join("\n"), "Active Quests", wrapFormat));
-      }
-
-      if (hasPersonaStats && Array.isArray(stats?.inventory) && stats.inventory.length > 0) {
-        const invLines = stats.inventory.map(
-          (item: any) =>
-            `- ${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ""}${item.description ? ` — ${item.description}` : ""}`,
-        );
-        trackerParts.push(wrapContent(invLines.join("\n"), "Inventory", wrapFormat));
-      }
-
-      if (hasPersonaStats && Array.isArray(stats?.stats) && stats.stats.length > 0) {
-        const statLines = stats.stats.map((s: any) => `- ${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`);
-        trackerParts.push(wrapContent(statLines.join("\n"), "Stats", wrapFormat));
-      }
-
-      if (hasCustomTracker && Array.isArray(stats?.customTrackerFields) && stats.customTrackerFields.length > 0) {
-        const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
-        trackerParts.push(wrapContent(customLines.join("\n"), "Custom Tracker", wrapFormat));
-      }
-    } catch {
-      /* ignore malformed tracker data */
-    }
-  }
-
-  const playerNotes = typeof chatMeta.gamePlayerNotes === "string" ? chatMeta.gamePlayerNotes.trim() : "";
-  if (playerNotes) {
-    trackerParts.push(
-      wrapContent(
-        `The player has written these personal notes. Consider them when narrating — they reflect what the player is tracking, their theories, and plans:\n${playerNotes}`,
-        "Player Notes",
-        wrapFormat,
-      ),
-    );
-  }
-
-  if (trackerParts.length <= 0) return null;
-  if (wrapFormat === "none") return trackerParts.join("\n\n");
-  if (wrapFormat === "xml") {
-    return `<context>\n${trackerParts.map((part) => "    " + part.replace(/\n/g, "\n    ")).join("\n")}\n</context>`;
-  }
-  return `# Context\n*(Established state as of the last message. Do not re-describe — advance from here.)*\n${trackerParts.join("\n")}`;
+  return buildCommittedTrackerContextBlock({
+    chatEnableAgents: args.chatEnableAgents,
+    activeAgentIds: args.activeAgentIds,
+    latestGameState: args.snap,
+    chatMetadata: args.chatMeta,
+    wrapFormat: args.wrapFormat,
+  });
 }
 
 function resolveLorebookGenerationTriggers(mode: unknown): string[] {
@@ -2076,7 +1969,7 @@ export async function chatsRoutes(app: FastifyInstance) {
           if (chatEnableAgents && activeAgentIds.length > 0) {
             const snap = await loadLatestChatGameSnapshot(app, req.params.id, visibleGameStateAnchor);
             const contextBlock = snap
-              ? formatPeekTrackerContextBlock({ wrapFormat, snap, chatMeta, activeAgentIds })
+              ? formatPeekTrackerContextBlock({ wrapFormat, snap, chatMeta, chatEnableAgents, activeAgentIds })
               : null;
 
             if (contextBlock) {

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2267,18 +2267,54 @@ export async function chatsRoutes(app: FastifyInstance) {
         user_name: "User",
         character_name: primaryCharName,
         create_date: chat.createdAt,
-        chat_metadata: {},
+        chat_metadata: {
+          ...metadata,
+          branchName,
+          marinara_metadata: metadata,
+        },
       }),
     ];
 
     for (const msg of msgs) {
+      const messageExtra = parseExportMetadata(msg.extra);
+      const swipes = await storage.getSwipes(msg.id);
+      const exportSwipes =
+        swipes.length > 0
+          ? swipes.map((swipe: { index: number; content: string; extra?: unknown; createdAt?: string }) => ({
+              index: swipe.index,
+              content: swipe.index === msg.activeSwipeIndex ? msg.content : swipe.content,
+              extra: swipe.index === msg.activeSwipeIndex ? messageExtra : parseExportMetadata(swipe.extra),
+              createdAt: swipe.createdAt,
+            }))
+          : [
+              {
+                index: 0,
+                content: msg.content,
+                extra: messageExtra,
+                createdAt: msg.createdAt,
+              },
+            ];
       lines.push(
         JSON.stringify({
           name: getDisplayName(msg),
           is_user: msg.role === "user",
-          is_system: msg.role === "system" || msg.role === "narrator",
+          is_system: msg.role === "system",
+          role: msg.role,
+          character_id: msg.characterId,
           mes: msg.content,
+          swipes: exportSwipes.map((swipe) => swipe.content),
+          swipe_id: msg.activeSwipeIndex,
           send_date: msg.createdAt,
+          extra: {
+            ...messageExtra,
+            marinara_role: msg.role,
+            marinara_character_id: msg.characterId,
+            marinara_swipes: exportSwipes.map((swipe) => ({
+              index: swipe.index,
+              extra: swipe.extra,
+              created_at: swipe.createdAt,
+            })),
+          },
         }),
       );
     }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1951,7 +1951,6 @@ export async function chatsRoutes(app: FastifyInstance) {
                   appearance: cardPromptText(charData.extensions?.appearance),
                   example: cardPromptText(charData.mes_example),
                   systemPrompt: cardPromptText(charData.system_prompt),
-                  postHistoryInstructions: cardPromptText(charData.post_history_instructions),
                 },
               };
               const resolveCharacterMacros = (value: string) => resolveMacros(value, characterMacroContext);
@@ -2007,15 +2006,6 @@ export async function chatsRoutes(app: FastifyInstance) {
                   wrapContent(
                     resolveCharacterMacros(characterMacroContext.characterFields.example),
                     "example_dialogue",
-                    wrapFormat,
-                    2,
-                  ),
-                );
-              if (characterMacroContext.characterFields.postHistoryInstructions)
-                parts.push(
-                  wrapContent(
-                    resolveCharacterMacros(characterMacroContext.characterFields.postHistoryInstructions),
-                    "post_history_instructions",
                     wrapFormat,
                     2,
                   ),

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -85,6 +85,16 @@ const MEMORY_RECALL_IMPORT_BODY_LIMIT_BYTES = 25 * 1024 * 1024;
 const MEMORY_RECALL_IMPORT_BATCH_SIZE = 500;
 const PROFESSOR_MARI_INTERNAL_CHAT_MARKER = "professor-mari";
 
+function parseSnapshotJson<T>(value: unknown, fallback: T): T {
+  if (value == null) return fallback;
+  if (typeof value !== "string") return value as T;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 function toSafeExportName(name: string, fallback: string) {
   const safe = name
     .trim()
@@ -2454,10 +2464,7 @@ export async function chatsRoutes(app: FastifyInstance) {
         targetSwipeIndex: number,
       ) => {
         try {
-          const overrides =
-            snapshot.manualOverrides && typeof snapshot.manualOverrides === "string"
-              ? (JSON.parse(snapshot.manualOverrides) as Record<string, string>)
-              : null;
+          const overrides = parseSnapshotJson<Record<string, string> | null>(snapshot.manualOverrides, null);
           await gameStateStore.create(
             {
               chatId: newChat.id,
@@ -2468,32 +2475,17 @@ export async function chatsRoutes(app: FastifyInstance) {
               location: (snapshot.location as string) ?? null,
               weather: (snapshot.weather as string) ?? null,
               temperature: (snapshot.temperature as string) ?? null,
-              presentCharacters:
-                typeof snapshot.presentCharacters === "string"
-                  ? JSON.parse(snapshot.presentCharacters)
-                  : (snapshot.presentCharacters ?? []),
-              recentEvents:
-                typeof snapshot.recentEvents === "string"
-                  ? JSON.parse(snapshot.recentEvents)
-                  : (snapshot.recentEvents ?? []),
-              playerStats:
-                snapshot.playerStats == null
-                  ? null
-                  : typeof snapshot.playerStats === "string"
-                    ? JSON.parse(snapshot.playerStats)
-                    : snapshot.playerStats,
-              personaStats:
-                snapshot.personaStats == null
-                  ? null
-                  : typeof snapshot.personaStats === "string"
-                    ? JSON.parse(snapshot.personaStats)
-                    : snapshot.personaStats,
+              presentCharacters: parseSnapshotJson(snapshot.presentCharacters, []),
+              recentEvents: parseSnapshotJson(snapshot.recentEvents, []),
+              playerStats: parseSnapshotJson(snapshot.playerStats, null),
+              personaStats: parseSnapshotJson(snapshot.personaStats, null),
               fieldLocks: parseTrackerFieldLocks(snapshot.fieldLocks),
               committed: (snapshot.committed as any) === 1,
             } as any,
             overrides,
           );
-        } catch {
+        } catch (err) {
+          logger.warn(err, "Failed to copy game-state snapshot while branching chat");
           // Ignore individual snapshot copy failures; branching should still succeed.
         }
       };

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1504,7 +1504,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     let updated: Awaited<ReturnType<typeof gameStateStore.updateLatest>> = null;
     if (hasExplicitTarget) {
       const targetMessage = await storage.getMessage(targetMessageId);
-      if (targetMessage?.chatId === req.params.id) {
+      const targetSnapshot = await gameStateStore.getByMessage(targetMessageId, targetSwipeIndex);
+      if (targetMessage?.chatId === req.params.id || targetSnapshot?.chatId === req.params.id) {
         updated = await gameStateStore.updateByMessage(
           targetMessageId,
           targetSwipeIndex,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3212,9 +3212,23 @@ export async function gameRoutes(app: FastifyInstance) {
         }
       }
 
+      const usedNpcNames = new Set<string>();
+      const uniqueNpcName = (rawName: string, fallbackName: string) => {
+        const base = rawName.trim() || fallbackName;
+        let candidate = base;
+        let suffix = 2;
+        while (usedNpcNames.has(candidate.toLowerCase())) {
+          candidate = `${base} ${suffix}`;
+          suffix += 1;
+        }
+        usedNpcNames.add(candidate.toLowerCase());
+        return candidate;
+      };
+
       const npcs = Array.from(setupData.startingNpcs as unknown[]).map((value, i) => {
         const n = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
-        const name = typeof n.name === "string" && n.name.trim() ? n.name.trim() : `NPC ${i + 1}`;
+        const rawName = typeof n.name === "string" ? n.name : "";
+        const name = uniqueNpcName(rawName, `NPC ${i + 1}`);
         const description = typeof n.description === "string" ? n.description : "";
         return {
           id: randomUUID(),

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1734,7 +1734,7 @@ async function runGameChatComplete(
   timeoutMs = GAME_GENERATION_TIMEOUT_MS,
 ): Promise<ChatCompletionResult> {
   const controller = new AbortController();
-  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   const parentSignal = options.signal;
   const abortFromParent = () => controller.abort(parentSignal?.reason);
   if (parentSignal?.aborted) {
@@ -1743,18 +1743,58 @@ async function runGameChatComplete(
     parentSignal?.addEventListener("abort", abortFromParent, { once: true });
   }
 
-  const timeout = setTimeout(() => {
-    timedOut = true;
-    controller.abort(new GameGenerationTimeoutError(label, timeoutMs));
-  }, timeoutMs);
+  const timeoutError = new GameGenerationTimeoutError(label, timeoutMs);
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
 
   try {
-    return await provider.chatComplete(messages, { ...options, signal: controller.signal });
-  } catch (err) {
-    if (timedOut) throw new GameGenerationTimeoutError(label, timeoutMs);
-    throw err;
+    return await Promise.race([provider.chatComplete(messages, { ...options, signal: controller.signal }), timeoutPromise]);
   } finally {
-    clearTimeout(timeout);
+    if (timeout) clearTimeout(timeout);
+    parentSignal?.removeEventListener("abort", abortFromParent);
+  }
+}
+
+async function runGameChatStream(
+  provider: { chat(messages: ChatMessage[], options: ChatOptions): AsyncIterable<string> },
+  messages: ChatMessage[],
+  options: ChatOptions,
+  label: string,
+  timeoutMs = GAME_GENERATION_TIMEOUT_MS,
+): Promise<string> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const parentSignal = options.signal;
+  const abortFromParent = () => controller.abort(parentSignal?.reason);
+  if (parentSignal?.aborted) {
+    abortFromParent();
+  } else {
+    parentSignal?.addEventListener("abort", abortFromParent, { once: true });
+  }
+
+  const timeoutError = new GameGenerationTimeoutError(label, timeoutMs);
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, timeoutMs);
+  });
+  const streamPromise = (async () => {
+    let streamed = "";
+    for await (const chunk of provider.chat(messages, { ...options, signal: controller.signal, stream: true })) {
+      streamed += chunk;
+    }
+    return streamed;
+  })();
+
+  try {
+    return await Promise.race([streamPromise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
     parentSignal?.removeEventListener("abort", abortFromParent);
   }
 }
@@ -2093,6 +2133,12 @@ export function normalizeGameLorebookKeeperEntries(raw: unknown): GameLorebookKe
       ];
     })
     .slice(0, GAME_LOREBOOK_KEEPER_MAX_ENTRIES);
+}
+
+function hasGameLorebookKeeperEntryEnvelope(raw: unknown): raw is { entries?: unknown[]; updates?: unknown[] } {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return false;
+  const container = raw as { entries?: unknown; updates?: unknown };
+  return Array.isArray(container.entries) || Array.isArray(container.updates);
 }
 
 function uniqueKeeperEntryName(name: string, usedNames: Set<string>): string {
@@ -2493,6 +2539,9 @@ async function runGameLorebookKeeperAfterConclusion(args: {
       });
       logger.warn(err, "[game/lorebook-keeper] Generated lorebook JSON failed to parse for chat %s", args.chatId);
       return { status: "failed", lorebookId: lorebook.id, error, rawJson: extraction.content };
+    }
+    if (!hasGameLorebookKeeperEntryEnvelope(parsed)) {
+      throw new Error("Lorebook Keeper JSON must include an entries or updates array.");
     }
     const entries = normalizeGameLorebookKeeperEntries(parsed);
     const createdCount = await createGameLorebookKeeperEntries({
@@ -4836,6 +4885,9 @@ export async function gameRoutes(app: FastifyInstance) {
       return;
     }
 
+    if (!hasGameLorebookKeeperEntryEnvelope(parsed)) {
+      throw new Error("Lorebook Keeper JSON must include an entries or updates array.");
+    }
     const entries = normalizeGameLorebookKeeperEntries(parsed);
     const lorebooksStore = createLorebooksStorage(app.db);
     const lorebook = await resolveGameLorebookKeeperBook({ lorebooksStore, chat, meta });
@@ -7010,10 +7062,7 @@ export async function gameRoutes(app: FastifyInstance) {
     // path. Retry once via streamed collection using the same JSON mode.
     if (!raw.trim()) {
       logger.warn("[game/scene-wrap] Empty buffered response, retrying with streamed JSON collection");
-      let streamed = "";
-      for await (const chunk of provider.chat(messages, { ...sceneWrapOptions, stream: true })) {
-        streamed += chunk;
-      }
+      const streamed = await runGameChatStream(provider, messages, sceneWrapOptions, "Game scene wrap streamed retry");
       sceneWrapExtraction = extractLeadingThinkingBlocks(streamed, gameGenerationParameters?.customThinkingTags);
       raw = sceneWrapExtraction.content;
     }

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -18,7 +18,7 @@ import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { extractLeadingThinkingBlocks } from "../services/llm/inline-thinking.js";
 import { type ChatCompletionResult, type ChatMessage, type ChatOptions } from "../services/llm/base-provider.js";
 import { isDiceNotation, rollDice } from "../services/game/dice.service.js";
-import { parseGameJsonish } from "../services/game/jsonish.js";
+import { jsonishLooksTruncated, parseGameJsonish } from "../services/game/jsonish.js";
 import { validateTransition } from "../services/game/state-machine.service.js";
 import {
   buildSetupPrompt,
@@ -90,6 +90,7 @@ import {
 } from "../services/game/journal.service.js";
 import { dedupeSessionSummaryLists } from "../services/game/session-summary-normalization.js";
 import {
+  findKnownModel,
   generationParametersSchema,
   isClaudeAdaptiveOnlyNoSamplingModel,
   supportsXhighReasoningEffort,
@@ -1531,6 +1532,38 @@ function resolveGameModelAccessPolicy(args: {
   };
 }
 
+function resolveKnownMaxOutputTokens(provider: APIProvider | string | null | undefined, model: string): number | null {
+  const knownModel = provider ? findKnownModel(provider as APIProvider, model.trim()) : undefined;
+  return knownModel?.maxOutput && knownModel.maxOutput > 0 ? Math.floor(knownModel.maxOutput) : null;
+}
+
+function clampGameMaxOutputTokens(args: {
+  provider: APIProvider | string | null | undefined;
+  model: string;
+  maxTokens: number;
+  maxTokensOverride?: number | null;
+}): number {
+  let capped = Math.max(1, Math.floor(args.maxTokens));
+  const knownMaxOutput = resolveKnownMaxOutputTokens(args.provider, args.model);
+  if (knownMaxOutput !== null) capped = Math.min(capped, knownMaxOutput);
+  if (
+    typeof args.maxTokensOverride === "number" &&
+    Number.isFinite(args.maxTokensOverride) &&
+    args.maxTokensOverride > 0
+  ) {
+    capped = Math.min(capped, Math.floor(args.maxTokensOverride));
+  }
+  return capped;
+}
+
+function isLengthFinishReason(finishReason: unknown): boolean {
+  return typeof finishReason === "string" && finishReason.trim().toLowerCase() === "length";
+}
+
+function isLikelyTruncatedJsonResponse(raw: string, finishReason: unknown): boolean {
+  return isLengthFinishReason(finishReason) || jsonishLooksTruncated(raw);
+}
+
 function resolveGameReasoningEffort(
   model: string,
   reasoningEffort: GenerationParameters["reasoningEffort"] | ChatOptions["reasoningEffort"] | null | undefined,
@@ -1664,6 +1697,7 @@ function gameGenOptions(
 
 const SESSION_SUMMARY_CHARS_PER_TOKEN = 4;
 const SESSION_SUMMARY_MIN_TRANSCRIPT_CHARS = 256;
+const GAME_SETUP_MIN_OUTPUT_TOKENS = 16_384;
 const SESSION_CONCLUSION_MIN_OUTPUT_TOKENS = 8192;
 const CAMPAIGN_PROGRESSION_MIN_OUTPUT_TOKENS = SESSION_CONCLUSION_MIN_OUTPUT_TOKENS;
 const GAME_GENERATION_TIMEOUT_MS = 4 * 60 * 1000;
@@ -3677,10 +3711,16 @@ export async function gameRoutes(app: FastifyInstance) {
       debugLog("[game/setup] === END PROMPT ===");
     }
 
+    const setupMaxTokens = clampGameMaxOutputTokens({
+      provider: conn.provider,
+      model: conn.model,
+      maxTokens: Math.max(GAME_SETUP_MIN_OUTPUT_TOKENS, setupGenerationParameters?.maxTokens ?? 0),
+      maxTokensOverride: conn.maxTokensOverride,
+    });
     const setupOptions = gameGenOptions(
       conn.model,
       {
-        maxTokens: setupGenerationParameters?.maxTokens ?? 16384,
+        maxTokens: setupMaxTokens,
         stream: streaming,
         ...(streaming
           ? {
@@ -3709,44 +3749,71 @@ export async function gameRoutes(app: FastifyInstance) {
       );
     }
 
-    const result = await runGameChatComplete(provider, messages, setupOptions, "Game setup");
-    const setupExtraction = extractLeadingThinkingBlocks(
-      result.content ?? "",
-      setupGenerationParameters?.customThinkingTags,
-    );
-    const responseText = setupExtraction.content;
-
-    if (debugLogsEnabled) {
-      debugLog("[game/setup] Response length: %d chars", responseText.length);
-      debugLog("[game/setup] Full response:\n%s", responseText);
-      if (setupExtraction.thinking) {
-        debugLog(
-          "[game/setup] Thinking tokens (%d chars):\n%s",
-          setupExtraction.thinking.length,
-          setupExtraction.thinking,
-        );
-      }
-    }
-
     let setupData: Record<string, unknown> = {};
+    let responseText = "";
     let parseError: string | null = null;
-    try {
-      setupData = parseJSON(responseText) as Record<string, unknown>;
-      logger.info("[game/setup] Parsed JSON keys: %s", Object.keys(setupData));
-    } catch (e) {
-      logger.error(e, "[game/setup] JSON parse failed");
-      parseError = "Model did not return valid JSON. The setup response could not be parsed.";
-    }
+    let setupFinishReason: ChatCompletionResult["finishReason"] | null = null;
 
-    if (!parseError) {
-      parseError = validateGameSetupPayload(setupData);
-      if (parseError) {
-        logger.warn("[game/setup] Validation failed: %s", parseError);
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      const result = await runGameChatComplete(
+        provider,
+        messages,
+        setupOptions,
+        attempt === 1 ? "Game setup" : "Game setup retry",
+      );
+      setupFinishReason = result.finishReason;
+      const setupExtraction = extractLeadingThinkingBlocks(
+        result.content ?? "",
+        setupGenerationParameters?.customThinkingTags,
+      );
+      responseText = setupExtraction.content;
+
+      if (debugLogsEnabled) {
+        debugLog("[game/setup] Response length: %d chars", responseText.length);
+        debugLog("[game/setup] Full response:\n%s", responseText);
+        if (setupExtraction.thinking) {
+          debugLog(
+            "[game/setup] Thinking tokens (%d chars):\n%s",
+            setupExtraction.thinking.length,
+            setupExtraction.thinking,
+          );
+        }
+      }
+
+      parseError = null;
+      setupData = {};
+      try {
+        setupData = parseJSON(responseText) as Record<string, unknown>;
+        logger.info("[game/setup] Parsed JSON keys: %s", Object.keys(setupData));
+      } catch (e) {
+        logger.error(e, "[game/setup] JSON parse failed");
+        parseError = "Model did not return valid JSON. The setup response could not be parsed.";
+      }
+
+      if (!parseError) {
+        parseError = validateGameSetupPayload(setupData);
+        if (parseError) {
+          logger.warn("[game/setup] Validation failed: %s", parseError);
+        }
+      }
+
+      if (!parseError) break;
+      if (attempt === 1) {
+        logger.warn("[game/setup] Setup JSON failed parse/validation; retrying world setup once");
       }
     }
 
     if (parseError) {
       logger.error("[game/setup] Returning 422: %s", parseError);
+      if (isLikelyTruncatedJsonResponse(responseText, setupFinishReason)) {
+        reply.code(422).send({
+          error:
+            "World generation response was cut off before the setup JSON completed. Increase this connection's max output tokens or use a model with a larger output limit, then try again.",
+          rawResponse: responseText,
+          finishReason: setupFinishReason ?? null,
+        });
+        return;
+      }
       sendJsonRepairError(
         reply,
         parseError,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -8216,9 +8216,12 @@ export async function gameRoutes(app: FastifyInstance) {
     if (!cp) throw new Error("Checkpoint not found");
     if (cp.chatId !== input.chatId) throw new Error("Checkpoint does not belong to this chat");
 
-    // Fetch the original snapshot
-    const snapshot = await stateStore.getByMessage(cp.messageId, 0);
-    if (!snapshot) throw new Error("Checkpoint snapshot no longer exists");
+    // Fetch the exact snapshot captured by the checkpoint. Do not fall back to
+    // message/swipe lookup: swipe indexes can shift while the snapshot row id
+    // remains stable, and a fallback could restore the wrong state.
+    const snapshot = await stateStore.getById(cp.snapshotId);
+    if (!snapshot) throw new Error("Checkpoint snapshot was deleted and can no longer be restored");
+    if (snapshot.chatId !== input.chatId) throw new Error("Checkpoint snapshot does not belong to this chat");
 
     // Create a system message to mark the restore point
     const restoreMsg = await chats.createMessage({

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2559,10 +2559,35 @@ function validateGameSetupPayload(setupData: Record<string, unknown>): string | 
   if (!setupData.storyArc) missing.push("storyArc");
   if (!setupData.worldOverview) missing.push("worldOverview");
   if (!Array.isArray(setupData.plotTwists) || setupData.plotTwists.length === 0) missing.push("plotTwists");
-  if (!Array.isArray(setupData.startingNpcs) || setupData.startingNpcs.length === 0) missing.push("startingNpcs");
+  const startingNpcs = setupData.startingNpcs;
+  if (!Array.isArray(startingNpcs) || startingNpcs.length === 0) {
+    missing.push("startingNpcs");
+  } else {
+    for (let index = 0; index < startingNpcs.length; index++) {
+      const npc = startingNpcs[index];
+      const name = npc && typeof npc === "object" && !Array.isArray(npc) ? (npc as Record<string, unknown>).name : null;
+      if (typeof name !== "string" || !name.trim()) {
+        missing.push(`startingNpcs[${index}].name`);
+      }
+    }
+  }
   return missing.length > 0
     ? `Setup generation incomplete — missing: ${missing.join(", ")}. Try again or repair the JSON manually.`
     : null;
+}
+
+function sendGameSetupApplyError(reply: FastifyReply, rawJson: string, chatId: string): void {
+  sendJsonRepairError(
+    reply,
+    "Game setup JSON could not be applied cleanly. Review the setup JSON or try again.",
+    buildJsonRepairPayload({
+      kind: "game_setup",
+      title: "Repair Game Setup JSON",
+      rawJson,
+      applyEndpoint: "/game/setup/apply-json",
+      applyBody: { chatId },
+    }),
+  );
 }
 
 function parseStoredJson<T>(raw: unknown): T | null {
@@ -3171,18 +3196,20 @@ export async function gameRoutes(app: FastifyInstance) {
         }
       }
 
-      const npcs = (setupData.startingNpcs as Array<Record<string, unknown>>).map((n, i) => {
-        const name = (n.name as string) || `NPC ${i + 1}`;
+      const npcs = Array.from(setupData.startingNpcs as unknown[]).map((value, i) => {
+        const n = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+        const name = typeof n.name === "string" && n.name.trim() ? n.name.trim() : `NPC ${i + 1}`;
+        const description = typeof n.description === "string" ? n.description : "";
         return {
           id: randomUUID(),
           name,
-          emoji: (n.emoji as string) || "🧑",
-          description: (n.description as string) || "",
-          descriptionSource: n.description ? "model" : undefined,
+          emoji: typeof n.emoji === "string" && n.emoji ? n.emoji : "🧑",
+          description,
+          descriptionSource: description ? "model" : undefined,
           gender: typeof n.gender === "string" ? n.gender : null,
           pronouns: typeof n.pronouns === "string" ? n.pronouns : null,
-          location: (n.location as string) || "Unknown",
-          reputation: (n.reputation as number) || 0,
+          location: typeof n.location === "string" && n.location ? n.location : "Unknown",
+          reputation: typeof n.reputation === "number" ? n.reputation : 0,
           notes: [] as string[],
           avatarUrl: charAvatarByName.get(name.toLowerCase()) ?? undefined,
         };
@@ -3829,12 +3856,19 @@ export async function gameRoutes(app: FastifyInstance) {
     }
 
     logger.info("[game/setup] Validation passed, transitioning to ready");
-    const setupResult = await applyGameSetupPayload({
-      chatId,
-      meta,
-      setupData,
-      rpgContext: { partyRpgStats, personaRpgStats, personaName },
-    });
+    let setupResult: Awaited<ReturnType<typeof applyGameSetupPayload>>;
+    try {
+      setupResult = await applyGameSetupPayload({
+        chatId,
+        meta,
+        setupData,
+        rpgContext: { partyRpgStats, personaRpgStats, personaName },
+      });
+    } catch (err) {
+      logger.error(err, "[game/setup] Failed to apply setup payload");
+      sendGameSetupApplyError(reply, responseText, chatId);
+      return;
+    }
     reply.send(setupResult);
   });
 
@@ -3885,12 +3919,19 @@ export async function gameRoutes(app: FastifyInstance) {
       return;
     }
 
-    const setupResult = await applyGameSetupPayload({
-      chatId,
-      meta,
-      setupData,
-      rpgContext: await loadSetupRpgContext(chat, setupConfig),
-    });
+    let setupResult: Awaited<ReturnType<typeof applyGameSetupPayload>>;
+    try {
+      setupResult = await applyGameSetupPayload({
+        chatId,
+        meta,
+        setupData,
+        rpgContext: await loadSetupRpgContext(chat, setupConfig),
+      });
+    } catch (err) {
+      logger.error(err, "[game/setup/apply-json] Failed to apply setup payload");
+      sendGameSetupApplyError(reply, rawJson, chatId);
+      return;
+    }
     reply.send(setupResult);
   });
 

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1976,7 +1976,7 @@ type GameLorebookKeeperBook = {
 
 type GameLorebookKeeperRunResult =
   | { status: "success"; lorebookId: string; entryCount: number }
-  | { status: "failed"; lorebookId: string | null; error: string }
+  | { status: "failed"; lorebookId: string | null; error: string; rawJson?: string }
   | { status: "skipped"; reason: string };
 
 function parseChatCharacterIds(value: unknown): string[] {
@@ -2462,7 +2462,23 @@ async function runGameLorebookKeeperAfterConclusion(args: {
       "Game lorebook keeper",
     );
     const extraction = extractLeadingThinkingBlocks(result.content ?? "", generationParameters?.customThinkingTags);
-    const parsed = parseJSON(extraction.content) as Record<string, unknown>;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = parseJSON(extraction.content) as Record<string, unknown>;
+    } catch (err) {
+      const error = formatGameLorebookKeeperError(err);
+      await chats.patchMetadata(args.chatId, {
+        gameLorebookKeeperLastRun: {
+          sessionNumber: args.sessionNumber,
+          status: "failed",
+          updatedAt: new Date().toISOString(),
+          lorebookId: lorebook.id,
+          error,
+        },
+      });
+      logger.warn(err, "[game/lorebook-keeper] Generated lorebook JSON failed to parse for chat %s", args.chatId);
+      return { status: "failed", lorebookId: lorebook.id, error, rawJson: extraction.content };
+    }
     const entries = normalizeGameLorebookKeeperEntries(parsed);
     const createdCount = await createGameLorebookKeeperEntries({
       lorebooksStore,
@@ -2514,7 +2530,7 @@ function queueGameLorebookKeeperAfterConclusion(
   });
 }
 
-type JsonRepairKind = "game_setup" | "session_conclusion" | "campaign_progression";
+type JsonRepairKind = "game_setup" | "session_conclusion" | "campaign_progression" | "lorebook_keeper";
 
 type JsonRepairPayload = {
   kind: JsonRepairKind;
@@ -4698,7 +4714,7 @@ export async function gameRoutes(app: FastifyInstance) {
   });
 
   // ── POST /game/session/regenerate-lorebook ──
-  app.post("/session/regenerate-lorebook", async (req) => {
+  app.post("/session/regenerate-lorebook", async (req, reply) => {
     const {
       chatId,
       connectionId,
@@ -4731,6 +4747,20 @@ export async function gameRoutes(app: FastifyInstance) {
     });
 
     if (result.status === "failed") {
+      if (result.rawJson) {
+        sendJsonRepairError(
+          reply,
+          result.error || "Game Lorebook Keeper returned invalid JSON.",
+          buildJsonRepairPayload({
+            kind: "lorebook_keeper",
+            title: `Repair Session ${sessionNumber} Lorebook JSON`,
+            rawJson: result.rawJson,
+            applyEndpoint: "/game/session/lorebook-keeper/apply-json",
+            applyBody: { chatId, connectionId, sessionNumber },
+          }),
+        );
+        return;
+      }
       throw new Error(result.error || "Game Lorebook Keeper failed");
     }
     if (result.status === "skipped") {
@@ -4742,6 +4772,72 @@ export async function gameRoutes(app: FastifyInstance) {
       lorebookId: result.lorebookId,
       entryCount: result.entryCount,
     };
+  });
+
+  // ── POST /game/session/lorebook-keeper/apply-json ──
+  app.post("/session/lorebook-keeper/apply-json", async (req, reply) => {
+    const { chatId, rawJson, sessionNumber } = jsonRepairApplySchema.parse(req.body);
+    const chats = createChatsStorage(app.db);
+    const chat = await chats.getById(chatId);
+    if (!chat) throw new Error("Chat not found");
+    if ((chat.mode as string) !== "game") throw new Error("Lorebook Keeper repair is only available in game mode");
+
+    const meta = parseMeta(chat.metadata);
+    if (meta.gameLorebookKeeperEnabled !== true) {
+      throw new Error("Game Lorebook Keeper is not enabled for this game");
+    }
+    if (!sessionNumber) throw new Error("Session number is required for Lorebook Keeper repair");
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = parseJSON(rawJson) as Record<string, unknown>;
+    } catch (err) {
+      logger.warn(err, "[game/lorebook-keeper/apply-json] Repaired lorebook JSON still failed to parse");
+      sendJsonRepairError(
+        reply,
+        "The edited Lorebook Keeper JSON is still invalid.",
+        buildJsonRepairPayload({
+          kind: "lorebook_keeper",
+          title: `Repair Session ${sessionNumber} Lorebook JSON`,
+          rawJson,
+          applyEndpoint: "/game/session/lorebook-keeper/apply-json",
+          applyBody: { chatId, sessionNumber },
+        }),
+      );
+      return;
+    }
+
+    const entries = normalizeGameLorebookKeeperEntries(parsed);
+    const lorebooksStore = createLorebooksStorage(app.db);
+    const lorebook = await resolveGameLorebookKeeperBook({ lorebooksStore, chat, meta });
+    if (!lorebook?.id) throw new Error("Could not resolve target lorebook.");
+
+    const createdCount = await createGameLorebookKeeperEntries({
+      lorebooksStore,
+      lorebookId: lorebook.id,
+      sessionNumber,
+      entries,
+      replaceExistingSessionEntries: true,
+    });
+
+    await chats.patchMetadata(chatId, (current) => {
+      const activeLorebookIds = Array.isArray(current.activeLorebookIds)
+        ? current.activeLorebookIds.filter((id): id is string => typeof id === "string")
+        : [];
+      return {
+        gameLorebookKeeperLorebookId: lorebook.id,
+        activeLorebookIds: Array.from(new Set([...activeLorebookIds, lorebook.id])),
+        gameLorebookKeeperLastRun: {
+          sessionNumber,
+          status: "success",
+          updatedAt: new Date().toISOString(),
+          lorebookId: lorebook.id,
+          entryCount: createdCount,
+        },
+      };
+    });
+
+    return { sessionNumber, lorebookId: lorebook.id, entryCount: createdCount };
   });
 
   // ── POST /game/session/regenerate-conclusion ──

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -97,9 +97,10 @@ import {
   scoreMusic,
   scoreAmbient,
   serializeResolvedSkillCheckTag,
+  applyTrackerFieldLocksToGameStatePatch,
   parseTrackerFieldLocks,
 } from "@marinara-engine/shared";
-import { mergeCustomParameters } from "./generate/generate-route-utils.js";
+import { mergeCustomParameters, parseGameStateRow } from "./generate/generate-route-utils.js";
 import {
   fitMessagesToModelAccessContext,
   mergeModelContextLimit,
@@ -1408,6 +1409,20 @@ function parseJsonField<T>(raw: unknown, fallback: T): T {
   } catch {
     return fallback;
   }
+}
+
+async function updateLatestGameStateWithTrackerLocks(
+  gameStateStore: ReturnType<typeof createGameStateStorage>,
+  chatId: string,
+  patch: Record<string, unknown>,
+) {
+  const latest = await gameStateStore.getLatest(chatId);
+  if (!latest) return null;
+  const lockedPatch = applyTrackerFieldLocksToGameStatePatch(
+    patch,
+    parseGameStateRow(latest as Record<string, unknown>),
+  );
+  return gameStateStore.updateLatest(chatId, lockedPatch as any);
 }
 
 function normalizeGameInventoryItems(raw: unknown): ChatInventoryItem[] {
@@ -6237,7 +6252,7 @@ export async function gameRoutes(app: FastifyInstance) {
 
     // Also update the game state snapshot so WeatherEffects picks it up
     const gameStateStore = createGameStateStorage(app.db);
-    await gameStateStore.updateLatest(chatId, {
+    await updateLatestGameStateWithTrackerLocks(gameStateStore, chatId, {
       time: formatGameTime(newTime),
     });
 
@@ -6270,7 +6285,7 @@ export async function gameRoutes(app: FastifyInstance) {
 
       await chats.updateMetadata(chatId, { ...meta, gameWeather: weather });
       const gameStateStore = createGameStateStorage(app.db);
-      await gameStateStore.updateLatest(chatId, {
+      await updateLatestGameStateWithTrackerLocks(gameStateStore, chatId, {
         weather: weather.type,
         temperature: `${weather.temperature}°C`,
       });
@@ -6288,7 +6303,7 @@ export async function gameRoutes(app: FastifyInstance) {
 
     // Also update the game state snapshot so WeatherEffects picks it up
     const gameStateStore = createGameStateStorage(app.db);
-    await gameStateStore.updateLatest(chatId, {
+    await updateLatestGameStateWithTrackerLocks(gameStateStore, chatId, {
       weather: weather.type,
       temperature: `${weather.temperature}°C`,
     });

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -16,7 +16,7 @@ import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { extractLeadingThinkingBlocks } from "../services/llm/inline-thinking.js";
-import { type ChatMessage, type ChatOptions } from "../services/llm/base-provider.js";
+import { type ChatCompletionResult, type ChatMessage, type ChatOptions } from "../services/llm/base-provider.js";
 import { isDiceNotation, rollDice } from "../services/game/dice.service.js";
 import { parseGameJsonish } from "../services/game/jsonish.js";
 import { validateTransition } from "../services/game/state-machine.service.js";
@@ -1666,6 +1666,47 @@ const SESSION_SUMMARY_CHARS_PER_TOKEN = 4;
 const SESSION_SUMMARY_MIN_TRANSCRIPT_CHARS = 256;
 const SESSION_CONCLUSION_MIN_OUTPUT_TOKENS = 8192;
 const CAMPAIGN_PROGRESSION_MIN_OUTPUT_TOKENS = SESSION_CONCLUSION_MIN_OUTPUT_TOKENS;
+const GAME_GENERATION_TIMEOUT_MS = 4 * 60 * 1000;
+
+class GameGenerationTimeoutError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`${label} timed out after ${Math.round(timeoutMs / 1000)} seconds`);
+    this.name = "GameGenerationTimeoutError";
+  }
+}
+
+async function runGameChatComplete(
+  provider: { chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> },
+  messages: ChatMessage[],
+  options: ChatOptions,
+  label: string,
+  timeoutMs = GAME_GENERATION_TIMEOUT_MS,
+): Promise<ChatCompletionResult> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const parentSignal = options.signal;
+  const abortFromParent = () => controller.abort(parentSignal?.reason);
+  if (parentSignal?.aborted) {
+    abortFromParent();
+  } else {
+    parentSignal?.addEventListener("abort", abortFromParent, { once: true });
+  }
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new GameGenerationTimeoutError(label, timeoutMs));
+  }, timeoutMs);
+
+  try {
+    return await provider.chatComplete(messages, { ...options, signal: controller.signal });
+  } catch (err) {
+    if (timedOut) throw new GameGenerationTimeoutError(label, timeoutMs);
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+    parentSignal?.removeEventListener("abort", abortFromParent);
+  }
+}
 const GAME_LOREBOOK_KEEPER_MIN_OUTPUT_TOKENS = 16_384;
 const GAME_LOREBOOK_KEEPER_MAX_ENTRIES = 32;
 const SESSION_SUMMARY_TRUNCATION_MARKER = "\n\n[Middle of session transcript truncated to fit context window]\n\n";
@@ -2348,7 +2389,12 @@ async function runGameLorebookKeeperAfterConclusion(args: {
       maxTokens: options.maxTokens,
     });
 
-    const result = await provider.chatComplete(fitted.trimmed ? fitted.messages : keeperMessages, options);
+    const result = await runGameChatComplete(
+      provider,
+      fitted.trimmed ? fitted.messages : keeperMessages,
+      options,
+      "Game lorebook keeper",
+    );
     const extraction = extractLeadingThinkingBlocks(result.content ?? "", generationParameters?.customThinkingTags);
     const parsed = parseJSON(extraction.content) as Record<string, unknown>;
     const entries = normalizeGameLorebookKeeperEntries(parsed);
@@ -3631,7 +3677,7 @@ export async function gameRoutes(app: FastifyInstance) {
       );
     }
 
-    const result = await provider.chatComplete(messages, setupOptions);
+    const result = await runGameChatComplete(provider, messages, setupOptions, "Game setup");
     const setupExtraction = extractLeadingThinkingBlocks(
       result.content ?? "",
       setupGenerationParameters?.customThinkingTags,
@@ -3993,7 +4039,8 @@ export async function gameRoutes(app: FastifyInstance) {
             { role: "user", content: "Generate the session recap." },
           ];
 
-          const result = await provider.chatComplete(
+          const result = await runGameChatComplete(
+            provider,
             recapMessages,
             gameGenOptions(
               conn.model,
@@ -4003,6 +4050,7 @@ export async function gameRoutes(app: FastifyInstance) {
               null,
               conn.provider,
             ),
+            "Game session recap",
           );
           const recapExtraction = extractLeadingThinkingBlocks(result.content ?? "");
           recapText = recapExtraction.content;
@@ -4186,7 +4234,12 @@ export async function gameRoutes(app: FastifyInstance) {
       );
     }
 
-    const result = await provider.chatComplete(conclusionMessages, conclusionOptions);
+    const result = await runGameChatComplete(
+      provider,
+      conclusionMessages,
+      conclusionOptions,
+      "Game session conclusion",
+    );
     logger.info("[game/session/conclude] Conclusion generation completed for chat %s", chatId);
     const conclusionExtraction = extractLeadingThinkingBlocks(
       result.content ?? "",
@@ -4566,7 +4619,12 @@ export async function gameRoutes(app: FastifyInstance) {
       );
     }
 
-    const result = await provider.chatComplete(conclusionMessages, conclusionOptions);
+    const result = await runGameChatComplete(
+      provider,
+      conclusionMessages,
+      conclusionOptions,
+      "Game session conclusion regeneration",
+    );
     const conclusionExtraction = extractLeadingThinkingBlocks(
       result.content ?? "",
       conclusionGenerationParameters?.customThinkingTags,
@@ -4837,7 +4895,12 @@ export async function gameRoutes(app: FastifyInstance) {
       );
     }
 
-    const result = await provider.chatComplete(fit.trimmed ? fit.messages : progressionMessages, progressionOptions);
+    const result = await runGameChatComplete(
+      provider,
+      fit.trimmed ? fit.messages : progressionMessages,
+      progressionOptions,
+      "Game campaign progression update",
+    );
     const rawProgressionContent = result.content ?? "";
     const extraction = extractLeadingThinkingBlocks(
       rawProgressionContent,
@@ -5150,12 +5213,14 @@ export async function gameRoutes(app: FastifyInstance) {
           language: setupConfig.language ?? null,
         });
 
-        const result = await provider.chatComplete(
+        const result = await runGameChatComplete(
+          provider,
           [
             { role: "system", content: prompt },
             { role: "user", content: `Create the recruited companion card for ${recruitName} now.` },
           ],
           gameGenOptions(conn.model, { temperature: 0.6, maxTokens: 1200 }, generationParameters, conn.provider),
+          "Game party recruit card",
         );
         const recruitExtraction = extractLeadingThinkingBlocks(
           result.content ?? "",
@@ -5510,7 +5575,8 @@ export async function gameRoutes(app: FastifyInstance) {
       { role: "user", content: "Generate the map." },
     ];
 
-    const result = await provider.chatComplete(
+    const result = await runGameChatComplete(
+      provider,
       messages,
       gameGenOptions(
         conn.model,
@@ -5520,6 +5586,7 @@ export async function gameRoutes(app: FastifyInstance) {
         null,
         conn.provider,
       ),
+      "Game map generation",
     );
     const mapExtraction = extractLeadingThinkingBlocks(result.content ?? "");
     const mapContent = mapExtraction.content;
@@ -6264,7 +6331,8 @@ export async function gameRoutes(app: FastifyInstance) {
       conn.openrouterProvider,
       conn.maxTokensOverride,
     );
-    const result = await provider.chatComplete(
+    const result = await runGameChatComplete(
+      provider,
       messages,
       gameGenOptions(
         conn.model ?? "",
@@ -6274,6 +6342,7 @@ export async function gameRoutes(app: FastifyInstance) {
         gameGenerationParameters,
         conn.provider,
       ),
+      "Game party turn",
     );
     const partyTurnExtraction = extractLeadingThinkingBlocks(
       result.content || "",
@@ -6590,7 +6659,7 @@ export async function gameRoutes(app: FastifyInstance) {
       gameGenerationParameters,
       conn.provider,
     );
-    const result = await provider.chatComplete(messages, sceneWrapOptions);
+    const result = await runGameChatComplete(provider, messages, sceneWrapOptions, "Game scene wrap");
 
     let sceneWrapExtraction = extractLeadingThinkingBlocks(
       result.content || "",

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -4008,6 +4008,17 @@ export async function gameRoutes(app: FastifyInstance) {
     string,
     Promise<{ sessionChat: StoredChatRecord; sessionNumber: number; recap: string }>
   >();
+  const pendingSessionConclusions = new Map<string, Promise<unknown>>();
+
+  const findSessionSummaryForNumber = (summaries: SessionSummary[], sessionNumber: number): SessionSummary | null =>
+    summaries.find((summary) => summary.sessionNumber === sessionNumber) ?? null;
+
+  const getAlreadyConcludedSummary = (meta: Record<string, unknown>): SessionSummary | null => {
+    if (meta.gameSessionStatus !== "concluded") return null;
+    const summaries = normalizeStoredSessionSummaries(meta.gamePreviousSessionSummaries);
+    const sessionNumber = typeof meta.gameSessionNumber === "number" ? meta.gameSessionNumber : summaries.length;
+    return findSessionSummaryForNumber(summaries, sessionNumber) ?? summaries.at(-1) ?? null;
+  };
 
   // ── POST /game/session/start ──
   app.post("/session/start", async (req) => {
@@ -4285,6 +4296,10 @@ export async function gameRoutes(app: FastifyInstance) {
   // ── POST /game/session/conclude ──
   app.post("/session/conclude", async (req, reply) => {
     const { chatId, connectionId, streaming, nextSessionRequest } = concludeSessionSchema.parse(req.body);
+    const existingConclusion = pendingSessionConclusions.get(chatId);
+    if (existingConclusion) return existingConclusion;
+
+    const conclusionRequest = (async () => {
     const trimmedNextSessionRequest = nextSessionRequest.trim();
     logger.info("[game/session/conclude] Starting manual conclude for chat %s", chatId);
     const chats = createChatsStorage(app.db);
@@ -4294,6 +4309,11 @@ export async function gameRoutes(app: FastifyInstance) {
     if (!chat) throw new Error("Chat not found");
 
     const meta = parseMeta(chat.metadata);
+    const alreadyConcludedSummary = getAlreadyConcludedSummary(meta);
+    if (alreadyConcludedSummary) {
+      logger.info("[game/session/conclude] Session already concluded for chat %s", chatId);
+      return { summary: alreadyConcludedSummary, alreadyConcluded: true };
+    }
     const setupConfig = meta.gameSetupConfig as GameSetupConfig | null;
     const chatCharacterIds = parseChatCharacterIds(chat.characterIds);
     const syncedPartyIds = setupConfig
@@ -4426,21 +4446,34 @@ export async function gameRoutes(app: FastifyInstance) {
       return;
     }
 
-    await chats.patchMetadata(chatId, (freshMeta) => ({
-      ...(syncedSetupConfig ? { gameSetupConfig: syncedSetupConfig } : {}),
-      gamePartyCharacterIds: syncedPartyIds,
-      gameSessionNumber: sessionNumber,
-      gameSessionStatus: "concluded",
-      gameStoryArc: appliedConclusion.updatedStoryArc,
-      gamePlotTwists: appliedConclusion.updatedPlotTwists,
-      gamePartyArcs: appliedConclusion.updatedPartyArcs,
-      gamePreviousSessionSummaries: [
-        ...normalizeStoredSessionSummaries(freshMeta.gamePreviousSessionSummaries),
-        appliedConclusion.summary,
-      ],
-      gameCharacterCards: appliedConclusion.updatedCards,
-      ...buildMoraleMetadataUpdates(freshMeta, appliedConclusion.updatedMorale),
-    }));
+    let conclusionWasStored = false;
+    let storedConclusionSummary = appliedConclusion.summary;
+    await chats.patchMetadata(chatId, (freshMeta) => {
+      const freshSummaries = normalizeStoredSessionSummaries(freshMeta.gamePreviousSessionSummaries);
+      const existingSummary = findSessionSummaryForNumber(freshSummaries, sessionNumber);
+      if (existingSummary) {
+        storedConclusionSummary = existingSummary;
+        return {};
+      }
+
+      conclusionWasStored = true;
+      return {
+        ...(syncedSetupConfig ? { gameSetupConfig: syncedSetupConfig } : {}),
+        gamePartyCharacterIds: syncedPartyIds,
+        gameSessionNumber: sessionNumber,
+        gameSessionStatus: "concluded",
+        gameStoryArc: appliedConclusion.updatedStoryArc,
+        gamePlotTwists: appliedConclusion.updatedPlotTwists,
+        gamePartyArcs: appliedConclusion.updatedPartyArcs,
+        gamePreviousSessionSummaries: [...freshSummaries, appliedConclusion.summary],
+        gameCharacterCards: appliedConclusion.updatedCards,
+        ...buildMoraleMetadataUpdates(freshMeta, appliedConclusion.updatedMorale),
+      };
+    });
+    if (!conclusionWasStored) {
+      logger.info("[game/session/conclude] Session %d was already concluded for chat %s", sessionNumber, chatId);
+      return { summary: storedConclusionSummary, alreadyConcluded: true };
+    }
 
     const sessionSummaryMsg = await chats.createMessage({
       chatId,
@@ -4501,17 +4534,36 @@ export async function gameRoutes(app: FastifyInstance) {
 
     logger.info("[game/session/conclude] Session %d concluded for chat %s", sessionNumber, chatId);
     return { summary: appliedConclusion.summary };
+    })();
+
+    pendingSessionConclusions.set(chatId, conclusionRequest);
+    try {
+      return await conclusionRequest;
+    } finally {
+      if (pendingSessionConclusions.get(chatId) === conclusionRequest) {
+        pendingSessionConclusions.delete(chatId);
+      }
+    }
   });
 
   // ── POST /game/session/conclude/apply-json ──
   app.post("/session/conclude/apply-json", async (req, reply) => {
     const { chatId, rawJson, connectionId, nextSessionRequest } = jsonRepairApplySchema.parse(req.body);
+    const existingConclusion = pendingSessionConclusions.get(chatId);
+    if (existingConclusion) return existingConclusion;
+
+    const conclusionRequest = (async () => {
     const trimmedNextSessionRequest = nextSessionRequest.trim();
     const chats = createChatsStorage(app.db);
     const chat = await chats.getById(chatId);
     if (!chat) throw new Error("Chat not found");
 
     const meta = parseMeta(chat.metadata);
+    const alreadyConcludedSummary = getAlreadyConcludedSummary(meta);
+    if (alreadyConcludedSummary) {
+      logger.info("[game/session/conclude/apply-json] Session already concluded for chat %s", chatId);
+      return { summary: alreadyConcludedSummary, alreadyConcluded: true };
+    }
     const setupConfig = meta.gameSetupConfig as GameSetupConfig | null;
     const chatCharacterIds = parseChatCharacterIds(chat.characterIds);
     const syncedPartyIds = setupConfig
@@ -4554,21 +4606,34 @@ export async function gameRoutes(app: FastifyInstance) {
       return;
     }
 
-    await chats.patchMetadata(chatId, (freshMeta) => ({
-      ...(syncedSetupConfig ? { gameSetupConfig: syncedSetupConfig } : {}),
-      gamePartyCharacterIds: syncedPartyIds,
-      gameSessionNumber: sessionNumber,
-      gameSessionStatus: "concluded",
-      gameStoryArc: appliedConclusion.updatedStoryArc,
-      gamePlotTwists: appliedConclusion.updatedPlotTwists,
-      gamePartyArcs: appliedConclusion.updatedPartyArcs,
-      gamePreviousSessionSummaries: [
-        ...normalizeStoredSessionSummaries(freshMeta.gamePreviousSessionSummaries),
-        appliedConclusion.summary,
-      ],
-      gameCharacterCards: appliedConclusion.updatedCards,
-      ...buildMoraleMetadataUpdates(freshMeta, appliedConclusion.updatedMorale),
-    }));
+    let conclusionWasStored = false;
+    let storedConclusionSummary = appliedConclusion.summary;
+    await chats.patchMetadata(chatId, (freshMeta) => {
+      const freshSummaries = normalizeStoredSessionSummaries(freshMeta.gamePreviousSessionSummaries);
+      const existingSummary = findSessionSummaryForNumber(freshSummaries, sessionNumber);
+      if (existingSummary) {
+        storedConclusionSummary = existingSummary;
+        return {};
+      }
+
+      conclusionWasStored = true;
+      return {
+        ...(syncedSetupConfig ? { gameSetupConfig: syncedSetupConfig } : {}),
+        gamePartyCharacterIds: syncedPartyIds,
+        gameSessionNumber: sessionNumber,
+        gameSessionStatus: "concluded",
+        gameStoryArc: appliedConclusion.updatedStoryArc,
+        gamePlotTwists: appliedConclusion.updatedPlotTwists,
+        gamePartyArcs: appliedConclusion.updatedPartyArcs,
+        gamePreviousSessionSummaries: [...freshSummaries, appliedConclusion.summary],
+        gameCharacterCards: appliedConclusion.updatedCards,
+        ...buildMoraleMetadataUpdates(freshMeta, appliedConclusion.updatedMorale),
+      };
+    });
+    if (!conclusionWasStored) {
+      logger.info("[game/session/conclude/apply-json] Session %d was already concluded for chat %s", sessionNumber, chatId);
+      return { summary: storedConclusionSummary, alreadyConcluded: true };
+    }
 
     const summaryContent = `**Session ${sessionNumber} Concluded**\n\n${appliedConclusion.summary.summary}\n\n*Party Dynamics:* ${appliedConclusion.summary.partyDynamics}`;
     await chats.createMessage({
@@ -4620,6 +4685,16 @@ export async function gameRoutes(app: FastifyInstance) {
     });
 
     return { summary: appliedConclusion.summary };
+    })();
+
+    pendingSessionConclusions.set(chatId, conclusionRequest);
+    try {
+      return await conclusionRequest;
+    } finally {
+      if (pendingSessionConclusions.get(chatId) === conclusionRequest) {
+        pendingSessionConclusions.delete(chatId);
+      }
+    }
   });
 
   // ── POST /game/session/regenerate-lorebook ──

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1667,6 +1667,8 @@ const SESSION_SUMMARY_MIN_TRANSCRIPT_CHARS = 256;
 const SESSION_CONCLUSION_MIN_OUTPUT_TOKENS = 8192;
 const CAMPAIGN_PROGRESSION_MIN_OUTPUT_TOKENS = SESSION_CONCLUSION_MIN_OUTPUT_TOKENS;
 const GAME_GENERATION_TIMEOUT_MS = 4 * 60 * 1000;
+const GAME_ASSET_GENERATION_TIMEOUT_MS = 220 * 1000;
+const GAME_ASSET_PORTRAIT_CONCURRENCY = 2;
 
 class GameGenerationTimeoutError extends Error {
   constructor(label: string, timeoutMs: number) {
@@ -1706,6 +1708,36 @@ async function runGameChatComplete(
     clearTimeout(timeout);
     parentSignal?.removeEventListener("abort", abortFromParent);
   }
+}
+
+function createResponseAbortSignal(reply: FastifyReply, timeoutMs: number, label: string): AbortSignal {
+  const controller = new AbortController();
+  let finished = false;
+  const abort = (reason: Error) => {
+    if (!controller.signal.aborted) controller.abort(reason);
+  };
+  const timeout = setTimeout(() => {
+    abort(new Error(`${label} timed out after ${Math.round(timeoutMs / 1000)} seconds`));
+  }, timeoutMs);
+  timeout.unref?.();
+
+  const cleanup = () => {
+    clearTimeout(timeout);
+    reply.raw.off("finish", onFinish);
+    reply.raw.off("close", onClose);
+  };
+  const onFinish = () => {
+    finished = true;
+    cleanup();
+  };
+  const onClose = () => {
+    if (!finished) abort(new Error(`${label} cancelled because the client disconnected`));
+    cleanup();
+  };
+
+  reply.raw.once("finish", onFinish);
+  reply.raw.once("close", onClose);
+  return controller.signal;
 }
 const GAME_LOREBOOK_KEEPER_MIN_OUTPUT_TOKENS = 16_384;
 const GAME_LOREBOOK_KEEPER_MAX_ENTRIES = 32;
@@ -7418,8 +7450,13 @@ export async function gameRoutes(app: FastifyInstance) {
     return { items };
   });
 
-  app.post("/generate-assets", async (req) => {
+  app.post("/generate-assets", async (req, reply) => {
     const input = generateAssetsSchema.parse(req.body);
+    const assetAbortSignal = createResponseAbortSignal(
+      reply,
+      GAME_ASSET_GENERATION_TIMEOUT_MS,
+      "Game asset generation",
+    );
     const requestDebug = input.debugMode === true;
     const debugOverrideEnabled = requestDebug || isDebugAgentsEnabled();
     const debugLogsEnabled = debugOverrideEnabled || logger.isLevelEnabled("debug");
@@ -7528,7 +7565,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const generatedNpcAvatars: Array<{ name: string; avatarUrl: string }> = [];
 
     // ── Generate background ──
-    if (input.backgroundTag) {
+    if (!assetAbortSignal.aborted && input.backgroundTag) {
       const slug = generatedBackgroundSlug(input.backgroundTag);
       const promptOverride = promptOverrideById.get(gameImagePromptReviewId("background", slug));
 
@@ -7558,6 +7595,7 @@ export async function gameRoutes(app: FastifyInstance) {
         size: backgroundSize,
         promptOverride: promptOverride?.prompt,
         negativePromptOverride: promptOverride?.negativePrompt,
+        signal: assetAbortSignal,
       });
       if (tag) {
         generatedBackground = tag;
@@ -7579,7 +7617,7 @@ export async function gameRoutes(app: FastifyInstance) {
     }
 
     // ── Generate rare VN illustration ──
-    if (input.illustration) {
+    if (!assetAbortSignal.aborted && input.illustration) {
       const allMsgs = await chats.listMessages(input.chatId);
       const approxTurnNumber = Math.max(1, allMsgs.filter((message) => message.role === "user").length + 1);
       const sessionNumber = currentGameSessionNumber(meta);
@@ -7652,6 +7690,7 @@ export async function gameRoutes(app: FastifyInstance) {
           size: backgroundSize,
           promptOverride: promptOverride?.prompt,
           negativePromptOverride: promptOverride?.negativePrompt,
+          signal: assetAbortSignal,
         });
 
         if (tag) {
@@ -7681,7 +7720,7 @@ export async function gameRoutes(app: FastifyInstance) {
     }
 
     // ── Generate NPC avatars ──
-    if (input.npcsNeedingAvatars?.length) {
+    if (!assetAbortSignal.aborted && input.npcsNeedingAvatars?.length) {
       const forceNpcAvatarNames = new Set(
         (input.forceNpcAvatarNames ?? []).map((name) => normalizeJournalMatch(name)).filter(Boolean),
       );
@@ -7719,54 +7758,63 @@ export async function gameRoutes(app: FastifyInstance) {
         }
       }
 
-      for (const npc of input.npcsNeedingAvatars) {
-        const normalizedNpcName = normalizeJournalMatch(npc.name);
-        const forceNpcAvatar = forceNpcAvatarNames.has(normalizedNpcName);
-        const existingAvatarUrl = existingNpcAvatarByName.get(normalizeJournalMatch(npc.name));
-        if (!forceNpcAvatar && existingAvatarUrl) {
-          logger.info('[game/generate-assets] NPC avatar exists, skipping generation: "%s"', npc.name);
-          generatedNpcAvatars.push({ name: npc.name, avatarUrl: existingAvatarUrl });
-          continue;
-        }
+      let nextNpcIndex = 0;
+      const runPortraitWorker = async () => {
+        while (!assetAbortSignal.aborted) {
+          const npc = input.npcsNeedingAvatars?.[nextNpcIndex++];
+          if (!npc) return;
 
-        const libAvatar = findCharAvatarFuzzy(npc.name, charAvatarByName);
-        if (!forceNpcAvatar && libAvatar) {
-          generatedNpcAvatars.push({ name: npc.name, avatarUrl: libAvatar });
-          continue;
-        }
-        const metadataNpc = findNpcRecordByName(currentNpcs, npc.name);
-        const presentCharacter = findRecordByName(presentCharacters, npc.name);
-        const avatarUrl = await generateNpcPortrait({
-          chatId: input.chatId,
-          npcName: npc.name,
-          appearance: npc.description,
-          gender: npc.gender ?? metadataNpc?.gender ?? optionalTrimmedString(presentCharacter?.gender),
-          pronouns: npc.pronouns ?? metadataNpc?.pronouns ?? optionalTrimmedString(presentCharacter?.pronouns),
-          artStyle,
-          imgSource,
-          imgModel,
-          imgBaseUrl,
-          imgApiKey,
-          imgService: imgServiceHint,
-          imgEndpointId,
-          imgComfyWorkflow,
-          imgDefaults,
-          styleProfiles,
-          styleProfileId,
-          debugLog: debugLogsEnabled ? debugLog : undefined,
-          promptOverridesStorage: createPromptOverridesStorage(app.db),
-          size: portraitSize,
-          promptOverride: promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name))?.prompt,
-          negativePromptOverride: promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name))?.negativePrompt,
-          force: forceNpcAvatar,
-        });
-        if (avatarUrl) {
-          generatedNpcAvatars.push({
-            name: npc.name,
-            avatarUrl: `${avatarUrl.split("?")[0]}?v=${Date.now()}`,
+          const normalizedNpcName = normalizeJournalMatch(npc.name);
+          const forceNpcAvatar = forceNpcAvatarNames.has(normalizedNpcName);
+          const existingAvatarUrl = existingNpcAvatarByName.get(normalizeJournalMatch(npc.name));
+          if (!forceNpcAvatar && existingAvatarUrl) {
+            logger.info('[game/generate-assets] NPC avatar exists, skipping generation: "%s"', npc.name);
+            generatedNpcAvatars.push({ name: npc.name, avatarUrl: existingAvatarUrl });
+            continue;
+          }
+
+          const libAvatar = findCharAvatarFuzzy(npc.name, charAvatarByName);
+          if (!forceNpcAvatar && libAvatar) {
+            generatedNpcAvatars.push({ name: npc.name, avatarUrl: libAvatar });
+            continue;
+          }
+          const metadataNpc = findNpcRecordByName(currentNpcs, npc.name);
+          const presentCharacter = findRecordByName(presentCharacters, npc.name);
+          const avatarUrl = await generateNpcPortrait({
+            chatId: input.chatId,
+            npcName: npc.name,
+            appearance: npc.description,
+            gender: npc.gender ?? metadataNpc?.gender ?? optionalTrimmedString(presentCharacter?.gender),
+            pronouns: npc.pronouns ?? metadataNpc?.pronouns ?? optionalTrimmedString(presentCharacter?.pronouns),
+            artStyle,
+            imgSource,
+            imgModel,
+            imgBaseUrl,
+            imgApiKey,
+            imgService: imgServiceHint,
+            imgEndpointId,
+            imgComfyWorkflow,
+            imgDefaults,
+            styleProfiles,
+            styleProfileId,
+            debugLog: debugLogsEnabled ? debugLog : undefined,
+            promptOverridesStorage: createPromptOverridesStorage(app.db),
+            size: portraitSize,
+            promptOverride: promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name))?.prompt,
+            negativePromptOverride: promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name))?.negativePrompt,
+            force: forceNpcAvatar,
+            signal: assetAbortSignal,
           });
+          if (avatarUrl) {
+            generatedNpcAvatars.push({
+              name: npc.name,
+              avatarUrl: `${avatarUrl.split("?")[0]}?v=${Date.now()}`,
+            });
+          }
         }
-      }
+      };
+      const portraitWorkerCount = Math.min(GAME_ASSET_PORTRAIT_CONCURRENCY, input.npcsNeedingAvatars.length);
+      await Promise.all(Array.from({ length: portraitWorkerCount }, () => runPortraitWorker()));
 
       // Persist avatar URLs to NPC list in metadata
       if (generatedNpcAvatars.length > 0) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3585,6 +3585,7 @@ export async function generateRoutes(app: FastifyInstance) {
           agentPromptTemplateSelections,
           chatProvider: provider,
           chatModel: conn.model,
+          chatCustomParameters: connectionParams?.customParameters ?? {},
           chatMaxParallelJobs: chatConnectionMaxParallelJobs,
           activeMusicPlayerSource,
           chatMetadata: chatMeta,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3503,12 +3503,15 @@ export async function generateRoutes(app: FastifyInstance) {
           verbosity = "high";
         }
 
-        // Game mode: force optimal generation defaults (ignore preset/chat overrides)
-        // unless the user is running a local Gemma model where these don't apply.
         const isLocalGemma = (conn.model ?? "").toLowerCase().includes("gemma");
+        applyParameterOverrides(connectionParams);
+        applyParameterOverrides(chatParams);
+
+        // Game mode: force optimal generation defaults after Advanced Parameters
+        // so leftover chat/connection overrides cannot sabotage structured GM output.
         if (chatMode === "game" && !isLocalGemma) {
           temperature = 1;
-          maxTokens = 16384;
+          maxTokens = 16_384;
           topP = 1;
           topK = 0;
           minP = 0;
@@ -3517,14 +3520,11 @@ export async function generateRoutes(app: FastifyInstance) {
           reasoningEffort = "maximum";
           verbosity = null;
         } else if (chatMode === "game") {
-          // Local Gemma: just ensure generous output
+          // Local Gemma: just ensure generous output unless the chat set its own budget.
           if (typeof chatParams?.maxTokens !== "number") {
-            maxTokens = Math.max(maxTokens, 16384);
+            maxTokens = Math.max(maxTokens, 16_384);
           }
         }
-
-        applyParameterOverrides(connectionParams);
-        applyParameterOverrides(chatParams);
 
         if (chatMode === "game") {
           maxTokens = clampGenerationMaxOutputTokens({

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -86,7 +86,6 @@ import {
   assemblePrompt,
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
-  collectCharacterPostHistoryEntries,
   resolveCharacterMacroData,
   resolveMacrosWithVariableSnapshot,
   resolvePromptMessageMacros,
@@ -3353,15 +3352,6 @@ export async function generateRoutes(app: FastifyInstance) {
           if (characterDepthEntries.length > 0) {
             finalMessages = injectAtDepth(finalMessages, characterDepthEntries);
           }
-          const characterPostHistoryEntries = await collectCharacterPostHistoryEntries(
-            app.db,
-            promptCharacterIds,
-            promptMacroContext,
-            wrapFormat,
-          );
-          if (characterPostHistoryEntries.length > 0) {
-            finalMessages = injectAtDepth(finalMessages, characterPostHistoryEntries);
-          }
         }
 
         // ── Author's Notes injection ──
@@ -4718,12 +4708,12 @@ export async function generateRoutes(app: FastifyInstance) {
                 {};
               // Skip:
               //   - Disabled entries (off-limits, by global flag or per-chat override).
-              //   - Constant entries, which are already injected by the standard lorebook path.
+              //   - Chat-active constant entries, which are already injected by the standard lorebook path.
               //   - Exhausted ephemeral entries (countdown reached 0 in this chat).
               //   - Entries excluded by character/tag/generation-trigger filters.
               knowledgeRouterEntries = entries
                 .filter((e: LorebookEntry) => {
-                  if (e.constant === true) return false;
+                  if (source === "chat_active" && e.constant === true) return false;
                   const ov = entryStateOverrides[e.id];
                   const isEnabled = ov?.enabled ?? e.enabled !== false;
                   if (!isEnabled) return false;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -30,6 +30,8 @@ import {
   unwrapConversationInstructions,
   wrapConversationInstructions,
   NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
+  findKnownModel,
+  type APIProvider,
 } from "@marinara-engine/shared";
 import type {
   AgentContext,
@@ -3575,6 +3577,11 @@ export async function generateRoutes(app: FastifyInstance) {
         );
 
         const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
+        const chatConnectionKnownModel = findKnownModel(conn.provider as APIProvider, conn.model.trim());
+        const chatConnectionMaxOutputTokens =
+          chatConnectionKnownModel?.maxOutput && chatConnectionKnownModel.maxOutput > 0
+            ? Math.floor(chatConnectionKnownModel.maxOutput)
+            : null;
         const { enabledConfigs, resolvedAgents, agentConnectionWarnings } = await resolveAgentPipelineAgents({
           connections,
           configuredAgents: configuredPromptAgents,
@@ -3586,6 +3593,7 @@ export async function generateRoutes(app: FastifyInstance) {
           chatProvider: provider,
           chatModel: conn.model,
           chatCustomParameters: connectionParams?.customParameters ?? {},
+          chatMaxOutputTokens: chatConnectionMaxOutputTokens,
           chatMaxParallelJobs: chatConnectionMaxParallelJobs,
           activeMusicPlayerSource,
           chatMetadata: chatMeta,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -788,6 +788,30 @@ async function isConversationYoutubeCommandAvailable(storage: {
   return typeof settings.youtubeApiKey === "string" && settings.youtubeApiKey.trim().length > 0;
 }
 
+function resolveKnownMaxOutputTokens(provider: APIProvider | string | null | undefined, model: string): number | null {
+  const knownModel = provider ? findKnownModel(provider as APIProvider, model.trim()) : undefined;
+  return knownModel?.maxOutput && knownModel.maxOutput > 0 ? Math.floor(knownModel.maxOutput) : null;
+}
+
+function clampGenerationMaxOutputTokens(args: {
+  provider: APIProvider | string | null | undefined;
+  model: string;
+  maxTokens: number;
+  maxTokensOverride?: number | null;
+}): number {
+  let capped = Math.max(1, Math.floor(args.maxTokens));
+  const knownMaxOutput = resolveKnownMaxOutputTokens(args.provider, args.model);
+  if (knownMaxOutput !== null) capped = Math.min(capped, knownMaxOutput);
+  if (
+    typeof args.maxTokensOverride === "number" &&
+    Number.isFinite(args.maxTokensOverride) &&
+    args.maxTokensOverride > 0
+  ) {
+    capped = Math.min(capped, Math.floor(args.maxTokensOverride));
+  }
+  return capped;
+}
+
 /** Fisher-Yates shuffle (in place); used for random emoji selection. */
 function shuffleInPlace<T>(items: T[]): T[] {
   for (let i = items.length - 1; i > 0; i--) {
@@ -3500,6 +3524,15 @@ export async function generateRoutes(app: FastifyInstance) {
 
         applyParameterOverrides(connectionParams);
         applyParameterOverrides(chatParams);
+
+        if (chatMode === "game") {
+          maxTokens = clampGenerationMaxOutputTokens({
+            provider: conn.provider,
+            model: conn.model,
+            maxTokens: Math.max(maxTokens, 16_384),
+            maxTokensOverride: conn.maxTokensOverride,
+          });
+        }
 
         const modelLower = (conn.model ?? "").toLowerCase();
         const providerLower = (conn.provider ?? "").toLowerCase();

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7842,7 +7842,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 // them with authoritative data in their own handler blocks below.
                 const snapshotChars = parseJsonField<any[]>(prevSnap?.presentCharacters, []);
                 const snapshotPersonaStats = parseJsonField<any[] | null>(prevSnap?.personaStats, null);
-                const snapshotPlayerStats = parseJsonField<Record<string, unknown> | null>(prevSnap?.playerStats, null);
+                const snapshotPlayerStats = parseJsonField<PlayerStats | null>(prevSnap?.playerStats, null);
                 const currentGameStateForLocks = prevSnap
                   ? parseGameStateRow(prevSnap as Record<string, unknown>)
                   : null;
@@ -8222,7 +8222,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 const hasStatus = typeof psData.status === "string";
                 const hasInventory = Array.isArray(psData.inventory);
                 const bars = hasStats ? (psData.stats as any[]) : [];
-                const status = hasStatus ? psData.status : "";
+                const status = hasStatus ? (psData.status as string) : "";
                 const inventory = hasInventory ? (psData.inventory as any[]) : [];
 
                 // Ensure a snapshot exists for this (messageId, swipeIndex).

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -197,6 +197,7 @@ import {
   isMessageHiddenFromAI,
   mergeCustomParameters,
   parseExtra,
+  parseJsonField,
   parseStoredGenerationParameters,
   parseGameStateRow,
   parseSnapshotPlayerStats,
@@ -7825,21 +7826,9 @@ export async function generateRoutes(app: FastifyInstance) {
                 // these fields from the previous snapshot — the dedicated tracker agents
                 // (character-tracker, persona-stats, quest, custom-tracker) will update
                 // them with authoritative data in their own handler blocks below.
-                const snapshotChars = prevSnap?.presentCharacters
-                  ? typeof prevSnap.presentCharacters === "string"
-                    ? JSON.parse(prevSnap.presentCharacters)
-                    : prevSnap.presentCharacters
-                  : [];
-                const snapshotPersonaStats = prevSnap?.personaStats
-                  ? typeof prevSnap.personaStats === "string"
-                    ? JSON.parse(prevSnap.personaStats)
-                    : prevSnap.personaStats
-                  : null;
-                const snapshotPlayerStats = prevSnap?.playerStats
-                  ? typeof prevSnap.playerStats === "string"
-                    ? JSON.parse(prevSnap.playerStats)
-                    : prevSnap.playerStats
-                  : null;
+                const snapshotChars = parseJsonField<any[]>(prevSnap?.presentCharacters, []);
+                const snapshotPersonaStats = parseJsonField<any[] | null>(prevSnap?.personaStats, null);
+                const snapshotPlayerStats = parseJsonField<Record<string, unknown> | null>(prevSnap?.playerStats, null);
                 const currentGameStateForLocks = prevSnap
                   ? parseGameStateRow(prevSnap as Record<string, unknown>)
                   : null;
@@ -7945,11 +7934,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   snapBeforeUpdate ??
                   baseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
-                const oldChars: any[] = previousCharacterSnapshot?.presentCharacters
-                  ? typeof previousCharacterSnapshot.presentCharacters === "string"
-                    ? JSON.parse(previousCharacterSnapshot.presentCharacters)
-                    : previousCharacterSnapshot.presentCharacters
-                  : [];
+                const oldChars = parseJsonField<any[]>(previousCharacterSnapshot?.presentCharacters, []);
                 preserveTrackerCharacterUiFields(chars, oldChars);
                 const characterLockState = previousCharacterSnapshot
                   ? parseGameStateRow(previousCharacterSnapshot as Record<string, unknown>)

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3602,7 +3602,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         const builtInAgentTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
         const userMessagesSinceLastAgentRun = async (agentType: string) => {
-          const lastRun = await agentsStore.getLastRunByType(agentType, input.chatId);
+          const lastRun = await agentsStore.getLastSuccessfulRunByType(agentType, input.chatId);
           if (!lastRun) return Number.POSITIVE_INFINITY;
 
           const lastRunIdx = allChatMessages.findIndex((message: any) => message.id === lastRun.messageId);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4680,10 +4680,12 @@ export async function generateRoutes(app: FastifyInstance) {
                 {};
               // Skip:
               //   - Disabled entries (off-limits, by global flag or per-chat override).
+              //   - Constant entries, which are already injected by the standard lorebook path.
               //   - Exhausted ephemeral entries (countdown reached 0 in this chat).
               //   - Entries excluded by character/tag/generation-trigger filters.
               knowledgeRouterEntries = entries
                 .filter((e: LorebookEntry) => {
+                  if (e.constant === true) return false;
                   const ov = entryStateOverrides[e.id];
                   const isEnabled = ov?.enabled ?? e.enabled !== false;
                   if (!isEnabled) return false;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5912,7 +5912,11 @@ export async function generateRoutes(app: FastifyInstance) {
           fullResponse = "";
           fullThinking = "";
           providerThinking = "";
-          if (tailMessages.assistantPrefillInjected && assistantPrefill) {
+          if (
+            tailMessages.assistantPrefillInjected &&
+            !tailMessages.googleUserRegenerationInjected &&
+            assistantPrefill
+          ) {
             await writeContentChunked(assistantPrefill);
           }
           let geminiResponseParts: unknown[] | null = null;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4241,8 +4241,9 @@ export async function generateRoutes(app: FastifyInstance) {
         );
 
         // Batch-fetch committed game state snapshots for assistant messages in the agent context
-        const assistantMsgIds = agentSlice.filter((m: any) => m.role === "assistant").map((m: any) => m.id as string);
-        const committedSnapshots = await gameStateStore.getCommittedForMessages(assistantMsgIds);
+        const committedSnapshots = await gameStateStore.getCommittedForMessages(
+          agentSlice.filter((m: any) => m.role === "assistant"),
+        );
         const visibleHistorySnapshot =
           latestGameState &&
           visibleGameStateAnchor &&
@@ -7929,8 +7930,8 @@ export async function generateRoutes(app: FastifyInstance) {
                     ),
                   );
                 }
-              } catch {
-                // Non-critical
+              } catch (err) {
+                logger.error(err, "[generate] Failed to apply world-state tracker update");
               }
             }
 
@@ -8274,8 +8275,8 @@ export async function generateRoutes(app: FastifyInstance) {
                     }
                   }
                 }
-              } catch {
-                // Non-critical
+              } catch (err) {
+                logger.error(err, "[generate] Failed to apply persona-stats tracker update");
               }
             }
 
@@ -8323,8 +8324,8 @@ export async function generateRoutes(app: FastifyInstance) {
                     );
                   }
                 }
-              } catch {
-                // Non-critical
+              } catch (err) {
+                logger.error(err, "[generate] Failed to apply custom tracker update");
               }
             }
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -10625,6 +10625,9 @@ export async function generateRoutes(app: FastifyInstance) {
         }
       }
     } catch (err) {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
       const message =
         err instanceof Error
           ? (err as { cause?: unknown }).cause instanceof Error

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -23,6 +23,8 @@ import {
   normalizeAgentPromptTemplateSelectionMap,
   normalizeThinkingTagPairs,
   applyTrackerFieldLocksToGameStatePatch,
+  normalizeTrackerFieldLocksForState,
+  trackerFieldLocksAreEmpty,
   customAgentHasCapability,
   supportsXhighReasoningEffort,
   DEFAULT_CONVERSATION_PROMPT,
@@ -7484,6 +7486,15 @@ export async function generateRoutes(app: FastifyInstance) {
             const refreshedForSwipe = await chats.getMessage(messageId);
             if (refreshedForSwipe) targetSwipeIndex = refreshedForSwipe.activeSwipeIndex ?? 0;
           }
+          const siblingSwipeSnapshot =
+            input.regenerateMessageId && messageId && targetSwipeIndex > 0
+              ? await gameStateStore.getByMessage(messageId, targetSwipeIndex - 1)
+              : null;
+          const trackerBaseGameStateSnapshot = siblingSwipeSnapshot ?? baseGameStateSnapshot;
+          const serializeMigratedTrackerLocks = (state: ReturnType<typeof parseGameStateRow> | null) => {
+            const locks = normalizeTrackerFieldLocksForState(state?.fieldLocks, state);
+            return trackerFieldLocksAreEmpty(locks) ? null : JSON.stringify(locks);
+          };
 
           const resolveAgentImageConnectionId = async (agent: ResolvedAgent | undefined): Promise<string | null> => {
             let imgConnId = (agent?.settings?.imageConnectionId as string) ?? null;
@@ -7805,7 +7816,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 // are NOT carried forward to new snapshots.  The agent naturally reads
                 // the edited prevSnap values and produces its own output.
                 const prevSnap =
-                  baseGameStateSnapshot ??
+                  trackerBaseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
 
                 // Build the new snapshot from agent output, falling back to previous snapshot.
@@ -7864,7 +7875,10 @@ export async function generateRoutes(app: FastifyInstance) {
                     recentEvents: (gs.recentEvents as string[]) ?? [],
                     playerStats: snapshotPlayerStats,
                     personaStats: snapshotPersonaStats,
-                    fieldLocks: currentGameStateForLocks?.fieldLocks ?? null,
+                    fieldLocks: normalizeTrackerFieldLocksForState(
+                      currentGameStateForLocks?.fieldLocks,
+                      currentGameStateForLocks,
+                    ),
                   },
                   null, // manual overrides are one-shot — never carry forward
                 );
@@ -7932,7 +7946,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                 const previousCharacterSnapshot =
                   snapBeforeUpdate ??
-                  baseGameStateSnapshot ??
+                  trackerBaseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
                 const oldChars = parseJsonField<any[]>(previousCharacterSnapshot?.presentCharacters, []);
                 preserveTrackerCharacterUiFields(chars, oldChars);
@@ -8083,7 +8097,8 @@ export async function generateRoutes(app: FastifyInstance) {
 
                         // Re-persist with avatar paths and notify client
                         const latestAvatarSnapshot =
-                          (await gameStateStore.getByMessage(messageId, targetSwipeIndex)) ?? baseGameStateSnapshot;
+                          (await gameStateStore.getByMessage(messageId, targetSwipeIndex)) ??
+                          trackerBaseGameStateSnapshot;
                         const latestAvatarState = latestAvatarSnapshot
                           ? parseGameStateRow(latestAvatarSnapshot as Record<string, unknown>)
                           : null;
@@ -8110,7 +8125,7 @@ export async function generateRoutes(app: FastifyInstance) {
                             presentCharacters,
                           },
                           undefined,
-                          { baseSnapshot: baseGameStateSnapshot },
+                          { baseSnapshot: trackerBaseGameStateSnapshot },
                         );
                         try {
                           logger.debug(
@@ -8138,7 +8153,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     presentCharacters: chars,
                   },
                   undefined,
-                  { baseSnapshot: baseGameStateSnapshot },
+                  { baseSnapshot: trackerBaseGameStateSnapshot },
                 );
                 logger.info(
                   `[generate] character-tracker: updateByMessage returned ${updated ? "ok" : "null (no snapshot)"}`,
@@ -8206,21 +8221,22 @@ export async function generateRoutes(app: FastifyInstance) {
                 let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                 if (!snap) {
                   await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
-                    baseSnapshot: baseGameStateSnapshot,
+                    baseSnapshot: trackerBaseGameStateSnapshot,
                   });
                   snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                 }
+                const personaLockState = snap ? parseGameStateRow(snap as Record<string, unknown>) : null;
                 const personaPatch = buildLockedPersonaTrackerPatch({
                   stats: bars,
                   status,
                   inventory,
                   snapshot: snap,
-                  lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+                  lockState: personaLockState,
                 });
                 if (snap && Object.keys(personaPatch.updates).length > 0) {
                   await app.db
                     .update(gameStateSnapshotsTable)
-                    .set(personaPatch.updates)
+                    .set({ ...personaPatch.updates, fieldLocks: serializeMigratedTrackerLocks(personaLockState) })
                     .where(eq(gameStateSnapshotsTable.id, snap.id));
                 }
                 if (personaPatch.changed) {
@@ -8267,20 +8283,24 @@ export async function generateRoutes(app: FastifyInstance) {
                   let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   if (!snap) {
                     await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
-                      baseSnapshot: baseGameStateSnapshot,
+                      baseSnapshot: trackerBaseGameStateSnapshot,
                     });
                     snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   }
+                  const customLockState = snap ? parseGameStateRow(snap as Record<string, unknown>) : null;
                   const customTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
                     field: "customTrackerFields",
                     values: rawFields,
                     snapshot: snap,
-                    lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+                    lockState: customLockState,
                   });
                   if (snap && customTrackerPatch.changed) {
                     await app.db
                       .update(gameStateSnapshotsTable)
-                      .set({ playerStats: JSON.stringify(customTrackerPatch.playerStats) })
+                      .set({
+                        playerStats: JSON.stringify(customTrackerPatch.playerStats),
+                        fieldLocks: serializeMigratedTrackerLocks(customLockState),
+                      })
                       .where(eq(gameStateSnapshotsTable.id, snap.id));
                   }
                   if (customTrackerPatch.changed) {
@@ -8317,7 +8337,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   if (!snap) {
                     await gameStateStore.updateByMessage(messageId, targetSwipeIndex, input.chatId, {}, undefined, {
-                      baseSnapshot: baseGameStateSnapshot,
+                      baseSnapshot: trackerBaseGameStateSnapshot,
                     });
                     snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   }
@@ -8325,11 +8345,12 @@ export async function generateRoutes(app: FastifyInstance) {
                   const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates, {
                     autoRemoveFullyCompleted: true,
                   });
+                  const questLockState = snap ? parseGameStateRow(snap as Record<string, unknown>) : null;
                   const questTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
                     field: "activeQuests",
                     values: questMerge.quests,
                     snapshot: snap,
-                    lockState: snap ? parseGameStateRow(snap as Record<string, unknown>) : null,
+                    lockState: questLockState,
                     basePlayerStats: questMerge.playerStats,
                   });
 
@@ -8338,7 +8359,10 @@ export async function generateRoutes(app: FastifyInstance) {
                     if (snap) {
                       await app.db
                         .update(gameStateSnapshotsTable)
-                        .set({ playerStats: JSON.stringify(questTrackerPatch.playerStats) })
+                        .set({
+                          playerStats: JSON.stringify(questTrackerPatch.playerStats),
+                          fieldLocks: serializeMigratedTrackerLocks(questLockState),
+                        })
                         .where(eq(gameStateSnapshotsTable.id, snap.id));
                     }
                     logger.debug("[game_state_patch] quests: %j", questTrackerPatch.values);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -82,6 +82,7 @@ import {
   assemblePrompt,
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
+  collectCharacterPostHistoryEntries,
   resolveCharacterMacroData,
   resolveMacrosWithVariableSnapshot,
   resolvePromptMessageMacros,
@@ -3321,6 +3322,15 @@ export async function generateRoutes(app: FastifyInstance) {
           );
           if (characterDepthEntries.length > 0) {
             finalMessages = injectAtDepth(finalMessages, characterDepthEntries);
+          }
+          const characterPostHistoryEntries = await collectCharacterPostHistoryEntries(
+            app.db,
+            promptCharacterIds,
+            promptMacroContext,
+            wrapFormat,
+          );
+          if (characterPostHistoryEntries.length > 0) {
+            finalMessages = injectAtDepth(finalMessages, characterPostHistoryEntries);
           }
         }
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -426,6 +426,7 @@ function customAgentCanEmitResult(
     case "character_tracker_update":
     case "persona_stats_update":
     case "custom_tracker_update":
+    case "quest_update":
       return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_trackers");
     case "image_prompt":
       return customAgentCanApplyResult(result, agents, builtInAgentTypes, "trigger_image_generation");
@@ -7804,6 +7805,7 @@ export async function generateRoutes(app: FastifyInstance) {
             if (
               result.success &&
               result.type === "game_state_update" &&
+              result.agentType !== "combat" &&
               result.data &&
               typeof result.data === "object" &&
               customAgentCanApplyResult(result, resolvedAgents, builtInAgentTypes, "edit_trackers")
@@ -7942,7 +7944,11 @@ export async function generateRoutes(app: FastifyInstance) {
             ) {
               try {
                 const ctData = result.data as Record<string, unknown>;
-                let chars = (ctData.presentCharacters as any[]) ?? [];
+                if (!Array.isArray(ctData.presentCharacters) || ctData.presentCharacters.length === 0) {
+                  logger.debug("[generate] character-tracker emitted no presentCharacters; keeping existing snapshot");
+                  continue;
+                }
+                let chars = ctData.presentCharacters as any[];
                 const snapBeforeUpdate = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                 const previousCharacterSnapshot =
                   snapBeforeUpdate ??
@@ -8211,9 +8217,12 @@ export async function generateRoutes(app: FastifyInstance) {
             ) {
               try {
                 const psData = result.data as Record<string, unknown>;
-                const bars = (psData.stats as any[]) ?? [];
-                const status = (psData.status as string) ?? "";
-                const inventory = (psData.inventory as any[]) ?? [];
+                const hasStats = Array.isArray(psData.stats);
+                const hasStatus = typeof psData.status === "string";
+                const hasInventory = Array.isArray(psData.inventory);
+                const bars = hasStats ? (psData.stats as any[]) : [];
+                const status = hasStatus ? psData.status : "";
+                const inventory = hasInventory ? (psData.inventory as any[]) : [];
 
                 // Ensure a snapshot exists for this (messageId, swipeIndex).
                 // If world-state didn't create one, updateByMessage clones the
@@ -8230,6 +8239,9 @@ export async function generateRoutes(app: FastifyInstance) {
                   stats: bars,
                   status,
                   inventory,
+                  hasStats,
+                  hasStatus,
+                  hasInventory,
                   snapshot: snap,
                   lockState: personaLockState,
                 });
@@ -8277,8 +8289,9 @@ export async function generateRoutes(app: FastifyInstance) {
             ) {
               try {
                 const ctData = result.data as Record<string, unknown>;
-                const rawFields = (ctData.fields as any[]) ?? [];
-                if (rawFields.length > 0) {
+                const hasFields = Array.isArray(ctData.fields);
+                const rawFields = hasFields ? (ctData.fields as any[]) : [];
+                if (hasFields) {
                   // Ensure a snapshot exists for this (messageId, swipeIndex)
                   let snap = await gameStateStore.getByMessage(messageId, targetSwipeIndex);
                   if (!snap) {

--- a/packages/server/src/routes/generate/agent-connection-guards.ts
+++ b/packages/server/src/routes/generate/agent-connection-guards.ts
@@ -1,7 +1,7 @@
 import { LOCAL_SIDECAR_CONNECTION_ID } from "@marinara-engine/shared";
 
 export type AgentConnectionWarning = {
-  code: "local_sidecar_unavailable" | "default_agent_connection_active";
+  code: "local_sidecar_unavailable" | "default_agent_connection_active" | "agent_connection_unavailable";
   severity: "warning";
   message: string;
   agentNames: string[];
@@ -62,5 +62,25 @@ export function buildDefaultAgentConnectionWarning(args: {
     connectionName: args.connectionName,
     model: args.model,
     message: `${agentList} ${noun} using the default agent connection "${args.connectionName}" (${args.model}). If this is a paid API model, agent calls may bill that provider.`,
+  };
+}
+
+export function buildAgentConnectionUnavailableWarning(args: {
+  agentNames: string[];
+  reason: string;
+  connectionName?: string;
+}): AgentConnectionWarning {
+  const normalizedNames = args.agentNames.length > 0 ? args.agentNames : ["Agent"];
+  const agentList = formatAgentNameList(normalizedNames);
+  const noun = normalizedNames.length === 1 ? "this agent" : "these agents";
+  const connectionText = args.connectionName ? ` "${args.connectionName}"` : "";
+
+  return {
+    code: "agent_connection_unavailable",
+    severity: "warning",
+    agentNames: normalizedNames,
+    fallbackPrevented: true,
+    connectionName: args.connectionName,
+    message: `${agentList} could not use agent connection${connectionText}: ${args.reason}. Marinara skipped ${noun} instead of falling back to the main chat model.`,
   };
 }

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -24,7 +24,6 @@ import {
   assemblePrompt,
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
-  collectCharacterPostHistoryEntries,
   resolveCharacterMacroData,
   resolveMacrosWithVariableSnapshot,
   resolvePromptMessageMacros,
@@ -1328,15 +1327,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       );
       if (characterDepthEntries.length > 0) {
         finalMessages = injectAtDepth(finalMessages as any, characterDepthEntries) as any;
-      }
-      const characterPostHistoryEntries = await collectCharacterPostHistoryEntries(
-        app.db,
-        promptCharacterIds,
-        promptMacroContext,
-        wrapFormat,
-      );
-      if (characterPostHistoryEntries.length > 0) {
-        finalMessages = injectAtDepth(finalMessages as any, characterPostHistoryEntries) as any;
       }
     }
 

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -25,6 +25,7 @@ import {
   assemblePrompt,
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
+  collectCharacterPostHistoryEntries,
   resolveCharacterMacroData,
   resolveMacrosWithVariableSnapshot,
   resolvePromptMessageMacros,
@@ -1402,6 +1403,15 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       );
       if (characterDepthEntries.length > 0) {
         finalMessages = injectAtDepth(finalMessages as any, characterDepthEntries) as any;
+      }
+      const characterPostHistoryEntries = await collectCharacterPostHistoryEntries(
+        app.db,
+        promptCharacterIds,
+        promptMacroContext,
+        wrapFormat,
+      );
+      if (characterPostHistoryEntries.length > 0) {
+        finalMessages = injectAtDepth(finalMessages as any, characterPostHistoryEntries) as any;
       }
     }
 

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -2,7 +2,6 @@ import type { FastifyInstance } from "fastify";
 import {
   LOCAL_SIDECAR_CONNECTION_ID,
   isClaudeAdaptiveOnlyNoSamplingModel,
-  formatCustomTrackerFieldForPrompt,
   supportsXhighReasoningEffort,
   resolveMacros,
   stripMacroComments,
@@ -62,10 +61,12 @@ import {
   normalizeServiceTier,
   resolveVisibleGameStateAnchor,
   resolveBaseUrl,
+  shouldEnableAgentsForGeneration,
   type PromptAttachment,
 } from "../generate/generate-route-utils.js";
 import { buildGenerationPromptPresetCandidates, type PromptPresetCandidateSource } from "./prompt-preset-selection.js";
 import { createGameStateStorage, type GameStateVisibleAnchor } from "../../services/storage/game-state.storage.js";
+import { buildCommittedTrackerContextBlock } from "../../services/generation/committed-tracker-context.js";
 import { logger } from "../../lib/logger.js";
 
 type WrapFormat = "xml" | "markdown" | "none";
@@ -131,105 +132,16 @@ function formatTrackersContextBlock(args: {
   wrapFormat: WrapFormat;
   snap: any;
   chatMeta: Record<string, unknown>;
+  chatEnableAgents: boolean;
+  activeAgentIds: string[];
 }): string | null {
-  const { wrapFormat, snap, chatMeta } = args;
-
-  const trackerParts: string[] = [];
-
-  const wsParts: string[] = [];
-  if (snap.date) wsParts.push(`Date: ${snap.date}`);
-  if (snap.time) wsParts.push(`Time: ${snap.time}`);
-  if (snap.location) wsParts.push(`Location: ${snap.location}`);
-  if (snap.weather) wsParts.push(`Weather: ${snap.weather}`);
-  if (snap.temperature) wsParts.push(`Temperature: ${snap.temperature}`);
-  if (wsParts.length > 0) trackerParts.push(wrapContent(wsParts.join("\n"), "World", wrapFormat));
-
-  try {
-    const presentChars = JSON.parse(snap.presentCharacters);
-    if (Array.isArray(presentChars) && presentChars.length > 0) {
-      const charLines = presentChars.map((c: any) => {
-        if (typeof c === "string") return `- ${c}`;
-        const details: string[] = [];
-        if (c.mood) details.push(`mood: ${c.mood}`);
-        if (c.appearance) details.push(`appearance: ${c.appearance}`);
-        if (c.outfit) details.push(`outfit: ${c.outfit}`);
-        if (c.thoughts) details.push(`thoughts: ${c.thoughts}`);
-        if (Array.isArray(c.stats) && c.stats.length > 0) {
-          const statStr = c.stats.map((s: any) => `${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`).join(", ");
-          details.push(`stats: ${statStr}`);
-        }
-        const detailStr = details.length > 0 ? ` (${details.join("; ")})` : "";
-        return `- ${c.emoji ?? ""} ${c.name ?? c}${detailStr}`;
-      });
-      trackerParts.push(wrapContent(charLines.join("\n"), "Present Characters", wrapFormat));
-    }
-  } catch {
-    /* ignore */
-  }
-
-  if (snap.personaStats) {
-    try {
-      const psBars = typeof snap.personaStats === "string" ? JSON.parse(snap.personaStats) : snap.personaStats;
-      if (Array.isArray(psBars) && psBars.length > 0) {
-        const barLines = psBars.map((b: any) => `- ${b.name}: ${b.value}/${b.max}`);
-        trackerParts.push(wrapContent(barLines.join("\n"), "Persona Stats", wrapFormat));
-      }
-    } catch {
-      /* ignore */
-    }
-  }
-
-  if (snap.playerStats) {
-    try {
-      const stats = typeof snap.playerStats === "string" ? JSON.parse(snap.playerStats) : snap.playerStats;
-      if (stats?.status) trackerParts.push(wrapContent(`Status: ${stats.status}`, "Status", wrapFormat));
-      if (Array.isArray(stats.activeQuests) && stats.activeQuests.length > 0) {
-        const questLines = stats.activeQuests.map((q: any) => {
-          const objectives = Array.isArray(q.objectives)
-            ? q.objectives.map((o: any) => `  ${o.completed ? "[x]" : "[ ]"} ${o.text}`).join("\n")
-            : "";
-          return `- ${q.name}${q.completed ? " (completed)" : ""}${objectives ? "\n" + objectives : ""}`;
-        });
-        trackerParts.push(wrapContent(questLines.join("\n"), "Active Quests", wrapFormat));
-      }
-      if (Array.isArray(stats.inventory) && stats.inventory.length > 0) {
-        const invLines = stats.inventory.map(
-          (item: any) =>
-            `- ${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ""}${item.description ? ` — ${item.description}` : ""}`,
-        );
-        trackerParts.push(wrapContent(invLines.join("\n"), "Inventory", wrapFormat));
-      }
-      if (Array.isArray(stats.stats) && stats.stats.length > 0) {
-        const statLines = stats.stats.map((s: any) => `- ${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`);
-        trackerParts.push(wrapContent(statLines.join("\n"), "Stats", wrapFormat));
-      }
-      if (Array.isArray(stats.customTrackerFields) && stats.customTrackerFields.length > 0) {
-        const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
-        trackerParts.push(wrapContent(customLines.join("\n"), "Custom Tracker", wrapFormat));
-      }
-    } catch {
-      /* ignore */
-    }
-  }
-
-  const playerNotes = typeof chatMeta.gamePlayerNotes === "string" ? chatMeta.gamePlayerNotes.trim() : "";
-  if (playerNotes) {
-    trackerParts.push(
-      wrapContent(
-        `The player has written these personal notes. Consider them when responding — they reflect what the player is tracking, their theories, and plans:\n${playerNotes}`,
-        "Player Notes",
-        wrapFormat,
-      ),
-    );
-  }
-
-  if (trackerParts.length <= 0) return null;
-
-  if (wrapFormat === "none") return trackerParts.join("\n\n");
-  if (wrapFormat === "xml") {
-    return `<context>\n${trackerParts.map((p) => "    " + p.replace(/\n/g, "\n    ")).join("\n")}\n</context>`;
-  }
-  return `# Context\n*(Established state as of the last message. Do not re-describe — advance from here.)*\n${trackerParts.join("\n")}`;
+  return buildCommittedTrackerContextBlock({
+    chatEnableAgents: args.chatEnableAgents,
+    activeAgentIds: args.activeAgentIds,
+    latestGameState: args.snap,
+    chatMetadata: args.chatMeta,
+    wrapFormat: args.wrapFormat,
+  });
 }
 
 function injectTrackerContext(
@@ -643,6 +555,13 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     // Pull existing messages, apply the same conversation-start + context limit filtering
     const allChatMessages = await chats.listMessages(chatId);
     const chatMode = (chat.mode as string) ?? "roleplay";
+    const dryRunActiveAgentIds = Array.isArray(chatMeta.activeAgentIds) ? (chatMeta.activeAgentIds as string[]) : [];
+    const dryRunChatEnableAgents = shouldEnableAgentsForGeneration({
+      chatEnableAgents: chatMeta.enableAgents === true,
+      chatMode,
+      impersonate,
+      impersonateBlockAgents: false,
+    });
     const supportsHiddenFromAI = chatMode === "conversation" || chatMode === "roleplay" || chatMode === "visual_novel";
     let startIdx = 0;
     for (let i = allChatMessages.length - 1; i >= 0; i--) {
@@ -1115,7 +1034,13 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         ? await (async () => {
             const snap = await loadLatestGameSnapshot(app, chatId, visibleGameStateAnchor, regenerateMessageId);
             if (!snap) return null;
-            return formatTrackersContextBlock({ wrapFormat, snap, chatMeta });
+            return formatTrackersContextBlock({
+              wrapFormat,
+              snap,
+              chatMeta,
+              chatEnableAgents: dryRunChatEnableAgents,
+              activeAgentIds: dryRunActiveAgentIds,
+            });
           })()
         : null;
 
@@ -1419,7 +1344,15 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     const resolvedInjectTrackersForRun = usePromptParts ? false : resolvedInjectTrackers;
     if (resolvedInjectTrackersForRun) {
       const snap = await loadLatestGameSnapshot(app, chatId, visibleGameStateAnchor, regenerateMessageId);
-      const contextBlock = snap ? formatTrackersContextBlock({ wrapFormat, snap, chatMeta }) : null;
+      const contextBlock = snap
+        ? formatTrackersContextBlock({
+            wrapFormat,
+            snap,
+            chatMeta,
+            chatEnableAgents: dryRunChatEnableAgents,
+            activeAgentIds: dryRunActiveAgentIds,
+          })
+        : null;
       if (contextBlock) {
         finalMessages = injectTrackerContext(finalMessages, contextBlock, "beforeLastHistoryMessage");
       }

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -1445,7 +1445,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     }
 
     if (typeof chatParams?.assistantPrefill === "string") assistantPrefill = chatParams.assistantPrefill;
-    if (assistantPrefill.trim()) {
+    if (!impersonate && assistantPrefill.trim()) {
       // Mirror the real send path: the trailing edge is stripped because Anthropic
       // rejects a final assistant message ending in whitespace.
       finalMessages.push({ role: "assistant", content: assistantPrefill.trimEnd() });

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1046,7 +1046,7 @@ export function parseGameStateRow(row: Record<string, unknown>): GameState {
     temperature: row.temperature as string | null,
     presentCharacters: parseJsonField<any[]>(row.presentCharacters, []),
     recentEvents: parseJsonField<string[]>(row.recentEvents, []),
-    playerStats: parseJsonField<Record<string, unknown> | null>(row.playerStats, null),
+    playerStats: parseJsonField<PlayerStats | null>(row.playerStats, null),
     personaStats: parseJsonField<any[] | null>(row.personaStats, null),
     manualOverrides,
     fieldLocks,

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1015,11 +1015,18 @@ export function preserveTrackerCharacterUiFields(
 }
 
 /** Parse game state JSON fields from a DB row. */
+export function parseJsonField<T>(value: unknown, fallback: T): T {
+  if (value == null) return fallback;
+  if (typeof value !== "string") return value as T;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 export function parseGameStateRow(row: Record<string, unknown>): GameState {
-  const manualOverrides =
-    row.manualOverrides && typeof row.manualOverrides === "string"
-      ? (JSON.parse(row.manualOverrides) as Record<string, string>)
-      : null;
+  const manualOverrides = parseJsonField<Record<string, string> | null>(row.manualOverrides, null);
   const fieldLocks = parseTrackerFieldLocks(row.fieldLocks);
   return {
     id: row.id as string,
@@ -1031,10 +1038,10 @@ export function parseGameStateRow(row: Record<string, unknown>): GameState {
     location: row.location as string | null,
     weather: row.weather as string | null,
     temperature: row.temperature as string | null,
-    presentCharacters: JSON.parse((row.presentCharacters as string) ?? "[]"),
-    recentEvents: JSON.parse((row.recentEvents as string) ?? "[]"),
-    playerStats: row.playerStats ? JSON.parse(row.playerStats as string) : null,
-    personaStats: row.personaStats ? JSON.parse(row.personaStats as string) : null,
+    presentCharacters: parseJsonField<any[]>(row.presentCharacters, []),
+    recentEvents: parseJsonField<string[]>(row.recentEvents, []),
+    playerStats: parseJsonField<Record<string, unknown> | null>(row.playerStats, null),
+    personaStats: parseJsonField<any[] | null>(row.personaStats, null),
     manualOverrides,
     fieldLocks,
     createdAt: row.createdAt as string,

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -538,8 +538,9 @@ export function appendGenerationTailMessages(
   const shouldAppendGoogleUserRegeneration =
     !options.impersonate && options.isGoogleProvider && !!options.regenerateUserMessage;
   const assistantPrefill = options.assistantPrefill.trim();
+  const shouldAppendAssistantPrefill = !options.impersonate && !!assistantPrefill;
 
-  if (assistantPrefill) {
+  if (shouldAppendAssistantPrefill) {
     // Strip the trailing edge: Anthropic's Messages API rejects a final assistant
     // message ending in whitespace (HTTP 400), which surfaces to users as a refusal.
     // A prefill ending in "\n" or a space is common. The user-facing prefill is
@@ -552,7 +553,7 @@ export function appendGenerationTailMessages(
   }
 
   return {
-    assistantPrefillInjected: !!assistantPrefill,
+    assistantPrefillInjected: shouldAppendAssistantPrefill,
     googleUserRegenerationInjected: shouldAppendGoogleUserRegeneration,
   };
 }

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -123,21 +123,27 @@ export function buildLockedPersonaTrackerPatch({
   stats,
   status,
   inventory,
+  hasStats,
+  hasStatus,
+  hasInventory,
   snapshot,
   lockState,
 }: {
   stats: CharacterStat[];
   status: string;
   inventory: InventoryItem[];
+  hasStats?: boolean;
+  hasStatus?: boolean;
+  hasInventory?: boolean;
   snapshot: { personaStats?: unknown; playerStats?: unknown } | null | undefined;
   lockState: GameState | null | undefined;
 }) {
   const rawPatch: Record<string, unknown> = {};
-  if (stats.length > 0) rawPatch.personaStats = stats;
+  if (hasStats ?? stats.length > 0) rawPatch.personaStats = stats;
 
   const rawPlayerStatsPatch: Record<string, unknown> = {};
-  if (status) rawPlayerStatsPatch.status = status;
-  if (inventory.length > 0) rawPlayerStatsPatch.inventory = inventory;
+  if (hasStatus ?? !!status) rawPlayerStatsPatch.status = status;
+  if (hasInventory ?? inventory.length > 0) rawPlayerStatsPatch.inventory = inventory;
   if (Object.keys(rawPlayerStatsPatch).length > 0) rawPatch.playerStats = rawPlayerStatsPatch;
 
   const patch = applyTrackerFieldLocksToGameStatePatch(rawPatch, lockState);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2439,7 +2439,7 @@ async function applyRetryResultEffects(args: {
           });
         }
       } catch (err) {
-        logger.error(err, "[retry-agents] Failed to apply custom tracker update");
+        logger.error(err, "[retry-agents] Failed to apply lorebook update");
       }
     }
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -14,9 +14,11 @@ import {
   normalizeAgentPromptTemplateSelectionMap,
   resolveAgentPromptTemplate,
   stripMacroComments,
+  findKnownModel,
   type AgentCallDebugEvent,
   type AgentContext,
   type AgentResult,
+  type APIProvider,
   type ChatMode,
   type GameMap,
   type WrapFormat,
@@ -884,6 +886,11 @@ async function resolveRetryAgents(args: {
   const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
   const chatConnectionCustomParameters =
     parseStoredGenerationParameters(conn.defaultParameters)?.customParameters ?? {};
+  const chatConnectionKnownModel = findKnownModel(conn.provider as APIProvider, conn.model.trim());
+  const chatConnectionMaxOutputTokens =
+    chatConnectionKnownModel?.maxOutput && chatConnectionKnownModel.maxOutput > 0
+      ? Math.floor(chatConnectionKnownModel.maxOutput)
+      : null;
   const resolvedAgents: ResolvedRetryAgent[] = [];
   const skippedLocalSidecarAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
@@ -919,6 +926,7 @@ async function resolveRetryAgents(args: {
       provider: any;
       model: string;
       customParameters: Record<string, unknown>;
+      maxOutputTokens: number | null;
       maxParallelJobs: number;
     } | null;
     unavailableReason?: string;
@@ -931,6 +939,7 @@ async function resolveRetryAgents(args: {
           provider,
           model: conn.model,
           customParameters: chatConnectionCustomParameters,
+          maxOutputTokens: chatConnectionMaxOutputTokens,
           maxParallelJobs: chatConnectionMaxParallelJobs,
         },
       };
@@ -943,6 +952,7 @@ async function resolveRetryAgents(args: {
           provider: getLocalSidecarProvider(),
           model: LOCAL_SIDECAR_MODEL,
           customParameters: {},
+          maxOutputTokens: null,
           maxParallelJobs: 1,
         },
       };
@@ -980,6 +990,10 @@ async function resolveRetryAgents(args: {
         ),
         model,
         customParameters: parseStoredGenerationParameters(agentConn.defaultParameters)?.customParameters ?? {},
+        maxOutputTokens: (() => {
+          const knownModel = findKnownModel(agentConn.provider as APIProvider, model);
+          return knownModel?.maxOutput && knownModel.maxOutput > 0 ? Math.floor(knownModel.maxOutput) : null;
+        })(),
         maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
       },
     };
@@ -1044,6 +1058,7 @@ async function resolveRetryAgents(args: {
         connectionId: effectiveConnectionId,
         settings,
         customParameters: agentConnection.entry.customParameters,
+        maxOutputTokens: agentConnection.entry.maxOutputTokens,
         provider: agentConnection.entry.provider,
         model: agentConnection.entry.model,
         maxParallelJobs: agentConnection.entry.maxParallelJobs,
@@ -1094,6 +1109,7 @@ async function resolveRetryAgents(args: {
         connectionId: builtInConnection.entry.connectionId,
         settings,
         customParameters: builtInConnection.entry.customParameters,
+        maxOutputTokens: builtInConnection.entry.maxOutputTokens,
         provider: builtInConnection.entry.provider,
         model: builtInConnection.entry.model,
         maxParallelJobs: builtInConnection.entry.maxParallelJobs,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -57,6 +57,7 @@ import {
   buildLockedPersonaTrackerPatch,
   isMessageHiddenFromAI,
   parseExtra,
+  parseStoredGenerationParameters,
   parseGameStateRow,
   parseSnapshotPlayerStats,
   preserveTrackerCharacterUiFields,
@@ -881,6 +882,8 @@ async function resolveRetryAgents(args: {
     conn.maxTokensOverride,
   );
   const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
+  const chatConnectionCustomParameters =
+    parseStoredGenerationParameters(conn.defaultParameters)?.customParameters ?? {};
   const resolvedAgents: ResolvedRetryAgent[] = [];
   const skippedLocalSidecarAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
@@ -911,7 +914,13 @@ async function resolveRetryAgents(args: {
   const resolveRetryAgentConnection = async (
     connectionId: string | null,
   ): Promise<{
-    entry: { connectionId: string | null; provider: any; model: string; maxParallelJobs: number } | null;
+    entry: {
+      connectionId: string | null;
+      provider: any;
+      model: string;
+      customParameters: Record<string, unknown>;
+      maxParallelJobs: number;
+    } | null;
     unavailableReason?: string;
     connectionName?: string;
   }> => {
@@ -921,6 +930,7 @@ async function resolveRetryAgents(args: {
           connectionId: null,
           provider,
           model: conn.model,
+          customParameters: chatConnectionCustomParameters,
           maxParallelJobs: chatConnectionMaxParallelJobs,
         },
       };
@@ -932,6 +942,7 @@ async function resolveRetryAgents(args: {
           connectionId,
           provider: getLocalSidecarProvider(),
           model: LOCAL_SIDECAR_MODEL,
+          customParameters: {},
           maxParallelJobs: 1,
         },
       };
@@ -968,6 +979,7 @@ async function resolveRetryAgents(args: {
           agentConn.maxTokensOverride,
         ),
         model,
+        customParameters: parseStoredGenerationParameters(agentConn.defaultParameters)?.customParameters ?? {},
         maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
       },
     };
@@ -1031,6 +1043,7 @@ async function resolveRetryAgents(args: {
         promptTemplate: selectedPromptTemplate,
         connectionId: effectiveConnectionId,
         settings,
+        customParameters: agentConnection.entry.customParameters,
         provider: agentConnection.entry.provider,
         model: agentConnection.entry.model,
         maxParallelJobs: agentConnection.entry.maxParallelJobs,
@@ -1080,6 +1093,7 @@ async function resolveRetryAgents(args: {
         promptTemplate: selectedPromptTemplate,
         connectionId: builtInConnection.entry.connectionId,
         settings,
+        customParameters: builtInConnection.entry.customParameters,
         provider: builtInConnection.entry.provider,
         model: builtInConnection.entry.model,
         maxParallelJobs: builtInConnection.entry.maxParallelJobs,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2377,7 +2377,7 @@ async function applyRetryResultEffects(args: {
         const hasStatus = typeof psData.status === "string";
         const hasInventory = Array.isArray(psData.inventory);
         const bars = hasStats ? (psData.stats as any[]) : [];
-        const status = hasStatus ? psData.status : "";
+        const status = hasStatus ? (psData.status as string) : "";
         const inventory = hasInventory ? (psData.inventory as any[]) : [];
         const latest = await loadRetryTargetGameStateSnapshot();
         const personaPatch = buildLockedPersonaTrackerPatch({

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -81,6 +81,7 @@ import { filterGameInternalAgentIds } from "../../services/lorebook/game-loreboo
 import { sendSseEvent, startSseReply } from "./sse.js";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection.js";
 import {
+  buildAgentConnectionUnavailableWarning,
   buildDefaultAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   isLocalSidecarConnectionId,
@@ -884,32 +885,98 @@ async function resolveRetryAgents(args: {
   const skippedLocalSidecarAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
   const defaultAgentConn = await conns.getDefaultForAgents();
-  const defaultAgentConnection = defaultAgentConn
-    ? (() => {
-        const baseUrl = resolveBaseUrl(defaultAgentConn);
-        if (!baseUrl) return null;
-        return {
-          connectionId: defaultAgentConn.id as string,
-          provider: createLLMProvider(
-            defaultAgentConn.provider,
-            baseUrl,
-            defaultAgentConn.apiKey,
-            defaultAgentConn.maxContext,
-            defaultAgentConn.openrouterProvider,
-            defaultAgentConn.maxTokensOverride,
-          ),
-          model: defaultAgentConn.model,
-          maxParallelJobs: Number(defaultAgentConn.maxParallelJobs) || 1,
-        };
-      })()
-    : null;
   const localSidecarAvailableForTrackers =
     sidecarModelService.getConfig().useForTrackers && sidecarModelService.getConfiguredModelRef() !== null;
+  const unavailableConnectionWarnings = new Map<
+    string,
+    { reason: string; connectionName?: string; agentNames: string[] }
+  >();
+  const addUnavailableConnectionWarning = (
+    agentName: string,
+    resolution: { unavailableReason?: string; connectionName?: string },
+  ) => {
+    const reason = resolution.unavailableReason ?? "the connection is unavailable";
+    const key = `${resolution.connectionName ?? ""}:${reason}`;
+    const existing = unavailableConnectionWarnings.get(key);
+    if (existing) {
+      existing.agentNames.push(agentName);
+    } else {
+      unavailableConnectionWarnings.set(key, {
+        reason,
+        connectionName: resolution.connectionName,
+        agentNames: [agentName],
+      });
+    }
+  };
+  const resolveRetryAgentConnection = async (
+    connectionId: string | null,
+  ): Promise<{
+    entry: { connectionId: string | null; provider: any; model: string; maxParallelJobs: number } | null;
+    unavailableReason?: string;
+    connectionName?: string;
+  }> => {
+    if (!connectionId) {
+      return {
+        entry: {
+          connectionId: null,
+          provider,
+          model: conn.model,
+          maxParallelJobs: chatConnectionMaxParallelJobs,
+        },
+      };
+    }
+
+    if (isLocalSidecarConnectionId(connectionId) && localSidecarAvailableForTrackers) {
+      return {
+        entry: {
+          connectionId,
+          provider: getLocalSidecarProvider(),
+          model: LOCAL_SIDECAR_MODEL,
+          maxParallelJobs: 1,
+        },
+      };
+    }
+
+    const agentConn = await conns.getWithKey(connectionId);
+    if (!agentConn) {
+      return { entry: null, unavailableReason: "the configured connection was deleted" };
+    }
+
+    const model = typeof agentConn.model === "string" ? agentConn.model.trim() : "";
+    if (!model) {
+      return { entry: null, unavailableReason: "no model is selected", connectionName: agentConn.name };
+    }
+
+    const agentBaseUrl = resolveBaseUrl(agentConn);
+    if (!agentBaseUrl) {
+      return {
+        entry: null,
+        unavailableReason: "the Base URL is empty or cannot be resolved",
+        connectionName: agentConn.name,
+      };
+    }
+
+    return {
+      entry: {
+        connectionId,
+        provider: createLLMProvider(
+          agentConn.provider,
+          agentBaseUrl,
+          agentConn.apiKey,
+          agentConn.maxContext,
+          agentConn.openrouterProvider,
+          agentConn.maxTokensOverride,
+        ),
+        model,
+        maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
+      },
+    };
+  };
+  const defaultAgentConnection = defaultAgentConn
+    ? await resolveRetryAgentConnection(defaultAgentConn.id as string)
+    : null;
 
   for (const cfg of enabledConfigs) {
-    let agentProvider = provider;
-    let agentModel = conn.model;
-    let agentMaxParallelJobs = chatConnectionMaxParallelJobs;
     const effectiveConnectionId = resolveAgentConnectionId({
       requestedConnectionId: cfg.connectionId as string | null,
       defaultAgentConnectionId: defaultAgentConn?.id ?? null,
@@ -925,34 +992,20 @@ async function resolveRetryAgents(args: {
       continue;
     }
 
-    if (effectiveConnectionId) {
-      if (isLocalSidecarConnectionId(effectiveConnectionId) && localSidecarAvailableForTrackers) {
-        agentProvider = getLocalSidecarProvider();
-        agentModel = LOCAL_SIDECAR_MODEL;
-      } else if (defaultAgentConnection && effectiveConnectionId === defaultAgentConnection.connectionId) {
-        agentProvider = defaultAgentConnection.provider;
-        agentModel = defaultAgentConnection.model;
-        agentMaxParallelJobs = defaultAgentConnection.maxParallelJobs;
-        defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
-      } else {
-        const agentConn = await conns.getWithKey(effectiveConnectionId);
-        if (agentConn) {
-          const agentBaseUrl = resolveBaseUrl(agentConn);
-          if (agentBaseUrl) {
-            agentProvider = createLLMProvider(
-              agentConn.provider,
-              agentBaseUrl,
-              agentConn.apiKey,
-              agentConn.maxContext,
-              agentConn.openrouterProvider,
-              agentConn.maxTokensOverride,
-            );
-            agentModel = agentConn.model;
-            agentMaxParallelJobs = Number(agentConn.maxParallelJobs) || 1;
-          }
-        }
-      }
+    const agentConnection = await resolveRetryAgentConnection(effectiveConnectionId);
+    if (!agentConnection.entry) {
+      addUnavailableConnectionWarning(cfg.name ?? cfg.type, agentConnection);
+      logger.warn(
+        "[retry-agents] Skipping agent %s because its connection is unavailable: %s",
+        cfg.type,
+        agentConnection.unavailableReason ?? "unknown reason",
+      );
+      continue;
     }
+    if (defaultAgentConn && effectiveConnectionId === defaultAgentConn.id) {
+      defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
+    }
+
     const rawSettings = typeof cfg.settings === "string" ? JSON.parse(cfg.settings) : (cfg.settings ?? {});
     let settings = applyDefaultBuiltInAgentTools(cfg.type, rawSettings);
     if (cfg.type === "spotify") {
@@ -978,12 +1031,12 @@ async function resolveRetryAgents(args: {
         promptTemplate: selectedPromptTemplate,
         connectionId: effectiveConnectionId,
         settings,
-        provider: agentProvider,
-        model: agentModel,
-        maxParallelJobs: agentMaxParallelJobs,
+        provider: agentConnection.entry.provider,
+        model: agentConnection.entry.model,
+        maxParallelJobs: agentConnection.entry.maxParallelJobs,
       },
-      agentProvider,
-      agentModel,
+      agentProvider: agentConnection.entry.provider,
+      agentModel: agentConnection.entry.model,
     });
   }
 
@@ -991,15 +1044,17 @@ async function resolveRetryAgents(args: {
     skippedLocalSidecarAgents.length > 0 ? [buildLocalSidecarUnavailableWarning(skippedLocalSidecarAgents)] : [];
 
   for (const builtIn of builtInFallbackConfigs) {
-    const builtInProvider = defaultAgentConnection ?? {
-      provider,
-      model: conn.model,
-      connectionId: null,
-      maxParallelJobs: chatConnectionMaxParallelJobs,
-    };
-    if (defaultAgentConnection) {
-      defaultAgentConnectionAgents.push(builtIn.name);
+    const builtInConnection = defaultAgentConn ? defaultAgentConnection : await resolveRetryAgentConnection(null);
+    if (!builtInConnection?.entry) {
+      addUnavailableConnectionWarning(builtIn.name, builtInConnection ?? {});
+      logger.warn(
+        "[retry-agents] Skipping built-in agent %s because its connection is unavailable: %s",
+        builtIn.id,
+        builtInConnection?.unavailableReason ?? "unknown reason",
+      );
+      continue;
     }
+    if (defaultAgentConn) defaultAgentConnectionAgents.push(builtIn.name);
 
     let settings = applyDefaultBuiltInAgentTools(builtIn.id, getDefaultBuiltInAgentSettings(builtIn.id));
     if (builtIn.id === "spotify") {
@@ -1023,15 +1078,19 @@ async function resolveRetryAgents(args: {
         name: builtIn.name,
         phase: resolveRetryAgentRuntimePhase(builtIn.id, builtIn.phase),
         promptTemplate: selectedPromptTemplate,
-        connectionId: builtInProvider.connectionId,
+        connectionId: builtInConnection.entry.connectionId,
         settings,
-        provider: builtInProvider.provider,
-        model: builtInProvider.model,
-        maxParallelJobs: builtInProvider.maxParallelJobs,
+        provider: builtInConnection.entry.provider,
+        model: builtInConnection.entry.model,
+        maxParallelJobs: builtInConnection.entry.maxParallelJobs,
       },
-      agentProvider: builtInProvider.provider,
-      agentModel: builtInProvider.model,
+      agentProvider: builtInConnection.entry.provider,
+      agentModel: builtInConnection.entry.model,
     });
+  }
+
+  for (const warning of unavailableConnectionWarnings.values()) {
+    warnings.push(buildAgentConnectionUnavailableWarning(warning));
   }
 
   if (defaultAgentConn && defaultAgentConnectionAgents.length > 0) {
@@ -1039,7 +1098,7 @@ async function resolveRetryAgents(args: {
       buildDefaultAgentConnectionWarning({
         agentNames: defaultAgentConnectionAgents,
         connectionName: defaultAgentConn.name,
-        model: defaultAgentConn.model,
+        model: String(defaultAgentConn.model ?? "").trim(),
       }),
     );
   }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -519,10 +519,9 @@ async function buildRetryAgentContext(args: {
       characterId: typeof message.characterId === "string" && message.characterId ? message.characterId : null,
     })),
   );
-  const retryAssistantMsgIds = agentSlice
-    .filter((message: any) => message.role === "assistant")
-    .map((message: any) => message.id as string);
-  const retryCommittedSnapshots = await gameStateStore.getCommittedForMessages(retryAssistantMsgIds);
+  const retryCommittedSnapshots = await gameStateStore.getCommittedForMessages(
+    agentSlice.filter((message: any) => message.role === "assistant"),
+  );
   const retryVisibleAnchor =
     historicalGameStateAnchor ??
     (useLatestGameStateFallback && lastAssistant ? resolveVisibleGameStateAnchor([lastAssistant]) : null);
@@ -2178,8 +2177,8 @@ async function applyRetryResultEffects(args: {
             },
           });
         }
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.warn(err, "[retry-agents] Failed to apply text rewrite");
       }
     }
 
@@ -2225,8 +2224,8 @@ async function applyRetryResultEffects(args: {
         }
 
         sendSseEvent(reply, { type: "game_state_patch", data: lockedWorldStatePatch });
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.error(err, "[retry-agents] Failed to apply world-state tracker update");
       }
     }
 
@@ -2313,8 +2312,8 @@ async function applyRetryResultEffects(args: {
           { baseSnapshot: await loadRetryBaseGameStateSnapshot() },
         );
         sendSseEvent(reply, { type: "game_state_patch", data: { presentCharacters } });
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.error(err, "[retry-agents] Failed to apply character-tracker update");
       }
     }
 
@@ -2349,8 +2348,8 @@ async function applyRetryResultEffects(args: {
         if (personaPatch.changed) {
           sendSseEvent(reply, { type: "game_state_patch", data: personaPatch.patch });
         }
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.error(err, "[retry-agents] Failed to apply persona-stats tracker update");
       }
     }
 
@@ -2363,8 +2362,8 @@ async function applyRetryResultEffects(args: {
             await agentsStore.setMemory(agentConfigId, chatId, "overarchingArc", plotData.overarchingArc ?? null);
           }
         }
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.warn(err, "[retry-agents] Failed to persist secret plot memory");
       }
     }
 
@@ -2386,8 +2385,8 @@ async function applyRetryResultEffects(args: {
             updates: retryUpdates,
           });
         }
-      } catch {
-        // Non-critical patching failure.
+      } catch (err) {
+        logger.error(err, "[retry-agents] Failed to apply custom tracker update");
       }
     }
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1449,6 +1449,7 @@ async function attachRetrySpotifyToolContexts(args: {
       (entry.resolved as any).__spotifyToolCalls = new Set<string>();
       (entry.resolved as any).__spotifyPlayApplied = false;
       (entry.resolved as any).__spotifyPlayError = null;
+      (entry.resolved as any).__spotifyToolError = spotifyError;
       (entry.resolved as any).__spotifyPlaybackPending = false;
     }
     entry.resolved.toolContext = {
@@ -1465,6 +1466,8 @@ async function attachRetrySpotifyToolContexts(args: {
           });
         }
         if (!spotifyAccessToken) {
+          (entry.resolved as any).__spotifyToolError =
+            spotifyError ?? "Spotify is not connected. Open the Music DJ agent and connect your account.";
           return JSON.stringify({
             error: spotifyError ?? "Spotify is not connected. Open the Music DJ agent and connect your account.",
           });
@@ -1600,6 +1603,12 @@ function buildSpotifyRetryQuery(result: AgentResult, context: AgentContext): { q
   };
 }
 
+function isBlockingSpotifyRetryToolError(error: string | null | undefined): error is string {
+  return (
+    !!error && /(not configured|not connected|token|scope|premium|active spotify device|playback failed)/i.test(error)
+  );
+}
+
 async function applyDeterministicSpotifyRetryFallback(args: {
   entry: ResolvedRetryAgent;
   result: AgentResult;
@@ -1701,6 +1710,10 @@ async function validateSpotifyRetryPlayback(
 ): Promise<AgentResult> {
   if (entry.resolved.type !== "spotify") return result;
   if (result.type !== "spotify_control") return result;
+  const spotifyToolError = (entry.resolved as any).__spotifyToolError;
+  if (isBlockingSpotifyRetryToolError(spotifyToolError)) {
+    return { ...result, success: false, error: spotifyToolError };
+  }
 
   const constraints =
     context.memory._spotifyDjConstraints && typeof context.memory._spotifyDjConstraints === "object"

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2183,7 +2183,13 @@ async function applyRetryResultEffects(args: {
       }
     }
 
-    if (result.success && result.type === "game_state_update" && result.data && typeof result.data === "object") {
+    if (
+      result.success &&
+      result.type === "game_state_update" &&
+      result.agentType !== "combat" &&
+      result.data &&
+      typeof result.data === "object"
+    ) {
       try {
         const gs = result.data as Record<string, unknown>;
         const worldStatePatch: Record<string, unknown> = {};
@@ -2270,7 +2276,11 @@ async function applyRetryResultEffects(args: {
     ) {
       try {
         const ctData = result.data as Record<string, unknown>;
-        let presentCharacters = (ctData.presentCharacters as any[]) ?? [];
+        if (!Array.isArray(ctData.presentCharacters) || ctData.presentCharacters.length === 0) {
+          logger.debug("[retry-agents] character-tracker emitted no presentCharacters; keeping existing snapshot");
+          continue;
+        }
+        let presentCharacters = ctData.presentCharacters as any[];
         const previousSnapshot = await loadRetryTargetGameStateSnapshot();
         let previousCharacters: any[] = [];
         if (previousSnapshot?.presentCharacters) {
@@ -2311,14 +2321,20 @@ async function applyRetryResultEffects(args: {
     if (result.success && result.type === "persona_stats_update" && result.data && typeof result.data === "object") {
       try {
         const psData = result.data as Record<string, unknown>;
-        const bars = (psData.stats as any[]) ?? [];
-        const status = (psData.status as string) ?? "";
-        const inventory = (psData.inventory as any[]) ?? [];
+        const hasStats = Array.isArray(psData.stats);
+        const hasStatus = typeof psData.status === "string";
+        const hasInventory = Array.isArray(psData.inventory);
+        const bars = hasStats ? (psData.stats as any[]) : [];
+        const status = hasStatus ? psData.status : "";
+        const inventory = hasInventory ? (psData.inventory as any[]) : [];
         const latest = await loadRetryTargetGameStateSnapshot();
         const personaPatch = buildLockedPersonaTrackerPatch({
           stats: bars,
           status,
           inventory,
+          hasStats,
+          hasStatus,
+          hasInventory,
           snapshot: latest,
           lockState: latest ? parseGameStateRow(latest as Record<string, unknown>) : null,
         });
@@ -2451,8 +2467,9 @@ async function applyRetryResultEffects(args: {
     if (result.success && result.type === "custom_tracker_update" && result.data && typeof result.data === "object") {
       try {
         const ctData = result.data as Record<string, unknown>;
-        const rawFields = (ctData.fields as any[]) ?? [];
-        if (rawFields.length > 0) {
+        const hasFields = Array.isArray(ctData.fields);
+        const rawFields = hasFields ? (ctData.fields as any[]) : [];
+        if (hasFields) {
           const snap = await loadRetryTargetGameStateSnapshot();
           const customTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
             field: "customTrackerFields",

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -9,6 +9,7 @@ import {
   applyTrackerFieldLocksToGameStatePatch,
   getDefaultBuiltInAgentSettings,
   NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
+  customAgentHasCapability,
   isAgentAvailableInChatMode,
   isAgentConfigDeleted,
   normalizeAgentPromptTemplateSelectionMap,
@@ -130,6 +131,50 @@ type ResolvedRetryAgent = {
 };
 
 const BUILT_IN_AGENT_TYPE_SET = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
+
+function findRetryResultAgent(result: AgentResult, agents: ResolvedRetryAgent[]): ResolvedAgent | null {
+  return (
+    agents.find((entry) => entry.resolved.id === result.agentId || entry.resolved.type === result.agentType)
+      ?.resolved ?? null
+  );
+}
+
+function customAgentCanApplyRetryResult(
+  result: AgentResult,
+  agents: ResolvedRetryAgent[],
+  capability: Parameters<typeof customAgentHasCapability>[1],
+): boolean {
+  if (BUILT_IN_AGENT_TYPE_SET.has(result.agentType)) return true;
+  const agent = findRetryResultAgent(result, agents);
+  return agent ? customAgentHasCapability(agent.settings, capability) : false;
+}
+
+function customAgentCanEmitRetryResult(result: AgentResult, agents: ResolvedRetryAgent[]): boolean {
+  if (BUILT_IN_AGENT_TYPE_SET.has(result.agentType)) return true;
+  switch (result.type) {
+    case "text_rewrite":
+      return customAgentCanApplyRetryResult(result, agents, "edit_messages");
+    case "lorebook_update":
+      return (
+        customAgentCanApplyRetryResult(result, agents, "edit_lorebooks") ||
+        customAgentCanApplyRetryResult(result, agents, "create_lorebooks")
+      );
+    case "game_state_update":
+    case "character_tracker_update":
+    case "persona_stats_update":
+    case "custom_tracker_update":
+    case "quest_update":
+      return customAgentCanApplyRetryResult(result, agents, "edit_trackers");
+    case "image_prompt":
+      return customAgentCanApplyRetryResult(result, agents, "trigger_image_generation");
+    case "prompt_patch":
+      return customAgentCanApplyRetryResult(result, agents, "edit_main_prompt");
+    case "frontend_theme_update":
+      return customAgentCanApplyRetryResult(result, agents, "change_frontend_styling");
+    default:
+      return true;
+  }
+}
 
 function applyDefaultBuiltInAgentTools(agentType: string, settings: unknown): Record<string, unknown> {
   const next =
@@ -2187,7 +2232,8 @@ async function applyRetryResultEffects(args: {
       result.type === "game_state_update" &&
       result.agentType !== "combat" &&
       result.data &&
-      typeof result.data === "object"
+      typeof result.data === "object" &&
+      customAgentCanApplyRetryResult(result, resolvedAgents, "edit_trackers")
     ) {
       try {
         const gs = result.data as Record<string, unknown>;
@@ -2271,7 +2317,8 @@ async function applyRetryResultEffects(args: {
       result.success &&
       result.type === "character_tracker_update" &&
       result.data &&
-      typeof result.data === "object"
+      typeof result.data === "object" &&
+      customAgentCanApplyRetryResult(result, resolvedAgents, "edit_trackers")
     ) {
       try {
         const ctData = result.data as Record<string, unknown>;
@@ -2317,7 +2364,13 @@ async function applyRetryResultEffects(args: {
       }
     }
 
-    if (result.success && result.type === "persona_stats_update" && result.data && typeof result.data === "object") {
+    if (
+      result.success &&
+      result.type === "persona_stats_update" &&
+      result.data &&
+      typeof result.data === "object" &&
+      customAgentCanApplyRetryResult(result, resolvedAgents, "edit_trackers")
+    ) {
       try {
         const psData = result.data as Record<string, unknown>;
         const hasStats = Array.isArray(psData.stats);
@@ -2390,7 +2443,13 @@ async function applyRetryResultEffects(args: {
       }
     }
 
-    if (result.success && result.type === "quest_update" && result.data && typeof result.data === "object") {
+    if (
+      result.success &&
+      result.type === "quest_update" &&
+      result.data &&
+      typeof result.data === "object" &&
+      customAgentCanApplyRetryResult(result, resolvedAgents, "edit_trackers")
+    ) {
       try {
         const qData = result.data as Record<string, unknown>;
         const updates = Array.isArray(qData.updates) ? qData.updates : [];
@@ -2403,7 +2462,9 @@ async function applyRetryResultEffects(args: {
         if (updates.length > 0) {
           const snap = await loadRetryTargetGameStateSnapshot();
           const existingPS = parseSnapshotPlayerStats(snap);
-          const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates);
+          const questMerge = applyQuestUpdatesToPlayerStats(existingPS, updates, {
+            autoRemoveFullyCompleted: true,
+          });
           const questTrackerPatch = buildLockedPlayerStatsArrayPatch<any>({
             field: "activeQuests",
             values: questMerge.quests,
@@ -2463,7 +2524,13 @@ async function applyRetryResultEffects(args: {
       }
     }
 
-    if (result.success && result.type === "custom_tracker_update" && result.data && typeof result.data === "object") {
+    if (
+      result.success &&
+      result.type === "custom_tracker_update" &&
+      result.data &&
+      typeof result.data === "object" &&
+      customAgentCanApplyRetryResult(result, resolvedAgents, "edit_trackers")
+    ) {
       try {
         const ctData = result.data as Record<string, unknown>;
         const hasFields = Array.isArray(ctData.fields);
@@ -3102,6 +3169,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       }
 
       for (const result of results) {
+        if (!customAgentCanEmitRetryResult(result, resolvedAgents)) continue;
         const cfg = resolvedAgents.find((entry) => entry.resolved.type === result.agentType)?.cfg;
         sendSseEvent(reply, {
           type: "agent_result",
@@ -3126,6 +3194,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       }
 
       for (const entry of lorebookKeeperRunEntries) {
+        if (!customAgentCanEmitRetryResult(entry.result, resolvedAgents)) continue;
         const cfg = lorebookKeeperAgent?.cfg;
         sendSseEvent(reply, {
           type: "agent_result",

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -147,6 +147,7 @@ function buildCompatibleLorebookExport(lb: Record<string, unknown>, entries: Arr
       key: asStringArray(entry.keys),
       keysecondary: asStringArray(entry.secondaryKeys),
       comment: String(entry.name ?? `Entry ${index + 1}`),
+      description: String(entry.description ?? ""),
       content: String(entry.content ?? ""),
       disable: entry.enabled === false,
       constant: entry.constant === true,
@@ -165,6 +166,8 @@ function buildCompatibleLorebookExport(lb: Record<string, unknown>, entries: Arr
       sticky: entry.sticky ?? null,
       cooldown: entry.cooldown ?? null,
       delay: entry.delay ?? null,
+      ephemeral: entry.ephemeral ?? null,
+      locked: entry.locked === true,
       useRegex: entry.useRegex === true,
       regex: entry.useRegex === true,
       preventRecursion: entry.preventRecursion === true,
@@ -226,6 +229,8 @@ function buildTransferredEntryInput(
     groupWeight: entry.groupWeight,
     folderId: null,
     preventRecursion: entry.preventRecursion,
+    excludeRecursion: entry.excludeRecursion,
+    delayUntilRecursion: entry.delayUntilRecursion,
     excludeFromVectorization: entry.excludeFromVectorization,
     locked: entry.locked,
     tag: entry.tag,
@@ -889,9 +894,12 @@ export async function lorebooksRoutes(app: FastifyInstance) {
           error: error instanceof Error ? error.message : "Lorebook embedding request failed",
         });
       }
-      if (embeddings.length !== batchTexts.length) {
+      const usableEmbeddingCount = embeddings.filter(
+        (embedding) => Array.isArray(embedding) && embedding.length > 0,
+      ).length;
+      if (embeddings.length !== batchTexts.length || usableEmbeddingCount !== batchTexts.length) {
         return reply.status(502).send({
-          error: `Lorebook embedding request returned ${embeddings.length} vectors for ${batchTexts.length} entries.`,
+          error: `Lorebook embedding request returned ${usableEmbeddingCount}/${batchTexts.length} usable vectors.`,
         });
       }
       const batchEmbeddingDimension = embeddings.find((embedding) => embedding.length > 0)?.length ?? null;

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -867,6 +867,11 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       ].join(", ");
       return `${e.name ?? ""}${keys ? ` [${keys}]` : ""}\n${e.content ?? ""}`.trim();
     });
+    const existingEmbeddingDimension = body.onlyMissing
+      ? ((allEntries as Array<Record<string, unknown>>)
+          .map((entry) => entry.embedding)
+          .find((embedding): embedding is unknown[] => Array.isArray(embedding) && embedding.length > 0)?.length ?? null)
+      : null;
 
     // Batch embed (most APIs support multiple texts per call)
     const BATCH_SIZE = 50;
@@ -874,7 +879,31 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     for (let i = 0; i < texts.length; i += BATCH_SIZE) {
       const batchTexts = texts.slice(i, i + BATCH_SIZE);
       const batchEntries = entries.slice(i, i + BATCH_SIZE);
-      const embeddings = await provider.embed(batchTexts, embeddingModel);
+      let embeddings: number[][];
+      try {
+        embeddings = await provider.embed(batchTexts, embeddingModel);
+      } catch (error) {
+        logger.warn(error, "[lorebooks] Embedding batch failed");
+        return reply.status(502).send({
+          error: error instanceof Error ? error.message : "Lorebook embedding request failed",
+        });
+      }
+      if (embeddings.length !== batchTexts.length) {
+        return reply.status(502).send({
+          error: `Lorebook embedding request returned ${embeddings.length} vectors for ${batchTexts.length} entries.`,
+        });
+      }
+      const batchEmbeddingDimension = embeddings.find((embedding) => embedding.length > 0)?.length ?? null;
+      if (
+        existingEmbeddingDimension &&
+        batchEmbeddingDimension &&
+        existingEmbeddingDimension !== batchEmbeddingDimension
+      ) {
+        return reply.status(409).send({
+          error:
+            "Embedding dimensions changed. Re-vectorize all entries instead of only missing entries before switching embedding models.",
+        });
+      }
       for (let j = 0; j < batchEntries.length; j++) {
         const entry = batchEntries[j] as Record<string, unknown>;
         if (embeddings[j]) {

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import { existsSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { extname, join } from "path";
+import { logger } from "../lib/logger.js";
 import {
   createLorebookSchema,
   updateLorebookSchema,

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -165,9 +165,11 @@ function buildCompatibleLorebookExport(lb: Record<string, unknown>, entries: Arr
       cooldown: entry.cooldown ?? null,
       delay: entry.delay ?? null,
       useRegex: entry.useRegex === true,
+      regex: entry.useRegex === true,
       preventRecursion: entry.preventRecursion === true,
       excludeRecursion: entry.excludeRecursion === true,
       delayUntilRecursion: entry.delayUntilRecursion === true,
+      vectorized: entry.excludeFromVectorization !== true,
     };
   });
 

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -102,7 +102,16 @@ function asStringArray(value: unknown): string[] {
 }
 
 function stSelectiveLogic(value: unknown): number {
-  return value === "or" ? 1 : value === "not" ? 2 : 0;
+  if (value === "or") return 0;
+  if (value === "not") return 2;
+  return 3;
+}
+
+function stPosition(value: unknown): number {
+  const position = Number(value ?? 0);
+  if (position === 2) return 4;
+  if (position === 1) return 1;
+  return 0;
 }
 
 function stRole(value: unknown): number {
@@ -141,7 +150,7 @@ function buildCompatibleLorebookExport(lb: Record<string, unknown>, entries: Arr
       selective: entry.selective === true,
       selectiveLogic: stSelectiveLogic(entry.selectiveLogic),
       order: Number(entry.order ?? 100),
-      position: Number(entry.position ?? 0),
+      position: stPosition(entry.position),
       depth: Number(entry.depth ?? 4),
       probability: entry.probability ?? null,
       scanDepth: entry.scanDepth ?? null,
@@ -153,6 +162,10 @@ function buildCompatibleLorebookExport(lb: Record<string, unknown>, entries: Arr
       sticky: entry.sticky ?? null,
       cooldown: entry.cooldown ?? null,
       delay: entry.delay ?? null,
+      useRegex: entry.useRegex === true,
+      preventRecursion: entry.preventRecursion === true,
+      excludeRecursion: entry.excludeRecursion === true,
+      delayUntilRecursion: entry.delayUntilRecursion === true,
     };
   });
 

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -102,9 +102,11 @@ function asStringArray(value: unknown): string[] {
 }
 
 function stSelectiveLogic(value: unknown): number {
-  if (value === "or") return 0;
+  if (value === "and" || value === "or") return 0;
+  if (value === "not_all") return 1;
   if (value === "not") return 2;
-  return 3;
+  if (value === "and_all") return 3;
+  return 0;
 }
 
 function stPosition(value: unknown): number {

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -54,6 +54,16 @@ function runtimeInstallDisabledPayload() {
   };
 }
 
+function createResponseAbortSignal(reply: FastifyReply, label: string): AbortSignal {
+  const controller = new AbortController();
+  reply.raw.once("close", () => {
+    if (!controller.signal.aborted) {
+      controller.abort(new Error(`${label} cancelled because the client disconnected`));
+    }
+  });
+  return controller.signal;
+}
+
 export const sidecarRoutes: FastifyPluginAsync = async (app) => {
   app.get("/status", async () => {
     void sidecarProcessService
@@ -367,7 +377,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
         debugLog("[debug/game/scene-analysis:sidecar] user prompt:\n%s", userPrompt);
       }
 
-      const raw = await analyzeScene(systemPrompt, userPrompt);
+      const raw = await analyzeScene(systemPrompt, userPrompt, createResponseAbortSignal(reply, "Sidecar scene analysis"));
       if (debugLogsEnabled) {
         debugLog("[debug/game/scene-analysis:sidecar] parsed model response:\n%s", JSON.stringify(raw, null, 2));
       }
@@ -450,7 +460,11 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const result = await runTrackerPrompt(body.systemPrompt, body.userPrompt);
+      const result = await runTrackerPrompt(
+        body.systemPrompt,
+        body.userPrompt,
+        createResponseAbortSignal(reply, "Sidecar tracker inference"),
+      );
       return { result };
     } catch (error) {
       return reply.status(500).send({

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -123,6 +123,9 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
 
   app.post("/restart", async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Sidecar restart" })) return;
+    if (isInferenceBusy()) {
+      return reply.status(409).send({ error: "Cannot restart the sidecar while inference is in progress" });
+    }
     await sidecarProcessService.restart();
     return { ok: true };
   });
@@ -211,7 +214,20 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
       Connection: "keep-alive",
     });
 
+    let completed = false;
+    const cancelActiveWork = () => {
+      if (completed) return;
+      sidecarModelService.cancelDownload();
+      mlxRuntimeService.cancelInstall();
+      sidecarRuntimeService.cancelInstall();
+      void sidecarProcessService.stop().catch((error) => {
+        logger.warn(error, "[sidecar] Failed to stop sidecar after download stream closed");
+      });
+    };
+    reply.raw.once("close", cancelActiveWork);
+
     const sendEvent = (data: unknown) => {
+      if (reply.raw.destroyed) return;
       reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
     };
 
@@ -228,8 +244,12 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
 
     try {
       await task();
+      completed = true;
       sendEvent({ done: true });
     } catch (error) {
+      if (reply.raw.destroyed) {
+        return;
+      }
       sendEvent({
         status: "error",
         phase: lastProgressPhase,
@@ -238,7 +258,10 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
       });
     } finally {
       sidecarModelService.removeProgressListener(listener);
-      reply.raw.end();
+      completed = true;
+      if (!reply.raw.destroyed) {
+        reply.raw.end();
+      }
     }
   }
 
@@ -246,6 +269,9 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     Body: { quantization: SidecarQuantization };
   }>("/download", async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Sidecar model download" })) return;
+    if (isInferenceBusy()) {
+      return reply.status(409).send({ error: "Cannot download or switch sidecar models while inference is in progress" });
+    }
     const { quantization } = z.object({ quantization: quantizationSchema }).parse(req.body);
     await handleDownloadSse(reply, async () => {
       await sidecarProcessService.stop();
@@ -258,6 +284,9 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     Body: { repo: string; modelPath?: string };
   }>("/download/custom", async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Sidecar custom model download" })) return;
+    if (isInferenceBusy()) {
+      return reply.status(409).send({ error: "Cannot download or switch sidecar models while inference is in progress" });
+    }
     const body = z
       .object({
         repo: hfRepoSchema,
@@ -277,6 +306,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     sidecarModelService.cancelDownload();
     mlxRuntimeService.cancelInstall();
     sidecarRuntimeService.cancelInstall();
+    await sidecarProcessService.stop();
     return { ok: true };
   });
 
@@ -287,11 +317,15 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     }
 
     await sidecarProcessService.stop();
-    sidecarModelService.deleteModel();
+    await sidecarModelService.deleteModel();
     return { ok: true };
   });
 
-  app.post("/unload", async () => {
+  app.post("/unload", async (req, reply) => {
+    if (!requirePrivilegedAccess(req, reply, { feature: "Sidecar unload" })) return;
+    if (isInferenceBusy()) {
+      return reply.status(409).send({ error: "Cannot unload the sidecar while inference is in progress" });
+    }
     await unloadModel();
     return { ok: true };
   });

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -98,7 +98,7 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     const body = configSchema.parse(req.body);
     const config = sidecarModelService.updateConfig(body);
     void sidecarProcessService
-      .syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false })
+      .syncForCurrentConfig({ suppressKnownFailure: true, allowRuntimeInstall: false, preemptStarting: true })
       .catch((error) => {
         logger.error(error, "[sidecar] Background sync from /config failed");
       });

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -50,6 +50,7 @@ export interface AgentExecConfig {
   connectionId: string | null;
   settings: Record<string, unknown>;
   customParameters?: Record<string, unknown>;
+  maxOutputTokens?: number | null;
 }
 
 /** Optional tool context for agents that need function calling. */
@@ -216,6 +217,14 @@ function applyProviderMaxTokensOverride(provider: BaseLLMProvider, maxTokens: nu
   return provider.maxTokensOverrideValue !== null ? Math.min(maxTokens, provider.maxTokensOverrideValue) : maxTokens;
 }
 
+function applyAgentMaxTokensCaps(provider: BaseLLMProvider, maxTokens: number, modelMaxOutput: unknown): number {
+  const cappedByConnection = applyProviderMaxTokensOverride(provider, maxTokens);
+  if (typeof modelMaxOutput !== "number" || !Number.isFinite(modelMaxOutput) || modelMaxOutput <= 0) {
+    return cappedByConnection;
+  }
+  return Math.min(cappedByConnection, Math.floor(modelMaxOutput));
+}
+
 function debugMessages(messages: ChatMessage[]): AgentCallDebugEvent["messages"] {
   return messages.map((message) => {
     const next: NonNullable<AgentCallDebugEvent["messages"]>[number] = {
@@ -311,7 +320,11 @@ export async function executeAgent(
 
     // Agents use lower temperature for reliability
     const temperature = normalizeAgentTemperature(config.settings.temperature);
-    const maxTokens = applyProviderMaxTokensOverride(provider, normalizeAgentMaxTokens(config.settings.maxTokens));
+    const maxTokens = applyAgentMaxTokensCaps(
+      provider,
+      normalizeAgentMaxTokens(config.settings.maxTokens),
+      config.maxOutputTokens,
+    );
     const streamResponses = context.streaming !== false;
     const customParameters = agentCustomParameters(config);
 
@@ -674,7 +687,8 @@ export async function executeAgentBatch(
   const temperature = Math.min(...configs.map((c) => normalizeAgentTemperature(c.settings.temperature)));
   const customParameters = agentCustomParameters(configs[0]!);
   const rawBatchMaxTokens = perAgentTokens.reduce((sum, tokens) => sum + tokens, 0);
-  const batchMaxTokens = applyProviderMaxTokensOverride(provider, rawBatchMaxTokens);
+  const modelMaxOutput = configs[0]!.maxOutputTokens;
+  const batchMaxTokens = applyAgentMaxTokensCaps(provider, rawBatchMaxTokens, modelMaxOutput);
 
   try {
     // Build merged system prompt (includes lore + agent extras)
@@ -691,10 +705,19 @@ export async function executeAgentBatch(
 
     // Each agent reserves its own configured output budget. The context fitter
     // may still reduce this further if the prompt needs more room.
-    const streamResponses = context.streaming !== false;
-    logger.info(
-      `[agent-batch] maxTokens: ${batchMaxTokens} (sum=${rawBatchMaxTokens} from [${perAgentTokens.join(", ")}]${provider.maxTokensOverrideValue !== null ? `, capped at ${provider.maxTokensOverrideValue}` : ""})`,
-    );
+  const streamResponses = context.streaming !== false;
+  const capDetails = [
+    provider.maxTokensOverrideValue !== null ? `connection cap=${provider.maxTokensOverrideValue}` : null,
+    modelMaxOutput ? `model cap=${modelMaxOutput}` : null,
+  ].filter(Boolean);
+  const capSuffix = capDetails.length ? `, ${capDetails.join(", ")}` : "";
+  logger.info(
+    "[agent-batch] maxTokens: %d (sum=%d from [%s]%s)",
+    batchMaxTokens,
+    rawBatchMaxTokens,
+    perAgentTokens.join(", "),
+    capSuffix,
+  );
 
     logger.debug(`\n[agent-batch] ═══ BATCH PROMPT — [${configs.map((c) => c.type).join(", ")}] — ${model} ═══`);
     for (const msg of messages) {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -21,6 +21,7 @@ const EXPRESSION_AGENT_CONTEXT_CHAR_LIMIT = 1200;
 const EXPRESSION_AGENT_RESPONSE_CHAR_LIMIT = 6000;
 const CHARACTER_LORE_DESCRIPTION_LIMIT = 2000;
 const CHARACTER_LORE_FIELD_LIMIT = 1200;
+const DEFAULT_AGENT_TEMPERATURE = 0.3;
 
 /** Strip HTML/XML-style tags (e.g. <div style="..."> <br> <speaker>) from text to save tokens. */
 function stripHtmlTags(text: string): string {
@@ -48,6 +49,7 @@ export interface AgentExecConfig {
   promptTemplate: string;
   connectionId: string | null;
   settings: Record<string, unknown>;
+  customParameters?: Record<string, unknown>;
 }
 
 /** Optional tool context for agents that need function calling. */
@@ -198,6 +200,18 @@ function normalizeAgentMaxTokens(value: unknown, fallback = DEFAULT_AGENT_MAX_TO
   return Math.max(MIN_AGENT_MAX_TOKENS, Math.trunc(parsed));
 }
 
+function normalizeAgentTemperature(value: unknown, fallback = DEFAULT_AGENT_TEMPERATURE): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(2, parsed));
+}
+
+function agentCustomParameters(config: AgentExecConfig): Record<string, unknown> | undefined {
+  return config.customParameters && Object.keys(config.customParameters).length > 0
+    ? config.customParameters
+    : undefined;
+}
+
 function applyProviderMaxTokensOverride(provider: BaseLLMProvider, maxTokens: number): number {
   return provider.maxTokensOverrideValue !== null ? Math.min(maxTokens, provider.maxTokensOverrideValue) : maxTokens;
 }
@@ -296,9 +310,10 @@ export async function executeAgent(
             : buildStandardAgentMessages(config, template, context);
 
     // Agents use lower temperature for reliability
-    const temperature = (config.settings.temperature as number) ?? 0.3;
+    const temperature = normalizeAgentTemperature(config.settings.temperature);
     const maxTokens = applyProviderMaxTokensOverride(provider, normalizeAgentMaxTokens(config.settings.maxTokens));
     const streamResponses = context.streaming !== false;
+    const customParameters = agentCustomParameters(config);
 
     // If tools are available, use the tool call loop.
     // `await` so a rethrow from the tool loop is caught by this function's
@@ -338,6 +353,7 @@ export async function executeAgent(
       model,
       temperature,
       maxTokens,
+      customParameters,
       stream: streamResponses,
       onToken: streamResponses
         ? (chunk) => {
@@ -380,6 +396,7 @@ export async function executeAgent(
         model,
         temperature,
         maxTokens,
+        customParameters,
         stream: streamResponses,
         onToken: streamResponses
           ? (chunk) => {
@@ -427,7 +444,7 @@ export async function executeAgent(
       ...agentDebugBase(
         config,
         model,
-        (config.settings.temperature as number) ?? 0.3,
+        normalizeAgentTemperature(config.settings.temperature),
         normalizeAgentMaxTokens(config.settings.maxTokens),
       ),
       messageCount: 0,
@@ -458,6 +475,7 @@ async function executeAgentWithTools(
   const loopMessages = [...initialMessages];
   let totalTokens = 0;
   const debugAgentsEnabled = isDebugAgentsEnabled() && logger.isLevelEnabled("debug");
+  const customParameters = agentCustomParameters(config);
 
   for (let round = 0; round < maxToolRounds; round++) {
     emitAgentDebug(context, {
@@ -472,6 +490,7 @@ async function executeAgentWithTools(
       model,
       temperature,
       maxTokens,
+      customParameters,
       stream: streamResponses,
       tools: toolContext.tools,
       signal: context.signal,
@@ -552,6 +571,7 @@ async function executeAgentWithTools(
     model,
     temperature,
     maxTokens,
+    customParameters,
     stream: streamResponses,
     signal: context.signal,
   });
@@ -651,7 +671,8 @@ export async function executeAgentBatch(
 
   const startTime = Date.now();
   const perAgentTokens = configs.map((c) => normalizeAgentMaxTokens(c.settings.maxTokens));
-  const temperature = Math.min(...configs.map((c) => (c.settings.temperature as number) ?? 0.3));
+  const temperature = Math.min(...configs.map((c) => normalizeAgentTemperature(c.settings.temperature)));
+  const customParameters = agentCustomParameters(configs[0]!);
   const rawBatchMaxTokens = perAgentTokens.reduce((sum, tokens) => sum + tokens, 0);
   const batchMaxTokens = applyProviderMaxTokensOverride(provider, rawBatchMaxTokens);
 
@@ -701,6 +722,7 @@ export async function executeAgentBatch(
       model,
       temperature,
       maxTokens: batchMaxTokens,
+      customParameters,
       stream: streamResponses,
       onToken: streamResponses
         ? (chunk) => {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -109,10 +109,16 @@ function readAgentSettingPath(settings: Record<string, unknown>, path: string): 
   return { found: true, value: cursor };
 }
 
-function renderAgentSettingsMacros(template: string, settings: Record<string, unknown>): string {
+function renderAgentSettingsMacros(
+  template: string,
+  settings: Record<string, unknown>,
+  options: { escapeValues?: boolean } = {},
+): string {
   return template.replace(/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g, (match, key: string) => {
     const { found, value } = readAgentSettingPath(settings, key);
-    return found ? stringifyAgentSettingMacroValue(value) : match;
+    if (!found) return match;
+    const rendered = stringifyAgentSettingMacroValue(value);
+    return options.escapeValues ? escapeXml(rendered) : rendered;
   });
 }
 
@@ -865,9 +871,10 @@ function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContex
     const template = renderAgentSettingsMacros(
       config.promptTemplate || getDefaultPromptForAgent(config),
       config.settings,
+      { escapeValues: true },
     );
     parts.push(``);
-    parts.push(`<agent_task id="${config.type}" name="${config.name}">`);
+    parts.push(`<agent_task id="${escapeXmlAttribute(config.type)}" name="${escapeXmlAttribute(config.name)}">`);
     parts.push(template);
     parts.push(`</agent_task>`);
   }
@@ -889,14 +896,20 @@ function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContex
   for (const config of configs) {
     const isJson = agentResponseIsJson(config);
     parts.push(
-      `<result agent="${config.type}">`,
+      `<result agent="${escapeXmlAttribute(config.type)}">`,
       isJson ? `{ ... valid JSON ... }` : `... your text output ...`,
       `</result>`,
     );
   }
   parts.push(``);
+  const escapedAgentIds = configs.map((config) => escapeXml(config.type)).join(", ");
   parts.push(
-    `CRITICAL: Output ALL ${configs.length} result blocks. Use exact agent IDs: ${configs.map((c) => c.type).join(", ")}. JSON agents must output valid JSON (no markdown fences). No text outside <result> blocks.`,
+    [
+      `CRITICAL: Output ALL ${configs.length} result blocks.`,
+      `Use exact agent IDs: ${escapedAgentIds}.`,
+      "JSON agents must output valid JSON (no markdown fences).",
+      "No text outside <result> blocks.",
+    ].join(" "),
   );
 
   return parts.join("\n");
@@ -916,37 +929,17 @@ function parseBatchResponse(
   const perAgentTokens = Math.round(totalTokens / configs.length);
   const parsed: AgentResult[] = [];
   const failed: AgentExecConfig[] = [];
+  const expectedAgentTypes = new Set(configs.map((config) => config.type));
+  const resultBlocks = extractResultBlocks(responseText);
+  const explicitResults = new Map<string, string>();
+  for (const block of resultBlocks) {
+    if (!expectedAgentTypes.has(block.agent) || explicitResults.has(block.agent)) continue;
+    explicitResults.set(block.agent, block.content.trim());
+  }
+  const residualText = removeSpans(responseText, resultBlocks.map((block) => [block.start, block.end] as const));
 
   for (const config of configs) {
-    const escaped = escapeRegex(config.type);
-    // Try several patterns the model might use:
-    // 1. <result agent="type">...</result>
-    // 2. <result agent='type'>...</result>
-    // 3. <result agent=type>...</result>  (unquoted)
-    // 4. <result_type>...</result_type>   (underscore variant)
-    // 5. <type>...</type>                 (bare agent ID as tag)
-    //
-    // We use GREEDY match ([\s\S]*) with a lookahead for the closing tag
-    // or the next <result to avoid stopping at a </result> inside JSON strings.
-    const patterns = [
-      new RegExp(
-        `<result\\s+agent\\s*=\\s*["']${escaped}["']\\s*>([\\s\\S]*?)</result\\s*>(?=\\s*(?:<result\\b|$))`,
-        "i",
-      ),
-      new RegExp(`<result\\s+agent\\s*=\\s*["']${escaped}["']\\s*>([\\s\\S]*?)</result>`, "i"),
-      new RegExp(`<result\\s+agent\\s*=\\s*${escaped}\\s*>([\\s\\S]*?)</result>`, "i"),
-      new RegExp(`<result_${escaped}>([\\s\\S]*?)</result_${escaped}>`, "i"),
-      new RegExp(`<${escaped}>([\\s\\S]*?)</${escaped}>`, "i"),
-    ];
-
-    let matchedOutput: string | null = null;
-    for (const pattern of patterns) {
-      const match = responseText.match(pattern);
-      if (match) {
-        matchedOutput = match[1]!.trim();
-        break;
-      }
-    }
+    const matchedOutput = explicitResults.get(config.type) ?? matchLegacyResultTag(config.type, residualText);
 
     if (matchedOutput !== null) {
       const parsedResult = parseAgentResponse(config, matchedOutput);
@@ -976,6 +969,82 @@ function parseBatchResponse(
   }
 
   return { parsed, failed };
+}
+
+type ExtractedResultBlock = {
+  agent: string;
+  content: string;
+  start: number;
+  end: number;
+};
+
+function extractResultBlocks(responseText: string): ExtractedResultBlock[] {
+  const openRegex = /<result\b([^>]*)>/gi;
+  const opens = Array.from(responseText.matchAll(openRegex));
+  const blocks: ExtractedResultBlock[] = [];
+
+  for (let i = 0; i < opens.length; i++) {
+    const open = opens[i]!;
+    const agent = readResultAgentAttribute(open[1] ?? "");
+    if (!agent) continue;
+
+    const contentStart = open.index + open[0].length;
+    const nextStart = opens[i + 1]?.index ?? responseText.length;
+    const closeRegex = /<\/result\s*>/gi;
+    closeRegex.lastIndex = contentStart;
+
+    let selectedClose: RegExpExecArray | null = null;
+    let closeMatch: RegExpExecArray | null;
+    while ((closeMatch = closeRegex.exec(responseText))) {
+      if (closeMatch.index >= nextStart) break;
+      selectedClose = closeMatch;
+    }
+    if (!selectedClose) continue;
+
+    blocks.push({
+      agent,
+      content: responseText.slice(contentStart, selectedClose.index),
+      start: open.index,
+      end: selectedClose.index + selectedClose[0].length,
+    });
+  }
+
+  return blocks;
+}
+
+function readResultAgentAttribute(attributes: string): string | null {
+  const match = attributes.match(/\bagent\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i);
+  const raw = match?.[1] ?? match?.[2] ?? match?.[3];
+  return raw ? decodeXmlAttribute(raw).trim() : null;
+}
+
+function decodeXmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function removeSpans(value: string, spans: ReadonlyArray<readonly [number, number]>): string {
+  if (spans.length === 0) return value;
+  const sorted = [...spans].sort((a, b) => a[0] - b[0]);
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const [start, end] of sorted) {
+    if (start > cursor) parts.push(value.slice(cursor, start));
+    cursor = Math.max(cursor, end);
+  }
+  if (cursor < value.length) parts.push(value.slice(cursor));
+  return parts.join("");
+}
+
+function matchLegacyResultTag(agentType: string, residualText: string): string | null {
+  if (!/^[A-Za-z_][A-Za-z0-9_.:-]*$/.test(agentType)) return null;
+  const escaped = escapeRegex(agentType);
+  const match = residualText.match(new RegExp(`<result_${escaped}>([\\s\\S]*?)</result_${escaped}>`, "i"));
+  return match?.[1]?.trim() ?? null;
 }
 
 function escapeRegex(str: string): string {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -22,6 +22,7 @@ const EXPRESSION_AGENT_RESPONSE_CHAR_LIMIT = 6000;
 const CHARACTER_LORE_DESCRIPTION_LIMIT = 2000;
 const CHARACTER_LORE_FIELD_LIMIT = 1200;
 const DEFAULT_AGENT_TEMPERATURE = 0.3;
+const DEFAULT_AGENT_CALL_TIMEOUT_MS = 5 * 60_000;
 
 /** Strip HTML/XML-style tags (e.g. <div style="..."> <br> <speaker>) from text to save tokens. */
 function stripHtmlTags(text: string): string {
@@ -219,6 +220,26 @@ function agentCustomParameters(config: AgentExecConfig): Record<string, unknown>
     : undefined;
 }
 
+function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
+  const activeSignals = signals.filter((signal) => !signal.aborted);
+  const abortedSignal = signals.find((signal) => signal.aborted);
+  if (abortedSignal) return abortedSignal;
+  if (activeSignals.length === 1) return activeSignals[0]!;
+  if (typeof AbortSignal.any === "function") return AbortSignal.any(activeSignals);
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  for (const signal of activeSignals) {
+    signal.addEventListener("abort", abort, { once: true });
+  }
+  return controller.signal;
+}
+
+function agentCallSignal(parentSignal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_AGENT_CALL_TIMEOUT_MS);
+  return parentSignal ? combineAbortSignals([parentSignal, timeoutSignal]) : timeoutSignal;
+}
+
 function applyProviderMaxTokensOverride(provider: BaseLLMProvider, maxTokens: number): number {
   return provider.maxTokensOverrideValue !== null ? Math.min(maxTokens, provider.maxTokensOverrideValue) : maxTokens;
 }
@@ -379,7 +400,7 @@ export async function executeAgent(
             responseText += chunk;
           }
         : undefined,
-      signal: context.signal,
+      signal: agentCallSignal(context.signal),
     });
 
     if (!responseText && result.content) responseText = result.content;
@@ -422,7 +443,7 @@ export async function executeAgent(
               retryResponseText += chunk;
             }
           : undefined,
-        signal: context.signal,
+        signal: agentCallSignal(context.signal),
       });
       totalTokens += retryResult.usage?.totalTokens ?? 0;
       if (!retryResponseText && retryResult.content) retryResponseText = retryResult.content;
@@ -512,7 +533,7 @@ async function executeAgentWithTools(
       customParameters,
       stream: streamResponses,
       tools: toolContext.tools,
-      signal: context.signal,
+      signal: agentCallSignal(context.signal),
     });
 
     totalTokens += result.usage?.totalTokens ?? 0;
@@ -592,7 +613,7 @@ async function executeAgentWithTools(
     maxTokens,
     customParameters,
     stream: streamResponses,
-    signal: context.signal,
+    signal: agentCallSignal(context.signal),
   });
   totalTokens += finalResult.usage?.totalTokens ?? 0;
   const responseText = finalResult.content?.trim() ?? "";
@@ -758,7 +779,7 @@ export async function executeAgentBatch(
             responseText += chunk;
           }
         : undefined,
-      signal: context.signal,
+      signal: agentCallSignal(context.signal),
     });
 
     // chatComplete also accumulates content, but streaming via onToken is

--- a/packages/server/src/services/agents/knowledge-retrieval.ts
+++ b/packages/server/src/services/agents/knowledge-retrieval.ts
@@ -18,6 +18,29 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
+function normalizeSourceContextBudget(value: unknown, fallback = 6000): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : NaN;
+  if (!Number.isFinite(parsed) || parsed < 256) return fallback;
+  return Math.max(256, Math.floor(parsed));
+}
+
+function splitOversizedEntry(text: string, maxTokens: number): string[] {
+  const maxChars = Math.max(1024, maxTokens * 4);
+  const chunks: string[] = [];
+  let remaining = text.trim();
+
+  while (remaining.length > maxChars) {
+    const window = remaining.slice(0, maxChars);
+    const splitAt = Math.max(window.lastIndexOf("\n"), window.lastIndexOf(". "), window.lastIndexOf("; "));
+    const cut = splitAt > maxChars * 0.5 ? splitAt + 1 : maxChars;
+    chunks.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trim();
+  }
+
+  if (remaining) chunks.push(remaining);
+  return chunks;
+}
+
 /**
  * Split text into chunks of approximately `maxTokens` tokens each.
  * Splits on double-newlines (entry boundaries) to keep entries intact.
@@ -28,6 +51,15 @@ function chunkText(text: string, maxTokens: number): string[] {
   let current = "";
 
   for (const entry of entries) {
+    if (estimateTokens(entry) > maxTokens) {
+      if (current.trim()) {
+        chunks.push(current.trim());
+        current = "";
+      }
+      chunks.push(...splitOversizedEntry(entry, maxTokens));
+      continue;
+    }
+
     const combined = current ? current + "\n\n" + entry : entry;
     if (estimateTokens(combined) > maxTokens && current) {
       chunks.push(current.trim());
@@ -61,7 +93,11 @@ export async function executeKnowledgeRetrieval(
 ): Promise<AgentResult> {
   // Reserve tokens for system prompt (~600) and context block (~1500).
   // Rough budget for source material: whatever's left
-  const contextBudget = (config.settings.sourceContextBudget as number) ?? 6000;
+  const requestedContextBudget = normalizeSourceContextBudget(config.settings.sourceContextBudget);
+  const providerContextBudget = provider.maxContextValue
+    ? Math.max(256, provider.maxContextValue - 2500)
+    : requestedContextBudget;
+  const contextBudget = Math.min(requestedContextBudget, providerContextBudget);
 
   const materialTokens = estimateTokens(sourceMaterial);
 
@@ -83,6 +119,7 @@ export async function executeKnowledgeRetrieval(
   let consolidatedText: string | null = null;
   let totalTokens = 0;
   let totalDuration = 0;
+  const failures: string[] = [];
 
   for (let i = 0; i < chunks.length; i++) {
     const isLastChunk = i === chunks.length - 1;
@@ -102,6 +139,11 @@ export async function executeKnowledgeRetrieval(
     const result = await executeAgent(config, chunkContext, provider, model);
     totalTokens += result.tokensUsed;
     totalDuration += result.durationMs;
+
+    if (!result.success) {
+      failures.push(result.error || `chunk ${i + 1} failed`);
+      continue;
+    }
 
     if (result.success && result.data) {
       const text = typeof result.data === "string" ? result.data : ((result.data as { text?: string })?.text ?? "");
@@ -125,7 +167,9 @@ export async function executeKnowledgeRetrieval(
   // covers the case where a middle chunk returned "No relevant information found.":
   // `extractions.length < chunks.length` no longer forces a partial concatenation
   // that would duplicate the facts the final pass already consolidated.
-  const finalText = consolidatedText && consolidatedText.length > 0 ? consolidatedText : extractions.filter(Boolean).join("\n\n");
+  const finalText =
+    consolidatedText && consolidatedText.length > 0 ? consolidatedText : extractions.filter(Boolean).join("\n\n");
+  const failedPasses = failures.length;
   return {
     agentId: config.id,
     agentType: config.type,
@@ -133,7 +177,10 @@ export async function executeKnowledgeRetrieval(
     data: { text: finalText },
     tokensUsed: totalTokens,
     durationMs: totalDuration,
-    success: true,
-    error: null,
+    success: failedPasses === 0,
+    error:
+      failedPasses > 0
+        ? `${failedPasses}/${chunks.length} knowledge retrieval extraction passes failed: ${failures[0]}`
+        : null,
   };
 }

--- a/packages/server/src/services/game/combat.service.ts
+++ b/packages/server/src/services/game/combat.service.ts
@@ -71,6 +71,8 @@ export interface InitiativeEntry {
   roll: number;
   speed: number;
   total: number;
+  skipsTurn?: boolean;
+  skipReason?: string;
 }
 
 export interface AttackResult {
@@ -102,6 +104,27 @@ export interface CombatRoundResult {
   statusTicks: Array<{ id: string; effect: string; expired: boolean }>;
   /** Elemental reactions that occurred this round */
   reactions: Array<{ attackerId: string; defenderId: string; reaction: string; description: string }>;
+}
+
+const TURN_SKIP_STATUS_NAMES = new Set(["frozen", "stunned", "imprisoned"]);
+
+function activeStatusEffects(combatant: CombatantStats): StatusEffect[] {
+  return combatant.statusEffects?.filter((effect) => effect.turnsLeft > 0) ?? [];
+}
+
+function getEffectiveSpeed(combatant: CombatantStats): number {
+  const speedModifier = activeStatusEffects(combatant)
+    .filter((effect) => effect.stat === "speed")
+    .reduce((sum, effect) => sum + effect.modifier, 0);
+  return Math.max(0, combatant.speed + speedModifier);
+}
+
+function getTurnSkipReason(combatant: CombatantStats, effectiveSpeed: number): string | null {
+  const skipEffect = activeStatusEffects(combatant).find((effect) =>
+    TURN_SKIP_STATUS_NAMES.has(effect.name.trim().toLowerCase()),
+  );
+  if (skipEffect) return skipEffect.name;
+  return effectiveSpeed <= 0 ? "immobilized" : null;
 }
 
 function resolveSkillAction(
@@ -302,14 +325,17 @@ function chooseAutoSkill(
 /** Roll initiative for all combatants. Returns sorted order (highest first). */
 export function rollInitiative(combatants: CombatantStats[]): InitiativeEntry[] {
   const entries: InitiativeEntry[] = combatants.map((c) => {
-    const speedMod = Math.floor(c.speed / 5);
+    const effectiveSpeed = getEffectiveSpeed(c);
+    const speedMod = Math.floor(effectiveSpeed / 5);
     const roll = rollDice("1d20").total;
+    const skipReason = getTurnSkipReason(c, effectiveSpeed);
     return {
       id: c.id,
       name: c.name,
       roll,
-      speed: c.speed,
-      total: roll + speedMod,
+      speed: effectiveSpeed,
+      total: skipReason ? -9999 : roll + speedMod,
+      ...(skipReason ? { skipsTurn: true, skipReason } : {}),
     };
   });
 
@@ -325,7 +351,8 @@ export function resolveAttack(
 ): AttackResult {
   // Attack roll: 1d20 + attack stat modifier
   const attackMod = Math.floor(attacker.attack / 3);
-  const attackRoll = rollDice("1d20").total + attackMod;
+  const rawAttackD20 = rollDice("1d20").total;
+  const attackRoll = rawAttackD20 + attackMod;
 
   // Defense check: 1d20 + defense stat modifier
   const defenseMod = Math.floor(defender.defense / 3);
@@ -335,7 +362,7 @@ export function resolveAttack(
   const isMiss = attackRoll < defenseRoll;
 
   // Critical hit check (natural 20 or attack roll exceeds defense by 10+)
-  const isCritical = !isMiss && (attackRoll - defenseMod >= 20 || attackRoll - defenseRoll >= 10);
+  const isCritical = !isMiss && (rawAttackD20 === 20 || attackRoll - defenseRoll >= 10);
 
   // Damage calculation
   let rawDamage = 0;
@@ -581,6 +608,7 @@ export function resolveCombatRound(
   for (const entry of initiative) {
     const attacker = combatants.find((c) => c.id === entry.id);
     if (!attacker || attacker.hp <= 0) continue;
+    if (entry.skipsTurn) continue;
 
     const isPlayerSide = (attacker as { side?: string }).side === "player";
 

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -369,6 +369,8 @@ export interface NpcPortraitRequest {
   negativePromptOverride?: string;
   /** When true, overwrite an existing generated NPC portrait instead of reusing it. */
   force?: boolean;
+  /** Optional request-scoped abort signal. */
+  signal?: AbortSignal;
 }
 
 export type CompiledGameImagePrompt = {
@@ -480,6 +482,7 @@ export async function generateNpcPortrait(req: NpcPortraitRequest): Promise<stri
         imageEndpointId: req.imgEndpointId || undefined,
         comfyWorkflow: req.imgComfyWorkflow || undefined,
         imageDefaults: req.imgDefaults ?? undefined,
+        signal: req.signal,
       },
     );
 
@@ -545,6 +548,8 @@ export interface BackgroundGenRequest {
   size?: ImageGenerationSize;
   promptOverride?: string;
   negativePromptOverride?: string;
+  /** Optional request-scoped abort signal. */
+  signal?: AbortSignal;
 }
 
 export interface ChatBackgroundGenRequest extends BackgroundGenRequest {
@@ -582,6 +587,8 @@ export interface SceneIllustrationGenRequest {
   size?: ImageGenerationSize;
   promptOverride?: string;
   negativePromptOverride?: string;
+  /** Optional request-scoped abort signal. */
+  signal?: AbortSignal;
 }
 
 async function buildBackgroundRawPrompt(req: BackgroundGenRequest): Promise<string> {
@@ -786,6 +793,7 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
         imageEndpointId: req.imgEndpointId || undefined,
         comfyWorkflow: req.imgComfyWorkflow || undefined,
         imageDefaults: req.imgDefaults ?? undefined,
+        signal: req.signal,
       },
     );
 
@@ -854,6 +862,7 @@ export async function generateChatBackground(req: ChatBackgroundGenRequest): Pro
         imageEndpointId: req.imgEndpointId || undefined,
         comfyWorkflow: req.imgComfyWorkflow || undefined,
         imageDefaults: req.imgDefaults ?? undefined,
+        signal: req.signal,
       },
     );
 
@@ -919,6 +928,7 @@ export async function generateSceneIllustration(req: SceneIllustrationGenRequest
         imageEndpointId: req.imgEndpointId || undefined,
         comfyWorkflow: req.imgComfyWorkflow || undefined,
         imageDefaults: req.imgDefaults ?? undefined,
+        signal: req.signal,
         referenceImages: req.referenceImages?.length ? req.referenceImages.slice(0, 4) : undefined,
       },
     );

--- a/packages/server/src/services/game/jsonish.ts
+++ b/packages/server/src/services/game/jsonish.ts
@@ -39,6 +39,14 @@ function extractObjectCandidate(raw: string): string {
   return end > start ? raw.slice(start, end + 1).trim() : raw.slice(start).trim();
 }
 
+function extractJsonishCandidate(raw: string): string {
+  const objectStart = raw.indexOf("{");
+  const arrayStart = raw.indexOf("[");
+  const starts = [objectStart, arrayStart].filter((index) => index >= 0);
+  if (starts.length === 0) return raw.trim();
+  return raw.slice(Math.min(...starts)).trim();
+}
+
 function scanJsonishStructure(raw: string): {
   started: boolean;
   mismatched: boolean;
@@ -237,7 +245,7 @@ export function parseGameJsonish(raw: string): unknown {
 }
 
 export function jsonishLooksTruncated(raw: string): boolean {
-  const candidate = extractObjectCandidate(stripFences(raw.trim()));
+  const candidate = extractJsonishCandidate(stripFences(raw.trim()));
   const scan = scanJsonishStructure(candidate);
   return scan.started && !scan.mismatched && (scan.inString || scan.escaped || scan.closers.length > 0);
 }

--- a/packages/server/src/services/game/jsonish.ts
+++ b/packages/server/src/services/game/jsonish.ts
@@ -39,6 +39,61 @@ function extractObjectCandidate(raw: string): string {
   return end > start ? raw.slice(start, end + 1).trim() : raw.slice(start).trim();
 }
 
+function scanJsonishStructure(raw: string): {
+  started: boolean;
+  mismatched: boolean;
+  inString: boolean;
+  escaped: boolean;
+  closers: string[];
+} {
+  const objectStart = raw.indexOf("{");
+  const arrayStart = raw.indexOf("[");
+  const starts = [objectStart, arrayStart].filter((index) => index >= 0);
+  const start = starts.length > 0 ? Math.min(...starts) : -1;
+  if (start === -1) {
+    return { started: false, mismatched: false, inString: false, escaped: false, closers: [] };
+  }
+
+  let inString = false;
+  let escaped = false;
+  let mismatched = false;
+  const closers: string[] = [];
+
+  for (let i = start; i < raw.length; i++) {
+    const char = raw[i]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && inString) {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (char === "{") {
+      closers.push("}");
+      continue;
+    }
+    if (char === "[") {
+      closers.push("]");
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      if (closers.at(-1) === char) {
+        closers.pop();
+      } else {
+        mismatched = true;
+      }
+    }
+  }
+
+  return { started: true, mismatched, inString, escaped, closers };
+}
+
 function sanitizeControlCharsInStrings(raw: string): string {
   let output = "";
   let inString = false;
@@ -125,10 +180,22 @@ function removeTrailingCommas(raw: string): string {
   return raw.replace(/,\s*([}\]])/g, "$1");
 }
 
+function closeUnbalancedJsonish(raw: string): string {
+  const scan = scanJsonishStructure(raw);
+  if (!scan.started || scan.mismatched || (!scan.inString && scan.closers.length === 0)) return raw;
+
+  let output = raw.trimEnd();
+  if (scan.escaped) output += "\\";
+  if (scan.inString) output += '"';
+  output = output.replace(/,\s*$/, "");
+  return `${output}${scan.closers.reverse().join("")}`;
+}
+
 function repairJsonish(raw: string): string {
-  return removeTrailingCommas(
-    insertMissingPropertyCommas(stripCommentsOutsideStrings(sanitizeControlCharsInStrings(raw))),
-  );
+  const sanitized = sanitizeControlCharsInStrings(raw);
+  const uncommented = stripCommentsOutsideStrings(sanitized);
+  const commaRepaired = insertMissingPropertyCommas(uncommented);
+  return closeUnbalancedJsonish(removeTrailingCommas(commaRepaired));
 }
 
 function unwrapJsonString(value: unknown): unknown {
@@ -167,4 +234,10 @@ export function parseGameJsonish(raw: string): unknown {
   } catch {
     return unwrapJsonString(JSON.parse(candidate));
   }
+}
+
+export function jsonishLooksTruncated(raw: string): boolean {
+  const candidate = extractObjectCandidate(stripFences(raw.trim()));
+  const scan = scanJsonishStructure(candidate);
+  return scan.started && !scan.mismatched && (scan.inString || scan.escaped || scan.closers.length > 0);
 }

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -9,6 +9,8 @@ import {
   LOCAL_SIDECAR_CONNECTION_ID,
   mergeBuiltInAgentSettings,
   resolveAgentPromptTemplate,
+  findKnownModel,
+  type APIProvider,
 } from "@marinara-engine/shared";
 import type { BaseLLMProvider } from "../llm/base-provider.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
@@ -46,6 +48,7 @@ type ResolveAgentPipelineAgentsArgs = {
   chatProvider: BaseLLMProvider;
   chatModel: string;
   chatCustomParameters: Record<string, unknown>;
+  chatMaxOutputTokens: number | null;
   chatMaxParallelJobs: number;
   activeMusicPlayerSource?: "spotify" | "youtube" | null;
   chatMetadata?: Record<string, unknown>;
@@ -56,6 +59,7 @@ type AgentProviderCacheEntry = {
   provider: BaseLLMProvider;
   model: string;
   customParameters: Record<string, unknown>;
+  maxOutputTokens: number | null;
   maxParallelJobs: number;
 };
 
@@ -121,6 +125,11 @@ function resolveConnectionCustomParameters(connection: { defaultParameters?: unk
   return parseStoredGenerationParameters(connection.defaultParameters)?.customParameters ?? {};
 }
 
+function resolveConnectionMaxOutputTokens(connection: { provider: string; model: string }): number | null {
+  const knownModel = findKnownModel(connection.provider as APIProvider, connection.model.trim());
+  return knownModel?.maxOutput && knownModel.maxOutput > 0 ? Math.floor(knownModel.maxOutput) : null;
+}
+
 async function resolveAgentConnectionProvider(args: {
   connections: ConnectionsStore;
   agentProviderCache: Map<string, AgentProviderCacheEntry>;
@@ -128,6 +137,7 @@ async function resolveAgentConnectionProvider(args: {
   fallbackProvider: BaseLLMProvider;
   fallbackModel: string;
   fallbackCustomParameters: Record<string, unknown>;
+  fallbackMaxOutputTokens: number | null;
   fallbackMaxParallelJobs: number;
   resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string;
 }): Promise<AgentConnectionResolution> {
@@ -137,6 +147,7 @@ async function resolveAgentConnectionProvider(args: {
         provider: args.fallbackProvider,
         model: args.fallbackModel,
         customParameters: args.fallbackCustomParameters,
+        maxOutputTokens: args.fallbackMaxOutputTokens,
         maxParallelJobs: args.fallbackMaxParallelJobs,
       },
     };
@@ -179,6 +190,7 @@ async function resolveAgentConnectionProvider(args: {
     ),
     model,
     customParameters: resolveConnectionCustomParameters(agentConn),
+    maxOutputTokens: resolveConnectionMaxOutputTokens({ provider: agentConn.provider, model }),
     maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
   };
   args.agentProviderCache.set(args.connectionId, resolved);
@@ -196,6 +208,7 @@ export async function resolveAgentPipelineAgents({
   chatProvider,
   chatModel,
   chatCustomParameters,
+  chatMaxOutputTokens,
   chatMaxParallelJobs,
   activeMusicPlayerSource,
   chatMetadata,
@@ -223,6 +236,7 @@ export async function resolveAgentPipelineAgents({
       provider: getLocalSidecarProvider(),
       model: LOCAL_SIDECAR_MODEL,
       customParameters: {},
+      maxOutputTokens: null,
       maxParallelJobs: 1,
     });
   }
@@ -299,6 +313,7 @@ export async function resolveAgentPipelineAgents({
       fallbackProvider: chatProvider,
       fallbackModel: chatModel,
       fallbackCustomParameters: chatCustomParameters,
+      fallbackMaxOutputTokens: chatMaxOutputTokens,
       fallbackMaxParallelJobs: chatMaxParallelJobs,
       resolveBaseUrl,
     });
@@ -328,6 +343,7 @@ export async function resolveAgentPipelineAgents({
       provider: resolvedProvider.entry.provider,
       model: resolvedProvider.entry.model,
       customParameters: resolvedProvider.entry.customParameters,
+      maxOutputTokens: resolvedProvider.entry.maxOutputTokens,
       maxParallelJobs: resolvedProvider.entry.maxParallelJobs,
     });
   }
@@ -355,6 +371,7 @@ export async function resolveAgentPipelineAgents({
       fallbackProvider: chatProvider,
       fallbackModel: chatModel,
       fallbackCustomParameters: chatCustomParameters,
+      fallbackMaxOutputTokens: chatMaxOutputTokens,
       fallbackMaxParallelJobs: chatMaxParallelJobs,
       resolveBaseUrl,
     });
@@ -401,6 +418,7 @@ export async function resolveAgentPipelineAgents({
       provider: builtInConnection.entry.provider,
       model: builtInConnection.entry.model,
       customParameters: builtInConnection.entry.customParameters,
+      maxOutputTokens: builtInConnection.entry.maxOutputTokens,
       maxParallelJobs: builtInConnection.entry.maxParallelJobs,
     });
   }

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -23,6 +23,7 @@ import {
   resolveAgentConnectionId,
   type AgentConnectionWarning,
 } from "../../routes/generate/agent-connection-guards.js";
+import { parseStoredGenerationParameters } from "../../routes/generate/generate-route-utils.js";
 import {
   applyTextRewriteAgentChatSettings,
   normalizeProseGuardianPromptTemplate,
@@ -44,6 +45,7 @@ type ResolveAgentPipelineAgentsArgs = {
   agentPromptTemplateSelections: Record<string, string>;
   chatProvider: BaseLLMProvider;
   chatModel: string;
+  chatCustomParameters: Record<string, unknown>;
   chatMaxParallelJobs: number;
   activeMusicPlayerSource?: "spotify" | "youtube" | null;
   chatMetadata?: Record<string, unknown>;
@@ -53,6 +55,7 @@ type ResolveAgentPipelineAgentsArgs = {
 type AgentProviderCacheEntry = {
   provider: BaseLLMProvider;
   model: string;
+  customParameters: Record<string, unknown>;
   maxParallelJobs: number;
 };
 
@@ -114,12 +117,17 @@ function getAgentFallbackPrompt(agentType: string, settings: Record<string, unkn
   return getDefaultAgentPrompt(agentType);
 }
 
+function resolveConnectionCustomParameters(connection: { defaultParameters?: unknown }): Record<string, unknown> {
+  return parseStoredGenerationParameters(connection.defaultParameters)?.customParameters ?? {};
+}
+
 async function resolveAgentConnectionProvider(args: {
   connections: ConnectionsStore;
   agentProviderCache: Map<string, AgentProviderCacheEntry>;
   connectionId: string | null;
   fallbackProvider: BaseLLMProvider;
   fallbackModel: string;
+  fallbackCustomParameters: Record<string, unknown>;
   fallbackMaxParallelJobs: number;
   resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string;
 }): Promise<AgentConnectionResolution> {
@@ -128,6 +136,7 @@ async function resolveAgentConnectionProvider(args: {
       entry: {
         provider: args.fallbackProvider,
         model: args.fallbackModel,
+        customParameters: args.fallbackCustomParameters,
         maxParallelJobs: args.fallbackMaxParallelJobs,
       },
     };
@@ -169,6 +178,7 @@ async function resolveAgentConnectionProvider(args: {
       agentConn.maxTokensOverride,
     ),
     model,
+    customParameters: resolveConnectionCustomParameters(agentConn),
     maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
   };
   args.agentProviderCache.set(args.connectionId, resolved);
@@ -185,6 +195,7 @@ export async function resolveAgentPipelineAgents({
   agentPromptTemplateSelections,
   chatProvider,
   chatModel,
+  chatCustomParameters,
   chatMaxParallelJobs,
   activeMusicPlayerSource,
   chatMetadata,
@@ -211,6 +222,7 @@ export async function resolveAgentPipelineAgents({
     agentProviderCache.set(LOCAL_SIDECAR_CONNECTION_ID, {
       provider: getLocalSidecarProvider(),
       model: LOCAL_SIDECAR_MODEL,
+      customParameters: {},
       maxParallelJobs: 1,
     });
   }
@@ -286,6 +298,7 @@ export async function resolveAgentPipelineAgents({
       connectionId: effectiveConnectionId,
       fallbackProvider: chatProvider,
       fallbackModel: chatModel,
+      fallbackCustomParameters: chatCustomParameters,
       fallbackMaxParallelJobs: chatMaxParallelJobs,
       resolveBaseUrl,
     });
@@ -314,6 +327,7 @@ export async function resolveAgentPipelineAgents({
       settings,
       provider: resolvedProvider.entry.provider,
       model: resolvedProvider.entry.model,
+      customParameters: resolvedProvider.entry.customParameters,
       maxParallelJobs: resolvedProvider.entry.maxParallelJobs,
     });
   }
@@ -340,6 +354,7 @@ export async function resolveAgentPipelineAgents({
       connectionId: defaultAgentConn?.id ?? null,
       fallbackProvider: chatProvider,
       fallbackModel: chatModel,
+      fallbackCustomParameters: chatCustomParameters,
       fallbackMaxParallelJobs: chatMaxParallelJobs,
       resolveBaseUrl,
     });
@@ -385,6 +400,7 @@ export async function resolveAgentPipelineAgents({
       settings: builtInSettings,
       provider: builtInConnection.entry.provider,
       model: builtInConnection.entry.model,
+      customParameters: builtInConnection.entry.customParameters,
       maxParallelJobs: builtInConnection.entry.maxParallelJobs,
     });
   }

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -17,6 +17,7 @@ import { sidecarModelService } from "../sidecar/sidecar-model.service.js";
 import type { ResolvedAgent } from "../agents/agent-pipeline.js";
 import { logger } from "../../lib/logger.js";
 import {
+  buildAgentConnectionUnavailableWarning,
   buildDefaultAgentConnectionWarning,
   buildLocalSidecarUnavailableWarning,
   resolveAgentConnectionId,
@@ -53,6 +54,12 @@ type AgentProviderCacheEntry = {
   provider: BaseLLMProvider;
   model: string;
   maxParallelJobs: number;
+};
+
+type AgentConnectionResolution = {
+  entry: AgentProviderCacheEntry | null;
+  unavailableReason?: string;
+  connectionName?: string;
 };
 
 export type ResolvedAgentPipelineAgents = {
@@ -115,44 +122,57 @@ async function resolveAgentConnectionProvider(args: {
   fallbackModel: string;
   fallbackMaxParallelJobs: number;
   resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string;
-}): Promise<AgentProviderCacheEntry> {
+}): Promise<AgentConnectionResolution> {
   if (!args.connectionId) {
     return {
-      provider: args.fallbackProvider,
-      model: args.fallbackModel,
-      maxParallelJobs: args.fallbackMaxParallelJobs,
+      entry: {
+        provider: args.fallbackProvider,
+        model: args.fallbackModel,
+        maxParallelJobs: args.fallbackMaxParallelJobs,
+      },
     };
   }
 
   const cached = args.agentProviderCache.get(args.connectionId);
-  if (cached) return cached;
+  if (cached) return { entry: cached };
 
   const agentConn = await args.connections.getWithKey(args.connectionId);
-  if (agentConn) {
-    const agentBaseUrl = args.resolveBaseUrl(agentConn);
-    if (agentBaseUrl) {
-      const resolved = {
-        provider: createLLMProvider(
-          agentConn.provider,
-          agentBaseUrl,
-          agentConn.apiKey,
-          agentConn.maxContext,
-          agentConn.openrouterProvider,
-          agentConn.maxTokensOverride,
-        ),
-        model: agentConn.model,
-        maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
-      };
-      args.agentProviderCache.set(args.connectionId, resolved);
-      return resolved;
-    }
+  if (!agentConn) {
+    return { entry: null, unavailableReason: "the configured connection was deleted" };
   }
 
-  return {
-    provider: args.fallbackProvider,
-    model: args.fallbackModel,
-    maxParallelJobs: args.fallbackMaxParallelJobs,
+  const model = typeof agentConn.model === "string" ? agentConn.model.trim() : "";
+  if (!model) {
+    return {
+      entry: null,
+      unavailableReason: "no model is selected",
+      connectionName: agentConn.name,
+    };
+  }
+
+  const agentBaseUrl = args.resolveBaseUrl(agentConn);
+  if (!agentBaseUrl) {
+    return {
+      entry: null,
+      unavailableReason: "the Base URL is empty or cannot be resolved",
+      connectionName: agentConn.name,
+    };
+  }
+
+  const resolved = {
+    provider: createLLMProvider(
+      agentConn.provider,
+      agentBaseUrl,
+      agentConn.apiKey,
+      agentConn.maxContext,
+      agentConn.openrouterProvider,
+      agentConn.maxTokensOverride,
+    ),
+    model,
+    maxParallelJobs: Number(agentConn.maxParallelJobs) || 1,
   };
+  args.agentProviderCache.set(args.connectionId, resolved);
+  return { entry: resolved };
 }
 
 export async function resolveAgentPipelineAgents({
@@ -195,28 +215,31 @@ export async function resolveAgentPipelineAgents({
     });
   }
 
-  const defaultAgentConn = await connections.getDefaultForAgents();
-  if (defaultAgentConn) {
-    const defaultAgentBaseUrl = resolveBaseUrl(defaultAgentConn);
-    if (defaultAgentBaseUrl) {
-      agentProviderCache.set(defaultAgentConn.id, {
-        provider: createLLMProvider(
-          defaultAgentConn.provider,
-          defaultAgentBaseUrl,
-          defaultAgentConn.apiKey,
-          defaultAgentConn.maxContext,
-          defaultAgentConn.openrouterProvider,
-          defaultAgentConn.maxTokensOverride,
-        ),
-        model: defaultAgentConn.model,
-        maxParallelJobs: Number(defaultAgentConn.maxParallelJobs) || 1,
-      });
-    }
-  }
-
   const agentConnectionWarnings: AgentConnectionWarning[] = [];
   const skippedLocalSidecarAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
+  const unavailableConnectionWarnings = new Map<
+    string,
+    { reason: string; connectionName?: string; agentNames: string[] }
+  >();
+  const addUnavailableConnectionWarning = (
+    agentName: string,
+    resolution: Pick<AgentConnectionResolution, "unavailableReason" | "connectionName">,
+  ) => {
+    const reason = resolution.unavailableReason ?? "the connection is unavailable";
+    const key = `${resolution.connectionName ?? ""}:${reason}`;
+    const existing = unavailableConnectionWarnings.get(key);
+    if (existing) {
+      existing.agentNames.push(agentName);
+    } else {
+      unavailableConnectionWarnings.set(key, {
+        reason,
+        connectionName: resolution.connectionName,
+        agentNames: [agentName],
+      });
+    }
+  };
+  const defaultAgentConn = await connections.getDefaultForAgents();
   for (const cfg of enabledConfigs) {
     if (hasPerChatAgentList && !perChatAgentSet.has(cfg.type)) continue;
 
@@ -257,10 +280,6 @@ export async function resolveAgentPipelineAgents({
       continue;
     }
 
-    if (defaultAgentConn && effectiveConnectionId === defaultAgentConn.id) {
-      defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
-    }
-
     const resolvedProvider = await resolveAgentConnectionProvider({
       connections,
       agentProviderCache,
@@ -270,6 +289,20 @@ export async function resolveAgentPipelineAgents({
       fallbackMaxParallelJobs: chatMaxParallelJobs,
       resolveBaseUrl,
     });
+    if (!resolvedProvider.entry) {
+      addUnavailableConnectionWarning(cfg.name ?? cfg.type, resolvedProvider);
+      logger.warn(
+        "[generate] Skipping agent %s for chat %s because its connection is unavailable: %s",
+        cfg.type,
+        chatId,
+        resolvedProvider.unavailableReason ?? "unknown reason",
+      );
+      continue;
+    }
+
+    if (defaultAgentConn && effectiveConnectionId === defaultAgentConn.id) {
+      defaultAgentConnectionAgents.push(cfg.name ?? cfg.type);
+    }
 
     resolvedAgents.push({
       id: cfg.id,
@@ -279,9 +312,9 @@ export async function resolveAgentPipelineAgents({
       promptTemplate: selectedPromptTemplate,
       connectionId: effectiveConnectionId,
       settings,
-      provider: resolvedProvider.provider,
-      model: resolvedProvider.model,
-      maxParallelJobs: resolvedProvider.maxParallelJobs,
+      provider: resolvedProvider.entry.provider,
+      model: resolvedProvider.entry.model,
+      maxParallelJobs: resolvedProvider.entry.maxParallelJobs,
     });
   }
 
@@ -301,10 +334,26 @@ export async function resolveAgentPipelineAgents({
       : [];
 
   for (const builtIn of builtInFallbacks) {
-    const builtInCached = defaultAgentConn ? agentProviderCache.get(defaultAgentConn.id) : null;
-    if (defaultAgentConn) {
-      defaultAgentConnectionAgents.push(builtIn.name);
+    const builtInConnection = await resolveAgentConnectionProvider({
+      connections,
+      agentProviderCache,
+      connectionId: defaultAgentConn?.id ?? null,
+      fallbackProvider: chatProvider,
+      fallbackModel: chatModel,
+      fallbackMaxParallelJobs: chatMaxParallelJobs,
+      resolveBaseUrl,
+    });
+    if (!builtInConnection.entry) {
+      addUnavailableConnectionWarning(builtIn.name, builtInConnection);
+      logger.warn(
+        "[generate] Skipping built-in agent %s for chat %s because its connection is unavailable: %s",
+        builtIn.id,
+        chatId,
+        builtInConnection.unavailableReason ?? "unknown reason",
+      );
+      continue;
     }
+    if (defaultAgentConn) defaultAgentConnectionAgents.push(builtIn.name);
     let builtInSettings = getDefaultBuiltInAgentSettings(builtIn.id);
     if (builtIn.id === "spotify") {
       builtInSettings = applyMusicPlayerSourceToMusicDjSettings(builtInSettings, activeMusicPlayerSource);
@@ -334,21 +383,25 @@ export async function resolveAgentPipelineAgents({
       promptTemplate: selectedPromptTemplate,
       connectionId: defaultAgentConn?.id ?? null,
       settings: builtInSettings,
-      provider: builtInCached?.provider ?? chatProvider,
-      model: builtInCached?.model ?? chatModel,
-      maxParallelJobs: builtInCached?.maxParallelJobs ?? chatMaxParallelJobs,
+      provider: builtInConnection.entry.provider,
+      model: builtInConnection.entry.model,
+      maxParallelJobs: builtInConnection.entry.maxParallelJobs,
     });
   }
 
   // Smart group response selection is hidden runtime infrastructure now. It uses
   // the main generation provider directly instead of resolving a public agent.
 
+  for (const warning of unavailableConnectionWarnings.values()) {
+    agentConnectionWarnings.push(buildAgentConnectionUnavailableWarning(warning));
+  }
+
   if (defaultAgentConn && defaultAgentConnectionAgents.length > 0) {
     agentConnectionWarnings.push(
       buildDefaultAgentConnectionWarning({
         agentNames: defaultAgentConnectionAgents,
         connectionName: defaultAgentConn.name,
-        model: defaultAgentConn.model,
+        model: String(defaultAgentConn.model ?? "").trim(),
       }),
     );
   }

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -164,7 +164,6 @@ export function injectIdentityFallbackMessages(args: {
         appearance: resolveCharacterMacros(character.appearance),
         system_prompt: resolveCharacterMacros(character.systemPrompt),
         example_dialogue: resolveCharacterMacros(character.mesExample),
-        post_history_instructions: resolveCharacterMacros(character.postHistoryInstructions),
       },
       args.wrapFormat,
     );

--- a/packages/server/src/services/generation/committed-tracker-context.ts
+++ b/packages/server/src/services/generation/committed-tracker-context.ts
@@ -46,6 +46,10 @@ function formatStatValue(value: unknown, max: unknown): string {
   return maxText ? `${valueText}/${maxText}` : valueText;
 }
 
+function isNonEmptyLine(line: string | null): line is string {
+  return !!line;
+}
+
 function formatStatLine(stat: any): string | null {
   const name = asText(stat?.name);
   if (!name) return null;
@@ -72,7 +76,7 @@ function formatCharacterLine(character: any): string | null {
   if (character.outfit) details.push(`outfit: ${character.outfit}`);
   if (character.thoughts) details.push(`thoughts: ${character.thoughts}`);
   if (Array.isArray(character.stats) && character.stats.length > 0) {
-    const statStr = character.stats.map(formatStatSummary).filter((line): line is string => !!line).join(", ");
+    const statStr = (character.stats as unknown[]).map(formatStatSummary).filter(isNonEmptyLine).join(", ");
     if (statStr) details.push(`stats: ${statStr}`);
   }
 
@@ -87,10 +91,10 @@ function formatQuestLine(quest: any): string | null {
   const objectives = Array.isArray(quest.objectives)
     ? quest.objectives
         .map((objective: any) => {
-          const text = asText(objective?.text);
-          return text ? `  ${objective.completed ? "[x]" : "[ ]"} ${text}` : null;
-        })
-        .filter((line): line is string => !!line)
+      const text = asText(objective?.text);
+      return text ? `  ${objective.completed ? "[x]" : "[ ]"} ${text}` : null;
+    })
+        .filter(isNonEmptyLine)
         .join("\n")
     : "";
   return `- ${name}${objectives ? "\n" + objectives : ""}`;
@@ -139,7 +143,7 @@ export function buildCommittedTrackerContextBlock(args: {
   if (hasCharTracker) {
     const presentChars = parseMaybeJson(snap.presentCharacters);
     if (Array.isArray(presentChars) && presentChars.length > 0) {
-      const charLines = presentChars.map(formatCharacterLine).filter((line): line is string => !!line);
+      const charLines = presentChars.map(formatCharacterLine).filter(isNonEmptyLine);
       if (charLines.length > 0) trackerParts.push(wrapContent(charLines.join("\n"), "Present Characters", args.wrapFormat));
     }
   }
@@ -147,7 +151,7 @@ export function buildCommittedTrackerContextBlock(args: {
   if (hasPersonaStats && snap.personaStats) {
     const psBars = parseMaybeJson(snap.personaStats);
     if (Array.isArray(psBars) && psBars.length > 0) {
-      const barLines = psBars.map(formatStatLine).filter((line): line is string => !!line);
+      const barLines = psBars.map(formatStatLine).filter(isNonEmptyLine);
       if (barLines.length > 0) trackerParts.push(wrapContent(barLines.join("\n"), "Persona Stats", args.wrapFormat));
     }
   }
@@ -161,19 +165,19 @@ export function buildCommittedTrackerContextBlock(args: {
 
       if (hasQuest && Array.isArray(stats.activeQuests) && stats.activeQuests.length > 0) {
         const activeQuestsForContext = compactQuestProgressForContext(stats.activeQuests);
-        const questLines = activeQuestsForContext.map(formatQuestLine).filter((line): line is string => !!line);
+        const questLines = activeQuestsForContext.map(formatQuestLine).filter(isNonEmptyLine);
         if (questLines.length > 0) {
           trackerParts.push(wrapContent(questLines.join("\n"), "Active Quests", args.wrapFormat));
         }
       }
 
       if (hasPersonaStats && Array.isArray(stats.inventory) && stats.inventory.length > 0) {
-        const invLines = stats.inventory.map(formatInventoryLine).filter((line): line is string => !!line);
+        const invLines = (stats.inventory as unknown[]).map(formatInventoryLine).filter(isNonEmptyLine);
         if (invLines.length > 0) trackerParts.push(wrapContent(invLines.join("\n"), "Inventory", args.wrapFormat));
       }
 
       if (hasPersonaStats && Array.isArray(stats.stats) && stats.stats.length > 0) {
-        const statLines = stats.stats.map(formatStatLine).filter((line): line is string => !!line);
+        const statLines = (stats.stats as unknown[]).map(formatStatLine).filter(isNonEmptyLine);
         if (statLines.length > 0) trackerParts.push(wrapContent(statLines.join("\n"), "Stats", args.wrapFormat));
       }
 

--- a/packages/server/src/services/generation/committed-tracker-context.ts
+++ b/packages/server/src/services/generation/committed-tracker-context.ts
@@ -29,17 +29,89 @@ function parseMaybeJson(value: unknown): unknown {
   }
 }
 
-export function injectCommittedTrackerContext(args: {
-  messages: PromptMessage[];
+function asText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function finiteNumberText(value: unknown): string | null {
+  const numberValue =
+    typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : Number.NaN;
+  return Number.isFinite(numberValue) ? String(numberValue) : null;
+}
+
+function formatStatValue(value: unknown, max: unknown): string {
+  const valueText = finiteNumberText(value);
+  const maxText = finiteNumberText(max);
+  if (!valueText) return "unknown";
+  return maxText ? `${valueText}/${maxText}` : valueText;
+}
+
+function formatStatLine(stat: any): string | null {
+  const name = asText(stat?.name);
+  if (!name) return null;
+  return `- ${name}: ${formatStatValue(stat?.value, stat?.max)}`;
+}
+
+function formatStatSummary(stat: any): string | null {
+  const name = asText(stat?.name);
+  if (!name) return null;
+  return `${name}: ${formatStatValue(stat?.value, stat?.max)}`;
+}
+
+function formatCharacterLine(character: any): string | null {
+  if (typeof character === "string") {
+    const name = asText(character);
+    return name ? `- ${name}` : null;
+  }
+  const name = asText(character?.name);
+  if (!name) return null;
+
+  const details: string[] = [];
+  if (character.mood) details.push(`mood: ${character.mood}`);
+  if (character.appearance) details.push(`appearance: ${character.appearance}`);
+  if (character.outfit) details.push(`outfit: ${character.outfit}`);
+  if (character.thoughts) details.push(`thoughts: ${character.thoughts}`);
+  if (Array.isArray(character.stats) && character.stats.length > 0) {
+    const statStr = character.stats.map(formatStatSummary).filter((line): line is string => !!line).join(", ");
+    if (statStr) details.push(`stats: ${statStr}`);
+  }
+
+  const label = [asText(character.emoji), name].filter(Boolean).join(" ");
+  const detailStr = details.length > 0 ? ` (${details.join("; ")})` : "";
+  return `- ${label}${detailStr}`;
+}
+
+function formatQuestLine(quest: any): string | null {
+  const name = asText(quest?.name);
+  if (!name) return null;
+  const objectives = Array.isArray(quest.objectives)
+    ? quest.objectives
+        .map((objective: any) => {
+          const text = asText(objective?.text);
+          return text ? `  ${objective.completed ? "[x]" : "[ ]"} ${text}` : null;
+        })
+        .filter((line): line is string => !!line)
+        .join("\n")
+    : "";
+  return `- ${name}${objectives ? "\n" + objectives : ""}`;
+}
+
+function formatInventoryLine(item: any): string | null {
+  const name = asText(item?.name);
+  if (!name) return null;
+  const quantity = finiteNumberText(item?.quantity);
+  const description = asText(item?.description);
+  return `- ${name}${quantity && Number(quantity) > 1 ? ` x${quantity}` : ""}${description ? ` — ${description}` : ""}`;
+}
+
+export function buildCommittedTrackerContextBlock(args: {
   chatEnableAgents: boolean;
   activeAgentIds: string[];
   latestGameState: GameStateSnapshotLike | null | undefined;
   chatMetadata: Record<string, unknown>;
   wrapFormat: WrapFormat;
-  dedupeLastMessageWrappers(messages: PromptMessage[]): void;
-  findTrackerContextInsertIndex(messages: PromptMessage[]): number;
-}): void {
-  if (!args.chatEnableAgents || args.activeAgentIds.length === 0) return;
+}): string | null {
+  if (!args.chatEnableAgents || args.activeAgentIds.length === 0) return null;
 
   const active = new Set(args.activeAgentIds);
   const hasWorldState = active.has("world-state");
@@ -47,10 +119,10 @@ export function injectCommittedTrackerContext(args: {
   const hasPersonaStats = active.has("persona-stats");
   const hasQuest = active.has("quest");
   const hasCustomTracker = active.has("custom-tracker");
-  if (!hasWorldState && !hasCharTracker && !hasPersonaStats && !hasQuest && !hasCustomTracker) return;
+  if (!hasWorldState && !hasCharTracker && !hasPersonaStats && !hasQuest && !hasCustomTracker) return null;
 
   const snap = args.latestGameState ?? undefined;
-  if (!snap) return;
+  if (!snap) return null;
 
   const trackerParts: string[] = [];
 
@@ -67,31 +139,16 @@ export function injectCommittedTrackerContext(args: {
   if (hasCharTracker) {
     const presentChars = parseMaybeJson(snap.presentCharacters);
     if (Array.isArray(presentChars) && presentChars.length > 0) {
-      const charLines = presentChars.map((character: any) => {
-        if (typeof character === "string") return `- ${character}`;
-        const details: string[] = [];
-        if (character.mood) details.push(`mood: ${character.mood}`);
-        if (character.appearance) details.push(`appearance: ${character.appearance}`);
-        if (character.outfit) details.push(`outfit: ${character.outfit}`);
-        if (character.thoughts) details.push(`thoughts: ${character.thoughts}`);
-        if (Array.isArray(character.stats) && character.stats.length > 0) {
-          const statStr = character.stats
-            .map((stat: any) => `${stat.name}: ${stat.value}${stat.max ? `/${stat.max}` : ""}`)
-            .join(", ");
-          details.push(`stats: ${statStr}`);
-        }
-        const detailStr = details.length > 0 ? ` (${details.join("; ")})` : "";
-        return `- ${character.emoji ?? ""} ${character.name ?? character}${detailStr}`;
-      });
-      trackerParts.push(wrapContent(charLines.join("\n"), "Present Characters", args.wrapFormat));
+      const charLines = presentChars.map(formatCharacterLine).filter((line): line is string => !!line);
+      if (charLines.length > 0) trackerParts.push(wrapContent(charLines.join("\n"), "Present Characters", args.wrapFormat));
     }
   }
 
   if (hasPersonaStats && snap.personaStats) {
     const psBars = parseMaybeJson(snap.personaStats);
     if (Array.isArray(psBars) && psBars.length > 0) {
-      const barLines = psBars.map((bar: any) => `- ${bar.name}: ${bar.value}/${bar.max}`);
-      trackerParts.push(wrapContent(barLines.join("\n"), "Persona Stats", args.wrapFormat));
+      const barLines = psBars.map(formatStatLine).filter((line): line is string => !!line);
+      if (barLines.length > 0) trackerParts.push(wrapContent(barLines.join("\n"), "Persona Stats", args.wrapFormat));
     }
   }
 
@@ -104,28 +161,20 @@ export function injectCommittedTrackerContext(args: {
 
       if (hasQuest && Array.isArray(stats.activeQuests) && stats.activeQuests.length > 0) {
         const activeQuestsForContext = compactQuestProgressForContext(stats.activeQuests);
-        const questLines = activeQuestsForContext.map((quest) => {
-          const objectives = Array.isArray(quest.objectives)
-            ? quest.objectives.map((objective) => `  [ ] ${objective.text}`).join("\n")
-            : "";
-          return `- ${quest.name}${objectives ? "\n" + objectives : ""}`;
-        });
+        const questLines = activeQuestsForContext.map(formatQuestLine).filter((line): line is string => !!line);
         if (questLines.length > 0) {
           trackerParts.push(wrapContent(questLines.join("\n"), "Active Quests", args.wrapFormat));
         }
       }
 
       if (hasPersonaStats && Array.isArray(stats.inventory) && stats.inventory.length > 0) {
-        const invLines = stats.inventory.map(
-          (item: any) =>
-            `- ${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ""}${item.description ? ` — ${item.description}` : ""}`,
-        );
-        trackerParts.push(wrapContent(invLines.join("\n"), "Inventory", args.wrapFormat));
+        const invLines = stats.inventory.map(formatInventoryLine).filter((line): line is string => !!line);
+        if (invLines.length > 0) trackerParts.push(wrapContent(invLines.join("\n"), "Inventory", args.wrapFormat));
       }
 
       if (hasPersonaStats && Array.isArray(stats.stats) && stats.stats.length > 0) {
-        const statLines = stats.stats.map((stat: any) => `- ${stat.name}: ${stat.value}${stat.max ? `/${stat.max}` : ""}`);
-        trackerParts.push(wrapContent(statLines.join("\n"), "Stats", args.wrapFormat));
+        const statLines = stats.stats.map(formatStatLine).filter((line): line is string => !!line);
+        if (statLines.length > 0) trackerParts.push(wrapContent(statLines.join("\n"), "Stats", args.wrapFormat));
       }
 
       if (hasCustomTracker && Array.isArray(stats.customTrackerFields) && stats.customTrackerFields.length > 0) {
@@ -146,16 +195,36 @@ export function injectCommittedTrackerContext(args: {
     );
   }
 
-  if (trackerParts.length === 0) return;
+  if (trackerParts.length === 0) return null;
+
+  return args.wrapFormat === "none"
+    ? trackerParts.join("\n\n")
+    : args.wrapFormat === "xml"
+      ? `<context>\n${trackerParts.map((part) => "    " + part.replace(/\n/g, "\n    ")).join("\n")}\n</context>`
+      : `# Context\n*(Established state as of the last message. Do not re-describe — advance from here.)*\n${trackerParts.join("\n")}`;
+}
+
+export function injectCommittedTrackerContext(args: {
+  messages: PromptMessage[];
+  chatEnableAgents: boolean;
+  activeAgentIds: string[];
+  latestGameState: GameStateSnapshotLike | null | undefined;
+  chatMetadata: Record<string, unknown>;
+  wrapFormat: WrapFormat;
+  dedupeLastMessageWrappers(messages: PromptMessage[]): void;
+  findTrackerContextInsertIndex(messages: PromptMessage[]): number;
+}): void {
+  const contextBlock = buildCommittedTrackerContextBlock({
+    chatEnableAgents: args.chatEnableAgents,
+    activeAgentIds: args.activeAgentIds,
+    latestGameState: args.latestGameState,
+    chatMetadata: args.chatMetadata,
+    wrapFormat: args.wrapFormat,
+  });
+
+  if (!contextBlock) return;
 
   args.dedupeLastMessageWrappers(args.messages);
-  const contextBlock =
-    args.wrapFormat === "none"
-      ? trackerParts.join("\n\n")
-      : args.wrapFormat === "xml"
-        ? `<context>\n${trackerParts.map((part) => "    " + part.replace(/\n/g, "\n    ")).join("\n")}\n</context>`
-        : `# Context\n*(Established state as of the last message. Do not re-describe — advance from here.)*\n${trackerParts.join("\n")}`;
-
   args.messages.splice(args.findTrackerContextInsertIndex(args.messages), 0, {
     role: "user",
     content: contextBlock,

--- a/packages/server/src/services/generation/game-journal-runtime.ts
+++ b/packages/server/src/services/generation/game-journal-runtime.ts
@@ -2,7 +2,6 @@ import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
 import { createJournal, type Journal } from "../game/journal.service.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
-import { parseExtra } from "../../routes/generate/generate-route-utils.js";
 
 export async function updateJournal(
   db: DB,
@@ -11,14 +10,11 @@ export async function updateJournal(
 ): Promise<void> {
   try {
     const chatsStore = createChatsStorage(db);
-    const chat = await chatsStore.getById(chatId);
-    if (!chat) return;
-    const meta = parseExtra(chat.metadata) as Record<string, unknown>;
-    const journal = (meta.gameJournal as Journal) ?? createJournal();
-    const updated = transform(journal);
-    if (updated) {
-      await chatsStore.updateMetadata(chatId, { ...meta, gameJournal: updated });
-    }
+    await chatsStore.patchMetadata(chatId, (freshMeta) => {
+      const journal = (freshMeta.gameJournal as Journal) ?? createJournal();
+      const updated = transform(journal);
+      return updated ? { gameJournal: updated } : {};
+    });
   } catch (error) {
     logger.warn(error, "[game] Journal auto-fill failed for chat %s", chatId);
     // Non-critical; generation should not fail because journal auto-fill failed.

--- a/packages/server/src/services/generation/runtime-agent-sections.ts
+++ b/packages/server/src/services/generation/runtime-agent-sections.ts
@@ -31,16 +31,17 @@ export function formatAgentInjections(injections: AgentInjection[], wrapFormat: 
   if (injections.length === 1) {
     const { agentType, agentName, text } = injections[0]!;
     const label = agentName?.trim() || agentType;
-    const tag = nameToXmlTag(label) || agentType.replace(/[^a-z0-9_-]/gi, "_");
+    const tag = agentInjectionXmlTag(label, agentType);
     if (wrapFormat === "markdown") return `## ${label}\n${text}`;
     if (wrapFormat === "xml") return `<${tag}>\n${text}\n</${tag}>`;
     return text;
   }
 
   const parts: string[] = [];
+  const usedXmlTags = new Set<string>();
   for (const { agentType, agentName, text } of injections) {
     const label = agentName?.trim() || agentType;
-    const tag = nameToXmlTag(label) || agentType.replace(/[^a-z0-9_-]/gi, "_");
+    const tag = uniqueAgentInjectionXmlTag(label, agentType, usedXmlTags);
     if (wrapFormat === "markdown") {
       parts.push(`## ${label}\n${text}`);
     } else if (wrapFormat === "xml") {
@@ -50,6 +51,23 @@ export function formatAgentInjections(injections: AgentInjection[], wrapFormat: 
     }
   }
   return parts.join("\n\n");
+}
+
+function agentInjectionXmlTag(label: string, agentType: string): string {
+  const tag = nameToXmlTag(label) || nameToXmlTag(agentType) || "agent";
+  return /^[a-z_]/i.test(tag) ? tag : `agent_${tag}`;
+}
+
+function uniqueAgentInjectionXmlTag(label: string, agentType: string, usedTags: Set<string>): string {
+  const base = agentInjectionXmlTag(label, agentType);
+  let tag = base;
+  let index = 2;
+  while (usedTags.has(tag)) {
+    tag = `${base}-${index}`;
+    index += 1;
+  }
+  usedTags.add(tag);
+  return tag;
 }
 
 export function toRuntimeAgentSectionType(

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -94,6 +94,8 @@ export interface ImageGenRequest {
   referenceImages?: string[];
   /** Request a transparent image background when the provider/model supports it. */
   transparentBackground?: boolean;
+  /** Optional caller-owned abort signal for cancelling long image requests. */
+  signal?: AbortSignal;
 }
 
 export interface ImageGenResult {
@@ -244,6 +246,11 @@ function withImageGenerationDeadline<T>(promise: Promise<T>): Promise<T> {
   return Promise.race([promise, deadline]).finally(() => {
     if (timeout) clearTimeout(timeout);
   });
+}
+
+function imageRequestSignal(request: Pick<ImageGenRequest, "signal">): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(IMAGE_GEN_TIMEOUT);
+  return request.signal ? AbortSignal.any([request.signal, timeoutSignal]) : timeoutSignal;
 }
 
 function normalizeImageUrl(url: string | URL): string {
@@ -549,9 +556,7 @@ async function readOpenAIImageResult(
   };
   const item = data.data?.[0];
   const b64 = item?.b64_json ?? item?.image_base64;
-  if (!b64 && item?.url) {
-    return downloadImageUrl(item.url, request.allowLocalUrls);
-  }
+  if (!b64 && item?.url) return downloadImageUrl(item.url, request.allowLocalUrls, request.signal);
   if (!b64) {
     const fields = item
       ? Object.keys(item).join(", ")
@@ -564,7 +569,11 @@ async function readOpenAIImageResult(
   return { base64: b64, mimeType: "image/png", ext: "png" };
 }
 
-async function downloadImageUrl(imageUrl: string, allowLocalUrls = false): Promise<ImageGenResult> {
+async function downloadImageUrl(
+  imageUrl: string,
+  allowLocalUrls = false,
+  signal?: AbortSignal,
+): Promise<ImageGenResult> {
   if (imageUrl.trim().startsWith("data:")) {
     return decodeImageDataUrl(imageUrl);
   }
@@ -572,7 +581,7 @@ async function downloadImageUrl(imageUrl: string, allowLocalUrls = false): Promi
   const normalizedImageUrl = normalizeImageUrl(imageUrl);
   const imgResp = await imageFetch(
     normalizedImageUrl,
-    { signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT) },
+    { signal: imageRequestSignal({ signal }) },
     { allowLocal: allowLocalUrls },
   );
   if (!imgResp.ok) {
@@ -635,7 +644,7 @@ async function generateOpenAI(baseUrl: string, apiKey: string, request: ImageGen
           Authorization: `Bearer ${apiKey}`,
         },
         body: formData,
-        signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+        signal: imageRequestSignal(request),
       },
       { allowLocal: request.allowLocalUrls },
     );
@@ -670,7 +679,7 @@ async function generateOpenAI(baseUrl: string, apiKey: string, request: ImageGen
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -704,7 +713,7 @@ async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenReq
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -717,7 +726,7 @@ async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenReq
   const data = (await resp.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
   const result = data.data?.[0];
   if (result?.b64_json) return { base64: result.b64_json, mimeType: "image/png", ext: "png" };
-  if (result?.url) return downloadImageUrl(result.url, request.allowLocalUrls);
+  if (result?.url) return downloadImageUrl(result.url, request.allowLocalUrls, request.signal);
 
   throw new Error("No image data in xAI response");
 }
@@ -759,7 +768,7 @@ async function generateNanoGPT(baseUrl: string, apiKey: string, request: ImageGe
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -772,7 +781,7 @@ async function generateNanoGPT(baseUrl: string, apiKey: string, request: ImageGe
   const data = (await resp.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
   const result = data.data?.[0];
   if (result?.b64_json) return { base64: result.b64_json, mimeType: "image/png", ext: "png" };
-  if (result?.url) return downloadImageUrl(result.url, request.allowLocalUrls);
+  if (result?.url) return downloadImageUrl(result.url, request.allowLocalUrls, request.signal);
 
   throw new Error("No image data in NanoGPT response");
 }
@@ -787,7 +796,7 @@ async function generatePollinations(request: ImageGenRequest): Promise<ImageGenR
   if (request.negativePrompt) params.set("negative", request.negativePrompt);
 
   const url = `https://image.pollinations.ai/prompt/${encodeURIComponent(request.prompt)}?${params}`;
-  const resp = await imageFetch(url, { signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT) });
+  const resp = await imageFetch(url, { signal: imageRequestSignal(request) });
 
   if (!resp.ok) {
     throw new Error(`Pollinations image generation failed (${resp.status})`);
@@ -860,7 +869,7 @@ async function generateHorde(baseUrl: string, apiKey: string, request: ImageGenR
       method: "POST",
       headers: hordeHeaders(apiKey),
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -881,7 +890,7 @@ async function generateHorde(baseUrl: string, apiKey: string, request: ImageGenR
       hordeUrl(baseUrl, `generate/check/${encodeURIComponent(jobId)}`),
       {
         headers: hordeHeaders(apiKey),
-        signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+        signal: imageRequestSignal(request),
       },
       { allowLocal: request.allowLocalUrls },
     );
@@ -913,7 +922,7 @@ async function generateHorde(baseUrl: string, apiKey: string, request: ImageGenR
     hordeUrl(baseUrl, `generate/status/${encodeURIComponent(jobId)}`),
     {
       headers: hordeHeaders(apiKey),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -933,7 +942,7 @@ async function generateHorde(baseUrl: string, apiKey: string, request: ImageGenR
 
   const image = generation.img.trim();
   if (image.startsWith("data:")) return decodeImageDataUrl(image);
-  if (/^https?:\/\//i.test(image)) return downloadImageUrl(image, request.allowLocalUrls);
+  if (/^https?:\/\//i.test(image)) return downloadImageUrl(image, request.allowLocalUrls, request.signal);
 
   const mimeType = detectImageMimeType(image);
   return { base64: image, mimeType, ext: imageExtensionFromMimeType(mimeType) };
@@ -1058,7 +1067,7 @@ async function generateStability(baseUrl: string, apiKey: string, request: Image
         Accept: "image/*",
       },
       body: formData,
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -1099,7 +1108,7 @@ async function generateStabilityV1(baseUrl: string, apiKey: string, request: Ima
         Accept: "application/json",
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -1137,7 +1146,7 @@ async function generateTogetherAI(baseUrl: string, apiKey: string, request: Imag
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -1271,7 +1280,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -1551,7 +1560,7 @@ async function generateOpenRouter(baseUrl: string, apiKey: string, request: Imag
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -1616,7 +1625,7 @@ async function generateOpenRouter(baseUrl: string, apiKey: string, request: Imag
     );
   }
 
-  return downloadImageUrl(imageUrl, request.allowLocalUrls);
+  return downloadImageUrl(imageUrl, request.allowLocalUrls, request.signal);
 }
 
 /**
@@ -1646,7 +1655,7 @@ async function generateViaChatCompletions(
         stream: false,
         temperature: 0.7,
       }),
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },
   );
@@ -1670,7 +1679,7 @@ async function generateViaChatCompletions(
     throw new Error(`No image URL found in proxy response: ${content.slice(0, 200)}`);
   }
 
-  return downloadImageUrl(imageUrl, request.allowLocalUrls);
+  return downloadImageUrl(imageUrl, request.allowLocalUrls, request.signal);
 }
 
 // ── ComfyUI ──
@@ -1799,7 +1808,7 @@ function replaceComfyUiPlaceholders(value: unknown, replacements: Record<string,
   return value;
 }
 
-async function uploadComfyReferenceImage(base: string, reference: string): Promise<string> {
+async function uploadComfyReferenceImage(base: string, reference: string, signal?: AbortSignal): Promise<string> {
   const decoded = decodeReferenceImage(reference);
   const imageBytes = Buffer.from(decoded.base64, "base64");
   const hash = createHash("sha256").update(imageBytes).digest("hex").slice(0, 16);
@@ -1812,7 +1821,7 @@ async function uploadComfyReferenceImage(base: string, reference: string): Promi
   const resp = await localImageBackendFetch(`${base}/upload/image`, {
     method: "POST",
     body: formData,
-    signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+    signal: imageRequestSignal({ signal }),
   });
 
   if (!resp.ok) {
@@ -1892,7 +1901,7 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
     if (i === 0) replacements["%reference_image%"] = reference;
 
     if (workflowJson.includes(namePlaceholder) || (i === 0 && workflowJson.includes("%reference_image_name%"))) {
-      const uploadedName = await uploadComfyReferenceImage(base, reference);
+      const uploadedName = await uploadComfyReferenceImage(base, reference, request.signal);
       replacements[namePlaceholder] = uploadedName;
       if (i === 0) replacements["%reference_image_name%"] = uploadedName;
     }
@@ -1904,7 +1913,7 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ prompt: resolvedWorkflow }),
-    signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+    signal: imageRequestSignal(request),
   });
 
   if (!queueResp.ok) {
@@ -1919,7 +1928,7 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
     await new Promise((r) => setTimeout(r, 1000));
 
     const historyResp = await localImageBackendFetch(`${base}/history/${prompt_id}`, {
-      signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+      signal: imageRequestSignal(request),
     });
     if (!historyResp.ok) continue;
 
@@ -1941,7 +1950,7 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
           });
 
           const imgResp = await localImageBackendFetch(`${base}/view?${params}`, {
-            signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+            signal: imageRequestSignal(request),
           });
           if (!imgResp.ok) {
             throw new Error(`ComfyUI image fetch failed (${imgResp.status})`);
@@ -2026,7 +2035,7 @@ async function generateAutomatic1111(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    signal: AbortSignal.timeout(IMAGE_GEN_TIMEOUT),
+    signal: imageRequestSignal(request),
   });
 
   if (!resp.ok) {

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -15,11 +15,23 @@ import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import { createPromptsStorage } from "../storage/prompts.storage.js";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "./import-timestamps.js";
 import { resolveLorebookEntryRole } from "./lorebook-role.js";
-import { resolvePosition, resolveSelectiveLogic } from "./st-lorebook.importer.js";
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from "../../utils/security.js";
+
+function resolveNativeSelectiveLogic(value: unknown): "and" | "or" | "not" {
+  return value === "or" || value === "not" ? value : "and";
+}
+
+function resolveNativePosition(value: unknown): number {
+  if (typeof value === "string") {
+    if (value === "after_char") return 1;
+    if (value === "at_depth" || value === "depth") return 2;
+    return 0;
+  }
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 2 ? value : 0;
+}
 
 // Decode a base64 data URL into validated image bytes. Returns null if the
 // payload is missing, malformed, or not a recognized image type — so callers
@@ -465,11 +477,11 @@ async function importLorebook(data: unknown, db: DB) {
       return {
         name: String(e.name ?? ""),
         content: String(e.content ?? ""),
-        // CodeRabbit-flagged: description, ephemeral, locked, and preventRecursion
+        // CodeRabbit-flagged: description, ephemeral, locked, and recursion flags
         // were absent from the previous map, so an exported lorebook would lose
         // these fields on re-import. Knowledge-router matching uses description,
         // ephemeral controls auto-disable countdown, locked protects entries
-        // from the Lorebook Keeper agent, and preventRecursion gates recursive
+        // from the Lorebook Keeper agent, and recursion flags gate recursive
         // scanning — all behaviors that should round-trip.
         description: String(e.description ?? ""),
         keys: Array.isArray(e.keys) ? e.keys.map(String) : [],
@@ -477,7 +489,7 @@ async function importLorebook(data: unknown, db: DB) {
         enabled: e.enabled !== false,
         constant: Boolean(e.constant),
         selective: Boolean(e.selective),
-        selectiveLogic: resolveSelectiveLogic(e.selectiveLogic),
+        selectiveLogic: resolveNativeSelectiveLogic(e.selectiveLogic),
         probability: e.probability != null ? Number(e.probability) : null,
         scanDepth: e.scanDepth != null ? Number(e.scanDepth) : null,
         matchWholeWords: Boolean(e.matchWholeWords),
@@ -492,7 +504,7 @@ async function importLorebook(data: unknown, db: DB) {
           ? e.generationTriggerFilters.map(String)
           : [],
         additionalMatchingSources: readMatchingSources(e.additionalMatchingSources),
-        position: resolvePosition(e.position),
+        position: resolveNativePosition(e.position),
         depth: Number(e.depth ?? 4),
         order: Number(e.order ?? 100),
         role: resolveLorebookEntryRole(e.role),
@@ -505,6 +517,8 @@ async function importLorebook(data: unknown, db: DB) {
         folderId: newFolderId,
         locked: Boolean(e.locked),
         preventRecursion: Boolean(e.preventRecursion),
+        excludeRecursion: Boolean(e.excludeRecursion),
+        delayUntilRecursion: Boolean(e.delayUntilRecursion),
         excludeFromVectorization: Boolean(e.excludeFromVectorization),
         tag: String(e.tag ?? ""),
         relationships: (e.relationships as any) ?? {},

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -20,8 +20,8 @@ import { join } from "path";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from "../../utils/security.js";
 
-function resolveNativeSelectiveLogic(value: unknown): "and" | "or" | "not" {
-  return value === "or" || value === "not" ? value : "and";
+function resolveNativeSelectiveLogic(value: unknown): "and" | "and_all" | "or" | "not" | "not_all" {
+  return value === "and_all" || value === "or" || value === "not" || value === "not_all" ? value : "and";
 }
 
 function resolveNativePosition(value: unknown): number {

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -753,6 +753,7 @@ function normalizeCharacterBook(raw: unknown): CharacterData["character_book"] {
     const passthrough = pickDefinedFields(e, CHARACTER_BOOK_ENTRY_PASSTHROUGH_FIELDS);
 
     return {
+      ...passthrough,
       keys: normalizeStringArray(e.key ?? e.keys),
       secondary_keys: normalizeStringArray(e.keysecondary ?? e.secondary_keys),
       content: String(e.content ?? ""),
@@ -767,7 +768,6 @@ function normalizeCharacterBook(raw: unknown): CharacterData["character_book"] {
       selective: Boolean(e.selective ?? false),
       constant: Boolean(e.constant ?? false),
       position,
-      ...passthrough,
       ...(depth !== null ? { depth } : {}),
       ...(role !== undefined ? { role } : {}),
     };

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -99,15 +99,16 @@ export interface STCharacterImportOptions {
 }
 
 // SillyTavern regex placement ids → our placement strings (1 = user input, 2 = AI output).
-function convertStPlacements(placement: unknown): RegexPlacement[] {
+// Unknown-only placement arrays are skipped by the importer instead of being
+// silently remapped to AI output.
+function convertStPlacements(placement: unknown): RegexPlacement[] | null {
+  if (!Array.isArray(placement)) return ["ai_output"];
   const out: RegexPlacement[] = [];
-  if (Array.isArray(placement)) {
-    for (const n of placement) {
-      if (n === 1 && !out.includes("user_input")) out.push("user_input");
-      else if (n === 2 && !out.includes("ai_output")) out.push("ai_output");
-    }
+  for (const n of placement) {
+    if (n === 1 && !out.includes("user_input")) out.push("user_input");
+    else if (n === 2 && !out.includes("ai_output")) out.push("ai_output");
   }
-  return out;
+  return out.length > 0 ? out : null;
 }
 
 /**
@@ -132,26 +133,23 @@ function convertStRegexScripts(
     const delimited = /^\/(.*)\/([a-z]*)$/is.exec(rawFind);
     const source = delimited ? delimited[1]! : rawFind;
     if (!source || !isPatternSafe(source)) continue;
-    let flags = Array.from(new Set((delimited?.[2] || "gi").replace(/[^gimsuy]/g, ""))).join("");
-    if (!flags.includes("g")) flags += "g";
+    const flags = Array.from(new Set((delimited?.[2] ?? "").replace(/[^gimsuy]/g, ""))).join("");
     try {
       new RegExp(source, flags);
     } catch {
       continue;
     }
     const placement = convertStPlacements(s.placement);
-    const resolvedPlacement: RegexPlacement[] = placement.length > 0 ? placement : ["ai_output"];
+    if (!placement) continue;
     out.push({
       name: typeof s.scriptName === "string" && s.scriptName.trim() ? s.scriptName.trim() : "Imported regex",
       enabled: s.disabled !== true,
       findRegex: source,
       replaceString: typeof s.replaceString === "string" ? s.replaceString : "",
       trimStrings: Array.isArray(s.trimStrings) ? s.trimStrings.filter((t): t is string => typeof t === "string") : [],
-      placement: resolvedPlacement,
+      placement,
       flags,
-      // Imported scripts transform displayed messages, gated by the chat's Scoped
-      // Regex mode — they stay opt-in per chat rather than always rewriting prompts.
-      promptOnly: false,
+      promptOnly: s.promptOnly === true || s.prompt_only === true || s.onlyFormatPrompt === true,
       targetCharacterIds: scope === "global" ? [] : [characterId],
       // Preserve the card's authoring order so multi-script imports keep a stable
       // execution/list order (all-zero ties leave it undefined). Gaps from skipped

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -9,7 +9,13 @@ import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import { createRegexScriptsStorage } from "../storage/regex-scripts.storage.js";
 import { importSTLorebook } from "./st-lorebook.importer.js";
 import { isPatternSafe } from "@marinara-engine/shared";
-import type { CharacterData, CreateRegexScriptInput, RegexPlacement } from "@marinara-engine/shared";
+import type {
+  CharacterBookEntryPosition,
+  CharacterBookEntryRole,
+  CharacterData,
+  CreateRegexScriptInput,
+  RegexPlacement,
+} from "@marinara-engine/shared";
 import { existsSync, mkdirSync } from "fs";
 import { unlink, writeFile } from "fs/promises";
 import { join } from "path";
@@ -534,6 +540,25 @@ function selectBestCharacterBook(...books: unknown[]): unknown {
   return best;
 }
 
+function normalizeCharacterBookPosition(value: unknown): CharacterBookEntryPosition {
+  if (typeof value === "string") {
+    if (value === "after_char" || value === "at_depth" || value === "depth") return value;
+    return "before_char";
+  }
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 6) {
+    return value as CharacterBookEntryPosition;
+  }
+  return "before_char";
+}
+
+function normalizeCharacterBookRole(value: unknown): CharacterBookEntryRole | undefined {
+  if (value === "system" || value === "user" || value === "assistant") return value;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 2) {
+    return value as CharacterBookEntryRole;
+  }
+  return undefined;
+}
+
 function buildCardSpecMetadata(raw: Record<string, unknown>) {
   const spec = typeof raw.spec === "string" ? raw.spec : null;
   const specVersion = typeof raw.spec_version === "string" ? raw.spec_version : null;
@@ -668,13 +693,9 @@ function normalizeCharacterBook(raw: unknown): CharacterData["character_book"] {
   const book = raw as Record<string, unknown>;
 
   const entries = getCharacterBookEntries(book).map((e, i) => {
-    const posRaw = e.position;
-    let position: "before_char" | "after_char" = "before_char";
-    if (typeof posRaw === "string") {
-      position = posRaw === "after_char" ? "after_char" : "before_char";
-    } else if (typeof posRaw === "number") {
-      position = posRaw === 1 ? "after_char" : "before_char";
-    }
+    const position = normalizeCharacterBookPosition(e.position);
+    const depth = typeof e.depth === "number" && Number.isFinite(e.depth) ? e.depth : null;
+    const role = normalizeCharacterBookRole(e.role);
     const title = firstNonEmptyString(e.comment, e.name) ?? `Entry ${i + 1}`;
 
     return {
@@ -692,6 +713,8 @@ function normalizeCharacterBook(raw: unknown): CharacterData["character_book"] {
       selective: Boolean(e.selective ?? false),
       constant: Boolean(e.constant ?? false),
       position,
+      ...(depth !== null ? { depth } : {}),
+      ...(role !== undefined ? { role } : {}),
     };
   });
 

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -21,6 +21,7 @@ import { unlink, writeFile } from "fs/promises";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import { DATA_DIR } from "../../utils/data-dir.js";
+import { isAllowedImageBuffer } from "../../utils/security.js";
 import AdmZip from "adm-zip";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "./import-timestamps.js";
 
@@ -222,16 +223,19 @@ export async function importSTCharacter(raw: Record<string, unknown>, db: DB, op
   // Save avatar image if provided
   let avatarPath: string | undefined;
   if (avatarDataUrl && avatarDataUrl.startsWith("data:image/")) {
-    ensureAvatarDir();
-    const ext = avatarDataUrl.match(/^data:image\/([\w+]+);/)?.[1]?.replace("+xml", "") ?? "png";
-    const filename = `${randomUUID()}.${ext}`;
-    const filePath = join(AVATAR_DIR, filename);
-
     // Strip data URL header → raw base64
     const base64 = avatarDataUrl.split(",")[1];
     if (base64) {
-      await writeFile(filePath, Buffer.from(base64, "base64"));
-      avatarPath = `/api/avatars/file/${filename}`;
+      const declaredExt = avatarDataUrl.match(/^data:image\/([\w+]+);/)?.[1]?.replace("+xml", "");
+      const avatarBuffer = Buffer.from(base64, "base64");
+      const imageInfo = isAllowedImageBuffer(avatarBuffer, declaredExt ? `.${declaredExt}` : undefined);
+      if (imageInfo) {
+        ensureAvatarDir();
+        const filename = `${randomUUID()}.${imageInfo.ext}`;
+        const filePath = join(AVATAR_DIR, filename);
+        await writeFile(filePath, avatarBuffer);
+        avatarPath = `/api/avatars/file/${filename}`;
+      }
     }
   }
 
@@ -434,9 +438,12 @@ export async function importCharX(buf: Buffer, db: DB, options?: STCharacterImpo
       const entry = zip.getEntry(fallback);
       if (entry) {
         const ext = fallback.split(".").pop() ?? "png";
-        const mime = ext === "jpg" ? "jpeg" : ext;
-        avatarDataUrl = `data:image/${mime};base64,${entry.getData().toString("base64")}`;
-        break;
+        const data = entry.getData();
+        const imageInfo = isAllowedImageBuffer(data, `.${ext}`);
+        if (imageInfo) {
+          avatarDataUrl = `data:${imageInfo.mimeType};base64,${data.toString("base64")}`;
+          break;
+        }
       }
     }
   }
@@ -673,9 +680,11 @@ function resolveCharXAsset(zip: AdmZip, uri: string, ext?: string): string | nul
   const entry = zip.getEntry(zipPath);
   if (!entry) return null;
 
+  const data = entry.getData();
   const fileExt = ext ?? zipPath.split(".").pop() ?? "png";
-  const mime = fileExt === "jpg" ? "jpeg" : fileExt;
-  return `data:image/${mime};base64,${entry.getData().toString("base64")}`;
+  const imageInfo = isAllowedImageBuffer(data, `.${fileExt}`);
+  if (!imageInfo) return null;
+  return `data:${imageInfo.mimeType};base64,${data.toString("base64")}`;
 }
 
 function normalizeV2(raw: Record<string, unknown>): CharacterData {

--- a/packages/server/src/services/import/st-character.importer.ts
+++ b/packages/server/src/services/import/st-character.importer.ts
@@ -487,13 +487,14 @@ function normalizeCharacterData(raw: Record<string, unknown>): CharacterData {
     // V2 / V3 format — extract from data wrapper
     return normalizeV2(raw.data as Record<string, unknown>);
   }
+  if (raw.type === "character" && raw.data) {
+    // RisuAI format
+    const data = raw.data && typeof raw.data === "object" ? (raw.data as Record<string, unknown>) : {};
+    return convertRisuToV2({ ...raw, ...data });
+  }
   if (raw.char_name || raw.name) {
     // V1 / Pygmalion format — convert to V2
     return convertV1toV2(raw);
-  }
-  if (raw.type === "character" && raw.data) {
-    // RisuAI format
-    return convertRisuToV2((raw.data as Record<string, unknown>) ?? {});
   }
   // Try treating the whole object as character data
   return normalizeV2(raw);
@@ -558,6 +559,51 @@ function normalizeCharacterBookRole(value: unknown): CharacterBookEntryRole | un
   }
   return undefined;
 }
+
+function optionalRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function pickDefinedFields(source: Record<string, unknown>, fields: string[]): Record<string, unknown> {
+  const picked: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (source[field] !== undefined) picked[field] = source[field];
+  }
+  return picked;
+}
+
+const V3_CHARACTER_DATA_FIELDS = [
+  "group_only_greetings",
+  "nickname",
+  "assets",
+  "creation_date",
+  "source",
+  "creator_notes_multilingual",
+];
+
+const CHARACTER_BOOK_ENTRY_PASSTHROUGH_FIELDS = [
+  "probability",
+  "useProbability",
+  "use_probability",
+  "selectiveLogic",
+  "sticky",
+  "cooldown",
+  "delay",
+  "group",
+  "groupWeight",
+  "scanDepth",
+  "scan_depth",
+  "matchWholeWords",
+  "match_whole_words",
+  "caseSensitive",
+  "case_sensitive",
+  "useRegex",
+  "regex",
+  "preventRecursion",
+  "excludeRecursion",
+  "delayUntilRecursion",
+  "vectorized",
+];
 
 function buildCardSpecMetadata(raw: Record<string, unknown>) {
   const spec = typeof raw.spec === "string" ? raw.spec : null;
@@ -635,8 +681,7 @@ function resolveCharXAsset(zip: AdmZip, uri: string, ext?: string): string | nul
 }
 
 function normalizeV2(raw: Record<string, unknown>): CharacterData {
-  const rawExtensions =
-    raw.extensions && typeof raw.extensions === "object" ? (raw.extensions as Record<string, unknown>) : {};
+  const rawExtensions = optionalRecord(raw.extensions);
   return {
     name: String(raw.name ?? "Unknown"),
     description: String(raw.description ?? ""),
@@ -667,6 +712,7 @@ function normalizeV2(raw: Record<string, unknown>): CharacterData {
       appearance: String(rawExtensions.appearance ?? ""),
     },
     character_book: normalizeCharacterBook(raw.character_book),
+    ...pickDefinedFields(raw, V3_CHARACTER_DATA_FIELDS),
   };
 }
 
@@ -697,6 +743,7 @@ function normalizeCharacterBook(raw: unknown): CharacterData["character_book"] {
     const depth = typeof e.depth === "number" && Number.isFinite(e.depth) ? e.depth : null;
     const role = normalizeCharacterBookRole(e.role);
     const title = firstNonEmptyString(e.comment, e.name) ?? `Entry ${i + 1}`;
+    const passthrough = pickDefinedFields(e, CHARACTER_BOOK_ENTRY_PASSTHROUGH_FIELDS);
 
     return {
       keys: normalizeStringArray(e.key ?? e.keys),
@@ -713,6 +760,7 @@ function normalizeCharacterBook(raw: unknown): CharacterData["character_book"] {
       selective: Boolean(e.selective ?? false),
       constant: Boolean(e.constant ?? false),
       position,
+      ...passthrough,
       ...(depth !== null ? { depth } : {}),
       ...(role !== undefined ? { role } : {}),
     };
@@ -751,21 +799,47 @@ function convertV1toV2(raw: Record<string, unknown>): CharacterData {
 }
 
 function convertRisuToV2(raw: Record<string, unknown>): CharacterData {
+  const risuExtensions: Record<string, unknown> = {
+    ...optionalRecord(raw.extensions),
+    ...pickDefinedFields(raw, [
+      "depth_prompt",
+      "depthPrompt",
+      "talkativeness",
+      "fav",
+      "world",
+      "regex_scripts",
+      "regexScripts",
+      "backstory",
+      "appearance",
+    ]),
+  };
+  if (risuExtensions.depth_prompt === undefined && raw.depthPrompt !== undefined) {
+    risuExtensions.depth_prompt = raw.depthPrompt;
+  }
+  if (risuExtensions.regex_scripts === undefined && raw.regexScripts !== undefined) {
+    risuExtensions.regex_scripts = raw.regexScripts;
+  }
+
   return normalizeV2({
     name: raw.name ?? "Unknown",
     description: raw.description ?? "",
     personality: raw.personality ?? "",
     scenario: raw.scenario ?? "",
-    first_mes: raw.firstMessage ?? raw.first_mes ?? "",
-    mes_example: raw.exampleMessage ?? raw.mes_example ?? "",
+    first_mes: raw.firstMessage ?? raw.first_mes ?? raw.first_message ?? "",
+    mes_example: raw.exampleMessage ?? raw.mes_example ?? raw.example_dialogue ?? "",
     system_prompt: raw.systemPrompt ?? "",
     creator_notes: raw.creatorNotes ?? "",
-    post_history_instructions: "",
+    post_history_instructions:
+      raw.postHistoryInstructions ?? raw.post_history_instructions ?? raw.jailbreak ?? raw.jailbreakPrompt ?? "",
     tags: Array.isArray(raw.tags) ? raw.tags.map(String) : [],
     creator: String(raw.creator ?? ""),
-    character_version: "",
-    alternate_greetings: Array.isArray(raw.alternateGreetings) ? raw.alternateGreetings.map(String) : [],
-    extensions: {},
-    character_book: null,
+    character_version: raw.characterVersion ?? raw.character_version ?? "",
+    alternate_greetings: Array.isArray(raw.alternateGreetings)
+      ? raw.alternateGreetings.map(String)
+      : Array.isArray(raw.alternate_greetings)
+        ? raw.alternate_greetings.map(String)
+        : [],
+    extensions: risuExtensions,
+    character_book: raw.character_book ?? raw.characterBook ?? raw.lorebook ?? raw.world_info ?? raw.worldInfo ?? null,
   });
 }

--- a/packages/server/src/services/import/st-chat.importer.ts
+++ b/packages/server/src/services/import/st-chat.importer.ts
@@ -344,11 +344,15 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
   // Preserve an imported branch/file label separately from the main thread/chat name.
   if (Object.keys(marinaraMetadata).length > 0 || importedBranchName) {
     const existingMetadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-    await storage.updateMetadata(chat.id, {
-      ...existingMetadata,
-      ...marinaraMetadata,
-      ...(importedBranchName ? { branchName: importedBranchName } : {}),
-    });
+    await storage.patchMetadata(
+      chat.id,
+      {
+        ...existingMetadata,
+        ...marinaraMetadata,
+        ...(importedBranchName ? { branchName: importedBranchName } : {}),
+      },
+      { touchUpdatedAt: false },
+    );
   }
 
   await storage.createMessagesBatch(chat.id, msgInputs, chatTimestamps);

--- a/packages/server/src/services/import/st-chat.importer.ts
+++ b/packages/server/src/services/import/st-chat.importer.ts
@@ -17,16 +17,25 @@ interface STChatHeader {
   chat_metadata?: Record<string, unknown>;
 }
 
+interface STChatMessageExtra extends Record<string, unknown> {
+  display_text?: string;
+  type?: string;
+  marinara_role?: string;
+  marinara_character_id?: string | null;
+  marinara_swipes?: unknown[];
+}
+
 interface STChatMessage {
-  name: string;
-  is_user: boolean;
+  name?: string;
+  is_user?: boolean;
   is_system?: boolean;
+  role?: unknown;
+  character_id?: unknown;
   send_date?: string;
-  mes: string;
-  extra?: {
-    display_text?: string;
-    type?: string;
-  };
+  mes?: unknown;
+  swipes?: unknown;
+  swipe_id?: unknown;
+  extra?: STChatMessageExtra;
 }
 
 interface ParsedSTChatMessageInput {
@@ -34,6 +43,14 @@ interface ParsedSTChatMessageInput {
   characterId: string | null;
   content: string;
   parsedCreatedAt: string | null;
+  extra?: Record<string, unknown>;
+  activeSwipeIndex?: number;
+  swipes?: Array<{
+    index: number;
+    content: string;
+    extra?: Record<string, unknown>;
+    createdAt?: string | null;
+  }>;
 }
 
 export interface ImportSTChatOptions {
@@ -106,6 +123,84 @@ function normalizeTranscriptTimestamps(
   });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeImportedRole(value: unknown): ParsedSTChatMessageInput["role"] | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case "system":
+    case "user":
+    case "assistant":
+    case "narrator":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function normalizeImportedExtra(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {};
+
+  const extra = { ...raw };
+  const displayText = typeof extra.display_text === "string" ? extra.display_text : null;
+  delete extra.display_text;
+  delete extra.marinara_role;
+  delete extra.marinara_character_id;
+  delete extra.marinara_swipes;
+
+  if (typeof extra.displayText !== "string" && displayText) {
+    extra.displayText = displayText;
+  }
+
+  return extra;
+}
+
+function normalizeSwipeContents(raw: unknown, fallbackContent: string): string[] {
+  if (!Array.isArray(raw)) return [fallbackContent];
+
+  const swipes = raw.filter((swipe): swipe is string => typeof swipe === "string");
+  return swipes.length > 0 ? swipes : [fallbackContent];
+}
+
+function normalizeSwipeIndex(raw: unknown, swipeCount: number): number {
+  const numeric = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : Number.NaN;
+  if (!Number.isInteger(numeric) || numeric < 0 || numeric >= swipeCount) return 0;
+  return numeric;
+}
+
+function normalizeMarinaraSwipeMetadata(extra: STChatMessageExtra | undefined) {
+  const rawSwipes = Array.isArray(extra?.marinara_swipes) ? extra.marinara_swipes : [];
+  const byIndex = new Map<
+    number,
+    {
+      extra: Record<string, unknown>;
+      createdAt: string | null;
+    }
+  >();
+
+  for (const rawSwipe of rawSwipes) {
+    if (!isRecord(rawSwipe)) continue;
+    const index = typeof rawSwipe.index === "number" && Number.isInteger(rawSwipe.index) ? rawSwipe.index : null;
+    if (index === null || index < 0) continue;
+    const createdAt = parseTrustedTimestamp(
+      typeof rawSwipe.created_at === "string"
+        ? rawSwipe.created_at
+        : typeof rawSwipe.createdAt === "string"
+          ? rawSwipe.createdAt
+          : undefined,
+    );
+    byIndex.set(index, {
+      extra: normalizeImportedExtra(rawSwipe.extra),
+      createdAt,
+    });
+  }
+
+  return byIndex;
+}
+
 /**
  * Import a SillyTavern JSONL chat file.
  *
@@ -123,6 +218,15 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
   const header = JSON.parse(lines[0]!) as STChatHeader;
   const characterName = header.character_name ?? "Unknown";
   const userName = header.user_name ?? "User";
+  const headerMetadata = isRecord(header.chat_metadata) ? header.chat_metadata : {};
+  const marinaraMetadata = isRecord(headerMetadata.marinara_metadata) ? headerMetadata.marinara_metadata : {};
+  const importedBranchName =
+    opts?.branchName ??
+    (typeof headerMetadata.branchName === "string"
+      ? headerMetadata.branchName
+      : typeof marinaraMetadata.branchName === "string"
+        ? marinaraMetadata.branchName
+        : null);
 
   // Build characterIds array. Caller-supplied list wins so an import-into-group
   // can fully inherit the existing chat's roster instead of being limited to a
@@ -149,20 +253,46 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
     try {
       const stMsg = JSON.parse(lines[i]!) as STChatMessage;
 
-      // Skip pure system messages (but keep user messages flagged as system — ST does this for RP intros)
-      if (stMsg.is_system && !stMsg.is_user) continue;
-
-      const role = stMsg.is_user ? "user" : "assistant";
-      const content = stMsg.extra?.display_text ?? stMsg.mes;
+      const role =
+        normalizeImportedRole(stMsg.role) ??
+        normalizeImportedRole(stMsg.extra?.marinara_role) ??
+        normalizeImportedRole(stMsg.extra?.type) ??
+        (stMsg.is_user ? "user" : stMsg.is_system ? "system" : "assistant");
+      const rawContent = typeof stMsg.mes === "string" ? stMsg.mes : "";
+      const messageExtra = normalizeImportedExtra(stMsg.extra);
+      const storedMessageExtra = Object.keys(messageExtra).length > 0 ? messageExtra : undefined;
+      const swipeContents = normalizeSwipeContents(stMsg.swipes, rawContent);
+      const activeSwipeIndex = normalizeSwipeIndex(stMsg.swipe_id, swipeContents.length);
+      const content = swipeContents[activeSwipeIndex] ?? rawContent;
+      const swipeMetadata = normalizeMarinaraSwipeMetadata(stMsg.extra);
+      const swipes = swipeContents.map((swipeContent, index) => {
+        const storedSwipe = swipeMetadata.get(index);
+        const swipeExtra =
+          index === activeSwipeIndex
+            ? { ...(storedSwipe?.extra ?? {}), ...(storedMessageExtra ?? {}) }
+            : (storedSwipe?.extra ?? {});
+        return {
+          index,
+          content: swipeContent,
+          extra: swipeExtra,
+          createdAt: storedSwipe?.createdAt ?? null,
+        };
+      });
 
       // Resolve character ID for this message
       let messageCharacterId: string | null = null;
-      if (!stMsg.is_user) {
+      if (role === "assistant") {
+        const exportedCharacterId =
+          typeof stMsg.character_id === "string"
+            ? stMsg.character_id
+            : typeof stMsg.extra?.marinara_character_id === "string"
+              ? stMsg.extra.marinara_character_id
+              : null;
         if (opts?.speakerMap && stMsg.name) {
           // Group chat: look up speaker
-          messageCharacterId = opts.speakerMap[stMsg.name] ?? opts?.characterId ?? null;
+          messageCharacterId = exportedCharacterId ?? opts.speakerMap[stMsg.name] ?? opts?.characterId ?? null;
         } else {
-          messageCharacterId = opts?.characterId ?? null;
+          messageCharacterId = exportedCharacterId ?? opts?.characterId ?? null;
         }
       }
 
@@ -173,6 +303,9 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
         characterId: messageCharacterId,
         content,
         parsedCreatedAt: createdAt,
+        extra: storedMessageExtra,
+        activeSwipeIndex,
+        swipes,
       });
     } catch {
       // Skip malformed lines
@@ -209,11 +342,12 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
   if (!chat) return { error: "Failed to create chat" };
 
   // Preserve an imported branch/file label separately from the main thread/chat name.
-  if (opts?.branchName) {
+  if (Object.keys(marinaraMetadata).length > 0 || importedBranchName) {
     const existingMetadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
     await storage.updateMetadata(chat.id, {
       ...existingMetadata,
-      branchName: opts.branchName,
+      ...marinaraMetadata,
+      ...(importedBranchName ? { branchName: importedBranchName } : {}),
     });
   }
 

--- a/packages/server/src/services/import/st-lorebook.importer.ts
+++ b/packages/server/src/services/import/st-lorebook.importer.ts
@@ -47,6 +47,7 @@ interface STWorldInfoEntry {
   delay?: number | null;
   ephemeral?: number | null;
   vectorized?: boolean;
+  excludeFromVectorization?: boolean;
   regex?: boolean;
   useRegex?: boolean;
   preventRecursion?: boolean;
@@ -430,21 +431,16 @@ export async function importSTLorebook(
     const entryUsesRegex = Boolean(entry.useRegex ?? entry.regex ?? false);
     const resolvedUseRegex =
       entryUsesRegex || hasSlashDelimitedRegex(rawResolvedKeys) || hasSlashDelimitedRegex(rawResolvedSecondaryKeys);
-    const vectorizedOnly = entry.vectorized === true;
-    const resolvedKeys = vectorizedOnly
-      ? []
-      : normalizeRegexKeys(rawResolvedKeys, {
-          useRegex: resolvedUseRegex,
-          entryUsesRegex,
-          matchWholeWords: resolvedMatchWholeWords,
-        });
-    const resolvedSecondaryKeys = vectorizedOnly
-      ? []
-      : normalizeRegexKeys(rawResolvedSecondaryKeys, {
-          useRegex: resolvedUseRegex,
-          entryUsesRegex,
-          matchWholeWords: resolvedMatchWholeWords,
-        });
+    const resolvedKeys = normalizeRegexKeys(rawResolvedKeys, {
+      useRegex: resolvedUseRegex,
+      entryUsesRegex,
+      matchWholeWords: resolvedMatchWholeWords,
+    });
+    const resolvedSecondaryKeys = normalizeRegexKeys(rawResolvedSecondaryKeys, {
+      useRegex: resolvedUseRegex,
+      entryUsesRegex,
+      matchWholeWords: resolvedMatchWholeWords,
+    });
     const sanitizedContent = normalizeString(entry.content);
     const sanitizedDescription = normalizeString(entry.description);
 
@@ -482,6 +478,7 @@ export async function importSTLorebook(
       preventRecursion: Boolean(entry.preventRecursion ?? false),
       excludeRecursion: Boolean(entry.excludeRecursion ?? false),
       delayUntilRecursion: Boolean(entry.delayUntilRecursion ?? false),
+      excludeFromVectorization: entry.vectorized === false ? true : entry.excludeFromVectorization === true,
       locked: Boolean(entry.locked ?? false),
     };
 

--- a/packages/server/src/services/import/st-lorebook.importer.ts
+++ b/packages/server/src/services/import/st-lorebook.importer.ts
@@ -206,10 +206,17 @@ function resolveProbability(entry: STWorldInfoEntry): number | null {
   return asNullablePercentage(entry.probability);
 }
 
-export function resolveSelectiveLogic(value: unknown): "and" | "or" | "not" {
-  const logicMap: Record<number, "and" | "or" | "not"> = { 0: "or", 1: "not", 2: "not", 3: "and" };
-  if (typeof value === "string" && ["and", "or", "not"].includes(value)) return value as "and" | "or" | "not";
-  return logicMap[typeof value === "number" ? value : 0] ?? "or";
+export function resolveSelectiveLogic(value: unknown): "and" | "and_all" | "or" | "not" | "not_all" {
+  const logicMap: Record<number, "and" | "and_all" | "not" | "not_all"> = {
+    0: "and",
+    1: "not_all",
+    2: "not",
+    3: "and_all",
+  };
+  if (typeof value === "string" && ["and", "and_all", "or", "not", "not_all"].includes(value)) {
+    return value as "and" | "and_all" | "or" | "not" | "not_all";
+  }
+  return logicMap[typeof value === "number" ? value : 0] ?? "and";
 }
 
 export function resolvePosition(value: unknown): number {

--- a/packages/server/src/services/import/st-lorebook.importer.ts
+++ b/packages/server/src/services/import/st-lorebook.importer.ts
@@ -51,6 +51,7 @@ interface STWorldInfoEntry {
   useRegex?: boolean;
   preventRecursion?: boolean;
   excludeRecursion?: boolean;
+  delayUntilRecursion?: boolean;
   locked?: boolean;
   extensions?: Record<string, unknown>;
 }
@@ -206,9 +207,9 @@ function resolveProbability(entry: STWorldInfoEntry): number | null {
 }
 
 export function resolveSelectiveLogic(value: unknown): "and" | "or" | "not" {
-  const logicMap: Record<number, "and" | "or" | "not"> = { 0: "and", 1: "or", 2: "not" };
+  const logicMap: Record<number, "and" | "or" | "not"> = { 0: "or", 1: "not", 2: "not", 3: "and" };
   if (typeof value === "string" && ["and", "or", "not"].includes(value)) return value as "and" | "or" | "not";
-  return logicMap[typeof value === "number" ? value : 0] ?? "and";
+  return logicMap[typeof value === "number" ? value : 0] ?? "or";
 }
 
 export function resolvePosition(value: unknown): number {
@@ -217,8 +218,45 @@ export function resolvePosition(value: unknown): number {
     if (value === "at_depth" || value === "depth") return 2;
     return 0;
   }
-  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 2) return value;
+  const positionMap: Record<number, number> = {
+    0: 0, // ST before_char
+    1: 1, // ST after_char
+    2: 0, // ST ANTop
+    3: 1, // ST ANBottom
+    4: 2, // ST @D / at-depth
+    5: 0, // ST EMTop
+    6: 1, // ST EMBottom
+  };
+  if (typeof value === "number" && Number.isInteger(value)) return positionMap[value] ?? 0;
   return 0;
+}
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseSlashDelimitedRegex(value: string): { source: string } | null {
+  const match = value.match(/^\/(.+)\/([dgimsuvy]*)$/u);
+  const source = match?.[1];
+  return source ? { source } : null;
+}
+
+function hasSlashDelimitedRegex(keys: string[]): boolean {
+  return keys.some((key) => parseSlashDelimitedRegex(key) !== null);
+}
+
+function normalizeRegexKeys(
+  keys: string[],
+  options: { useRegex: boolean; entryUsesRegex: boolean; matchWholeWords: boolean },
+): string[] {
+  if (!options.useRegex) return keys;
+  return keys.map((key) => {
+    const parsed = parseSlashDelimitedRegex(key);
+    if (parsed) return parsed.source;
+    if (options.entryUsesRegex) return key;
+    const escaped = escapeRegexLiteral(key);
+    return options.matchWholeWords ? `\\b${escaped}\\b` : escaped;
+  });
 }
 
 function detectCategory(entries: STWorldInfoEntry[], name?: string): LorebookCategory {
@@ -369,19 +407,37 @@ export async function importSTLorebook(
   for (const entry of entryList) {
     // Resolve fields that differ between ST World Info format and V2 Character Book format
     const rawKeys = entry.key ?? entry.keys;
-    const resolvedKeys = asStringArray(rawKeys);
+    const rawResolvedKeys = asStringArray(rawKeys);
     const rawSecondary = entry.keysecondary ?? entry.secondary_keys;
-    const resolvedSecondaryKeys = asStringArray(rawSecondary);
+    const rawResolvedSecondaryKeys = asStringArray(rawSecondary);
     const resolvedName = nonEmptyString(entry.comment, entry.name) ?? `Entry ${imported + 1}`;
     // ST uses `disable` (inverted), V2 uses `enabled`
     const resolvedEnabled = entry.disable != null ? !entry.disable : (entry.enabled ?? true);
-    const resolvedOrder = asNumber(entry.order ?? entry.insertion_order ?? entry.uid ?? entry.id, 100);
+    const resolvedOrder = asNumber(entry.order ?? entry.insertion_order, 100);
     // V2 position can be string ("before_char"/"after_char") — map to number
     const resolvedPosition = resolvePosition(entry.position);
     // Role can be a number (ST) or string (V2)
     const resolvedRole = resolveLorebookEntryRole(entry.role);
     const resolvedCaseSensitive = entry.caseSensitive ?? entry.case_sensitive ?? false;
     const resolvedMatchWholeWords = entry.matchWholeWords ?? entry.match_whole_words ?? false;
+    const entryUsesRegex = Boolean(entry.useRegex ?? entry.regex ?? false);
+    const resolvedUseRegex =
+      entryUsesRegex || hasSlashDelimitedRegex(rawResolvedKeys) || hasSlashDelimitedRegex(rawResolvedSecondaryKeys);
+    const vectorizedOnly = entry.vectorized === true;
+    const resolvedKeys = vectorizedOnly
+      ? []
+      : normalizeRegexKeys(rawResolvedKeys, {
+          useRegex: resolvedUseRegex,
+          entryUsesRegex,
+          matchWholeWords: resolvedMatchWholeWords,
+        });
+    const resolvedSecondaryKeys = vectorizedOnly
+      ? []
+      : normalizeRegexKeys(rawResolvedSecondaryKeys, {
+          useRegex: resolvedUseRegex,
+          entryUsesRegex,
+          matchWholeWords: resolvedMatchWholeWords,
+        });
     const sanitizedContent = normalizeString(entry.content);
     const sanitizedDescription = normalizeString(entry.description);
 
@@ -400,7 +456,7 @@ export async function importSTLorebook(
       scanDepth: asNullableNumber(entry.scanDepth ?? entry.scan_depth),
       matchWholeWords: resolvedMatchWholeWords,
       caseSensitive: resolvedCaseSensitive,
-      useRegex: Boolean(entry.useRegex ?? entry.regex ?? false),
+      useRegex: resolvedUseRegex,
       position: resolvedPosition,
       depth: asNumber(entry.depth, 4),
       order: resolvedOrder,
@@ -416,7 +472,9 @@ export async function importSTLorebook(
       dynamicState: {},
       activationConditions: [],
       schedule: null,
-      preventRecursion: Boolean(entry.preventRecursion ?? entry.excludeRecursion ?? false),
+      preventRecursion: Boolean(entry.preventRecursion ?? false),
+      excludeRecursion: Boolean(entry.excludeRecursion ?? false),
+      delayUntilRecursion: Boolean(entry.delayUntilRecursion ?? false),
       locked: Boolean(entry.locked ?? false),
     };
 

--- a/packages/server/src/services/import/st-prompt.importer.ts
+++ b/packages/server/src/services/import/st-prompt.importer.ts
@@ -27,10 +27,76 @@ function normalizeTopP(v: number | null | undefined) {
   return clamped <= 0 ? 1 : clamped;
 }
 function toReasoningEffort(v: unknown): "low" | "medium" | "high" | "xhigh" | "maximum" | null {
+  if (typeof v === "string" && v === "min") return "low";
+  if (typeof v === "string" && v === "max") return "maximum";
   if (typeof v === "string" && v === "auto") return "maximum";
   if (typeof v === "string" && VALID_REASONING.has(v))
     return v as "low" | "medium" | "high" | "xhigh" | "maximum";
   return null;
+}
+
+function toVerbosity(v: unknown): "low" | "medium" | "high" | null {
+  return v === "low" || v === "medium" || v === "high" ? v : null;
+}
+
+function parseStringArray(raw: unknown, parseJsonString: boolean): string[] {
+  if (Array.isArray(raw)) return raw.filter((item): item is string => typeof item === "string" && item.length > 0);
+  if (typeof raw !== "string") return [];
+  if (!parseJsonString) return raw ? [raw] : [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string" && item.length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeStopSequences(preset: STPreset): string[] {
+  const seen = new Set<string>();
+  const stops = [
+    ...parseStringArray(preset.custom_stopping_strings, true),
+    ...parseStringArray(preset.stop, false),
+  ];
+  return stops.filter((stop) => {
+    if (seen.has(stop)) return false;
+    seen.add(stop);
+    return true;
+  });
+}
+
+function parseScalar(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed.replace(/^(['"])(.*)\1$/, "$2");
+  }
+}
+
+function parseCustomParameters(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>;
+  if (typeof raw !== "string" || !raw.trim()) return {};
+
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    const out: Record<string, unknown> = {};
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const separator = trimmed.indexOf(":");
+      if (separator <= 0) continue;
+      const key = trimmed.slice(0, separator).trim();
+      if (!key) continue;
+      out[key] = parseScalar(trimmed.slice(separator + 1));
+    }
+    return out;
+  }
 }
 
 interface STPromptEntry {
@@ -100,14 +166,14 @@ export async function importSTPreset(
         frequencyPenalty: clamp(preset.frequency_penalty ?? 0, -2, 2),
         presencePenalty: clamp(preset.presence_penalty ?? 0, -2, 2),
         reasoningEffort: toReasoningEffort(preset.reasoning_effort),
-        verbosity: null,
+        verbosity: toVerbosity(preset.verbosity ?? preset.verbosity_level ?? preset.verbosity_levels),
         serviceTier: null,
-        assistantPrefill: "",
-        customParameters: {},
+        assistantPrefill: typeof preset.assistant_prefill === "string" ? preset.assistant_prefill : "",
+        customParameters: parseCustomParameters(preset.custom_include_body),
         squashSystemMessages: preset.squash_system_messages ?? true,
         showThoughts: preset.show_thoughts ?? true,
         useMaxContext: false,
-        stopSequences: [],
+        stopSequences: normalizeStopSequences(preset),
         strictRoleFormatting: true,
         singleUserMessage: false,
       },

--- a/packages/server/src/services/import/st-prompt.importer.ts
+++ b/packages/server/src/services/import/st-prompt.importer.ts
@@ -120,6 +120,7 @@ export async function importSTPreset(
   // Determine the section order from prompt_order (prefer the custom 100001 ordering)
   const orderDef = preset.prompt_order?.find((o) => o.character_id === 100001) ?? preset.prompt_order?.[0];
   const orderMap = new Map(orderDef?.order?.map((o, i) => [o.identifier, { index: i, enabled: o.enabled }]) ?? []);
+  const chatHistoryIndex = orderMap.get("chatHistory")?.index ?? Number.MAX_SAFE_INTEGER;
 
   // Import each prompt entry as a section
   const prompts = preset.prompts ?? [];
@@ -165,14 +166,20 @@ export async function importSTPreset(
     if (entry.role === "assistant") role = "assistant";
 
     // Determine injection position
-    const injectionPosition = entry.injection_position === 1 ? ("depth" as const) : ("ordered" as const);
+    const entryOrderIndex = orderMap.get(entry.identifier)?.index ?? Number.MAX_SAFE_INTEGER;
+    const isPostHistoryEntry =
+      entryOrderIndex > chatHistoryIndex &&
+      /(?:jailbreak|post[_-]?history|posthistory)/i.test(`${entry.identifier} ${entry.name}`);
+    if (isPostHistoryEntry) role = "user";
+    const injectionPosition =
+      isPostHistoryEntry || entry.injection_position === 1 ? ("depth" as const) : ("ordered" as const);
 
     // Check override from prompt_order
     const orderInfo = orderMap.get(entry.identifier);
     const enabled = orderInfo?.enabled ?? entry.enabled ?? true;
 
     // Assign to group if the entry was between bracket markers
-    const groupId = groupIdMap.get(entry.identifier) ?? null;
+    const groupId = isPostHistoryEntry ? null : (groupIdMap.get(entry.identifier) ?? null);
 
     // Use friendly names for consolidated markers
     const sectionName = mappedMarkerConfig ? (MARKER_DISPLAY_NAMES[mappedMarkerConfig.type] ?? entry.name) : entry.name;
@@ -186,7 +193,7 @@ export async function importSTPreset(
       enabled,
       isMarker: !!mappedMarkerConfig,
       injectionPosition,
-      injectionDepth: entry.injection_depth ?? 0,
+      injectionDepth: isPostHistoryEntry ? 0 : (entry.injection_depth ?? 0),
       injectionOrder: entry.injection_order ?? 100,
       groupId,
       markerConfig: mappedMarkerConfig,

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -668,9 +668,17 @@ export function parseEmbeddingResponse(json: unknown): number[][] {
     if (!isPlainRecord(item) || !Array.isArray(item.embedding)) {
       throw new Error("Embedding response contained an invalid embedding item.");
     }
+    const rawIndex = item.index;
+    let index: number | null = null;
+    if (rawIndex !== undefined) {
+      if (!(typeof rawIndex === "number" && Number.isInteger(rawIndex) && rawIndex >= 0)) {
+        throw new Error("Embedding response contained an invalid embedding index.");
+      }
+      index = rawIndex;
+    }
     return {
       embedding: item.embedding as number[],
-      index: typeof item.index === "number" && Number.isInteger(item.index) && item.index >= 0 ? item.index : null,
+      index,
     };
   });
 

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -664,12 +664,38 @@ export function parseEmbeddingResponse(json: unknown): number[][] {
     throw new Error("Embedding response did not include an embedding array.");
   }
 
-  return data.map((item) => {
+  const items = data.map((item) => {
     if (!isPlainRecord(item) || !Array.isArray(item.embedding)) {
       throw new Error("Embedding response contained an invalid embedding item.");
     }
-    return item.embedding as number[];
+    return {
+      embedding: item.embedding as number[],
+      index: typeof item.index === "number" && Number.isInteger(item.index) && item.index >= 0 ? item.index : null,
+    };
   });
+
+  const indexedCount = items.filter((item) => item.index !== null).length;
+  if (indexedCount > 0 && indexedCount !== items.length) {
+    throw new Error("Embedding response mixed indexed and unindexed items.");
+  }
+
+  if (indexedCount === items.length) {
+    const ordered: number[][] = [];
+    for (const item of items) {
+      if (item.index! >= items.length || ordered[item.index!] !== undefined) {
+        throw new Error("Embedding response contained duplicate or out-of-range indexes.");
+      }
+      ordered[item.index!] = item.embedding;
+    }
+    for (let index = 0; index < items.length; index += 1) {
+      if (!ordered[index]) {
+        throw new Error("Embedding response indexes did not cover every input.");
+      }
+    }
+    return ordered;
+  }
+
+  return items.map((item) => item.embedding);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -568,6 +568,13 @@ export abstract class BaseLLMProvider {
     return this.maxTokensOverride ?? null;
   }
 
+  /** Returns the configured context window for this provider connection, if known. */
+  public get maxContextValue(): number | null {
+    return typeof this.defaultMaxContext === "number" && Number.isFinite(this.defaultMaxContext)
+      ? this.defaultMaxContext
+      : null;
+  }
+
   protected fitMessagesToContext(messages: ChatMessage[], options: ContextFitOptions) {
     return fitMessagesToContext(messages, options, this.defaultMaxContext);
   }

--- a/packages/server/src/services/llm/providers/local-sidecar.provider.ts
+++ b/packages/server/src/services/llm/providers/local-sidecar.provider.ts
@@ -7,7 +7,7 @@ import { resolveSidecarRequestModel } from "../../sidecar/sidecar-request-model.
 import { getEmbeddingRequestTimeoutMs } from "../../../config/runtime-config.js";
 
 function isNotFoundError(error: unknown): boolean {
-  return error instanceof Error && /\(404\)|\b404\b/.test(error.message);
+  return error instanceof Error && /\(404\)|\b404\b|\(501\)|\b501\b|not enabled|not supported/i.test(error.message);
 }
 
 export class LocalSidecarProvider extends BaseLLMProvider {
@@ -74,7 +74,16 @@ export class LocalSidecarProvider extends BaseLLMProvider {
   }
 
   async embed(texts: string[], _model: string): Promise<number[][]> {
-    const baseUrl = await sidecarProcessService.ensureReady({ forceStart: true });
+    if (sidecarModelService.getResolvedBackend() === "mlx") {
+      throw new Error("Local sidecar embeddings are not supported on the MLX backend.");
+    }
+    if (!sidecarModelService.isEnabled()) {
+      throw new Error(
+        "Local sidecar embeddings require the local model to be enabled for trackers or game scene analysis.",
+      );
+    }
+
+    const baseUrl = await sidecarProcessService.ensureReady();
     const requestModel = this.getRequestModel();
 
     try {

--- a/packages/server/src/services/llm/providers/local-sidecar.provider.ts
+++ b/packages/server/src/services/llm/providers/local-sidecar.provider.ts
@@ -31,6 +31,11 @@ export class LocalSidecarProvider extends BaseLLMProvider {
   private assertToolCallsAvailable(options: ChatOptions): void {
     if (!options.tools?.length) return;
     const config = sidecarModelService.getConfig();
+    if (sidecarModelService.getResolvedBackend() === "mlx") {
+      throw new Error(
+        "Local sidecar tool calls are not supported on the MLX backend. Use llama.cpp with Native Tool Calls enabled or choose a remote tool-capable connection.",
+      );
+    }
     if (sidecarModelService.getResolvedBackend() === "llama_cpp" && !config.enableNativeToolCalls) {
       throw new Error(
         "Local sidecar native tool calls are disabled. Open Local AI Model > Runtime Settings and enable Native Tool Calls before using tools with the local sidecar.",
@@ -52,14 +57,27 @@ export class LocalSidecarProvider extends BaseLLMProvider {
       temperature: structuredOutput ? 0 : config.temperature,
       topP: structuredOutput ? 1 : config.topP,
       topK: structuredOutput ? 0 : config.topK,
+      minP: structuredOutput ? 0 : options.minP,
+    };
+  }
+
+  private applyBackendRequestConstraints(options: ChatOptions): ChatOptions {
+    if (sidecarModelService.getResolvedBackend() !== "mlx") {
+      return options;
+    }
+
+    return {
+      ...options,
+      responseFormat: undefined,
     };
   }
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     this.assertToolCallsAvailable(options);
     const delegate = await this.createDelegate();
+    const runtimeOptions = this.applyBackendRequestConstraints(this.applyRuntimeSettings(options));
     return yield* delegate.chat(messages, {
-      ...this.applyRuntimeSettings(options),
+      ...runtimeOptions,
       model: this.getRequestModel(),
     });
   }
@@ -67,8 +85,9 @@ export class LocalSidecarProvider extends BaseLLMProvider {
   async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
     this.assertToolCallsAvailable(options);
     const delegate = await this.createDelegate();
+    const runtimeOptions = this.applyBackendRequestConstraints(this.applyRuntimeSettings(options));
     return delegate.chatComplete(messages, {
-      ...this.applyRuntimeSettings(options),
+      ...runtimeOptions,
       model: this.getRequestModel(),
     });
   }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -1382,7 +1382,9 @@ export class OpenAIProvider extends BaseLLMProvider {
 
   /**
    * Convert chat-completion-style messages into Responses API `input` items.
-   * System messages are extracted into the top-level `instructions` field.
+   * Leading system messages are extracted into the top-level `instructions`
+   * field. Later system messages keep their position so post-history
+   * instruction sections do not lose recency.
    * Tool messages become `function_call_output` items.
    * Assistant messages with tool_calls become `function_call` items.
    */
@@ -1407,20 +1409,26 @@ export class OpenAIProvider extends BaseLLMProvider {
     let instructions: string | undefined;
     const input: Array<Record<string, unknown>> = [];
 
+    let sawNonSystemInput = false;
     for (const m of messages) {
       if (m.role === "system") {
-        // Merge all system messages into the top-level `instructions` field,
-        // which is the canonical way to pass system/developer messages in
-        // the Responses API.
         if (m.content?.trim()) {
-          if (instructions) {
-            instructions += "\n\n" + m.content;
+          if (!sawNonSystemInput) {
+            // Leading system/developer messages belong in the top-level
+            // instructions field for Responses.
+            if (instructions) {
+              instructions += "\n\n" + m.content;
+            } else {
+              instructions = m.content;
+            }
           } else {
-            instructions = m.content;
+            input.push({ role: "system", content: m.content });
           }
         }
         continue;
       }
+
+      sawNonSystemInput = true;
 
       if (m.role === "tool") {
         // Tool result → function_call_output item

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -42,13 +42,15 @@ function asStringArray(value: unknown): string[] {
 /**
  * Map a standalone-lorebook entry row (post `parseEntryRow`) onto a V2
  * Character Book entry. Field mapping mirrors the inverse done by
- * `importSTLorebook`. Position 1 in the DB maps to "after_char"; anything
- * else collapses to "before_char" because the V2 spec only has those two
- * values.
+ * `importSTLorebook`. At-depth entries use ST's numeric @D position so a
+ * synced embedded book can round-trip through the standalone lorebook without
+ * losing depth placement.
  */
 function toCharacterBookEntry(entry: LoreEntryRow, index: number): CharacterBookEntry {
   const order = asNumber(entry.order, 100);
-  const position = entry.position === 1 ? "after_char" : "before_char";
+  const positionValue = asNumber(entry.position, 0);
+  const position = positionValue === 2 ? 4 : positionValue === 1 ? "after_char" : "before_char";
+  const role = entry.role === "user" ? 1 : entry.role === "assistant" ? 2 : 0;
   return {
     keys: asStringArray(entry.keys),
     content: asString(entry.content),
@@ -64,6 +66,8 @@ function toCharacterBookEntry(entry: LoreEntryRow, index: number): CharacterBook
     secondary_keys: asStringArray(entry.secondaryKeys),
     constant: entry.constant === true,
     position,
+    depth: asNumber(entry.depth, 4),
+    role,
   };
 }
 

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -68,6 +68,15 @@ function normalizePositiveInteger(value: unknown, fallback: number): number {
   return Math.max(1, Math.trunc(numeric));
 }
 
+function getExistingEmbeddingDimension(entries: LorebookEntry[]): number | null {
+  for (const entry of entries) {
+    if (entry.embedding && entry.embedding.length > 0) {
+      return entry.embedding.length;
+    }
+  }
+  return null;
+}
+
 async function embedLorebookTexts(texts: string[], options: LorebookEmbeddingOptions): Promise<number[][]> {
   return embedMemoryRecallTexts(texts, {
     localEmbedder: options.localEmbedder ?? localEmbed,
@@ -89,6 +98,17 @@ export async function warmLorebookEntryEmbeddings(
   const texts = candidates.map(buildLorebookEntryEmbeddingText);
   const embeddings = await embedLorebookTexts(texts, options);
   if (embeddings.length === 0) return { attempted: candidates.length, embedded: 0 };
+
+  const embeddingDimension = embeddings.find((embedding) => embedding.length > 0)?.length ?? null;
+  const existingDimension = getExistingEmbeddingDimension(entries);
+  if (embeddingDimension && existingDimension && embeddingDimension !== existingDimension) {
+    logger.warn(
+      "[lorebook-embeddings] Skipping warmup because embedding dimension changed from %d to %d. Refresh lorebook embeddings before mixing embedding models.",
+      existingDimension,
+      embeddingDimension,
+    );
+    return { attempted: candidates.length, embedded: 0 };
+  }
 
   const storage = createLorebooksStorage(db);
   let embedded = 0;

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -70,6 +70,7 @@ function normalizePositiveInteger(value: unknown, fallback: number): number {
 
 function getExistingEmbeddingDimension(entries: LorebookEntry[]): number | null {
   for (const entry of entries) {
+    if (entry.excludeFromVectorization) continue;
     if (entry.embedding && entry.embedding.length > 0) {
       return entry.embedding.length;
     }
@@ -91,7 +92,7 @@ export async function warmLorebookEntryEmbeddings(
 ): Promise<LorebookEmbeddingWarmupResult> {
   const batchSize = normalizePositiveInteger(options.batchSize, DEFAULT_WARMUP_BATCH_SIZE);
   const candidates = entries
-    .filter((entry) => entry.enabled && (!entry.embedding || entry.embedding.length === 0))
+    .filter((entry) => entry.enabled && !entry.excludeFromVectorization && (!entry.embedding || entry.embedding.length === 0))
     .slice(0, batchSize);
   if (candidates.length === 0) return { attempted: 0, embedded: 0 };
 

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -702,7 +702,9 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
 ): { selected: ActivatedEntry[]; budgetSkippedEntries: LorebookBudgetSkippedEntry[] } {
   let state = createLorebookBudgetSelectionState();
   const processedIds = new Set<string>();
-  let frontier = scanForActivatedEntries(messages, entries, options);
+  const probabilityDecisions = options.probabilityDecisions ?? new Map<string, boolean>();
+  const scanOptions = { ...options, probabilityDecisions };
+  let frontier = scanForActivatedEntries(messages, entries, scanOptions);
   const budgetSkippedEntries: LorebookBudgetSkippedEntry[] = [];
 
   for (let depth = 0; frontier.length > 0; depth++) {
@@ -740,7 +742,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
     if (remaining.length === 0) break;
 
     frontier = scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, {
-      ...options,
+      ...scanOptions,
       recursionPass: true,
     });
   }

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -734,10 +734,15 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
     const recursiveContent = recursiveContentParts.join("\n");
     if (!recursiveContent) break;
 
-    const remaining = entries.filter((entry) => !processedIds.has(entry.id) && !state.selectedIds.has(entry.id));
+    const remaining = entries.filter(
+      (entry) => !processedIds.has(entry.id) && !state.selectedIds.has(entry.id) && !entry.excludeRecursion,
+    );
     if (remaining.length === 0) break;
 
-    frontier = scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, options);
+    frontier = scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, {
+      ...options,
+      recursionPass: true,
+    });
   }
 
   return {

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -605,7 +605,11 @@ export function recursiveScan(
     // Scan remaining entries against the content of activated entries
     const remaining = entries.filter((e) => !activatedIds.has(e.id) && !e.excludeRecursion);
     const newMessages: ScanMessage[] = [{ role: "system", content: newContent }];
-    const newActivated = scanForActivatedEntries(newMessages, remaining, { ...scanOptions, recursionPass: true });
+    const newActivated = scanForActivatedEntries(newMessages, remaining, {
+      ...scanOptions,
+      chatEmbedding: null,
+      recursionPass: true,
+    });
 
     if (newActivated.length === 0) break;
 

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -102,12 +102,20 @@ export function evaluateConditions(conditions: ActivationCondition[], gameState:
       case "not_contains":
         if (fieldValue.toLowerCase().includes(condition.value.toLowerCase())) return false;
         break;
-      case "gt":
-        if (parseFloat(fieldValue) <= parseFloat(condition.value)) return false;
+      case "gt": {
+        const actual = Number.parseFloat(fieldValue);
+        const expected = Number.parseFloat(condition.value);
+        if (!Number.isFinite(actual) || !Number.isFinite(expected)) return false;
+        if (actual <= expected) return false;
         break;
-      case "lt":
-        if (parseFloat(fieldValue) >= parseFloat(condition.value)) return false;
+      }
+      case "lt": {
+        const actual = Number.parseFloat(fieldValue);
+        const expected = Number.parseFloat(condition.value);
+        if (!Number.isFinite(actual) || !Number.isFinite(expected)) return false;
+        if (actual >= expected) return false;
         break;
+      }
     }
   }
 
@@ -253,8 +261,11 @@ export function updateTimingStatesForScan(
       state.delayRemaining = 0;
     } else {
       if (state.delayRemaining > 0) state.delayRemaining -= 1;
-      if (state.cooldownRemaining > 0) state.cooldownRemaining -= 1;
-      if (state.stickyCount > 0) state.stickyCount -= 1;
+      if (state.stickyCount > 0) {
+        state.stickyCount -= 1;
+      } else if (state.cooldownRemaining > 0) {
+        state.cooldownRemaining -= 1;
+      }
     }
 
     if (shouldPersistTimingState(entry, state)) {
@@ -315,7 +326,27 @@ function getAdditionalMatchingText(entry: LorebookEntry, sourceText: Partial<Rec
 /**
  * Group-based selection: within a group, only activate entries up to weight limits.
  */
-function applyGroupSelection(entries: ActivatedEntry[]): ActivatedEntry[] {
+function getGroupWeight(entry: ActivatedEntry): number {
+  const weight = Number(entry.entry.groupWeight ?? 100);
+  return Number.isFinite(weight) && weight > 0 ? weight : 0;
+}
+
+function pickWeightedGroupEntry(entries: ActivatedEntry[], random: () => number): ActivatedEntry | null {
+  if (entries.length === 0) return null;
+  const totalWeight = entries.reduce((total, entry) => total + getGroupWeight(entry), 0);
+  if (totalWeight <= 0) {
+    return [...entries].sort((a, b) => a.entry.order - b.entry.order)[0] ?? null;
+  }
+
+  let roll = random() * totalWeight;
+  for (const entry of entries) {
+    roll -= getGroupWeight(entry);
+    if (roll <= 0) return entry;
+  }
+  return entries[entries.length - 1] ?? null;
+}
+
+function applyGroupSelection(entries: ActivatedEntry[], random: () => number): ActivatedEntry[] {
   const grouped = new Map<string, ActivatedEntry[]>();
   const ungrouped: ActivatedEntry[] = [];
 
@@ -333,18 +364,8 @@ function applyGroupSelection(entries: ActivatedEntry[]): ActivatedEntry[] {
   const result: ActivatedEntry[] = [...ungrouped];
 
   for (const [, groupEntries] of grouped) {
-    // Sort by weight (higher = more likely), then by order
-    groupEntries.sort((a, b) => {
-      const wA = a.entry.groupWeight ?? 100;
-      const wB = b.entry.groupWeight ?? 100;
-      if (wA !== wB) return wB - wA;
-      return a.entry.order - b.entry.order;
-    });
-    // Pick the highest-weight entry from each group
-    const top = groupEntries[0];
-    if (top) {
-      result.push(top);
-    }
+    const selected = pickWeightedGroupEntry(groupEntries, random);
+    if (selected) result.push(selected);
   }
 
   return result;
@@ -375,6 +396,8 @@ export interface ScanOptions {
   ignoreTiming?: boolean;
   /** True while scanning content surfaced by a prior lorebook activation. */
   recursionPass?: boolean;
+  /** Shared per-generation probability rolls, including recursive scan passes. */
+  probabilityDecisions?: Map<string, boolean>;
   /** Random source for probability gates; injectable for deterministic tests. */
   random?: () => number;
 }
@@ -401,6 +424,7 @@ export function scanForActivatedEntries(
     additionalMatchingSourceText = {},
     ignoreTiming = false,
     recursionPass = false,
+    probabilityDecisions = new Map<string, boolean>(),
     random = Math.random,
   } = options;
   const filterContext: LorebookFilterValueContext = {
@@ -417,7 +441,6 @@ export function scanForActivatedEntries(
 
   const activated: ActivatedEntry[] = [];
   const activatedIds = new Set<string>();
-  const probabilityDecisions = new Map<string, boolean>();
   const passesEntryProbability = (entry: LorebookEntry) => {
     const existing = probabilityDecisions.get(entry.id);
     if (existing !== undefined) return existing;
@@ -547,7 +570,7 @@ export function scanForActivatedEntries(
   }
 
   // Apply group selection
-  const afterGroups = applyGroupSelection(activated);
+  const afterGroups = applyGroupSelection(activated, random);
 
   // Sort by injection order (lower = higher priority)
   afterGroups.sort((a, b) => a.injectionOrder - b.injectionOrder);
@@ -564,7 +587,9 @@ export function recursiveScan(
   options: ScanOptions = {},
   maxDepth: number = 3,
 ): ActivatedEntry[] {
-  const allActivated = scanForActivatedEntries(messages, entries, options);
+  const probabilityDecisions = options.probabilityDecisions ?? new Map<string, boolean>();
+  const scanOptions = { ...options, probabilityDecisions };
+  const allActivated = scanForActivatedEntries(messages, entries, scanOptions);
   const activatedIds = new Set(allActivated.map((a) => a.entry.id));
   let newlyActivated = allActivated;
 
@@ -580,7 +605,7 @@ export function recursiveScan(
     // Scan remaining entries against the content of activated entries
     const remaining = entries.filter((e) => !activatedIds.has(e.id) && !e.excludeRecursion);
     const newMessages: ScanMessage[] = [{ role: "system", content: newContent }];
-    const newActivated = scanForActivatedEntries(newMessages, remaining, { ...options, recursionPass: true });
+    const newActivated = scanForActivatedEntries(newMessages, remaining, { ...scanOptions, recursionPass: true });
 
     if (newActivated.length === 0) break;
 

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -425,6 +425,23 @@ export function scanForActivatedEntries(
     probabilityDecisions.set(entry.id, passes);
     return passes;
   };
+  const getEntryScanText = (entry: LorebookEntry) => {
+    // Per-entry scan depth:
+    //   0    = explicit "scan all" (deliberate user choice) — scan full history
+    //   > 0  = scan that many recent messages
+    //   null = inherit the bounded global default (combinedText)
+    const baseEntryScanText =
+      entry.scanDepth === 0
+        ? messages.map((m) => m.content).join("\n")
+        : entry.scanDepth !== null && entry.scanDepth > 0
+          ? messages
+              .slice(-entry.scanDepth)
+              .map((m) => m.content)
+              .join("\n")
+          : combinedText;
+    const extraMatchingText = getAdditionalMatchingText(entry, additionalMatchingSourceText);
+    return extraMatchingText ? `${baseEntryScanText}\n${extraMatchingText}` : baseEntryScanText;
+  };
 
   for (const entry of entries) {
     if (entry.delayUntilRecursion && !recursionPass) continue;
@@ -459,22 +476,7 @@ export function scanForActivatedEntries(
       continue;
     }
 
-    // Per-entry scan depth:
-    //   0    = explicit "scan all" (deliberate user choice) — scan full history
-    //   > 0  = scan that many recent messages
-    //   null = inherit the bounded global default (combinedText)
-    const baseEntryScanText =
-      entry.scanDepth === 0
-        ? messages.map((m) => m.content).join("\n")
-        : entry.scanDepth !== null && entry.scanDepth > 0
-          ? messages
-              .slice(-entry.scanDepth)
-              .map((m) => m.content)
-              .join("\n")
-          : combinedText;
-    const extraMatchingText = getAdditionalMatchingText(entry, additionalMatchingSourceText);
-    const entryScanText = extraMatchingText ? `${baseEntryScanText}\n${extraMatchingText}` : baseEntryScanText;
-
+    const entryScanText = getEntryScanText(entry);
     const matchOptions = {
       useRegex: entry.useRegex,
       matchWholeWords: entry.matchWholeWords,
@@ -519,6 +521,20 @@ export function scanForActivatedEntries(
 
       const similarity = cosineSimilarity(chatEmbedding, entry.embedding);
       if (similarity >= semanticThreshold) {
+        const entryScanText = getEntryScanText(entry);
+        const matchOptions = {
+          useRegex: entry.useRegex,
+          matchWholeWords: entry.matchWholeWords,
+          caseSensitive: entry.caseSensitive,
+          regexExecutor: vmRegexExecutor,
+        };
+        if (
+          entry.selective &&
+          entry.secondaryKeys.length > 0 &&
+          !testSecondaryKeys(entry.secondaryKeys, entryScanText, entry.selectiveLogic, matchOptions)
+        ) {
+          continue;
+        }
         if (!passesEntryProbability(entry)) continue;
         activated.push({
           entry,

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -373,6 +373,8 @@ export interface ScanOptions {
   additionalMatchingSourceText?: Partial<Record<LorebookMatchingSource, string>>;
   /** Ignore sticky/cooldown/delay runtime state for preview/debug scans. */
   ignoreTiming?: boolean;
+  /** True while scanning content surfaced by a prior lorebook activation. */
+  recursionPass?: boolean;
   /** Random source for probability gates; injectable for deterministic tests. */
   random?: () => number;
 }
@@ -398,6 +400,7 @@ export function scanForActivatedEntries(
     generationTriggers = ["chat"],
     additionalMatchingSourceText = {},
     ignoreTiming = false,
+    recursionPass = false,
     random = Math.random,
   } = options;
   const filterContext: LorebookFilterValueContext = {
@@ -424,6 +427,9 @@ export function scanForActivatedEntries(
   };
 
   for (const entry of entries) {
+    if (entry.delayUntilRecursion && !recursionPass) continue;
+    if (entry.excludeRecursion && recursionPass) continue;
+
     const timingState = timingStates.get(entry.id);
 
     if (!ignoreTiming && timingState?.stickyCount && timingState.stickyCount > 0) {
@@ -504,6 +510,8 @@ export function scanForActivatedEntries(
   if (chatEmbedding && chatEmbedding.length > 0) {
     for (const entry of entries) {
       if (!entry.enabled || entry.constant || activatedIds.has(entry.id)) continue;
+      if (entry.delayUntilRecursion && !recursionPass) continue;
+      if (entry.excludeRecursion && recursionPass) continue;
       if (entry.excludeFromVectorization) continue;
       if (!entry.embedding || entry.embedding.length === 0) continue;
       const timingState = timingStates.get(entry.id);
@@ -554,9 +562,9 @@ export function recursiveScan(
     if (!newContent) break;
 
     // Scan remaining entries against the content of activated entries
-    const remaining = entries.filter((e) => !activatedIds.has(e.id));
+    const remaining = entries.filter((e) => !activatedIds.has(e.id) && !e.excludeRecursion);
     const newMessages: ScanMessage[] = [{ role: "system", content: newContent }];
-    const newActivated = scanForActivatedEntries(newMessages, remaining, options);
+    const newActivated = scanForActivatedEntries(newMessages, remaining, { ...options, recursionPass: true });
 
     if (newActivated.length === 0) break;
 

--- a/packages/server/src/services/memory-recall-embedding.ts
+++ b/packages/server/src/services/memory-recall-embedding.ts
@@ -5,6 +5,7 @@ import { isLocalEmbedderAvailable } from "./local-embedder.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "./llm/local-sidecar.js";
 import { createLLMProvider } from "./llm/provider-registry.js";
 import type { MemoryRecallEmbeddingSource } from "./memory-recall.js";
+import { sidecarModelService } from "./sidecar/sidecar-model.service.js";
 import { createConnectionsStorage } from "./storage/connections.storage.js";
 
 type ConnectionStorage = ReturnType<typeof createConnectionsStorage>;
@@ -35,6 +36,14 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function isLocalSidecarEmbeddingSupported(): boolean {
+  return (
+    sidecarModelService.getResolvedBackend() === "llama_cpp" &&
+    sidecarModelService.isEnabled() &&
+    sidecarModelService.getConfiguredModelRef() !== null
+  );
+}
+
 export async function resolveMemoryRecallEmbeddingSource(
   db: DB,
   options: {
@@ -58,6 +67,13 @@ export async function resolveMemoryRecallEmbeddingSource(
     nonEmptyString(chatMeta.embeddingConnectionId) ?? nonEmptyString(activeConnection.embeddingConnectionId);
 
   if (embeddingConnId === LOCAL_SIDECAR_CONNECTION_ID) {
+    if (!isLocalSidecarEmbeddingSupported()) {
+      logger.warn(
+        "[memory-recall] Local sidecar was selected for embeddings, but sidecar embeddings require an enabled llama.cpp local model",
+      );
+      return null;
+    }
+
     const provider = getLocalSidecarProvider();
     const label = "Local Model sidecar";
     return {
@@ -126,6 +142,6 @@ export async function isMemoryRecallVectorizerAvailable(
     activeBaseUrl?: string | null;
   },
 ): Promise<boolean> {
-  if (isLocalEmbedderAvailable()) return true;
-  return (await resolveMemoryRecallEmbeddingSource(db, options)) !== null;
+  if ((await resolveMemoryRecallEmbeddingSource(db, options)) !== null) return true;
+  return isLocalEmbedderAvailable();
 }

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -37,6 +37,16 @@ function cosineSimilarity(a: number[], b: number[]): number {
   return denom === 0 ? 0 : dot / denom;
 }
 
+function parseStoredEmbedding(value: string | null): number[] | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as number[]) : null;
+  } catch {
+    return null;
+  }
+}
+
 // ── Public API ──
 
 export interface RecalledMemory {
@@ -61,21 +71,20 @@ export async function embedMemoryRecallTexts(
   texts: string[],
   options: MemoryRecallEmbeddingOptions = {},
 ): Promise<number[][]> {
+  if (options.embeddingSource) {
+    const configuredEmbeddings = await options.embeddingSource.embed(texts);
+    if (configuredEmbeddings) {
+      logger.debug("[memory-recall] Used configured embedding source %s", options.embeddingSource.label);
+      return configuredEmbeddings;
+    }
+    return [];
+  }
+
   const localEmbedder = options.localEmbedder ?? localEmbed;
   const localEmbeddings = await localEmbedder(texts);
   if (localEmbeddings) return localEmbeddings;
 
-  if (!options.embeddingSource) {
-    logger.warn("[memory-recall] Local embeddings are unavailable and no embedding connection is configured");
-    return [];
-  }
-
-  const fallbackEmbeddings = await options.embeddingSource.embed(texts);
-  if (fallbackEmbeddings) {
-    logger.debug("[memory-recall] Used configured embedding source %s", options.embeddingSource.label);
-    return fallbackEmbeddings;
-  }
-
+  logger.warn("[memory-recall] Local embeddings are unavailable and no embedding connection is configured");
   return [];
 }
 
@@ -95,7 +104,7 @@ export async function chunkAndEmbedMessages(
   const lastChunk = await db
     .select({ lastMessageAt: memoryChunks.lastMessageAt })
     .from(memoryChunks)
-    .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId)))
+    .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId), isNotNull(memoryChunks.embedding)))
     .orderBy(desc(memoryChunks.lastMessageAt))
     .limit(1);
 
@@ -154,6 +163,36 @@ export async function chunkAndEmbedMessages(
   // Embed all chunks using local model
   const texts = chunksToCreate.map((c) => c.content);
   const embeddings = await embedMemoryRecallTexts(texts, options);
+  if (
+    embeddings.length !== chunksToCreate.length ||
+    embeddings.some((embedding) => !Array.isArray(embedding) || embedding.length === 0)
+  ) {
+    logger.warn(
+      "[memory-recall] Skipping %d memory chunk(s) for chat %s because embedding generation returned %d/%d usable vectors",
+      chunksToCreate.length,
+      chatId,
+      embeddings.filter((embedding) => Array.isArray(embedding) && embedding.length > 0).length,
+      chunksToCreate.length,
+    );
+    return;
+  }
+
+  const embeddingDimension = embeddings[0]!.length;
+  const existingEmbeddedChunk = await db
+    .select({ embedding: memoryChunks.embedding })
+    .from(memoryChunks)
+    .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId), isNotNull(memoryChunks.embedding)))
+    .limit(1);
+  const existingEmbedding = parseStoredEmbedding(existingEmbeddedChunk[0]?.embedding ?? null);
+  if (Array.isArray(existingEmbedding) && existingEmbedding.length > 0 && existingEmbedding.length !== embeddingDimension) {
+    logger.warn(
+      "[memory-recall] Skipping memory chunk insert for chat %s because embedding dimension changed from %d to %d. Rebuild memories before mixing embedding models.",
+      chatId,
+      existingEmbedding.length,
+      embeddingDimension,
+    );
+    return;
+  }
 
   // Store chunks
   const timestamp = now();
@@ -163,7 +202,7 @@ export async function chunkAndEmbedMessages(
       id: newId(),
       chatId,
       content: chunk.content,
-      embedding: embeddings[i] ? JSON.stringify(embeddings[i]) : null,
+      embedding: JSON.stringify(embeddings[i]!),
       messageCount: chunk.messageCount,
       firstMessageAt: chunk.firstMessageAt,
       lastMessageAt: chunk.lastMessageAt,

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -41,7 +41,9 @@ function parseStoredEmbedding(value: string | null): number[] | null {
   if (!value) return null;
   try {
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? (parsed as number[]) : null;
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === "number" && Number.isFinite(item))
+      ? parsed
+      : null;
   } catch {
     return null;
   }
@@ -276,15 +278,16 @@ export async function recallMemories(
 
   // Score each chunk by cosine similarity
   const scored = chunks
-    .map((chunk) => {
-      const embedding: number[] = JSON.parse(chunk.embedding!);
-      if (!dimensionMismatchLogged && embedding.length !== queryEmbedding.length) {
-        dimensionMismatchLogged = true;
-        logger.warn(
-          "[memory-recall] Skipping one or more memory chunks with embedding dimensions that do not match the query vector (%d vs %d). Refresh memories after changing embedding models.",
-          embedding.length,
-          queryEmbedding.length,
-        );
+    .map((chunk): RecalledMemory | null => {
+      const embedding = parseStoredEmbedding(chunk.embedding);
+      if (!embedding || embedding.length !== queryEmbedding.length) {
+        if (!dimensionMismatchLogged) {
+          dimensionMismatchLogged = true;
+          logger.warn(
+            "[memory-recall] Skipping one or more memory chunks with embedding dimensions that do not match the query vector. Refresh memories after changing embedding models.",
+          );
+        }
+        return null;
       }
       return {
         chatId: chunk.chatId,
@@ -294,7 +297,7 @@ export async function recallMemories(
         lastMessageAt: chunk.lastMessageAt,
       };
     })
-    .filter((s) => s.similarity >= SIMILARITY_THRESHOLD)
+    .filter((s): s is RecalledMemory => s !== null && s.similarity >= SIMILARITY_THRESHOLD)
     .sort((a, b) => b.similarity - a.similarity)
     .slice(0, options.topK ?? DEFAULT_TOP_K);
 

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -216,8 +216,9 @@ export async function recallMemories(
 
   const matchingChatIds = chatIds.slice(0, 50);
 
-  // Load embedded chunks from matching chats (capped to prevent memory blowup)
-  const MAX_CHUNKS = 500;
+  // Load every embedded chunk in scope before scoring. Applying a recency cap
+  // here would exclude old-but-relevant memories before cosine similarity can
+  // evaluate them.
   const chunks = await db
     .select({
       id: memoryChunks.id,
@@ -228,9 +229,7 @@ export async function recallMemories(
       lastMessageAt: memoryChunks.lastMessageAt,
     })
     .from(memoryChunks)
-    .where(and(inArray(memoryChunks.chatId, matchingChatIds), isNotNull(memoryChunks.embedding)))
-    .orderBy(desc(memoryChunks.lastMessageAt))
-    .limit(MAX_CHUNKS);
+    .where(and(inArray(memoryChunks.chatId, matchingChatIds), isNotNull(memoryChunks.embedding)));
 
   if (chunks.length === 0) return [];
 

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -5,6 +5,7 @@
 // persona, and per-chat choice selections.
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
+import { logger } from "../../lib/logger.js";
 import type {
   ChatMLMessage,
   PromptPreset,
@@ -335,14 +336,20 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
       }
     }
 
-    const resolved = await resolveSection(section, {
-      macroCtx,
-      markerCtx,
-      macroOptions: deferAllMacroOptions,
-      wrapFormat,
-      runtimeAgentData: input.runtimeAgentData ?? {},
-      runtimeAgentTypesUsed,
-    });
+    let resolved: ResolvedSection | null;
+    try {
+      resolved = await resolveSection(section, {
+        macroCtx,
+        markerCtx,
+        macroOptions: deferAllMacroOptions,
+        wrapFormat,
+        runtimeAgentData: input.runtimeAgentData ?? {},
+        runtimeAgentTypesUsed,
+      });
+    } catch (err) {
+      logger.warn(err, "[prompt] Skipping section %s after marker expansion failed", section.id);
+      continue;
+    }
 
     if (!resolved) continue;
 

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -26,6 +26,7 @@ import type { LorebookScanResult } from "../lorebook/index.js";
 import {
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
+  collectCharacterPostHistoryEntries,
   resolveMacrosWithVariableSnapshot,
 } from "./macro-context.js";
 
@@ -345,7 +346,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
 
     if (!resolved) continue;
 
-    if (section.injectionPosition === "depth" && section.injectionDepth > 0) {
+    if (section.injectionPosition === "depth" && section.injectionDepth >= 0) {
       depthSections.push(resolved);
     } else {
       orderedSections.push(resolved);
@@ -451,6 +452,16 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   const characterDepthEntries = await collectCharacterDepthPromptEntries(input.db, input.characterIds, macroCtx);
   if (characterDepthEntries.length > 0) {
     allDepthEntries.push(characterDepthEntries);
+  }
+
+  const characterPostHistoryEntries = await collectCharacterPostHistoryEntries(
+    input.db,
+    input.characterIds,
+    macroCtx,
+    wrapFormat,
+  );
+  if (characterPostHistoryEntries.length > 0) {
+    allDepthEntries.push(characterPostHistoryEntries);
   }
 
   const combinedDepthEntries = allDepthEntries.flat();
@@ -750,12 +761,9 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
     const msg = messages[idx]!;
 
     if (msg.role === "system") {
-      const leadingSystem = result[0];
-      if (leadingSystem?.role === "system") {
-        mergeInto(leadingSystem, msg);
-      } else {
-        result.unshift({ ...msg });
-      }
+      const prev = result[result.length - 1];
+      if (prev?.role === "system") mergeInto(prev, msg);
+      else result.push({ ...msg });
       continue;
     }
 

--- a/packages/server/src/services/prompt/index.ts
+++ b/packages/server/src/services/prompt/index.ts
@@ -7,6 +7,7 @@ export { expandMarker, type MarkerContext, type ExpandedMarker } from "./marker-
 export {
   buildPromptMacroContext,
   collectCharacterDepthPromptEntries,
+  collectCharacterPostHistoryEntries,
   resolvePromptMessageMacros,
   resolveMacrosWithVariableSnapshot,
   resolveCharacterMacroData,

--- a/packages/server/src/services/prompt/macro-context.ts
+++ b/packages/server/src/services/prompt/macro-context.ts
@@ -7,13 +7,16 @@
 
 import {
   resolveMacros,
+  stripMacroComments,
   type CharacterMacroProfile,
   type CharacterData,
   type MacroContext,
   type ResolveMacroOptions,
+  type WrapFormat,
 } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
+import { wrapContent } from "./format-engine.js";
 
 type PersonaFields = NonNullable<MacroContext["personaFields"]>;
 
@@ -263,6 +266,48 @@ export async function collectCharacterDepthPromptEntries(
 
     if (content.trim()) {
       entries.push({ content, role: depthPrompt.role, depth: depthPrompt.depth });
+    }
+  }
+
+  return entries;
+}
+
+export async function collectCharacterPostHistoryEntries(
+  db: DB,
+  characterIds: string[],
+  macroCtx: MacroContext,
+  wrapFormat: WrapFormat,
+): Promise<PromptDepthEntry[]> {
+  if (characterIds.length === 0) return [];
+
+  const chars = createCharactersStorage(db);
+  const entries: PromptDepthEntry[] = [];
+  const multiCharacter = characterIds.length > 1;
+
+  for (const id of characterIds) {
+    const row = await chars.getById(id);
+    const data = parseCharacterData(row?.data);
+    const raw = stripMacroComments(data?.post_history_instructions ?? "").trim();
+    if (!data || !raw) continue;
+
+    const content = resolveMacros(raw, {
+      ...macroCtx,
+      char: data.name ?? macroCtx.char,
+      characterFields: {
+        description: data.description ?? "",
+        personality: data.personality ?? "",
+        backstory: data.extensions?.backstory ?? "",
+        appearance: data.extensions?.appearance ?? "",
+        scenario: data.scenario ?? "",
+        example: data.mes_example ?? "",
+        systemPrompt: data.system_prompt ?? "",
+        postHistoryInstructions: data.post_history_instructions ?? "",
+      },
+    }).trim();
+
+    if (content) {
+      const label = multiCharacter ? `${data.name ?? "Character"} post-history instructions` : "post-history instructions";
+      entries.push({ content: wrapContent(content, label, wrapFormat), role: "user", depth: 0 });
     }
   }
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -3,6 +3,7 @@
 // sections into actual content at assembly time.
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
+import { logger } from "../../lib/logger.js";
 import {
   formatCustomTrackerFieldForPrompt,
   resolveCharacterScopedMacros,
@@ -486,7 +487,19 @@ async function expandAgentData(config: MarkerConfig, ctx: MarkerContext): Promis
   const run = latestRuns[0];
   if (!run) return { content: "" };
 
-  const resultData = JSON.parse(run.resultData);
+  let resultData: unknown;
+  try {
+    resultData = JSON.parse(run.resultData);
+  } catch (err) {
+    logger.warn(
+      err,
+      "[prompt] Skipping malformed agent result data for %s in chat %s",
+      agentType,
+      ctx.chatId,
+    );
+    return { content: "" };
+  }
+
   // Format result data as readable text
   return { content: formatAgentResult(resultData) };
 }

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -146,12 +146,12 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
       "backstory",
       "appearance",
       "system_prompt",
-      "post_history_instructions",
     ];
 
     const charParts: string[] = [];
     for (const field of fields) {
       if (field === "name") continue; // Name is used as the parent tag, not a child field
+      if (field === "post_history_instructions") continue; // Injected after chat history by the assembler.
       // Skip per-character scenario when a group scenario override is active
       if (field === "scenario" && ctx.groupScenarioOverrideText) continue;
       const value = cardPromptText(getCharacterField(data, field));

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -4,11 +4,7 @@
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
-import {
-  formatCustomTrackerFieldForPrompt,
-  resolveCharacterScopedMacros,
-  stripMacroComments,
-} from "@marinara-engine/shared";
+import { resolveCharacterScopedMacros, stripMacroComments } from "@marinara-engine/shared";
 import type {
   CharacterMacroProfile,
   MarkerConfig,
@@ -23,7 +19,6 @@ import { createAgentsStorage } from "../storage/agents.storage.js";
 import { processLorebooks, type LorebookFinalContentResolver, type LorebookScanResult } from "../lorebook/index.js";
 import { wrapContent } from "./format-engine.js";
 import { agentRuns } from "../../db/schema/index.js";
-import { gameStateSnapshots } from "../../db/schema/index.js";
 import { eq, and, desc } from "drizzle-orm";
 
 /** Context required for expanding markers. */
@@ -461,14 +456,6 @@ async function expandAgentData(config: MarkerConfig, ctx: MarkerContext): Promis
     return { content: "" };
   }
 
-  // Special case: world-state uses game_state_snapshots for richer structured data
-  if (agentType === "world-state") {
-    const wsStorage = createAgentsStorage(ctx.db);
-    const wsConfig = await wsStorage.getByType("world-state");
-    if (wsConfig && wsConfig.enabled !== "true") return { content: "" };
-    return expandWorldStateAgent(ctx);
-  }
-
   // Generic: find latest successful agent run for this chat
   const agentsStorage = createAgentsStorage(ctx.db);
   const agentConfig = await agentsStorage.getByType(agentType);
@@ -502,113 +489,6 @@ async function expandAgentData(config: MarkerConfig, ctx: MarkerContext): Promis
 
   // Format result data as readable text
   return { content: formatAgentResult(resultData) };
-}
-
-async function expandWorldStateAgent(ctx: MarkerContext): Promise<ExpandedMarker> {
-  // Prefer committed game state — uncommitted snapshots from swipes/regens
-  // are normally skipped so the prompt stays clean between swipes.
-  const committedRows = await ctx.db
-    .select()
-    .from(gameStateSnapshots)
-    .where(and(eq(gameStateSnapshots.chatId, ctx.chatId), eq(gameStateSnapshots.committed, 1)))
-    .orderBy(desc(gameStateSnapshots.createdAt))
-    .limit(1);
-
-  let snap = committedRows[0];
-
-  // Fallback: if no committed snapshot exists yet (e.g. first agent run),
-  // use the latest snapshot regardless of committed status so world state
-  // data isn't silently dropped until the next user message.
-  if (!snap) {
-    const anyRows = await ctx.db
-      .select()
-      .from(gameStateSnapshots)
-      .where(eq(gameStateSnapshots.chatId, ctx.chatId))
-      .orderBy(desc(gameStateSnapshots.createdAt))
-      .limit(1);
-    snap = anyRows[0];
-  }
-
-  if (!snap) return { content: "" };
-
-  // Only include fields from agents that are currently active.
-  // World-state's own fields (date/time/location/weather/temperature) are always included
-  // since this function is only called when world-state is enabled.
-  const active = new Set(ctx.activeAgentIds);
-  const hasCharTracker = active.size === 0 || active.has("character-tracker");
-  const hasPersonaStats = active.size === 0 || active.has("persona-stats");
-  const hasQuest = active.size === 0 || active.has("quest");
-  const hasCustomTracker = active.size === 0 || active.has("custom-tracker");
-
-  const parts: string[] = [];
-  if (snap.date) parts.push(`Date: ${snap.date}`);
-  if (snap.time) parts.push(`Time: ${snap.time}`);
-  if (snap.location) parts.push(`Location: ${snap.location}`);
-  if (snap.weather) parts.push(`Weather: ${snap.weather}`);
-  if (snap.temperature) parts.push(`Temperature: ${snap.temperature}`);
-
-  if (hasCharTracker) {
-    const presentChars = JSON.parse(snap.presentCharacters);
-    if (Array.isArray(presentChars) && presentChars.length > 0) {
-      const charLines = presentChars.map((c: any) => {
-        if (typeof c === "string") return `- ${c}`;
-        const details: string[] = [];
-        if (c.mood) details.push(`mood: ${c.mood}`);
-        if (c.appearance) details.push(`appearance: ${c.appearance}`);
-        if (c.outfit) details.push(`outfit: ${c.outfit}`);
-        if (c.thoughts) details.push(`thoughts: ${c.thoughts}`);
-        if (Array.isArray(c.stats) && c.stats.length > 0) {
-          const statStr = c.stats.map((s: any) => `${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`).join(", ");
-          details.push(`stats: ${statStr}`);
-        }
-        const detailStr = details.length > 0 ? ` (${details.join("; ")})` : "";
-        return `- ${c.emoji ?? ""} ${c.name ?? c}${detailStr}`;
-      });
-      parts.push(`Present Characters:\n${charLines.join("\n")}`);
-    }
-  }
-
-  // Persona stats (needs/condition bars)
-  if (hasPersonaStats && snap.personaStats) {
-    const psBars = typeof snap.personaStats === "string" ? JSON.parse(snap.personaStats) : snap.personaStats;
-    if (Array.isArray(psBars) && psBars.length > 0) {
-      const barLines = psBars.map((b: any) => `- ${b.name}: ${b.value}/${b.max}`);
-      parts.push(`Persona Stats:\n${barLines.join("\n")}`);
-    }
-  }
-
-  if (snap.playerStats) {
-    const stats = typeof snap.playerStats === "string" ? JSON.parse(snap.playerStats) : snap.playerStats;
-    const statParts: string[] = [];
-    if (hasPersonaStats && stats.status) statParts.push(`Status: ${stats.status}`);
-    if (hasQuest && Array.isArray(stats.activeQuests) && stats.activeQuests.length > 0) {
-      const questLines = stats.activeQuests.map((q: any) => {
-        const objectives = Array.isArray(q.objectives)
-          ? q.objectives.map((o: any) => `  ${o.completed ? "[x]" : "[ ]"} ${o.text}`).join("\n")
-          : "";
-        return `- ${q.name}${q.completed ? " (completed)" : ""}${objectives ? "\n" + objectives : ""}`;
-      });
-      statParts.push(`Active Quests:\n${questLines.join("\n")}`);
-    }
-    if (hasPersonaStats && Array.isArray(stats.inventory) && stats.inventory.length > 0) {
-      const invLines = stats.inventory.map(
-        (item: any) =>
-          `- ${item.name}${item.quantity > 1 ? ` x${item.quantity}` : ""}${item.description ? ` — ${item.description}` : ""}`,
-      );
-      statParts.push(`Inventory:\n${invLines.join("\n")}`);
-    }
-    if (hasPersonaStats && Array.isArray(stats.stats) && stats.stats.length > 0) {
-      const statLines = stats.stats.map((s: any) => `- ${s.name}: ${s.value}${s.max ? `/${s.max}` : ""}`);
-      statParts.push(`Stats:\n${statLines.join("\n")}`);
-    }
-    if (hasCustomTracker && Array.isArray(stats.customTrackerFields) && stats.customTrackerFields.length > 0) {
-      const customLines = stats.customTrackerFields.map(formatCustomTrackerFieldForPrompt);
-      statParts.push(`Custom:\n${customLines.join("\n")}`);
-    }
-    if (statParts.length > 0) parts.push(statParts.join("\n"));
-  }
-
-  return { content: parts.join("\n") };
 }
 
 function formatAgentResult(data: unknown): string {

--- a/packages/server/src/services/sidecar/mlx-runtime.service.ts
+++ b/packages/server/src/services/sidecar/mlx-runtime.service.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn, type ChildProcess } from "child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import type { SidecarDownloadProgress, SidecarRuntimeInfo } from "@marinara-engine/shared";
 import { getDataDir } from "../../utils/data-dir.js";
@@ -92,6 +92,18 @@ function writeInstalledPackageSpec(): void {
   writeFileSync(MLX_LM_PACKAGE_STAMP_PATH, `${MLX_LM_PACKAGE_SPEC}\n`, "utf-8");
 }
 
+function getMlxRepoCachePath(repo: string): string {
+  return join(MLX_HF_HOME, "hub", `models--${repo.replace(/\//g, "--")}`);
+}
+
+function hasMlxRepoSnapshot(repo: string): boolean {
+  try {
+    return readdirSync(join(getMlxRepoCachePath(repo), "snapshots")).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function buildInstallRecord(version: string): MlxRuntimeInstall {
   return {
     backend: "mlx",
@@ -128,6 +140,10 @@ class MlxRuntimeService {
     return MLX_HF_HOME;
   }
 
+  hasModelCache(repo: string | null | undefined): boolean {
+    return !!repo && hasMlxRepoSnapshot(repo);
+  }
+
   cancelInstall(): void {
     this.cancelRequested = true;
     this.activeFetchAbort?.abort();
@@ -149,7 +165,12 @@ class MlxRuntimeService {
     rmSync(MLX_RUNTIME_DIR, { recursive: true, force: true });
   }
 
-  clearModelCache(): void {
+  clearModelCache(repo?: string | null): void {
+    if (repo) {
+      rmSync(getMlxRepoCachePath(repo), { recursive: true, force: true });
+      return;
+    }
+
     rmSync(MLX_HF_HOME, { recursive: true, force: true });
   }
 
@@ -172,6 +193,45 @@ class MlxRuntimeService {
     return this.installPromise;
   }
 
+  async downloadModel(
+    repo: string,
+    label: string,
+    totalBytes: number | null | undefined,
+    onProgress?: (progress: SidecarDownloadProgress) => void,
+  ): Promise<void> {
+    const runtime = await this.ensureInstalled(onProgress);
+    mkdirSync(runtime.hfHomePath, { recursive: true });
+
+    this.emitModelProgress(onProgress, "downloading", label, totalBytes ?? 0);
+    this.cancelRequested = false;
+    try {
+      await this.runCommand(
+        runtime.pythonPath,
+        [
+          "-c",
+          [
+            "from huggingface_hub import snapshot_download",
+            `snapshot_download(repo_id=${JSON.stringify(repo)}, local_files_only=False)`,
+          ].join("\n"),
+        ],
+        {
+          cwd: runtime.directoryPath,
+          env: {
+            HF_HOME: runtime.hfHomePath,
+            HF_HUB_CACHE: join(runtime.hfHomePath, "hub"),
+          },
+        },
+      );
+    } finally {
+      this.activeChild = null;
+      this.cancelRequested = false;
+    }
+    if (!hasMlxRepoSnapshot(repo)) {
+      throw new Error(`MLX model download completed but no cache entry was found for ${repo}.`);
+    }
+    this.emitModelProgress(onProgress, "complete", label, totalBytes ?? 0);
+  }
+
   private emitProgress(
     onProgress: ((progress: SidecarDownloadProgress) => void) | undefined,
     status: SidecarDownloadProgress["status"],
@@ -186,6 +246,22 @@ class MlxRuntimeService {
       speed: 0,
       label,
       error,
+    });
+  }
+
+  private emitModelProgress(
+    onProgress: ((progress: SidecarDownloadProgress) => void) | undefined,
+    status: SidecarDownloadProgress["status"],
+    label: string,
+    total: number,
+  ): void {
+    onProgress?.({
+      phase: "model",
+      status,
+      downloaded: status === "complete" ? total : 0,
+      total,
+      speed: 0,
+      label,
     });
   }
 

--- a/packages/server/src/services/sidecar/sidecar-download.ts
+++ b/packages/server/src/services/sidecar/sidecar-download.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { createWriteStream, existsSync, mkdirSync, renameSync, statSync, unlinkSync } from "fs";
 import { dirname } from "path";
 import { Readable } from "stream";
 import { pipeline as streamPipeline } from "stream/promises";
@@ -21,6 +21,7 @@ export interface DownloadFileOptions {
   destPath: string;
   signal?: AbortSignal;
   headers?: Record<string, string>;
+  expectedBytes?: number | null;
   progress: Omit<SidecarDownloadProgress, "downloaded" | "total" | "speed" | "status">;
   onProgress?: (progress: SidecarDownloadProgress) => void;
 }
@@ -105,6 +106,10 @@ export async function downloadFileWithProgress(options: DownloadFileOptions): Pr
   }
 
   const total = Number.parseInt(response.headers.get("content-length") || "0", 10) || 0;
+  const contentEncoding = response.headers.get("content-encoding")?.trim().toLowerCase() ?? "";
+  const expectedBytes =
+    typeof options.expectedBytes === "number" && options.expectedBytes > 0 ? options.expectedBytes : total;
+  const canValidateSize = expectedBytes > 0 && (!contentEncoding || contentEncoding === "identity");
   let downloaded = 0;
   let lastReportTime = Date.now();
   let lastReportBytes = 0;
@@ -130,7 +135,7 @@ export async function downloadFileWithProgress(options: DownloadFileOptions): Pr
             ...options.progress,
             status: "downloading",
             downloaded,
-            total,
+            total: total || expectedBytes,
             speed,
           });
           lastReportTime = now;
@@ -146,12 +151,16 @@ export async function downloadFileWithProgress(options: DownloadFileOptions): Pr
 
   try {
     await streamPipeline(readable, writable);
+    const writtenBytes = statSync(tempPath).size;
+    if (canValidateSize && writtenBytes !== expectedBytes) {
+      throw new Error(`Downloaded file size mismatch: expected ${expectedBytes} bytes, received ${writtenBytes} bytes.`);
+    }
     renameSync(tempPath, options.destPath);
     options.onProgress?.({
       ...options.progress,
       status: "complete",
-      downloaded: total || downloaded,
-      total: total || downloaded,
+      downloaded: expectedBytes || writtenBytes || downloaded,
+      total: expectedBytes || writtenBytes || downloaded,
       speed: 0,
     });
   } catch (error) {

--- a/packages/server/src/services/sidecar/sidecar-inference.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-inference.service.ts
@@ -7,7 +7,7 @@
 
 import { randomUUID } from "crypto";
 import type { SceneAnalysis } from "@marinara-engine/shared";
-import { sanitizeApiError } from "../llm/base-provider.js";
+import { fitMessagesToContext, llmFetch, sanitizeApiError, type ChatMessage } from "../llm/base-provider.js";
 import { sidecarModelService } from "./sidecar-model.service.js";
 import { sidecarProcessService } from "./sidecar-process.service.js";
 import { resolveSidecarRequestModel } from "./sidecar-request-model.js";
@@ -27,6 +27,8 @@ export function isInferenceBusy(): boolean {
 
 const MAX_OUTPUT_TOKENS = 8192;
 const SCENE_ANALYSIS_MAX_TOKENS = 4096;
+const STREAM_IDLE_TIMEOUT_MS = 120_000;
+const MAX_ACCUMULATED_TEXT_CHARS = 4_000_000;
 
 type SidecarMessage = {
   role: "system" | "user" | "assistant";
@@ -51,6 +53,7 @@ type SidecarChatCompletionResponse = {
 };
 
 type SidecarChatCompletionChunk = {
+  error?: unknown;
   choices?: Array<{
     delta?: {
       content?: unknown;
@@ -62,6 +65,51 @@ type SidecarChatCompletionChunk = {
     };
   }>;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function extractSidecarErrorMessage(parsed: Record<string, unknown>): string | null {
+  const error = parsed.error;
+  if (typeof error === "string") return error;
+  if (isRecord(error)) {
+    const message = error.message;
+    if (typeof message === "string" && message.trim()) return message;
+    const detail = error.detail;
+    if (typeof detail === "string" && detail.trim()) return detail;
+  }
+  return null;
+}
+
+function normalizeResponseFormat(responseFormat?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!responseFormat) return undefined;
+  if (responseFormat.type !== "json_schema") return responseFormat;
+
+  const jsonSchema = isRecord(responseFormat.json_schema) ? responseFormat.json_schema : {};
+  const schema = isRecord(jsonSchema.schema)
+    ? jsonSchema.schema
+    : isRecord(responseFormat.schema)
+      ? responseFormat.schema
+      : {};
+  return {
+    type: "json_schema",
+    json_schema: {
+      name: typeof jsonSchema.name === "string" && jsonSchema.name.trim() ? jsonSchema.name.trim() : "response",
+      schema,
+      strict: typeof jsonSchema.strict === "boolean" ? jsonSchema.strict : true,
+    },
+  };
+}
+
+function formatStreamOutput(content: string, reasoning: string): string {
+  return content.trim() || reasoning.trim();
+}
+
+function isContextOverflowError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return /context|ctx|prompt.*too|slot|exceed|overflow|too many tokens/.test(message);
+}
 
 function getRequestModel(): string {
   return resolveSidecarRequestModel(
@@ -150,97 +198,150 @@ async function streamChatCompletion(options: {
   messages: SidecarMessage[];
   maxTokens: number;
   responseFormat?: Record<string, unknown>;
+  signal?: AbortSignal;
 }): Promise<string> {
   const baseUrl = await sidecarProcessService.ensureReady();
   const generation = getRuntimeGenerationSettings();
-  const maxTokens = Math.min(Math.max(1, Math.floor(options.maxTokens)), generation.maxTokens);
-  const response = await fetch(`${baseUrl}/v1/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: getRequestModel(),
-      stream: true,
-      messages: options.messages,
-      max_tokens: maxTokens,
-      temperature: generation.temperature,
-      top_p: generation.topP,
-      ...(generation.topK > 0 ? { top_k: generation.topK } : {}),
-      ...(options.responseFormat ? { response_format: options.responseFormat } : {}),
-    }),
-    signal: AbortSignal.timeout(5 * 60_000),
+  const config = sidecarModelService.getConfig();
+  const requestedMaxTokens = Math.min(Math.max(1, Math.floor(options.maxTokens)), MAX_OUTPUT_TOKENS);
+  const responseFormat = normalizeResponseFormat(options.responseFormat);
+  const fitted = fitMessagesToContext(options.messages as ChatMessage[], {
+    maxContext: config.contextSize,
+    maxTokens: requestedMaxTokens,
   });
+  const fittedMessages = fitted.messages.map((message) => ({
+    role: message.role as SidecarMessage["role"],
+    content: typeof message.content === "string" ? message.content : "",
+  }));
+  const maxTokens = Math.max(1, Math.min(fitted.maxTokens ?? requestedMaxTokens, requestedMaxTokens));
+  const structuredOutput = !!responseFormat;
 
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => "");
-    throw new Error(`llama-server error ${response.status}: ${sanitizeApiError(errorText || response.statusText)}`);
-  }
+  const send = async (sendMaxTokens: number): Promise<string> => {
+    const response = await llmFetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: getRequestModel(),
+        stream: true,
+        messages: fittedMessages,
+        max_tokens: sendMaxTokens,
+        temperature: structuredOutput ? 0 : generation.temperature,
+        top_p: structuredOutput ? 1 : generation.topP,
+        ...(!structuredOutput && generation.topK > 0 ? { top_k: generation.topK } : {}),
+        ...(responseFormat ? { response_format: responseFormat } : {}),
+      }),
+      signal: options.signal,
+    });
 
-  if (!response.body) {
-    throw new Error("llama-server returned no response body");
-  }
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(`llama-server error ${response.status}: ${sanitizeApiError(errorText || response.statusText)}`);
+    }
 
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  let content = "";
-  let reasoning = "";
+    if (!response.body) {
+      throw new Error("llama-server returned no response body");
+    }
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let content = "";
+    let reasoning = "";
+    const readChunk = async () => {
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      try {
+        return await Promise.race([
+          reader.read(),
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => reject(new Error("llama-server stream stalled waiting for tokens")), STREAM_IDLE_TIMEOUT_MS);
+          }),
+        ]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    };
 
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
+    const appendText = (nextContent: string, nextReasoning: string) => {
+      content += nextContent;
+      reasoning += nextReasoning;
+      if (content.length + reasoning.length > MAX_ACCUMULATED_TEXT_CHARS) {
+        throw new Error("llama-server response exceeded local inference size limit");
+      }
+    };
 
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith("data: ")) continue;
-
-      const data = trimmed.slice(6);
+    const handlePayload = (data: string): string | null => {
       if (data === "[DONE]") {
-        return content;
+        return formatStreamOutput(content, reasoning);
       }
 
-      try {
-        const parsed = JSON.parse(data) as SidecarChatCompletionChunk;
+      const parsed = JSON.parse(data) as SidecarChatCompletionChunk;
+      const providerError = extractSidecarErrorMessage(parsed as Record<string, unknown>);
+      if (providerError) throw new Error(`llama-server stream error: ${sanitizeApiError(providerError)}`);
 
-        const choice = parsed.choices?.[0];
-        if (!choice) continue;
-        const extracted = extractChoiceContent(choice);
-        content += extracted.content;
-        reasoning += extracted.reasoning;
+      const choice = parsed.choices?.[0];
+      if (!choice) return null;
+      const extracted = extractChoiceContent(choice);
+      appendText(extracted.content, extracted.reasoning);
+      return null;
+    };
+
+    const flushTrailingPayload = () => {
+      if (!buffer.trim().startsWith("data: ")) return;
+      const trailing = buffer.trim().slice(6);
+      if (trailing === "[DONE]") return;
+      try {
+        handlePayload(trailing);
       } catch {
-        // Ignore malformed chunks and keep streaming.
+        // Ignore malformed trailing chunk after the stream has ended.
       }
-    }
-  }
+    };
 
-  if (buffer.trim().startsWith("data: ")) {
-    const trailing = buffer.trim().slice(6);
-    if (trailing !== "[DONE]") {
-      try {
-        const parsed = JSON.parse(trailing) as SidecarChatCompletionChunk;
-        const choice = parsed.choices?.[0];
-        if (choice) {
-          const extracted = extractChoiceContent(choice);
-          content += extracted.content;
-          reasoning += extracted.reasoning;
+    try {
+      while (true) {
+        const { done, value } = await readChunk();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data: ")) continue;
+          const output = handlePayload(trimmed.slice(6));
+          if (output !== null) return output;
         }
+      }
+    } catch (err) {
+      const partial = formatStreamOutput(content, reasoning);
+      const partialIsUsable =
+        partial &&
+        (options.signal?.aborted ||
+          (err instanceof Error && /aborted|abort|stalled waiting for tokens/i.test(`${err.name} ${err.message}`)));
+      if (partialIsUsable) return partial;
+      throw err;
+    } finally {
+      try {
+        await reader.cancel();
       } catch {
-        // Ignore malformed trailing chunk.
+        // Already closed.
       }
     }
-  }
 
-  const trimmedContent = content.trim();
-  if (trimmedContent) {
-    return trimmedContent;
-  }
+    flushTrailingPayload();
+    return formatStreamOutput(content, reasoning);
+  };
 
-  return reasoning.trim();
+  try {
+    return await send(maxTokens);
+  } catch (err) {
+    if (maxTokens > 512 && isContextOverflowError(err)) {
+      return await send(Math.max(512, Math.floor(maxTokens / 2)));
+    }
+    throw err;
+  }
 }
 
 export async function runTestMessage(): Promise<SidecarTestMessageOutput> {
@@ -488,7 +589,7 @@ const SCENE_ANALYSIS_SCHEMA = {
   required: ["background", "music", "ambient", "weather", "timeOfDay", "reputationChanges", "segmentEffects"] as const,
 };
 
-export async function analyzeScene(systemPrompt: string, userPrompt: string): Promise<SceneAnalysis> {
+export async function analyzeScene(systemPrompt: string, userPrompt: string, signal?: AbortSignal): Promise<SceneAnalysis> {
   return withRequestTracking(async () => {
     const raw = await streamChatCompletion({
       messages: [
@@ -498,15 +599,20 @@ export async function analyzeScene(systemPrompt: string, userPrompt: string): Pr
       maxTokens: SCENE_ANALYSIS_MAX_TOKENS,
       responseFormat: {
         type: "json_schema",
-        schema: SCENE_ANALYSIS_SCHEMA,
+        json_schema: {
+          name: "scene_analysis",
+          schema: SCENE_ANALYSIS_SCHEMA,
+          strict: true,
+        },
       },
+      signal,
     });
 
     return extractJsonPayload<SceneAnalysis>(raw);
   });
 }
 
-export async function runTrackerPrompt(systemPrompt: string, userPrompt: string): Promise<string> {
+export async function runTrackerPrompt(systemPrompt: string, userPrompt: string, signal?: AbortSignal): Promise<string> {
   return withRequestTracking(async () => {
     return await streamChatCompletion({
       messages: [
@@ -514,6 +620,7 @@ export async function runTrackerPrompt(systemPrompt: string, userPrompt: string)
         { role: "user", content: userPrompt },
       ],
       maxTokens: MAX_OUTPUT_TOKENS,
+      signal,
     });
   });
 }

--- a/packages/server/src/services/sidecar/sidecar-inference.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-inference.service.ts
@@ -201,6 +201,7 @@ async function streamChatCompletion(options: {
   signal?: AbortSignal;
 }): Promise<string> {
   const baseUrl = await sidecarProcessService.ensureReady();
+  const backend = sidecarModelService.getResolvedBackend();
   const generation = getRuntimeGenerationSettings();
   const config = sidecarModelService.getConfig();
   const requestedMaxTokens = Math.min(Math.max(1, Math.floor(options.maxTokens)), MAX_OUTPUT_TOKENS);
@@ -217,21 +218,25 @@ async function streamChatCompletion(options: {
   const structuredOutput = !!responseFormat;
 
   const send = async (sendMaxTokens: number): Promise<string> => {
+    const requestBody: Record<string, unknown> = {
+      model: getRequestModel(),
+      stream: true,
+      messages: fittedMessages,
+      max_tokens: sendMaxTokens,
+      temperature: structuredOutput ? 0 : generation.temperature,
+      top_p: structuredOutput ? 1 : generation.topP,
+      ...(!structuredOutput && generation.topK > 0 ? { top_k: generation.topK } : {}),
+    };
+    if (responseFormat && backend !== "mlx") {
+      requestBody.response_format = responseFormat;
+    }
+
     const response = await llmFetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        model: getRequestModel(),
-        stream: true,
-        messages: fittedMessages,
-        max_tokens: sendMaxTokens,
-        temperature: structuredOutput ? 0 : generation.temperature,
-        top_p: structuredOutput ? 1 : generation.topP,
-        ...(!structuredOutput && generation.topK > 0 ? { top_k: generation.topK } : {}),
-        ...(responseFormat ? { response_format: responseFormat } : {}),
-      }),
+      body: JSON.stringify(requestBody),
       signal: options.signal,
     });
 
@@ -353,36 +358,41 @@ export async function runTestMessage(): Promise<SidecarTestMessageOutput> {
     const config = sidecarModelService.getConfig();
     const shouldKeepRunning = config.useForTrackers || config.useForGameScene;
     const baseUrl = await sidecarProcessService.ensureReady({ forceStart: true });
+    const backend = sidecarModelService.getResolvedBackend();
     const nonce = `marinara-${randomUUID().slice(0, 8)}`;
 
     try {
+      const body: Record<string, unknown> = {
+        model: getRequestModel(),
+        stream: false,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a local runtime smoke test. Follow the user's format exactly and do not omit the verification token.",
+          },
+          {
+            role: "user",
+            content: `Reply in exactly two lines.
+Line 1: TOKEN ${nonce}
+Line 2: one short sentence confirming that the local sidecar test succeeded.`,
+          },
+        ] satisfies SidecarMessage[],
+        max_tokens: 48,
+        temperature: 0.2,
+        top_p: 0.9,
+      };
+      if (backend !== "mlx") {
+        body.reasoning_format = "none";
+        body.chat_template_kwargs = { enable_thinking: false };
+      }
+
       const response = await fetch(`${baseUrl}/v1/chat/completions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          model: getRequestModel(),
-          stream: false,
-          messages: [
-            {
-              role: "system",
-              content:
-                "You are a local runtime smoke test. Follow the user's format exactly and do not omit the verification token.",
-            },
-            {
-              role: "user",
-              content: `Reply in exactly two lines.
-Line 1: TOKEN ${nonce}
-Line 2: one short sentence confirming that the local sidecar test succeeded.`,
-            },
-          ] satisfies SidecarMessage[],
-          max_tokens: 48,
-          temperature: 0.2,
-          top_p: 0.9,
-          reasoning_format: "none",
-          chat_template_kwargs: { enable_thinking: false },
-        }),
+        body: JSON.stringify(body),
         signal: AbortSignal.timeout(45_000),
       });
 

--- a/packages/server/src/services/sidecar/sidecar-launch-plan.ts
+++ b/packages/server/src/services/sidecar/sidecar-launch-plan.ts
@@ -37,6 +37,8 @@ export function buildLlamaArgs(options: {
     args.push("--jinja");
   }
 
+  args.push("--embeddings", "--pooling", "mean");
+
   // Gemma 4 needs split mode disabled on CUDA multi-GPU launches,
   // but non-CUDA builds may reject the flag entirely.
   if (/cuda/i.test(options.runtimeVariant) && options.gpuLayers > 0 && needsCudaSingleGpuSplitMode(options.modelPath)) {

--- a/packages/server/src/services/sidecar/sidecar-launch-plan.ts
+++ b/packages/server/src/services/sidecar/sidecar-launch-plan.ts
@@ -5,6 +5,10 @@ export type LlamaStartupPlan = {
 
 const LLAMA_SERVER_PARALLEL_SLOTS = 2;
 
+function needsCudaSingleGpuSplitMode(modelPath: string): boolean {
+  return /gemma/i.test(modelPath);
+}
+
 export function buildLlamaArgs(options: {
   modelPath: string;
   gpuLayers: number;
@@ -35,7 +39,7 @@ export function buildLlamaArgs(options: {
 
   // Gemma 4 needs split mode disabled on CUDA multi-GPU launches,
   // but non-CUDA builds may reject the flag entirely.
-  if (/cuda/i.test(options.runtimeVariant) && options.gpuLayers > 0) {
+  if (/cuda/i.test(options.runtimeVariant) && options.gpuLayers > 0 && needsCudaSingleGpuSplitMode(options.modelPath)) {
     args.push("-sm", "none");
   }
 

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -28,6 +28,7 @@ import { downloadFileWithProgress, fetchJson, isAbortError } from "./sidecar-dow
 import { mlxRuntimeService } from "./mlx-runtime.service.js";
 import { sidecarRuntimeService } from "./sidecar-runtime.service.js";
 import { assertSupportedLlamaCppModelPath, isSupportedLlamaCppModelFilename } from "./sidecar-model-files.js";
+import { logger } from "../../lib/logger.js";
 
 export const MODELS_DIR = join(getDataDir(), "models");
 export const CUSTOM_MODELS_DIR = join(MODELS_DIR, "custom");
@@ -102,6 +103,10 @@ function repoLeaf(repo: string): string {
 
 function isRuntimePreference(value: unknown): value is SidecarConfig["runtimePreference"] {
   return typeof value === "string" && (SIDECAR_RUNTIME_PREFERENCES as readonly string[]).includes(value);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function normalizeIntegerSetting(value: unknown, fallback: number, min: number, max?: number): number {
@@ -814,13 +819,30 @@ class SidecarModelService {
     this.downloadAbort = null;
   }
 
-  deleteModel(): void {
+  private async removeModelFileWithRetry(modelPath: string): Promise<void> {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      try {
+        unlinkSync(modelPath);
+        return;
+      } catch (error) {
+        const code = error instanceof Error && "code" in error ? String((error as NodeJS.ErrnoException).code) : "";
+        const canRetry = (code === "EBUSY" || code === "EPERM") && attempt < 4;
+        if (!canRetry) {
+          logger.warn(error, "[sidecar] Failed to remove local model file %s", modelPath);
+          return;
+        }
+        await delay(250);
+      }
+    }
+  }
+
+  async deleteModel(): Promise<void> {
     if (this.resolveBackend() === "mlx") {
       mlxRuntimeService.clearModelCache();
     } else {
       const modelPath = this.getModelFilePath();
       if (modelPath && existsSync(modelPath)) {
-        unlinkSync(modelPath);
+        await this.removeModelFileWithRetry(modelPath);
       }
     }
 

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -276,7 +276,9 @@ class SidecarModelService {
   }
 
   private hasConfiguredModel(config: SidecarConfig = this.config): boolean {
-    return this.resolveBackend(config) === "mlx" ? !!config.modelRepo : this.getModelFilePathForConfig(config) !== null;
+    return this.resolveBackend(config) === "mlx"
+      ? mlxRuntimeService.hasModelCache(config.modelRepo)
+      : this.getModelFilePathForConfig(config) !== null;
   }
 
   private getConfiguredModelSize(config: SidecarConfig = this.config): number | null {
@@ -296,6 +298,26 @@ class SidecarModelService {
       return statSync(modelPath).size;
     } catch {
       return null;
+    }
+  }
+
+  private isUsableModelFile(path: string, expectedSize: number | null | undefined): boolean {
+    try {
+      const actualSize = statSync(path).size;
+      if (actualSize <= 0) {
+        return false;
+      }
+      return typeof expectedSize === "number" && expectedSize > 0 ? actualSize === expectedSize : true;
+    } catch {
+      return false;
+    }
+  }
+
+  private removeInvalidModelFile(path: string): void {
+    try {
+      unlinkSync(path);
+    } catch {
+      // Best-effort cleanup; the follow-up download will surface persistent filesystem errors.
     }
   }
 
@@ -319,7 +341,7 @@ class SidecarModelService {
 
     if (previousBackend === "mlx") {
       if (previousConfig.modelRepo && previousConfig.modelRepo !== nextConfig.modelRepo) {
-        mlxRuntimeService.clearModelCache();
+        mlxRuntimeService.clearModelCache(previousConfig.modelRepo);
       }
       return;
     }
@@ -477,7 +499,11 @@ class SidecarModelService {
   }
 
   getConfiguredModelRef(): string | null {
-    return this.resolveBackend() === "mlx" ? this.config.modelRepo : this.getModelFilePath();
+    return this.resolveBackend() === "mlx"
+      ? mlxRuntimeService.hasModelCache(this.config.modelRepo)
+        ? this.config.modelRepo
+        : null
+      : this.getModelFilePath();
   }
 
   getModelFilePath(): string | null {
@@ -535,21 +561,20 @@ class SidecarModelService {
         quantization,
         customModelRepo: null,
       };
+      this.status = "downloading_model";
+      try {
+        await mlxRuntimeService.downloadModel(repoId, modelInfo.label, modelInfo.sizeBytes, (progress) =>
+          this.emitProgress(progress, onProgress),
+        );
+      } catch (error) {
+        this.status = this.detectStatus();
+        this.emitProgress(this.buildModelErrorProgress(error), onProgress);
+        throw error;
+      }
       this.cleanupPreviousModel(previousConfig, nextConfig);
       this.config = nextConfig;
       this.saveConfig();
       this.status = "downloaded";
-      this.emitProgress(
-        {
-          phase: "model",
-          status: "complete",
-          downloaded: modelInfo.sizeBytes,
-          total: modelInfo.sizeBytes,
-          speed: 0,
-          label: modelInfo.label,
-        },
-        onProgress,
-      );
       return;
     }
 
@@ -563,7 +588,7 @@ class SidecarModelService {
       quantization,
       customModelRepo: null,
     };
-    if (existsSync(destination)) {
+    if (existsSync(destination) && this.isUsableModelFile(destination, modelInfo.sizeBytes)) {
       this.cleanupPreviousModel(previousConfig, nextConfig);
       this.config = nextConfig;
       this.saveConfig();
@@ -581,6 +606,9 @@ class SidecarModelService {
       );
       return;
     }
+    if (existsSync(destination)) {
+      this.removeInvalidModelFile(destination);
+    }
 
     if (!modelInfo.downloadUrl) {
       throw new Error(`The ${modelInfo.label} preset is missing a download URL.`);
@@ -591,6 +619,7 @@ class SidecarModelService {
         url: modelInfo.downloadUrl,
         relativePath,
         label: modelInfo.label,
+        expectedBytes: modelInfo.sizeBytes,
       },
       onProgress,
     );
@@ -655,21 +684,20 @@ class SidecarModelService {
         quantization: null,
         customModelRepo: repo,
       };
+      this.status = "downloading_model";
+      try {
+        await mlxRuntimeService.downloadModel(repo, selected.filename, selected.sizeBytes, (progress) =>
+          this.emitProgress(progress, onProgress),
+        );
+      } catch (error) {
+        this.status = this.detectStatus();
+        this.emitProgress(this.buildModelErrorProgress(error), onProgress);
+        throw error;
+      }
       this.cleanupPreviousModel(previousConfig, nextConfig);
       this.config = nextConfig;
       this.saveConfig();
       this.status = "downloaded";
-      this.emitProgress(
-        {
-          phase: "model",
-          status: "complete",
-          downloaded: selected.sizeBytes ?? 0,
-          total: selected.sizeBytes ?? 0,
-          speed: 0,
-          label: selected.filename,
-        },
-        onProgress,
-      );
       return selected;
     }
 
@@ -690,12 +718,17 @@ class SidecarModelService {
       quantization: null,
       customModelRepo: repo,
     };
+    if (existsSync(destination) && !this.isUsableModelFile(destination, selected.sizeBytes)) {
+      this.removeInvalidModelFile(destination);
+    }
+
     if (!existsSync(destination)) {
       await this.downloadModelFile(
         {
           url: selected.downloadUrl,
           relativePath,
           label: selected.filename,
+          expectedBytes: selected.sizeBytes,
         },
         onProgress,
       );
@@ -739,7 +772,7 @@ class SidecarModelService {
   }
 
   private async downloadModelFile(
-    input: { url: string; relativePath: string; label: string },
+    input: { url: string; relativePath: string; label: string; expectedBytes?: number | null },
     onProgress?: ProgressCallback,
   ): Promise<void> {
     if (this.downloadAbort) {
@@ -755,6 +788,7 @@ class SidecarModelService {
         url: input.url,
         destPath: destination,
         signal: this.downloadAbort.signal,
+        expectedBytes: input.expectedBytes,
         progress: {
           phase: "model",
           label: input.label,

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -847,8 +847,11 @@ class SidecarProcessService {
       return;
     }
 
-    this.child?.removeAllListeners("error");
-    this.child?.removeAllListeners("exit");
+    const currentChild = this.child;
+    currentChild?.stdout?.removeAllListeners("data");
+    currentChild?.stderr?.removeAllListeners("data");
+    currentChild?.removeAllListeners("error");
+    currentChild?.removeAllListeners("exit");
     this.child = null;
     this.ready = false;
     this.baseUrl = null;

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -11,6 +11,7 @@ import { buildLlamaProcessEnv } from "./sidecar-runtime-env.js";
 import { mlxRuntimeService, type MlxRuntimeInstall } from "./mlx-runtime.service.js";
 import { sidecarRuntimeService, type SidecarRuntimeInstall } from "./sidecar-runtime.service.js";
 import { assertSupportedLlamaCppModelPath } from "./sidecar-model-files.js";
+import { resolveSidecarRequestModel } from "./sidecar-request-model.js";
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -428,6 +429,30 @@ class SidecarProcessService {
     return ["-m", "mlx_lm.server", "--model", modelRepo, "--host", "127.0.0.1", "--port", String(port)];
   }
 
+  private async waitForMlxCompletionProbe(baseUrl: string): Promise<void> {
+    const model = resolveSidecarRequestModel("mlx", sidecarModelService.getConfiguredModelRef());
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        stream: false,
+        messages: [{ role: "user", content: "Reply with OK." }],
+        max_tokens: 1,
+        temperature: 0,
+        top_p: 1,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${body || response.statusText}`);
+    }
+  }
+
   private usesGpuRuntime(runtime: SidecarRuntimeInstall): boolean {
     return runtime.gpuCapable ?? sidecarRuntimeService.isGpuVariant(runtime.variant);
   }
@@ -745,6 +770,9 @@ class SidecarProcessService {
           signal: AbortSignal.timeout(3_000),
         });
         if (response.ok) {
+          if (backend === "mlx") {
+            await this.waitForMlxCompletionProbe(baseUrl);
+          }
           return;
         }
         lastError = new Error(`HTTP ${response.status}`);

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -88,6 +88,7 @@ class SidecarProcessService {
   private stopRequested = false;
   private stopRequestId = 0;
   private unexpectedCrashCount = 0;
+  private unexpectedCrashWindowStartedAt = 0;
   private lastReadyAt = 0;
   private starting = false;
   private syncLock: Promise<void> = Promise.resolve();
@@ -140,6 +141,8 @@ class SidecarProcessService {
     return this.withLock(async () => {
       this.clearStopRequest(stopRequestId);
       this.clearStartupFailure();
+      this.unexpectedCrashCount = 0;
+      this.unexpectedCrashWindowStartedAt = 0;
       this.currentSignature = null;
       await this.stopUnlocked();
       await this.syncUnlocked({ forceStart: true, allowRuntimeInstall: false });
@@ -205,6 +208,8 @@ class SidecarProcessService {
       try {
         await this.stopUnlocked();
         this.clearStartupFailure();
+        this.unexpectedCrashCount = 0;
+        this.unexpectedCrashWindowStartedAt = 0;
         if (sidecarModelService.getConfiguredModelRef()) {
           sidecarModelService.setStatus("downloaded");
         } else {
@@ -514,6 +519,7 @@ class SidecarProcessService {
           backend,
           pythonPath: this.getMlxPythonPath(runtime),
           modelRef,
+          contextSize: config.contextSize,
         })
       : JSON.stringify({
           backend,
@@ -744,7 +750,6 @@ class SidecarProcessService {
 
   private markReady(): void {
     this.ready = true;
-    this.unexpectedCrashCount = 0;
     this.lastReadyAt = Date.now();
     this.clearStartupFailure();
     sidecarModelService.setStatus("ready");
@@ -881,8 +886,15 @@ class SidecarProcessService {
       return;
     }
 
-    const crashedSoonAfterReady = this.lastReadyAt > 0 && Date.now() - this.lastReadyAt < 30_000;
-    this.unexpectedCrashCount = crashedSoonAfterReady ? this.unexpectedCrashCount + 1 : 1;
+    const now = Date.now();
+    const withinRepeatedCrashWindow =
+      this.unexpectedCrashWindowStartedAt > 0 && now - this.unexpectedCrashWindowStartedAt < 5 * 60_000;
+    if (!withinRepeatedCrashWindow) {
+      this.unexpectedCrashWindowStartedAt = now;
+      this.unexpectedCrashCount = 1;
+    } else {
+      this.unexpectedCrashCount += 1;
+    }
 
     if (this.unexpectedCrashCount > 1) {
       this.startupError = "The local sidecar server crashed repeatedly after startup";

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -40,6 +40,7 @@ type SyncOptions = {
   suppressKnownFailure?: boolean;
   forceStart?: boolean;
   allowRuntimeInstall?: boolean;
+  preemptStarting?: boolean;
 };
 type EnsureReadyOptions = {
   forceStart?: boolean;
@@ -59,6 +60,20 @@ class SidecarServerExitError extends Error {
   }
 }
 
+class SidecarStartupTimeoutError extends Error {
+  constructor() {
+    super("Timed out waiting for the local sidecar server to become ready");
+    this.name = "SidecarStartupTimeoutError";
+  }
+}
+
+class SidecarStartupCancelledError extends Error {
+  constructor() {
+    super("Local sidecar startup was cancelled");
+    this.name = "SidecarStartupCancelledError";
+  }
+}
+
 class SidecarProcessService {
   private child: ChildProcess | null = null;
   private logStream: WriteStream | null = null;
@@ -69,10 +84,13 @@ class SidecarProcessService {
   private startupError: string | null = null;
   private failedRuntimeVariant: string | null = null;
   private intentionalStop = false;
+  private stopRequested = false;
+  private stopRequestId = 0;
   private unexpectedCrashCount = 0;
   private lastReadyAt = 0;
   private starting = false;
   private syncLock: Promise<void> = Promise.resolve();
+  private childErrors = new WeakMap<ChildProcess, Error>();
 
   isReady(): boolean {
     return this.ready && this.baseUrl !== null;
@@ -106,13 +124,20 @@ class SidecarProcessService {
 
   async syncForCurrentConfig(options?: boolean | SyncOptions): Promise<void> {
     const normalizedOptions = this.normalizeSyncOptions(options);
+    const preemptStopRequestId =
+      normalizedOptions.preemptStarting && this.starting ? this.requestStopForStartup("sync") : null;
     return this.withLock(async () => {
+      if (preemptStopRequestId !== null) {
+        this.clearStopRequest(preemptStopRequestId);
+      }
       await this.syncUnlocked(normalizedOptions);
     });
   }
 
   async restart(): Promise<void> {
+    const stopRequestId = this.requestStopForStartup("restart");
     return this.withLock(async () => {
+      this.clearStopRequest(stopRequestId);
       this.clearStartupFailure();
       this.currentSignature = null;
       await this.stopUnlocked();
@@ -173,24 +198,68 @@ class SidecarProcessService {
   }
 
   async stop(): Promise<void> {
-    if (this.starting && this.child) {
-      this.intentionalStop = true;
-      try {
-        this.child.kill("SIGTERM");
-      } catch {
-        // Best-effort early stop while startup is still waiting.
-      }
-    }
+    const stopRequestId = this.requestStopForStartup("stop");
 
     return this.withLock(async () => {
-      await this.stopUnlocked();
-      this.clearStartupFailure();
-      if (sidecarModelService.getConfiguredModelRef()) {
-        sidecarModelService.setStatus("downloaded");
-      } else {
-        sidecarModelService.setStatus("not_downloaded");
+      try {
+        await this.stopUnlocked();
+        this.clearStartupFailure();
+        if (sidecarModelService.getConfiguredModelRef()) {
+          sidecarModelService.setStatus("downloaded");
+        } else {
+          sidecarModelService.setStatus("not_downloaded");
+        }
+      } finally {
+        this.clearStopRequest(stopRequestId);
       }
     });
+  }
+
+  killCurrentChildForProcessExit(): void {
+    const child = this.child;
+    if (!child || child.exitCode !== null) {
+      return;
+    }
+
+    this.intentionalStop = true;
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      // Best-effort process-exit reaping.
+    }
+
+    if (child.exitCode === null) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // Best-effort forced process-exit reaping.
+      }
+    }
+  }
+
+  private requestStopForStartup(reason: "restart" | "stop" | "sync"): number {
+    this.stopRequested = true;
+    this.stopRequestId += 1;
+    const stopRequestId = this.stopRequestId;
+
+    if (!this.starting || !this.child) {
+      return stopRequestId;
+    }
+
+    this.intentionalStop = true;
+    try {
+      this.child.kill("SIGTERM");
+    } catch {
+      logger.debug("[sidecar] Failed to signal startup child during %s", reason);
+    }
+
+    return stopRequestId;
+  }
+
+  private clearStopRequest(stopRequestId: number): void {
+    if (this.stopRequestId === stopRequestId) {
+      this.stopRequested = false;
+    }
   }
 
   private async withLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -371,8 +440,8 @@ class SidecarProcessService {
     });
   }
 
-  private shouldRetryStartup(error: unknown): error is SidecarServerExitError {
-    return error instanceof SidecarServerExitError;
+  private shouldRetryStartup(error: unknown): boolean {
+    return error instanceof SidecarServerExitError || error instanceof SidecarStartupTimeoutError;
   }
 
   private formatCommandArgs(args: string[]): string {
@@ -401,7 +470,12 @@ class SidecarProcessService {
     return new Error(`${baseMessage}\nCommand: ${commandLine}\nRecent sidecar log:\n${recentLogs}`);
   }
 
-  private getChildExitError(child: ChildProcess): SidecarServerExitError | null {
+  private getChildExitError(child: ChildProcess): Error | null {
+    const spawnError = this.childErrors.get(child);
+    if (spawnError) {
+      return spawnError;
+    }
+
     if (child.exitCode === null && child.signalCode === null) {
       return null;
     }
@@ -477,6 +551,10 @@ class SidecarProcessService {
         await this.startLlamaForInstalledRuntimeUnlocked(activeRuntime, modelPath, runtimeSignature);
         return;
       } catch (error) {
+        if (error instanceof SidecarStartupCancelledError) {
+          throw error;
+        }
+
         lastError = error instanceof Error ? error : new Error("The local sidecar server failed to start");
 
         const nextRuntime: ManagedRuntimeInstall | null = this.usesGpuRuntime(activeRuntime)
@@ -517,6 +595,10 @@ class SidecarProcessService {
     const startupPlans = this.buildLlamaStartupPlans(runtime);
 
     for (let attempt = 0; attempt < startupPlans.length; attempt += 1) {
+      if (this.stopRequested) {
+        throw new SidecarStartupCancelledError();
+      }
+
       const plan = startupPlans[attempt]!;
       const port = await getFreePort();
       const args = this.buildLlamaArgs(modelPath, plan.gpuLayers, port, runtime);
@@ -544,6 +626,10 @@ class SidecarProcessService {
         const decoratedError = this.decorateStartupError(error, runtime.serverPath, args);
         await this.stopUnlocked();
 
+        if (this.stopRequested) {
+          throw new SidecarStartupCancelledError();
+        }
+
         const nextPlan = startupPlans[attempt + 1];
         if (nextPlan && this.shouldRetryStartup(error)) {
           logger.warn(error, "[sidecar] Startup with %s failed. Retrying with %s.", plan.label, nextPlan.label);
@@ -558,6 +644,10 @@ class SidecarProcessService {
   }
 
   private async startMlxUnlocked(runtime: MlxRuntimeInstall, modelRepo: string): Promise<void> {
+    if (this.stopRequested) {
+      throw new SidecarStartupCancelledError();
+    }
+
     const port = await getFreePort();
     const args = this.buildMlxArgs(modelRepo, port);
     const signature = this.buildRuntimeSignature("mlx", runtime, modelRepo);
@@ -583,6 +673,11 @@ class SidecarProcessService {
       await this.waitForReady(this.baseUrl!, child, "mlx");
       this.markReady();
     } catch (error) {
+      if (error instanceof SidecarStartupCancelledError) {
+        await this.stopUnlocked();
+        throw error;
+      }
+
       const decorated = this.decorateStartupError(error, runtime.pythonPath, args);
       await this.stopUnlocked();
       this.rememberStartupFailure(signature, runtime.variant, decorated);
@@ -604,8 +699,21 @@ class SidecarProcessService {
     child.stderr?.on("data", (chunk) => {
       logStream.write(chunk);
     });
+    child.on("error", (error) => {
+      const spawnError = error instanceof Error ? error : new Error(String(error));
+      this.childErrors.set(child, spawnError);
+      logStream.write(`[sidecar] process error: ${spawnError.message}\n`);
+
+      if (this.child === child) {
+        this.startupError = spawnError.message;
+        sidecarModelService.setStatus("server_error");
+      }
+    });
     child.on("exit", (code, signal) => {
-      void this.handleChildExit(code, signal);
+      if (this.child !== child) {
+        return;
+      }
+      void this.handleChildExit(child, code, signal);
     });
   }
 
@@ -623,6 +731,10 @@ class SidecarProcessService {
     let lastError: unknown = null;
 
     while (Date.now() < timeoutAt) {
+      if (this.stopRequested) {
+        throw new SidecarStartupCancelledError();
+      }
+
       const exitError = this.getChildExitError(child);
       if (exitError) {
         throw exitError;
@@ -647,26 +759,35 @@ class SidecarProcessService {
       await delay(backend === "mlx" ? 1_000 : 500);
     }
 
+    if (this.stopRequested) {
+      throw new SidecarStartupCancelledError();
+    }
+
     const exitError = this.getChildExitError(child);
     if (exitError) {
       throw exitError;
     }
 
-    throw lastError instanceof Error ? lastError : new Error("Timed out waiting for the local sidecar server");
+    if (lastError instanceof Error) {
+      logger.warn(lastError, "[sidecar] Readiness probe timed out after repeated failures");
+    }
+    throw new SidecarStartupTimeoutError();
   }
 
   private async stopUnlocked(): Promise<void> {
     const child = this.child;
     if (!child) {
-      this.ready = false;
-      this.baseUrl = null;
+      this.cleanupChildState();
       return;
     }
 
     this.intentionalStop = true;
-    const exited = new Promise<void>((resolve) => {
-      child.once("exit", () => resolve());
-    });
+    const exited =
+      child.exitCode === null
+        ? new Promise<void>((resolve) => {
+            child.once("exit", () => resolve());
+          })
+        : Promise.resolve();
 
     try {
       child.kill("SIGTERM");
@@ -685,10 +806,16 @@ class SidecarProcessService {
       }
     }
 
-    this.cleanupChildState();
+    this.cleanupChildState(child);
   }
 
-  private cleanupChildState(): void {
+  private cleanupChildState(child?: ChildProcess): void {
+    if (child && this.child !== child) {
+      return;
+    }
+
+    this.child?.removeAllListeners("error");
+    this.child?.removeAllListeners("exit");
     this.child = null;
     this.ready = false;
     this.baseUrl = null;
@@ -699,10 +826,18 @@ class SidecarProcessService {
     }
   }
 
-  private async handleChildExit(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
-    const wasIntentional = this.intentionalStop;
+  private async handleChildExit(
+    child: ChildProcess,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): Promise<void> {
+    if (this.child !== child) {
+      return;
+    }
+
+    const wasIntentional = this.intentionalStop || this.stopRequested;
     this.intentionalStop = false;
-    this.cleanupChildState();
+    this.cleanupChildState(child);
 
     if (wasIntentional) {
       return;

--- a/packages/server/src/services/sidecar/sidecar-runtime.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-runtime.service.ts
@@ -345,9 +345,12 @@ class SidecarRuntimeService {
       return this.installPromise;
     }
 
-    this.installPromise = this.installLatest(onProgress, excludedVariants, preference).finally(() => {
-      this.installPromise = null;
-    });
+    const preserveCurrentInstall = excludedVariants.size > 0 && current !== null;
+    this.installPromise = this.installLatest(onProgress, excludedVariants, preference, { preserveCurrentInstall }).finally(
+      () => {
+        this.installPromise = null;
+      },
+    );
     return this.installPromise;
   }
 
@@ -401,7 +404,10 @@ class SidecarRuntimeService {
     writeFileSync(CURRENT_RUNTIME_PATH, JSON.stringify(record, null, 2), "utf-8");
   }
 
-  private cleanupBundledArtifacts(keepDirectoryName?: string | null): void {
+  private cleanupBundledArtifacts(
+    keepDirectoryName?: string | null,
+    options: { preserveRuntimeDirectories?: boolean } = {},
+  ): void {
     for (const entry of readdirSync(RUNTIME_DIR, { withFileTypes: true })) {
       if (entry.name === "mlx" || entry.name === "server.log") {
         continue;
@@ -419,9 +425,8 @@ class SidecarRuntimeService {
         continue;
       }
 
-      const isBundledArtifact =
-        /^llama-/i.test(entry.name) || /\.(extract|zip)$/i.test(entry.name) || entry.name.endsWith(".tar.gz");
-      if (isBundledArtifact || entry.isDirectory()) {
+      const isTemporaryArtifact = /\.(extract|zip)$/i.test(entry.name) || entry.name.endsWith(".tar.gz");
+      if (isTemporaryArtifact || (entry.isDirectory() && !options.preserveRuntimeDirectories)) {
         rmSync(fullPath, { recursive: true, force: true });
       }
     }
@@ -440,6 +445,7 @@ class SidecarRuntimeService {
     onProgress?: (progress: SidecarDownloadProgress) => void,
     excludedVariants: Set<string> = new Set(),
     preference: SidecarRuntimePreference = "auto",
+    options: { preserveCurrentInstall?: boolean } = {},
   ): Promise<SidecarRuntimeInstall> {
     const abortController = new AbortController();
     this.installAbort = abortController;
@@ -558,8 +564,10 @@ class SidecarRuntimeService {
         systemPath: null,
         gpuCapable: this.isGpuVariant(match.variant),
       };
-      this.writeCurrentInstall(install);
-      this.cleanupBundledArtifacts(directoryName);
+      if (!options.preserveCurrentInstall) {
+        this.writeCurrentInstall(install);
+      }
+      this.cleanupBundledArtifacts(directoryName, { preserveRuntimeDirectories: options.preserveCurrentInstall });
       return install;
     } catch (error) {
       if (extractDirectory) {
@@ -725,7 +733,10 @@ class SidecarRuntimeService {
     }
 
     if (platform === "win32") {
-      return false;
+      const windowsDir = process.env.SystemRoot || process.env.WINDIR || "C:\\Windows";
+      return [join(windowsDir, "System32", "vulkan-1.dll"), join(windowsDir, "SysWOW64", "vulkan-1.dll")].some(
+        (path) => existsSync(path),
+      );
     }
 
     if (platform === "linux") {

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -10,6 +10,7 @@ import {
   getDefaultBuiltInAgentSettings,
   markAgentConfigDeletedSettings,
   normalizeAgentPhaseForType,
+  parseAgentSettingsRecord,
   type CreateAgentConfigInput,
   type AgentResult,
 } from "@marinara-engine/shared";
@@ -62,6 +63,29 @@ function parseRunData(value: string): unknown {
   } catch {
     return value;
   }
+}
+
+function mergeBuiltInCreateUpdate(
+  existing: AgentConfigRow,
+  input: CreateAgentConfigInput,
+): Partial<CreateAgentConfigInput> {
+  const currentSettings = parseAgentSettingsRecord(existing.settings);
+  const nextSettings = { ...currentSettings, ...(input.settings ?? {}) };
+  if (input.resultType !== undefined) nextSettings.resultType = input.resultType;
+
+  const update: Partial<CreateAgentConfigInput> = {
+    name: input.name,
+    description: input.description,
+    phase: input.phase,
+    enabled: input.enabled,
+    settings: nextSettings,
+  };
+
+  if (input.connectionId !== null) update.connectionId = input.connectionId;
+  if (input.imagePath !== null) update.imagePath = input.imagePath;
+  if (input.promptTemplate.trim().length > 0) update.promptTemplate = input.promptTemplate;
+
+  return update;
 }
 
 function serializeRunWithConfig(row: { agent_runs: AgentRunRow; agent_configs: AgentConfigRow }) {
@@ -187,7 +211,7 @@ export function createAgentsStorage(db: DB) {
       if (builtInType) {
         const existing = await getByType(input.type);
         if (existing) {
-          return this.update(existing.id, input);
+          return this.update(existing.id, mergeBuiltInCreateUpdate(existing, input));
         }
       }
 
@@ -233,7 +257,7 @@ export function createAgentsStorage(db: DB) {
           updateFields.settings = JSON.stringify(settings);
         } else {
           const current = await getById(id);
-          const currentSettings = current?.settings ? JSON.parse(current.settings as string) : {};
+          const currentSettings = parseAgentSettingsRecord(current?.settings);
           updateFields.settings = JSON.stringify({ ...currentSettings, resultType: data.resultType });
         }
       }

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -316,6 +316,13 @@ export function createChatsStorage(db: DB) {
       return rows[0] ?? null;
     },
 
+    async touch(id: string, opts?: { tx?: Pick<DB, "select" | "update"> }) {
+      const conn = opts?.tx ?? db;
+      await conn.update(chats).set({ updatedAt: now() }).where(eq(chats.id, id));
+      const rows = await conn.select().from(chats).where(eq(chats.id, id));
+      return rows[0] ?? null;
+    },
+
     /**
      * Set the folder assignment for a chat, propagating to every branch that
      * shares its groupId. The sidebar collapses each group to a single visible

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -8,6 +8,7 @@ import {
   messages,
   messageSwipes,
   gameStateSnapshots,
+  gameCheckpoints,
   gameEngineState,
   chatImages,
   oocInfluences,
@@ -190,6 +191,28 @@ async function invalidateMemoryChunksFrom(db: DB, chatId: string, createdAt: str
 
 /** Create the chat storage facade used by routes and importers. */
 export function createChatsStorage(db: DB) {
+  async function deleteGameStateForMessages(messageIds: string[]) {
+    const ids = Array.from(new Set(messageIds.filter(Boolean)));
+    if (ids.length === 0) return;
+
+    const CHUNK = 500;
+    for (let i = 0; i < ids.length; i += CHUNK) {
+      const chunk = ids.slice(i, i + CHUNK);
+      const snapshots = await db
+        .select({ id: gameStateSnapshots.id })
+        .from(gameStateSnapshots)
+        .where(inArray(gameStateSnapshots.messageId, chunk));
+      const snapshotIds = snapshots.map((row) => row.id).filter(Boolean);
+
+      for (let j = 0; j < snapshotIds.length; j += CHUNK) {
+        const snapshotChunk = snapshotIds.slice(j, j + CHUNK);
+        await db.delete(gameCheckpoints).where(inArray(gameCheckpoints.snapshotId, snapshotChunk));
+      }
+      await db.delete(gameCheckpoints).where(inArray(gameCheckpoints.messageId, chunk));
+      await db.delete(gameStateSnapshots).where(inArray(gameStateSnapshots.messageId, chunk));
+    }
+  }
+
   async function collectFreshConversationSchedules(
     characterIds: string[],
     excludeChatId?: string,
@@ -484,6 +507,8 @@ export function createChatsStorage(db: DB) {
       // Clean up agent data referencing this chat
       await db.delete(agentRuns).where(eq(agentRuns.chatId, id));
       await db.delete(agentMemory).where(eq(agentMemory.chatId, id));
+      await db.delete(gameCheckpoints).where(eq(gameCheckpoints.chatId, id));
+      await db.delete(gameStateSnapshots).where(eq(gameStateSnapshots.chatId, id));
 
       // Clean up gallery images (DB records + files on disk)
       await db.delete(chatImages).where(eq(chatImages.chatId, id));
@@ -500,6 +525,8 @@ export function createChatsStorage(db: DB) {
       for (const chat of groupChats) {
         await db.delete(agentRuns).where(eq(agentRuns.chatId, chat.id));
         await db.delete(agentMemory).where(eq(agentMemory.chatId, chat.id));
+        await db.delete(gameCheckpoints).where(eq(gameCheckpoints.chatId, chat.id));
+        await db.delete(gameStateSnapshots).where(eq(gameStateSnapshots.chatId, chat.id));
         await db.delete(chatImages).where(eq(chatImages.chatId, chat.id));
         const galleryDir = join(GALLERY_DIR, chat.id);
         if (existsSync(galleryDir)) rmSync(galleryDir, { recursive: true, force: true });
@@ -804,6 +831,7 @@ export function createChatsStorage(db: DB) {
 
     async removeMessage(id: string) {
       const existing = await this.getMessage(id);
+      if (existing) await deleteGameStateForMessages([id]);
       await db.delete(messages).where(eq(messages.id, id));
       if (existing) {
         await invalidateMemoryChunksFrom(db, existing.chatId, existing.createdAt);
@@ -820,13 +848,14 @@ export function createChatsStorage(db: DB) {
           ? and(inArray(messages.id, chunk), eq(messages.chatId, chatId))
           : inArray(messages.id, chunk);
         const existingRows = await db
-          .select({ chatId: messages.chatId, createdAt: messages.createdAt })
+          .select({ id: messages.id, chatId: messages.chatId, createdAt: messages.createdAt })
           .from(messages)
           .where(condition);
         for (const row of existingRows) {
           const current = earliestByChat.get(row.chatId);
           if (!current || row.createdAt < current) earliestByChat.set(row.chatId, row.createdAt);
         }
+        await deleteGameStateForMessages(existingRows.map((row) => row.id));
         await db.delete(messages).where(condition);
       }
       for (const [affectedChatId, createdAt] of earliestByChat) {

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -440,7 +440,7 @@ export function createGameStateStorage(db: DB) {
       manual?: boolean,
     ) {
       const updates: Record<string, unknown> = {};
-      const lockMigrationState = buildLockMigrationState(row);
+      const existingLockMigrationState = buildLockMigrationState(row);
       if (fields.date !== undefined) updates.date = coerceGameStateTextValue(fields.date);
       if (fields.time !== undefined) updates.time = coerceGameStateTextValue(fields.time);
       if (fields.location !== undefined) updates.location = coerceGameStateTextValue(fields.location);
@@ -471,10 +471,18 @@ export function createGameStateStorage(db: DB) {
       }
 
       if (fields.fieldLocks !== undefined) {
-        updates.fieldLocks = serializeFieldLocks(normalizeTrackerFieldLocksForState(fields.fieldLocks, lockMigrationState));
+        const incomingLockMigrationState = buildLockMigrationState({
+          ...row,
+          ...(fields.presentCharacters !== undefined ? { presentCharacters: fields.presentCharacters } : {}),
+          ...(fields.playerStats !== undefined ? { playerStats: fields.playerStats } : {}),
+          ...(fields.personaStats !== undefined ? { personaStats: fields.personaStats } : {}),
+        });
+        updates.fieldLocks = serializeFieldLocks(
+          normalizeTrackerFieldLocksForState(fields.fieldLocks, incomingLockMigrationState),
+        );
       } else if (row.fieldLocks) {
         updates.fieldLocks = serializeFieldLocks(
-          normalizeTrackerFieldLocksForState(parseTrackerFieldLocks(row.fieldLocks), lockMigrationState),
+          normalizeTrackerFieldLocksForState(parseTrackerFieldLocks(row.fieldLocks), existingLockMigrationState),
         );
       }
 

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -34,6 +34,24 @@ type GameStateUpdateFields = Partial<
   >
 >;
 
+type LockMigrationStateSource = {
+  id?: unknown;
+  chatId?: unknown;
+  messageId?: unknown;
+  swipeIndex?: unknown;
+  date?: unknown;
+  time?: unknown;
+  location?: unknown;
+  weather?: unknown;
+  temperature?: unknown;
+  presentCharacters?: unknown;
+  recentEvents?: unknown;
+  playerStats?: unknown;
+  personaStats?: unknown;
+  fieldLocks?: unknown;
+  createdAt?: unknown;
+};
+
 function coerceSnapshotTextFields(fields: Partial<Pick<GameState, (typeof MANUAL_OVERRIDE_FIELDS)[number]>>) {
   return {
     date: coerceGameStateTextValue(fields.date),
@@ -79,9 +97,7 @@ function parseSnapshotJson<T>(value: unknown, fallback: T): T {
   return value == null ? fallback : (value as T);
 }
 
-function buildLockMigrationState(
-  row: Partial<typeof gameStateSnapshots.$inferSelect> & { chatId?: string; messageId?: string; swipeIndex?: number },
-): GameState {
+function buildLockMigrationState(row: LockMigrationStateSource): GameState {
   return {
     id: typeof row.id === "string" ? row.id : "",
     chatId: typeof row.chatId === "string" ? row.chatId : "",
@@ -457,7 +473,9 @@ export function createGameStateStorage(db: DB) {
       if (fields.fieldLocks !== undefined) {
         updates.fieldLocks = serializeFieldLocks(normalizeTrackerFieldLocksForState(fields.fieldLocks, lockMigrationState));
       } else if (row.fieldLocks) {
-        updates.fieldLocks = serializeFieldLocks(normalizeTrackerFieldLocksForState(row.fieldLocks, lockMigrationState));
+        updates.fieldLocks = serializeFieldLocks(
+          normalizeTrackerFieldLocksForState(parseTrackerFieldLocks(row.fieldLocks), lockMigrationState),
+        );
       }
 
       if (Object.keys(updates).length === 0) return row;

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -79,6 +79,11 @@ export function createGameStateStorage(db: DB) {
       return rows[0] ?? null;
     },
 
+    async getById(id: string) {
+      const rows = await db.select().from(gameStateSnapshots).where(eq(gameStateSnapshots.id, id)).limit(1);
+      return rows[0] ?? null;
+    },
+
     /** Get the latest committed game state — the one the user "accepted" by sending their next message. */
     async getLatestCommitted(chatId: string) {
       const rows = await db

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -8,6 +8,7 @@ import { newId, now } from "../../utils/id-generator.js";
 import {
   coerceGameStateTextValue,
   normalizeTrackerFieldLocks,
+  normalizeTrackerFieldLocksForState,
   parseTrackerFieldLocks,
   trackerFieldLocksAreEmpty,
   type GameState,
@@ -65,6 +66,39 @@ function serializeManualOverrides(manualOverrides: Record<string, string> | null
 function serializeFieldLocks(fieldLocks: TrackerFieldLocks | null | undefined) {
   const normalized = normalizeTrackerFieldLocks(fieldLocks);
   return trackerFieldLocksAreEmpty(normalized) ? null : JSON.stringify(normalized);
+}
+
+function parseSnapshotJson<T>(value: unknown, fallback: T): T {
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return fallback;
+    }
+  }
+  return value == null ? fallback : (value as T);
+}
+
+function buildLockMigrationState(
+  row: Partial<typeof gameStateSnapshots.$inferSelect> & { chatId?: string; messageId?: string; swipeIndex?: number },
+): GameState {
+  return {
+    id: typeof row.id === "string" ? row.id : "",
+    chatId: typeof row.chatId === "string" ? row.chatId : "",
+    messageId: typeof row.messageId === "string" ? row.messageId : "",
+    swipeIndex: typeof row.swipeIndex === "number" ? row.swipeIndex : 0,
+    date: coerceGameStateTextValue(row.date),
+    time: coerceGameStateTextValue(row.time),
+    location: coerceGameStateTextValue(row.location),
+    weather: coerceGameStateTextValue(row.weather),
+    temperature: coerceGameStateTextValue(row.temperature),
+    presentCharacters: parseSnapshotJson(row.presentCharacters, []),
+    recentEvents: parseSnapshotJson(row.recentEvents, []),
+    playerStats: parseSnapshotJson(row.playerStats, null),
+    personaStats: parseSnapshotJson(row.personaStats, null),
+    fieldLocks: parseTrackerFieldLocks(row.fieldLocks),
+    createdAt: typeof row.createdAt === "string" ? row.createdAt : now(),
+  };
 }
 
 export function createGameStateStorage(db: DB) {
@@ -341,6 +375,10 @@ export function createGameStateStorage(db: DB) {
           : null,
         fieldLocks: parseTrackerFieldLocks(latest?.fieldLocks),
       };
+      baseState.fieldLocks = normalizeTrackerFieldLocksForState(
+        baseState.fieldLocks,
+        buildLockMigrationState(baseState),
+      );
 
       // Apply the incoming fields on top of the cloned base
       if (fields.date !== undefined) baseState.date = coerceGameStateTextValue(fields.date);
@@ -351,7 +389,9 @@ export function createGameStateStorage(db: DB) {
       if (fields.presentCharacters !== undefined) baseState.presentCharacters = fields.presentCharacters as any;
       if (fields.playerStats !== undefined) baseState.playerStats = fields.playerStats as any;
       if (fields.personaStats !== undefined) baseState.personaStats = fields.personaStats as any;
-      if (fields.fieldLocks !== undefined) baseState.fieldLocks = normalizeTrackerFieldLocks(fields.fieldLocks);
+      if (fields.fieldLocks !== undefined) {
+        baseState.fieldLocks = normalizeTrackerFieldLocksForState(fields.fieldLocks, buildLockMigrationState(baseState));
+      }
 
       const manualOverrides = manual
         ? MANUAL_OVERRIDE_FIELDS.reduce<Record<string, string>>((acc, key) => {
@@ -373,6 +413,7 @@ export function createGameStateStorage(db: DB) {
       manual?: boolean,
     ) {
       const updates: Record<string, unknown> = {};
+      const lockMigrationState = buildLockMigrationState(row);
       if (fields.date !== undefined) updates.date = coerceGameStateTextValue(fields.date);
       if (fields.time !== undefined) updates.time = coerceGameStateTextValue(fields.time);
       if (fields.location !== undefined) updates.location = coerceGameStateTextValue(fields.location);
@@ -403,7 +444,9 @@ export function createGameStateStorage(db: DB) {
       }
 
       if (fields.fieldLocks !== undefined) {
-        updates.fieldLocks = serializeFieldLocks(fields.fieldLocks);
+        updates.fieldLocks = serializeFieldLocks(normalizeTrackerFieldLocksForState(fields.fieldLocks, lockMigrationState));
+      } else if (row.fieldLocks) {
+        updates.fieldLocks = serializeFieldLocks(normalizeTrackerFieldLocksForState(row.fieldLocks, lockMigrationState));
       }
 
       if (Object.keys(updates).length === 0) return row;

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -253,15 +253,26 @@ export function createGameStateStorage(db: DB) {
     },
 
     /** Batch-fetch committed snapshots for multiple messages. Returns a Map of messageId → row. */
-    async getCommittedForMessages(messageIds: string[]) {
+    async getCommittedForMessages(messagesOrIds: Array<string | { id: string; activeSwipeIndex?: number | null }>) {
+      const activeSwipeByMessageId = new Map<string, number>();
+      const messageIds = messagesOrIds.map((messageOrId) => {
+        if (typeof messageOrId === "string") return messageOrId;
+        if (typeof messageOrId.activeSwipeIndex === "number") {
+          activeSwipeByMessageId.set(messageOrId.id, messageOrId.activeSwipeIndex);
+        }
+        return messageOrId.id;
+      });
       if (messageIds.length === 0) return new Map<string, typeof gameStateSnapshots.$inferSelect>();
       const rows = await db
         .select()
         .from(gameStateSnapshots)
-        .where(and(inArray(gameStateSnapshots.messageId, messageIds), eq(gameStateSnapshots.committed, 1)));
+        .where(and(inArray(gameStateSnapshots.messageId, messageIds), eq(gameStateSnapshots.committed, 1)))
+        .orderBy(desc(gameStateSnapshots.createdAt));
       const map = new Map<string, typeof gameStateSnapshots.$inferSelect>();
       for (const row of rows) {
-        map.set(row.messageId, row);
+        const activeSwipeIndex = activeSwipeByMessageId.get(row.messageId);
+        if (activeSwipeIndex !== undefined && row.swipeIndex !== activeSwipeIndex) continue;
+        if (!map.has(row.messageId)) map.set(row.messageId, row);
       }
       return map;
     },

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -157,6 +157,8 @@ function parseEntryRow(row: Record<string, unknown>) {
     useRegex: row.useRegex === "true",
     locked: row.locked === "true",
     preventRecursion: row.preventRecursion === "true",
+    excludeRecursion: row.excludeRecursion === "true",
+    delayUntilRecursion: row.delayUntilRecursion === "true",
     excludeFromVectorization: row.excludeFromVectorization === "true",
     folderId: (row.folderId as string | null | undefined) ?? null,
     keys: parseStringArray(row.keys),
@@ -565,6 +567,8 @@ export function createLorebooksStorage(db: DB) {
         schedule: input.schedule ? JSON.stringify(input.schedule) : null,
         locked: String(input.locked ?? false),
         preventRecursion: String(input.preventRecursion ?? false),
+        excludeRecursion: String(input.excludeRecursion ?? false),
+        delayUntilRecursion: String(input.delayUntilRecursion ?? false),
         excludeFromVectorization: String(input.excludeFromVectorization ?? false),
         createdAt: timestamp,
         updatedAt: timestamp,
@@ -647,6 +651,9 @@ export function createLorebooksStorage(db: DB) {
       if (input.schedule !== undefined) updates.schedule = input.schedule ? JSON.stringify(input.schedule) : null;
       if (input.locked !== undefined) updates.locked = String(input.locked);
       if (input.preventRecursion !== undefined) updates.preventRecursion = String(input.preventRecursion);
+      if (input.excludeRecursion !== undefined) updates.excludeRecursion = String(input.excludeRecursion);
+      if (input.delayUntilRecursion !== undefined)
+        updates.delayUntilRecursion = String(input.delayUntilRecursion);
       if (input.excludeFromVectorization !== undefined)
         updates.excludeFromVectorization = String(input.excludeFromVectorization);
       if (shouldClearEmbedding) updates.embedding = null;

--- a/packages/shared/src/features/agents/character-tracker/manifest.ts
+++ b/packages/shared/src/features/agents/character-tracker/manifest.ts
@@ -9,5 +9,5 @@ export const characterTrackerAgentManifest = {
   enabledByDefault: false,
   defaultInjectAsSection: true,
   category: "tracker",
-  defaultTools: ["update_game_state"],
+  defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/combat/manifest.ts
+++ b/packages/shared/src/features/agents/combat/manifest.ts
@@ -8,5 +8,5 @@ export const combatAgentManifest = {
   enabledByDefault: false,
   category: "misc",
   modeAllowlist: ["roleplay", "visual_novel"],
-  defaultTools: ["roll_dice", "update_game_state"],
+  defaultTools: ["roll_dice"],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/custom-tracker/manifest.ts
+++ b/packages/shared/src/features/agents/custom-tracker/manifest.ts
@@ -9,5 +9,5 @@ export const customTrackerAgentManifest = {
   enabledByDefault: false,
   defaultInjectAsSection: true,
   category: "tracker",
-  defaultTools: ["update_game_state"],
+  defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/persona-stats/manifest.ts
+++ b/packages/shared/src/features/agents/persona-stats/manifest.ts
@@ -9,5 +9,5 @@ export const personaStatsAgentManifest = {
   enabledByDefault: false,
   defaultInjectAsSection: true,
   category: "tracker",
-  defaultTools: ["update_game_state"],
+  defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/quest/manifest.ts
+++ b/packages/shared/src/features/agents/quest/manifest.ts
@@ -9,5 +9,5 @@ export const questAgentManifest = {
   defaultInjectAsSection: true,
   category: "tracker",
   modeAllowlist: ["roleplay", "visual_novel"],
-  defaultTools: ["update_game_state"],
+  defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/features/agents/world-state/manifest.ts
+++ b/packages/shared/src/features/agents/world-state/manifest.ts
@@ -9,5 +9,5 @@ export const worldStateAgentManifest = {
   defaultInjectAsSection: true,
   category: "tracker",
   modeAllowlist: ["roleplay", "visual_novel"],
-  defaultTools: ["update_game_state"],
+  defaultTools: [],
 } satisfies BuiltInAgentManifest;

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -34,7 +34,15 @@ export const characterBookEntrySchema = z.object({
   selective: z.boolean().default(false),
   secondary_keys: z.array(z.string()).default([]),
   constant: z.boolean().default(false),
-  position: z.enum(["before_char", "after_char"]).catch("before_char").default("before_char"),
+  position: z
+    .union([
+      z.enum(["before_char", "after_char", "at_depth", "depth"]),
+      z.number().int().min(0).max(6),
+    ])
+    .catch("before_char")
+    .default("before_char"),
+  depth: z.number().optional(),
+  role: z.union([z.enum(["system", "user", "assistant"]), z.number().int().min(0).max(2)]).optional(),
 });
 
 export const characterBookSchema = z.object({

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -9,6 +9,24 @@ export const depthPromptSchema = z.object({
   role: z.enum(["system", "user", "assistant"]).default("system"),
 });
 
+const characterBookPositionSchema = z.union([
+  z.enum(["before_char", "after_char", "at_depth", "depth"]),
+  z.literal(0),
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+  z.literal(6),
+]);
+
+const characterBookRoleSchema = z.union([
+  z.enum(["system", "user", "assistant"]),
+  z.literal(0),
+  z.literal(1),
+  z.literal(2),
+]);
+
 export const characterExtensionsSchema = z
   .object({
     talkativeness: z.number().min(0).max(1).default(0.5),
@@ -35,15 +53,9 @@ export const characterBookEntrySchema = z
     selective: z.boolean().default(false),
     secondary_keys: z.array(z.string()).default([]),
     constant: z.boolean().default(false),
-    position: z
-      .union([
-        z.enum(["before_char", "after_char", "at_depth", "depth"]),
-        z.number().int().min(0).max(6),
-      ])
-      .catch("before_char")
-      .default("before_char"),
+    position: characterBookPositionSchema.catch("before_char").default("before_char"),
     depth: z.number().optional(),
-    role: z.union([z.enum(["system", "user", "assistant"]), z.number().int().min(0).max(2)]).optional(),
+    role: characterBookRoleSchema.optional(),
   })
   .passthrough();
 

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -20,30 +20,32 @@ export const characterExtensionsSchema = z
   })
   .passthrough();
 
-export const characterBookEntrySchema = z.object({
-  keys: z.array(z.string()).default([]),
-  content: z.string().default(""),
-  extensions: z.record(z.unknown()).default({}),
-  enabled: z.boolean().default(true),
-  insertion_order: z.number().default(100),
-  case_sensitive: z.boolean().default(false),
-  name: z.string().default(""),
-  priority: z.number().default(100),
-  id: z.number().default(0),
-  comment: z.string().default(""),
-  selective: z.boolean().default(false),
-  secondary_keys: z.array(z.string()).default([]),
-  constant: z.boolean().default(false),
-  position: z
-    .union([
-      z.enum(["before_char", "after_char", "at_depth", "depth"]),
-      z.number().int().min(0).max(6),
-    ])
-    .catch("before_char")
-    .default("before_char"),
-  depth: z.number().optional(),
-  role: z.union([z.enum(["system", "user", "assistant"]), z.number().int().min(0).max(2)]).optional(),
-});
+export const characterBookEntrySchema = z
+  .object({
+    keys: z.array(z.string()).default([]),
+    content: z.string().default(""),
+    extensions: z.record(z.unknown()).default({}),
+    enabled: z.boolean().default(true),
+    insertion_order: z.number().default(100),
+    case_sensitive: z.boolean().default(false),
+    name: z.string().default(""),
+    priority: z.number().default(100),
+    id: z.number().default(0),
+    comment: z.string().default(""),
+    selective: z.boolean().default(false),
+    secondary_keys: z.array(z.string()).default([]),
+    constant: z.boolean().default(false),
+    position: z
+      .union([
+        z.enum(["before_char", "after_char", "at_depth", "depth"]),
+        z.number().int().min(0).max(6),
+      ])
+      .catch("before_char")
+      .default("before_char"),
+    depth: z.number().optional(),
+    role: z.union([z.enum(["system", "user", "assistant"]), z.number().int().min(0).max(2)]).optional(),
+  })
+  .passthrough();
 
 export const characterBookSchema = z.object({
   name: z.string().default(""),
@@ -55,23 +57,25 @@ export const characterBookSchema = z.object({
   entries: z.array(characterBookEntrySchema).default([]),
 });
 
-export const characterDataSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().default(""),
-  personality: z.string().default(""),
-  scenario: z.string().default(""),
-  first_mes: z.string().default(""),
-  mes_example: z.string().default(""),
-  creator_notes: z.string().default(""),
-  system_prompt: z.string().default(""),
-  post_history_instructions: z.string().default(""),
-  tags: z.array(z.string()).default([]),
-  creator: z.string().default(""),
-  character_version: z.string().default(""),
-  alternate_greetings: z.array(z.string()).default([]),
-  extensions: characterExtensionsSchema.default({}),
-  character_book: characterBookSchema.nullable().default(null),
-});
+export const characterDataSchema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().default(""),
+    personality: z.string().default(""),
+    scenario: z.string().default(""),
+    first_mes: z.string().default(""),
+    mes_example: z.string().default(""),
+    creator_notes: z.string().default(""),
+    system_prompt: z.string().default(""),
+    post_history_instructions: z.string().default(""),
+    tags: z.array(z.string()).default([]),
+    creator: z.string().default(""),
+    character_version: z.string().default(""),
+    alternate_greetings: z.array(z.string()).default([]),
+    extensions: characterExtensionsSchema.default({}),
+    character_book: characterBookSchema.nullable().default(null),
+  })
+  .passthrough();
 
 export const characterCardV2Schema = z.object({
   spec: z.literal("chara_card_v2"),

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -189,6 +189,8 @@ export const createLorebookEntrySchema = z.object({
   /** Optional folder this entry belongs to. Null/omitted = root level. */
   folderId: z.string().nullable().default(null),
   preventRecursion: z.boolean().default(false),
+  excludeRecursion: z.boolean().default(false),
+  delayUntilRecursion: z.boolean().default(false),
   locked: z.boolean().default(false),
   tag: z.string().default(""),
   relationships: z.record(z.string()).default({}),
@@ -232,6 +234,8 @@ export const updateLorebookEntrySchema = z.object({
   groupWeight: z.number().nullable().optional(),
   folderId: z.string().nullable().optional(),
   preventRecursion: z.boolean().optional(),
+  excludeRecursion: z.boolean().optional(),
+  delayUntilRecursion: z.boolean().optional(),
   locked: z.boolean().optional(),
   tag: z.string().optional(),
   relationships: z.record(z.string()).optional(),

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -13,7 +13,7 @@ export const lorebookScopeSchema = z.object({
   chatIds: z.array(z.string()).default([]),
 });
 
-export const selectiveLogicSchema = z.enum(["and", "or", "not"]);
+export const selectiveLogicSchema = z.enum(["and", "and_all", "or", "not", "not_all"]);
 
 export const lorebookFilterModeSchema = z.enum(["any", "include", "exclude"]);
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -486,6 +486,7 @@ const CUSTOM_AGENT_RESULT_CAPABILITY: Partial<Record<AgentResultType, CustomAgen
   character_tracker_update: "edit_trackers",
   persona_stats_update: "edit_trackers",
   custom_tracker_update: "edit_trackers",
+  quest_update: "edit_trackers",
   game_state_update: "edit_trackers",
   image_prompt: "trigger_image_generation",
   prompt_patch: "edit_main_prompt",

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -78,6 +78,20 @@ export interface CharacterBook {
   entries: CharacterBookEntry[];
 }
 
+export type CharacterBookEntryPosition =
+  | "before_char"
+  | "after_char"
+  | "at_depth"
+  | "depth"
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6;
+export type CharacterBookEntryRole = "system" | "user" | "assistant" | 0 | 1 | 2;
+
 /** A single entry in a character book. */
 export interface CharacterBookEntry {
   keys: string[];
@@ -93,7 +107,9 @@ export interface CharacterBookEntry {
   selective: boolean;
   secondary_keys: string[];
   constant: boolean;
-  position: "before_char" | "after_char";
+  position: CharacterBookEntryPosition;
+  depth?: number;
+  role?: CharacterBookEntryRole;
 }
 
 /** Our internal Character representation (extends V2 with engine-specific fields). */

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -25,6 +25,7 @@ export interface CharacterData {
   alternate_greetings: string[];
   extensions: CharacterExtensions;
   character_book: CharacterBook | null;
+  [key: string]: unknown;
 }
 
 /** ST-compatible extension fields. */
@@ -110,6 +111,7 @@ export interface CharacterBookEntry {
   position: CharacterBookEntryPosition;
   depth?: number;
   role?: CharacterBookEntryRole;
+  [key: string]: unknown;
 }
 
 /** Our internal Character representation (extends V2 with engine-specific fields). */

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -191,6 +191,10 @@ export interface LorebookEntry {
   locked: boolean;
   /** When true, this entry's content won't trigger further entries during recursive scanning */
   preventRecursion: boolean;
+  /** When true, this entry cannot be activated by recursive scanning */
+  excludeRecursion: boolean;
+  /** When true, this entry only activates during recursive scanning */
+  delayUntilRecursion: boolean;
   /** Sub-category tag for the entry (e.g. "location", "item", "lore", "quest") */
   tag: string;
   /** Relationships to other entries: { entryId: relationshipType } */

--- a/packages/shared/src/types/lorebook.ts
+++ b/packages/shared/src/types/lorebook.ts
@@ -14,7 +14,7 @@ export interface LorebookScope {
 }
 
 /** Selective logic operators. */
-export type SelectiveLogic = "and" | "or" | "not";
+export type SelectiveLogic = "and" | "and_all" | "or" | "not" | "not_all";
 
 /** Role for injected lorebook content. */
 export type LorebookRole = "system" | "user" | "assistant";

--- a/packages/shared/src/utils/lorebook-keyword-matching.ts
+++ b/packages/shared/src/utils/lorebook-keyword-matching.ts
@@ -77,7 +77,7 @@ export function testPrimaryKeys(
   return { matched: matchedKeys.length > 0, matchedKeys };
 }
 
-/** Secondary key set with selective logic (and/or/not). Empty list passes. */
+/** Secondary key set with selective logic. Empty list passes. */
 export function testSecondaryKeys(
   secondaryKeys: string[],
   text: string,
@@ -90,11 +90,14 @@ export function testSecondaryKeys(
 
   switch (logic) {
     case "and":
-      return results.every(Boolean);
     case "or":
       return results.some(Boolean);
+    case "and_all":
+      return results.every(Boolean);
     case "not":
       return !results.some(Boolean);
+    case "not_all":
+      return !results.every(Boolean);
     default:
       return true;
   }

--- a/packages/shared/src/utils/quest-state.ts
+++ b/packages/shared/src/utils/quest-state.ts
@@ -221,14 +221,11 @@ export function compactQuestProgressForContext(value: unknown): QuestProgress[] 
   return normalizeQuestCollectionForQuestMerge(value).flatMap((quest) => {
     if (quest.completed) return [];
 
-    const objectives = quest.objectives.filter((objective) => !objective.completed);
-    if (quest.objectives.length > 0 && objectives.length === 0) return [];
-
     return [
       {
         ...quest,
         completed: false,
-        objectives,
+        objectives: quest.objectives,
       },
     ];
   });

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -760,9 +760,8 @@ function mergeCharacterCustomFieldsWithLocks(
 ): Record<string, string> | undefined {
   let next = nextFields ? { ...nextFields } : null;
   const current = currentFields ?? {};
-  const nextEntries = Object.entries(next ?? {});
   let hasLockedField = false;
-  for (const [index, [name, value]] of Object.entries(current).entries()) {
+  for (const [name, value] of Object.entries(current)) {
     const nameLocked = isTrackerFieldLocked(
       locks,
       characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"),
@@ -773,15 +772,7 @@ function mergeCharacterCustomFieldsWithLocks(
     );
     if (nameLocked || valueLocked) {
       hasLockedField = true;
-      const renamedCandidate = nameLocked ? nextEntries[index]?.[0] : undefined;
-      const renamedValue =
-        renamedCandidate && renamedCandidate !== name && !Object.prototype.hasOwnProperty.call(current, renamedCandidate)
-          ? (next ?? {})[renamedCandidate]
-          : undefined;
-      if (renamedCandidate && renamedCandidate !== name && renamedValue !== undefined) {
-        delete (next ??= {})[renamedCandidate];
-      }
-      const nextValue = (next ?? {})[name] ?? renamedValue;
+      const nextValue = (next ?? {})[name];
       (next ??= {})[name] = valueLocked ? value : typeof nextValue === "string" ? nextValue : value;
     }
   }

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -42,7 +42,7 @@ function normalizeComparableText(value: unknown) {
 }
 
 function stableIndexRef(index: number | null | undefined) {
-  return Number.isSafeInteger(index) && index >= 0 ? index : 0;
+  return typeof index === "number" && Number.isSafeInteger(index) && index >= 0 ? index : 0;
 }
 
 function namedRowLockRef(rowOrIndex: NamedLockRow | number | null | undefined, index?: number) {

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -16,6 +16,8 @@ type InventoryField = "name" | "quantity" | "description" | "location";
 type QuestField = "name" | "completed" | "currentStage";
 type QuestObjectiveField = "text" | "completed";
 type CustomTrackerFieldKey = "name" | "value";
+type NamedLockRow = { name?: string | null };
+type ObjectiveLockRow = { text?: string | null };
 
 const PLAYER_STATS_FALLBACK: PlayerStats = {
   stats: [],
@@ -37,6 +39,36 @@ function encodeSegment(value: string | number | null | undefined) {
 
 function normalizeComparableText(value: unknown) {
   return typeof value === "string" ? value.normalize("NFKC").trim().toLowerCase().replace(/\s+/g, " ") : "";
+}
+
+function stableIndexRef(index: number | null | undefined) {
+  return Number.isSafeInteger(index) && index >= 0 ? index : 0;
+}
+
+function namedRowLockRef(rowOrIndex: NamedLockRow | number | null | undefined, index?: number) {
+  if (typeof rowOrIndex !== "number") {
+    const name = typeof rowOrIndex?.name === "string" ? rowOrIndex.name.trim() : "";
+    if (name) return `name:${encodeSegment(name)}`;
+  }
+  return `index:${stableIndexRef(typeof rowOrIndex === "number" ? rowOrIndex : index)}`;
+}
+
+function objectiveLockRef(rowOrIndex: ObjectiveLockRow | number | null | undefined, index?: number) {
+  if (typeof rowOrIndex !== "number") {
+    const text = typeof rowOrIndex?.text === "string" ? rowOrIndex.text.trim() : "";
+    if (text) return `text:${encodeSegment(text)}`;
+  }
+  return `index:${stableIndexRef(typeof rowOrIndex === "number" ? rowOrIndex : index)}`;
+}
+
+function replaceLockKey(
+  locks: TrackerFieldLocks,
+  legacyKey: string,
+  stableKey: string,
+) {
+  if (locks[legacyKey] !== true || legacyKey === stableKey) return;
+  locks[stableKey] = true;
+  delete locks[legacyKey];
 }
 
 export function normalizeTrackerFieldLocks(value: unknown): TrackerFieldLocks {
@@ -154,6 +186,31 @@ export function removeTrackerFieldLockPrefix(locks: TrackerFieldLocks | null | u
   return next;
 }
 
+export function renameTrackerFieldLockPrefix(
+  locks: TrackerFieldLocks | null | undefined,
+  fromPrefix: string,
+  toPrefix: string,
+) {
+  const normalized = normalizeTrackerFieldLocks(locks);
+  const source = fromPrefix.trim();
+  const target = toPrefix.trim();
+  if (!source || !target || source === target) return normalized;
+
+  const next: TrackerFieldLocks = {};
+  const sourceChildPrefix = `${source}.`;
+  for (const [key, enabled] of Object.entries(normalized)) {
+    if (enabled !== true) continue;
+    if (key === source) {
+      next[target] = true;
+    } else if (key.startsWith(sourceChildPrefix)) {
+      next[`${target}${key.slice(source.length)}`] = true;
+    } else {
+      next[key] = true;
+    }
+  }
+  return next;
+}
+
 function shiftIndexedReferenceLocks(
   locks: TrackerFieldLocks | null | undefined,
   collectionPrefix: string,
@@ -174,16 +231,38 @@ export function personaStatusTrackerLockKey() {
   return "persona.status";
 }
 
-export function personaStatTrackerLockKey(index: number, field: StatField) {
-  return `persona.stats.${index}.${field}`;
+export function personaStatTrackerLockKey(
+  statOrIndex: Pick<CharacterStat, "name"> | number | null | undefined,
+  field: StatField,
+  index?: number,
+) {
+  return `${personaStatTrackerLockPrefix(statOrIndex, index)}.${field}`;
+}
+
+export function personaStatTrackerLockPrefix(
+  statOrIndex: Pick<CharacterStat, "name"> | number | null | undefined,
+  index?: number,
+) {
+  return `persona.stats.${namedRowLockRef(statOrIndex, index)}`;
 }
 
 export function personaStatsTrackerLockPrefix() {
   return "persona.stats";
 }
 
-export function inventoryTrackerLockKey(index: number, field: InventoryField) {
-  return `player.inventory.${index}.${field}`;
+export function inventoryTrackerLockKey(
+  itemOrIndex: Pick<InventoryItem, "name"> | number | null | undefined,
+  field: InventoryField,
+  index?: number,
+) {
+  return `${inventoryItemTrackerLockPrefix(itemOrIndex, index)}.${field}`;
+}
+
+export function inventoryItemTrackerLockPrefix(
+  itemOrIndex: Pick<InventoryItem, "name"> | number | null | undefined,
+  index?: number,
+) {
+  return `player.inventory.${namedRowLockRef(itemOrIndex, index)}`;
 }
 
 export function inventoryTrackerLockPrefix() {
@@ -217,10 +296,11 @@ export function characterTrackerLockKey(
 export function characterStatTrackerLockKey(
   character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
   characterIndex: number,
-  statIndex: number,
+  statOrIndex: Pick<CharacterStat, "name"> | number | null | undefined,
   field: StatField,
+  statIndex?: number,
 ) {
-  return `${characterStatsTrackerLockPrefix(character, characterIndex)}.${statIndex}.${field}`;
+  return `${characterStatTrackerLockPrefix(character, characterIndex, statOrIndex, statIndex)}.${field}`;
 }
 
 export function characterStatsTrackerLockPrefix(
@@ -228,6 +308,15 @@ export function characterStatsTrackerLockPrefix(
   index: number,
 ) {
   return `${characterTrackerLockPrefix(character, index)}.stats`;
+}
+
+export function characterStatTrackerLockPrefix(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  characterIndex: number,
+  statOrIndex: Pick<CharacterStat, "name"> | number | null | undefined,
+  statIndex?: number,
+) {
+  return `${characterStatsTrackerLockPrefix(character, characterIndex)}.${namedRowLockRef(statOrIndex, statIndex)}`;
 }
 
 export function removeTrackerCharacterLocks(
@@ -278,10 +367,11 @@ export function questTrackerLockKey(
 export function questObjectiveTrackerLockKey(
   quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
   questIndex: number,
-  objectiveIndex: number,
+  objectiveOrIndex: ObjectiveLockRow | number | null | undefined,
   field: QuestObjectiveField,
+  objectiveIndex?: number,
 ) {
-  return `${questObjectivesTrackerLockPrefix(quest, questIndex)}.${objectiveIndex}.${field}`;
+  return `${questObjectiveTrackerLockPrefix(quest, questIndex, objectiveOrIndex, objectiveIndex)}.${field}`;
 }
 
 export function questObjectivesTrackerLockPrefix(
@@ -289,6 +379,15 @@ export function questObjectivesTrackerLockPrefix(
   index: number,
 ) {
   return `${questTrackerLockPrefix(quest, index)}.objectives`;
+}
+
+export function questObjectiveTrackerLockPrefix(
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  questIndex: number,
+  objectiveOrIndex: ObjectiveLockRow | number | null | undefined,
+  objectiveIndex?: number,
+) {
+  return `${questObjectivesTrackerLockPrefix(quest, questIndex)}.${objectiveLockRef(objectiveOrIndex, objectiveIndex)}`;
 }
 
 export function removeTrackerQuestLocks(
@@ -303,23 +402,115 @@ export function removeTrackerQuestLocks(
   );
 }
 
-export function customTrackerLockKey(index: number, field: CustomTrackerFieldKey) {
-  return `player.custom.${index}.${field}`;
+export function customTrackerLockKey(
+  fieldOrIndex: Pick<CustomTrackerField, "name"> | number | null | undefined,
+  field: CustomTrackerFieldKey,
+  index?: number,
+) {
+  return `${customTrackerFieldLockPrefix(fieldOrIndex, index)}.${field}`;
 }
 
 export function customTrackerLockPrefix() {
   return "player.custom";
 }
 
+export function customTrackerFieldLockPrefix(
+  fieldOrIndex: Pick<CustomTrackerField, "name"> | number | null | undefined,
+  index?: number,
+) {
+  return `player.custom.${namedRowLockRef(fieldOrIndex, index)}`;
+}
+
+function legacyPersonaStatTrackerLockKey(index: number, field: StatField) {
+  return `persona.stats.${index}.${field}`;
+}
+
+function legacyInventoryTrackerLockKey(index: number, field: InventoryField) {
+  return `player.inventory.${index}.${field}`;
+}
+
+function legacyCharacterStatTrackerLockKey(
+  character: Pick<PresentCharacter, "characterId" | "name"> | null | undefined,
+  characterIndex: number,
+  statIndex: number,
+  field: StatField,
+) {
+  return `${characterStatsTrackerLockPrefix(character, characterIndex)}.${statIndex}.${field}`;
+}
+
+function legacyQuestObjectiveTrackerLockKey(
+  quest: Pick<QuestProgress, "questEntryId" | "name"> | null | undefined,
+  questIndex: number,
+  objectiveIndex: number,
+  field: QuestObjectiveField,
+) {
+  return `${questObjectivesTrackerLockPrefix(quest, questIndex)}.${objectiveIndex}.${field}`;
+}
+
+function legacyCustomTrackerLockKey(index: number, field: CustomTrackerFieldKey) {
+  return `player.custom.${index}.${field}`;
+}
+
+export function normalizeTrackerFieldLocksForState(
+  locks: TrackerFieldLocks | null | undefined,
+  state: GameState | null | undefined,
+) {
+  const next = normalizeTrackerFieldLocks(locks);
+  if (!state) return next;
+
+  state.personaStats?.forEach((stat, index) => {
+    for (const field of ["name", "value", "max"] as const) {
+      replaceLockKey(next, legacyPersonaStatTrackerLockKey(index, field), personaStatTrackerLockKey(stat, field, index));
+    }
+  });
+
+  state.presentCharacters?.forEach((character, characterIndex) => {
+    character.stats?.forEach((stat, statIndex) => {
+      for (const field of ["name", "value", "max"] as const) {
+        replaceLockKey(
+          next,
+          legacyCharacterStatTrackerLockKey(character, characterIndex, statIndex, field),
+          characterStatTrackerLockKey(character, characterIndex, stat, field, statIndex),
+        );
+      }
+    });
+  });
+
+  const playerStats = getPlayerStats(state);
+  playerStats.inventory?.forEach((item, index) => {
+    for (const field of ["name", "quantity", "description", "location"] as const) {
+      replaceLockKey(next, legacyInventoryTrackerLockKey(index, field), inventoryTrackerLockKey(item, field, index));
+    }
+  });
+  playerStats.customTrackerFields?.forEach((field, index) => {
+    for (const key of ["name", "value"] as const) {
+      replaceLockKey(next, legacyCustomTrackerLockKey(index, key), customTrackerLockKey(field, key, index));
+    }
+  });
+  playerStats.activeQuests?.forEach((quest, questIndex) => {
+    quest.objectives?.forEach((objective, objectiveIndex) => {
+      for (const field of ["text", "completed"] as const) {
+        replaceLockKey(
+          next,
+          legacyQuestObjectiveTrackerLockKey(quest, questIndex, objectiveIndex, field),
+          questObjectiveTrackerLockKey(quest, questIndex, objective, field, objectiveIndex),
+        );
+      }
+    });
+  });
+
+  return next;
+}
+
 function normalizeEffectiveTrackerFieldLocks(
   value: TrackerFieldLocks | null | undefined,
   currentState: GameState | null | undefined,
 ) {
-  const locks = normalizeTrackerFieldLocks(value);
+  const locks = normalizeTrackerFieldLocksForState(value, currentState);
   const legacyFields = currentState?.playerStats?.customTrackerFields;
   if (!Array.isArray(legacyFields)) return locks;
   legacyFields.forEach((field, index) => {
-    if (field?.locked === true) locks[customTrackerLockKey(index, "value")] = true;
+    if (field?.locked === true) locks[customTrackerLockKey(field, "value", index)] = true;
   });
   return locks;
 }
@@ -332,7 +523,7 @@ function getPlayerStats(state: GameState | null | undefined): PlayerStats {
   return state?.playerStats ?? PLAYER_STATS_FALLBACK;
 }
 
-function findCurrentCharacterIndex(
+function findCurrentCharacterMatch(
   next: Partial<PresentCharacter>,
   currentCharacters: PresentCharacter[],
   fallbackIndex: number,
@@ -340,31 +531,37 @@ function findCurrentCharacterIndex(
   const id = typeof next.characterId === "string" ? next.characterId.trim() : "";
   if (id) {
     const byId = currentCharacters.findIndex((character) => character.characterId === id);
-    if (byId >= 0) return byId;
+    if (byId >= 0) return { index: byId, matchedByIdentity: true };
   }
   const name = normalizeComparableText(next.name);
   if (name) {
     const byName = currentCharacters.findIndex((character) => normalizeComparableText(character.name) === name);
-    if (byName >= 0) return byName;
+    if (byName >= 0) return { index: byName, matchedByIdentity: true };
   }
-  return fallbackIndex < currentCharacters.length ? fallbackIndex : -1;
+  return {
+    index: fallbackIndex < currentCharacters.length ? fallbackIndex : -1,
+    matchedByIdentity: false,
+  };
 }
 
-function findCurrentQuestIndex(next: Partial<QuestProgress>, currentQuests: QuestProgress[], fallbackIndex: number) {
+function findCurrentQuestMatch(next: Partial<QuestProgress>, currentQuests: QuestProgress[], fallbackIndex: number) {
   const id = typeof next.questEntryId === "string" ? next.questEntryId.trim() : "";
   if (id) {
     const byId = currentQuests.findIndex((quest) => quest.questEntryId === id);
-    if (byId >= 0) return byId;
+    if (byId >= 0) return { index: byId, matchedByIdentity: true };
   }
   const name = normalizeComparableText(next.name);
   if (name) {
     const byName = currentQuests.findIndex((quest) => normalizeComparableText(quest.name) === name);
-    if (byName >= 0) return byName;
+    if (byName >= 0) return { index: byName, matchedByIdentity: true };
   }
-  return fallbackIndex < currentQuests.length ? fallbackIndex : -1;
+  return {
+    index: fallbackIndex < currentQuests.length ? fallbackIndex : -1,
+    matchedByIdentity: false,
+  };
 }
 
-function findCurrentNamedIndex<T extends { name?: string }>(
+function findCurrentNamedMatch<T extends { name?: string }>(
   next: Partial<T>,
   current: T[],
   fallbackIndex: number,
@@ -373,9 +570,12 @@ function findCurrentNamedIndex<T extends { name?: string }>(
   const name = normalizeComparableText(next.name);
   if (name) {
     const byName = current.findIndex((item, index) => !usedCurrent.has(index) && normalizeComparableText(item.name) === name);
-    if (byName >= 0) return byName;
+    if (byName >= 0) return { index: byName, matchedByIdentity: true };
   }
-  return fallbackIndex < current.length && !usedCurrent.has(fallbackIndex) ? fallbackIndex : -1;
+  return {
+    index: fallbackIndex < current.length && !usedCurrent.has(fallbackIndex) ? fallbackIndex : -1,
+    matchedByIdentity: false,
+  };
 }
 
 function mergeNamedRowsWithLocks<T extends { name?: string }>(
@@ -387,21 +587,26 @@ function mergeNamedRowsWithLocks<T extends { name?: string }>(
     prefixFor,
   }: {
     mergeRow: (nextRow: T, currentRow: T, currentIndex: number) => T;
-    prefixFor: (currentIndex: number) => string;
+    prefixFor: (currentRow: T, currentIndex: number) => string;
   },
 ) {
   const current = currentRows ?? [];
   const usedCurrent = new Set<number>();
   const merged = nextRows.map((row, index) => {
-    const currentIndex = findCurrentNamedIndex(row, current, index, usedCurrent);
+    const match = findCurrentNamedMatch(row, current, index, usedCurrent);
+    const currentIndex = match.index;
     const currentRow = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentRow) return row;
+    if (!match.matchedByIdentity && hasLockWithPrefix(locks, prefixFor(currentRow, currentIndex))) {
+      return row;
+    }
     usedCurrent.add(currentIndex);
     return mergeRow(row, currentRow, currentIndex);
   });
   for (let index = 0; index < current.length; index += 1) {
     if (usedCurrent.has(index)) continue;
-    if (hasLockWithPrefix(locks, prefixFor(index))) merged.push(current[index]!);
+    const currentRow = current[index]!;
+    if (hasLockWithPrefix(locks, prefixFor(currentRow, index))) merged.push(currentRow);
   }
   return merged;
 }
@@ -410,17 +615,17 @@ function mergeStatsWithLocks(
   nextStats: CharacterStat[],
   currentStats: CharacterStat[] | null | undefined,
   locks: TrackerFieldLocks,
-  keyFor: (index: number, field: StatField) => string,
+  keyFor: (stat: CharacterStat, index: number, field: StatField) => string,
 ) {
   return mergeNamedRowsWithLocks(nextStats, currentStats, locks, {
     mergeRow: (stat, currentStat, currentIndex) => {
       const next = { ...stat };
-      if (isTrackerFieldLocked(locks, keyFor(currentIndex, "name"))) next.name = currentStat.name;
-      if (isTrackerFieldLocked(locks, keyFor(currentIndex, "value"))) next.value = currentStat.value;
-      if (isTrackerFieldLocked(locks, keyFor(currentIndex, "max"))) next.max = currentStat.max;
+      if (isTrackerFieldLocked(locks, keyFor(currentStat, currentIndex, "name"))) next.name = currentStat.name;
+      if (isTrackerFieldLocked(locks, keyFor(currentStat, currentIndex, "value"))) next.value = currentStat.value;
+      if (isTrackerFieldLocked(locks, keyFor(currentStat, currentIndex, "max"))) next.max = currentStat.max;
       return next;
     },
-    prefixFor: (index) => keyFor(index, "name").replace(/\.name$/, "."),
+    prefixFor: (stat, index) => keyFor(stat, index, "name").replace(/\.name$/, "."),
   });
 }
 
@@ -433,13 +638,13 @@ function mergeInventoryWithLocks(
     mergeRow: (item, currentItem, currentIndex) => {
       const next = { ...item };
       for (const field of ["name", "quantity", "description", "location"] as const) {
-        if (isTrackerFieldLocked(locks, inventoryTrackerLockKey(currentIndex, field))) {
+        if (isTrackerFieldLocked(locks, inventoryTrackerLockKey(currentItem, field, currentIndex))) {
           next[field] = currentItem[field] as never;
         }
       }
       return next;
     },
-    prefixFor: (index) => `player.inventory.${index}.`,
+    prefixFor: (item, index) => `${inventoryItemTrackerLockPrefix(item, index)}.`,
   });
 }
 
@@ -451,11 +656,13 @@ function mergeCustomTrackerFieldsWithGenericLocks(
   return mergeNamedRowsWithLocks(nextFields, currentFields, locks, {
     mergeRow: (field, currentField, currentIndex) => {
       const next = { ...field };
-      if (isTrackerFieldLocked(locks, customTrackerLockKey(currentIndex, "name"))) next.name = currentField.name;
-      if (isTrackerFieldLocked(locks, customTrackerLockKey(currentIndex, "value"))) next.value = currentField.value;
+      if (isTrackerFieldLocked(locks, customTrackerLockKey(currentField, "name", currentIndex))) next.name = currentField.name;
+      if (isTrackerFieldLocked(locks, customTrackerLockKey(currentField, "value", currentIndex))) {
+        next.value = currentField.value;
+      }
       return next;
     },
-    prefixFor: (index) => `player.custom.${index}.`,
+    prefixFor: (field, index) => `${customTrackerFieldLockPrefix(field, index)}.`,
   });
 }
 
@@ -467,20 +674,40 @@ function mergeQuestObjectivesWithLocks(
   questIndex: number,
 ) {
   const current = currentObjectives ?? [];
+  const usedCurrent = new Set<number>();
   const merged = nextObjectives.map((objective, index) => {
-    const currentObjective = current[index];
+    const text = normalizeComparableText(objective.text);
+    const byText = text
+      ? current.findIndex((candidate, candidateIndex) => {
+          return !usedCurrent.has(candidateIndex) && normalizeComparableText(candidate.text) === text;
+        })
+      : -1;
+    const fallbackIndex = index < current.length && !usedCurrent.has(index) ? index : -1;
+    const currentIndex = byText >= 0 ? byText : fallbackIndex;
+    const currentObjective = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentObjective) return objective;
+    const currentPrefix = questObjectiveTrackerLockPrefix(quest, questIndex, currentObjective, currentIndex);
+    if (byText < 0 && hasLockWithPrefix(locks, `${currentPrefix}.`)) {
+      return objective;
+    }
+    usedCurrent.add(currentIndex);
     const next = { ...objective };
-    if (isTrackerFieldLocked(locks, questObjectiveTrackerLockKey(quest, questIndex, index, "text"))) {
+    if (isTrackerFieldLocked(locks, questObjectiveTrackerLockKey(quest, questIndex, currentObjective, "text", currentIndex))) {
       next.text = currentObjective.text;
     }
-    if (isTrackerFieldLocked(locks, questObjectiveTrackerLockKey(quest, questIndex, index, "completed"))) {
+    if (
+      isTrackerFieldLocked(
+        locks,
+        questObjectiveTrackerLockKey(quest, questIndex, currentObjective, "completed", currentIndex),
+      )
+    ) {
       next.completed = currentObjective.completed;
     }
     return next;
   });
-  for (let index = nextObjectives.length; index < current.length; index += 1) {
-    const prefix = questObjectiveTrackerLockKey(quest, questIndex, index, "text").replace(/\.text$/, ".");
+  for (let index = 0; index < current.length; index += 1) {
+    if (usedCurrent.has(index)) continue;
+    const prefix = `${questObjectiveTrackerLockPrefix(quest, questIndex, current[index]!, index)}.`;
     if (hasLockWithPrefix(locks, prefix)) merged.push(current[index]!);
   }
   return merged;
@@ -494,9 +721,13 @@ function mergeQuestsWithLocks(
   const current = currentQuests ?? [];
   const usedCurrent = new Set<number>();
   const merged = nextQuests.map((quest, index) => {
-    const currentIndex = findCurrentQuestIndex(quest, current, index);
+    const match = findCurrentQuestMatch(quest, current, index);
+    const currentIndex = match.index;
     const currentQuest = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentQuest) return quest;
+    if (!match.matchedByIdentity && hasLockWithPrefix(locks, `${questTrackerLockPrefix(currentQuest, currentIndex)}.`)) {
+      return quest;
+    }
     usedCurrent.add(currentIndex);
     const next = { ...quest };
     if (isTrackerFieldLocked(locks, questTrackerLockKey(currentQuest, currentIndex, "name"))) {
@@ -529,8 +760,9 @@ function mergeCharacterCustomFieldsWithLocks(
 ): Record<string, string> | undefined {
   let next = nextFields ? { ...nextFields } : null;
   const current = currentFields ?? {};
+  const nextEntries = Object.entries(next ?? {});
   let hasLockedField = false;
-  for (const [name, value] of Object.entries(current)) {
+  for (const [index, [name, value]] of Object.entries(current).entries()) {
     const nameLocked = isTrackerFieldLocked(
       locks,
       characterCustomFieldTrackerLockKey(character, characterIndex, name, "name"),
@@ -541,7 +773,15 @@ function mergeCharacterCustomFieldsWithLocks(
     );
     if (nameLocked || valueLocked) {
       hasLockedField = true;
-      const nextValue = (next ?? {})[name];
+      const renamedCandidate = nameLocked ? nextEntries[index]?.[0] : undefined;
+      const renamedValue =
+        renamedCandidate && renamedCandidate !== name && !Object.prototype.hasOwnProperty.call(current, renamedCandidate)
+          ? (next ?? {})[renamedCandidate]
+          : undefined;
+      if (renamedCandidate && renamedCandidate !== name && renamedValue !== undefined) {
+        delete (next ??= {})[renamedCandidate];
+      }
+      const nextValue = (next ?? {})[name] ?? renamedValue;
       (next ??= {})[name] = valueLocked ? value : typeof nextValue === "string" ? nextValue : value;
     }
   }
@@ -556,9 +796,16 @@ function mergeCharactersWithLocks(
   const current = currentCharacters ?? [];
   const usedCurrent = new Set<number>();
   const merged = nextCharacters.map((character, index) => {
-    const currentIndex = findCurrentCharacterIndex(character, current, index);
+    const match = findCurrentCharacterMatch(character, current, index);
+    const currentIndex = match.index;
     const currentCharacter = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentCharacter) return character;
+    if (
+      !match.matchedByIdentity &&
+      hasLockWithPrefix(locks, `${characterTrackerLockPrefix(currentCharacter, currentIndex)}.`)
+    ) {
+      return character;
+    }
     usedCurrent.add(currentIndex);
     const next = { ...character };
     for (const field of ["emoji", "name", "mood", "appearance", "outfit", "thoughts"] as const) {
@@ -567,8 +814,8 @@ function mergeCharactersWithLocks(
       }
     }
     if (Array.isArray(next.stats)) {
-      next.stats = mergeStatsWithLocks(next.stats, currentCharacter.stats, locks, (statIndex, field) =>
-        characterStatTrackerLockKey(currentCharacter, currentIndex, statIndex, field),
+      next.stats = mergeStatsWithLocks(next.stats, currentCharacter.stats, locks, (stat, statIndex, field) =>
+        characterStatTrackerLockKey(currentCharacter, currentIndex, stat, field, statIndex),
       );
     }
     const customFields = mergeCharacterCustomFieldsWithLocks(
@@ -608,8 +855,8 @@ export function applyTrackerFieldLocksToGameStatePatch<T extends Record<string, 
   }
 
   if (Array.isArray(next.personaStats)) {
-    next.personaStats = mergeStatsWithLocks(next.personaStats as CharacterStat[], currentState.personaStats, locks, (index, field) =>
-      personaStatTrackerLockKey(index, field),
+    next.personaStats = mergeStatsWithLocks(next.personaStats as CharacterStat[], currentState.personaStats, locks, (stat, index, field) =>
+      personaStatTrackerLockKey(stat, field, index),
     );
   }
 


### PR DESCRIPTION
## Linked issue

Closes #2675, #2676, #2677, #2682, #2683, #2684, #2685, #2686, #2687, #2688, #2689, #2690, #2691, #2692, #2693, #2694, #2695, #2696, #2697, #2698, #2699, #2700, #2701, #2702, #2703, #2704, #2705, #2706, #2707, #2708, #2709, #2710, #2711, #2712, #2713, #2714, #2715, #2716, #2717, #2718, #2719, #2720, #2722, #2723, #2724, #2725, #2726, #2727, #2728, #2729.

Skipped #2678 because aeriondyseti explicitly claimed it in the issue thread, and it remains open for that owner.

## Why this change

- Sweep the open SpicyMarinara issue queue and bring the fixes into one staging PR.
- Remove drift between first-generation and retry-agent tracker behavior.
- Harden game, tracker, import/export, sidecar, agent, lorebook, and UI persistence paths found during the issue sweep.

## What changed

- Fixed chat recency, post-history prompt ordering, assistant prefill tail handling, and agent marker/output handling.
- Hardened agent execution around connection fallback, max tokens, XML batching, timeout bounds, run cadence, and built-in import state.
- Preserved SillyTavern/Marinara import-export fidelity for lorebooks, regex, presets, character cards, avatars, chat JSONL, backups, browser cards, and vectorized exports.
- Stabilized local sidecar setup, backend routing, embedding paths, process lifecycle, and model provisioning checks.
- Reworked tracker/game snapshot paths around field locks, committed tracker context, retry-agent capability gates, quest auto-removal, snapshot cleanup, rerun races, and malformed stat rendering.
- Fixed game-mode generation/setup wait bounds, world setup failures, journal/conclusion serialization, checkpoint restore, combat/NPC identity controls, HUD widget persistence, inventory grids, timer completion persistence, and off-screen panel recovery.
- Added validation cleanup so shared/server/client type builds pass after the sweep.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `git diff --check` passed.
- `pnpm --filter @marinara-engine/server lint` passed.
- `pnpm --filter @marinara-engine/client build` passed.
- `pnpm check` passed.
- The local shell is using Node v20.11.1, so pnpm emitted the repo engine warning (`>=24 <26`) and Vite emitted its Node warning (`20.19+ or 22.12+`), but the commands completed successfully.
- Per maintainer instruction, issue-by-issue pnpm validation was deferred until after the sweep was complete.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured; this sweep was validated through type/lint/build gates rather than browser screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added stricter lorebook logic modes for secondary keys (AND All, NOT All)
  * Implemented chat activity tracking to improve recent conversation retrieval
  * Added avatar image validation for safer character imports

* **Improvements**
  * Enhanced tracker field locking with granular control and renaming capabilities
  * Improved HUD panel clamping to keep content visible in viewport
  * Better error handling for character data normalization and lorebook recursion

* **Bug Fixes**
  * Fixed quest and stat editing lock handling
  * Improved model validation and cache management
  * Enhanced robustness of game state patch merging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->