### PR TITLE
[codex] Fix game custom agents and Claude prefill steering

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -72,7 +72,6 @@ import { HelpTooltip } from "../ui/HelpTooltip";
 import {
   BUILT_IN_AGENTS,
   BUILT_IN_TOOLS,
-  createFolderEntry,
   DEFAULT_AGENT_CONTEXT_SIZE,
   DEFAULT_AGENT_TOOLS,
   DEFAULT_AGENT_MAX_TOKENS,
@@ -96,8 +95,12 @@ import {
   type CustomAgentCapabilityMap,
   type ToolDefinition,
 } from "@marinara-engine/shared";
-import { sanitizeAgentSettingsForTransfer } from "../../lib/agent-transfer";
-import { downloadJsonFile } from "../../lib/download-json";
+import {
+  createAgentFolderPackageFilename,
+  createAgentFolderPackageFiles,
+  sanitizeAgentSettingsForTransfer,
+} from "../../lib/agent-transfer";
+import { downloadZipFile } from "../../lib/download-zip";
 
 function parseActivationKeywordsText(value: string): string[] {
   const seen = new Set<string>();
@@ -1125,33 +1128,22 @@ export function AgentEditor() {
       ...(localImagePositivePrompt.trim() ? { imagePositivePrompt: localImagePositivePrompt.trim() } : {}),
       ...(localImageNegativePrompt.trim() ? { imageNegativePrompt: localImageNegativePrompt.trim() } : {}),
     });
-    const agentEntry = createFolderEntry({
-      folderName: "Agents",
-      itemName: agentType,
-      itemKind: "marinara.agent",
-      config: {
-        type: agentType,
-        name: localName,
-        description: localDescription,
-        phase: savedPhase,
-        enabled: localAgentEnabled,
-        connectionId: null,
-        imagePath: null,
-        promptTemplate: localPrompt,
-        settings,
-        ...(isEditingCustomAgent ? { resultType: localResultType } : {}),
-      },
-      fallbackName: "agent",
-    });
-    downloadJsonFile(
-      {
-        kind: "marinara.agent-folder",
-        version: 1,
-        exportedAt: new Date().toISOString(),
-        folderName: "Agents",
-        agents: [agentEntry],
-      },
-      "marinara-agent.json",
+    downloadZipFile(
+      createAgentFolderPackageFiles([
+        {
+          type: agentType,
+          name: localName,
+          description: localDescription,
+          phase: savedPhase,
+          enabled: localAgentEnabled,
+          connectionId: null,
+          imagePath: null,
+          promptTemplate: localPrompt,
+          settings,
+          ...(isEditingCustomAgent ? { resultType: localResultType } : {}),
+        },
+      ]),
+      createAgentFolderPackageFilename(localName || agentType, "agent"),
     );
     toast.success(`Exported ${localName || "agent"}`);
   };

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -18,11 +18,11 @@ import { useUIStore, type CharacterLibrarySort } from "../../stores/ui.store";
 import type { CharacterData } from "@marinara-engine/shared";
 
 const libraryToolbarButtonClass =
-  "mari-chrome-control h-10 min-w-0 px-3 text-[0.75rem] md:h-9";
+  "mari-chrome-control mari-chrome-control--primary h-10 min-h-10 min-w-0 px-3 text-[0.75rem]";
 const libraryToolbarFieldClass =
   "mari-chrome-field h-10 w-full text-[0.75rem] md:h-9";
 const libraryNewCharacterButtonClass =
-  "mari-chrome-control mari-chrome-control--primary h-10 min-w-0 px-3 text-[0.75rem] md:h-9";
+  "mari-panel-gradient-button mari-panel-gradient--characters h-10 min-h-10 min-w-0 px-3 text-[0.75rem]";
 
 type CharacterRow = {
   id: string;

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2154,7 +2154,6 @@ export function ChatArea() {
 
           <ChatCommonOverlays
             chat={chat}
-            activeChatId={activeChatId}
             settingsOpen={settingsOpen}
             settingsAnchor={settingsAnchor}
             filesOpen={filesOpen}

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -396,7 +396,7 @@ export function ChatBranchSelector({
                           type="button"
                           onClick={() => void handleDeleteBranch(branch.id)}
                           disabled={deleteChat.isPending}
-                          className="rounded-lg p-1.5 text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 disabled:opacity-50"
+                          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
                           title="Delete branch"
                         >
                           <Trash2 size="0.75rem" />
@@ -427,7 +427,7 @@ export function ChatBranchSelector({
                     setOpen(false);
                   }}
                   disabled={deleteChatGroup.isPending}
-                  className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-2 text-[0.6875rem] font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-colors hover:bg-[var(--destructive)]/20 disabled:opacity-50"
+                  className="mari-chrome-control mari-chrome-control--primary w-full px-3 py-2 text-[0.6875rem] disabled:opacity-50"
                 >
                   <Trash2 size="0.75rem" />
                   Delete All Branches

--- a/packages/client/src/components/chat/ChatCommonOverlays.tsx
+++ b/packages/client/src/components/chat/ChatCommonOverlays.tsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy, type ComponentProps } from "react";
 import type { SpriteSide } from "@marinara-engine/shared";
 import { ChevronUp, ChevronDown, Trash2 } from "lucide-react";
-import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import type { PeekPromptData } from "./chat-area.types";
 
 const ChatSettingsDrawer = lazy(async () => {
@@ -179,7 +178,6 @@ function MultiSelectBar({
 
 type ChatCommonOverlaysProps = {
   chat: ChatData | null | undefined;
-  activeChatId: string;
   settingsOpen: boolean;
   settingsAnchor: ChatFloatingPanelAnchor;
   settingsInitialSection?: ChatSettingsInitialSection;
@@ -215,7 +213,6 @@ type ChatCommonOverlaysProps = {
 
 export function ChatCommonOverlays({
   chat,
-  activeChatId,
   settingsOpen,
   settingsAnchor,
   settingsInitialSection,
@@ -287,7 +284,6 @@ export function ChatCommonOverlays({
       {chat && (
         <Suspense fallback={null}>{wizardOpen && <ChatSetupWizard chat={chat} onFinish={onWizardFinish} />}</Suspense>
       )}
-      <PinnedImageOverlay activeChatId={activeChatId} />
       <Suspense fallback={null}>
         {peekPromptData && <PeekPromptModal data={peekPromptData} onClose={onClosePeekPrompt} />}
       </Suspense>

--- a/packages/client/src/components/chat/ChatConversationSurface.tsx
+++ b/packages/client/src/components/chat/ChatConversationSurface.tsx
@@ -186,7 +186,6 @@ export function ChatConversationSurface({
 
       <ChatCommonOverlays
         chat={chat}
-        activeChatId={activeChatId}
         settingsOpen={settingsOpen}
         settingsAnchor={settingsAnchor}
         settingsInitialSection={settingsInitialSection}

--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -319,10 +319,10 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
                           void handleDelete(cf.id);
                         }}
                         disabled={deleteChat.isPending}
-                        className="rounded-lg p-1.5 transition-all hover:bg-[var(--destructive)]/15"
+                        className="rounded-lg p-1.5 text-[var(--muted-foreground)] ring-1 ring-transparent transition-all hover:bg-[var(--accent)]/80 hover:text-[var(--foreground)] hover:ring-[var(--border)] active:scale-[0.95] disabled:opacity-50"
                         title="Delete branch"
                       >
-                        <Trash2 size="0.75rem" className="text-[var(--destructive)]" />
+                        <Trash2 size="0.75rem" />
                       </button>
                     </div>
                   )}
@@ -351,7 +351,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
               onClose();
             }}
             disabled={deleteChatGroup.isPending}
-            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98] disabled:opacity-50"
+            className="mari-chrome-control mari-chrome-control--primary w-full px-3 py-2 text-xs disabled:opacity-50"
           >
             <Trash2 size="0.8125rem" />
             Delete All Branches

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -52,6 +52,7 @@ import {
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { EndSceneBar } from "./SceneBanner";
 import { ChatCommonOverlays } from "./ChatCommonOverlays";
+import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import {
   ROLEPLAY_POPOVER_SCROLL_AREA,
   ROLEPLAY_POPOVER_SHELL,
@@ -1551,6 +1552,7 @@ export function ChatRoleplaySurface({
                 <div ref={messagesEndRef} />
               </div>
             </div>
+            <PinnedImageOverlay activeChatId={activeChatId} />
 
             <div
               ref={inputChromeRef}
@@ -1609,7 +1611,6 @@ export function ChatRoleplaySurface({
 
       <ChatCommonOverlays
         chat={chat}
-        activeChatId={activeChatId}
         settingsOpen={settingsOpen}
         settingsAnchor={settingsAnchor}
         settingsInitialSection={settingsInitialSection}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2564,8 +2564,8 @@ export function ChatSettingsDrawer({
     );
   };
 
-  const renderCustomAgentPicker = () => {
-    if (customAgents.length === 0) return null;
+  const renderCustomAgentPicker = ({ showWhenEmpty = false }: { showWhenEmpty?: boolean } = {}) => {
+    if (customAgents.length === 0 && !showWhenEmpty) return null;
     return (
       <AgentCategorySection
         label="Custom Agents"
@@ -2590,6 +2590,25 @@ export function ChatSettingsDrawer({
                 </div>
               </button>
             ))}
+          </div>
+        ) : customAgents.length === 0 ? (
+          <div className="space-y-2 px-1">
+            <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+              No custom agents are available yet. Create one in the Agents panel, then attach it to this game here.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                onClose();
+                const ui = useUIStore.getState();
+                ui.openRightPanel("agents");
+                ui.openAgentDetail("__new__");
+              }}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-2 text-[0.6875rem] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)]"
+            >
+              <Plus size="0.75rem" />
+              Create Custom Agent
+            </button>
           </div>
         ) : (
           <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
@@ -4866,7 +4885,6 @@ export function ChatSettingsDrawer({
                     />
                   </div>
                 </button>
-                {isGame && renderCustomAgentPicker()}
                 <AgentSettingsToggle
                   label="Review Agent Outputs"
                   description={
@@ -6368,6 +6386,7 @@ export function ChatSettingsDrawer({
                     )}
                   </>
                 )}
+                {isGame && renderCustomAgentPicker({ showWhenEmpty: true })}
               </div>
             </Section>
           )}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2254,6 +2254,7 @@ export function ChatSettingsDrawer({
 
       await updateMeta.mutateAsync({
         id: chat.id,
+        enableAgents: true,
         activeAgentIds: Array.from(new Set([...activeAgentIds, agent.id])),
         ...buildAgentAddMetadataPatch(agent.id, setup, metadata, {
           allowSecretPlot: supportsNarrativeDirectorSecretPlot,
@@ -2596,6 +2597,63 @@ export function ChatSettingsDrawer({
           </p>
         )}
       </AgentCategorySection>
+    );
+  };
+
+  const renderActiveCustomAgentSettingsCard = () => {
+    if (!metadata.enableAgents || activeCustomAgents.length === 0) return null;
+    return (
+      <AgentSettingsCard
+        id={getAgentSettingsMenuId(chat.id, "custom-agents")}
+        icon={renderRoleplayAgentMenuIcon("custom-agents")}
+        title="Custom Agents"
+        description="Configure custom agents currently attached to this chat."
+        order={CUSTOM_AGENT_SETTINGS_ORDER}
+      >
+        <div className="space-y-1.5">
+          {activeCustomAgents.map((agent) => {
+            const tokenEst = agentLoadCost.tokensByType.get(agent.id);
+            const promptOptions = getPromptOptionsForAgent(agent.id);
+            return (
+              <div key={agent.id} className="rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
+                <div className="flex items-start gap-2.5">
+                  <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="block min-w-0 truncate text-xs font-medium">{agent.name}</span>
+                      {tokenEst != null ? (
+                        <span
+                          className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
+                          title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
+                        >
+                          ~{tokenEst.toLocaleString()}
+                        </span>
+                      ) : null}
+                    </div>
+                    <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
+                      {agent.description}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => {
+                      void toggleAgent(agent.id);
+                    }}
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+                    title="Remove from chat"
+                  >
+                    <Trash2 size="0.6875rem" />
+                  </button>
+                </div>
+                <AgentPromptTemplateSelect
+                  options={promptOptions}
+                  selectedId={agentPromptTemplateSelections[agent.id] ?? DEFAULT_AGENT_PROMPT_TEMPLATE_ID}
+                  onChange={(promptTemplateId) => updateAgentPromptTemplateSelection(agent.id, promptTemplateId)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </AgentSettingsCard>
     );
   };
 
@@ -4753,8 +4811,8 @@ export function ChatSettingsDrawer({
               <div className="space-y-2">
                 {isGame && metadata.enableAgents && (
                   <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                    Toggle agents for this game session. Only the ones below are allowed to ensure the game's format
-                    doesn't break.
+                    Toggle scene analysis and custom agents for this game session. Roleplay-only built-ins stay hidden so
+                    the game's format doesn't break.
                   </p>
                 )}
                 <button
@@ -4769,10 +4827,10 @@ export function ChatSettingsDrawer({
                   )}
                 >
                   <div className="flex-1 min-w-0">
-                    <span className="text-xs font-medium">{isGame ? "Enable Scene Analysis" : "Enable Agents"}</span>
+                    <span className="text-xs font-medium">Enable Agents</span>
                     <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                       {isGame
-                        ? "Analyse scenes for backgrounds, music, weather, and cinematic effects after each GM turn."
+                        ? "Run scene analysis and any attached custom agents during generation."
                         : "Run AI agents during generation (world state, expressions, etc.)"}
                     </p>
                     {isGame &&
@@ -5846,66 +5904,7 @@ export function ChatSettingsDrawer({
                       </AgentSettingsCard>
                     )}
 
-                    {metadata.enableAgents && activeCustomAgents.length > 0 && (
-                      <AgentSettingsCard
-                        id={getAgentSettingsMenuId(chat.id, "custom-agents")}
-                        icon={renderRoleplayAgentMenuIcon("custom-agents")}
-                        title="Custom Agents"
-                        description="Configure custom agents currently attached to this chat."
-                        order={CUSTOM_AGENT_SETTINGS_ORDER}
-                      >
-                        <div className="space-y-1.5">
-                          {activeCustomAgents.map((agent) => {
-                            const tokenEst = agentLoadCost.tokensByType.get(agent.id);
-                            const promptOptions = getPromptOptionsForAgent(agent.id);
-                            return (
-                              <div
-                                key={agent.id}
-                                className="rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]"
-                              >
-                                <div className="flex items-start gap-2.5">
-                                  <Sparkles size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
-                                  <div className="min-w-0 flex-1">
-                                    <div className="flex min-w-0 items-center gap-1.5">
-                                      <span className="block min-w-0 truncate text-xs font-medium">{agent.name}</span>
-                                      {tokenEst != null ? (
-                                        <span
-                                          className="shrink-0 tabular-nums text-[0.625rem] text-[var(--muted-foreground)]"
-                                          title={`~${tokenEst.toLocaleString()} tokens of agent instructions (estimated)`}
-                                        >
-                                          ~{tokenEst.toLocaleString()}
-                                        </span>
-                                      ) : null}
-                                    </div>
-                                    <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
-                                      {agent.description}
-                                    </span>
-                                  </div>
-                                  <button
-                                    onClick={() => {
-                                      void toggleAgent(agent.id);
-                                    }}
-                                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
-                                    title="Remove from chat"
-                                  >
-                                    <Trash2 size="0.6875rem" />
-                                  </button>
-                                </div>
-                                <AgentPromptTemplateSelect
-                                  options={promptOptions}
-                                  selectedId={
-                                    agentPromptTemplateSelections[agent.id] ?? DEFAULT_AGENT_PROMPT_TEMPLATE_ID
-                                  }
-                                  onChange={(promptTemplateId) =>
-                                    updateAgentPromptTemplateSelection(agent.id, promptTemplateId)
-                                  }
-                                />
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </AgentSettingsCard>
-                    )}
+                    {renderActiveCustomAgentSettingsCard()}
 
                     {/* Haptic Feedback — not for game mode */}
                     {metadata.enableAgents && !isGame && hapticActive && (
@@ -6219,6 +6218,7 @@ export function ChatSettingsDrawer({
                           </div>
                         )}
                         {renderCustomAgentPicker()}
+                        {renderActiveCustomAgentSettingsCard()}
                       </div>
                     ) : (
                       <>

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2593,7 +2593,9 @@ export function ChatSettingsDrawer({
           </div>
         ) : (
           <p className="px-1 text-[0.625rem] text-[var(--muted-foreground)]">
-            All custom agents are active. Configure them below the other agent menus.
+            {isGame && !metadata.enableAgents
+              ? "All custom agents are already attached. Enable Agents to configure or run them."
+              : "All custom agents are active. Configure them below the other agent menus."}
           </p>
         )}
       </AgentCategorySection>
@@ -4864,6 +4866,7 @@ export function ChatSettingsDrawer({
                     />
                   </div>
                 </button>
+                {isGame && renderCustomAgentPicker()}
                 <AgentSettingsToggle
                   label="Review Agent Outputs"
                   description={
@@ -6217,7 +6220,6 @@ export function ChatSettingsDrawer({
                             })}
                           </div>
                         )}
-                        {renderCustomAgentPicker()}
                         {renderActiveCustomAgentSettingsCard()}
                       </div>
                     ) : (

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -24,6 +24,7 @@ import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
 import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
 import { ConversationPresenceCard } from "./ConversationPresenceCard";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
+import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import { useChatStore } from "../../stores/chat.store";
 import { useUnoGameStore } from "../../stores/uno-game.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -852,7 +853,7 @@ export function ConversationView({
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}
-        <div className="sticky top-0 z-10 flex items-center justify-between px-4 py-2">
+        <div className="sticky top-0 z-30 flex items-center justify-between px-4 py-2">
           <ConversationPresenceCard
             chatId={chatId}
             chatMeta={chatMeta}
@@ -1105,6 +1106,7 @@ export function ConversationView({
 
         <div ref={messagesEndRef} className="h-1" />
       </div>
+      <PinnedImageOverlay activeChatId={chatId} />
 
       {/* ── Autonomous message toast notification ── */}
       {hasAutonomousMessaging && (

--- a/packages/client/src/components/chat/PinnedImageOverlay.tsx
+++ b/packages/client/src/components/chat/PinnedImageOverlay.tsx
@@ -189,7 +189,7 @@ function PinnedImageViewer({
 
   return (
     <div
-      className="group fixed z-[110] cursor-grab select-none touch-none active:cursor-grabbing"
+      className="group fixed z-[20] cursor-grab select-none touch-none active:cursor-grabbing"
       style={{ left: pos.x, top: pos.y, width: size.w, height: size.h }}
       onPointerDown={onDragStart}
       onPointerMove={onDragMove}

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   Wand2,
   ArrowRight,
@@ -26,13 +27,19 @@ import { DEFAULT_GAME_SYSTEM_PROMPT, type GameSetupConfig, type GameGmMode } fro
 import { getCharacterTitle } from "../../lib/character-display";
 import { api } from "../../lib/api-client";
 import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../lib/utils";
-import { Modal } from "../ui/Modal";
 import {
   GenerationParametersFields,
   getEditableGenerationParameters,
   ROLEPLAY_PARAMETER_DEFAULTS,
   type EditableGenerationParameters,
 } from "../ui/GenerationParametersEditor";
+import {
+  NEUTRAL_PANEL_HEADER,
+  NEUTRAL_PANEL_SCROLL_AREA,
+  NEUTRAL_PANEL_SHELL,
+  NEUTRAL_PANEL_SUBTITLE,
+  NEUTRAL_PANEL_TITLE,
+} from "../ui/neutral-surface-styles";
 import {
   createDefaultGameHudWidget,
   GameWidgetSetupEditor,
@@ -137,6 +144,48 @@ const GAME_SETUP_GHOST_BUTTON_CLASS =
   "flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]";
 const GAME_SETUP_PRIMARY_BUTTON_CLASS =
   "flex items-center gap-1 rounded-lg bg-[var(--primary)] px-4 py-1.5 text-xs font-medium text-[var(--primary-foreground)] transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50";
+const GAME_SETUP_WIZARD_PANEL_CLASS = cn(
+  NEUTRAL_PANEL_SHELL,
+  "pointer-events-auto flex max-h-[calc(100dvh-1.5rem)] w-full max-w-lg flex-col overflow-hidden sm:max-h-[min(90dvh,44rem)]",
+);
+
+const GAME_SETUP_STEPS = [
+  {
+    key: "connection",
+    title: "Connection",
+    body: "Name the game and choose which AI connection should run the Game Master.",
+  },
+  {
+    key: "world",
+    title: "World",
+    body: "Pick genre, tone, difficulty, rating, and the starting language.",
+  },
+  {
+    key: "party",
+    title: "Party",
+    body: "Choose your player persona, Game Master style, and party members.",
+  },
+  {
+    key: "goals",
+    title: "Goals",
+    body: "Tell the GM what you want from the adventure and which mood to prioritize.",
+  },
+  {
+    key: "lorebooks",
+    title: "Lorebooks",
+    body: "Attach optional lorebooks to seed the world with durable context.",
+  },
+  {
+    key: "features",
+    title: "Features",
+    body: "Choose optional visual, music, lore, and HUD features for the session.",
+  },
+  {
+    key: "gm",
+    title: "GM",
+    body: "Review advanced GM instructions before starting the world.",
+  },
+] as const;
 
 type GameSpotifySourceType = "liked" | "playlist" | "artist" | "any";
 
@@ -437,8 +486,8 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
     [personas, personaSearch],
   );
 
-  const steps = ["Connection", "World", "Party", "Goals", "Lorebooks", "Features", "GM"];
-  const currentStepName = steps[step] ?? steps[0]!;
+  const steps = GAME_SETUP_STEPS;
+  const currentStep = steps[step] ?? steps[0]!;
   const learnedGenres = useMemo(
     () => filterLearnedOptions(learnedGameSetupOptions?.genres, [...GENRES, ...genres]),
     [genres, learnedGameSetupOptions?.genres],
@@ -604,13 +653,39 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
   };
 
   return (
-    <Modal open={true} onClose={onCancel} title="New Game" width="max-w-lg">
-      <div className="mb-4">
-        <h3 className="text-sm font-semibold text-[var(--foreground)]">{currentStepName}</h3>
-      </div>
+    <>
+      <div className="fixed inset-0 z-[10000] bg-black/45 backdrop-blur-[2px]" onClick={onCancel} />
+      <div className="fixed inset-0 z-[10001] flex items-center justify-center p-3 pointer-events-none max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={currentStep.key}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="game-setup-wizard-title"
+            initial={{ opacity: 0, y: 12, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -12, scale: 0.97 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            className={GAME_SETUP_WIZARD_PANEL_CLASS}
+          >
+            <div className={cn(NEUTRAL_PANEL_HEADER, "flex shrink-0 items-center justify-between")}>
+              <h3 id="game-setup-wizard-title" className={NEUTRAL_PANEL_TITLE}>
+                New Game
+              </h3>
+              <button
+                type="button"
+                onClick={onCancel}
+                className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                aria-label="Close setup"
+              >
+                <X size="0.875rem" />
+              </button>
+            </div>
 
-      {/* Step content */}
-      <div className="mb-5 space-y-4">
+            <div className={cn(NEUTRAL_PANEL_SCROLL_AREA, "min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4")}>
+              <h4 className="text-sm font-semibold text-[var(--foreground)]">{currentStep.title}</h4>
+              <p className={cn(NEUTRAL_PANEL_SUBTITLE, "mb-4")}>{currentStep.body}</p>
+              <div className="space-y-4">
         {step === 0 && (
           <>
             <div>
@@ -1829,77 +1904,80 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
             </div>
           </>
         )}
-      </div>
+              </div>
+            </div>
 
-      {/* Footer */}
-      <div className="sticky bottom-0 -mx-5 -mb-4 border-t border-[var(--border)]/30 bg-[var(--card)] px-5 pb-4 pt-3 shadow-[0_-12px_18px_rgba(0,0,0,0.18)]">
-        <div className="mb-3 flex items-center justify-center gap-1.5">
-          {steps.map((s, i) => (
-            <button
-              key={s}
-              type="button"
-              aria-label={`Go to ${s}`}
-              aria-current={i === step ? "step" : undefined}
-              disabled={i >= step}
-              onClick={() => {
-                if (i < step) setStep(i);
-              }}
-              className={cn(
-                "h-1.5 rounded-full transition-all duration-300 disabled:cursor-default",
-                i === step
-                  ? "w-5 bg-[var(--primary)]"
-                  : i < step
-                    ? "w-3 bg-[var(--primary)]/45 hover:bg-[var(--primary)]/70"
-                    : "w-1.5 bg-[var(--muted-foreground)]/25",
+            <div className="shrink-0 border-t border-[var(--border)]/70 px-5 py-3">
+              <div className="mb-3 flex items-center justify-center gap-1.5">
+                {steps.map((item, i) => (
+                  <button
+                    key={item.key}
+                    type="button"
+                    aria-label={`Go to ${item.title}`}
+                    aria-current={i === step ? "step" : undefined}
+                    disabled={i >= step}
+                    onClick={() => {
+                      if (i < step) setStep(i);
+                    }}
+                    className={cn(
+                      "h-1.5 rounded-full transition-all duration-300 disabled:cursor-default",
+                      i === step
+                        ? "w-5 bg-[var(--primary)]"
+                        : i < step
+                          ? "w-3 bg-[var(--primary)]/45 hover:bg-[var(--primary)]/70"
+                          : "w-1.5 bg-[var(--muted-foreground)]/25",
+                    )}
+                  />
+                ))}
+              </div>
+
+              {step === steps.length - 1 && !canStart && (
+                <p className="mb-3 text-center text-[0.6875rem] text-[var(--destructive)]">
+                  Select a connection on the first step before starting.
+                </p>
               )}
-            />
-          ))}
-        </div>
 
-        {step === steps.length - 1 && !canStart && (
-          <p className="mb-3 text-center text-[0.6875rem] text-[var(--destructive)]">
-            Select a connection on the first step before starting.
-          </p>
-        )}
+              <div className="flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={step === 0 ? onCancel : () => setStep(step - 1)}
+                  className={GAME_SETUP_GHOST_BUTTON_CLASS}
+                >
+                  <ArrowLeft size={14} />
+                  {step === 0 ? "Cancel" : "Back"}
+                </button>
 
-        <div className="flex items-center justify-between">
-          <button
-            type="button"
-            onClick={step === 0 ? onCancel : () => setStep(step - 1)}
-            className={GAME_SETUP_GHOST_BUTTON_CLASS}
-          >
-            <ArrowLeft size={14} />
-            {step === 0 ? "Cancel" : "Back"}
-          </button>
-
-          {step < steps.length - 1 ? (
-            <button type="button" onClick={() => setStep(step + 1)} className={GAME_SETUP_PRIMARY_BUTTON_CLASS}>
-              Next
-              <ArrowRight size={14} />
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={handleComplete}
-              disabled={isLoading || !canStart}
-              className={GAME_SETUP_PRIMARY_BUTTON_CLASS}
-              title={!canStart ? "Select a connection on the first step" : undefined}
-            >
-              {isLoading ? (
-                <>
-                  <Loader2 size={14} className="animate-spin" />
-                  Generating World…
-                </>
-              ) : (
-                <>
-                  <Wand2 size={14} />
-                  Start Game
-                </>
-              )}
-            </button>
-          )}
-        </div>
+                {step < steps.length - 1 ? (
+                  <button type="button" onClick={() => setStep(step + 1)} className={GAME_SETUP_PRIMARY_BUTTON_CLASS}>
+                    Next
+                    <ArrowRight size={14} />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleComplete}
+                    disabled={isLoading || !canStart}
+                    className={GAME_SETUP_PRIMARY_BUTTON_CLASS}
+                    title={!canStart ? "Select a connection on the first step" : undefined}
+                  >
+                    {isLoading ? (
+                      <>
+                        <Loader2 size={14} className="animate-spin" />
+                        Generating World…
+                      </>
+                    ) : (
+                      <>
+                        <Wand2 size={14} />
+                        Start Game
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        </AnimatePresence>
       </div>
-    </Modal>
+    </>
   );
 }

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -1404,7 +1404,7 @@ export function ChatSidebar() {
                   }
                   setDeleteTarget(null);
                 }}
-                className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--destructive)]/10 px-3 py-2.5 text-xs font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/20 transition-all hover:bg-[var(--destructive)]/20 active:scale-[0.98]"
+                className="mari-chrome-control mari-chrome-control--primary w-full text-xs"
               >
                 <Trash2 size="0.8125rem" />
                 Delete All {deleteTarget.branchCount} Branches

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -17,6 +17,7 @@ import {
   Download,
   Check,
   FolderPlus,
+  FolderOpen,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useUIStore } from "../../stores/ui.store";
@@ -30,7 +31,6 @@ import {
 import {
   BUILT_IN_AGENTS,
   DEFAULT_AGENT_TOOLS,
-  createFolderEntry,
   getDefaultBuiltInAgentSettings,
   getFolderImportEntries,
   getFolderManifestConfig,
@@ -42,10 +42,19 @@ import {
 } from "@marinara-engine/shared";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
-import { downloadJsonFile } from "../../lib/download-json";
 import { downloadZipFile } from "../../lib/download-zip";
-import { sanitizeAgentSettingsForTransfer } from "../../lib/agent-transfer";
-import { isZipFile, readTextFileFromZip } from "../../lib/read-zip-text";
+import {
+  createAgentFolderPackageFilename,
+  createAgentFolderPackageFiles,
+  sanitizeAgentSettingsForTransfer,
+  type AgentTransferConfig,
+} from "../../lib/agent-transfer";
+import {
+  collectFolderPackageEntries,
+  readTextFilesFromFileList,
+  type FolderPackageImportEntry,
+} from "../../lib/folder-package-transfer";
+import { isZipFile, readTextFilesFromZip } from "../../lib/read-zip-text";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
 import {
   getNextUnnamedLibraryFolderName,
@@ -91,7 +100,7 @@ function getAgentImportEntries(parsed: unknown) {
   return getFolderImportEntries(parsed, ["agents"]);
 }
 
-function serializeAgentConfig(agent: AgentConfigRow) {
+function serializeAgentConfig(agent: AgentConfigRow): AgentTransferConfig {
   const settings = sanitizeAgentSettingsForTransfer(parseAgentSettings(agent.settings));
   if (typeof settings.author !== "string" || !settings.author.trim()) {
     settings.author = "Unknown";
@@ -109,16 +118,6 @@ function serializeAgentConfig(agent: AgentConfigRow) {
     settings,
     ...(resultType ? { resultType } : {}),
   };
-}
-
-function serializeAgentFolderEntry(agent: AgentConfigRow) {
-  return createFolderEntry({
-    folderName: "Agents",
-    itemName: agent.type,
-    itemKind: "marinara.agent",
-    config: serializeAgentConfig(agent),
-    fallbackName: "custom-agent",
-  });
 }
 
 function createBuiltInAgentConfigRow(
@@ -170,7 +169,7 @@ function createDuplicateAgentInput(agent: AgentConfigRow) {
   };
 }
 
-function normalizeAgentImportEntry(entry: unknown) {
+function normalizeAgentImportEntry(entry: unknown, resolveTextFile?: (path: unknown) => string | null) {
   const source = getFolderManifestConfig(entry);
   if (!isJsonRecord(source)) return null;
 
@@ -180,7 +179,8 @@ function normalizeAgentImportEntry(entry: unknown) {
   if (!type || !name) return null;
   const phase = normalizeAgentPhaseForType(type, normalizeAgentPhaseValue(source.phase));
 
-  const settings = sanitizeAgentSettingsForTransfer(parseAgentSettings(source.settings));
+  const settingsText = resolveTextFile?.(source.settingsPath);
+  const settings = sanitizeAgentSettingsForTransfer(parseAgentSettings(settingsText ?? source.settings));
   if (typeof source.author === "string" && !settings.author) {
     settings.author = source.author;
   }
@@ -200,7 +200,8 @@ function normalizeAgentImportEntry(entry: unknown) {
     enabled: parseBooleanValue(source.enabled),
     connectionId: null,
     imagePath: null,
-    promptTemplate: typeof source.promptTemplate === "string" ? source.promptTemplate : "",
+    promptTemplate:
+      resolveTextFile?.(source.promptTemplatePath) ?? (typeof source.promptTemplate === "string" ? source.promptTemplate : ""),
     settings,
     ...(typeof resultType === "string" ? { resultType } : {}),
   };
@@ -220,6 +221,7 @@ export function AgentsPanel() {
   const [agentSearch, setAgentSearch] = useState("");
   const agentImageInputRef = useRef<HTMLInputElement>(null);
   const agentImportInputRef = useRef<HTMLInputElement>(null);
+  const agentFolderImportInputRef = useRef<HTMLInputElement>(null);
   const imageTargetAgentIdRef = useRef<string | null>(null);
   const [agentImportError, setAgentImportError] = useState<string | null>(null);
   const [agentImportSuccess, setAgentImportSuccess] = useState<string | null>(null);
@@ -401,21 +403,13 @@ export function AgentsPanel() {
 
     setExportingSelected(true);
     try {
-      const envelope = {
-        kind: "marinara.agent-folder",
-        version: 1,
-        exportedAt: new Date().toISOString(),
-        folderName: "Agents",
-        agents: selectedAgents.map(serializeAgentFolderEntry),
-      };
-      if (selectedAgents.length > 1) {
-        downloadZipFile(
-          [{ path: "marinara-agents.json", content: JSON.stringify(envelope, null, 2) }],
-          "marinara-agents.zip",
-        );
-      } else {
-        downloadJsonFile(envelope, "marinara-agents.json");
-      }
+      const files = createAgentFolderPackageFiles(selectedAgents.map(serializeAgentConfig));
+      const firstAgent = selectedAgents[0];
+      const filename =
+        selectedAgents.length === 1 && firstAgent
+          ? createAgentFolderPackageFilename(getAgentLibraryDisplayName(firstAgent), "agent")
+          : "marinara-agents.zip";
+      downloadZipFile(files, filename);
       toast.success(`Exported ${selectedAgents.length} agent${selectedAgents.length === 1 ? "" : "s"}`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to export agents");
@@ -472,6 +466,36 @@ export function AgentsPanel() {
     exitSelectionMode();
   }, [deleteAgent, exitSelectionMode, selectedAgents]);
 
+  const importAgentEntries = useCallback(
+    async (entries: FolderPackageImportEntry[]) => {
+      if (entries.length === 0) throw new Error("No agents found in file");
+
+      let imported = 0;
+      const failed: string[] = [];
+      for (const entry of entries) {
+        const normalized = normalizeAgentImportEntry(entry.raw, entry.resolveTextFile);
+        if (!normalized) continue;
+        try {
+          await createAgent.mutateAsync(normalized);
+          imported++;
+        } catch (error) {
+          failed.push(error instanceof Error ? error.message : `Failed to import ${normalized.name}`);
+        }
+      }
+
+      if (imported === 0 && failed.length === 0) {
+        throw new Error("No valid agents found in file");
+      }
+      if (imported > 0) {
+        setAgentImportSuccess(`Imported ${imported} agent${imported === 1 ? "" : "s"}.`);
+      }
+      if (failed.length > 0) {
+        setAgentImportError(`${failed.length} agent${failed.length === 1 ? "" : "s"} failed. ${failed[0]}`);
+      }
+    },
+    [createAgent],
+  );
+
   const handleImportAgents = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
       setAgentImportError(null);
@@ -480,40 +504,45 @@ export function AgentsPanel() {
       if (!file) return;
 
       try {
-        const text = isZipFile(file) ? await readTextFileFromZip(file, ["marinara-agents.json"]) : await file.text();
-        const parsed = JSON.parse(text);
-        const entries = getAgentImportEntries(parsed);
-        if (entries.length === 0) throw new Error("No agents found in file");
-
-        let imported = 0;
-        const failed: string[] = [];
-        for (const entry of entries) {
-          const normalized = normalizeAgentImportEntry(entry);
-          if (!normalized) continue;
-          try {
-            await createAgent.mutateAsync(normalized);
-            imported++;
-          } catch (error) {
-            failed.push(error instanceof Error ? error.message : `Failed to import ${normalized.name}`);
-          }
-        }
-
-        if (imported === 0 && failed.length === 0) {
-          throw new Error("No valid agents found in file");
-        }
-        if (imported > 0) {
-          setAgentImportSuccess(`Imported ${imported} agent${imported === 1 ? "" : "s"}.`);
-        }
-        if (failed.length > 0) {
-          setAgentImportError(`${failed.length} agent${failed.length === 1 ? "" : "s"} failed. ${failed[0]}`);
-        }
+        const entries = isZipFile(file)
+          ? collectFolderPackageEntries(await readTextFilesFromZip(file), {
+              rootFilenames: ["marinara-agents.json", "marinara-agent.json"],
+              collectionKeys: ["agents"],
+            })
+          : getAgentImportEntries(JSON.parse(await file.text())).map(
+              (raw): FolderPackageImportEntry => ({
+                raw,
+                path: file.name,
+                basePath: "",
+                resolveTextFile: () => null,
+              }),
+            );
+        await importAgentEntries(entries);
       } catch (error) {
         setAgentImportError(error instanceof Error ? error.message : "Failed to import agents");
       }
 
       event.target.value = "";
     },
-    [createAgent],
+    [importAgentEntries],
+  );
+
+  const handleImportAgentFolder = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      setAgentImportError(null);
+      setAgentImportSuccess(null);
+      try {
+        const entries = collectFolderPackageEntries(await readTextFilesFromFileList(event.target.files), {
+          rootFilenames: ["marinara-agents.json", "marinara-agent.json"],
+          collectionKeys: ["agents"],
+        });
+        await importAgentEntries(entries);
+      } catch (error) {
+        setAgentImportError(error instanceof Error ? error.message : "Failed to import agents");
+      }
+      event.target.value = "";
+    },
+    [importAgentEntries],
   );
 
   const handlePickAgentImage = useCallback((agentIdOrType: string) => {
@@ -652,6 +681,15 @@ export function AgentsPanel() {
         className="hidden"
         onChange={handleImportAgents}
       />
+      <input
+        ref={agentFolderImportInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleImportAgentFolder}
+        // @ts-expect-error — webkitdirectory is a non-standard but widely-supported attribute
+        webkitdirectory=""
+      />
 
       <div className="flex gap-2">
         <button onClick={handleCreateAgent} className={cn("flex-1 text-xs", AGENT_GRADIENT_BUTTON)} title="New">
@@ -663,6 +701,13 @@ export function AgentsPanel() {
           title="Import agents"
         >
           <Download size="0.8125rem" />
+        </button>
+        <button
+          onClick={() => agentFolderImportInputRef.current?.click()}
+          className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
+          title="Import agent folder"
+        >
+          <FolderOpen size="0.8125rem" />
         </button>
         <button
           onClick={() => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -117,7 +117,21 @@ import { ExportFormatDialog, type ExportFormatChoice } from "../ui/ExportFormatD
 import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-import";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
+import { downloadZipFile } from "../../lib/download-zip";
+import {
+  createExtensionFolderPackageFilename,
+  createExtensionFolderPackageFiles,
+} from "../../lib/extension-transfer";
+import {
+  collectFolderPackageEntries,
+  getPackagePathBasename,
+  readTextFilesFromFileList,
+  resolvePackageTextPaths,
+  type FolderPackageImportEntry,
+  type PackageTextFile,
+} from "../../lib/folder-package-transfer";
 import { HOST_DEVICE_FILE_MANAGER_MESSAGE } from "../../lib/host-device";
+import { isZipFile as isZipArchiveFile, readTextFilesFromZip } from "../../lib/read-zip-text";
 
 type CustomFontFace = {
   filename: string;
@@ -1778,8 +1792,10 @@ function AppearanceSettings() {
   const setDefaultRoleplayBackground = useUIStore((s) => s.setDefaultRoleplayBackground);
   const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
   const setChatBackgroundBlur = useUIStore((s) => s.setChatBackgroundBlur);
+  const resetAppearanceSettings = useUIStore((s) => s.resetAppearanceSettings);
   const activeChatId = useChatStore((s) => s.activeChatId);
   const updateMeta = useUpdateChatMetadata();
+  const setActiveSyncedTheme = useSetActiveTheme();
   const handleAppBackgroundColorChange = useCallback(
     (color: string) => {
       const normalized = color.trim();
@@ -1863,6 +1879,25 @@ function AppearanceSettings() {
     setDraftFrom(currentGradient.from);
     setDraftTo(currentGradient.to);
   }, [activeGradientScheme, currentGradient.from, currentGradient.to]);
+  const handleResetAppearance = useCallback(() => {
+    resetAppearanceSettings();
+    setActiveGradientScheme("dark");
+    setDraftFrom("#0a0a0e");
+    setDraftTo("#1c2133");
+    document.getElementById("marinara-css-editor-preview")?.remove();
+    if (activeChatId) {
+      updateMeta.mutate({ id: activeChatId, background: chatBackgroundUrlToMetadata(null) });
+    }
+    void setActiveSyncedTheme
+      .mutateAsync(null)
+      .then(() => {
+        toast.success("Appearance reset to Marinara defaults.");
+      })
+      .catch((err) => {
+        console.error("[AppearanceSettings] Failed to clear active synced theme:", err);
+        toast.warning("Appearance reset locally, but the active synced theme could not be cleared.");
+      });
+  }, [activeChatId, resetAppearanceSettings, setActiveSyncedTheme, updateMeta]);
   const fontSize = useUIStore((s) => s.fontSize);
   const setFontSize = useUIStore((s) => s.setFontSize);
   const chatFontSize = useUIStore((s) => s.chatFontSize);
@@ -1992,6 +2027,22 @@ function AppearanceSettings() {
         icon={<Paintbrush size="0.875rem" />}
       >
         <div className="flex flex-col gap-3">
+          <div className="flex justify-start">
+            <button
+              type="button"
+              onClick={handleResetAppearance}
+              disabled={setActiveSyncedTheme.isPending}
+              className={SETTINGS_BUTTON_CLASS}
+              title="Reset all Appearance settings to Marinara defaults"
+            >
+              {setActiveSyncedTheme.isPending ? (
+                <Loader2 size="0.75rem" className="animate-spin" />
+              ) : (
+                <RotateCcw size="0.75rem" />
+              )}
+              Reset Appearance
+            </button>
+          </div>
           {/* ── Visual Style ── */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-1.5">
@@ -3779,6 +3830,68 @@ const CSS_TEMPLATE = `/* ══════════════════�
    You can also add any custom CSS below: */
 `;
 
+function createInlineFolderPackageImportEntry(raw: unknown, path: string): FolderPackageImportEntry {
+  return {
+    raw,
+    path,
+    basePath: "",
+    resolveTextFile: () => null,
+  };
+}
+
+function normalizeExtensionImportEntry(entry: FolderPackageImportEntry, fallbackName: string) {
+  const source = getFolderManifestConfig(entry.raw);
+  if (!source || typeof source !== "object" || Array.isArray(source)) return null;
+  const record = source as Record<string, unknown>;
+  const folderName = getPackagePathBasename(entry.basePath) || fallbackName;
+  const name = typeof record.name === "string" && record.name.trim() ? record.name.trim() : folderName;
+  if (!name) return null;
+  const cssFromFiles = resolvePackageTextPaths(entry.resolveTextFile, record.cssPath ?? record.cssPaths);
+  const jsFromFiles = resolvePackageTextPaths(entry.resolveTextFile, record.jsPath ?? record.jsPaths);
+
+  return {
+    name,
+    description: typeof record.description === "string" ? record.description : "",
+    css: cssFromFiles ?? (typeof record.css === "string" ? record.css : null),
+    js: jsFromFiles ?? (typeof record.js === "string" ? record.js : null),
+    enabled: typeof record.enabled === "boolean" ? record.enabled : true,
+  };
+}
+
+function createLooseExtensionFolderImportEntries(
+  files: PackageTextFile[],
+  fallbackName: string,
+): FolderPackageImportEntry[] {
+  const css = files
+    .filter((file) => file.path.toLowerCase().endsWith(".css"))
+    .map((file) => file.text)
+    .join("\n\n");
+  const js = files
+    .filter((file) => /\.(js|mjs|cjs)$/i.test(file.path))
+    .map((file) => file.text)
+    .join("\n\n");
+  if (!css && !js) return [];
+  return [
+    createInlineFolderPackageImportEntry(
+      {
+        name: fallbackName || "extension",
+        description: "Extension imported from folder",
+        css: css || null,
+        js: js || null,
+        enabled: true,
+      },
+      fallbackName || "extension",
+    ),
+  ];
+}
+
+function getLooseExtensionFolderName(files: PackageTextFile[], fallbackName: string) {
+  const firstPath = files[0]?.path;
+  if (!firstPath) return fallbackName;
+  const firstSlash = firstPath.indexOf("/");
+  return firstSlash > 0 ? firstPath.slice(0, firstSlash) : fallbackName;
+}
+
 function ExtensionsSettings() {
   const { data: extensions, isLoading } = useExtensions();
   const extensionList = extensions ?? [];
@@ -3786,52 +3899,70 @@ function ExtensionsSettings() {
   const updateExtension = useUpdateExtension();
   const deleteExtension = useDeleteExtension();
   const fileRef = useRef<HTMLInputElement>(null);
+  const folderRef = useRef<HTMLInputElement>(null);
+
+  const importExtensionEntries = async (
+    entries: FolderPackageImportEntry[],
+    installedAt: string,
+    fallbackName: string,
+  ) => {
+    let imported = 0;
+    let failed = 0;
+    for (const entry of entries) {
+      const normalized = normalizeExtensionImportEntry(entry, fallbackName);
+      if (!normalized) continue;
+      try {
+        await createExtension.mutateAsync({
+          ...normalized,
+          installedAt,
+        });
+        imported++;
+      } catch (err) {
+        failed++;
+        console.warn("[ExtensionsSettings] Failed to import extension entry:", normalized.name, err);
+      }
+    }
+    if (imported === 0 && failed === 0) throw new Error("No valid extensions found in file");
+    if (failed > 0) {
+      toast.warning(
+        imported > 0
+          ? `Installed ${imported} extension${imported === 1 ? "" : "s"} (${failed} failed).`
+          : `Failed to install ${failed} extension${failed === 1 ? "" : "s"}.`,
+      );
+    } else {
+      toast.success(`Installed ${imported} extension${imported === 1 ? "" : "s"}`);
+    }
+  };
 
   const handleImportExtension = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     try {
-      const text = await file.text();
       const installedAt = new Date().toISOString();
+      const fallbackName = file.name.replace(/\.(json|css|js|zip)$/i, "");
+      const lowerName = file.name.toLowerCase();
 
-      if (file.name.endsWith(".json")) {
+      if (isZipArchiveFile(file)) {
+        const files = await readTextFilesFromZip(file);
+        const entries = collectFolderPackageEntries(files, {
+          rootFilenames: ["marinara-extensions.json", "marinara-extension.json"],
+          collectionKeys: ["extensions"],
+        });
+        await importExtensionEntries(
+          entries.length > 0 ? entries : createLooseExtensionFolderImportEntries(files, fallbackName),
+          installedAt,
+          fallbackName,
+        );
+      } else if (lowerName.endsWith(".json")) {
+        const text = await file.text();
         const parsed = JSON.parse(text);
-        const entries = getFolderImportEntries(parsed, ["extensions"]);
-        let imported = 0;
-        let failed = 0;
-        for (const entry of entries) {
-          const source = getFolderManifestConfig(entry);
-          if (!source || typeof source !== "object" || Array.isArray(source)) continue;
-          const record = source as Record<string, unknown>;
-          const name =
-            typeof record.name === "string" && record.name.trim() ? record.name : file.name.replace(/\.json$/, "");
-          try {
-            await createExtension.mutateAsync({
-              name,
-              description: typeof record.description === "string" ? record.description : "",
-              css: typeof record.css === "string" ? record.css : null,
-              js: typeof record.js === "string" ? record.js : null,
-              enabled: typeof record.enabled === "boolean" ? record.enabled : true,
-              installedAt,
-            });
-            imported++;
-          } catch (err) {
-            failed++;
-            console.warn("[ExtensionsSettings] Failed to import extension entry:", name, err);
-          }
-        }
-        if (imported === 0 && failed === 0) throw new Error("No valid extensions found in file");
-        if (failed > 0) {
-          toast.warning(
-            imported > 0
-              ? `Installed ${imported} extension${imported === 1 ? "" : "s"} (${failed} failed).`
-              : `Failed to install ${failed} extension${failed === 1 ? "" : "s"}.`,
-          );
-        } else {
-          toast.success(`Installed ${imported} extension${imported === 1 ? "" : "s"}`);
-        }
-      } else if (file.name.endsWith(".js")) {
-        const name = file.name.replace(/\.js$/, "");
+        const entries = getFolderImportEntries(parsed, ["extensions"]).map((entry) =>
+          createInlineFolderPackageImportEntry(entry, file.name),
+        );
+        await importExtensionEntries(entries, installedAt, fallbackName);
+      } else if (lowerName.endsWith(".js")) {
+        const text = await file.text();
+        const name = file.name.replace(/\.js$/i, "");
         await createExtension.mutateAsync({
           name,
           description: "JS extension imported from file",
@@ -3840,8 +3971,9 @@ function ExtensionsSettings() {
           installedAt,
         });
         toast.success(`Extension "${name}" installed`);
-      } else if (file.name.endsWith(".css")) {
-        const name = file.name.replace(/\.css$/, "");
+      } else if (lowerName.endsWith(".css")) {
+        const text = await file.text();
+        const name = file.name.replace(/\.css$/i, "");
         await createExtension.mutateAsync({
           name,
           description: "CSS extension imported from file",
@@ -3851,10 +3983,30 @@ function ExtensionsSettings() {
         });
         toast.success(`Extension "${name}" installed`);
       } else {
-        toast.error("Only .json, .css, and .js extension files are supported.");
+        toast.error("Only .zip, .json, .css, and .js extension files are supported.");
       }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to import extension.");
+    }
+    e.target.value = "";
+  };
+
+  const handleImportExtensionFolder = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    try {
+      const installedAt = new Date().toISOString();
+      const files = await readTextFilesFromFileList(e.target.files);
+      const folderName = getLooseExtensionFolderName(files, "extension");
+      const entries = collectFolderPackageEntries(files, {
+        rootFilenames: ["marinara-extensions.json", "marinara-extension.json"],
+        collectionKeys: ["extensions"],
+      });
+      await importExtensionEntries(
+        entries.length > 0 ? entries : createLooseExtensionFolderImportEntries(files, folderName),
+        installedAt,
+        folderName,
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to import extension folder.");
     }
     e.target.value = "";
   };
@@ -3874,14 +4026,29 @@ function ExtensionsSettings() {
             onClick={() => fileRef.current?.click()}
             className="flex items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-[var(--border)] p-3 text-xs text-[var(--muted-foreground)] transition-all hover:border-[var(--primary)]/40 hover:bg-[var(--secondary)]/50"
           >
-            <Download size="0.875rem" /> Import Extension (.json, .css, or .js)
+            <Download size="0.875rem" /> Import Extension File (.zip, .json, .css, or .js)
+          </button>
+          <button
+            onClick={() => folderRef.current?.click()}
+            className="flex items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-[var(--border)] p-3 text-xs text-[var(--muted-foreground)] transition-all hover:border-[var(--primary)]/40 hover:bg-[var(--secondary)]/50"
+          >
+            <FolderOpen size="0.875rem" /> Import Extension Folder
           </button>
           <input
             ref={fileRef}
             type="file"
-            accept=".json,.css,.js"
+            accept=".zip,.json,.css,.js,application/zip,application/json"
             className="hidden"
             onChange={handleImportExtension}
+          />
+          <input
+            ref={folderRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={handleImportExtensionFolder}
+            // @ts-expect-error — webkitdirectory is a non-standard but widely-supported attribute
+            webkitdirectory=""
           />
 
           {/* Extension list */}
@@ -3918,29 +4085,17 @@ function ExtensionsSettings() {
                 </div>
                 <button
                   onClick={() => {
-                    downloadJsonFile(
-                      {
-                        kind: "marinara.extension-folder",
-                        version: 1,
-                        exportedAt: new Date().toISOString(),
-                        folderName: "Extensions",
-                        extensions: [
-                          createFolderEntry({
-                            folderName: "Extensions",
-                            itemName: ext.name,
-                            itemKind: "marinara.extension",
-                            config: {
-                              name: ext.name,
-                              description: ext.description ?? "",
-                              css: ext.css ?? null,
-                              js: ext.js ?? null,
-                              enabled: ext.enabled,
-                            },
-                            fallbackName: "extension",
-                          }),
-                        ],
-                      },
-                      `${sanitizeExportFilenamePart(ext.name, "extension")}.json`,
+                    downloadZipFile(
+                      createExtensionFolderPackageFiles([
+                        {
+                          name: ext.name,
+                          description: ext.description ?? "",
+                          css: ext.css ?? null,
+                          js: ext.js ?? null,
+                          enabled: ext.enabled,
+                        },
+                      ]),
+                      createExtensionFolderPackageFilename(ext.name, "extension"),
                     );
                   }}
                   className="rounded p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-emerald-500/10 hover:text-emerald-400"
@@ -3960,16 +4115,16 @@ function ExtensionsSettings() {
 
             {!isLoading && extensionList.length === 0 && (
               <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
-                No extensions installed. Import a .json, .css, or .js extension file above.
+                No extensions installed. Import an extension file or folder above.
               </p>
             )}
           </div>
 
           {/* Info box */}
           <div className="rounded-lg bg-[var(--secondary)]/50 p-2.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-            <strong>JSON format:</strong>{" "}
-            <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "description": "...", "css": "..." }`}</code>
-            . Extensions can inject custom CSS and/or JavaScript to modify the UI.
+            <strong>Folder format:</strong>{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">Extensions/My Extension/manifest.json</code>
+            . Extensions can include CSS and/or JavaScript files to modify the UI.
           </div>
           <div className="rounded-lg bg-[var(--secondary)]/35 p-2.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
             Extensions can be downloaded from the official Marinara Engine Discord server.

--- a/packages/client/src/lib/agent-transfer.ts
+++ b/packages/client/src/lib/agent-transfer.ts
@@ -1,3 +1,20 @@
+import { sanitizeFolderSegment } from "@marinara-engine/shared";
+import type { ZipFileInput } from "./download-zip";
+import { reservePackageFolderSegment } from "./folder-package-transfer";
+
+export type AgentTransferConfig = {
+  type: string;
+  name: string;
+  description: string;
+  phase: unknown;
+  enabled: unknown;
+  connectionId: null;
+  imagePath: null;
+  promptTemplate: string;
+  settings: Record<string, unknown>;
+  resultType?: unknown;
+};
+
 const TRANSFER_UNSAFE_AGENT_SETTING_KEYS = new Set([
   "spotifyAccessToken",
   "spotifyRefreshToken",
@@ -28,4 +45,56 @@ export function sanitizeAgentSettingsForTransfer(settings: Record<string, unknow
   }
 
   return sanitized;
+}
+
+export function createAgentFolderPackageFiles(agents: AgentTransferConfig[]): ZipFileInput[] {
+  const usedSegments = new Set<string>();
+  const entries = agents.map((agent) => {
+    const segment = reservePackageFolderSegment(agent.type || agent.name, "agent", usedSegments);
+    const folderPath = `Agents/${segment}`;
+    const promptTemplatePath = "prompt.md";
+    const settingsPath = "settings.json";
+    const config = {
+      ...agent,
+      promptTemplatePath,
+      settingsPath,
+    };
+    const manifest = {
+      kind: "marinara.agent",
+      version: 1 as const,
+      config,
+    };
+    return {
+      folderPath,
+      promptTemplatePath,
+      settingsPath,
+      entry: {
+        path: `${folderPath}/manifest.json`,
+        manifest,
+      },
+      manifest,
+      config,
+    };
+  });
+
+  const envelope = {
+    kind: "marinara.agent-folder",
+    version: 1 as const,
+    exportedAt: new Date().toISOString(),
+    folderName: "Agents",
+    agents: entries.map(({ entry }) => entry),
+  };
+
+  return [
+    { path: "marinara-agents.json", content: JSON.stringify(envelope, null, 2) },
+    ...entries.flatMap(({ folderPath, promptTemplatePath, settingsPath, manifest, config }) => [
+      { path: `${folderPath}/manifest.json`, content: JSON.stringify(manifest, null, 2) },
+      { path: `${folderPath}/${promptTemplatePath}`, content: config.promptTemplate },
+      { path: `${folderPath}/${settingsPath}`, content: JSON.stringify(config.settings, null, 2) },
+    ]),
+  ];
+}
+
+export function createAgentFolderPackageFilename(name: string, fallback = "marinara-agent") {
+  return `${sanitizeFolderSegment(name, fallback)}.agent.zip`;
 }

--- a/packages/client/src/lib/download-zip.ts
+++ b/packages/client/src/lib/download-zip.ts
@@ -1,4 +1,4 @@
-type ZipFileInput = {
+export type ZipFileInput = {
   path: string;
   content: string | Uint8Array;
 };

--- a/packages/client/src/lib/extension-transfer.ts
+++ b/packages/client/src/lib/extension-transfer.ts
@@ -1,0 +1,65 @@
+import { sanitizeFolderSegment } from "@marinara-engine/shared";
+import type { ZipFileInput } from "./download-zip";
+import { reservePackageFolderSegment } from "./folder-package-transfer";
+
+export type ExtensionTransferConfig = {
+  name: string;
+  description?: string | null;
+  css?: string | null;
+  js?: string | null;
+  enabled: boolean;
+};
+
+export function createExtensionFolderPackageFiles(extensions: ExtensionTransferConfig[]): ZipFileInput[] {
+  const usedSegments = new Set<string>();
+  const entries = extensions.map((extension) => {
+    const segment = reservePackageFolderSegment(extension.name, "extension", usedSegments);
+    const folderPath = `Extensions/${segment}`;
+    const css = extension.css ?? null;
+    const js = extension.js ?? null;
+    const config = {
+      name: extension.name,
+      description: extension.description ?? "",
+      css,
+      js,
+      enabled: extension.enabled,
+      ...(css ? { cssPath: "extension.css" } : {}),
+      ...(js ? { jsPath: "extension.js" } : {}),
+    };
+    const manifest = {
+      kind: "marinara.extension",
+      version: 1 as const,
+      config,
+    };
+    return {
+      folderPath,
+      entry: {
+        path: `${folderPath}/manifest.json`,
+        manifest,
+      },
+      manifest,
+      config,
+    };
+  });
+
+  const envelope = {
+    kind: "marinara.extension-folder",
+    version: 1 as const,
+    exportedAt: new Date().toISOString(),
+    folderName: "Extensions",
+    extensions: entries.map(({ entry }) => entry),
+  };
+
+  return [
+    { path: "marinara-extensions.json", content: JSON.stringify(envelope, null, 2) },
+    ...entries.flatMap(({ folderPath, manifest, config }) => [
+      { path: `${folderPath}/manifest.json`, content: JSON.stringify(manifest, null, 2) },
+      ...(config.css ? [{ path: `${folderPath}/extension.css`, content: config.css }] : []),
+      ...(config.js ? [{ path: `${folderPath}/extension.js`, content: config.js }] : []),
+    ]),
+  ];
+}
+
+export function createExtensionFolderPackageFilename(name: string, fallback = "extension") {
+  return `${sanitizeFolderSegment(name, fallback)}.extension.zip`;
+}

--- a/packages/client/src/lib/folder-package-transfer.ts
+++ b/packages/client/src/lib/folder-package-transfer.ts
@@ -1,0 +1,147 @@
+import { getFolderImportEntries, isJsonRecord, sanitizeFolderSegment } from "@marinara-engine/shared";
+
+export type PackageTextFile = {
+  path: string;
+  text: string;
+};
+
+export type FolderPackageImportEntry = {
+  raw: unknown;
+  path: string;
+  basePath: string;
+  resolveTextFile: (path: unknown) => string | null;
+};
+
+const PACKAGE_TEXT_FILE_RE = /\.(json|js|mjs|cjs|css|md|txt|ts|tsx)$/i;
+
+export function normalizePackagePath(path: string) {
+  return path
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((part) => part.trim())
+    .filter((part) => part && part !== "." && part !== "..")
+    .join("/");
+}
+
+export function getPackagePathBasename(path: string) {
+  const normalized = normalizePackagePath(path);
+  const slashIndex = normalized.lastIndexOf("/");
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+export function getPackagePathDirname(path: string) {
+  const normalized = normalizePackagePath(path);
+  const slashIndex = normalized.lastIndexOf("/");
+  return slashIndex >= 0 ? normalized.slice(0, slashIndex) : "";
+}
+
+export function reservePackageFolderSegment(value: string, fallback: string, usedSegments: Set<string>) {
+  const baseSegment = sanitizeFolderSegment(value, fallback);
+  let segment = baseSegment;
+  let suffix = 2;
+  while (usedSegments.has(segment.toLowerCase())) {
+    segment = `${baseSegment}-${suffix}`;
+    suffix++;
+  }
+  usedSegments.add(segment.toLowerCase());
+  return segment;
+}
+
+export async function readTextFilesFromFileList(fileList: FileList | null): Promise<PackageTextFile[]> {
+  const result: PackageTextFile[] = [];
+  for (const file of Array.from(fileList ?? [])) {
+    const relativePath = normalizePackagePath((file as File & { webkitRelativePath?: string }).webkitRelativePath ?? "");
+    const path = relativePath || normalizePackagePath(file.name);
+    if (!path || !PACKAGE_TEXT_FILE_RE.test(path)) continue;
+    result.push({ path, text: await file.text() });
+  }
+  return result.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function collectFolderPackageEntries(
+  files: PackageTextFile[],
+  {
+    rootFilenames,
+    collectionKeys,
+  }: {
+    rootFilenames: string[];
+    collectionKeys: string[];
+  },
+): FolderPackageImportEntry[] {
+  const textByPath = new Map(files.map((file) => [normalizePackagePath(file.path).toLowerCase(), file.text]));
+  const normalizedFiles = files.map((file) => ({
+    path: normalizePackagePath(file.path),
+    text: file.text,
+  }));
+  const normalizedRootFilenames = new Set(rootFilenames.map((name) => name.toLowerCase()));
+  const packageEntries: FolderPackageImportEntry[] = [];
+
+  for (const file of normalizedFiles) {
+    if (!normalizedRootFilenames.has(getPackagePathBasename(file.path).toLowerCase())) continue;
+    const parsed = parsePackageJson(file.text);
+    if (parsed === null) continue;
+    for (const raw of getFolderImportEntries(parsed, collectionKeys)) {
+      packageEntries.push(createPackageImportEntry(raw, file.path, textByPath));
+    }
+  }
+
+  if (packageEntries.length > 0) return packageEntries;
+
+  for (const file of normalizedFiles) {
+    if (getPackagePathBasename(file.path).toLowerCase() !== "manifest.json") continue;
+    const parsed = parsePackageJson(file.text);
+    if (parsed === null) continue;
+    packageEntries.push(createPackageImportEntry(parsed, file.path, textByPath));
+  }
+
+  return packageEntries;
+}
+
+export function resolvePackageTextPaths(resolveTextFile: (path: unknown) => string | null, value: unknown) {
+  const paths = Array.isArray(value) ? value : [value];
+  const parts = paths
+    .map((path) => resolveTextFile(path))
+    .filter((text): text is string => typeof text === "string");
+  return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+function parsePackageJson(text: string) {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function createPackageImportEntry(
+  raw: unknown,
+  packagePath: string,
+  textByPath: Map<string, string>,
+): FolderPackageImportEntry {
+  const entryPath = isJsonRecord(raw) && typeof raw.path === "string" ? raw.path : packagePath;
+  const normalizedEntryPath = normalizePackagePath(entryPath);
+  const basePath =
+    getPackagePathBasename(normalizedEntryPath).toLowerCase() === "manifest.json"
+      ? getPackagePathDirname(normalizedEntryPath)
+      : getPackagePathDirname(packagePath);
+
+  return {
+    raw,
+    path: normalizedEntryPath || packagePath,
+    basePath,
+    resolveTextFile: (path) => {
+      if (typeof path !== "string" || !path.trim()) return null;
+      const normalizedPath = normalizePackagePath(path);
+      if (!normalizedPath) return null;
+      const candidates = [
+        basePath ? normalizePackagePath(`${basePath}/${normalizedPath}`) : normalizedPath,
+        normalizedPath,
+      ];
+      for (const candidate of candidates) {
+        const text = textByPath.get(candidate.toLowerCase());
+        if (typeof text === "string") return text;
+      }
+      return null;
+    },
+  };
+}

--- a/packages/client/src/lib/read-zip-text.ts
+++ b/packages/client/src/lib/read-zip-text.ts
@@ -2,6 +2,19 @@ const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
 const ZIP_CENTRAL_DIRECTORY_FILE_HEADER = 0x02014b50;
 const ZIP_LOCAL_FILE_HEADER = 0x04034b50;
 
+type ZipTextEntry = {
+  path: string;
+  text: string;
+};
+
+type ZipCentralDirectoryEntry = {
+  localHeaderOffset: number;
+  compressedSize: number;
+  uncompressedSize: number;
+  compressionMethod: number;
+  filename: string;
+};
+
 function readUint16(bytes: Uint8Array, offset: number) {
   return bytes[offset]! | (bytes[offset + 1]! << 8);
 }
@@ -29,6 +42,38 @@ export function isZipFile(file: File) {
 }
 
 export async function readTextFileFromZip(file: File, preferredPaths: string[]) {
+  const preferred = new Set(preferredPaths.map((path) => path.toLowerCase()));
+  let fallbackJsonEntry: ZipCentralDirectoryEntry | null = null;
+
+  const { bytes, entries } = await readZipCentralDirectory(file);
+  for (const entry of entries) {
+    const normalizedName = entry.filename.replace(/^\/+/, "").toLowerCase();
+    if (preferred.has(normalizedName)) {
+      return await readZipTextEntry(bytes, entry);
+    }
+    if (!fallbackJsonEntry && normalizedName.endsWith(".json") && !normalizedName.endsWith("/")) {
+      fallbackJsonEntry = entry;
+    }
+  }
+
+  if (fallbackJsonEntry) return await readZipTextEntry(bytes, fallbackJsonEntry);
+  throw new Error("No JSON file found in zip");
+}
+
+export async function readTextFilesFromZip(file: File): Promise<ZipTextEntry[]> {
+  const { bytes, entries } = await readZipCentralDirectory(file);
+  const textEntries: ZipTextEntry[] = [];
+  for (const entry of entries) {
+    if (!isPackageTextPath(entry.filename)) continue;
+    textEntries.push({
+      path: entry.filename.replace(/^\/+/, ""),
+      text: await readZipTextEntry(bytes, entry),
+    });
+  }
+  return textEntries;
+}
+
+async function readZipCentralDirectory(file: File) {
   const bytes = new Uint8Array(await file.arrayBuffer());
   const endOffset = findEndOfCentralDirectory(bytes);
   if (endOffset < 0) throw new Error("Invalid zip file");
@@ -36,10 +81,7 @@ export async function readTextFileFromZip(file: File, preferredPaths: string[]) 
   const entryCount = readUint16(bytes, endOffset + 10);
   const centralDirectoryOffset = readUint32(bytes, endOffset + 16);
   const decoder = new TextDecoder();
-  const preferred = new Set(preferredPaths.map((path) => path.toLowerCase()));
-  let fallbackJsonEntry:
-    | { localHeaderOffset: number; compressedSize: number; compressionMethod: number; filename: string }
-    | null = null;
+  const entries: ZipCentralDirectoryEntry[] = [];
 
   let offset = centralDirectoryOffset;
   for (let index = 0; index < entryCount; index++) {
@@ -49,35 +91,24 @@ export async function readTextFileFromZip(file: File, preferredPaths: string[]) 
 
     const compressionMethod = readUint16(bytes, offset + 10);
     const compressedSize = readUint32(bytes, offset + 20);
+    const uncompressedSize = readUint32(bytes, offset + 24);
     const filenameLength = readUint16(bytes, offset + 28);
     const extraLength = readUint16(bytes, offset + 30);
     const commentLength = readUint16(bytes, offset + 32);
     const localHeaderOffset = readUint32(bytes, offset + 42);
     const filename = decoder.decode(bytes.slice(offset + 46, offset + 46 + filenameLength));
-    const normalizedName = filename.replace(/^\/+/, "").toLowerCase();
-    const entry = { localHeaderOffset, compressedSize, compressionMethod, filename };
-
-    if (preferred.has(normalizedName)) {
-      return readZipTextEntry(bytes, entry);
-    }
-    if (!fallbackJsonEntry && normalizedName.endsWith(".json")) {
-      fallbackJsonEntry = entry;
-    }
+    entries.push({ localHeaderOffset, compressedSize, uncompressedSize, compressionMethod, filename });
 
     offset += 46 + filenameLength + extraLength + commentLength;
   }
 
-  if (fallbackJsonEntry) return readZipTextEntry(bytes, fallbackJsonEntry);
-  throw new Error("No JSON file found in zip");
+  return { bytes, entries };
 }
 
-function readZipTextEntry(
+async function readZipTextEntry(
   bytes: Uint8Array,
-  entry: { localHeaderOffset: number; compressedSize: number; compressionMethod: number; filename: string },
+  entry: ZipCentralDirectoryEntry,
 ) {
-  if (entry.compressionMethod !== 0) {
-    throw new Error(`Zip entry ${entry.filename} is compressed; export it without compression before importing.`);
-  }
   const headerOffset = entry.localHeaderOffset;
   if (readUint32(bytes, headerOffset) !== ZIP_LOCAL_FILE_HEADER) throw new Error("Invalid zip local file header");
   const filenameLength = readUint16(bytes, headerOffset + 26);
@@ -85,5 +116,39 @@ function readZipTextEntry(
   const dataOffset = headerOffset + 30 + filenameLength + extraLength;
   const dataEnd = dataOffset + entry.compressedSize;
   if (dataEnd > bytes.length) throw new Error("Zip entry is truncated");
-  return new TextDecoder().decode(bytes.slice(dataOffset, dataEnd));
+  const compressed = bytes.slice(dataOffset, dataEnd);
+  if (entry.compressionMethod === 0) {
+    return new TextDecoder().decode(compressed);
+  }
+  if (entry.compressionMethod === 8) {
+    const inflated = await inflateDeflateRaw(compressed, entry);
+    return new TextDecoder().decode(inflated);
+  }
+  throw new Error(`Zip entry ${entry.filename} uses an unsupported compression method.`);
+}
+
+async function inflateDeflateRaw(compressed: Uint8Array, entry: ZipCentralDirectoryEntry) {
+  const ctor = (globalThis as {
+    DecompressionStream?: new (format: string) => {
+      readable: ReadableStream<Uint8Array>;
+      writable: WritableStream<Uint8Array>;
+    };
+  }).DecompressionStream;
+  if (!ctor) {
+    throw new Error(`Zip entry ${entry.filename} is compressed; export it without compression before importing.`);
+  }
+  const compressedBuffer = new ArrayBuffer(compressed.byteLength);
+  new Uint8Array(compressedBuffer).set(compressed);
+  const stream = new Blob([compressedBuffer]).stream().pipeThrough(new ctor("deflate-raw"));
+  const inflated = new Uint8Array(await new Response(stream).arrayBuffer());
+  if (entry.uncompressedSize > 0 && inflated.length !== entry.uncompressedSize) {
+    throw new Error(`Zip entry ${entry.filename} has an unexpected size.`);
+  }
+  return inflated;
+}
+
+function isPackageTextPath(path: string) {
+  const normalized = path.replace(/^\/+/, "").toLowerCase();
+  if (!normalized || normalized.endsWith("/")) return false;
+  return /\.(json|js|mjs|cjs|css|md|txt|ts|tsx)$/.test(normalized);
 }

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -756,6 +756,7 @@ interface UIState {
   requestChatModeShortcut: (mode: ChatModeShortcut) => void;
   setVisualTheme: (v: VisualTheme) => void;
   setConvoGradientField: (scheme: "dark" | "light", field: "from" | "to", value: string) => void;
+  resetAppearanceSettings: () => void;
   setConvoNotificationSound: (v: boolean) => void;
   setRpNotificationSound: (v: boolean) => void;
   setGameNotificationSound: (v: boolean) => void;
@@ -1632,6 +1633,53 @@ export const useUIStore = create<UIState>()(
             [scheme]: { ...s.convoGradient[scheme], [field]: value },
           },
         })),
+      resetAppearanceSettings: () =>
+        set({
+          trackerPanelEnabled: true,
+          trackerPanelOpen: false,
+          trackerPanelSide: "right" as TrackerPanelSide,
+          trackerPanelHideHudWidgets: false,
+          trackerPanelUseExpressionSprites: false,
+          trackerPanelThoughtBubbleDisplay: "inline" as TrackerThoughtBubbleDisplay,
+          trackerPanelDockedThoughtsAlwaysVisible: false,
+          trackerPanelSizeProfile: "standard" as TrackerPanelSizeProfile,
+          trackerPanelBackgroundColor: TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR,
+          trackerTemperatureUnit: "celsius" as TrackerTemperatureUnit,
+          trackerPanelCollapsedSections: {},
+          trackerPanelSectionOrder: [...TRACKER_DATA_PANEL_SECTIONS],
+          theme: "dark" as const,
+          appBackgroundColor: "",
+          appAccentColor: "",
+          appAccentRgbMode: false,
+          chatBackground: null,
+          defaultRoleplayBackground: DEFAULT_ROLEPLAY_BACKGROUND_URL,
+          chatBackgroundBlur: 0,
+          fontSize: 17 as FontSize,
+          chatFontSize: 16,
+          fontFamily: "",
+          conversationMessageStyle: "classic" as ConversationMessageStyle,
+          narrationFontColor: "",
+          narrationOpacity: 80,
+          chatFontColor: "",
+          chatChromeTextColor: "",
+          chatFontOpacity: 90,
+          roleplayAvatarStyle: "circles" as RoleplayAvatarStyle,
+          roleplayAvatarScale: 1,
+          roleplayAvatarsScrollable: false,
+          roleplaySpriteScale: 1,
+          gameDialogueDisplayMode: "classic" as GameDialogueDisplayMode,
+          gameAvatarScale: 1,
+          gameFullBodySpriteScale: 1.35,
+          textStrokeWidth: 0.5,
+          textStrokeColor: "#000000",
+          visualTheme: "default" as VisualTheme,
+          convoGradient: {
+            dark: { from: "#0a0a0e", to: "#1c2133" },
+            light: { from: "#f2eff7", to: "#eae6f0" },
+          },
+          weatherEffects: true,
+          hudPosition: "top" as HudPosition,
+        }),
       setConvoNotificationSound: (v) => set({ convoNotificationSound: v }),
       setRpNotificationSound: (v) => set({ rpNotificationSound: v }),
       setGameNotificationSound: (v) => set({ gameNotificationSound: v }),

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -27,6 +27,7 @@ import { logger } from "../../../lib/logger.js";
 import { isClaudeSubscriptionResumeEnabled } from "../../../config/runtime-config.js";
 import {
   assembleEntries,
+  buildAssistantPrefillContinuationPrompt,
   currentToSdkUserMessage,
   SDK_VERSION,
   splitHistoryForResume,
@@ -169,8 +170,14 @@ function extractSystemPrompt(messages: ChatMessage[]): string | undefined {
 function renderTranscript(messages: ChatMessage[]): { systemPrompt: string | undefined; prompt: string } {
   const systemBlocks: string[] = [];
   const turns: string[] = [];
+  const nonSystemMessages = messages.filter((message) => message.role !== "system");
+  const trailingAssistant =
+    nonSystemMessages.length > 0 && nonSystemMessages[nonSystemMessages.length - 1]!.role === "assistant"
+      ? nonSystemMessages[nonSystemMessages.length - 1]!
+      : null;
 
   for (const message of messages) {
+    if (message === trailingAssistant) continue;
     const text = message.content?.trim();
     if (!text) continue;
     if (message.role === "system") {
@@ -179,6 +186,10 @@ function renderTranscript(messages: ChatMessage[]): { systemPrompt: string | und
     }
     const label = message.role === "user" ? "User" : "Assistant";
     turns.push(`${label}: ${text}`);
+  }
+
+  if (trailingAssistant) {
+    turns.push(`User: ${buildAssistantPrefillContinuationPrompt(trailingAssistant.content ?? "")}`);
   }
 
   // Claude Agent SDK requires a non-empty prompt; if the caller only supplied
@@ -232,6 +243,12 @@ function selectPromptPath(messages: ChatMessage[], model: string): PromptSelecti
 function buildResumeSelection(messages: ChatMessage[], model: string): PromptSelection {
   const split = splitHistoryForResume(messages);
   const systemPrompt = extractSystemPrompt(messages);
+  if (split.shape === "trailing-assistant-continue") {
+    logger.warn(
+      "[claude-subscription] assistant prefill routed through synthetic continuation prompt because SDK prompts are user-only (prefillChars=%d)",
+      split.assistantPrefillLength ?? 0,
+    );
+  }
 
   if (split.history.length === 0) {
     // Resuming an empty transcript makes the SDK throw "No conversation found

--- a/packages/server/src/services/llm/providers/claude-subscription/jsonl-entries.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription/jsonl-entries.ts
@@ -337,13 +337,14 @@ export function buildAssistantPrefillContinuationPrompt(prefill: string): string
   if (!normalized.trim()) {
     return "Continue the assistant's reply.";
   }
+  const safePrefill = normalized.replaceAll("</assistant_prefill>", "&lt;/assistant_prefill&gt;");
   return [
     "Continue the assistant's reply as if it already began with the prefill below.",
     "The prefill is already part of the assistant message, so do not repeat it.",
     "Start with the very next text that should follow it, preserving the same voice, format, and momentum.",
     "",
     "<assistant_prefill>",
-    normalized,
+    safePrefill,
     "</assistant_prefill>",
   ].join("\n");
 }

--- a/packages/server/src/services/llm/providers/claude-subscription/jsonl-entries.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription/jsonl-entries.ts
@@ -322,19 +322,31 @@ export function assembleEntries(
 /** Synthetic user prompt when no history exists (connection-test pings, dry runs). */
 const SYNTHETIC_START = "[Start]";
 /**
- * Synthetic user prompt when the trailing message is an assistant turn
- * (prefill / "continue this" flows). This is the closest in-SDK approximation
- * of Anthropic Messages API native prefill — the SDK's `prompt` is user-only,
- * so we can't author a trailing assistant in the outbound API call. The
- * trailing assistant turn stays in JSONL (real assistant entry) and this
- * synthetic user message asks the model to continue.
+ * Build the closest in-SDK approximation of Anthropic Messages API native
+ * assistant prefill. The Claude Agent SDK `prompt` is user-only, and Marinara
+ * already streams/saves the prefill before provider output, so the synthetic
+ * turn tells Claude to continue after the prefilled text rather than repeat it.
  *
- * TODO(passthrough): If/when the loopback-passthrough is added, rewrite the
+ * TODO(passthrough): If/when loopback-passthrough is added, rewrite the
  * outbound API body to keep the trailing assistant in its proper position and
  * elide this synthetic continuation — that unlocks native prefill semantics
- * (model extends the prefill turn rather than producing a new turn).
+ * (model extends the prefill turn directly).
  */
-const SYNTHETIC_CONTINUE = "(continue)";
+export function buildAssistantPrefillContinuationPrompt(prefill: string): string {
+  const normalized = prefill.trimEnd();
+  if (!normalized.trim()) {
+    return "Continue the assistant's reply.";
+  }
+  return [
+    "Continue the assistant's reply as if it already began with the prefill below.",
+    "The prefill is already part of the assistant message, so do not repeat it.",
+    "Start with the very next text that should follow it, preserving the same voice, format, and momentum.",
+    "",
+    "<assistant_prefill>",
+    normalized,
+    "</assistant_prefill>",
+  ].join("\n");
+}
 
 export interface SplitResult {
   /** Messages that go into the JSONL session file as prior history. */
@@ -343,6 +355,8 @@ export interface SplitResult {
   current: ChatMessage;
   /** Diagnostic tag describing which branch shaped `current`. */
   shape: "trailing-user" | "trailing-tool" | "trailing-assistant-continue" | "synthetic-start";
+  /** Present when a trailing assistant prefill was converted into synthetic continuation steering. */
+  assistantPrefillLength?: number;
 }
 
 /**
@@ -350,8 +364,8 @@ export interface SplitResult {
  * SDK prompt) shape the resume path needs.
  *
  * - Trailing `user` or `tool`: JSONL = all-but-trailing; prompt source = trailing.
- * - Trailing `assistant`: JSONL = all messages (prefill stays in JSONL);
- *   prompt source = synthetic "(continue)" user turn.
+ * - Trailing `assistant`: JSONL = all-but-trailing; prompt source =
+ *   synthetic continuation instruction containing the prefill text.
  * - Empty or system-only: JSONL = [] (system messages ride `systemPrompt`,
  *   not the JSONL); prompt source = synthetic "[Start]" user turn.
  *
@@ -360,7 +374,7 @@ export interface SplitResult {
  * assistant turn from `finalMessages` BEFORE calling provider.chat(). Any
  * trailing assistant reaching this function is therefore intentional —
  * specifically the `assistantPrefill` feature (see
- * packages/shared/src/types/prompt.ts:177 and generate.routes.ts:5953,
+ * packages/shared/src/types/prompt.ts and appendGenerationTailMessages(),
  * where the prefill is pushed as the final assistant message).
  *
  * If that upstream contract ever changes — i.e. regen starts leaving the
@@ -390,9 +404,10 @@ export function splitHistoryForResume(messages: readonly ChatMessage[]): SplitRe
 
   if (trailing.role === "assistant") {
     return {
-      history: nonSystem,
-      current: { role: "user", content: SYNTHETIC_CONTINUE },
+      history: nonSystem.slice(0, nonSystem.length - 1),
+      current: { role: "user", content: buildAssistantPrefillContinuationPrompt(trailing.content ?? "") },
       shape: "trailing-assistant-continue",
+      assistantPrefillLength: (trailing.content ?? "").length,
     };
   }
 


### PR DESCRIPTION
## Linked issue

Fixes #2678

Custom agent game-mode support is a maintainer-requested follow-up from this thread.

## Why this change

- Game chats should let users attach and manage custom agents like conversation chats do.
- Claude Subscription was losing assistant-prefill steering by storing the prefill as a completed assistant JSONL turn, then sending a raw synthetic `(continue)` user prompt.

## What changed

- Adding an agent now enables the chat agent pipeline and game mode shows active custom-agent settings/removal controls.
- Claude Subscription resume now strips trailing assistant prefill from JSONL history and sends a synthetic continuation instruction that preserves the prefill steering without asking Claude to repeat it.
- Claude Subscription fold fallback uses the same continuation instruction, and resume emits a warn-level breadcrumb when this approximation is used.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm --filter @marinara-engine/client lint`.
- Ran `pnpm --filter @marinara-engine/client build` successfully; this shell warns that Node `20.11.1` is below the repo engine/Vite-supported version.
- Ran `pnpm --filter @marinara-engine/server lint`.
- Ran a focused `tsx` assertion proving Claude Subscription prefill split removes the trailing assistant from resume history and preserves the prefill in the continuation prompt.
- Ran `git diff --check`.
- Tried `pnpm --filter @marinara-engine/server test`; it failed before running tests because the configured test glob could not find `packages/server/src/services/image/__tests__/*.test.ts` in this checkout.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not captured. The game custom-agent change is a Chat Settings UI flow and still needs browser click-through before review is marked complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents automatically enable in chat settings when adding a new agent

* **Improvements**
  * Updated agent toggle descriptions to explicitly reference scene analysis and custom agents
  * Enhanced Claude assistant continuation prompt handling for improved response generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->