### PR TITLE
Refine accent RGB and pulse controls

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -186,6 +186,7 @@ export function App() {
   const fontFamily = useUIStore((s) => s.fontFamily);
   const appBackgroundColor = useUIStore((s) => s.appBackgroundColor);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
+  const appAccentPulseMode = useUIStore((s) => s.appAccentPulseMode);
   const appAccentRgbMode = useUIStore((s) => s.appAccentRgbMode);
   const chatChromeTextColor = useUIStore((s) => s.chatChromeTextColor);
   const hasModalOpen = useUIStore((s) => s.modal !== null);
@@ -268,6 +269,7 @@ export function App() {
     const accentSource = accent || defaultAccent;
     const solidAccent = getCssColorFallback(accentSource, defaultAccent);
     const accentIsGradient = isCssGradient(accentSource);
+    const accentAnimationEnabled = (appAccentRgbMode && accentIsGradient) || (appAccentPulseMode && !accentIsGradient);
     const gradientStops = accentIsGradient ? getCssGradientColorStops(accentSource, solidAccent) : [solidAccent];
 
     let accentAnimationTimer: ReturnType<typeof window.setInterval> | null = null;
@@ -329,7 +331,7 @@ export function App() {
     };
 
     const syncAccentAnimationState = () => {
-      if (appAccentRgbMode && canRunAccentAnimation()) {
+      if (accentAnimationEnabled && canRunAccentAnimation()) {
         startAccentAnimation();
       } else {
         stopAccentAnimation();
@@ -340,7 +342,7 @@ export function App() {
       syncAccentAnimationState();
     };
 
-    if (!appAccentRgbMode) {
+    if (!accentAnimationEnabled) {
       applyStaticAccent();
     }
     syncAccentAnimationState();
@@ -364,7 +366,7 @@ export function App() {
       }
       delete root.dataset.marinaraAccentAnimation;
     };
-  }, [appAccentColor, appAccentRgbMode, theme]);
+  }, [appAccentColor, appAccentPulseMode, appAccentRgbMode, theme]);
 
   useEffect(() => {
     const root = document.documentElement;

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1790,13 +1790,28 @@ function AppearanceSettings() {
   const handleAppAccentColorChange = useCallback(
     (color: string) => {
       const normalized = color.trim();
-      setAppAccentColor(normalized.toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : normalized);
-      if (appAccentRgbMode && !isCssGradient(normalized || defaultAppAccentColor)) {
+      const normalizedAccent = normalized.toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : normalized;
+      const nextAccent = normalizedAccent || defaultAppAccentColor;
+
+      setAppAccentColor(normalizedAccent);
+
+      if (isCssGradient(nextAccent)) {
+        setAppAccentPulseMode(false);
+      }
+
+      if (appAccentRgbMode && !isCssGradient(nextAccent)) {
         setAppAccentRgbMode(false);
         setAppAccentColorBeforeRgbMode(null);
       }
     },
-    [appAccentRgbMode, defaultAppAccentColor, setAppAccentColor, setAppAccentColorBeforeRgbMode, setAppAccentRgbMode],
+    [
+      appAccentRgbMode,
+      defaultAppAccentColor,
+      setAppAccentColor,
+      setAppAccentColorBeforeRgbMode,
+      setAppAccentPulseMode,
+      setAppAccentRgbMode,
+    ],
   );
   const handleAppAccentRgbModeChange = useCallback(
     (enabled: boolean) => {

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -2049,10 +2049,15 @@ function AppearanceSettings() {
             gradient
             compact
             label="Accent Color"
-            helpText="Colors the shared app accent layer: buttons, active icons, focus rings, highlights, panel outlines, and chat chrome."
+            helpText={
+              appAccentRgbMode
+                ? "Turn off RGB Mode to edit the saved accent color. While RGB Mode is on, the app accent is controlled by the animated rainbow preset."
+                : "Colors the shared app accent layer: buttons, active icons, focus rings, highlights, panel outlines, and chat chrome."
+            }
             emptyText={`Default ${defaultAppAccentColor}`}
             emptyPreviewValue={defaultAppAccentColor}
             clearLabel="Reset to default"
+            disabled={appAccentRgbMode}
           />
 
           <ToggleSetting

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -28,6 +28,7 @@ import { ADMIN_SECRET_STORAGE_KEY, ApiError, api, getAdminSecretHeader } from ".
 import { chatBackgroundUrlToMetadata } from "../../lib/backgrounds";
 import { normalizeThemeCss } from "../../lib/theme-css";
 import { forceRefreshSpa } from "@/lib/browser-runtime";
+import { isCssGradient, RAINBOW_GRADIENT_PRESET } from "../../lib/css-colors";
 import React, { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import {
@@ -1756,6 +1757,10 @@ function AppearanceSettings() {
   const setAppBackgroundColor = useUIStore((s) => s.setAppBackgroundColor);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
   const setAppAccentColor = useUIStore((s) => s.setAppAccentColor);
+  const appAccentColorBeforeRgbMode = useUIStore((s) => s.appAccentColorBeforeRgbMode);
+  const setAppAccentColorBeforeRgbMode = useUIStore((s) => s.setAppAccentColorBeforeRgbMode);
+  const appAccentPulseMode = useUIStore((s) => s.appAccentPulseMode);
+  const setAppAccentPulseMode = useUIStore((s) => s.setAppAccentPulseMode);
   const appAccentRgbMode = useUIStore((s) => s.appAccentRgbMode);
   const setAppAccentRgbMode = useUIStore((s) => s.setAppAccentRgbMode);
   const defaultAppBackgroundColor = getDefaultAppBackgroundColor(theme);
@@ -1764,6 +1769,7 @@ function AppearanceSettings() {
   const defaultAppAccentColor = getDefaultAppAccentColor(theme);
   const displayedAppAccentColor =
     appAccentColor.trim().toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : appAccentColor;
+  const appAccentIsGradient = isCssGradient(displayedAppAccentColor || defaultAppAccentColor);
   const visualTheme = useUIStore((s) => s.visualTheme);
   const setVisualTheme = useUIStore((s) => s.setVisualTheme);
   const chatBackground = useUIStore((s) => s.chatBackground);
@@ -1785,8 +1791,34 @@ function AppearanceSettings() {
     (color: string) => {
       const normalized = color.trim();
       setAppAccentColor(normalized.toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : normalized);
+      if (appAccentRgbMode && !isCssGradient(normalized || defaultAppAccentColor)) {
+        setAppAccentRgbMode(false);
+        setAppAccentColorBeforeRgbMode(null);
+      }
     },
-    [defaultAppAccentColor, setAppAccentColor],
+    [appAccentRgbMode, defaultAppAccentColor, setAppAccentColor, setAppAccentColorBeforeRgbMode, setAppAccentRgbMode],
+  );
+  const handleAppAccentRgbModeChange = useCallback(
+    (enabled: boolean) => {
+      if (enabled) {
+        setAppAccentColorBeforeRgbMode(appAccentColor);
+        setAppAccentColor(RAINBOW_GRADIENT_PRESET);
+        setAppAccentRgbMode(true);
+        return;
+      }
+      setAppAccentRgbMode(false);
+      if (appAccentColorBeforeRgbMode !== null) {
+        setAppAccentColor(appAccentColorBeforeRgbMode);
+        setAppAccentColorBeforeRgbMode(null);
+      }
+    },
+    [
+      appAccentColor,
+      appAccentColorBeforeRgbMode,
+      setAppAccentColor,
+      setAppAccentColorBeforeRgbMode,
+      setAppAccentRgbMode,
+    ],
   );
   // Persist background changes to the active chat's metadata immediately so
   // a clear (or pick) survives chat switches and page reloads. The effect-based
@@ -2024,11 +2056,29 @@ function AppearanceSettings() {
           />
 
           <ToggleSetting
-            label="RGB Mode"
+            label={
+              <span
+                className={cn(
+                  appAccentRgbMode && appAccentIsGradient && "mari-logo-gradient-text mari-logo-gradient-text--active",
+                )}
+              >
+                RGB Mode
+              </span>
+            }
             checked={appAccentRgbMode}
-            onChange={setAppAccentRgbMode}
-            help="Cycles the accent token itself. Solid accents gently brighten and darken; gradient accents slowly move color-to-color through the selected stops. Reduced-motion preferences are respected."
+            onChange={handleAppAccentRgbModeChange}
+            switchClassName={appAccentRgbMode && appAccentIsGradient ? "mari-rgb-toggle-track" : undefined}
+            help="Switches the app accent to the rainbow gradient while enabled, then restores your previous accent when disabled. Reduced-motion preferences are respected."
           />
+
+          {!appAccentIsGradient && (
+            <ToggleSetting
+              label="Accent Pulse"
+              checked={appAccentPulseMode}
+              onChange={setAppAccentPulseMode}
+              help="Gently brightens and darkens solid accent colors. Reduced-motion preferences are respected."
+            />
+          )}
 
           <label className="flex flex-col gap-1">
             <span className="text-xs font-medium inline-flex items-center gap-1">

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -286,6 +286,7 @@ type SettingsSwitchProps = SettingsSwitchAccessibleLabel & {
   labelPosition?: "start" | "end";
   className?: string;
   labelClassName?: string;
+  /** Appended last so callers can intentionally override checked-track visuals. */
   switchClassName?: string;
 };
 

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -172,12 +172,14 @@ export function ToggleSetting({
   onChange,
   help,
   disabled = false,
+  switchClassName,
 }: {
-  label: string;
+  label: ReactNode;
   checked: boolean;
   onChange: (v: boolean) => void;
   help?: string;
   disabled?: boolean;
+  switchClassName?: string;
 }) {
   return (
     <SettingsSwitch
@@ -189,6 +191,7 @@ export function ToggleSetting({
       labelPosition="start"
       className="justify-between gap-3 p-1.5"
       labelClassName="text-xs"
+      switchClassName={switchClassName}
     />
   );
 }
@@ -283,6 +286,7 @@ type SettingsSwitchProps = SettingsSwitchAccessibleLabel & {
   labelPosition?: "start" | "end";
   className?: string;
   labelClassName?: string;
+  switchClassName?: string;
 };
 
 export function SettingsSwitch({
@@ -297,6 +301,7 @@ export function SettingsSwitch({
   labelPosition = "end",
   className,
   labelClassName,
+  switchClassName,
 }: SettingsSwitchProps) {
   const inputId = useId();
   const switchControl = (
@@ -318,6 +323,7 @@ export function SettingsSwitch({
           checked ? "bg-[var(--primary)]/70" : "bg-[var(--border)]",
           checked && "mari-accent-animated",
           disabled ? "cursor-not-allowed" : "cursor-pointer",
+          switchClassName,
         )}
       >
         <span

--- a/packages/client/src/components/ui/ColorPicker.tsx
+++ b/packages/client/src/components/ui/ColorPicker.tsx
@@ -27,6 +27,8 @@ interface ColorPickerProps {
   clearValue?: string;
   /** Optional compact control shown beside the label. */
   headerAction?: ReactNode;
+  /** Prevent editing while still showing the current preview. */
+  disabled?: boolean;
 }
 
 /** Preset palette colors */
@@ -97,6 +99,7 @@ export function ColorPicker({
   clearLabel = "Clear",
   clearValue = "",
   headerAction,
+  disabled = false,
 }: ColorPickerProps) {
   const isGradient = isCssGradient(value);
   const [mode, setMode] = useState<"solid" | "gradient">(isGradient ? "gradient" : "solid");
@@ -119,6 +122,12 @@ export function ColorPicker({
       setMode("solid");
     }
   }, [value]);
+
+  useEffect(() => {
+    if (disabled) {
+      setExpanded(false);
+    }
+  }, [disabled]);
 
   const handleSolidChange = useCallback(
     (color: string) => {
@@ -193,6 +202,7 @@ export function ColorPicker({
             <button
               type="button"
               onClick={clearColor}
+              disabled={disabled}
               className="flex items-center gap-1 rounded-lg px-1.5 py-0.5 text-[0.625rem] text-[var(--muted-foreground)] transition-all hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
             >
               <X size="0.625rem" />
@@ -206,11 +216,15 @@ export function ColorPicker({
       {/* Preview + trigger */}
       <button
         type="button"
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => {
+          if (!disabled) setExpanded(!expanded);
+        }}
+        disabled={disabled}
         className={cn(
           "flex w-full items-center rounded-xl border border-[var(--border)] bg-[var(--secondary)] transition-all hover:border-[var(--primary)]/30",
           compact ? "gap-2 rounded-lg p-1.5" : "gap-3 p-2.5",
           expanded && "border-[var(--primary)]/40 ring-1 ring-[var(--primary)]/20",
+          disabled && "cursor-not-allowed opacity-60 hover:border-[var(--border)]",
         )}
       >
         <div

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -2127,10 +2127,10 @@ export const useUIStore = create<UIState>()(
         if (version <= 59 && persisted.appAccentRgbMode === undefined) {
           persisted.appAccentRgbMode = false;
         }
-        if (persisted.appAccentColorBeforeRgbMode === undefined) {
+        if (version <= 60 && persisted.appAccentColorBeforeRgbMode === undefined) {
           persisted.appAccentColorBeforeRgbMode = null;
         }
-        if (persisted.appAccentPulseMode === undefined) {
+        if (version <= 60 && persisted.appAccentPulseMode === undefined) {
           persisted.appAccentPulseMode = false;
         }
         persisted.characterLibrarySort = normalizeCharacterLibrarySort(persisted.characterLibrarySort);

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -10,6 +10,7 @@ import {
   type ImageStyleProfileSettings,
   type QuoteFormat,
 } from "@marinara-engine/shared";
+import { isCssGradient } from "../lib/css-colors";
 
 type Panel =
   | "chat"
@@ -356,6 +357,8 @@ interface UIState {
   theme: "dark" | "light";
   appBackgroundColor: string;
   appAccentColor: string;
+  appAccentColorBeforeRgbMode: string | null;
+  appAccentPulseMode: boolean;
   appAccentRgbMode: boolean;
   chatBackground: string | null;
   /** Default background applied when a Roleplay chat has no saved background yet. */
@@ -641,6 +644,8 @@ interface UIState {
   setTheme: (theme: "dark" | "light") => void;
   setAppBackgroundColor: (color: string) => void;
   setAppAccentColor: (color: string) => void;
+  setAppAccentColorBeforeRgbMode: (color: string | null) => void;
+  setAppAccentPulseMode: (enabled: boolean) => void;
   setAppAccentRgbMode: (enabled: boolean) => void;
   setChatBackground: (url: string | null) => void;
   setDefaultRoleplayBackground: (url: string) => void;
@@ -996,6 +1001,8 @@ export const useUIStore = create<UIState>()(
       theme: "dark" as const,
       appBackgroundColor: "",
       appAccentColor: "",
+      appAccentColorBeforeRgbMode: null,
+      appAccentPulseMode: false,
       appAccentRgbMode: false,
       chatBackground: null,
       defaultRoleplayBackground: DEFAULT_ROLEPLAY_BACKGROUND_URL,
@@ -1202,6 +1209,9 @@ export const useUIStore = create<UIState>()(
       setTheme: (theme) => set({ theme }),
       setAppBackgroundColor: (color) => set({ appBackgroundColor: normalizeAppBackgroundColor(color) }),
       setAppAccentColor: (color) => set({ appAccentColor: normalizeAppAccentColor(color) }),
+      setAppAccentColorBeforeRgbMode: (color) =>
+        set({ appAccentColorBeforeRgbMode: color === null ? null : normalizeAppAccentColor(color) }),
+      setAppAccentPulseMode: (enabled) => set({ appAccentPulseMode: enabled }),
       setAppAccentRgbMode: (enabled) => set({ appAccentRgbMode: enabled }),
       setChatBackground: (url) => set({ chatBackground: url }),
       setDefaultRoleplayBackground: (url) => set({ defaultRoleplayBackground: normalizeDefaultRoleplayBackground(url) }),
@@ -1713,7 +1723,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 60,
+      version: 61,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2117,6 +2127,12 @@ export const useUIStore = create<UIState>()(
         if (version <= 59 && persisted.appAccentRgbMode === undefined) {
           persisted.appAccentRgbMode = false;
         }
+        if (persisted.appAccentColorBeforeRgbMode === undefined) {
+          persisted.appAccentColorBeforeRgbMode = null;
+        }
+        if (persisted.appAccentPulseMode === undefined) {
+          persisted.appAccentPulseMode = false;
+        }
         persisted.characterLibrarySort = normalizeCharacterLibrarySort(persisted.characterLibrarySort);
         persisted.characterPanelScrollTop = normalizeScrollTop(persisted.characterPanelScrollTop);
         persisted.characterLibraryScrollTop = normalizeScrollTop(persisted.characterLibraryScrollTop);
@@ -2131,7 +2147,20 @@ export const useUIStore = create<UIState>()(
           persisted.recentUserActivities = [];
         }
         persisted.appAccentColor = normalizeAppAccentColor(persisted.appAccentColor);
+        persisted.appAccentColorBeforeRgbMode =
+          persisted.appAccentColorBeforeRgbMode === null
+            ? null
+            : normalizeAppAccentColor(persisted.appAccentColorBeforeRgbMode);
         persisted.appBackgroundColor = normalizeAppBackgroundColor(persisted.appBackgroundColor);
+        persisted.appAccentPulseMode = persisted.appAccentPulseMode === true;
+        if (version <= 60 && persisted.appAccentRgbMode === true) {
+          const persistedTheme = persisted.theme === "light" ? "light" : "dark";
+          const persistedAccentSource = persisted.appAccentColor || getDefaultAppAccentColor(persistedTheme);
+          if (!isCssGradient(persistedAccentSource)) {
+            persisted.appAccentPulseMode = true;
+            persisted.appAccentRgbMode = false;
+          }
+        }
         persisted.appAccentRgbMode = persisted.appAccentRgbMode === true;
         persisted.chatChromeTextColor = normalizeChatChromeTextColor(persisted.chatChromeTextColor);
         persisted.defaultRoleplayBackground = normalizeDefaultRoleplayBackground(persisted.defaultRoleplayBackground);
@@ -2175,6 +2204,8 @@ export const useUIStore = create<UIState>()(
         theme: state.theme,
         appBackgroundColor: state.appBackgroundColor,
         appAccentColor: state.appAccentColor,
+        appAccentColorBeforeRgbMode: state.appAccentColorBeforeRgbMode,
+        appAccentPulseMode: state.appAccentPulseMode,
         appAccentRgbMode: state.appAccentRgbMode,
         chatBackground: state.chatBackground,
         defaultRoleplayBackground: state.defaultRoleplayBackground,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2335,6 +2335,20 @@ summary[class*="cursor-pointer"],
   animation: mari-logo-title-shift 5.2s ease-in-out infinite;
 }
 
+.mari-rgb-toggle-track {
+  background: linear-gradient(
+    90deg,
+    var(--mari-logo-title-cyan) 0%,
+    var(--mari-logo-title-orange) 28%,
+    var(--mari-logo-title-pink) 55%,
+    var(--mari-logo-title-orange) 78%,
+    var(--mari-logo-title-cyan) 100%
+  );
+  background-position: 0% 50%;
+  background-size: 220% 100%;
+  animation: mari-logo-title-shift 5.2s ease-in-out infinite;
+}
+
 @keyframes mari-logo-title-shift {
   0%,
   100% {
@@ -2349,6 +2363,10 @@ summary[class*="cursor-pointer"],
 
 @media (prefers-reduced-motion: reduce) {
   .mari-logo-gradient-text--active {
+    animation: none;
+  }
+
+  .mari-rgb-toggle-track {
     animation: none;
   }
 }


### PR DESCRIPTION
## Linked issue

No linked issue yet. One should be opened before this PR is submitted for review.

## Why this change

- Splits accent animation behavior more cleanly between solid accents and gradient accents, and prevents the accent picker from exposing edits that are lost while `RGB Mode` is active.

## What changed

- Adds `Accent Pulse` for solid accent colors while keeping animated gradient handling scoped to `RGB Mode`.
- Preserves and restores the previous accent when toggling `RGB Mode`, including persisted store handling for older saved state.
- Disables the shared `Accent Color` picker while `RGB Mode` owns the active accent and updates the settings help text accordingly.
- Adds shared UI support for disabled `ColorPicker` controls and custom toggle track styling used by the RGB toggle.
- Follows up on review feedback by version-gating the new persisted fields, clearing stale pulse state when a gradient accent is selected manually, and documenting `switchClassName` override behavior.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/client build`
- `pnpm --filter @marinara-engine/client exec eslint src/components/ui/ColorPicker.tsx src/components/panels/SettingsPanel.tsx --max-warnings=0`
- `pnpm --filter @marinara-engine/client exec eslint src/components/panels/SettingsPanel.tsx src/components/panels/settings/SettingControls.tsx src/stores/ui.store.ts --max-warnings=0`
- `pnpm check` was started earlier, but the repo-wide lint step hit the session timeout before it returned a final result.
- No browser click-through, mobile verification, or human manual proof is claimed by this update.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="280" height="182" alt="Bildschirmfoto 2026-06-21 um 17 20 37" src="https://github.com/user-attachments/assets/d7ec1aa9-2d2a-4566-9a8c-b9132e3c07b1" />
<img width="277" height="228" alt="Bildschirmfoto 2026-06-21 um 17 20 29" src="https://github.com/user-attachments/assets/a991aacc-f1b6-4d84-9939-3aba44bd25e1" />