### PR TITLE
[codex] Normalize post-history system prompt roles

### DIFF
--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -56,6 +56,7 @@ import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import {
+  appendNonLeadingSystemMessagesToLastUser,
   findTrackerContextInsertIndex,
   isManualTrackerCharacterId,
   parseExtra,
@@ -268,9 +269,16 @@ function resolveChatCharacterIds(raw: unknown): string[] {
 }
 
 function toPeekPromptMessages(
-  messages: Array<{ role: string; content: string }>,
+  messages: Array<{
+    role: "system" | "user" | "assistant";
+    content: string;
+    contextKind?: "prompt" | "history" | "injection";
+  }>,
 ): Array<{ role: string; content: string }> {
-  return messages.map((message) => ({ role: message.role, content: message.content }));
+  return appendNonLeadingSystemMessagesToLastUser(messages).map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
 }
 
 function cardPromptText(value: unknown): string {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -193,6 +193,7 @@ import {
   buildLockedPlayerStatsArrayPatch,
   buildLockedPersonaTrackerPatch,
   extractImageAttachmentDataUrls,
+  appendNonLeadingSystemMessagesToLastUser,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
@@ -5909,19 +5910,10 @@ export async function generateRoutes(app: FastifyInstance) {
           };
 
           const prepareProviderMessages = (messages: ChatMessage[]): ChatMessage[] => {
-            // Convert mid-prompt system messages to user role after context fitting.
+            // Append mid-prompt system messages to the last user turn after context fitting.
             // This keeps prompt/injection system blocks protected while trimming history,
             // then preserves provider alternation rules for the actual request.
-            let pastLeadingSystem = false;
-            const converted = messages.map((m) => {
-              if (!pastLeadingSystem) {
-                if (m.role !== "system") pastLeadingSystem = true;
-                return m;
-              }
-              if (m.role === "system") return { ...m, role: "user" as const };
-              return m;
-            });
-            return mergeProviderAdjacentMessages(converted);
+            return mergeProviderAdjacentMessages(appendNonLeadingSystemMessagesToLastUser(messages));
           };
 
           let finalPromptSent: ChatMessage[] = [];

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -43,6 +43,7 @@ import { applyRegexScriptsToPromptMessages } from "../../services/regex/regex-ap
 import { sendSseEvent, startSseReply } from "./sse.js";
 import {
   appendReadableAttachmentsToContent,
+  appendNonLeadingSystemMessagesToLastUser,
   dedupeLastMessageWrappers,
   extractFileAttachmentInputs,
   extractImageAttachmentDataUrls,
@@ -1474,19 +1475,10 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       }));
 
     const prepareProviderMessages = (messages: ChatMessage[]): ChatMessage[] => {
-      // Convert mid-prompt system messages to user role after context fitting.
+      // Append mid-prompt system messages to the last user turn after context fitting.
       // This mirrors /api/generate while keeping prompt/injection blocks protected
       // during history trimming.
-      let pastLeadingSystem = false;
-      const converted = messages.map((m) => {
-        if (!pastLeadingSystem) {
-          if (m.role !== "system") pastLeadingSystem = true;
-          return m;
-        }
-        if (m.role === "system") return { ...m, role: "user" as const };
-        return m;
-      });
-      return mergeAdjacentMessages(converted as any) as ChatMessage[];
+      return mergeAdjacentMessages(appendNonLeadingSystemMessagesToLastUser(messages) as any) as ChatMessage[];
     };
 
     const fit = fitMessagesForModelAccess({

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -390,7 +390,10 @@ function appendPromptMessageContent(target: PromptRoleMessage, source: PromptRol
     target.files = [...(target.files ?? []), ...source.files.map((file) => ({ ...file }))];
   }
   if (source.providerMetadata) {
-    target.providerMetadata = { ...source.providerMetadata };
+    target.providerMetadata = {
+      ...(target.providerMetadata ?? {}),
+      ...source.providerMetadata,
+    };
   }
 }
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -359,6 +359,88 @@ export function findTrackerContextInsertIndex(
   return messages.length;
 }
 
+type PromptRoleMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  contextKind?: "prompt" | "history" | "injection";
+  characterId?: string | null;
+  images?: string[];
+  files?: Array<{ type: string; data: string; filename?: string }>;
+  providerMetadata?: Record<string, unknown>;
+};
+
+function clonePromptRoleMessage<T extends PromptRoleMessage>(message: T): T {
+  return {
+    ...message,
+    ...(message.images ? { images: [...message.images] } : {}),
+    ...(message.files ? { files: message.files.map((file) => ({ ...file })) } : {}),
+    ...(message.providerMetadata ? { providerMetadata: { ...message.providerMetadata } } : {}),
+  };
+}
+
+function appendPromptMessageContent(target: PromptRoleMessage, source: PromptRoleMessage) {
+  target.content = `${target.content}\n\n${source.content}`;
+  if (target.contextKind !== source.contextKind) {
+    delete target.contextKind;
+  }
+  if (source.images?.length) {
+    target.images = [...(target.images ?? []), ...source.images];
+  }
+  if (source.files?.length) {
+    target.files = [...(target.files ?? []), ...source.files.map((file) => ({ ...file }))];
+  }
+  if (source.providerMetadata) {
+    target.providerMetadata = { ...source.providerMetadata };
+  }
+}
+
+/**
+ * Provider-safe role normalization for strict prompt presets.
+ *
+ * System blocks before chat history stay as provider system messages. Once
+ * conversation turns have started, later system blocks are appended to the
+ * latest user message so the request remains system/user/assistant/user...
+ * without making post-history preset sections removable during context fitting.
+ * Depth injections are already positioned in history, so they become user
+ * messages in place instead of moving to the latest user turn.
+ */
+export function appendNonLeadingSystemMessagesToLastUser<T extends PromptRoleMessage>(messages: T[]): T[] {
+  const result: T[] = [];
+  let pastLeadingSystem = false;
+  let lastUserIndex = -1;
+
+  for (const message of messages) {
+    const cloned = clonePromptRoleMessage(message);
+    if (!pastLeadingSystem) {
+      if (cloned.role !== "system") pastLeadingSystem = true;
+      result.push(cloned);
+      if (cloned.role === "user") lastUserIndex = result.length - 1;
+      continue;
+    }
+
+    if (cloned.role === "system") {
+      const converted = { ...cloned, role: "user" as const };
+      if (cloned.contextKind === "injection") {
+        result.push(converted as T);
+        lastUserIndex = result.length - 1;
+        continue;
+      }
+      if (lastUserIndex >= 0) {
+        appendPromptMessageContent(result[lastUserIndex]!, converted);
+      } else {
+        result.push(converted as T);
+        lastUserIndex = result.length - 1;
+      }
+      continue;
+    }
+
+    result.push(cloned);
+    if (cloned.role === "user") lastUserIndex = result.length - 1;
+  }
+
+  return result;
+}
+
 /** Parse a JSON extra field safely. */
 export function parseExtra(extra: unknown): Record<string, unknown> {
   if (!extra) return {};


### PR DESCRIPTION
## Linked issue

No linked issue. Maintainer-requested fix from a prompt preview / preset assembly bug report; open a tracking issue if public discussion is needed.

## Why this change

Roleplay prompt presets can include system-role sections after the chat history marker. Those sections should not be hoisted or sent as mid-conversation system messages; they need to preserve provider-safe system/user/assistant alternation.

## What changed

- Added shared provider-safe prompt role normalization for non-leading system messages.
- Updated live generation, dry-run prompt preview, and Peek Prompt live preview to share the same normalization.
- Preserved depth-injected system sections by converting them to user role in place, instead of moving them to the latest user turn.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Commands run locally:

- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/server build`
- `pnpm check`
- `git diff --check`

`pnpm check` completed successfully. Local environment still prints the existing Node/Vite version warnings.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Server-side prompt assembly fix; no screenshot attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system message handling in chat generation pipeline for more consistent prompt processing across routes.
  * Enhanced handling of mid-prompt system messages to better preserve injection-type prompts during provider message preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->